### PR TITLE
Update WooCommerce Onboarding Connection Login/Signup colors

### DIFF
--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -22,14 +22,14 @@
 	--color-accent-light: #beabce;
 	--color-accent-dark:  #6d3e64;
 
-	--color-woocommerce-onboarding-background:  #f6f6f6;
-	--color-woocommerce-header-border: #e1e2e2;
+	--color-woocommerce-onboarding-background:  #f6f7f7;
+	--color-woocommerce-header-border: #dcdcde;
 
 	// Override global colors with accent variables
 	--color-primary:                         var( --color-accent-dark );
-	--color-primary-100:					 var( --color-gray-600 );
-	--color-neutral-200:				  	 var( --color-gray-600 );
-	--color-primary-200:					 var( --color-gray-600 );
+	--color-primary-100:					 #50575e;
+	--color-neutral-200:				  	 #50575e;
+	--color-primary-200:					 #50575e;
 	--color-primary-light:                   var( --color-accent-light );
 	--color-button-primary-background-hover: #ca2a7c;
 	--color-accent-600:                      var( --color-accent-dark );
@@ -37,5 +37,23 @@
 	::selection {
 		color: var( --color-white );
 		background: var( --color-accent );
+	}
+
+	// @todo Once Calypso has updated to color-studio v2, WooCommerce Onboarding's Connection flow can switch to using studio variables.
+	button.is-primary {
+		background-color: #c9356e; // $studio-pink;
+		border-color: #8c1749; // $studio-pink-70;
+
+		&:hover,
+		&:focus:enabled {
+			background: #bf3269; // shadded 50%
+			border-color: #651b37;
+			color: var( --color-white );
+		}
+
+		&:hover {
+			background: #bf3269;
+			border-color: #651b37;
+		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -897,7 +897,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.jetpack-connect__main-logo {
 			text-align: center;
-			border-bottom: 1px solid var( --color-gray-50 );
+			border-bottom: 1px solid #646970; // $studio-gray-50
 			position: absolute;
 			width: 100%;
 			left: 0;
@@ -937,19 +937,19 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.jetpack-logo__icon-circle {
-			fill: var( --color-gray-800 );
+			fill: #2c3338; // $studio-gray-80;
 		}
 
 		.jetpack-logo__icon-triangle {
-			fill: var( --color-gray-0 );
+			fill: #f6f7f7; // $studio-gray-0;
 		}
 
 		.signup-form__social p {
-			color: var( --color-gray-600 );
+			color: #50575e; // $studio-gray-60;
 		}
 
 		.formatted-header__title {
-			color: var( --color-gray-800 );
+			color: #2c3338; // $studio-gray-80;
 		}
 
 		.signup-form__submit {
@@ -958,11 +958,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.jetpack-header__partner-logo-plus svg {
-			stroke: var( --color-gray-800 );
+			stroke: #2c3338; // $studio-gray-80;
 		}
 
 		.jetpack-header__partner-logo-plus .gridicon {
-			color: var( --color-gray-800 );
+			color: #2c3338; // $studio-gray-80;
 		}
 
 		.jetpack-connect__main,
@@ -985,13 +985,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		.signup-form__terms-of-service-link,
 		.signup-form__terms-of-service-link a {
 			text-align: left;
-			color: var( --color-gray-600 );
+			color: #50575e; // $studio-gray-60;
 		}
 
 		.logged-out-form__link-item {
 			text-align: center;
 			text-decoration: underline;
-			color: var( --color-gray-600 );
+			color: #50575e; // $studio-gray-60;
 			font-size: 14px;
 		}
 
@@ -1003,8 +1003,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			}
 
 			.social-buttons__button {
-				border: 1px solid $muriel-woo-purple-500;
-				color: $muriel-woo-purple-500;
+				border: 1px solid #c9356e; // $studio-pink;
+				color: #c9356e; // $studio-pink
 				box-shadow: none;
 			}
 		}
@@ -1035,7 +1035,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			.jetpack-connect__tos-link,
 			.jetpack-connect__tos-link a {
 				text-align: left;
-				color: var( --color-gray-600 );
+				color: #50575e; // $studio-gray-60;
 				font-size: 12px;
 			}
 		}
@@ -1052,15 +1052,15 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.woocommerce-muriel-text-control,
 		.muriel-input-text {
-			border-color: var( --color-gray-200 );
+			border-color: #a7aaad; // $studio-gray-20;
 
 			.components-base-control__label,
 			.text-control__label {
-				color: var( --color-gray-500 );
+				color: #646970; // $studio-gray-50;
 			}
 
 			&.active {
-				box-shadow: 0 0 0 2px var( --color-hot-purple-600 );
+				box-shadow: 0 0 0 2px #674399; // $studio-woocommerce-purple-60
 				border-color: transparent;
 			}
 		}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -229,14 +229,14 @@ $image-height: 47px;
 	.wp-login__links a {
 		border-bottom: none;
 		line-height: 3.4em;
-		color: var( --color-gray-600 );
+		color: #50575e; // $studio-gray-60;
 		font-size: 14px;
 		text-decoration: underline;
 		font-weight: normal;
 	}
 
 	.login__form-header {
-		color: var( --color-gray-800 );
+		color: #2c3338; // $studio-gray-80;
 	}
 
 	.wp-login__main.main {
@@ -256,14 +256,14 @@ $image-height: 47px;
 	}
 
 	.login__form-change-username {
-		color: var( --color-gray-600 );
+		color: #50575e; // $studio-gray-60;
 	}
 
 	.login__form-terms,
 	.login__form-terms a,
 	.login__form-terms a:hover {
 		text-align: left;
-		color: var( --color-gray-600 );
+		color: #50575e; // $studio-gray-60;
 		font-size: 12px;
 	}
 
@@ -286,25 +286,25 @@ $image-height: 47px;
 
 	.login__social-buttons {
 		.social-buttons__button {
-			border: 1px solid $muriel-woo-purple-500;
-			color: $muriel-woo-purple-500;
+			border: 1px solid #c9356e; // $studio-pink;
+			color: #c9356e; // $studio-pink
 			box-shadow: none;
 		}
 	}
 
 	.woocommerce-muriel-text-control,
 	.muriel-input-text {
-		border-color: var( --color-gray-200 );
+		border-color:  #a7aaad; // $studio-gray-20;
 
 		.text-control__label,
 		.components-base-control__label {
-			color: var( --color-gray-500 );
+			color: #646970; // $studio-gray-50;
 			font-size: 12px;
 			font-weight: normal;
 		}
 
 		&.active {
-			box-shadow: 0 0 0 2px var( --color-hot-purple-600 );
+			box-shadow: 0 0 0 2px #674399; // $studio-woocommerce-purple-60
 			border-color: transparent;
 		}
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -172,17 +172,17 @@ body.is-section-signup .layout.gravatar .formatted-header {
 
 	.woocommerce-muriel-text-control,
 	.muriel-input-text {
-		border-color: var( --color-gray-200 );
+		border-color: #a7aaad; // $studio-gray-20;
 
 		.text-control__label,
 		.components-base-control__label {
-			color: var( --color-gray-500 );
+			color: #646970; // $studio-gray-50;
 			font-size: 12px;
 			font-weight: normal;
 		}
 
 		&.active {
-			box-shadow: 0 0 0 2px var( --color-hot-purple-600 );
+			box-shadow: 0 0 0 2px #674399; // $studio-woocommerce-purple-60
 			border-color: transparent;
 		}
 	}
@@ -213,7 +213,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 
 	.login__woocommerce-logo {
 		text-align: center;
-		border-bottom: 1px solid var( --color-gray-50 );
+		border-bottom: 1px solid #646970; // $studio-gray-50;
 		position: absolute;
 		left: 0;
 		top: 0;
@@ -285,8 +285,8 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		}
 
 		.social-buttons__button {
-			border: 1px solid $muriel-woo-purple-500;
-			color: $muriel-woo-purple-500;
+			border: 1px solid #c9356e; // $studio-pink;
+			color: #c9356e; // $studio-pink
 			box-shadow: none;
 			max-width: 250px;
 			height: 48px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/woocommerce/woocommerce-admin/issues/2574.

This PR updates the colors used in the new WooCommerce Onboarding connection flows (unreleased and behind a feature flag) to match our latest designs, and the colors used in the WooCommerce Admin part of the project. These changes do not affect any other flows.

Note that these colors are colors from v2.1 of the color-studio pallet. Calypso currently uses 1.0.5. There are breaking changes between the versions as variables have been renamed. Via p97Xot-14w-p2, Calypso will update soon. For now, I'm hard coding the colors we want, but added comments for what variables we can use once the version update happens.

<img width="1115" alt="Screen Shot 2019-08-26 at 3 59 57 PM" src="https://user-images.githubusercontent.com/689165/63720853-0893f880-c81e-11e9-9ee4-3407d03d088e.png">

#### Testing instructions

You can either test the WooCommerce + Jetpack Connection flow or the WooCommerce Helper flow (or both).

### Testing the WooCommerce + Jetpack Connection flow:

If you have WooCommerce / WooCommerce Admin Installed via `master`:

* Enable the onboarding flow in `WooCommerce Admin` and to tell it to point at local Calypso. 
    * Start WooCommerce in development mode
    * Define the following constant in your `wp-config.php` or a plugin file: `define( 'WOOCOMMERCE_CALYPSO_LOCAL', true );`.
    * Make a `POST` request to `/wp-json/wc-admin/v1/onboarding/profile` on your local site, setting `skipped` and `completed` to false.
* Visit `/wp-admin/admin.php?page=wc-admin` on your local site, and the onboarding wizard should be displayed.
* Click `Get Started`, and then `Activate & Continue`.
* You should end up on the onboarding themed login page. Verify things look correct. Click sign-up and verify colors look good there too.

If you don't want to install WooCommerce Admin:

* Disconnect Jetpack from your site
* Click “Setup Jetpack”.
* On the connection/authorization screen ( https://wordpress.com/jetpack/connect/authorize?client_id= ….. ) copy and paste the whole URL.
* Replace `https://wordpress.com` with ` http://calypso.localhost:3000` and replace the `from` parameter in the URL (it may be something like `connection-banner` or `landing-page-bottom`) with  `from=woocommerce-setup-wizard` . See Pastebin `213d5`  or ping me if you have issues.
* You should end up on the onboarding themed login page. Verify things look correct. Click sign-up and verify colors look good there too.

### Testing the WooCommerce Helper Connection Flow

* Run `master` of https://github.com/woocommerce/wc-admin.
* In your local WordPress install, add `define( 'WOOCOMMERCE_CALYPSO_LOCAL', true );` to your `wp-config.php`.
* Logout of WooCommerce.com and WordPress.com (otherwise you may immediately end up on the authorization screen).
* Go to WooCommerce > Extensions > WooCommerce.com Subscriptions and disconnect from WooCommerce.com.
* Go to the dashboard and click the connection task.
	* If you don’t see the connection task:
		* Make sure you have skipped the profiler and have `items_purchased` set to true: https://gist.github.com/justinshreve/da09cc57ec8e0d07ac8e919cef7a926c. 
		* In WooCommerce Admin, edit `client/dashboard/index.js` and set `requiredTasksComplete` to false.
* You should end up on the onboarding themed login page. Verify things look correct. Click sign-up and verify colors look good there too.