### PR TITLE
Home: link to home page editing

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -75,7 +75,8 @@ class Home extends Component {
 		},
 		isSiteEligible: PropTypes.bool.isRequired,
 		trackAction: PropTypes.func.isRequired,
-		staticHomePageId: PropTypes.number.isRequired,
+		isStaticHomePage: PropTypes.bool.isRequired,
+		staticHomePageId: PropTypes.number, // this is unused if isStaticHomePage is false. In such case, it's null.
 	};
 
 	state = {
@@ -361,7 +362,6 @@ const connectHome = connect(
 		const siteChecklist = getSiteChecklist( state, siteId );
 		const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
-		const isStaticHomePage = 'page' === getSiteOption( state, siteId, 'show_on_front' );
 
 		return {
 			site: getSelectedSite( state ),
@@ -373,8 +373,8 @@ const connectHome = connect(
 			hasChecklistData,
 			isChecklistComplete,
 			isSiteEligible: isSiteEligibleForCustomerHome( state, siteId ),
-			isStaticHomePage,
-			staticHomePageId: isStaticHomePage ? getSiteFrontPage( state, siteId ) : -Infinity,
+			isStaticHomePage: 'page' === getSiteOption( state, siteId, 'show_on_front' ),
+			staticHomePageId: getSiteFrontPage( state, siteId ),
 		};
 	},
 	dispatch => ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* when site has a front page assigned, the Edit Homepage button now goes to its editing screen


#### Testing instructions

* set a front page on WP Admin > Settings > Reading
* Go to Customer Home and ensure the button Edit Homepage loads the home page in the block editor 

Fixes #35773 
