### PR TITLE
Checklist: updating the checklist component display behaviour so that the inline help component d…

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
@@ -31,11 +31,25 @@ import './style.scss';
 export class ChecklistBanner extends Component {
 	static propTypes = {
 		isEligibleForDotcomChecklist: PropTypes.bool,
+		isLoading: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
 
-	state = { closed: false };
+	static defaultProps = {
+		taskList: [],
+		isLoading: true,
+	};
+
+	state = { closed: false, hasLoaded: false };
+
+	componentDidUpdate() {
+		if ( ! this.state.hasLoaded && ! this.props.isLoading ) {
+			this.setLoaded( true );
+		}
+	}
+
+	setLoaded = hasLoaded => this.setState( { hasLoaded } );
 
 	handleClose = () => {
 		const { siteId } = this.props;
@@ -49,15 +63,16 @@ export class ChecklistBanner extends Component {
 	};
 
 	render() {
-		if ( this.state.closed || this.props.isLoading ) {
+		const { translate, taskList } = this.props;
+
+		if ( this.state.closed || ! this.state.hasLoaded ) {
 			return null;
 		}
 
-		const { translate, taskList } = this.props;
-		const childrenArray = Children.toArray( this.props.children );
-		const { total, completed, percentage } = taskList.getCompletionStatus();
 		const firstIncomplete = taskList.getFirstIncompleteTask();
 		const isFinished = ! firstIncomplete;
+		const { total, completed, percentage } = taskList.getCompletionStatus();
+		const childrenArray = Children.toArray( this.props.children );
 
 		return (
 			<Card className="checklist-banner">

--- a/client/my-sites/checklist/wpcom-checklist/checklist-navigation/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-navigation/index.jsx
@@ -16,6 +16,7 @@ import ProgressBar from 'components/progress-bar';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 
 /**
  * Style dependencies
@@ -45,13 +46,17 @@ export class ChecklistNavigation extends Component {
 	};
 
 	render() {
-		const { siteSlug, translate, showNotification, taskList } = this.props;
+		const { isLoading, siteSlug, translate, showNotification, taskList } = this.props;
+		const { total, completed } = taskList.getCompletionStatus();
+
+		if ( total === completed || isLoading ) {
+			return null;
+		}
 
 		const buttonClasses = classNames( 'checklist-navigation__count', {
 			'has-notification': showNotification,
 		} );
 
-		const { total, completed } = taskList.getCompletionStatus();
 		const checklistLink = '/checklist/' + siteSlug;
 
 		return (
@@ -90,6 +95,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		return {
 			siteSlug: getSiteSlug( state, siteId ),
+			isLoading: isSiteChecklistLoading( state, siteId ),
 		};
 	},
 	{ recordTracksEvent }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Today, we're updating the checklist component display behaviour so that the inline help doesn't display when the tasks are complete^, and the banner does not refresh after the tasks have already loaded.

![Aug-27-2019 10-49-18](https://user-images.githubusercontent.com/6458278/63737785-e4422580-c8ca-11e9-99cc-c36a849cf96d.gif)

^ raised in: p58i-80Q-p2#comment-42876

## Testing instructions

1. Create a new site
2. Go to `stats/day/{yoursite.wordpress.com}`
3. Open and close the inline help modal
    * The checklist banner should display the correct progress percentage and should not re-render
4. Go to `/checklist/{yoursite.wordpress.com}`
5. Complete all the tasks
6. Return to `stats/day/{yoursite.wordpress.com}`
7. Open  the inline help modal
    * The checklist banner should display the correct progress percentage (100%)
    * The inline help checklist prompt should not appear


Fixes #35776