### PR TITLE
Remove /start/website flow

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -152,15 +152,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	removeWebsiteFlow: {
-		datestamp: '20190813',
-		variations: {
-			remove: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	customerHomePage: {
 		datestamp: '20190820',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -93,13 +93,6 @@ export function generateFlows( {
 			lastModified: '2017-09-01',
 		},
 
-		website: {
-			steps: [ 'user', 'website-themes', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'Signup flow starting with website themes',
-			lastModified: '2017-09-01',
-		},
-
 		'rebrand-cities': {
 			steps: [ 'rebrand-cities-welcome', 'user' ],
 			destination: function( dependencies ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -169,12 +169,6 @@ class Signup extends React.Component {
 			return page.redirect( getStepUrl( 'onboarding', destinationStep, this.props.locale ) );
 		}
 
-		if ( 'remove' === abtest( 'removeWebsiteFlow' ) && 'website' === this.props.flowName ) {
-			const destinationStep = flows.getFlow( 'onboarding' ).steps[ 0 ];
-			this.setState( { resumingStep: destinationStep } );
-			return page.redirect( getStepUrl( 'onboarding', destinationStep, this.props.locale ) );
-		}
-
 		this.recordStep();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap up the `removeWebsiteFlow` A/B test (more context for this flow in p8Eqe3-Lk-p2#comment-2109 )
* Remove the `/start/website` flow — requests will automatically be redirected to the main onboarding flow 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/start/website
* This should redirect you to the first step in the onboarding flow, e.g. http://calypso.localhost:3000/start/user, or if you are already logged in it will take you to http://calypso.localhost:3000/start/site-type
* Complete creating a site, just to be sure that the onboarding flow is unaffected.

