### PR TITLE
Imports: Improve import progress text to be more informative

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -179,8 +179,8 @@ class ImportingPane extends React.PureComponent {
 		}
 
 		return this.props.translate(
-			'Waiting on %(numResources)s resource to import',
-			'Waiting on %(numResources)s resources to import',
+			'%(numResources)s post, page, or media file left to import',
+			'%(numResources)s posts, pages, and media files left to import',
 			{
 				count: numResources,
 				args: { numResources: numberFormat( numResources ) },


### PR DESCRIPTION
The text `Waiting on xxx resources to import` beneath the import progress bar is currently not very helpful to ordinary folks: it won't be clear to them what "resources" means.

I'm proposing this change as an interim measure which may be replaced if we implement better progress reporting for imports. Personally I'm not sure about the wordiness this adds to the UI. I'd say there's even a case for making it simpler with `xxx things left to import`.

#### Changes proposed in this Pull Request

* Change the wording in the progress message.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR and run Calypso locally, or use `calypso.live`.
* Go to the import page `/import/[ site ]`, choose the WordPress importer and upload a test import file. Go past the author mapping stage and wait for the progress bar to appear.
* The progress wording should be `xxx posts, pages and media files left to import`.

<img width="792" alt="image" src="https://user-images.githubusercontent.com/1647564/63759333-3710e280-c8b5-11e9-8259-654eaa287d4c.png">

