### PR TITLE
Devdocs: Remove obsolete endpoints

### DIFF
--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -30,10 +30,6 @@ export default {
 		fetchDocsEndpoint( 'search', { q: term }, callback );
 	},
 
-	list: function( filenames, callback ) {
-		fetchDocsEndpoint( 'list', { files: filenames.join( ',' ) }, callback );
-	},
-
 	fetch: function( path, callback ) {
 		fetchDocsEndpoint( 'content', { path: path }, callback );
 	},

--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -26,10 +26,6 @@ async function fetchDocsEndpoint( endpoint, params, callback ) {
  * query term or filename(s), and also to separately retrieve the document body by path.
  */
 export default {
-	search: function( term, callback ) {
-		fetchDocsEndpoint( 'search', { q: term }, callback );
-	},
-
 	fetch: function( path, callback ) {
 		fetchDocsEndpoint( 'content', { path: path }, callback );
 	},

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -8,7 +8,7 @@ import fs from 'fs';
 import fspath from 'path';
 import marked from 'marked';
 import lunr from 'lunr';
-import { find, escape as escapeHTML } from 'lodash';
+import { escape as escapeHTML } from 'lodash';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-json';
@@ -59,31 +59,6 @@ function queryDocs( query ) {
 			path: doc.path,
 			title: doc.title,
 			snippet: snippet,
-		};
-	} );
-}
-
-/**
- * Return an array of results based on the provided filenames
- * @param {array} filePaths An array of file paths
- * @returns {array} The results from the docs
- */
-function listDocs( filePaths ) {
-	return filePaths.map( path => {
-		const doc = find( documents, entry => entry.path === path );
-
-		if ( doc ) {
-			return {
-				path: path,
-				title: doc.title,
-				snippet: defaultSnippet( doc ),
-			};
-		}
-
-		return {
-			path: path,
-			title: 'Not found: ' + path,
-			snippet: '',
 		};
 	} );
 }
@@ -193,20 +168,6 @@ module.exports = function() {
 		}
 
 		response.json( queryDocs( query ) );
-	} );
-
-	// return a listing of documents from filenames supplied in the "files" parameter
-	app.get( '/devdocs/service/list', ( request, response ) => {
-		const files = request.query.files;
-
-		if ( ! files ) {
-			response.status( 400 ).json( {
-				message: 'Missing required "files" parameter',
-			} );
-			return;
-		}
-
-		response.json( listDocs( files.split( ',' ) ) );
 	} );
 
 	// return the content of a document in the given format (assumes that the document is in

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -1,8 +1,6 @@
-/** @format */
 /**
  * External dependencies
  */
-
 import express from 'express';
 import fs from 'fs';
 import fspath from 'path';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove server-side routes (endpoints) `/devdocs/service/list` and `/devdocs/service/search`, which AFAICS aren't used anywhere.

Somewhat related to #35809, where I hope to replace the `/devdocs/service/content` endpoint with a Webpack loader.

#### Testing instructions

* Go to Devdocs (http://calypso.localhost:3000/devdocs/design/) and give it some thorough testing (try searching for components and selectors to verify that search functionality isn't touched by this).
* Verify that the `/devdocs/service/list` and `/devdocs/service/search` routes aren't used anywhere in the code.
