### PR TITLE
Update the link to Support Articles for consistency

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -310,7 +310,7 @@ class Home extends Component {
 									external
 									onClick={ () => trackAction( 'support', 'docs' ) }
 								>
-									{ translate( 'Support docs' ) }
+									{ translate( 'Support articles' ) }
 								</VerticalNavItem>
 								<VerticalNavItem
 									path="/help/contact"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the wording on the Customer Home page to be Support Articles rather than Support Docs, for consistency with other parts of the application.

#### Testing instructions

Check the wording on the Customer Home page!

Fixes #35781
