### PR TITLE
Checkout: Show Stripe initialization error and prevent submission

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -60,6 +60,7 @@ export function CreditCardForm( {
 	stripe,
 	stripeConfiguration,
 	isStripeLoading,
+	stripeLoadingError,
 	setStripeError,
 } ) {
 	const [ formSubmitting, setFormSubmitting ] = useState( false );
@@ -159,6 +160,7 @@ export function CreditCardForm( {
 					countriesList={ countriesList }
 					stripe={ stripe }
 					isStripeLoading={ isStripeLoading }
+					stripeLoadingError={ stripeLoadingError }
 					eventFormName="Edit Card Details Form"
 					onFieldChange={ onFieldChange }
 					getErrorMessage={ getErrorMessage }
@@ -204,6 +206,7 @@ CreditCardForm.propTypes = {
 	onCancel: PropTypes.func,
 	stripe: PropTypes.object,
 	isStripeLoading: PropTypes.bool,
+	stripeLoadingError: PropTypes.object,
 	setStripeError: PropTypes.func,
 	translate: PropTypes.func.isRequired,
 };

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -106,6 +106,7 @@ function CreditCardNumberField( {
 	translate,
 	stripe,
 	isStripeLoading,
+	stripeLoadingError,
 	createField,
 	getErrorMessage,
 	card,
@@ -134,11 +135,16 @@ function CreditCardNumberField( {
 		);
 	}
 
+	const disabled =
+		isStripeLoading || stripeLoadingError
+			? ! shouldRenderAdditionalCountryFields( card.country )
+			: false;
+
 	return createField( 'number', CreditCardNumberInput, {
 		inputMode: 'numeric',
 		label: cardNumberLabel,
 		placeholder: '•••• •••• •••• ••••',
-		disabled: !! isStripeLoading, // isStripeLoading might be undefined
+		disabled,
 	} );
 }
 
@@ -149,12 +155,14 @@ CreditCardNumberField.propTypes = {
 	stripe: PropTypes.object,
 	card: PropTypes.object.isRequired,
 	isStripeLoading: PropTypes.bool,
+	stripeLoadingError: PropTypes.object,
 };
 
 function CreditCardExpiryAndCvvFields( {
 	translate,
 	stripe,
 	isStripeLoading,
+	stripeLoadingError,
 	createField,
 	getErrorMessage,
 	card,
@@ -202,12 +210,17 @@ function CreditCardExpiryAndCvvFields( {
 		);
 	}
 
+	const disabled =
+		isStripeLoading || stripeLoadingError
+			? ! shouldRenderAdditionalCountryFields( card.country )
+			: false;
+
 	return (
 		<React.Fragment>
 			{ createField( 'expiration-date', Input, {
 				inputMode: 'numeric',
 				label: expiryLabel,
-				disabled: !! isStripeLoading, // isStripeLoading might be undefined
+				disabled,
 				placeholder: translate( 'MM/YY', {
 					comment: 'Expiry placeholder for Expiry date on credit card form',
 				} ),
@@ -215,7 +228,7 @@ function CreditCardExpiryAndCvvFields( {
 
 			{ createField( 'cvv', Input, {
 				inputMode: 'numeric',
-				disabled: !! isStripeLoading, // isStripeLoading might be undefined
+				disabled,
 				placeholder: ' ',
 				label: translate( 'Security Code {{span}}("CVC" or "CVV"){{/span}} {{infoPopover/}}', {
 					components: {
@@ -235,6 +248,7 @@ CreditCardExpiryAndCvvFields.propTypes = {
 	card: PropTypes.object.isRequired,
 	stripe: PropTypes.object,
 	isStripeLoading: PropTypes.bool,
+	stripeLoadingError: PropTypes.object,
 };
 
 export class CreditCardFormFields extends React.Component {
@@ -248,6 +262,7 @@ export class CreditCardFormFields extends React.Component {
 		isNewTransaction: PropTypes.bool,
 		stripe: PropTypes.object,
 		isStripeLoading: PropTypes.bool,
+		stripeLoadingError: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -345,6 +360,7 @@ export class CreditCardFormFields extends React.Component {
 						translate={ this.props.translate }
 						stripe={ this.props.stripe }
 						isStripeLoading={ this.props.isStripeLoading }
+						stripeLoadingError={ this.props.stripeLoadingError }
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }
@@ -356,6 +372,7 @@ export class CreditCardFormFields extends React.Component {
 						translate={ this.props.translate }
 						stripe={ this.props.stripe }
 						isStripeLoading={ this.props.isStripeLoading }
+						stripeLoadingError={ this.props.stripeLoadingError }
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isEmpty, noop } from 'lodash';
+import notices from 'notices';
 import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
 
 /**
@@ -167,6 +168,10 @@ function CreditCardExpiryAndCvvFields( {
 	getErrorMessage,
 	card,
 } ) {
+	if ( stripeLoadingError && ! shouldRenderAdditionalCountryFields( card.country ) ) {
+		notices.error( stripeLoadingError.message || 'Error loading Stripe' );
+	}
+
 	const cvcLabel = translate( 'Security Code {{span}}("CVC" or "CVV"){{/span}}', {
 		components: {
 			span: <span className="credit-card-form-fields__explainer" />,

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -207,6 +207,7 @@ export function useStripeJs( stripeConfiguration ) {
 	const [ stripeJs, setStripeJs ] = useState( null );
 	const [ isStripeLoading, setStripeLoading ] = useState( true );
 	useEffect( () => {
+		let isSubscribed = true;
 		if ( ! stripeConfiguration ) {
 			return;
 		}
@@ -226,16 +227,20 @@ export function useStripeJs( stripeConfiguration ) {
 					return;
 				}
 				debug( 'stripe.js loaded!' );
+				if ( ! isSubscribed ) {
+					return;
+				}
 				setStripeLoading( false );
 				setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
 			} );
 		} catch ( error ) {
 			if ( error ) {
 				debug( 'error while loading stripeJs', error );
-				setStripeLoading( false );
+				isSubscribed && setStripeLoading( false );
 				return;
 			}
 		}
+		return () => ( isSubscribed = false );
 	}, [ stripeConfiguration, stripeJs ] );
 	return { stripeJs, isStripeLoading };
 }
@@ -250,9 +255,11 @@ export function useStripeConfiguration( requestArgs = {} ) {
 	const [ stripeError, setStripeError ] = useState();
 	const [ stripeConfiguration, setStripeConfiguration ] = useState();
 	useEffect( () => {
-		getStripeConfiguration( requestArgs ).then( configuration =>
-			setStripeConfiguration( configuration )
+		let isSubscribed = true;
+		getStripeConfiguration( requestArgs ).then(
+			configuration => isSubscribed && setStripeConfiguration( configuration )
 		);
+		return () => ( isSubscribed = false );
 	}, [ requestArgs, stripeError ] );
 	return { stripeConfiguration, setStripeError };
 }

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -250,12 +250,20 @@ function loadScriptAsync( url ) {
 /**
  * React custom Hook for loading the Stripe Configuration
  *
+ * Returns an object with two properties: `stripeConfiguration`, and
+ * `setStripeError`.
+ *
+ * `stripeConfiguration` is an object as returned by the stripe configuration
+ * endpoint, possibly including a Setup Intent if one was requested (via
+ * `needs_intent`).
+ *
  * If there is a stripe error, it may be necessary to reload the configuration
  * since (for example) a Setup Intent may need to be recreated. You can force
- * the configuration to reload by setting a value with `setStripeError()`.
+ * the configuration to reload by setting a value by calling `setStripeError()`
+ * with a value for that error.
  *
  * @param {object} requestArgs (optional) Can include `country` or `needs_intent`
- * @return {object} Stripe Configuration as returned by the stripe configuration endpoint
+ * @return {object} See above
  */
 export function useStripeConfiguration( requestArgs = {} ) {
 	const [ stripeError, setStripeError ] = useState();

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -84,6 +84,7 @@ class CreditCardPaymentBox extends React.Component {
 		translate: PropTypes.func.isRequired,
 		stripe: PropTypes.object,
 		isStripeLoading: PropTypes.bool,
+		stripeLoadingError: PropTypes.object,
 		stripeConfiguration: PropTypes.object,
 	};
 
@@ -195,6 +196,7 @@ class CreditCardPaymentBox extends React.Component {
 			transaction,
 			stripe,
 			isStripeLoading,
+			stripeLoadingError,
 			translate,
 		} = this.props;
 
@@ -208,6 +210,7 @@ class CreditCardPaymentBox extends React.Component {
 						transaction={ transaction }
 						stripe={ stripe }
 						isStripeLoading={ isStripeLoading }
+						stripeLoadingError={ stripeLoadingError }
 						translate={ translate }
 					/>
 

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -83,6 +83,7 @@ class CreditCardSelector extends React.Component {
 					selected={ selected }
 					stripe={ this.props.stripe }
 					isStripeLoading={ this.props.isStripeLoading }
+					stripeLoadingError={ this.props.stripeLoadingError }
 				/>
 			</CreditCard>
 		);

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -25,6 +25,7 @@ class NewCardForm extends Component {
 		selected: PropTypes.bool,
 		stripe: PropTypes.object,
 		isStripeLoading: PropTypes.bool,
+		stripeLoadingError: PropTypes.object,
 	};
 
 	getErrorMessage = fieldName => {
@@ -43,6 +44,7 @@ class NewCardForm extends Component {
 				getErrorMessage={ this.getErrorMessage }
 				stripe={ this.props.stripe }
 				isStripeLoading={ this.props.isStripeLoading }
+				stripeLoadingError={ this.props.stripeLoadingError }
 			/>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Once stripe.js has been loaded, we call `window.Stripe()` to initialize the library and create the object we need for other Stripe operations. If that throws an error (for example if the current url is not https), this diff does the following things:

- Announces the error in the global notices area.
- Keeps the Stripe fields (card number, expiry, cvc) disabled, which will prevent the form from being submitted.

One reason for this is that it will also prevent submitting the checkout form without Stripe.js (or EBANX) being loaded.

<img width="837" alt="Screen Shot 2019-08-27 at 3 47 49 PM" src="https://user-images.githubusercontent.com/2036909/63803074-0b582180-c8e2-11e9-922e-94836fd1984e.png">


#### Testing instructions

- Make sure the store is not sandboxed.
- Add a plan to your cart and visit the checkout page.
- Verify that you see a Stripe error in the global notices (when using calypso on localhost. If using . calypo.live, everything should work as usual).
- Sandbox the store.
- Add a plan to your cart and visit the checkout page.
- Verify that there is no trouble filling out the form.