### PR TITLE
Full Site Editing: Get it ready for the Varia themes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -1,6 +1,11 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
 import { PlainText } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -48,7 +53,7 @@ function SiteDescriptionEdit( {
 	return (
 		<Fragment>
 			<PlainText
-				className={ className }
+				className={ classNames( 'site-description', className ) }
 				value={ option }
 				onChange={ value => handleChange( value ) }
 				onKeyDown={ onKeyDown }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -40,15 +40,6 @@
 	}
 }
 
-// Adjust the block content positioning without borders
-@media only screen and ( min-width: 768px ) {
-	.editor-styles-wrapper .wp-block.template__block-container[data-align='full'] {
-		left: calc( -12.5% - 13px );
-		max-width: calc( 125% + 116px );
-		width: calc( 125% + 116px );
-	}
-}
-
 .template-block__overlay {
 	background: rgba( #ffffff, 0.8 );
 	border: 0 solid rgba( #7b86a2, 0.3 ); // Gutenberg $dark-opacity-light-600

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -18,10 +18,6 @@
 	.editor-post-switch-to-draft {
 		display: none;
 	}
-
-	.editor-block-list__layout {
-		padding-top: 28px;
-	}
 }
 
 .post-type-page, .post-type-wp_template {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -35,8 +35,13 @@
 		box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 
 		@media ( max-width: 768px ) {
-  			margin: 0;
+			margin: 0;
 		}
+	}
+
+	// Remove the 50vh bottom padding that looks off with the FSE frame.
+	.editor-writing-flow__click-redirect {
+		display: none;
 	}
 }
 
@@ -49,7 +54,7 @@
 
 .post-type-page {
 	.edit-post-visual-editor {
-		padding: 0 0 4px;
+		padding-top: 0;
 	}
 
 	.block-editor-writing-flow {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -36,7 +36,6 @@ const EditorTemplateClasses = withSelect( select => {
 		clearInterval( blockListInception );
 
 		blockList.className = classNames( 'a8c-template-editor', ...templateClasses );
-		blockList.style.padding = 0;
 	} );
 
 	return null;


### PR DESCRIPTION
Requires https://github.com/Automattic/themes/pull/1332

#### Changes proposed in this Pull Request

In order to drop support to Modern Business and add support to Varia and children themes, this PR removes some of the overrides required by Modern Business that aren't needed anymore.

* Remove the frame paddings. In particular, hide the "editor writing flow", a 50vh long whitespace under the content, that looks awkward with the FSE framed page.
* Stop repositioning the Template block overlay! 🎉 
* Add the `.site-description` class to the Site Description block for easier CSS targeting.
* Stop overriding the editor paddings.

| Varia Demo | FSE Page | FSE Page Editor | FSE Header Editor |
| - | - | - | - |
| ![Screenshot 2019-08-28 at 12 01 19](https://user-images.githubusercontent.com/2070010/63850807-d9e86000-c98c-11e9-886f-d7ece9fd6065.png) | ![Screenshot 2019-08-28 at 12 01 35](https://user-images.githubusercontent.com/2070010/63850814-dfde4100-c98c-11e9-96a4-3aec298744f3.png) | ![Screenshot 2019-08-28 at 12 02 13](https://user-images.githubusercontent.com/2070010/63850878-000e0000-c98d-11e9-8d51-c8315fdcd8a0.png) | ![Screenshot 2019-08-28 at 12 01 47](https://user-images.githubusercontent.com/2070010/63850824-e4a2f500-c98c-11e9-9535-4380894d692c.png) |
| ![Screenshot 2019-08-28 at 12 07 32](https://user-images.githubusercontent.com/2070010/63850903-0b612b80-c98d-11e9-8e7b-f975f0c444cd.png) | ![Screenshot 2019-08-28 at 12 07 42](https://user-images.githubusercontent.com/2070010/63850911-0e5c1c00-c98d-11e9-8645-b6d2b1215fae.png) | ![Screenshot 2019-08-28 at 12 08 18](https://user-images.githubusercontent.com/2070010/63850924-1451fd00-c98d-11e9-8fd4-e2a30e0f51ea.png) | ![Screenshot 2019-08-28 at 12 07 51](https://user-images.githubusercontent.com/2070010/63850927-1916b100-c98d-11e9-8420-3884447f0553.png) |

#### Notes

- While I took care of the basic stylings, I've intentionally avoided some more complicated tasks (such as the vertical spacing of the various header elements) because this is Varia, which as far as I know, it should only be used as parent theme (but to be fair, it's available on our [themes library](https://wordpress.com/theme/varia)), and so we should do that kind of things in the children themes instead.
- At the same time, I've styled the navigation button on small screen. This is because in my audit I've noticed that it has that same behaviour on most themes.
  - ⚠️ I've added the "Menu" text straight in CSS, so it's not localized. We can leave it as is during the 10% rollout, but we should eventually replace it with a localized string. I'm not sure how to do that in CSS, so I guess we'll be forced to use some JS trickery in Varia. I wouldn't suggest to do that in the FSE plugin, as then we would too tightly couple the navigation menu to the Varia themes (not even all of them).

#### Testing instructions

* Apply this PR on an FSE site.
* Apply https://github.com/Automattic/themes/pull/1332 to the Varia theme on the FSE site.
* Change the theme to Varia. (If this is the first time, it will create new header and footer template parts, fetching them from the Modern Business demo site, so don't expect them to look like the Varia demo site.)
* Smoke test:
  - Page Editor
  - Template Editor
  - Front End
* Compare with how the [Varia Demo](https://variademo.wordpress.com/) looks like.

Fixes #35442