### PR TITLE
Gutenberg: Wait for preview URL before sending data to Calypso

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -471,8 +471,8 @@ function handlePreview( calypsoPort ) {
 			dispatch( 'core/editor' ).autosave( { isPreview: true } );
 		}
 		const unsubscribe = subscribe( () => {
-			const isSavingPost = select( 'core/editor' ).isSavingPost();
-			if ( ! isSavingPost ) {
+			const previewUrl = select( 'core/editor' ).getEditedPostPreviewLink();
+			if ( ! previewUrl ) {
 				unsubscribe();
 				sendPreviewData();
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to preview a Gutenberg post in Calypso, we were using the `isSavingPost` selector to know when it was safe to send a message to the parent frame that will render the previewed content.

Seems we cannot rely in that selector as of Gutenberg 6.4.0 when used in combination with the `autosave` action, since there is race condition issue that makes the action to not trigger a `isSavingPost` change before our `isSavingPost` check.

Given that the goal of the `isSavingPost` check was to ensure that the post contains a preview URL, this PR replaces that check with a preview URL check.

#### Testing instructions

* Upload a new build of the `wpcom-block-editor` app to your sandbox (PCYsg-l4k-p2#building).
* Sandbox `widgets.wp.com`.
* Go to https://horizon.wordpress.com/block-editor (Gutenberg 6.4.0).
* Select your sandbox site.
* Enter a title and some content.
* Preview the post.
* Make sure the preview appears correctly.
* Make sure the previews still work as expected on https://wordpress.com/block-editor (Gutenberg 6.2.0).

Fixes #35818
