### PR TITLE
Billing: fix cancellation date

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -113,7 +113,7 @@ class CancelPurchase extends React.Component {
 
 	renderFooterText = () => {
 		const { purchase } = this.props;
-		const { refundText, renewDate, refundAmount, currencySymbol, currency } = purchase;
+		const { refundText, expiryDate, refundAmount, currencySymbol, currency } = purchase;
 
 		if ( isRefundable( purchase ) ) {
 			if ( this.state.cancelBundledDomain && this.props.includedDomainPurchase ) {
@@ -134,21 +134,21 @@ class CancelPurchase extends React.Component {
 			} );
 		}
 
-		const renewalDate = this.props.moment( renewDate ).format( 'LL' );
+		const expirationDate = this.props.moment( expiryDate ).format( 'LL' );
 
 		if ( isDomainRegistration( purchase ) ) {
 			return this.props.translate(
-				'After you confirm this change, the domain will be removed on %(renewalDate)s',
+				'After you confirm this change, the domain will be removed on %(expirationDate)s',
 				{
-					args: { renewalDate },
+					args: { expirationDate },
 				}
 			);
 		}
 
 		return this.props.translate(
-			'After you confirm this change, the subscription will be removed on %(renewalDate)s',
+			'After you confirm this change, the subscription will be removed on %(expirationDate)s',
 			{
-				args: { renewalDate },
+				args: { expirationDate },
 			}
 		);
 	};


### PR DESCRIPTION
There's a bug in the date displayed when you go to cancel a subscription outside the refund window.  A detailed write up of the bug can be found here: pNPgK-4Eu-p2
The fix is pretty simple, change the cancellation date from the renewal date (30 days before expiration) to the actual expiration date.

#### Changes proposed in this Pull Request

* Change `renewDate` to `expiryDate`

#### Testing instructions

1. Start with a subscription with auto-renew on that is outside the refund window (or otherwise not refundable) and view it on Manage Purchases.
1. Click “Cancel Subscription”.
1. Notice that the date shown for when the subscription will stop is the auto-renewal date (i.e. 30 days before the expiration date). It should show the expiration date instead.

cc @Automattic/payments 