### PR TITLE
Show video plays module on stats section for Jetpack sites as well

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -125,24 +125,12 @@ class StatsSite extends Component {
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
-		let videoList;
 		let fileDownloadList;
 
 		const query = memoizedQuery( period, endOf );
 
 		// Video plays and file downloads are not yet supported in Jetpack Stats
 		if ( ! isJetpack ) {
-			videoList = (
-				<StatsModule
-					path="videoplays"
-					moduleStrings={ moduleStrings.videoplays }
-					period={ this.props.period }
-					query={ query }
-					statType="statsVideoPlays"
-					showSummaryLink
-				/>
-			);
-
 			fileDownloadList = (
 				<StatsModule
 					path="filedownloads"
@@ -256,7 +244,14 @@ class StatsSite extends Component {
 								className="stats__author-views"
 								showSummaryLink
 							/>
-							{ videoList }
+							<StatsModule
+								path="videoplays"
+								moduleStrings={ moduleStrings.videoplays }
+								period={ this.props.period }
+								query={ query }
+								statType="statsVideoPlays"
+								showSummaryLink
+							/>
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -129,7 +129,7 @@ class StatsSite extends Component {
 
 		const query = memoizedQuery( period, endOf );
 
-		// Video plays and file downloads are not yet supported in Jetpack Stats
+		// File downloads are not yet supported in Jetpack Stats
 		if ( ! isJetpack ) {
 			fileDownloadList = (
 				<StatsModule


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show video plays module on the Stats section for Jetpack sites as well

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start with a Jetpack site on the live branch available below
- Ensure that video hosting is enabled on https://wordpress.com/settings/performance
- Upload a video to the site at https://wordpress.com/media
- Add that video to a post/page
- Visit the page on an incognito tab.
- Play the video.
- After 30 minutes or so, visit the `/stats/day/site.com` path on this branch
- Ensure that you see a video plays module as shown below

<img width="1103" alt="Screenshot 2019-08-28 at 07 19 40" src="https://user-images.githubusercontent.com/18581859/63819922-d8a33d00-c964-11e9-87bf-7dffe5433a10.png">

Fixes #35703