### PR TITLE
Update 'Chaange Images' link to point to the media manager

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -255,7 +255,7 @@ class Home extends Component {
 								iconSrc="/calypso/images/customer-home/menus.svg"
 							/>
 							<ActionBox
-								href="https://support.wordpress.com/images/"
+								href={ `/media/${ siteSlug }` }
 								onClick={ () => trackAction( 'my_site', 'change_images' ) }
 								label={ translate( 'Change images' ) }
 								iconSrc="/calypso/images/customer-home/images.svg"


### PR DESCRIPTION
It was felt that linking to the support article on managing images was
the wrong action for this button. This change updates it to send the
user to the media manager itself. There is a future plan to include a
feature tour for the first time someone visits the manaager.

#### Testing instructions

Visit the customer home for a site and click the 'Change Images' button. You should be taken to the media manager at `/media/<SITE DOMAIN>`

Fixes #35782
