### PR TITLE
Site importer: fix for issue where site import preview persists from previous import

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -26,6 +26,7 @@ import {
 	validateSiteIsImportable,
 	resetSiteImporterImport,
 	setValidationError,
+	clearSiteImporterImport,
 } from 'state/imports/site-importer/actions';
 import ImporterActionButton from 'my-sites/importer/importer-action-buttons/action-button';
 import ImporterCloseButton from 'my-sites/importer/importer-action-buttons/close-button';
@@ -63,6 +64,12 @@ class SiteImporterInputPane extends React.Component {
 	};
 
 	componentDidMount() {
+		const { importStage } = this.props;
+		if ( 'importable' === importStage ) {
+			// Clear any leftover state from previous imports
+			this.props.clearSiteImporterImport();
+		}
+
 		this.validateSite();
 
 		if ( config.isEnabled( 'manage/import/site-importer-endpoints' ) ) {
@@ -338,6 +345,7 @@ export default flowRight(
 			importSite,
 			validateSiteIsImportable,
 			resetSiteImporterImport,
+			clearSiteImporterImport,
 			setValidationError,
 		}
 	),

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -231,3 +231,7 @@ export const resetSiteImporterImport = ( { importStage, site, targetSiteUrl } ) 
 		} ),
 		{ type: SITE_IMPORTER_IMPORT_RESET }
 	);
+
+export const clearSiteImporterImport = () => ( {
+	type: SITE_IMPORTER_IMPORT_RESET,
+} );


### PR DESCRIPTION
When you complete a Wix or GoDaddy import, and then start a second one, you see the preview page from the previous import instead of the form inviting you to enter the URL of the next site you want to import.

#### Changes proposed in this Pull Request

* This change clears the `importStage` state of the `SiteImporterInputPane` component on mounting, if the state is `importable`. This state should never occur on first mounting: it's only set after the importer has checked a given URL for importability.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR and run Calypso locally, or use `calypso.live`.
* Starting at URL: `/import/[ site ]`, open  the Wix or GoDaddy importer and import a Wix or GoDaddy site.
* When the import is complete, click on "Export" or some other sidebar menu item, and then back on "Import" to return to the importers page. (This clears the "import finished" view.)
* Open the Wix or GoDaddy importer again. You should see the site importer form with input to enter a URL, never the site preview page.

<img width="725" alt="image" src="https://user-images.githubusercontent.com/1647564/63852254-cab6e180-c98f-11e9-921a-7cc362b120cf.png">

* Complete the second import and verify that all goes as normal and there are no errors in the console.
* Do a Wix or GoDaddy import from the `/start` flow to verify that still works as expected.

Fixes Samus issue 35335
