### PR TITLE
SPT: remove pointer-events `none`

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -226,7 +226,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	background: $template-selector-empty-background;
 	border: 1px solid $template-selector-border-color;
 	border-radius: 6px;
-	pointer-events: none;
 	overflow-x: hidden;
 	overflow-y: auto;
 }


### PR DESCRIPTION
It allows performing scrolling the template content in the Large Preview. Right now it's blocked because it has defined a pointer-events to `none`

#### Testing instructions
Confirm that you are not able to scroll the template content in the Large Preview (when it's possible ). After applying these changes you should be able to scroll it and see the scrollbar right there:

<img width="930" alt="Screen Shot 2019-08-28 at 9 42 20 AM" src="https://user-images.githubusercontent.com/77539/63856546-4311a880-c978-11e9-8479-90e7311fdfe5.png">

Fixes #35780
