### PR TITLE
ExternalLink: use ScreenReaderText to guarantee presence of CSS styles

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -12,6 +12,11 @@ import Gridicon from 'gridicons';
 import { translate } from 'i18n-calypso';
 
 /**
+ * Internal dependencies
+ */
+import ScreenReaderText from 'components/screen-reader-text';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -34,18 +39,12 @@ class ExternalLink extends Component {
 	};
 
 	render() {
-		const classes = classnames(
-			'external-link',
-			this.props.className,
-			{
-				'icon-first': !! this.props.showIconFirst,
-			},
-			{
-				'has-icon': !! this.props.icon,
-			}
-		);
+		const classes = classnames( 'external-link', this.props.className, {
+			'icon-first': this.props.showIconFirst,
+			'has-icon': this.props.icon,
+		} );
+
 		const props = assign(
-			{},
 			omit( this.props, 'icon', 'iconSize', 'showIconFirst', 'iconClassName' ),
 			{
 				className: classes,
@@ -75,11 +74,11 @@ class ExternalLink extends Component {
 				{ this.props.children }
 				{ this.props.icon && ! this.props.showIconFirst && iconComponent }
 				{ this.props.icon && (
-					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-					<span className="screen-reader-text">
-						{ /* translators: accessibility text */
-						translate( '(opens in a new tab)' ) }
-					</span>
+					<ScreenReaderText>
+						{ translate( '(opens in a new tab)', {
+							comment: 'accessibility label for an external link',
+						} ) }
+					</ScreenReaderText>
 				) }
 			</a>
 		);


### PR DESCRIPTION
Use `ScreenReaderText` component instead of `<span className="screen-reader-text">` to ensure bundling of the CSS styles for the component.

Currently, I see this on a login 2FA pages because the CSS for `.screen-reader-text` is not present in the `login` section CSS chunk:

<img width="403" alt="Screenshot 2019-08-28 at 14 42 10" src="https://user-images.githubusercontent.com/664258/63857485-15425900-c9a4-11e9-8cbe-1301d15833cb.png">

