### PR TITLE
SPT: add template title in large preview

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -6,14 +6,23 @@
  * @param {string} title Template title
  * @return {*} Component
  */
-export default ( { title } ) => (
+
+const PreviewTemplateTitle = ( { title, scale } ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	<div className="editor-post-content">
 		<div className="editor-post-title">
 			<div className="editor-post-title__block">
-				<textarea className="editor-post-title__input" value={ title } />
+				<textarea
+					style={ {
+						transform: `scale( ${ scale } )`,
+					} }
+					className="editor-post-title__input"
+					value={ title }
+				/>
 			</div>
 		</div>
 	</div>
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 );
+
+export default PreviewTemplateTitle;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -1,0 +1,17 @@
+/**
+ * Return a component which acts as a PostTitle,
+ * applying the css classes needed to follow ths styles
+ * inherited from the theme.
+ *
+ * @param {string} title Template title
+ * @return {*} Component
+ */
+export default ( { title } ) => (
+	<div className="editor-post-content">
+		<div className="editor-post-title">
+			<div className="editor-post-title__block">
+				<textarea className="editor-post-title__input" value={ title } />
+			</div>
+		</div>
+	</div>
+);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -1,7 +1,7 @@
 /**
  * Return a component which acts as a PostTitle,
- * applying the css classes needed to follow ths styles
- * inherited from the theme.
+ * applying the css classes needed to follow the styles
+ * inherited from the Editor.
  *
  * @param {string} title Template title - transform css rule.
  * @return {*} Component

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -3,22 +3,16 @@
  * applying the css classes needed to follow ths styles
  * inherited from the theme.
  *
- * @param {string} title Template title
+ * @param {string} title Template title - transform css rule.
  * @return {*} Component
  */
 
-const PreviewTemplateTitle = ( { title, scale } ) => (
+const PreviewTemplateTitle = ( { title, transform } ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	<div className="editor-post-content">
 		<div className="editor-post-title">
 			<div className="editor-post-title__block">
-				<textarea
-					style={ {
-						transform: `scale( ${ scale } )`,
-					} }
-					className="editor-post-title__input"
-					value={ title }
-				/>
+				<textarea style={ { transform } } className="editor-post-title__input" value={ title } />
 			</div>
 		</div>
 	</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -7,6 +7,7 @@
  * @return {*} Component
  */
 export default ( { title } ) => (
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	<div className="editor-post-content">
 		<div className="editor-post-title">
 			<div className="editor-post-title__block">
@@ -14,4 +15,5 @@ export default ( { title } ) => (
 			</div>
 		</div>
 	</div>
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -9,11 +9,9 @@
 
 const PreviewTemplateTitle = ( { title, transform } ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	<div className="editor-post-content">
-		<div className="editor-post-title">
-			<div className="editor-post-title__block">
-				<textarea style={ { transform } } className="editor-post-title__input" value={ title } />
-			</div>
+	<div className="editor-post-title" style={ { transform } }>
+		<div className="editor-post-title__block">
+			<textarea className="editor-post-title__input" value={ title } />
 		</div>
 	</div>
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -8,7 +8,6 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useRef } from '@wordpress/element';
 import { Disabled } from '@wordpress/components';
 /**
  * Internal dependencies
@@ -16,10 +15,7 @@ import { Disabled } from '@wordpress/components';
 import BlockPreview from './block-template-preview';
 
 const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
-	const previewElClasses = classnames(
-		'template-selector-preview',
-		'editor-styles-wrapper',
-	);
+	const previewElClasses = classnames( 'template-selector-preview', 'editor-styles-wrapper' );
 
 	if ( isEmpty( blocks ) ) {
 		return (

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -30,8 +30,9 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	// once the PR ships (finger-crossed)
 	// https://github.com/WordPress/gutenberg/pull/17242
 	useLayoutEffect( () => {
+		setVisibility( 'hidden' );
+
 		setTimeout( () => {
-			setVisibility( 'hidden' );
 			// Get DOM reference.
 			if ( ! ref || ! ref.current ) {
 				return;
@@ -69,10 +70,14 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 		<div className={ previewElClasses }>
 			<Disabled>
 				<div ref={ ref } className="edit-post-visual-editor">
-					<div className="editor-styles-wrapper">
-						<div style={ { visibility } } className="editor-writing-flow">
-							<PreviewTemplateTitle title={ title } transform={ transform } />
-							<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+					<div className="editor-styles-wrapper" style={ { visibility } }>
+						<div className="editor-writing-flow">
+							<div className="editor-block-list__layout">
+								<div className="block-editor-block-list__block-edit">
+									<PreviewTemplateTitle title={ title } transform={ transform } />
+									<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -8,13 +8,16 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { BlockPreview } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
-import BlockPreview from './block-template-preview';
 
-const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
+import PreviewTemplateTitle from './preview-template-title';
+
+const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	const previewElClasses = classnames( 'template-selector-preview', 'editor-styles-wrapper' );
 
 	if ( isEmpty( blocks ) ) {
@@ -28,11 +31,20 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	}
 
 	return (
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<div className={ previewElClasses }>
 			<Disabled>
-				<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+				<div className="edit-post-visual-editor">
+					<div className="editor-styles-wrapper">
+						<div className="editor-writing-flow">
+							<PreviewTemplateTitle title={ title } />
+							<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+						</div>
+					</div>
+				</div>
 			</Disabled>
 		</div>
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -10,15 +10,17 @@ import { isEmpty } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-
 import PreviewTemplateTitle from './preview-template-title';
 
 const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	const previewElClasses = classnames( 'template-selector-preview', 'editor-styles-wrapper' );
+	const [ previewScale, setPreviewScale ] = useState( 1 );
+	const [ visibility, setVisibility ] = useState( 'hidden' );
 
 	if ( isEmpty( blocks ) ) {
 		return (
@@ -36,9 +38,16 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 			<Disabled>
 				<div className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper">
-						<div className="editor-writing-flow">
-							<PreviewTemplateTitle title={ title } />
-							<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+						<div style={ { visibility } } className="editor-writing-flow">
+							<PreviewTemplateTitle title={ title } scale={ previewScale } />
+							<BlockPreview
+								blocks={ blocks }
+								viewportWidth={ viewportWidth }
+								onReady={ ( { scale } ) => {
+									setPreviewScale( scale );
+									setVisibility( 'visible' );
+								} }
+							/>
 						</div>
 					</div>
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -72,12 +72,8 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 				<div ref={ ref } className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper" style={ { visibility } }>
 						<div className="editor-writing-flow">
-							<div className="editor-block-list__layout">
-								<div className="block-editor-block-list__block-edit">
-									<PreviewTemplateTitle title={ title } transform={ transform } />
-									<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
-								</div>
-							</div>
+							<PreviewTemplateTitle title={ title } transform={ transform } />
+							<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
 						</div>
 					</div>
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -171,6 +171,7 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorPreview
 								blocks={ this.getBlocksByTemplateSlug() }
 								viewportWidth={ 960 }
+								title={ this.state.title }
 							/>
 						</>
 					) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -241,8 +241,6 @@ $template-large-preview-title-height: 115px;
 		transform-origin: top left;
 		width: 960px;
 		display: block;
-		margin-top: 0;
-		margin-bottom: 0;
 		position: absolute;
 		top: 0;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -230,6 +230,24 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	overflow-y: auto;
 }
 
+.show-post-title-before-content .template-selector-preview .editor-styles-wrapper {
+	.editor-post-title .editor-post-title__block,
+	.editor-post-title .editor-post-title__block .editor-post-title__input {
+		height: 48px;
+		line-height: 48px;
+		margin: 0;
+		padding: 0;
+	}
+
+	.editor-post-title .editor-post-title__block .editor-post-title__input {
+		font-size: 1em;
+	}
+
+	.editor-post-title {
+		display: block;
+	}
+}
+
 .template-selector-preview__placeholder {
 	position: absolute;
 	top: 50%;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -230,23 +230,34 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	overflow-y: auto;
 }
 
+.show-post-title-before-content .template-selector-preview .edit-post-visual-editor {
+	margin-top: 20px;
+}
+
+$template-large-preview-title-height: 115px;
 .show-post-title-before-content .template-selector-preview .editor-styles-wrapper {
-	.editor-post-title .editor-post-title__block,
-	.editor-post-title .editor-post-title__block .editor-post-title__input {
-		height: 60px;
-		line-height: 60px;
-		margin: 0;
-		padding: 0;
-	}
-
-	.editor-post-title .editor-post-title__block {
-		margin-top: 20px;
-	}
-
+	// Set the
 	.editor-post-title {
+		transform-origin: top left;
+		width: 960px;
 		display: block;
-		padding: 0;
-		margin: 0;
+		margin-top: 0;
+		margin-bottom: 0;
+		position: absolute;
+		top: 0;
+	}
+
+	.editor-post-title,
+	.editor-post-title, .editor-post-title__block {
+		height: $template-large-preview-title-height;
+		margin-top: 0;
+		margin-bottom: 0;
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	.block-editor-block-preview__content .block-editor-block-list__layout {
+		margin-top: $template-large-preview-title-height;
 	}
 }
 
@@ -330,8 +341,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	transform: translate( -50%, -50% );
 	display: flex;
     align-items: flex-end;
-}
 
-.page-template-modal__loading .components-spinner {
-	float: none;
+	.components-spinner {
+		float: none;
+	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -151,6 +151,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		&.is-rendering {
 			opacity: 0.5;
 		}
+
+        .block-editor-block-list__layout,
+        .block-editor-block-list__block {
+			padding: inherit;
+        }
 	}
 
 	.template-selector-item__media {
@@ -254,7 +259,7 @@ $template-large-preview-title-height: 115px;
 		padding-bottom: 0;
 	}
 
-	.block-editor-block-preview__content .block-editor-block-list__layout {
+	.block-editor-block-preview__content > .block-editor-block-list__layout {
 		margin-top: $template-large-preview-title-height;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -233,8 +233,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .show-post-title-before-content .template-selector-preview .editor-styles-wrapper {
 	.editor-post-title .editor-post-title__block,
 	.editor-post-title .editor-post-title__block .editor-post-title__input {
-		height: 48px;
-		line-height: 48px;
+		height: 60px;
+		line-height: 60px;
 		margin: 0;
 		padding: 0;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -239,6 +239,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		padding: 0;
 	}
 
+	.editor-post-title .editor-post-title__block {
+		margin-top: 20px;
+	}
+
 	.editor-post-title .editor-post-title__block .editor-post-title__input {
 		transform: scale( 0.361458 ); // it's copied from the current computing of the BlockPreview.
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -240,7 +240,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	.editor-post-title .editor-post-title__block .editor-post-title__input {
-		font-size: 1em;
+		transform: scale( 0.361458 ); // it's copied from the current computing of the BlockPreview.
 	}
 
 	.editor-post-title {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -243,12 +243,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		margin-top: 20px;
 	}
 
-	.editor-post-title .editor-post-title__block .editor-post-title__input {
-		transform: scale( 0.361458 ); // it's copied from the current computing of the BlockPreview.
-	}
-
 	.editor-post-title {
 		display: block;
+		padding: 0;
+		margin: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the template title into the Large Preview. The implementation tweaks the styles related to title size but allowing inherit styles defined for the current theme.

#### Twenty Nineteen

![image](https://user-images.githubusercontent.com/77539/64053060-313a2c00-cb57-11e9-930c-91893bc84b6a.png)


#### Redhill theme

![image](https://user-images.githubusercontent.com/77539/64053081-4dd66400-cb57-11e9-966b-21b2cd414e5b.png)

#### Sophisticated Business (dark theme)

![image](https://user-images.githubusercontent.com/77539/64053101-6c3c5f80-cb57-11e9-979d-089e1957efc4.png)


#### Testing instructions

Once these changes are applied confirm that you see the template title into the large preview container.

Fixes #35777
