### PR TITLE
Update wording and remove link that goes to checklist

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
@@ -111,12 +111,7 @@ export class ChecklistBanner extends Component {
 						<ChecklistBannerTask
 							bannerImageSrc="/calypso/images/stats/tasks/ready-to-share.svg"
 							description={ translate(
-								'We did it! You have completed {{a}}all the tasks{{/a}} on our checklist.',
-								{
-									components: {
-										a: <a href={ `/checklist/${ this.props.siteSlug }` } />,
-									},
-								}
+								'You did it! You have completed all the tasks on your checklist.'
 							) }
 							title={ translate( 'Your site is ready to share' ) }
 						>

--- a/client/my-sites/checklist/wpcom-checklist/checklist-prompt/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-prompt/index.jsx
@@ -44,12 +44,7 @@ export class ChecklistPrompt extends Component {
 				{ isFinished ? (
 					<ChecklistPromptTask
 						description={ translate(
-							'We did it! You have completed {{a}}all the tasks{{/a}} on your checklist.',
-							{
-								components: {
-									a: <a href={ `/checklist/${ this.props.siteSlug }` } />,
-								},
-							}
+							'You did it! You have completed all the tasks on your checklist.'
 						) }
 						title={ translate( 'Your site is ready to share' ) }
 					/>


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* update We and Our to You and Your
* remove link to checklist. With the Customer Home in place, the checklist won't be displayed anymore

#### Testing instructions

*

Fixes #35813
