### PR TITLE
Fix renewal links for domains in the expired domain emails

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -36,7 +36,7 @@ export function checkout( context, next ) {
 	}
 
 	let product;
-	if ( selectedSite && selectedSite.slug !== domainOrProduct ) {
+	if ( selectedSite && selectedSite.slug !== domainOrProduct && domainOrProduct ) {
 		product = domainOrProduct;
 	} else {
 		product = context.params.product;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

domainOrProduct can be null while product is not null. This is the case for renew links like this:

https://wordpress.com/checkout/domain_map:dzverbg710.com/renew/702590/dzverbg710.wordpress.com

The problem was a side effect of https://github.com/Automattic/wp-calypso/commit/ea46a2486eab21393445e195d1769ed146ebadd5

#### Testing instructions

1. Add a Domain Mapping or Registration subscription without a plan
2. Generate renewal link in wpsh

`get_notifications_renew_url( $subs )
`
3. Visit that renewal link in Calypso. The wpcom link will not work, it will redirect to /plans because product is undefined instead of domain_map:domain

Fixes #
