### PR TITLE
FSE: Use get_theme_support instead of theme whitelist

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -40,17 +40,6 @@ class Full_Site_Editing {
 	public $wp_template_inserter;
 
 	/**
-	 * List of FSE supported themes.
-	 *
-	 * @var array
-	 */
-	const SUPPORTED_THEMES = [
-		'maywood',
-		'modern-business',
-		'varia',
-	];
-
-	/**
 	 * Full_Site_Editing constructor.
 	 */
 	private function __construct() {
@@ -99,7 +88,7 @@ class Full_Site_Editing {
 	 */
 	public function is_supported_theme( $theme_slug ) {
 		$theme_slug = $this->normalize_theme_slug( $theme_slug );
-		return in_array( $theme_slug, self::SUPPORTED_THEMES, true );
+		return get_theme_support( 'full-site-editing' );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -82,13 +82,16 @@ class Full_Site_Editing {
 	/**
 	 * Determines whether provided theme supports FSE.
 	 *
+	 * @deprecated being replaced soon by an is_active static method - don't add new usages
 	 * @param string $theme_slug Theme slug to check support for.
 	 *
 	 * @return bool True if passed theme supports FSE, false otherwise.
 	 */
-	public function is_supported_theme( $theme_slug ) {
-		$theme_slug = $this->normalize_theme_slug( $theme_slug );
-		return get_theme_support( 'full-site-editing' );
+	// phpcs:disable
+	public function is_supported_theme( $theme_slug = null ) {
+		// phpcs:enable
+		// now in reality is_current_theme_supported.
+		return current_theme_supports( 'full-site-editing' );
 	}
 
 	/**
@@ -98,8 +101,8 @@ class Full_Site_Editing {
 	 * It is hooked into after_switch_theme action.
 	 */
 	public function insert_default_data() {
-		// Bail if theme doesn't support FSE.
-		if ( ! $this->is_supported_theme( $this->theme_slug ) ) {
+		// Bail if current theme doesn't support FSE.
+		if ( ! $this->is_supported_theme() ) {
 			return;
 		}
 
@@ -361,12 +364,12 @@ class Full_Site_Editing {
 	 * 3. OR on a block editor screen (inlined requests using `rest_preload_api_request` )
 	 * 4. AND editing a post_type that supports full site editing
 	 *
-   * @param \WP_Post post object for the check
+	 * @param \WP_Post $post object for the check.
 	 * @return bool
 	 */
 	private function should_merge_template_and_post( $post ) {
-		$is_rest_api_wpcom = ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST );
-		$is_rest_api_core = ( defined( 'REST_REQUEST' ) && REST_REQUEST );
+		$is_rest_api_wpcom      = ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST );
+		$is_rest_api_core       = ( defined( 'REST_REQUEST' ) && REST_REQUEST );
 		$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );
 
 		if ( ! ( $is_block_editor_screen || $is_rest_api_core || $is_rest_api_wpcom ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the theme whitelist and use get_theme_support( 'full-site-editing' ) to determine theme compatibility

#### Testing instructions

* Apply this patch and https://github.com/Automattic/themes/pull/1351/files to your local FSE dev env
* Check that enabling Modern Business, Maywood and Varia with FSE plugin enabled still populates the template data and shows header and footer template parts when viewing or adding a page

