### PR TITLE
Signup: removing duplicated trademark notice code

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -13,7 +13,6 @@ import { localize, getLocaleSlug } from 'i18n-calypso';
  * Internal dependencies
  */
 import MapDomainStep from 'components/domains/map-domain-step';
-import TrademarkClaimsNotice from 'components/domains/trademark-claims-notice';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import UseYourDomainStep from 'components/domains/use-your-domain-step';
 import RegisterDomainStep from 'components/domains/register-domain-step';
@@ -158,16 +157,6 @@ class DomainsStep extends React.Component {
 		};
 
 		this.props.recordAddDomainButtonClick( suggestion.domain_name, this.getAnalyticsSection() );
-
-		const trademarkClaimsNoticeInfo = get( suggestion, 'trademark_claims_notice_info' );
-		if ( ! isEmpty( trademarkClaimsNoticeInfo ) ) {
-			this.setState( {
-				suggestion,
-				showTrademarkClaimsNotice: true,
-			} );
-			return;
-		}
-
 		this.props.saveSignupStep( stepData );
 
 		defer( () => {
@@ -470,34 +459,6 @@ class DomainsStep extends React.Component {
 		);
 	};
 
-	rejectTrademarkClaim = () => {
-		this.setState( { showTrademarkClaimsNotice: false } );
-	};
-
-	acceptTrademarkClaim = () => {
-		const { suggestion } = this.state;
-
-		suggestion.trademark_claims_notice_info = null;
-		this.handleAddDomain( suggestion );
-	};
-
-	trademarkClaimsNotice = () => {
-		const { suggestion } = this.state;
-		const domain = get( suggestion, 'domain_name' );
-		const trademarkClaimsNoticeInfo = get( suggestion, 'trademark_claims_notice_info' );
-
-		return (
-			<TrademarkClaimsNotice
-				basePath={ this.props.path }
-				domain={ domain }
-				isSignupStep
-				onAccept={ this.acceptTrademarkClaim }
-				onReject={ this.rejectTrademarkClaim }
-				trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo }
-			/>
-		);
-	};
-
 	getSubHeaderText() {
 		const { flowName, siteType, translate } = this.props;
 		const onboardingSubHeaderCopy =
@@ -540,10 +501,6 @@ class DomainsStep extends React.Component {
 
 		if ( ! this.props.stepSectionName || this.props.isDomainOnly ) {
 			content = this.domainForm();
-		}
-
-		if ( this.state.showTrademarkClaimsNotice ) {
-			content = this.trademarkClaimsNotice();
 		}
 
 		if ( this.props.step && 'invalid' === this.props.step.status ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -75,7 +75,6 @@ class DomainsStep extends React.Component {
 	getDefaultState = () => ( {
 		previousStepSectionName: this.props.stepSectionName,
 		suggestion: null,
-		showTrademarkClaimsNotice: false,
 	} );
 
 	state = this.getDefaultState();
@@ -120,16 +119,9 @@ class DomainsStep extends React.Component {
 		}
 	}
 
-	static getDerivedStateFromProps( nextProps, prevState ) {
-		let showTrademarkClaimsNotice = prevState.showTrademarkClaimsNotice;
-
-		if ( nextProps.stepSectionName !== prevState.previousStepSectionName ) {
-			showTrademarkClaimsNotice = false;
-		}
-
+	static getDerivedStateFromProps( nextProps ) {
 		return {
 			previousStepSectionName: nextProps.stepSectionName,
-			showTrademarkClaimsNotice,
 		};
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

The trademark code is duplicated in the domains step component and [register-domain-step/index.jsx](client/components/domains/register-domain-step/index.jsx)

This result is that the user has to click the accept button twice.

![Aug-29-2019 19-15-17](https://user-images.githubusercontent.com/6458278/63927899-f3270480-ca91-11e9-9028-7dbb8381ac04.gif)

This PR remove the trademark logic from the domain step component. Since the domains step pulls in the register-domain-step component anyway, there doesn't seem to be any reason to keep it. 

As you see, the site preview gets in the way too. I've created [another PR](https://github.com/Automattic/wp-calypso/pull/35831) to fix that.

Disabling the **Choose Another Domain** button until the user scrolls to the bottom doesn't seem to me to be very user friendly either, but I've left that for another day.

## Testing instructions

Go through the onboarding flow at /start!

To test the trademark screen, search for and select `dairyqueen.dev` as your domain, unsandboxed.

You shouldn't have to accept twice to continue onto plans.