### PR TITLE
Remove React Virtualized styles from the main stylesheet

### DIFF
--- a/assets/stylesheets/_vendor.scss
+++ b/assets/stylesheets/_vendor.scss
@@ -1,7 +1,3 @@
-
-// External Dependencies
-@import '~react-virtualized/styles';
-
 .gridicon {
 	fill: currentColor;
 


### PR DESCRIPTION
The React Virtualized `styles.css` file doesn't contain any styles that would be interesting for Calypso. There are only styles for the `ReactVirtualized__Table` component that we don't use.

If we ever start using the `Table` component, it will be much better to provide our own styles. The built-in styles are not essential, but rather make hello-world-style demos look good out of the box.

**How to test:**
Test that usages of React Virtualized don't visually break.