### PR TITLE
Full Site Editing: Update the merge_template_and_post early return conditions

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -348,13 +348,7 @@ class Full_Site_Editing {
 	 */
 	public function merge_template_and_post( $post ) {
 		// Bail if not a REST API Request and not in the editor.
-		global $pagenow;
-		if ( 'post.php' !== $pagenow && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-			return;
-		}
-
-		// Bail if the post is not a full site page.
-		if ( ! $this->is_full_site_page() ) {
+		if ( ! $this->should_merge_template_and_post() ) {
 			return;
 		}
 
@@ -367,6 +361,27 @@ class Full_Site_Editing {
 		}
 
 		$post->post_content = preg_replace( '@(<!-- wp:a8c/post-content)(.*?)(/-->)@', "$1$2-->$post->post_content<!-- /wp:a8c/post-content -->", $template_content );
+	}
+
+	/**
+	 * Detects if we are in a context where the template and post should be merged.
+	 *
+	 * Conditions:
+	 * 1. in a REST API request (either flavour)
+	 * 2. OR on a block editor screen (inlined requests using `rest_preload_api_request` )
+	 * 3. AND editing a post_type that supports full site editing
+	 *
+	 * @return bool
+	 */
+	private function should_merge_template_and_post() {
+		$is_rest_api_wpcom = ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST );
+		$is_rest_api_core = ( defined( 'REST_REQUEST' ) && REST_REQUEST );
+		$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );
+
+		if ( ! ( $is_block_editor_screen || $is_rest_api_core || $is_rest_api_wpcom ) ) {
+			return false;
+		}
+		return $this->is_full_site_page();
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -347,8 +347,9 @@ class Full_Site_Editing {
 	 * @param \WP_Post $post Post instance.
 	 */
 	public function merge_template_and_post( $post ) {
-		// Bail if not a REST API Request.
-		if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		// Bail if not a REST API Request and not in the editor.
+		global $pagenow;
+		if ( 'post.php' !== $pagenow && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only bail from `merge_template_and_post` if the context is not a REST API request **and** the current screen is not the editor.

#### Testing instructions

* Enable Jetpack on an FSE site, then enable Jetpack's Sharing Buttons and set them to appear on all available post types.
* Edit a page and make sure it shows the template blocks.
* Edit a template, and make sure it works as expected (this shouldn't be impacted anyway for a following early return).
* Open page in the front end and make sure that:
  * There are no infinite loops breaking the page.
  * The sharing buttons only appear at the bottom of the page content, and not for the template parts too.