### PR TITLE
Jetpack Connect: Fix visual regression

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -126,6 +126,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__site-url-entry-container {
+	margin: 0 auto;
 	max-width: 400px;
 }
 


### PR DESCRIPTION
I'm not sure when or why and didn't bother tracking it down, but there was a visual regression for one of the Jetpack connect views.

## Screens

### Before

![Screen Shot 2019-08-29 at 14 46 03](https://user-images.githubusercontent.com/841763/63941741-80eff900-ca6c-11e9-87b7-07761d976d09.png)

### After

![Screen Shot 2019-08-29 at 14 49 26](https://user-images.githubusercontent.com/841763/63941747-85b4ad00-ca6c-11e9-985e-575b2d487ecd.png)

## Testing

Visit [`/jetpack/connect`](https://calypso.live/jetpack/connect?branch=fix/jpc-alignment) and verify the centered is content.