### PR TITLE
Add GM Closure Notice component to Help Contact

### DIFF
--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -109,28 +109,28 @@ const GMClosureNotice = ( {
 
 	const REASON_MESSAGES = {
 		hasPlan: translate(
-			'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, you can submit an email ticket through the contact form: {{a}}https://wordpress.com/help/contact{{/a}}',
+			'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, you can submit an email ticket through the contact form: {{contactLink}}https://wordpress.com/help/contact{{/contactLink}}',
 			{
 				components: {
-					a: <a href="/help/contact" />,
+					contactLink: <a href="/help/contact" />,
 				},
 			}
 		),
 		nonPlan: translate(
-			'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, check our support site at {{a}}https://en.support.wordpress.com{{/a}}',
+			'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, check our support site at {{supportLink}}https://en.support.wordpress.com{{/supportLink}}',
 			{
 				components: {
-					a: <a href="https://en.support.wordpress.com" />,
+					supportLink: <a href="https://en.support.wordpress.com" />,
 				},
 			}
 		),
 	};
 
 	const FORUMS_NOTE = translate(
-		'Our staff will be keeping an eye on the {{a}}Forums{{/a}} for urgent matters.',
+		'Our staff will be keeping an eye on the {{forumLink}}Forums{{/forumLink}} for urgent matters.',
 		{
 			components: {
-				a: <a href="https://en.forums.wordpress.com/forum/support/" />,
+				forumLink: <a href="https://en.forums.wordpress.com/forum/support/" />,
 			},
 		}
 	);

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -1,0 +1,181 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import 'moment-timezone'; // monkey patches the existing moment.js
+
+/**
+ * Internal dependencies
+ */
+import { isEcommercePlan, isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
+import FoldableCard from 'components/foldable-card';
+import FormSectionHeading from 'components/forms/form-section-HEADING';
+import { useLocalizedMoment } from 'components/localized-moment';
+import { getSitePlanSlug } from 'state/sites/selectors';
+import { getHelpSelectedSiteId } from 'state/help/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const DATE_FORMAT_SHORT = 'MMMM D';
+const DATE_FORMAT_LONG = 'dddd, MMMM Do';
+
+const GMClosureNotice = ( {
+	businessAndEcommerceClosesAt,
+	businessAndEcommerceReopensAt,
+	compact,
+	defaultClosesAt,
+	defaultReopensAt,
+	displayAt,
+	selectedSitePlanSlug,
+} ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	const isBusinessOrEcommercePlan =
+		isBusinessPlan( selectedSitePlanSlug ) || isEcommercePlan( selectedSitePlanSlug );
+	const isPersonalOrPremiumPlan =
+		isPersonalPlan( selectedSitePlanSlug ) || isPremiumPlan( selectedSitePlanSlug );
+	const isNonPlan = ! isBusinessOrEcommercePlan && ! isPersonalOrPremiumPlan;
+
+	const currentDate = moment();
+	const guessedTimezone = moment.tz.guess();
+
+	const [ closesAt, closedUntil, reopensAt ] = [
+		moment.tz(
+			isBusinessOrEcommercePlan ? businessAndEcommerceClosesAt : defaultClosesAt,
+			guessedTimezone
+		),
+		moment
+			.tz(
+				isBusinessOrEcommercePlan ? businessAndEcommerceReopensAt : defaultReopensAt,
+				guessedTimezone
+			)
+			.subtract( 1, 'days' ),
+		moment.tz(
+			isBusinessOrEcommercePlan ? businessAndEcommerceReopensAt : defaultReopensAt,
+			guessedTimezone
+		),
+	];
+
+	if ( ! currentDate.isBetween( displayAt, reopensAt ) ) {
+		return null;
+	}
+
+	const HEADING = translate( 'Limited Support %(closesAt)s – %(closedUntil)s', {
+		args: {
+			closesAt: closesAt.format( DATE_FORMAT_SHORT ),
+			closedUntil: closedUntil.format(
+				closedUntil.isSame( closesAt, 'month' ) ? 'D' : DATE_FORMAT_SHORT
+			),
+		},
+	} );
+
+	const mainMessageArgs = {
+		closesAt: closesAt.format( DATE_FORMAT_LONG ),
+		closedUntil: closedUntil.format( DATE_FORMAT_LONG ),
+		reopensAt: reopensAt.format( DATE_FORMAT_LONG ),
+	};
+
+	const MAIN_MESSAGES = {
+		before: {
+			hasPlan: translate(
+				'Live chat support will be closed %(closesAt)s through %(closedUntil)s, included. Email support will be open during that time, and we will reopen live chat on %(reopensAt)s.',
+				{ args: mainMessageArgs }
+			),
+			nonPlan: translate(
+				'Private support will be closed %(closesAt)s through %(closedUntil)s, included. We will reopen private support on %(reopensAt)s.',
+				{ args: mainMessageArgs }
+			),
+		},
+		during: {
+			hasPlan: translate(
+				'Live chat support will be closed through %(closedUntil)s, included. Email support will be open during that time, and we will reopen live chat on %(reopensAt)s.',
+				{ args: mainMessageArgs }
+			),
+			nonPlan: translate(
+				'Private support will be closed through %(closedUntil)s, included. We will reopen private support on %(reopensAt)s.',
+				{ args: mainMessageArgs }
+			),
+		},
+	};
+
+	const REASON_MESSAGES = {
+		hasPlan: translate(
+			'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, you can submit an email ticket through the contact form: {{a}}https://wordpress.com/help/contact{{/a}}',
+			{
+				components: {
+					a: <a href="https://wordpress.com/help/contact" />,
+				},
+			}
+		),
+		nonPlan: translate(
+			'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, check our support site at {{a}}https://en.support.wordpress.com{{/a}}',
+			{
+				components: {
+					a: <a href="https://en.support.wordpress.com" />,
+				},
+			}
+		),
+	};
+
+	const FORUMS_NOTE = translate(
+		'Our staff will be keeping an eye on the {{a}}Forums{{/a}} for urgent matters.',
+		{
+			components: {
+				a: <a href="https://en.forums.wordpress.com/forum/support/" />,
+			},
+		}
+	);
+
+	const period = currentDate.isBefore( closesAt ) ? 'before' : 'during';
+	const mainMessage = isNonPlan ? MAIN_MESSAGES[ period ].nonPlan : MAIN_MESSAGES[ period ].hasPlan;
+	const reason = isNonPlan ? REASON_MESSAGES.nonPlan : REASON_MESSAGES.hasPlan;
+
+	if ( compact ) {
+		return (
+			<FoldableCard
+				className="gm-closure-notice"
+				clickableHeader={ true }
+				compact={ true }
+				header={ HEADING }
+			>
+				{ mainMessage }
+				<br />
+				<br />
+				{ reason }
+				{ isNonPlan && (
+					<Fragment>
+						<br />
+						<br />
+						{ FORUMS_NOTE }
+					</Fragment>
+				) }
+			</FoldableCard>
+		);
+	}
+
+	return (
+		<div className="gm-closure-notice">
+			<FormSectionHeading>{ HEADING }</FormSectionHeading>
+			<div>
+				<p>{ mainMessage }</p>
+				<p>{ reason }</p>
+				{ isNonPlan && <p>{ FORUMS_NOTE }</p> }
+			</div>
+			<hr />
+		</div>
+	);
+};
+
+export default connect( state => {
+	const selectedSiteId = getHelpSelectedSiteId( state );
+	return { selectedSitePlanSlug: getSitePlanSlug( state, selectedSiteId ) };
+} )( GMClosureNotice );

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -26,7 +26,7 @@ import { getUserPurchases } from 'state/purchases/selectors';
 import './style.scss';
 
 const DATE_FORMAT_SHORT = 'MMMM D';
-const DATE_FORMAT_LONG = 'dddd, MMMM Do';
+const DATE_FORMAT_LONG = 'dddd, MMMM Do LT';
 
 const GMClosureNotice = ( {
 	businessAndEcommerceClosesAt,
@@ -53,17 +53,11 @@ const GMClosureNotice = ( {
 	const currentDate = moment();
 	const guessedTimezone = moment.tz.guess();
 
-	const [ closesAt, closedUntil, reopensAt ] = [
+	const [ closesAt, reopensAt ] = [
 		moment.tz(
 			hasBusinessOrEcommercePlan ? businessAndEcommerceClosesAt : defaultClosesAt,
 			guessedTimezone
 		),
-		moment
-			.tz(
-				hasBusinessOrEcommercePlan ? businessAndEcommerceReopensAt : defaultReopensAt,
-				guessedTimezone
-			)
-			.subtract( 1, 'days' ),
 		moment.tz(
 			hasBusinessOrEcommercePlan ? businessAndEcommerceReopensAt : defaultReopensAt,
 			guessedTimezone
@@ -74,41 +68,39 @@ const GMClosureNotice = ( {
 		return null;
 	}
 
-	const HEADING = translate( 'Limited Support %(closesAt)s – %(closedUntil)s', {
+	const HEADING = translate( 'Limited Support %(closesAt)s – %(reopensAt)s', {
 		args: {
 			closesAt: closesAt.format( DATE_FORMAT_SHORT ),
-			closedUntil: closedUntil.format(
-				closedUntil.isSame( closesAt, 'month' ) ? 'D' : DATE_FORMAT_SHORT
+			reopensAt: reopensAt.format(
+				reopensAt.isSame( closesAt, 'month' ) ? 'D' : DATE_FORMAT_SHORT
 			),
 		},
 	} );
 
 	const mainMessageArgs = {
-		closed_start_date: closesAt.format( DATE_FORMAT_LONG ),
-		closed_end_date: closedUntil.format( DATE_FORMAT_LONG ),
-		support_resume_date: reopensAt.format( DATE_FORMAT_LONG ),
+		closes_at: closesAt.format( DATE_FORMAT_LONG ),
+		reopens_at: reopensAt.format( DATE_FORMAT_LONG ),
 	};
 
 	const MAIN_MESSAGES = {
 		before: {
 			hasPlan: translate(
-				'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
+				'Live chat support will be closed from %(closes_at)s until %(reopens_at)s. Email support will remain open.',
 				{ args: mainMessageArgs }
 			),
 			nonPlan: translate(
-				'Private support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. We will reopen private support on %(support_resume_date)s.',
+				'Private support will be closed from %(closes_at)s until %(reopens_at)s.',
 				{ args: mainMessageArgs }
 			),
 		},
 		during: {
 			hasPlan: translate(
-				'Live chat support will be closed through %(closed_end_date)s, included. Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
+				'Live chat support is closed until %(reopens_at)s. In the meantime you can still reach us by email.',
 				{ args: mainMessageArgs }
 			),
-			nonPlan: translate(
-				'Private support will be closed through %(closed_end_date)s, included. We will reopen private support on %(support_resume_date)s.',
-				{ args: mainMessageArgs }
-			),
+			nonPlan: translate( 'Private support is closed until %(reopens_at)s.', {
+				args: mainMessageArgs,
+			} ),
 		},
 	};
 

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -29,11 +29,11 @@ const DATE_FORMAT_SHORT = 'MMMM D';
 const DATE_FORMAT_LONG = 'dddd, MMMM Do LT';
 
 const GMClosureNotice = ( {
-	businessAndEcommerceClosesAt,
-	businessAndEcommerceReopensAt,
+	priorityChatClosesAt,
+	priorityChatReopensAt,
 	compact,
-	defaultClosesAt,
-	defaultReopensAt,
+	basicChatClosesAt,
+	basicChatReopensAt,
 	displayAt,
 	purchases,
 } ) => {
@@ -55,11 +55,11 @@ const GMClosureNotice = ( {
 
 	const [ closesAt, reopensAt ] = [
 		moment.tz(
-			hasBusinessOrEcommercePlan ? businessAndEcommerceClosesAt : defaultClosesAt,
+			hasBusinessOrEcommercePlan ? priorityChatClosesAt : basicChatClosesAt,
 			guessedTimezone
 		),
 		moment.tz(
-			hasBusinessOrEcommercePlan ? businessAndEcommerceReopensAt : defaultReopensAt,
+			hasBusinessOrEcommercePlan ? priorityChatReopensAt : basicChatReopensAt,
 			guessedTimezone
 		),
 	];

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -112,7 +112,7 @@ const GMClosureNotice = ( {
 			'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, you can submit an email ticket through the contact form: {{a}}https://wordpress.com/help/contact{{/a}}',
 			{
 				components: {
-					a: <a href="https://wordpress.com/help/contact" />,
+					a: <a href="/help/contact" />,
 				},
 			}
 		),

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -8,13 +8,14 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import 'moment-timezone'; // monkey patches the existing moment.js
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isEcommercePlan, isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
 import FoldableCard from 'components/foldable-card';
-import FormSectionHeading from 'components/forms/form-section-HEADING';
+import FormSectionHeading from 'components/forms/form-section-heading';
 import { useLocalizedMoment } from 'components/localized-moment';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getUserPurchases } from 'state/purchases/selectors';
@@ -39,10 +40,12 @@ const GMClosureNotice = ( {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
-	const hasBusinessOrEcommercePlan = purchases.some(
+	const hasBusinessOrEcommercePlan = some(
+		purchases,
 		( { productSlug } ) => isBusinessPlan( productSlug ) || isEcommercePlan( productSlug )
 	);
-	const hasPersonalOrPremiumPlan = purchases.some(
+	const hasPersonalOrPremiumPlan = some(
+		purchases,
 		( { productSlug } ) => isPersonalPlan( productSlug ) || isPremiumPlan( productSlug )
 	);
 	const hasNoPlan = ! hasBusinessOrEcommercePlan && ! hasPersonalOrPremiumPlan;

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -81,29 +81,29 @@ const GMClosureNotice = ( {
 	} );
 
 	const mainMessageArgs = {
-		closesAt: closesAt.format( DATE_FORMAT_LONG ),
-		closedUntil: closedUntil.format( DATE_FORMAT_LONG ),
-		reopensAt: reopensAt.format( DATE_FORMAT_LONG ),
+		closed_start_date: closesAt.format( DATE_FORMAT_LONG ),
+		closed_end_date: closedUntil.format( DATE_FORMAT_LONG ),
+		support_resume_date: reopensAt.format( DATE_FORMAT_LONG ),
 	};
 
 	const MAIN_MESSAGES = {
 		before: {
 			hasPlan: translate(
-				'Live chat support will be closed %(closesAt)s through %(closedUntil)s, included. Email support will be open during that time, and we will reopen live chat on %(reopensAt)s.',
+				'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
 				{ args: mainMessageArgs }
 			),
 			nonPlan: translate(
-				'Private support will be closed %(closesAt)s through %(closedUntil)s, included. We will reopen private support on %(reopensAt)s.',
+				'Private support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. We will reopen private support on %(support_resume_date)s.',
 				{ args: mainMessageArgs }
 			),
 		},
 		during: {
 			hasPlan: translate(
-				'Live chat support will be closed through %(closedUntil)s, included. Email support will be open during that time, and we will reopen live chat on %(reopensAt)s.',
+				'Live chat support will be closed through %(closed_end_date)s, included. Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
 				{ args: mainMessageArgs }
 			),
 			nonPlan: translate(
-				'Private support will be closed through %(closedUntil)s, included. We will reopen private support on %(reopensAt)s.',
+				'Private support will be closed through %(closed_end_date)s, included. We will reopen private support on %(support_resume_date)s.',
 				{ args: mainMessageArgs }
 			),
 		},
@@ -129,10 +129,10 @@ const GMClosureNotice = ( {
 	};
 
 	const FORUMS_NOTE = translate(
-		'Our staff will be keeping an eye on the {{forumLink}}Forums{{/forumLink}} for urgent matters.',
+		'Our staff will be keeping an eye on the {{link}}Forums{{/link}} for urgent matters.',
 		{
 			components: {
-				forumLink: <a href="https://en.forums.wordpress.com/forum/support/" />,
+				link: <a href="https://en.forums.wordpress.com/forum/support/" />,
 			},
 		}
 	);
@@ -152,7 +152,7 @@ const GMClosureNotice = ( {
 				{ mainMessage }
 				<br />
 				<br />
-				{ translate( '{{contactLink}}Read more{{/contactLink}}', {
+				{ translate( '{{contactLink}}Read more.{{/contactLink}}', {
 					components: { contactLink: <a href="/help/contact" /> },
 				} ) }
 			</FoldableCard>

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import 'moment-timezone'; // monkey patches the existing moment.js
@@ -150,14 +150,9 @@ const GMClosureNotice = ( {
 				{ mainMessage }
 				<br />
 				<br />
-				{ reason }
-				{ isNonPlan && (
-					<Fragment>
-						<br />
-						<br />
-						{ FORUMS_NOTE }
-					</Fragment>
-				) }
+				{ translate( '{{contactLink}}Read more{{/contactLink}}', {
+					components: { contactLink: <a href="/help/contact" /> },
+				} ) }
 			</FoldableCard>
 		);
 	}

--- a/client/me/help/gm-closure-notice/style.scss
+++ b/client/me/help/gm-closure-notice/style.scss
@@ -1,0 +1,14 @@
+/** @format */
+
+.gm-closure-notice {
+	color: var( --color-neutral-700 );
+	font-size: 14px;
+	&.card.is-compact {
+		margin: 0 0 16px;
+		font-size: 12px;
+
+		a {
+			font-size: 1em;
+		}
+	}
+}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -534,10 +534,10 @@ class HelpContact extends React.Component {
 					<GMClosureNotice
 						compact={ compact }
 						displayAt="2019-08-31 00:00Z"
-						defaultClosesAt="2019-09-06 23:00Z"
-						defaultReopensAt="2019-09-23 04:00Z"
-						businessAndEcommerceClosesAt="2019-09-09 23:00Z"
-						businessAndEcommerceReopensAt="2019-09-19 04:00Z"
+						basicChatClosesAt="2019-09-06 23:00Z"
+						basicChatReopensAt="2019-09-23 04:00Z"
+						priorityChatClosesAt="2019-09-09 23:00Z"
+						priorityChatReopensAt="2019-09-19 04:00Z"
 					/>
 				) }
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -20,6 +20,7 @@ import Card from 'components/card';
 import Notice from 'components/notice';
 import HelpContactForm from 'me/help/help-contact-form';
 import LiveChatClosureNotice from 'me/help/live-chat-closure-notice';
+import GMClosureNotice from 'me/help/gm-closure-notice';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
 import HeaderCake from 'components/header-cake';
 import wpcomLib from 'lib/wp';
@@ -538,6 +539,14 @@ class HelpContact extends React.Component {
 							displayAt="2019-04-18 00:00Z"
 							closesAt="2019-04-21 06:00Z"
 							reopensAt="2019-04-22 06:00Z"
+						/>
+						<GMClosureNotice
+							compact={ compact }
+							displayAt="2019-08-31 00:00Z"
+							defaultClosesAt="2019-09-07 06:00Z"
+							defaultReopensAt="2019-09-23 06:00Z"
+							businessAndEcommerceClosesAt="2019-09-10 06:00Z"
+							businessAndEcommerceReopensAt="2019-09-19 06:00Z"
 						/>
 					</Fragment>
 				) }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -19,7 +19,6 @@ import Main from 'components/main';
 import Card from 'components/card';
 import Notice from 'components/notice';
 import HelpContactForm from 'me/help/help-contact-form';
-import LiveChatClosureNotice from 'me/help/live-chat-closure-notice';
 import GMClosureNotice from 'me/help/gm-closure-notice';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
 import HeaderCake from 'components/header-cake';
@@ -533,13 +532,6 @@ class HelpContact extends React.Component {
 			<div>
 				{ isUserAffectedByLiveChatClosure && (
 					<Fragment>
-						<LiveChatClosureNotice
-							holidayName="Easter"
-							compact={ compact }
-							displayAt="2019-04-18 00:00Z"
-							closesAt="2019-04-21 06:00Z"
-							reopensAt="2019-04-22 06:00Z"
-						/>
 						<GMClosureNotice
 							compact={ compact }
 							displayAt="2019-08-31 00:00Z"

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -534,10 +534,10 @@ class HelpContact extends React.Component {
 					<GMClosureNotice
 						compact={ compact }
 						displayAt="2019-08-31 00:00Z"
-						defaultClosesAt="2019-09-07 06:00Z"
-						defaultReopensAt="2019-09-23 06:00Z"
-						businessAndEcommerceClosesAt="2019-09-10 06:00Z"
-						businessAndEcommerceReopensAt="2019-09-19 06:00Z"
+						defaultClosesAt="2019-09-06 23:00Z"
+						defaultReopensAt="2019-09-23 04:00Z"
+						businessAndEcommerceClosesAt="2019-09-09 23:00Z"
+						businessAndEcommerceReopensAt="2019-09-19 04:00Z"
 					/>
 				) }
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -531,16 +531,14 @@ class HelpContact extends React.Component {
 		return (
 			<div>
 				{ isUserAffectedByLiveChatClosure && (
-					<Fragment>
-						<GMClosureNotice
-							compact={ compact }
-							displayAt="2019-08-31 00:00Z"
-							defaultClosesAt="2019-09-07 06:00Z"
-							defaultReopensAt="2019-09-23 06:00Z"
-							businessAndEcommerceClosesAt="2019-09-10 06:00Z"
-							businessAndEcommerceReopensAt="2019-09-19 06:00Z"
-						/>
-					</Fragment>
+					<GMClosureNotice
+						compact={ compact }
+						displayAt="2019-08-31 00:00Z"
+						defaultClosesAt="2019-09-07 06:00Z"
+						defaultReopensAt="2019-09-23 06:00Z"
+						businessAndEcommerceClosesAt="2019-09-10 06:00Z"
+						businessAndEcommerceReopensAt="2019-09-19 06:00Z"
+					/>
 				) }
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (
 					<Notice


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a reusable GMClosureNotice component to notify users about Automattic's support level over the Grand Meetup.
* Sets up a notice for the 2019 Grand Meetup on the Contact form (both the dedicated page and the Inline Help widget).
* _Clean up:_ Removes the Live Chat Closure Notice for Easter 2019.

<img width="715" alt="Screen Shot 2019-08-29 at 23 40 41" src="https://user-images.githubusercontent.com/555336/63951590-fc779780-cab8-11e9-851a-19cabca7b3fd.png">

#### Testing instructions

1. Open the Inline Help widget or go to `/help/contact`.
2. Alter your system clock to check messages for times before/after the `displayAt`, `defaultCloses/ReopensAt`, and `businessAndEcommerceCloses/ReopensAt` times.

Fixes 663-gh-hg
