### PR TITLE
Improve `MultiCheckbox`: rewrite to typed, functional, propType-free component

### DIFF
--- a/client/components/forms/multi-checkbox/index.jsx
+++ b/client/components/forms/multi-checkbox/index.jsx
@@ -1,12 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { includes, omit } from 'lodash';
 
 export default class MultiCheckbox extends Component {
 	static propTypes = {
@@ -44,20 +40,25 @@ export default class MultiCheckbox extends Component {
 	};
 
 	render() {
-		const { disabled, name, options } = this.props;
-		const checked = this.props.checked || this.state.initialChecked;
+		const {
+			checked,
+			defaultChecked,
+			disabled,
+			onChange,
+			name,
+			options,
+			...otherProps
+		} = this.props;
+		const checkedItems = checked || this.state.initialChecked;
 		return (
-			<div
-				className="multi-checkbox"
-				{ ...omit( this.props, Object.keys( MultiCheckbox.propTypes ) ) }
-			>
+			<div className="multi-checkbox" { ...otherProps }>
 				{ options.map( option => (
 					<label key={ option.value }>
 						<input
 							name={ name + '[]' }
 							type="checkbox"
 							value={ option.value }
-							checked={ includes( checked, option.value ) }
+							checked={ checkedItems.includes( option.value ) }
 							onChange={ this.handleChange }
 							disabled={ disabled }
 						/>

--- a/client/components/forms/multi-checkbox/index.tsx
+++ b/client/components/forms/multi-checkbox/index.tsx
@@ -2,10 +2,39 @@
  * External dependencies
  */
 import React, { useCallback, useRef } from 'react';
-import PropTypes from 'prop-types';
 
-export default function MultiCheckbox( props ) {
-	const { checked, defaultChecked, disabled, onChange, name, options, ...otherProps } = props;
+type OptionValue = number | string;
+
+interface Option {
+	value: OptionValue;
+	label: string;
+}
+
+interface ChangeList {
+	value: OptionValue[];
+}
+
+interface Props {
+	options: Option[];
+	checked?: OptionValue[];
+	defaultChecked?: OptionValue[];
+	onChange?: ( list: ChangeList ) => void;
+	disabled?: boolean;
+	name?: string;
+}
+
+type DivProps = React.ComponentProps< 'div' >;
+
+export default function MultiCheckbox( props: Props & DivProps ) {
+	const {
+		checked,
+		defaultChecked = [] as OptionValue[],
+		disabled = false,
+		onChange = () => {},
+		name = 'multiCheckbox',
+		options,
+		...otherProps
+	} = props;
 
 	// Used to store the initial value of the `defaultChecked` prop. Never updated.
 	// This is done to avoid changing the active items if the defaults change after the initial render.
@@ -14,14 +43,14 @@ export default function MultiCheckbox( props ) {
 	const handleChange = useCallback(
 		event => {
 			const target = event.target;
-			let checkedEventValue = checked || defaultCheckedOnStart.current;
-			checkedEventValue = checkedEventValue.concat( [ target.value ] ).filter( currentValue => {
+			let changeEventValue = checked || defaultCheckedOnStart.current;
+			changeEventValue = changeEventValue.concat( [ target.value ] ).filter( currentValue => {
 				return currentValue !== target.value || target.checked;
 			} );
 
-			onChange( {
-				value: checkedEventValue,
-			} );
+			if ( onChange ) {
+				onChange( { value: changeEventValue } );
+			}
 
 			event.stopPropagation();
 		},
@@ -47,19 +76,3 @@ export default function MultiCheckbox( props ) {
 		</div>
 	);
 }
-
-MultiCheckbox.propTypes = {
-	checked: PropTypes.array,
-	defaultChecked: PropTypes.array,
-	disabled: PropTypes.bool,
-	onChange: PropTypes.func,
-	options: PropTypes.array.isRequired,
-	name: PropTypes.string,
-};
-
-MultiCheckbox.defaultProps = {
-	defaultChecked: Object.freeze( [] ),
-	disabled: false,
-	onChange: () => {},
-	name: 'multiCheckbox',
-};

--- a/client/components/forms/multi-checkbox/test/index.jsx
+++ b/client/components/forms/multi-checkbox/test/index.jsx
@@ -1,110 +1,135 @@
 /**
- * @format
  * @jest-environment jsdom
  */
 
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
-import ReactDom from 'react-dom';
+import ReactDOM from 'react-dom';
+import { act, Simulate } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
  */
 import MultiCheckbox from '../';
 
+let container;
+
 describe( 'index', () => {
 	const options = [ { value: 1, label: 'One' }, { value: 2, label: 'Two' } ];
 
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
 	afterEach( () => {
-		ReactDom.unmountComponentAtNode( document.body );
+		document.body.removeChild( container );
+		ReactDOM.unmountComponentAtNode( container );
+		container = null;
 	} );
 
 	describe( 'rendering', () => {
 		test( 'should render a set of checkboxes', () => {
-			let checkboxes = TestUtils.renderIntoDocument(
-					<MultiCheckbox name="favorite_colors" options={ options } />
-				),
-				labels = TestUtils.scryRenderedDOMComponentsWithTag( checkboxes, 'label' );
+			act( () => {
+				ReactDOM.render( <MultiCheckbox name="favorite_colors" options={ options } />, container );
+			} );
 
-			assert.equal( options.length, labels.length );
-			labels.forEach( function( label, i ) {
-				let labelNode = label,
-					inputNode = labelNode.querySelector( 'input' );
-				assert.equal( 'favorite_colors[]', inputNode.name );
-				assert.equal( options[ i ].value, inputNode.value );
-				assert.equal( options[ i ].label, labelNode.textContent );
+			const labels = container.querySelectorAll( 'label' );
+			expect( labels.length ).toEqual( options.length );
+
+			labels.forEach( ( label, i ) => {
+				const labelNode = label;
+				const inputNode = labelNode.querySelector( 'input' );
+				expect( inputNode.name ).toEqual( 'favorite_colors[]' );
+				expect( inputNode.value ).toEqual( options[ i ].value.toString() );
+				expect( labelNode.textContent ).toEqual( options[ i ].label );
 			} );
 		} );
 
 		test( 'should accept an array of checked values', () => {
-			let checkboxes = TestUtils.renderIntoDocument(
+			act( () => {
+				ReactDOM.render(
 					<MultiCheckbox
 						name="favorite_colors"
 						options={ options }
 						checked={ [ options[ 0 ].value ] }
-					/>
-				),
-				labels = TestUtils.scryRenderedDOMComponentsWithTag( checkboxes, 'label' );
+					/>,
+					container
+				);
+			} );
+			const labels = container.querySelectorAll( 'label' );
 
-			assert.equal( true, labels[ 0 ].querySelector( 'input' ).checked );
-			assert.equal( false, labels[ 1 ].querySelector( 'input' ).checked );
+			expect( labels[ 0 ].querySelector( 'input' ).checked ).toBe( true );
+			expect( labels[ 1 ].querySelector( 'input' ).checked ).toBe( false );
 		} );
 
 		test( 'should accept an array of defaultChecked', () => {
-			let checkboxes = TestUtils.renderIntoDocument(
+			act( () => {
+				ReactDOM.render(
 					<MultiCheckbox
 						name="favorite_colors"
 						options={ options }
 						defaultChecked={ [ options[ 0 ].value ] }
-					/>
-				),
-				labels = TestUtils.scryRenderedDOMComponentsWithTag( checkboxes, 'label' );
+					/>,
+					container
+				);
+			} );
+			const labels = container.querySelectorAll( 'label' );
 
-			assert.equal( true, labels[ 0 ].querySelector( 'input' ).checked );
-			assert.equal( false, labels[ 1 ].querySelector( 'input' ).checked );
+			expect( labels[ 0 ].querySelector( 'input' ).checked ).toBe( true );
+			expect( labels[ 1 ].querySelector( 'input' ).checked ).toBe( false );
 		} );
 
 		test( 'should accept an onChange event handler', done => {
-			let checkboxes = TestUtils.renderIntoDocument(
-					<MultiCheckbox name="favorite_colors" options={ options } onChange={ finishTest } />
-				),
-				labels = TestUtils.scryRenderedDOMComponentsWithTag( checkboxes, 'label' );
-
-			TestUtils.Simulate.change( labels[ 0 ].querySelector( 'input' ), {
-				target: {
-					value: options[ 0 ].value,
-					checked: true,
-				},
-			} );
-
-			function finishTest( event ) {
-				assert.deepEqual( [ options[ 0 ].value ], event.value );
+			const finishTest = event => {
+				expect( event.value ).toEqual( [ options[ 0 ].value ] );
 				done();
-			}
+			};
+
+			act( () => {
+				ReactDOM.render(
+					<MultiCheckbox name="favorite_colors" options={ options } onChange={ finishTest } />,
+					container
+				);
+			} );
+			const labels = container.querySelectorAll( 'label' );
+
+			act( () => {
+				Simulate.change( labels[ 0 ].querySelector( 'input' ), {
+					target: {
+						value: options[ 0 ].value,
+						checked: true,
+					},
+				} );
+			} );
 		} );
 
 		test( 'should accept a disabled boolean', () => {
-			let checkboxes = TestUtils.renderIntoDocument(
-					<MultiCheckbox name="favorite_colors" options={ options } disabled={ true } />
-				),
-				labels = TestUtils.scryRenderedDOMComponentsWithTag( checkboxes, 'label' );
+			act( () => {
+				ReactDOM.render(
+					<MultiCheckbox name="favorite_colors" options={ options } disabled={ true } />,
+					container
+				);
+			} );
+			const labels = container.querySelectorAll( 'label' );
 
-			assert.ok( labels[ 0 ].querySelector( 'input' ).disabled );
-			assert.ok( labels[ 1 ].querySelector( 'input' ).disabled );
+			expect( labels[ 0 ].querySelector( 'input' ).disabled ).toBe( true );
+			expect( labels[ 1 ].querySelector( 'input' ).disabled ).toBe( true );
 		} );
 
 		test( 'should transfer props to the rendered element', () => {
-			let className = 'transferred-class',
-				checkboxes = TestUtils.renderIntoDocument(
-					<MultiCheckbox name="favorite_colors" options={ options } className={ className } />
-				),
-				div = TestUtils.findRenderedDOMComponentWithTag( checkboxes, 'div' );
+			const className = 'transferred-class';
+			act( () => {
+				ReactDOM.render(
+					<MultiCheckbox name="favorite_colors" options={ options } className={ className } />,
+					container
+				);
+			} );
+			const div = container.querySelector( 'div' );
 
-			assert.notEqual( -1, div.className.indexOf( className ) );
+			expect( div.className ).toContain( className );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make `MultiCheckbox` not use propTypes on render.
* Rewrite `MultiCheckbox` as a functional component.
* Update `MultiCheckbox` tests to not rely on it being a class-based component.
* Add types to `MultiCheckbox`.

Fixes one of the issues in #35695.

#### Testing instructions

* Ensure that `MultiCheckbox` continues to work correctly. The best place I've found for this is the sharing button options ("Show like and sharing buttons on") in Marketing.