### PR TITLE
Enable Sign in with Apple in prod

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -80,6 +80,7 @@
 		"rubberband-scroll-disable": false,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"sign-in-with-apple": false,
 		"signup/onboarding-flow": false,
 		"signup/ecommerce-flow": false,
 		"signup/social": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,6 +91,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"sign-in-with-apple": false,
 		"signup/full-site-editing": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -99,6 +99,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"sign-in-with-apple": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This enables SIWA (Sign in with Apple) in production

#### Testing instructions

Should already have been tested internally, with the call for testing

