### PR TITLE
Signup: remove the import in signup ab test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,15 +124,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	showImportFlowInSiteTypeStep: {
-		datestamp: '20190820',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-	},
 	removeBlogFlow: {
 		datestamp: '20190813',
 		variations: {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
+import { isEnabled } from 'config';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import Button from 'components/button';
 import SiteTypeForm from './form';
@@ -54,7 +55,7 @@ class SiteType extends Component {
 	};
 
 	renderImportButton() {
-		if ( 'show' !== abtest( 'showImportFlowInSiteTypeStep' ) ) {
+		if ( ! isEnabled( 'signup/import' ) ) {
 			return null;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -146,6 +146,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": true,
 		"signup/full-site-editing": true,
+		"signup/import": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -117,6 +117,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
+		"signup/import": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `showImportFlowInSiteTypeStep` abtest
* Add `signup/import` feature flag

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that all instances of `showImportFlowInSiteTypeStep` have been removed.
* Check that `signup/import` feature flag is enabled by default in `development` and `wpcalypso` by visiting `/start` and verifying that the import link still appears beneath the site type options on the site type step.
* Verify that when you disable the feature flag (visit http://calypso.localhost:3000/start/site-type?flags=-signup/import) that the link no longer appears beneath the site type step.
