### PR TITLE
Full Site Editing: Update Navigation Menu block markup

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -16,8 +16,9 @@ function render_navigation_menu_block() {
 	$menu = wp_nav_menu(
 		[
 			'echo'           => false,
-			'menu_class'     => 'main-menu',
-			'fallback_cb'    => 'a8c_fse_get_fallback_navigation_menu',
+			'fallback_cb'    => 'get_fallback_navigation_menu',
+			'items_wrap'     => '<ul id="%1$s" class="%2$s" aria-label="submenu">%3$s</ul>',
+			'menu_class'     => 'main-menu footer-menu',
 			'theme_location' => 'menu-1',
 		]
 	);
@@ -26,7 +27,15 @@ function render_navigation_menu_block() {
 	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	?>
 	<nav class="main-navigation wp-block-a8c-navigation-menu">
-		<div class="menu-nav-container">
+		<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
+		<label for="toggle" id="toggle-menu" class="button">
+			<?php esc_html_e( 'Menu', 'full-site-editing' ); ?>
+			<span class="dropdown-icon open">+</span>
+			<span class="dropdown-icon close">&times;</span>
+			<span class="hide-visually expanded-text"><?php esc_html_e( 'expanded', 'full-site-editing' ); ?></span>
+			<span class="hide-visually collapsed-text"><?php esc_html_e( 'collapsed', 'full-site-editing' ); ?></span>
+		</label>
+		<div class="menu-primary-container">
 			<?php echo $menu ? $menu : get_fallback_navigation_menu(); ?>
 		</div>
 	</nav>
@@ -49,7 +58,7 @@ function get_fallback_navigation_menu() {
 			'before'      => false,
 			'container'   => 'ul',
 			'echo'        => false,
-			'menu_class'  => 'main-menu default-menu',
+			'menu_class'  => 'main-menu footer-menu',
 			'sort_column' => 'post_date',
 		]
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the Navigation Menu block markup from Modern Business to Varia format.

_Note: this PR only takes care of the Navigation Menu. Everything else is out of scope and I'm tracking it in a [specific issue](https://github.com/Automattic/wp-calypso/issues/35870). Feel free to add an item over there if I missed something (very likely)._

Currently, the Navigation Menu block renders some markup based upon the Modern Business main navigation component.
With this PR, it renders instead a markup based upon the Varia header navigation.

![Screenshot 2019-08-29 at 20 08 00](https://user-images.githubusercontent.com/2070010/63970138-523d4700-ca9b-11e9-9b3d-d7803ad655b6.png)
![Screenshot 2019-08-29 at 20 16 13](https://user-images.githubusercontent.com/2070010/63970137-523d4700-ca9b-11e9-86e2-9fe2f0ef3e65.png)

There is a caveat: Varia's navigation in the [header](https://github.com/Automattic/themes/blob/33eef2268bba09959ec411c185712b7b5133f94f/varia/header.php#L42-L60) and in the [footer](https://github.com/Automattic/themes/blob/33eef2268bba09959ec411c185712b7b5133f94f/varia/footer.php#L31-L41) are different.
They have different CSS classes (`.main-navigation` vs `.footer-navigation`, etc.) and also different markup (the header version collapses into a toggle button on small screens, while the footer version has no such thing).
This poses a problem as we don't have a way to make a block output different markups depending on the context its in.
My solution consists is a bit twisted, but it seems to work without major issues:
- Add **inside** (not on the `.main-navigation wrapper!) the navigation both the header and footer classes.
- In SCSS, `.main-navigation` extends `.footer-navigation`. Since we can't extend nested classes (e.g. `@extend .footer-navigation .footer menu`), we are constrained to inheriting the whole thing, and so can't just add `.footer-navigation` to the component main wrapper.
- In the header editor, also import the front end's button style (which is not usually imported in the editor to avoid clashing with the core styles), in order to style appropriately the toggle button that appears when the menu is collapsed.
- In the footer, simply hide the toggle button, and force showing the menu as an inline list on all screen sizes.

Note: as it seems, the `.footer-navigation` doesn't really consider submenus.
@iamtakashi is this intentional?
In any case, I've decided to hide the submenus on small screens because they look unstyled, but they look off on large screen as well.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR and https://github.com/Automattic/themes/pull/1364 on an FSE theme with both Varia and Maywood themes installed.
* Activate Maywood.
* Poke around the editor and front end to see if the navigation menu looks good in both the header and the footer, and in all screen sizes.