### PR TITLE
Site Selector: Use text rather than icons for flags in the sidebar for clarity

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -146,18 +146,16 @@ class Site extends React.Component {
 						<div className="site__title">
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ this.props.site.is_private && (
-								<span className="site__badge">
-									<Gridicon icon="lock" size={ 14 } />
-								</span>
+								<span className="site__badge site__badge-private">{ translate( 'Private' ) }</span>
 							) }
 							{ site.options && site.options.is_redirect && (
-								<span className="site__badge">
-									<Gridicon icon="block" size={ 14 } />
+								<span className="site__badge site__badge-redirect">
+									{ translate( 'Redirect' ) }
 								</span>
 							) }
 							{ site.options && site.options.is_domain_only && (
-								<span className="site__badge">
-									<Gridicon icon="domains" size={ 14 } />
+								<span className="site__badge site__badge-domain-only">
+									{ translate( 'Domain' ) }
 								</span>
 							) }
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -144,7 +144,16 @@ class Site extends React.Component {
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />
 					<div className="site__info">
 						<div className="site__title">
-							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+							{ site.title }
+						</div>
+						<div className="site__domain">
+							{ this.props.homeLink
+								? translate( 'View %(domain)s', {
+										args: { domain: site.domain },
+								  } )
+								: site.domain }
+						</div>
+						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ this.props.site.is_private && (
 								<span className="site__badge site__badge-private">{ translate( 'Private' ) }</span>
 							) }
@@ -158,16 +167,7 @@ class Site extends React.Component {
 									{ translate( 'Domain' ) }
 								</span>
 							) }
-							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-							{ site.title }
-						</div>
-						<div className="site__domain">
-							{ this.props.homeLink
-								? translate( 'View %(domain)s', {
-										args: { domain: site.domain },
-								  } )
-								: site.domain }
-						</div>
+						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 					</div>
 					{ this.props.homeLink && this.props.showHomeIcon && (
 						<span className="site__home">

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -173,6 +173,7 @@
 	clear: both;
 	display: inline-block;
 	margin-top: 6px;
+	margin-right: 3px;
 	padding: 1px 10px;
 }
 

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -177,12 +177,13 @@
 	padding: 1px 10px;
 }
 
-.site:hover .site__badge {
+.site__content:hover .site__badge {
 	background: var( --color-sidebar-background );
 	color: var( --color-sidebar-text );
 }
 
-.current-site .site:hover .site__badge {
+.current-site .site__content:hover .site__badge,
+.purchases-site .site__content:hover .site__badge {
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
 }

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -175,3 +175,13 @@
 	margin-top: 6px;
 	padding: 1px 10px;
 }
+
+.site:hover .site__badge {
+	background: var( --color-sidebar-background );
+	color: var( --color-sidebar-text );
+}
+
+.current-site .site:hover .site__badge {
+	background: var( --color-sidebar-menu-hover-background );
+	color: var( --color-sidebar-menu-hover-text );
+}

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -166,8 +166,8 @@
 }
 
 .site__badge {
-	background: var( --sidebar-menu-hover-background );
-	color: var( --sidebar-menu-hover-color );
+	background: var( --color-sidebar-menu-hover-background );
+	color: var( --color-sidebar-menu-hover-text );
 	font-size: 12px;
 	border-radius: 12px;
 	margin-right: 4px;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -170,8 +170,8 @@
 	color: var( --color-sidebar-menu-hover-text );
 	font-size: 12px;
 	border-radius: 12px;
-	margin-right: 4px;
+	clear: both;
 	display: inline-block;
-	padding: 2px 10px;
-	vertical-align: baseline;
+	margin-top: 6px;
+	padding: 1px 10px;
 }

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -92,7 +92,7 @@
 	height: 30px;
 	width: 30px;
 	overflow: hidden;
-	align-self: center;
+	align-self: flex-start;
 	margin-right: 8px;
 	flex: 0 0 auto;
 }
@@ -108,7 +108,7 @@
 	display: block;
 	font-size: 13px;
 	font-weight: 400;
-	line-height: 1.4;
+	line-height: 1.3;
 }
 
 .site__domain {
@@ -117,6 +117,7 @@
 	max-width: 95%;
 	font-size: 11px;
 	line-height: 1.4;
+	margin-top: 2px;
 }
 
 .site__title,
@@ -143,7 +144,7 @@
 	transform: translate3d( 0, 0, 0 );
 	position: absolute;
 	left: 16px;
-	top: 17px;
+	top: 16px;
 
 	.gridicon {
 		margin-top: 5px;
@@ -165,7 +166,12 @@
 }
 
 .site__badge {
-	color: var( --color-neutral );
+	background: var( --sidebar-menu-hover-background );
+	color: var( --sidebar-menu-hover-color );
+	font-size: 12px;
+	border-radius: 12px;
 	margin-right: 4px;
-	vertical-align: middle;
+	display: inline-block;
+	padding: 2px 10px;
+	vertical-align: baseline;
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -160,11 +160,7 @@
 	.site__domain::after {
 		@include long-content-fade( $color: var( --color-sidebar-background-rgb ) );
 	}
-	
-	.site__badge {
-		color: var( --color-sidebar-gridicon-fill );
-	}
-	
+
 	.site-selector {
 		&.is-large .site-selector__sites {
 			border-color: var( --color-sidebar-border );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Same changes as in #35241 but this also updates the other types of icons (Redirect and Domain Only) to use text rather than an icon for clarity.
* I'm not clear about what a "domain-only" site is, so I'm not sure how we should refer to it in text, or how to make that appear for testing purposes.

**Before**

<img width="273" alt="Screen Shot 2019-09-24 at 12 18 37 PM" src="https://user-images.githubusercontent.com/2124984/65530210-7edf5580-dec5-11e9-8a5a-33ebe81665a9.png">

**After**

<img width="273" alt="Screen Shot 2019-09-24 at 12 17 59 PM" src="https://user-images.githubusercontent.com/2124984/65530232-87379080-dec5-11e9-9d53-bed800e961ee.png">

#### Testing instructions

* Switch to this PR
* Check the sidebar on a site that is private; you should see the above site privacy flag next to the domain.
* Check sites that are only used as redirects to ensure you see the "Redirect" text and style rather than an icon
* I don't know how to get the domain-only flag to appear.
* Check other color schemes to ensure there's sufficient contrast.
* Check other instances of the site selector (Write button in the masterbar, site selector when viewing a URL that has no site specified) to ensure they appear as expected.