### PR TITLE
Customer Home: hide Customizer links for Full Site Editing sites

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -38,6 +38,7 @@ import QuerySiteChecklist from 'components/data/query-site-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 /**
  * Style dependencies
@@ -167,6 +168,7 @@ class Home extends Component {
 			expandToolsAndTrack,
 			isStaticHomePage,
 			staticHomePageId,
+			showCustomizer,
 		} = this.props;
 		const editHomePageUrl =
 			isStaticHomePage && `/block-editor/page/${ siteSlug }/${ staticHomePageId }`;
@@ -234,12 +236,14 @@ class Home extends Component {
 									iconSrc="/calypso/images/customer-home/comment.svg"
 								/>
 							) }
-							<ActionBox
-								href={ customizeUrl }
-								onClick={ () => trackAction( 'my_site', 'customize_theme' ) }
-								label={ translate( 'Customize theme' ) }
-								iconSrc="/calypso/images/customer-home/customize.svg"
-							/>
+							{ showCustomizer && (
+								<ActionBox
+									href={ customizeUrl }
+									onClick={ () => trackAction( 'my_site', 'customize_theme' ) }
+									label={ translate( 'Customize theme' ) }
+									iconSrc="/calypso/images/customer-home/customize.svg"
+								/>
+							) }
 							<ActionBox
 								onClick={ () => {
 									trackAction( 'my_site', 'change_theme' );
@@ -248,12 +252,14 @@ class Home extends Component {
 								label={ translate( 'Change theme' ) }
 								iconSrc="/calypso/images/customer-home/theme.svg"
 							/>
-							<ActionBox
-								href={ menusUrl }
-								onClick={ () => trackAction( 'my_site', 'edit_menus' ) }
-								label={ translate( 'Edit menus' ) }
-								iconSrc="/calypso/images/customer-home/menus.svg"
-							/>
+							{ showCustomizer && (
+								<ActionBox
+									href={ menusUrl }
+									onClick={ () => trackAction( 'my_site', 'edit_menus' ) }
+									label={ translate( 'Edit menus' ) }
+									iconSrc="/calypso/images/customer-home/menus.svg"
+								/>
+							) }
 							<ActionBox
 								href={ `/media/${ siteSlug }` }
 								onClick={ () => trackAction( 'my_site', 'change_images' ) }
@@ -379,6 +385,7 @@ const connectHome = connect(
 			isSiteEligible: isSiteEligibleForCustomerHome( state, siteId ),
 			isStaticHomePage: 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 			staticHomePageId: getSiteFrontPage( state, siteId ),
+			showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
 		};
 	},
 	dispatch => ( {


### PR DESCRIPTION
Hide **Customize theme** and **Edit menus** links in Customer Home for sites with Full Site Editing active

This is needed before #35181 can ship.

### Testing instructions

1. To obtain a site with Full Site Editing active, create a **new user** and new site through ttp://calypso.localhost:3000/start/test-fse
2. If you do not see "Home" for your new site, you can select it here 
  <img width="527" alt="image" src="https://user-images.githubusercontent.com/195089/63977849-7b011480-ca7a-11e9-9d70-1311b93c50d9.png">
3. Your site should now no longer have the "Customize theme" or "Edit menus" links. Both of these matters are taken care of inside the block editor under Full Site Editing

#### BEFORE:
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/195089/63978018-eb0f9a80-ca7a-11e9-9e54-8df7a56410b8.png">


#### AFTER:
![image](https://user-images.githubusercontent.com/195089/63977914-b00d6700-ca7a-11e9-9af8-627c1aadca7c.png)

