### PR TITLE
FSE: Fix header and footer editor styles in 6.4.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -13,6 +13,11 @@
 	.edit-post-visual-editor {
 		margin-top: 20px;
 		padding-top: 0;
+
+		.block-editor-writing-flow__click-redirect {
+			// override core for FSE header and footer editing
+			height: 50px;
+		}
 	}
 
 	.editor-post-switch-to-draft {


### PR DESCRIPTION
In Gutenberg 6.4, styles were introduced for the typewriter feature that interfere with our editor styles for Full Site Editing (specifically while editing headers and footers):

<img width="1658" alt="Screen Shot 2019-08-29 at 3 22 53 PM" src="https://user-images.githubusercontent.com/349751/63980573-ea720680-ca70-11e9-8f9e-a1cbfa7a3cc1.png">

Restoring the previous styles does not seem to interfere with typewriter behaviour, so let's put them back to as they were for 6.2, but only while editing `wp_template`s.

#### Testing instructions

* Load this branch in your FSE testing environment.
* Make sure you're using Gutenberg 6.4.
* Load a page populated by FSE (that has an FSE header and footer).
* Edit the header, and verify that the visual editing container is only the size of the header itself, like in the "Expected" image above.

Fixes #35848 
