### PR TITLE
Create GM Closure Notice for Support Sessions

### DIFF
--- a/client/me/concierge/shared/gm-closure-notice.js
+++ b/client/me/concierge/shared/gm-closure-notice.js
@@ -1,0 +1,76 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import 'moment-timezone'; // monkey patches the existing moment.js
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card/compact';
+import { useLocalizedMoment } from 'components/localized-moment';
+
+const DATE_FORMAT = 'dddd, MMMM Do LT';
+
+const GMClosureNotice = ( { closesAt, displayAt, reopensAt } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	const currentDate = moment();
+	const guessedTimezone = moment.tz.guess();
+
+	if ( ! currentDate.isBetween( displayAt, reopensAt ) ) {
+		return null;
+	}
+
+	let message;
+
+	if ( currentDate.isBefore( closesAt ) ) {
+		message = translate(
+			'{{strong}}Note:{{/strong}} Support sessions will not be available between %(closesAt)s and %(reopensAt)s.',
+			{
+				args: {
+					closesAt: moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
+					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
+				},
+				components: {
+					strong: <strong />,
+				},
+			}
+		);
+	} else {
+		message = translate(
+			'{{strong}}Note:{{/strong}} Support sessions are not available before %(reopensAt)s.',
+			{
+				args: {
+					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
+				},
+				components: {
+					strong: <strong />,
+				},
+			}
+		);
+	}
+
+	const reason = translate(
+		'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together to work on improving our services, building new features, and learning how to better serve our customers like you. But never fear! If you need help in the meantime, you can submit an email ticket through the contact form: {{contactLink}}https://wordpress.com/help/contact{{/contactLink}}',
+		{
+			components: {
+				contactLink: <a href="/help/contact" />,
+			},
+		}
+	);
+
+	return (
+		<Card>
+			<p>{ message }</p>
+			<p>{ reason }</p>
+		</Card>
+	);
+};
+
+export default GMClosureNotice;

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -9,7 +9,7 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
-import ClosureNotice from '../shared/closure-notice';
+import GMClosureNotice from '../shared/gm-closure-notice';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
 import { localize } from 'i18n-calypso';
@@ -21,17 +21,10 @@ class PrimaryHeader extends Component {
 
 		return (
 			<Fragment>
-				<ClosureNotice
-					holidayName="Christmas"
-					displayAt="2018-12-17 00:00Z"
-					closesAt="2018-12-24 00:00Z"
-					reopensAt="2018-12-26 07:00Z"
-				/>
-				<ClosureNotice
-					holidayName="New Year's Day"
-					displayAt="2018-12-26 07:00Z"
-					closesAt="2019-01-01 00:00Z"
-					reopensAt="2019-01-02 07:00Z"
+				<GMClosureNotice
+					displayAt="2019-09-03 00:00Z"
+					closesAt="2019-09-10 00:00Z"
+					reopensAt="2019-09-19 04:00Z"
 				/>
 				<Card>
 					<img


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Creates a re-usable component to notify Support Sessions when there is a closure due to the GM.

#### Testing instructions

Go to http://calypso.localhost:3000/me/concierge/ and pick a site on a Business plan. Then open your computer's time and date settings to view in the following contexts:

- When viewing before September 3 @ 0:00 UTC no notice should be seen
- When viewing between September 3 @ 0:00 UTC and September 10 @ 0:00 UTC, you'll see this message:  
  <img width="857" alt="Screen Shot 2019-09-03 at 10 29 32 PM" src="https://user-images.githubusercontent.com/518059/63991387-3347b080-caad-11e9-9013-38418af0c2f0.png">
- When viewing between September 10 @ 0:00 UTC and September 19 @ 4:00 UTC, you'll see this message:  
  <img width="857" alt="Screen Shot 2019-09-10 at 10 30 23 PM" src="https://user-images.githubusercontent.com/518059/63991415-56726000-caad-11e9-8820-1d3dfce5c5f5.png">
- When viewing after September 19 @ 4:00 UTC, no notice should be seen. 
