### PR TITLE
Revert "Refactor the post checkout code"

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -18,8 +18,6 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import WpcomChecklist from './wpcom-checklist';
 import ChecklistShowShare from './share';
 import GetAppsBlock from 'blocks/get-apps';
-import QueryActiveTheme from 'components/data/query-active-theme';
-import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 
 /**
  * State dependencies
@@ -29,7 +27,6 @@ import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite, isNewSite } from 'state/sites/selectors';
-import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
 
 /**
  * Style dependencies
@@ -73,7 +70,7 @@ class ChecklistMain extends PureComponent {
 	 * @return {String} The translated string
 	 */
 	getSubHeaderText() {
-		const { displayMode, currentTheme, translate } = this.props;
+		const { displayMode, translate } = this.props;
 
 		switch ( displayMode ) {
 			case 'gsuite':
@@ -96,19 +93,6 @@ class ChecklistMain extends PureComponent {
 					{
 						args: {
 							email: this.props.user.email,
-						},
-					}
-				);
-
-			case 'theme':
-				return translate(
-					'Your theme %(themeName)s by %(themeAuthor)s is now active on your site. ' +
-						"Now that your site has been created, it's time to get it ready for you to share. " +
-						"We've prepared a list of things that will help you get there quickly.",
-					{
-						args: {
-							themeName: currentTheme && currentTheme.name,
-							themeAuthor: currentTheme && currentTheme.author,
 						},
 					}
 				);
@@ -178,7 +162,7 @@ class ChecklistMain extends PureComponent {
 	}
 
 	render() {
-		const { displayMode, siteId, currentThemeId, translate } = this.props;
+		const { displayMode, siteId, translate } = this.props;
 
 		let translatedTitle = translate( 'Site Checklist' );
 		let title = 'Site Checklist';
@@ -195,8 +179,6 @@ class ChecklistMain extends PureComponent {
 				<SidebarNavigation />
 				<DocumentHead title={ translatedTitle } />
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-				{ siteId && 'theme' === displayMode && <QueryActiveTheme siteId={ siteId } /> }
-				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 				{ this.renderHeader() }
 				<WpcomChecklist updateCompletion={ this.handleCompletionUpdate } viewMode="checklist" />
 			</Main>
@@ -204,16 +186,10 @@ class ChecklistMain extends PureComponent {
 	}
 }
 
-export default connect( ( state, props ) => {
+export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
-	let themeInfo = {};
-	if ( props.displayMode && 'theme' === props.displayMode ) {
-		const currentThemeId = getActiveTheme( state, siteId );
-		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
-		themeInfo = { currentTheme, currentThemeId };
-	}
 
 	return {
 		isAtomic,
@@ -223,6 +199,5 @@ export default connect( ( state, props ) => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		user: getCurrentUser( state ),
-		...themeInfo,
 	};
 } )( localize( ChecklistMain ) );

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -443,6 +443,9 @@ export class CheckoutThankYou extends React.Component {
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } { ...planProps } />
 				</Main>
 			);
+		} else if ( wasJetpackPlanPurchased ) {
+			page( `/plans/my-plan/${ this.props.siteId }?thank-you&install=all` );
+			return null;
 		}
 
 		if ( this.props.domainOnlySiteFlow && purchases.length > 0 && ! failedPurchases.length ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -17,7 +17,6 @@ export function generateFlows( {
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
 	getThankYouNoSiteDestination = noop,
-	getChecklistThemeDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -105,9 +104,9 @@ export function generateFlows( {
 
 		'with-theme': {
 			steps: [ 'domains-theme-preselected', 'plans', 'user' ],
-			destination: getChecklistThemeDestination,
+			destination: getSiteDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
-			lastModified: '2019-08-20',
+			lastModified: '2016-01-27',
 		},
 
 		main: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -57,16 +57,11 @@ function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
 
-function getChecklistThemeDestination( dependencies ) {
-	return `/checklist/${ dependencies.siteSlug }?d=theme`;
-}
-
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
 	getSignupDestination,
 	getThankYouNoSiteDestination,
-	getChecklistThemeDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -58,6 +58,7 @@ import EmailClient from '../lib/email-client.js';
 import NewUserRegistrationUnavailableComponent from '../lib/components/new-user-domain-registration-unavailable-component';
 import DeleteAccountFlow from '../lib/flows/delete-account-flow';
 import DeletePlanFlow from '../lib/flows/delete-plan-flow';
+import ThemeDialogComponent from '../lib/components/theme-dialog-component';
 import SignUpStep from '../lib/flows/sign-up-step';
 
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
@@ -1383,7 +1384,10 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+		step( 'Can see the theme thanks dialog', async function() {
+			const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
+			await themeDialogComponent.goToThemeDetail();
+		} );
 
 		step( 'Can delete the plan', async function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'theme' );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#35283

Reverting because on staging, for an unknown reason the sandbox checkout payment is not completing in FF, even though it works in Chrome. 

