### PR TITLE
Customer Home: rename navigation menu item Home to My Home

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -6,7 +6,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { format as formatUrl, parse as parseUrl } from 'url';
 import { memoize } from 'lodash';
 
@@ -182,7 +182,7 @@ export class MySitesSidebar extends Component {
 
 		const itemProps = isCustomerHomeEnabled
 			? {
-					label: translate( 'Home' ),
+					label: translate( 'My Home' ),
 					selected: itemLinkMatches( [ '/home' ], path ),
 					link: '/home' + siteSuffix,
 			  }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* rename Home to My Home

<img width="276" alt="Screen Shot 2019-08-30 at 09 11 47" src="https://user-images.githubusercontent.com/1041600/64019732-52266100-cb06-11e9-90cb-cdc1dcace5ad.png">

#### Testing instructions

* ensure the navigation item says My Home not Home

Fixes #35900
