### PR TITLE
Deprecate createReducer[WithValidation].

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -123,6 +123,14 @@ module.exports = {
 						importNames: [ 'combineReducers' ],
 						message: "`combineReducers` should be imported from 'state/utils', not 'redux'.",
 					},
+					// Deprecate createReducer and createReducerWithValidation.
+					{
+						name: 'state/utils',
+						importNames: [ 'createReducer', 'createReducerWithValidation' ],
+						message:
+							'This method is deprecated; please use a plain reducer function ' +
+							'and wrap it with `withSchemaValidation` if it needs schema validation.',
+					},
 					// Use fetch instead of superagent.
 					{
 						name: 'superagent',

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -159,16 +159,16 @@ const hexPersister = ( state = 0, { type } ) => {
 	switch ( type ) {
 		case INCREMENT:
 			return state + 1;
-		
+
 		case DECREMENT:
 			return state - 1;
-		
+
 		case DESERIALIZE:
 			return parseInt( state, 16 );
-		
+
 		case SERIALIZE:
 			return state.toString( 16 );
-		
+
 		default:
 			return state;
 	}
@@ -183,11 +183,9 @@ hexNumbers.hasCustomPersistence = true;
 When Calypso boots up it loads the last-known state out of persistent storage in the browser.
 If that state was saved from an old version of the reducer code it could be incompatible with the new state model.
 Thankfully we are given the ability to validate the schema and conditionally load the persisted state only if it's valid.
-This can be done by passing a schema into a call to `createReducer()`, but sometimes `createReducer()` provides more abstraction than is necessary.
 
 This helper produces a new reducer given an original reducer and schema.
 The new reducer will automatically validate the persisted state when Calypso loads and reinitialize if it isn't valid.
-It is in most regards a lightweight version of `createReducer()`.
 
 #### Example
 

--- a/client/state/utils/create-reducer-with-validation.js
+++ b/client/state/utils/create-reducer-with-validation.js
@@ -10,6 +10,8 @@ import { createBaseReducer } from './create-base-reducer';
  * passing both the current state and action object. Defines default
  * serialization (persistence) handlers based on the presence of a schema.
  *
+ * @deprecated Use a plain reducer function wrapped with `withSchemaValidation` instead.
+ *
  * @param  {*}        initialState   Initial state
  * @param  {Object}   handlers       Object mapping action types to state action handlers
  * @param  {?Object}  schema         JSON schema object for deserialization validation

--- a/client/state/utils/create-reducer.js
+++ b/client/state/utils/create-reducer.js
@@ -11,6 +11,8 @@ import { createBaseReducer } from './create-base-reducer';
  * of invoking the handler key corresponding with the dispatched action type,
  * passing both the current state and action object.
  *
+ * @deprecated Use a plain reducer function instead.
+ *
  * @param  {*}        initialState   Initial state
  * @param  {Object}   handlers       Object mapping action types to state action handlers
  * @return {Function}                Reducer function
@@ -18,7 +20,8 @@ import { createBaseReducer } from './create-base-reducer';
 export function createReducer( initialState, handlers, __deprecatedArg__ ) {
 	if ( __deprecatedArg__ !== undefined ) {
 		throw new Error(
-			'Schema support in createReducer is no longer available. Please use createReducerWithValidation instead.'
+			'Schema support in createReducer is no longer available. ' +
+				'Please use a plain reducer function wrapped with `withSchemaValidation`.'
 		);
 	}
 	const reducer = createBaseReducer( initialState, handlers );

--- a/docs/data-persistence.md
+++ b/docs/data-persistence.md
@@ -39,22 +39,42 @@ Because browser storage is only capable of storing simple JavaScript objects, th
 type reducer handler is to return a plain object representation. In a subtree that uses Immutable.js it should be
 similar to:
 ```javascript
-export const items = createReducer( defaultState, {
-	[THEMES_RECEIVE]: ( state, action ) => // ...
-	[SERIALIZE]: state => state.toJS()
-} );
+export function items( state = defaultState, action ) {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE:
+			return // ...
+		case SERIALIZE:
+			return state.toJS();
+		default:
+			return state;
+	}
+}
+items.hasCustomPersistence = true;
 ```
+
+Be sure to set `hasCustomPersistence` to true, in order to indicate that you have special handling for these actions.
 
 In turn, when the store instance is initialized with the browser storage copy of state, you can convert
 your subtree state back to its expected format from the `DESERIALIZE` handler. In a subtree that uses Immutable.js
 instead of returning a plain object, we create an Immutable.js instance:
 ```javascript
-export const items = createReducer( defaultState, {
-	[THEMES_RECEIVE]: ( state, action ) => // ...
-	[DESERIALIZE]: state => fromJS( state )
-} );
+export function items( state = defaultState, action ) {
+	switch ( action.type ) {
+		case THEMES_RECEIVE:
+			return // ...
+		case DESERIALIZE:
+			return fromJS( state );
+		default:
+			return state;
+	}
+}
+items.hasCustomPersistence = true;
 ```
-If your reducer state can be serialized by the browser without additional work (eg a plain object, string or boolean),
+
+Once again, be sure to set `hasCustomPersistence` to true, in order to indicate that you have special handling for
+these actions.
+
+If your reducer state can be serialized by the browser without additional work (e.g. a plain object, string or boolean),
 the `SERIALIZE` and `DESERIALIZE` handlers are not needed. However, please note that the subtree can still see errors
 from changing data shapes, as described below.
 
@@ -103,12 +123,17 @@ export const itemsSchema = {
 A JSON Schema must be provided if the subtree chooses to persist state. If we find that our persisted data doesn't
 match our described data shape, we should throw it out and rebuild that section of the tree with our default state.
 
-You can use `createReducerWithValidation` similarly to `createReducer`, passing the schema as the third param, and all
+You can use `withSchemaValidation` to wrap a plain reducer, passing the schema as the first param, and all
 that will be handled for you.
 ```javascript
-export const items = createReducerWithValidation( defaultState, {
-	[THEMES_RECEIVE]: ( state, action ) => // ...
-}, itemsSchema );
+export const items = withSchemaValidation( itemsSchema, ( state = defaultState, action ) => {
+	switch ( action.type ) {
+		case THEMES_RECEIVE:
+			return // ...
+		default:
+			return state;
+	}
+} );
 ```
 
 If you are not satisfied with the default handling, it is possible to implement your own `SERIALIZE` and
@@ -145,15 +170,17 @@ and another one for `reader` key. Both objects will be stored as two distinct ro
 When booting Calypso, we initially load only the `root` stored state. The `reader` key is loaded and deserialized only
 when the `reader` reducer is being added dynamically.
 
-### Opt-in to Persistence ( [#13542](https://github.com/Automattic/wp-calypso/pull/13542) )
+### Opt-in to Persistence
 
-If we choose not to use `createReducer` we can opt-in to persistence by adding a schema as a property on the reducer.
-We do this by combining all of our reducers using `combineReducers` from `state/utils` at every level of the tree instead
+Note that we opt-in to persistence simply by wrapping the reducer with `withSchemaValidation`.
+`withSchemaValidation` returns a wrapped reducer that validates on `DESERIALIZE` if a schema is present and returns
+initial state on both `SERIALIZE` and `DESERIALIZE` if a schema is not present.
+
+In Calypso, we combine all of our reducers using `combineReducers` from `state/utils` at every level of the tree instead
 of the default implementation of [combineReducers](http://redux.js.org/docs/api/combineReducers.html) from `redux`.
-Each reducer is then wrapped with `withSchemaValidation` which returns a wrapped reducer that validates on `DESERIALIZE`
-if a schema is present and returns initial state on both `SERIALIZE` and `DESERIALIZE` if a schema is not present.
+The custom `combineReducers` handles persistence for the reducers it's combining.
 
-To opt-out of persistence we combine the reducers without any attached schema.
+To opt-out of persistence we simply combine reducers without any attached schema.
 ```javascript
 return combineReducers( {
     age,
@@ -161,10 +188,10 @@ return combineReducers( {
 } );
 ```
 
-To persist, we add the schema by wrapping the reducer with the `withValidation` util:
+To persist, we add the schema by wrapping the reducer with the `withSchemaValidation` util:
 ```javascript
 return combineReducers( {
-    age: withValidation( ageSchema, age ),
+    age: withSchemaValidation( ageSchema, age ),
     height,
 } );
 ```


### PR DESCRIPTION
These methods don't add much anymore, and it's best to use plain reducer functions (wrapped with `withSchemaValidation` when schema validation is needed) instead.

Note that `createReducer`-based reducers that implement custom serialization (i.e., respond to `SERIALIZE` or `DESERIALIZE` actions) will need to explicitly set `hasCustomPersistence` to `true` when converted to plain reducer functions, since `createReducer` can no longer do it for them.

```js
export function items( state = defaultState, action ) {
  switch ( action.type ) {
    case THEMES_RECEIVE:
      return // ...
    case DESERIALIZE:
      return fromJS( state );
    default:
      return state;
  }
}
items.hasCustomPersistence = true;
```

This PR is a follow-up to #35576, where deprecating the two methods was proposed.

#### Changes proposed in this Pull Request

* Deprecate `createReducer` and `createReducerWithValidation` in JSDoc and with a lint rule.
* Update a couple of docs that mention the deprecated methods.

#### Testing instructions

Open a file that imports `createReducer` or `createReducerWithValidation`, and ensure that import is marked with a linting error.
