### PR TITLE
Adding context to string

### DIFF
--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -117,7 +117,7 @@ export class ImageEditorToolbar extends Component {
 		const items = [
 			{
 				action: AspectRatios.FREE,
-				label: translate( 'Free', {context: 'Crop option in image editor'} ),
+				label: translate( 'Freeform', {context: 'Crop option in image editor for freeform aspect ratio tool'} ),
 			},
 			{
 				action: AspectRatios.ORIGINAL,

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -117,7 +117,7 @@ export class ImageEditorToolbar extends Component {
 		const items = [
 			{
 				action: AspectRatios.FREE,
-				label: translate( 'Free' ),
+				label: translate( 'Free', {context: 'Crop option in image editor'} ),
 			},
 			{
 				action: AspectRatios.ORIGINAL,

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -117,7 +117,7 @@ export class ImageEditorToolbar extends Component {
 		const items = [
 			{
 				action: AspectRatios.FREE,
-				label: translate( 'Freeform', {context: 'Crop option in image editor for freeform aspect ratio tool'} ),
+				label: translate( 'Freeform', {context: 'Option in image editor used to crop images using freeform aspect ratio'} ),
 			},
 			{
 				action: AspectRatios.ORIGINAL,


### PR DESCRIPTION
Adding 'context' to the string 'Free' to distinguish between free (price) and free (without constraint). This will allow translators to provide an accurate translation.