### PR TITLE
Jetpack Connection Flow: new `close_window_after_login` param

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -5,7 +5,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import debugModule from 'debug';
-import Gridicon from 'gridicons';
 import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight, get, includes, startsWith } from 'lodash';
@@ -23,6 +22,7 @@ import Disclaimer from './disclaimer';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
+import Gridicon from 'components/gridicon';
 import HelpButton from './help-button';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isVipSite from 'state/selectors/is-vip-site';

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -116,12 +116,17 @@ export class JetpackAuthorize extends Component {
 	UNSAFE_componentWillMount() {
 		const { recordTracksEvent, isMobileAppFlow } = this.props;
 
-		const { from, clientId } = this.props.authQuery;
+		const { from, clientId, closeWindowAfterLogin } = this.props.authQuery;
 		const tracksProperties = {
 			from,
 			is_mobile_app_flow: isMobileAppFlow,
 			site: clientId,
 		};
+
+		if ( closeWindowAfterLogin && typeof window !== 'undefined' ) {
+			debug( 'Closing window after login' );
+			window.close();
+		}
 
 		recordTracksEvent( 'calypso_jpc_authorize_form_view', tracksProperties );
 		recordTracksEvent( 'calypso_jpc_auth_view', tracksProperties );

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -124,6 +124,9 @@ export class JetpackAuthorize extends Component {
 		};
 
 		if ( closeWindowAfterLogin && typeof window !== 'undefined' ) {
+			// Certain connection flows may complete the login step within a popup window.
+			// In these cases, we'll want to automatically close the window when the login
+			// step is complete, and continue authorization in the parent window.
 			debug( 'Closing window after login' );
 			window.close();
 		}

--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -21,6 +21,7 @@ export const authorizeQueryDataSchema = {
 		auth_approved: { type: 'string' },
 		blogname: { type: 'string' },
 		client_id: { pattern: '^\\d+$', type: 'string' },
+		close_window_after_login: { type: 'string' },
 		from: { type: 'string' },
 		home_url: { type: 'string' },
 		jp_version: { type: 'string' },

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -20,6 +20,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
             "authApproved": false,
             "blogname": "Example Blog",
             "clientId": 98765,
+            "closeWindowAfterLogin": false,
             "from": "banner-44-slide-1-dashboard",
             "homeUrl": "http://an.example.site",
             "jpVersion": "5.4",
@@ -73,7 +74,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         <LoggedOutFormLinkItem
           href="http://an.example.site/wp-admin/admin.php?page=jetpack"
         >
-          <t
+          <Memo([object Object])
             icon="arrow-left"
             size={18}
           />

--- a/client/jetpack-connect/test/__snapshots__/utils.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/utils.js.snap
@@ -6,6 +6,7 @@ Object {
   "authApproved": false,
   "blogname": "Just Another WordPress.com Site",
   "clientId": 12345,
+  "closeWindowAfterLogin": false,
   "from": "[unknown]",
   "homeUrl": "https://yourjetpack.blog",
   "jpVersion": null,

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -35,6 +35,7 @@ const DEFAULT_PROPS = deepFreeze( {
 		authApproved: false,
 		blogname: 'Example Blog',
 		clientId: CLIENT_ID,
+		closeWindowAfterLogin: false,
 		from: 'banner-44-slide-1-dashboard',
 		homeUrl: `http://${ SITE_SLUG }`,
 		jpVersion: '5.4',

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -75,6 +75,7 @@ describe( 'parseAuthorizationQuery', () => {
 			_wp_nonce: 'foobar',
 			blogname: 'Just Another WordPress.com Site',
 			client_id: '12345',
+			closeWindowAfterLogin: false,
 			home_url: 'https://yourjetpack.blog',
 			redirect_uri: 'https://yourjetpack.blog/wp-admin/admin.php',
 			scope: 'administrator:34579bf2a3185a47d1b31aab30125d',

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -17,6 +17,7 @@ export function authQueryTransformer( queryObject ) {
 	return {
 		// Required
 		clientId: parseInt( queryObject.client_id, 10 ),
+		closeWindowAfterLogin: !! queryObject.close_window_after_login,
 		homeUrl: queryObject.home_url,
 		nonce: queryObject._wp_nonce,
 		redirectUri: queryObject.redirect_uri,


### PR DESCRIPTION
If this URL param is present and truthy, we'll close the window after logging in and reaching the authorization screen.

Some context: Jetpack is launching a new connection flow that takes place entirely within the wp-admin of a Jetpack site. During that flow, if a user needs to login to WordPress.com, a popup window will open to facilitate the login. After the login is complete, we'll want to close the popup window automatically from within the Calypso app.

#### Changes proposed in this Pull Request

* The Jetpack Authorization State will now persist a `closeWindowAfterLogin` parameter, which will be translated from a URL parameter.

#### Testing instructions

- Get this pumpkin running on calypso.localhost:3000 ⚡️ 
- On a jetpack test site, run https://github.com/Automattic/jetpack/pull/13369
- Set these constants on your Jetpack site:
```
define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );
define( 'CALYPSO_ENV', 'development' );
```
- While logged out of wordpress.com, try to connect
- Can you login / create a new account?
