### PR TITLE
Fix padding issues in previews

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -241,7 +241,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 // Preview adjustments.
 // Tweak styles which are inside of the preview container.
-.block-editor-block-preview__container {
+.block-editor-block-preview__container,
+.template-selector-preview {
 	.editor-styles-wrapper {
 		.wp-block {
 			width: 100%;
@@ -282,6 +283,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			}
 		}
 
+		// Fix upstream: https://github.com/WordPress/gutenberg/pull/17202.
+		.block-editor-block-list__layout,
+		.block-editor-block-list__block {
+			padding: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
Let's us use the style fixes while waiting for https://github.com/WordPress/gutenberg/pull/17202.


#### Before/After Services template
![Screen Shot 2019-08-30 at 8 53 50 AM](https://user-images.githubusercontent.com/1398304/64034598-d4f9ec80-cb03-11e9-82aa-3ce7e2160be7.png)
![Screen Shot 2019-08-30 at 8 52 47 AM](https://user-images.githubusercontent.com/1398304/64034596-d4615600-cb03-11e9-89a5-928b7b922e30.png)

#### Before/After Team template
![Screen Shot 2019-08-30 at 8 53 59 AM](https://user-images.githubusercontent.com/1398304/64034600-d4f9ec80-cb03-11e9-9da3-7637791922cb.png)
![Screen Shot 2019-08-30 at 8 53 02 AM](https://user-images.githubusercontent.com/1398304/64034597-d4615600-cb03-11e9-93fe-7d5b0e936b8e.png)

See #35888.