### PR TITLE
FSE: Add Custom CSS card in My Plan section

### DIFF
--- a/client/blocks/product-purchase-features-list/custom-css.jsx
+++ b/client/blocks/product-purchase-features-list/custom-css.jsx
@@ -1,0 +1,51 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+import { isEnabled } from 'config';
+
+/**
+ * Image dependencies
+ */
+import customizeImage from 'assets/images/illustrations/dashboard.svg';
+
+function isCustomizeEnabled() {
+	return isEnabled( 'manage/customize' );
+}
+
+function getEditCSSLink( selectedSite ) {
+	const adminUrl = selectedSite.URL + '/wp-admin/',
+		customizerInAdmin =
+			adminUrl +
+			'customize.php?return=' +
+			encodeURIComponent( window.location.href ) +
+			'&section=jetpack_custom_css';
+
+	return isCustomizeEnabled() ? '/customize/custom-css/' + selectedSite.slug : customizerInAdmin;
+}
+
+export default localize( ( { selectedSite, translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon={ <img alt="" src={ customizeImage } /> }
+				title={ translate( 'Custom CSS' ) }
+				description={ translate(
+					"Make advanced changes to your site's appearance by " + 'writing your own CSS.'
+				) }
+				buttonText={ translate( 'Edit CSS' ) }
+				href={ getEditCSSLink( selectedSite ) }
+				target={ isCustomizeEnabled() ? undefined : '_blank' }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features-list/custom-css.jsx
+++ b/client/blocks/product-purchase-features-list/custom-css.jsx
@@ -40,7 +40,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon={ <img alt="" src={ customizeImage } /> }
 				title={ translate( 'Custom CSS' ) }
 				description={ translate(
-					"Make advanced changes to your site's appearance by " + 'writing your own CSS.'
+					"Make advanced changes to your site's appearance by writing your own CSS."
 				) }
 				buttonText={ translate( 'Edit CSS' ) }
 				href={ getEditCSSLink( selectedSite ) }

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -28,6 +28,7 @@ import UploadPlugins from './upload-plugins';
 import AdvertisingRemoved from './advertising-removed';
 import GoogleVouchers from './google-vouchers';
 import CustomizeTheme from './customize-theme';
+import CustomCSS from './custom-css';
 import VideoAudioPosts from './video-audio-posts';
 import MonetizeSite from './monetize-site';
 import BusinessOnboarding from './business-onboarding';
@@ -84,6 +85,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
+				{ ! showCustomizerFeature && <CustomCSS selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
@@ -122,6 +124,8 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
 				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
+				{ ! showCustomizerFeature && <CustomCSS selectedSite={ selectedSite } /> }
+				<CustomCSS selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
@@ -148,6 +152,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<AdvertisingRemoved isBusinessPlan={ false } selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
 				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
+				{ ! showCustomizerFeature && <CustomCSS selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a Custom CSS card to My Plan section for those users that have FSE enabled and the Customizer links are hidden:

<img width="539" alt="Screen Shot 2019-08-31 at 2 52 06 PM" src="https://user-images.githubusercontent.com/1464705/64069517-9b0e1080-cbff-11e9-9ff6-179f0e65e024.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with FSE enabled, and subscribe to a paid plan at the Premium level or above.
* Visit https://wordpress.com/plans/my-plan
* Confirm that you do not see the "Advanced Customization" card, and you instead see the "Custom CSS" card.
* Test on a site that does not have FSE enabled, and confirm the reverse is true.
* Confirm that clicking on "Edit CSS" takes you to the correct section in the customizer.

Fixes #35851
