### PR TITLE
Site Picker: Display Regardless of Site Visibility

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -20,7 +18,7 @@ import Gridicon from 'gridicons';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import getSelectedOrAllSites from 'state/selectors/get-selected-or-all-sites';
-import getVisibleSites from 'state/selectors/get-visible-sites';
+import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { hasAllSitesList } from 'state/sites/selectors';
 
@@ -101,7 +99,7 @@ export default connect(
 	state => ( {
 		selectedSite: getSelectedSite( state ),
 		anySiteSelected: getSelectedOrAllSites( state ),
-		siteCount: getVisibleSites( state ).length,
+		siteCount: getCurrentUserSiteCount( state ),
 		hasAllSitesList: hasAllSitesList( state ),
 	} ),
 	{ recordGoogleEvent, setLayoutFocus }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -14,7 +14,7 @@ import AsyncLoad from 'components/async-load';
 import Button from 'components/button';
 import Card from 'components/card';
 import Site from 'blocks/site';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import getSelectedOrAllSites from 'state/selectors/get-selected-or-all-sites';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes switching the check for visible sites when displaying the Site Picker to just checking for any site (including hidden sites). The check is here:

https://github.com/Automattic/wp-calypso/blob/1951f770d435e8109a72db361004b27cb0f87447/client/my-sites/current-site/index.jsx#L70

#### Testing instructions

* Start on account with two or more sites
* Visit https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs
* Set all sites to "Hidden" except for one 

Whereas before, Calypso would assume that you only have one site and not display the Site Picker, this change should now display the Site Picker.

* Go back to Calypso
* Verify the Site Picker at the top appears and "Add New Site" at the bottom doesn't

<img width="268" alt="Screenshot 2019-09-01 at 14 01 19" src="https://user-images.githubusercontent.com/43215253/64076910-b9891000-ccc2-11e9-81d0-f56502cfe7cd.png">

cc @shaunandrews, @jsnajdr, @kokkieh

Fixes #22286
