### PR TITLE
G Suite: Add an extra field to collect an `alternateEmail` different from the domain being provisioned

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -57,6 +57,7 @@ const CONTACT_DETAILS_FORM_FIELDS = [
 	'lastName',
 	'organization',
 	'email',
+	'alternateEmail',
 	'phone',
 	'address1',
 	'address2',
@@ -445,6 +446,17 @@ export class ContactDetailsFormFields extends Component {
 		);
 	}
 
+	renderAlternateEmailFieldForGSuite() {
+		return (
+			<div className="contact-details-form-fields__row g-suite-alternate-mail">
+				<Input
+					label={ this.props.translate( 'Alternate Email' ) }
+					{ ...this.getFieldProps( 'alternate-email' ) }
+				/>
+			</div>
+		);
+	}
+
 	render() {
 		const { translate, onCancel, disableSubmitButton, labelTexts } = this.props;
 		const countryCode = this.getCountryCode();
@@ -460,6 +472,7 @@ export class ContactDetailsFormFields extends Component {
 						label: translate( 'Last Name' ),
 					} ) }
 				</div>
+				{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }
 
 				{ this.props.needsOnlyGoogleAppsDetails
 					? this.renderGAppsFieldset()

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -90,6 +90,7 @@ export class ContactDetailsFormFields extends Component {
 		className: PropTypes.string,
 		userCountryCode: PropTypes.string,
 		needsOnlyGoogleAppsDetails: PropTypes.bool,
+		needsAlternateEmailForGSuite: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
 	};
 
@@ -109,6 +110,7 @@ export class ContactDetailsFormFields extends Component {
 		disableSubmitButton: false,
 		className: '',
 		needsOnlyGoogleAppsDetails: false,
+		needsAlternateEmailForGSuite: false,
 		hasCountryStates: false,
 		translate: identity,
 		userCountryCode: 'US',
@@ -448,9 +450,9 @@ export class ContactDetailsFormFields extends Component {
 
 	renderAlternateEmailFieldForGSuite() {
 		return (
-			<div className="contact-details-form-fields__row g-suite-alternate-mail">
+			<div className="contact-details-form-fields__row">
 				<Input
-					label={ this.props.translate( 'Alternate Email' ) }
+					label={ this.props.translate( 'Alternate Email Address' ) }
 					{ ...this.getFieldProps( 'alternate-email' ) }
 				/>
 			</div>

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -683,6 +683,19 @@ export function fillGoogleAppsRegistrationData( cart, registrationData ) {
 	);
 }
 
+const getDomainPartFromEmail = emailAddress => {
+	emailAddress = emailAddress || '';
+	return emailAddress.replace( /.*@([^@]+)$/, '$1' );
+};
+
+export function needsExplicitAlternateEmailForGSuite( cart, contactDetails ) {
+	return some( cart.products, [ 'meta', getDomainPartFromEmail( contactDetails.email ) ] );
+}
+
+export function hasInvalidAlternateEmailDomain( cart, contactDetails ) {
+	return some( cart.products, [ 'meta', getDomainPartFromEmail( contactDetails.alternateEmail ) ] );
+}
+
 export function hasGoogleApps( cart ) {
 	return some( getAllCartItems( cart ), isGoogleApps );
 }

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -691,6 +691,7 @@ export function fillGoogleAppsRegistrationData( cart, registrationData ) {
  * @returns {String} the domain
  */
 const getDomainPartFromEmail = emailAddress =>
+	// Domain is any string after `@` character
 	'string' === typeof emailAddress || 0 < emailAddress.indexOf( '@' )
 		? emailAddress.replace( /.*@([^@>]+)>?$/, '$1' )
 		: null;

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -21,6 +21,7 @@ import {
 	toLower,
 	uniq,
 } from 'lodash';
+import emailValidator from 'email-validator';
 
 /**
  * Internal dependencies
@@ -684,12 +685,15 @@ export function fillGoogleAppsRegistrationData( cart, registrationData ) {
 }
 
 const getDomainPartFromEmail = emailAddress => {
-	emailAddress = emailAddress || '';
+	emailAddress = ( `${ emailAddress }` || '' ).toLowerCase().trim();
 	return emailAddress.replace( /.*@([^@]+)$/, '$1' );
 };
 
 export function needsExplicitAlternateEmailForGSuite( cart, contactDetails ) {
-	return some( cart.products, [ 'meta', getDomainPartFromEmail( contactDetails.email ) ] );
+	return (
+		! emailValidator.validate( contactDetails.email ) ||
+		some( cart.products, [ 'meta', getDomainPartFromEmail( contactDetails.email ) ] )
+	);
 }
 
 export function hasInvalidAlternateEmailDomain( cart, contactDetails ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -685,8 +685,11 @@ export function fillGoogleAppsRegistrationData( cart, registrationData ) {
 }
 
 const getDomainPartFromEmail = emailAddress => {
-	emailAddress = ( `${ emailAddress }` || '' ).toLowerCase().trim();
-	return emailAddress.replace( /.*@([^@]+)$/, '$1' );
+	emailAddress = emailAddress || '';
+	return emailAddress
+		.toLowerCase()
+		.trim()
+		.replace( /.*@([^@]+)$/, '$1' );
 };
 
 export function needsExplicitAlternateEmailForGSuite( cart, contactDetails ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -684,23 +684,45 @@ export function fillGoogleAppsRegistrationData( cart, registrationData ) {
 	);
 }
 
-const getDomainPartFromEmail = emailAddress => {
-	emailAddress = emailAddress || '';
-	return emailAddress
-		.toLowerCase()
-		.trim()
-		.replace( /.*@([^@]+)$/, '$1' );
-};
+/**
+ * Returns the domain part of an email address.
+ *
+ * @param {String} emailAddress - a valid email address
+ * @returns {String} the domain
+ */
+const getDomainPartFromEmail = emailAddress =>
+	'string' === typeof emailAddress || 0 < emailAddress.indexOf( '@' )
+		? emailAddress.replace( /.*@([^@>]+)>?$/, '$1' )
+		: null;
+
+/**
+ * Returns a predicate that determines if a domain matches a product meta.
+ *
+ * @param {String} domain domain to compare.
+ * @returns {function(*=): (boolean)} true if the domain matches.
+ */
+const isSameDomainAsProductMeta = domain => product =>
+	product &&
+	product.meta &&
+	'string' === typeof domain &&
+	'string' === typeof product.meta &&
+	product.meta.trim().toUpperCase() === domain.trim().toUpperCase();
 
 export function needsExplicitAlternateEmailForGSuite( cart, contactDetails ) {
 	return (
 		! emailValidator.validate( contactDetails.email ) ||
-		some( cart.products, [ 'meta', getDomainPartFromEmail( contactDetails.email ) ] )
+		some(
+			cart.products,
+			isSameDomainAsProductMeta( getDomainPartFromEmail( contactDetails.email ) )
+		)
 	);
 }
 
 export function hasInvalidAlternateEmailDomain( cart, contactDetails ) {
-	return some( cart.products, [ 'meta', getDomainPartFromEmail( contactDetails.alternateEmail ) ] );
+	return some(
+		cart.products,
+		isSameDomainAsProductMeta( getDomainPartFromEmail( contactDetails.email ) )
+	);
 }
 
 export function hasGoogleApps( cart ) {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -87,24 +87,21 @@ export class DomainDetailsForm extends PureComponent {
 		this.setState( newState );
 	}
 
-	mergedValidationHandlerIntegratingAlternateMail = ( fieldValues, validationHandler ) => (
-		error,
-		data
-	) => {
+	addAlternateEmailToValidationHandler = ( fieldValues, validationHandler ) => ( error, data ) => {
 		if ( this.needsAlternateEmailForGSuite() ) {
 			let message = null;
 			if ( ! emailValidator.validate( fieldValues.alternateEmail ) ) {
-				message = this.props.translate( 'Invalid email address' );
+				message = this.props.translate( 'Please provide a valid email address.' );
 			} else if ( hasInvalidAlternateEmailDomain( this.props.cart, this.props.contactDetails ) ) {
 				message = this.props.translate(
-					'Email domain cannot be the same as prospective G Suite Domain'
+					'Please provide an email address that does not use the same domain than the G Suite account being purchased.'
 				);
 			}
-			if ( null != message ) {
+			if ( null !== message ) {
 				data = merge( data, { success: false, messages: { alternateEmail: [ message ] } } );
 			}
 		}
-		validationHandler( null, data );
+		validationHandler( error, data );
 	};
 
 	validate = ( fieldValues, onComplete ) => {
@@ -116,7 +113,7 @@ export class DomainDetailsForm extends PureComponent {
 		if ( this.needsOnlyGoogleAppsDetails() ) {
 			wpcom.validateGoogleAppsContactInformation(
 				fieldValues,
-				this.mergedValidationHandlerIntegratingAlternateMail( fieldValues, validationHandler )
+				this.addAlternateEmailToValidationHandler( fieldValues, validationHandler )
 			);
 			return;
 		}


### PR DESCRIPTION
This adds an extra form field to collect a contact email address with a domain different from the domain in the prospective G Suite domain.

#### Changes proposed in this Pull Request

* Added an additional key `alternateEmail` in the default contact fields props.
* Added an additional field to accept an alternate email address with client side validation to keep the associated domain different than the G Suite domain.
* Added an additional key `alternateEmail` in the registration data sent along with the cart for retrieval by the provisioning process.

#### Testing instructions

For the purposes of this test *only*, the domain we want to sample/test e.g `test-domain.com` will be referred to as the domain under test i.e. **DUT**

**Before**

* Load calypso locally ( i.e. calypso.localhost ) and sandbox the API.

* Login to a WP account that has a profile email that ends on the same domain as the DUT. If you have purchased any domains with WP on this account ( i.e registered, transferred ), ensure that the contact email associated with the domain purchase ends with the DUT.

* Attempt to add G Suite to the DUT . You would be presented with a form which collects user registration information.

<img width="741" alt="Screenshot 2019-09-01 at 4 43 14 PM" src="https://user-images.githubusercontent.com/277661/64078863-2a86f280-ccd8-11e9-87f6-85bb6bc04c25.png">

**After**

* Now checkout this branch and allow the Calypso build to be refreshed. Carry out the same action as before the checkout, observe that the registration form now asks for an alternate email address that is validated on the client side. 

* Confirm that the alternate email cannot be invalid or contain a domain that ends in the DUT.

* _You can use a WP account that has an unrelated email in the profile, or domain with unrelated contact email to confirm that the alternate email field is not brought up if the email on file already complies and validates_

<img width="733" alt="Screenshot 2019-09-01 at 4 43 26 PM" src="https://user-images.githubusercontent.com/277661/64078869-35418780-ccd8-11e9-90f3-b2ada07d280b.png">

* This works in harmony with D32310-code

Fixes #

* Prevents an issue where the prospective G Suite account that is about to be created has an email address for the primary contact in the aforementioned domain. This is an error as the email address doesn't exist yet at the time.


