### PR TITLE
[Checklist]: remove inline help checklist notification

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -32,14 +32,6 @@ class WpcomChecklist extends Component {
 		viewMode: 'checklist',
 	};
 
-	componentDidMount() {
-		this.setNotification( this.props.shouldShowNotification );
-	}
-
-	componentDidUpdate() {
-		this.setNotification( this.props.shouldShowNotification );
-	}
-
 	setNotification = value => {
 		if ( this.props.setNotification && this.props.viewMode === 'notification' ) {
 			this.props.setNotification( value );
@@ -47,7 +39,7 @@ class WpcomChecklist extends Component {
 	};
 
 	render() {
-		const { shouldRender, shouldShowNotification, ...ownProps } = this.props;
+		const { shouldRender, ...ownProps } = this.props;
 
 		if ( ! shouldRender ) {
 			return null;
@@ -93,26 +85,6 @@ function shouldChecklistRender(
 	return true;
 }
 
-function shouldChecklistShowNotification(
-	taskList,
-	storedTask,
-	isEligibleForChecklist,
-	isSectionEligible
-) {
-	const firstIncomplete = taskList && taskList.getFirstIncompleteTask();
-
-	if (
-		firstIncomplete &&
-		( storedTask !== firstIncomplete.id || storedTask === null ) &&
-		isEligibleForChecklist &&
-		isSectionEligible
-	) {
-		return true;
-	}
-
-	return false;
-}
-
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	const designType = getSiteOption( state, siteId, 'design_type' );
@@ -131,7 +103,7 @@ export default connect( ( state, ownProps ) => {
 		siteVerticals,
 	} );
 
-	const { viewMode, storedTask } = ownProps;
+	const { viewMode } = ownProps;
 
 	return {
 		shouldRender: shouldChecklistRender(
@@ -140,12 +112,6 @@ export default connect( ( state, ownProps ) => {
 			taskList,
 			isSectionEligible,
 			siteId
-		),
-		shouldShowNotification: shouldChecklistShowNotification(
-			taskList,
-			storedTask,
-			isEligibleForChecklist,
-			isSectionEligible
 		),
 	};
 } )( WpcomChecklist );


### PR DESCRIPTION
## Changes proposed in this Pull Request

With the introduction to the sidebar of My Home, which defaults to the checklist, the checklist-specific notification appears to be an overkill. 

Furthermore, it appears regardless of whether you've completed the checklist or not. 

This is partly due to the [task filter logic](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checklist/wpcom-checklist/component.jsx#L269) in checklist component.jsx, which filters out the to-be-rendered tasks if they don't have a matching URL. 

Unfortunately the location of the filter constrains the way we can accurately communicate tasks completed status _across_ the app. 

The least jarring way to address this for now is to remove the notification that relates to checklist completion. The checklist will be in the user's face anyway due to it being the default view on the home section.

<img width="670" alt="Screen Shot 2019-09-02 at 7 56 59 am" src="https://user-images.githubusercontent.com/6458278/64083508-4e901580-cd64-11e9-848c-161052199bbe.png">

See: p1567187605019600-slack-onboarding-exp

## Testing instructions

Test with sites with completed an uncompleted checklists. The pink notification circle should not make a peep.