### PR TITLE
Update from unlimited storage to 200 GB in plans list.

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -204,7 +204,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_UNLIMITED_STORAGE_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_UNLIMITED_STORAGE_SIGNUP,
-		getTitle: () => i18n.translate( 'Unlimited storage' ),
+		getTitle: () => i18n.translate( '200 GB storage' ),
 		getDescription: () =>
 			i18n.translate(
 				"With increased storage space you'll be able to upload more images, videos, audio, and documents to your website."
@@ -276,7 +276,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_UNLIMITED_STORAGE ]: {
 		getSlug: () => constants.FEATURE_UNLIMITED_STORAGE,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Unlimited{{/strong}} Storage Space', {
+			i18n.translate( '{{strong}}200 GB{{/strong}} Storage Space', {
 				components: {
 					strong: <strong />,
 				},

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -293,7 +293,7 @@ const getPlanBusinessDetails = () => ( {
 		i18n.translate(
 			'{{strong}}Best for Small Businesses:{{/strong}} Power your' +
 				' business website with custom plugins and themes, unlimited premium and business theme templates,' +
-				' Google Analytics support, unlimited' +
+				' Google Analytics support, 200 GB' +
 				' storage, and the ability to remove WordPress.com branding.',
 			{
 				components: {
@@ -306,7 +306,7 @@ const getPlanBusinessDetails = () => ( {
 	getShortDescription: () =>
 		i18n.translate(
 			'Power your business website with custom plugins and themes, unlimited premium and business theme templates,' +
-				' Google Analytics support, unlimited' +
+				' Google Analytics support, 200 GB' +
 				' storage, and the ability to remove WordPress.com branding.'
 		),
 	getTagline: () =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update from unlimited storage to 200 GB in plans list. pau2Xa-qW-p2

#### Testing instructions

* Use calypso.live link below.
* In signup, confirm Business plan reads '200 GB` instead of unlimited.
* Open /plans/[site] and confirm Business and eCommerce reads '200 GB' instead of unlimited.

---

_These changes are meant to improve consistency between WP.com landing pages and Calypso. Long-term, additional follow-ups may be needed to update to 200 GB in other places in Calypso._

---

<img width="1068" alt="Screen Shot 2019-09-01 at 20 10 41" src="https://user-images.githubusercontent.com/1563559/64084009-a4c57000-ccf4-11e9-83ba-fd8c6aaf7ec0.png">

<img width="893" alt="Screen Shot 2019-09-01 at 20 11 53" src="https://user-images.githubusercontent.com/1563559/64084029-c7f01f80-ccf4-11e9-9ef1-6249653d4e46.png">

