### PR TITLE
Signup: ensure the site type list is translated

### DIFF
--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -28,14 +28,11 @@ class SiteTypeForm extends Component {
 
 		// from localize() HoC
 		translate: PropTypes.func.isRequired,
-		siteTypeDefinitions: PropTypes.array,
 	};
 
 	static defaultProps = {
 		showDescriptions: true,
 		showPurchaseRequired: true,
-		// Specify which site types we'd like to render in the UI
-		siteTypeDefinitions: getAllSiteTypes( [ 1, 2, 3, 4 ] ),
 	};
 
 	handleSubmit = type => {
@@ -46,8 +43,9 @@ class SiteTypeForm extends Component {
 	};
 
 	render() {
-		const { showDescriptions, showPurchaseRequired, siteTypeDefinitions, translate } = this.props;
-
+		const { showDescriptions, showPurchaseRequired, translate } = this.props;
+		// Specify which site types we'd like to render in the UI
+		const siteTypeDefinitions = getAllSiteTypes( [ 1, 2, 3, 4 ] );
 		return (
 			<>
 				<Card className="site-type__wrapper">


### PR DESCRIPTION
## Changes proposed in this Pull Request

Bon jour! Let's grab the site type defs each time so we can ensure that `translate` is called over all the strings in the case of a language switch.

<img width="521" alt="Screen Shot 2019-09-02 at 3 04 33 pm" src="https://user-images.githubusercontent.com/6458278/64091326-00ded180-cd93-11e9-99ba-0f67d50ab77c.png">

## Testing

Change the language before you sign in at `/start` (use a mag 16 lang such as German, French, Chinese (any) or Spanish etc...)

The site type step text should be translated! Magnifique!
