### PR TITLE
Atomic: Update blacklisted plugins from July 2019

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -253,6 +253,7 @@ export class PluginMeta extends Component {
 			'plugins-garbage-collector',
 			'post-type-switcher',
 			'reset-wp',
+			'secure-file-manager',
 			'ultimate-wp-reset',
 			'username-changer',
 			'username-updater',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -247,7 +247,6 @@ export class PluginMeta extends Component {
 			'database-browser',
 			'duplicator',
 			'extended-wp-reset',
-			'google-captcha',
 			'file-manager-advanced',
 			'file-manager',
 			'plugins-garbage-collector',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -275,7 +275,6 @@ export class PluginMeta extends Component {
 			'backup-wd',
 			'backupwordpress',
 			'backwpup',
-			'updraftplus',
 			'wp-db-backup',
 
 			// caching

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -344,6 +344,7 @@ export class PluginMeta extends Component {
 			'porn-embed',
 			'propellerads-official',
 			'speed-contact-bar',
+			'really-simple-ssl',
 			'robo-gallery',
 			'under-construction-page',
 			'video-importer',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -331,6 +331,7 @@ export class PluginMeta extends Component {
 
 			// misc
 			'adult-mass-photos-downloader',
+			'adult-mass-videos-embedder',
 			'ari-adminer',
 			'automatic-video-posts',
 			'bwp-minify',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -282,6 +282,7 @@ export class PluginMeta extends Component {
 			'comet-cache',
 			'hyper-cache',
 			'powered-cache',
+			'jch-optimize',
 			'quick-cache',
 			'sg-cachepress',
 			'w3-total-cache',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -344,6 +344,7 @@ export class PluginMeta extends Component {
 			'porn-embed',
 			'propellerads-official',
 			'speed-contact-bar',
+			'unplug-jetpack',
 			'really-simple-ssl',
 			'robo-gallery',
 			'under-construction-page',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -330,6 +330,7 @@ export class PluginMeta extends Component {
 			'wp-staging',
 
 			// misc
+			'adult-mass-photos-downloader',
 			'ari-adminer',
 			'automatic-video-posts',
 			'bwp-minify',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update list of blocked plugins from July 2019
- These plugins are not compatible on the Atomic environment.
- A few may be removed from the list as well, as they are now compatible
- Details: p9F6qB-3zP-p2

List of plugins added:

- really-simple-ssl
- unplug-jetpack
- secure-file-manager
- jch-optimize
- adult-mass-photos-downloader
- adult-mass-videos-embedded

Removed from the list:

- updraftplus
- google-catpcha