### PR TITLE
Full Site Editing: Prevent infinite loop in a8c/posts-list

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
@@ -20,6 +20,13 @@ class Posts_List_Block {
 	private static $instance = null;
 
 	/**
+ 	 * Whether we are in the process of rendering the block.
+ 	 *
+ 	 * @var bool
+ 	 */
+	private $rendering_block = false;
+
+	/**
 	 * A8C_Post_List constructor.
 	 */
 	private function __construct() {
@@ -103,6 +110,7 @@ class Posts_List_Block {
 	 * @return string
 	 */
 	public function render_a8c_post_list_block( $attributes, $content ) {
+
 		$posts_list = new \WP_Query(
 			array(
 				'post_type'        => 'post',
@@ -114,12 +122,19 @@ class Posts_List_Block {
 
 		add_filter( 'excerpt_more', array( $this, 'custom_excerpt_read_more' ) );
 
-		$content = render_template(
-			'posts-list',
-			array(
-				'posts_list' => $posts_list,
-			)
-		);
+		// Prevent situations when the block attempts rendering another a8c/posts-list block.
+		if ( $this->rendering_block !== true ) {
+			$this->rendering_block = true;
+
+			$content = render_template(
+				'posts-list',
+				array(
+					'posts_list' => $posts_list,
+				)
+			);
+
+			$this->rendering_block = false;
+		}
 
 		remove_filter( 'excerpt_more', array( $this, 'custom_excerpt_read_more' ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In case the excerpt printed in terms of the FSE's (Full Site Editing) posts list block ( `a8c/posts-list` ) is filtered the way it contains whole post's content (eg.: on homepage when Jetpack's Content Options is set to Full post ), rendering of posts list block may get into a infinite loop.

This is more a clash in between multiple plugins when this happen, but since we can't fix all the plugins, it's easier to fix this in here, as it would take care of all possible classes of issues.

The infinite loop is being prevented via class property, serving as flag for identifying whether we are in a process of rendering the block or not.

#### Testing instructions

1. Install Jetpack
1. Set the "Full post" as a content option in Jetpack
1. Create a new post containing a Posts lists block
1. Open a home page or an archive (containing the new post) of your blog
1. The page should run into OOM w/o this patch

Fixes #35929
