### PR TITLE
Google login: ensure auth2 init only happens once.

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -18,6 +18,8 @@ import { preventWidows } from 'lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { isFormDisabled } from 'state/login/selectors';
 
+let auth2InitDone = false;
+
 /**
  * Style dependencies
  */
@@ -71,6 +73,21 @@ class GoogleLoginButton extends Component {
 		return window.gapi;
 	}
 
+	async initializeAuth2( gapi ) {
+		if ( auth2InitDone ) {
+			return;
+		}
+
+		await gapi.auth2.init( {
+			fetch_basic_profile: this.props.fetchBasicProfile,
+			client_id: this.props.clientId,
+			scope: this.props.scope,
+			ux_mode: this.props.uxMode,
+			redirect_uri: this.props.redirectUri,
+		} );
+		auth2InitDone = true;
+	}
+
 	initialize() {
 		if ( this.initialized ) {
 			return this.initialized;
@@ -83,27 +100,19 @@ class GoogleLoginButton extends Component {
 		this.initialized = this.loadDependency()
 			.then( gapi => new Promise( resolve => gapi.load( 'auth2', resolve ) ).then( () => gapi ) )
 			.then( gapi =>
-				gapi.auth2
-					.init( {
-						fetch_basic_profile: this.props.fetchBasicProfile,
-						client_id: this.props.clientId,
-						scope: this.props.scope,
-						ux_mode: this.props.uxMode,
-						redirect_uri: this.props.redirectUri,
-					} )
-					.then( () => {
-						this.setState( { isDisabled: false } );
+				this.initializeAuth2( gapi ).then( () => {
+					this.setState( { isDisabled: false } );
 
-						const googleAuth = gapi.auth2.getAuthInstance();
-						const currentUser = googleAuth.currentUser.get();
+					const googleAuth = gapi.auth2.getAuthInstance();
+					const currentUser = googleAuth.currentUser.get();
 
-						// handle social authentication response from a redirect-based oauth2 flow
-						if ( currentUser && this.props.uxMode === 'redirect' ) {
-							this.props.responseHandler( currentUser, false );
-						}
+					// handle social authentication response from a redirect-based oauth2 flow
+					if ( currentUser && this.props.uxMode === 'redirect' ) {
+						this.props.responseHandler( currentUser, false );
+					}
 
-						return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
-					} )
+					return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
+				} )
 			)
 			.catch( error => {
 				this.initialized = null;


### PR DESCRIPTION
Fixes an issue introduced in #35019 and discussed there. It was causing Google login buttons to be disabled and console error messages to be displayed in the testing conditions below.

#### Changes proposed in this Pull Request

* Fix issue with Google login globals being initialised more than once.

#### Testing instructions

* Ensure you're logged out
* Open the Login page (`/log-in`) in the live branch
* Click the Sign Up link in the top right corner
* Ensure that the Google login button is enabled and works correctly
