### PR TITLE
Customer Home: Add the stats banners to the Customer Home page

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -39,6 +39,7 @@ import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import StatsBanners from 'my-sites/stats/stats-banners';
 
 /**
  * Style dependencies
@@ -114,7 +115,7 @@ class Home extends Component {
 	}
 
 	render() {
-		const { translate, canUserUseCustomerHome } = this.props;
+		const { translate, canUserUseCustomerHome, siteSlug } = this.props;
 
 		if ( ! canUserUseCustomerHome ) {
 			const title = this.props.isSiteEligible
@@ -136,6 +137,7 @@ class Home extends Component {
 				<PageViewTracker path={ `/home/:site` } title={ translate( 'Customer Home' ) } />
 				<DocumentHead title={ translate( 'Customer Home' ) } />
 				<SidebarNavigation />
+				<StatsBanners siteId={ siteId } slug={ siteSlug } />
 				{ renderChecklistCompleteBanner && (
 					<Banner
 						dismissPreferenceName="checklist-complete"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -28,6 +28,7 @@ import StickyPanel from 'components/sticky-panel';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
@@ -120,7 +121,7 @@ class StatsSite extends Component {
 	};
 
 	render() {
-		const { date, isJetpack, siteId, slug } = this.props;
+		const { date, isJetpack, siteId, slug, isCustomerHomeEnabled } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -162,7 +163,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<div id="my-stats-content">
-					<StatsBanners siteId={ siteId } slug={ slug } />
+					{ ! isCustomerHomeEnabled && <StatsBanners siteId={ siteId } slug={ slug } /> }
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
 						activeLegend={ this.state.activeLegend }
@@ -271,6 +272,7 @@ export default connect(
 			siteId,
 			slug: getSelectedSiteSlug( state ),
 			planSlug: getSitePlanSlug( state, siteId ),
+			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 		};
 	},
 	{ recordGoogleEvent }


### PR DESCRIPTION
The various nudges that appear at the top of the stats page, will now be
seen by fewer people as we direct them to the Customer Home page by
default. This change adds the `StatsBanner` component to the Customer
Home page, so that they will have the same reach.

Later we will need to refactor this component to `HomeBanners` and check
that the customer is redirected to the Customer Home, whenever it's
appropriate.

#### Testing instructions

* Place yourself in the `customerHome` A/B test using the menu in the environment badge, either using the dev environment or wpcalypso. The test group is `show`.
* With a site created after the 6th August 2019 go to the stats page and notice that no banners are displayed. 
* Go to the 'My Home' page by following the link in the sidebar and you should see the banners there.
_(N.B._ you may need to create a new site and complete the checklist, so at least one banner is displayed)_

You could also check that the banners are still displayed on the stats page for a site that is ineligible for customer home. Either take yourself out of the A/B test or use an older/Jetpack site.
