### PR TITLE
Change current user to plain reducers.

### DIFF
--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -14,7 +14,7 @@ import {
 	PLANS_RECEIVE,
 	PRODUCTS_LIST_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, createReducerWithValidation, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
 import gravatarStatus from './gravatar-status/reducer';
 import emailVerification from './email-verification/reducer';
@@ -32,22 +32,23 @@ import emailVerification from './email-verification/reducer';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const id = createReducerWithValidation(
-	null,
-	{
-		[ CURRENT_USER_RECEIVE ]: ( state, action ) => action.user.ID,
-	},
-	idSchema
-);
+export const id = withSchemaValidation( idSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case CURRENT_USER_RECEIVE:
+			return action.user.ID;
+		default:
+			return state;
+	}
+} );
 
-export const flags = createReducerWithValidation(
-	[],
-	{
-		[ CURRENT_USER_RECEIVE ]: ( state, action ) =>
-			get( action.user, 'meta.data.flags.active_flags', [] ),
-	},
-	flagsSchema
-);
+export const flags = withSchemaValidation( flagsSchema, ( state = [], action ) => {
+	switch ( action.type ) {
+		case CURRENT_USER_RECEIVE:
+			return get( action.user, [ 'meta', 'data', 'flags', 'active_flags' ], [] );
+		default:
+			return state;
+	}
+} );
 
 /**
  * Tracks the currency code of the current user
@@ -57,25 +58,22 @@ export const flags = createReducerWithValidation(
  * @return {Object}        Updated state
  *
  */
-export const currencyCode = createReducerWithValidation(
-	null,
-	{
-		[ PRODUCTS_LIST_RECEIVE ]: ( state, action ) => {
+export const currencyCode = withSchemaValidation( currencyCodeSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case PRODUCTS_LIST_RECEIVE:
 			return get(
 				action.productsList,
 				[ first( keys( action.productsList ) ), 'currency_code' ],
 				state
 			);
-		},
-		[ PLANS_RECEIVE ]: ( state, action ) => {
+		case PLANS_RECEIVE:
 			return get( action.plans, [ 0, 'currency_code' ], state );
-		},
-		[ SITE_PLANS_FETCH_COMPLETED ]: ( state, action ) => {
+		case SITE_PLANS_FETCH_COMPLETED:
 			return get( action.plans, [ 0, 'currencyCode' ], state );
-		},
-	},
-	currencyCodeSchema
-);
+		default:
+			return state;
+	}
+} );
 
 /**
  * Returns the updated capabilities state after an action has been dispatched.


### PR DESCRIPTION
This PR is a split-out from #35905, and illustrates example usage of plain reducer functions to replace deprecated usage of `createReducerWithValidation`.

#### Changes proposed in this Pull Request

* Rewrite current user reducers without `createReducerWithValidation`, as an example.

#### Testing instructions

The reimplemented reducers have unit tests that continue working nicely without any changes, and should be enough for the purposes of ensuring that behaviour remains the same.
