### PR TITLE
Jetpack Guided Tours: fix commas

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
@@ -73,7 +73,7 @@ export const JetpackLazyImagesTour = makeTour(
 						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
@@ -74,7 +74,7 @@ export const JetpackMonitoringTour = makeTour(
 						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -93,7 +93,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-search-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-search-tour/index.js
@@ -72,7 +72,7 @@ export const JetpackSearchTour = makeTour(
 						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-search-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-search-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-search-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-search-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
@@ -70,7 +70,7 @@ export const JetpackSignInTour = makeTour(
 						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
@@ -73,7 +73,7 @@ export const JetpackSiteAcceleratorTour = makeTour(
 						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
@@ -77,7 +77,7 @@ export const JetpackVideoHostingTour = makeTour(
 						<SiteLink isButton href="/plans/my-plan/:site">
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix commas in Jetpack Guided Tours
* Also updates the Gridicons reference because the old one was failing tests

#### Before

![image](https://user-images.githubusercontent.com/390760/64185790-a5314880-ce65-11e9-9ab6-e9ee01751090.png)


#### After

![image](https://user-images.githubusercontent.com/390760/64185812-afebdd80-ce65-11e9-93e0-f296fb31cb8a.png)


#### Testing instructions

* Fire up this PR.
* Connect a new site.
* Purchase a Jetpack plan.
* Go through the a checklist step (e.g.: Site accelerator).
* Ensure that the confirmation dialog now shows the updated copy.
