### PR TITLE
Site Cloning: Do not prefill host field for alternate restores

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -20,7 +20,7 @@ import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import QueryRewindState from 'components/data/query-rewind-state';
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
 import { getSiteSlug } from 'state/sites/selectors';

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -138,9 +138,11 @@ export class RewindCredentialsForm extends Component {
 		nextForm.user = isEmpty( nextForm.user ) && credentials ? credentials.user : nextForm.user;
 		nextForm.path = isEmpty( nextForm.path ) && credentials ? credentials.path : nextForm.path;
 
-		// Populate the host field with the site slug if needed
-		nextForm.host =
-			isEmpty( nextForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : nextForm.host;
+		// Populate the host field with the site slug if needed, only for main restores
+		if ( 'main' === role ) {
+			nextForm.host =
+				isEmpty( nextForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : nextForm.host;
+		}
 
 		this.setState( { form: nextForm } );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This prevents us from filling the credentials host field with the assumed hostname during alternate restores.

#### Testing instructions

* Load up the "Clone Site" flow and proceed to the credentials step. The host field should be empty.
