### PR TITLE
spt: re-render on viewport change

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -43,8 +43,6 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 			// Try to get the preview content element.
 			const previewContainerEl = ref.current.querySelector( '.block-editor-block-preview__content' );
-			console.log( { previewContainerEl } );
-
 			if ( ! previewContainerEl ) {
 				return;
 			}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -35,32 +35,33 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	// https://github.com/WordPress/gutenberg/pull/17242
 
 	const updateTemplateTitle = () => {
-		// Try to get the preview content element.
-		const previewContainerEl = ref.current.querySelector( '.block-editor-block-preview__content' );
-		if ( ! previewContainerEl ) {
-			return;
-		}
-
-		// Try to get the `transform` css rule from the preview container element.
-		const elStyles = window.getComputedStyle( previewContainerEl );
-		if ( elStyles && elStyles.transform ) {
-			setTransform( elStyles.transform ); // apply the same transform css rule to template title.
-		}
-	};
-
-	useLayoutEffect( () => {
-		setVisibility( 'hidden' );
-
+		// Get DOM reference.
 		setTimeout( () => {
-			// Get DOM reference.
 			if ( ! ref || ! ref.current ) {
 				return;
 			}
 
-			updateTemplateTitle();
+			// Try to get the preview content element.
+			const previewContainerEl = ref.current.querySelector( '.block-editor-block-preview__content' );
+			console.log( { previewContainerEl } );
+
+			if ( ! previewContainerEl ) {
+				return;
+			}
+
+			// Try to get the `transform` css rule from the preview container element.
+			const elStyles = window.getComputedStyle( previewContainerEl );
+			if ( elStyles && elStyles.transform ) {
+				setTransform( elStyles.transform ); // apply the same transform css rule to template title.
+			}
 
 			setVisibility( 'visible' );
 		}, 300 );
+	};
+
+	useLayoutEffect( () => {
+		setVisibility( 'hidden' );
+		updateTemplateTitle();
 	}, [ blocks ] );
 
 	useEffect( () => {
@@ -68,7 +69,12 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 			return;
 		}
 
-		const refreshPreview = debounce( triggerRecompute, THRESHOLD_RESIZE );
+		const rePreviewTemplate = () => {
+			updateTemplateTitle();
+			triggerRecompute();
+		};
+
+		const refreshPreview = debounce( rePreviewTemplate, THRESHOLD_RESIZE );
 		window.addEventListener( 'resize', refreshPreview );
 
 		return () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -33,6 +33,21 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	// The following approach can be easily replace calling this callback
 	// once the PR ships (finger-crossed)
 	// https://github.com/WordPress/gutenberg/pull/17242
+
+	const updateTemplateTitle = () => {
+		// Try to get the preview content element.
+		const previewContainerEl = ref.current.querySelector( '.block-editor-block-preview__content' );
+		if ( ! previewContainerEl ) {
+			return;
+		}
+
+		// Try to get the `transform` css rule from the preview container element.
+		const elStyles = window.getComputedStyle( previewContainerEl );
+		if ( elStyles && elStyles.transform ) {
+			setTransform( elStyles.transform ); // apply the same transform css rule to template title.
+		}
+	};
+
 	useLayoutEffect( () => {
 		setVisibility( 'hidden' );
 
@@ -42,19 +57,8 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 				return;
 			}
 
-			// Try to get the preview content element.
-			const previewContainerEl = ref.current.querySelector(
-				'.block-editor-block-preview__content'
-			);
-			if ( ! previewContainerEl ) {
-				return;
-			}
+			updateTemplateTitle();
 
-			// Try to get the `transform` css rule from the preview container element.
-			const elStyles = window.getComputedStyle( previewContainerEl );
-			if ( elStyles && elStyles.transform ) {
-				setTransform( elStyles.transform ); // apply the same transform css rule to template title.
-			}
 			setVisibility( 'visible' );
 		}, 300 );
 	}, [ blocks ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the content of the Large preview when the window viewport resizes.

![spt-resize](https://user-images.githubusercontent.com/77539/64200808-7bb6f380-ce4a-11e9-96b3-f2747b44894e.gif)


#### Testing instructions

* Apply these changes.
* Start to add a new page - you should see the templates selector modal
* Resize the window viewport.
* Confirm that the large preview is updated.

Fixes #35952 #35957 #35956
