### PR TITLE
(1P) SPT: increase bottom margin of template title

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -238,7 +238,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		margin-top: 20px;
 	}
 
-	$template-large-preview-title-height: 115px;
+	$template-large-preview-title-height: 117px;
 	.editor-styles-wrapper {
 		.editor-post-title {
 			transform-origin: top left;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR increases the margin-bottom between the template title and the content.

**before**
![image](https://user-images.githubusercontent.com/77539/64204304-b9b81580-ce52-11e9-8521-7d41295e4e0f.png)

**after**
![image](https://user-images.githubusercontent.com/77539/64204317-c0468d00-ce52-11e9-9019-4edb5d3f4bf8.png)


#### Testing instructions
Once the patch is applied, select the template paying attention to the separation between the template title and its content


Fixes https://github.com/Automattic/wp-calypso/issues/35955
