### PR TITLE
FSE: Add default template content and error logging to better handle template population failures

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -113,6 +113,7 @@ class WP_Template_Inserter {
 		$max_retries = 3;
 
 		$response = wp_remote_get( $request_url, $request_args );
+		
 		if ( ! is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -146,7 +146,7 @@ class WP_Template_Inserter {
 				<p>' .
 				__(
 					'The theme did not activate correctly so it may not look identical to the demo site. 
-				You are however able to edit the header and footer content to make it suit your needs.',
+					You are still able to edit the header and footer content to suit your needs.',
 					'full-site-editing'
 				)
 				.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -82,7 +82,7 @@ class WP_Template_Inserter {
 		$response = $this->fetch_retry( $request_url, $request_args );
 
 		if ( ! $response ) {
-			$this->log_template_error();
+			do_action( 'fse_log_template_error' );
 			$this->header_content = $this->get_default_header();
 			$this->footer_content = $this->get_default_footer();
 			return;
@@ -94,7 +94,7 @@ class WP_Template_Inserter {
 		if ( ! empty( $api_response['headers'] ) ) {
 			$this->header_content = $api_response['headers'][0];
 		} else {
-			$this->log_template_error( 'header' );
+			do_action( 'fse_log_template_error', 'header' );
 			$this->header_content = $this->get_default_header();
 		}
 
@@ -102,7 +102,7 @@ class WP_Template_Inserter {
 		if ( ! empty( $api_response['footers'] ) ) {
 			$this->footer_content = $api_response['footers'][0];
 		} else {
-			$this->log_template_error( 'footer' );
+			do_action( 'fse_log_template_error', 'footer' );
 			$this->footer_content = $this->get_default_footer();
 		}
 	}
@@ -161,29 +161,6 @@ class WP_Template_Inserter {
 	public function get_default_footer() {
 		return '<!-- wp:a8c/navigation-menu /--><!-- wp:paragraph -->
 				<!-- /wp:paragraph -->';
-	}
-
-	/**
-	 * Logs an error if the header and footer templates were not populated.
-	 *
-	 * @param string $templates Description of templates that failed.
-	 */
-	public function log_template_error( $templates = 'header and footer' ) {
-		$message = sprintf( 'The FSE %s templates failed to populate at point of activation', $templates );
-
-		if ( is_file( ABSPATH . 'wp-content/lib/log2logstash/log2logstash.php' ) ) {
-			require_once ABSPATH . 'wp-content/lib/log2logstash/log2logstash.php';
-
-			log2logstash(
-				array(
-					'feature'    => 'fse_template_population_failure',
-					'message'    => $message,
-					'blog_id'    => get_current_blog_id(),
-					'theme_slug' => get_stylesheet(),
-				)
-			);
-			return;
-		}
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -82,7 +82,7 @@ class WP_Template_Inserter {
 		$response = $this->fetch_retry( $request_url, $request_args );
 
 		if ( ! $response ) {
-			do_action( 'fse_log_template_error' );
+			do_action( 'fse_log_template_population_error' );
 			$this->header_content = $this->get_default_header();
 			$this->footer_content = $this->get_default_footer();
 			return;
@@ -93,17 +93,11 @@ class WP_Template_Inserter {
 		// Default to first returned header for now. Support for multiple headers will be added in future iterations.
 		if ( ! empty( $api_response['headers'] ) ) {
 			$this->header_content = $api_response['headers'][0];
-		} else {
-			do_action( 'fse_log_template_error', 'header' );
-			$this->header_content = $this->get_default_header();
 		}
 
 		// Default to first returned footer for now. Support for multiple footers will be added in future iterations.
 		if ( ! empty( $api_response['footers'] ) ) {
 			$this->footer_content = $api_response['footers'][0];
-		} else {
-			do_action( 'fse_log_template_error', 'footer' );
-			$this->footer_content = $this->get_default_footer();
 		}
 	}
 
@@ -119,7 +113,6 @@ class WP_Template_Inserter {
 		$max_retries = 3;
 
 		$response = wp_remote_get( $request_url, $request_args );
-
 		if ( ! is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -113,7 +113,7 @@ class WP_Template_Inserter {
 		$max_retries = 3;
 
 		$response = wp_remote_get( $request_url, $request_args );
-		
+
 		if ( ! is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -153,8 +153,7 @@ class WP_Template_Inserter {
 	 * @return string Content of a default footer
 	 */
 	public function get_default_footer() {
-		return '<!-- wp:a8c/navigation-menu /--><!-- wp:paragraph -->
-				<!-- /wp:paragraph -->';
+		return '<!-- wp:a8c/navigation-menu /-->';
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -82,7 +82,14 @@ class WP_Template_Inserter {
 		$response = $this->fetch_retry( $request_url, $request_args );
 
 		if ( ! $response ) {
-			do_action( 'a8c_fse_log', 'The FSE templates failed to populate at point of activation' );
+			do_action(
+				'a8c_fse_log',
+				'template_population_failure',
+				array(
+					'theme_slug' => $this->theme_slug,
+					'context'    => 'WP_Template_Inserter->fetch_template_parts',
+				)
+			);
 			$this->header_content = $this->get_default_header();
 			$this->footer_content = $this->get_default_footer();
 			return;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -82,7 +82,7 @@ class WP_Template_Inserter {
 		$response = $this->fetch_retry( $request_url, $request_args );
 
 		if ( ! $response ) {
-			do_action( 'fse_log_template_population_error' );
+			do_action( 'a8c_fse_log', 'The FSE templates failed to populate at point of activation' );
 			$this->header_content = $this->get_default_header();
 			$this->footer_content = $this->get_default_footer();
 			return;
@@ -135,16 +135,7 @@ class WP_Template_Inserter {
 	public function get_default_header() {
 		return '<!-- wp:a8c/site-description /-->
 			<!-- wp:a8c/site-title /-->
-			<!-- wp:a8c/navigation-menu /-->
-			<!-- wp:paragraph -->
-				<p>' .
-				__(
-					'The theme did not activate correctly so it may not look identical to the demo site. 
-					You are still able to edit the header and footer content to suit your needs.',
-					'full-site-editing'
-				)
-				.
-				'</p><!-- /wp:paragraph -->';
+			<!-- wp:a8c/navigation-menu /-->';
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add default template content if call to API to get content fails
* Add error log when call to get template content fails

#### Testing instructions
*  Apply this patch to FSE dev enviroment
* Temporarily change [domain name here](https://github.com/Automattic/wp-calypso/blob/5589ce100348b02bbd02ed5845cae6c63540cc48/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php#L76) to an invalid domain name, eg. public-api-bogus.wordpress.com
* Build FSE plugin and sync to sandbox
* Also apply D32445-code to sandbox
* Sandbox API, and also domain of test FSE site you are about to create on Horizon with new user via `/start/test-fse`
* Create a new FSE site with the domain name you sandboxed through the CfT flow
* Check that the header and footer templates were created but with the default content below instead of the default theme content
* Also check that a logstash log was added for the failure by searching kibana for `a8c_fse`

<img width="896" alt="Screen Shot 2019-09-04 at 12 09 43 PM" src="https://user-images.githubusercontent.com/3629020/64216464-1bd55100-cf0d-11e9-966e-3850e27bc71e.png">

Fixes #35077
