### PR TITLE
(2P) SPT: Remove dependency on FSE

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -233,34 +233,33 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	border-radius: 6px;
 	overflow-x: hidden;
 	overflow-y: auto;
-}
 
-.show-post-title-before-content .template-selector-preview .edit-post-visual-editor {
-	margin-top: 20px;
-}
-
-$template-large-preview-title-height: 115px;
-.show-post-title-before-content .template-selector-preview .editor-styles-wrapper {
-	// Set the
-	.editor-post-title {
-		transform-origin: top left;
-		width: 960px;
-		display: block;
-		position: absolute;
-		top: 0;
+	.edit-post-visual-editor {
+		margin-top: 20px;
 	}
 
-	.editor-post-title,
-	.editor-post-title, .editor-post-title__block {
-		height: $template-large-preview-title-height;
-		margin-top: 0;
-		margin-bottom: 0;
-		padding-top: 0;
-		padding-bottom: 0;
-	}
+	$template-large-preview-title-height: 115px;
+	.editor-styles-wrapper {
+		.editor-post-title {
+			transform-origin: top left;
+			width: 960px;
+			display: block;
+			position: absolute;
+			top: 0;
+		}
 
-	.block-editor-block-preview__content > .block-editor-block-list__layout {
-		margin-top: $template-large-preview-title-height;
+		.editor-post-title,
+		.editor-post-title__block {
+			height: $template-large-preview-title-height;
+			margin-top: 0;
+			margin-bottom: 0;
+			padding-top: 0;
+			padding-bottom: 0;
+		}
+
+		body.show-post-title-before-content & .block-editor-block-preview__content > .block-editor-block-list__layout {
+			margin-top: $template-large-preview-title-height;
+		}
 	}
 }
 


### PR DESCRIPTION
The `.show-post-title-before-content` body class is only available if FSE is activated, which it might not always be. Like when a theme doesn't support it.

Test with FSE enabled and disabled, check that the post title looks proportionate to the template.
To disable FSE, add this in an mu-plugin: 
`add_filter( 'a8c_disable_full_site_editing', '__return_true' );`


#### Before:
![Screen Shot 2019-09-03 at 2 55 32 PM](https://user-images.githubusercontent.com/1398304/64211409-ee2fcf80-ce5a-11e9-8dde-e95adca6dc69.png)

#### After:
![Screen Shot 2019-09-03 at 2 54 59 PM](https://user-images.githubusercontent.com/1398304/64211415-f12ac000-ce5a-11e9-9f1c-e8685c83c794.png)
