### PR TITLE
Fix page and post title overflows

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -417,6 +417,7 @@
 
 .reader-post-card__title {
 	line-height: 1.4;
+	overflow-wrap: break-word;
 }
 
 // Needs to overwrite .reader__content a

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -131,6 +131,8 @@
 	display: inline;
 	margin-right: 33px;
 
+	word-break: break-word;
+
 	.gridicon {
 		color: var( --color-neutral-light );
 		margin: 2px 8px -2px 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix post title overflow in reader post card
* Fix page title overflow in My Sites > Pages

#### Testing instructions

1. Create a new page with a massively long title. Alternatively, edit an existing page's title. Then visit page list at http://calypso.localhost:3000/pages.

BEFORE:
![pages-list-long-title-before](https://user-images.githubusercontent.com/1288616/64229779-6dc7a800-cf08-11e9-873f-bddccb67aee0.png)

AFTER:
![pages-list-long-title-after](https://user-images.githubusercontent.com/1288616/64229806-7fa94b00-cf08-11e9-845f-3618ae03fa61.png)

2. Visit the Reader page (default home page), or http://calypso.localhost:3000/discover if you are not following any site. A list of posts will appear. Use browser's devtools to target any post and make its title massively long.

BEFORE:
![reader-post-card-long-title-before](https://user-images.githubusercontent.com/1288616/64229953-f0506780-cf08-11e9-9ebb-cc0e1a2ca01e.png)

AFTER:
![reader-post-card-long-title-after](https://user-images.githubusercontent.com/1288616/64229960-f5adb200-cf08-11e9-93af-3341756d3a97.png)

Fixes #35834 
Fixes #35828

CC @bluefuton @blowery 