### PR TITLE
Fixup host parameter in server.listen call

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const server = createServer();
 
 // The desktop app runs Calypso in a fork. Let non-forks listen on any host.
 
-server.listen( { port, host: process.env.CALYPSO_IS_FORK ? null : host }, function() {
+server.listen( { port, host: process.env.CALYPSO_IS_FORK ? host : null }, function() {
 	// Tell the parent process that Calypso has booted.
 	sendBootStatus( 'ready' );
 } );


### PR DESCRIPTION
Broken in ESLint cleanup in #35934. Flipped the ternary condition.