### PR TITLE
DismissableCard: Keep card hidden until preferences are recieved

### DIFF
--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -17,7 +17,7 @@ import Gridicon from 'gridicons';
 import Card from 'components/card';
 import QueryPreferences from 'components/data/query-preferences';
 import { savePreference, setPreference } from 'state/preferences/actions';
-import { getPreference } from 'state/preferences/selectors';
+import { getPreference, hasReceivedRemotePreferences } from 'state/preferences/selectors';
 
 /**
  * Style dependencies
@@ -41,9 +41,9 @@ class DismissibleCard extends Component {
 	};
 
 	render() {
-		const { className, isDismissed, onClick, dismissCard } = this.props;
+		const { className, isDismissed, onClick, dismissCard, hasReceivedPreferences } = this.props;
 
-		if ( isDismissed ) {
+		if ( isDismissed || ! hasReceivedPreferences ) {
 			return null;
 		}
 
@@ -67,8 +67,10 @@ class DismissibleCard extends Component {
 export default connect(
 	( state, ownProps ) => {
 		const preference = `${ PREFERENCE_PREFIX }${ ownProps.preferenceName }`;
+
 		return {
 			isDismissed: getPreference( state, preference ),
+			hasReceivedPreferences: hasReceivedRemotePreferences( state ),
 		};
 	},
 	( dispatch, ownProps ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Render `null` in cases where the remote preferences have not been received yet.

@jsnajdr spotted that this component doesn't properly handle the case where the user preferences are not yet done fetching. If those preferences have not been received the current logic sees the lack of a `true` and shows the card whereas it should have waited until we have a response before (accidentally) making that assumption.

In this PR I'm using the `hasReceivedRemotePreferences` selector to figure out if we've had our first fetch yet or not and rendering null in those circumstances too.

#### Testing instructions

This ones a little tricky to test as I'm not actually sure how to show the issue to start with - even in devdocs the data is received before the component mounts... Here's how to test that the component still works as expected but you may need to be creative in properly checking that we are not rendering cards before the preferences are recieved.

- Switch to this branch 
- Go to the [DismissableCard dev docs page](http://calypso.localhost:3000/devdocs/blocks/dismissible-card) 
- It should render just as before, with 2 example cards that can each be dismissed
