### PR TITLE
SPT: close modal once `blank` selected

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -66,6 +66,12 @@ class PageTemplateModal extends Component {
 		this.setState( { blocks } );
 	}
 
+	setBeforeInsertTemplate = ( slug, title, blocks ) => {
+		this.props.saveTemplateChoice( slug );
+		this.props.insertTemplate( title, blocks );
+		this.setState( { isOpen: false } );
+	};
+
 	setTemplate = ( slug, title ) => {
 		this.setState( {
 			error: null,
@@ -75,6 +81,11 @@ class PageTemplateModal extends Component {
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
 		const blocks = this.state.blocks[ slug ];
+
+		// Do not prefetch for `blank` template.
+		if ( 'blank' === slug ) {
+			return this.setBeforeInsertTemplate( slug, title, blocks );
+		}
 
 		// Skip inserting if there's nothing to insert.
 		if ( ! blocks || ! blocks.length ) {
@@ -89,9 +100,8 @@ class PageTemplateModal extends Component {
 				if ( ! this.state.isOpen ) {
 					return;
 				}
-				this.props.saveTemplateChoice( slug );
-				this.props.insertTemplate( title, blocksWithAssets );
-				this.setState( { isOpen: false } );
+
+				this.setBeforeInsertTemplate( slug, title, blocksWithAssets );
 			} )
 			.catch( error => {
 				this.setState( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This patch fixes the issue when the user selects the `blank` template.

#### Testing instructions

* Confirm that without the patch the template modal isn't closed once click on the `blank` template.

![image](https://user-images.githubusercontent.com/77539/64253073-b3b94780-ced9-11e9-8a91-3d8a8c761f45.png)

* Apply the patch
* Confirm that it closes modal.

Fixes #35971
