### PR TITLE
Domains: Send empty fax when we don't need it in checkout

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -165,7 +165,7 @@ export class ContactDetailsFormFields extends Component {
 
 	getMainFieldValues() {
 		const mainFieldValues = formState.getAllFieldValues( this.state.form );
-		const { countryCode, hasCountryStates } = this.props;
+		const { countryCode, hasCountryStates, needsFax } = this.props;
 		let state = mainFieldValues.state;
 
 		// domains registered according to ancient validation rules may have state set even though not required
@@ -177,8 +177,14 @@ export class ContactDetailsFormFields extends Component {
 			state = '';
 		}
 
+		let fax = mainFieldValues.fax;
+		if ( ! needsFax ) {
+			fax = '';
+		}
+
 		return {
 			...mainFieldValues,
+			fax,
 			state,
 			phone: toIcannFormat( mainFieldValues.phone, countries[ this.state.phoneCountryCode ] ),
 		};


### PR DESCRIPTION
Only very select TLDs need the fax field - to avoid validation errors,
we don't show it for the rest. But if a customer has a value in the fax
field already, there's a validation error, but the error is not visible,
so it's not possible to proceed.

This fixes it by simply sending an empty fax value when the fax field is
not needed.

### Testing

Need access to a sandbox and modify your user so that it has an invalid fax (like `+`). You can use my test user `testarz` who already is in this state.

Then go to Domain Management, add a domain to cart and try to fill out the domain contact form. Verify that the fax field is not visible. But without the patch, on validating the form, we make a request to `validate` method and send the non-empty `fax` value (resulting in a validation error).
With the patch, the field is emptied before sending the values to the backend for validation (and saving).