### PR TITLE
SPT: Avoid deprecated warning

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -223,7 +223,7 @@ const PageTemplatesPlugin = compose(
 
 				// Insert blocks.
 				const postContentBlock = ownProps.postContentBlock;
-				editorDispatcher.insertBlocks(
+				dispatch( 'core/block-editor' ).insertBlocks(
 					blocks,
 					0,
 					postContentBlock ? postContentBlock.clientId : '',


### PR DESCRIPTION
Avoids a deprecated warning when inserting a template.

#### Testing instructions

Monitor your browser's console. When inserting a template, the following message should not show up:

> `wp.data.dispatch( 'core/editor' ).insertBlocks` is deprecated. Please use `wp.data.dispatch( 'core/block-editor' ).insertBlocks` instead.