### PR TITLE
Add Explicit Error On Invalid Google My Business Site Keyring

### DIFF
--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -18,7 +18,7 @@ import DocumentHead from 'components/data/document-head';
 import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
 import GoogleMyBusinessLocation from 'my-sites/google-my-business/location';
 import GoogleMyBusinessStatsChart from 'my-sites/google-my-business/stats/chart';
-import Gridicon from 'compnents/gridicon';
+import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import Notice from 'components/notice';
 import PageViewTracker from 'lib/analytics/page-view-tracker';

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -221,7 +221,22 @@ class GoogleMyBusinessStats extends Component {
 				<QueryKeyringConnections forceRefresh />
 				<QueryKeyringServices />
 
-				{ ! isLocationVerified && (
+				{ ! locationData && (
+					<Notice
+						status="is-error"
+						text={ translate(
+							'There is an error with your Google My Business Connection. ' +
+								'Please {{a}}contact support{{/a}}',
+							{
+								components: {
+									a: <a href="/help/contact" target="_blank" rel="noopener noreferrer" />,
+								},
+							}
+						) }
+					/>
+				) }
+
+				{ !! locationData && ! isLocationVerified && (
 					<Notice
 						status="is-error"
 						text={ translate(

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -14,6 +14,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import DocumentHead from 'components/data/document-head';
 import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
 import GoogleMyBusinessLocation from 'my-sites/google-my-business/location';
@@ -21,6 +22,7 @@ import GoogleMyBusinessStatsChart from 'my-sites/google-my-business/stats/chart'
 import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QueryKeyringServices from 'components/data/query-keyring-services';
@@ -224,16 +226,11 @@ class GoogleMyBusinessStats extends Component {
 				{ ! locationData && (
 					<Notice
 						status="is-error"
-						text={ translate(
-							'There is an error with your Google My Business Connection. ' +
-								'Please {{a}}contact support{{/a}}',
-							{
-								components: {
-									a: <a href="/help/contact" target="_blank" rel="noopener noreferrer" />,
-								},
-							}
-						) }
-					/>
+						showDismiss={ false }
+						text={ translate( 'There is an error with your Google My Business account.' ) }
+					>
+						<NoticeAction href={ CALYPSO_CONTACT }>{ translate( 'Contact Support' ) }</NoticeAction>
+					</Notice>
 				) }
 
 				{ !! locationData && ! isLocationVerified && (

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -18,6 +18,7 @@ import DocumentHead from 'components/data/document-head';
 import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
 import GoogleMyBusinessLocation from 'my-sites/google-my-business/location';
 import GoogleMyBusinessStatsChart from 'my-sites/google-my-business/stats/chart';
+import Gridicon from 'compnents/gridicon';
 import Main from 'components/main';
 import Notice from 'components/notice';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -130,8 +131,8 @@ class GoogleMyBusinessStats extends Component {
 		}
 
 		return (
-			<div className="gmb-stats__metrics">
-				<div className="gmb-stats__metric">
+			<div className="stats__metrics">
+				<div className="stats__metric">
 					<GoogleMyBusinessStatsChart
 						title={ translate( 'How customers search for your business' ) }
 						statType="queries"
@@ -154,7 +155,7 @@ class GoogleMyBusinessStats extends Component {
 					/>
 				</div>
 
-				<div className="gmb-stats__metric">
+				<div className="stats__metric">
 					<GoogleMyBusinessStatsChart
 						title={ translate( 'Where your customers view your business on Google' ) }
 						description={ translate(
@@ -174,7 +175,7 @@ class GoogleMyBusinessStats extends Component {
 					/>
 				</div>
 
-				<div className="gmb-stats__metric">
+				<div className="stats__metric">
 					<GoogleMyBusinessStatsChart
 						title={ translate( 'Customer Actions' ) }
 						description={ translate(

--- a/client/my-sites/google-my-business/stats/style.scss
+++ b/client/my-sites/google-my-business/stats/style.scss
@@ -1,4 +1,4 @@
-.gmb-stats__metrics {
+.stats__metrics {
 
 	.pie-chart__chart-drawing,
 	.pie-chart__placeholder-drawing {
@@ -6,7 +6,7 @@
 	}
 }
 
-.gmb-stats__metric {
+.stats__metric {
 	display: inline-block;
 	margin-top: 1px; // Fixes shadow truncated at the top of the second column
 	width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change Error Message on Google My Business Stats page to reflect connection is in error
* Miscellaneous fixes to style to pass lint 

**BEFORE**
<img width="450" alt="Screen Shot 2019-09-04 at 10 31 47 AM" src="https://user-images.githubusercontent.com/2810519/64278024-9ea3df00-cf00-11e9-8e78-55469c5b354a.png">
**AFTER**
<img width="450" alt="Screen Shot 2019-09-05 at 10 24 04 AM" src="https://user-images.githubusercontent.com/2810519/64364249-53a0cf00-cfc7-11e9-9bc9-766d194e523c.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have Business site with Google My Business connection
* Get the site ID of the blog with the connection
* Navigate to `https://developer.wordpress.com/docs/api/console/` as your test user
* GET  `/sites/$site/keyrings` ( where $site is your blog id ) to get the site keyrings <img width="450" alt="Screen Shot 2019-09-04 at 10 48 49 AM" src="https://user-images.githubusercontent.com/2810519/64278533-d3fcfc80-cf01-11e9-9f61-a2dd6093fccf.png">
* POST to `/sites/$site/keyrings` with the `keyring_id` and `service` correct and `external_keyring_id` set to `0` <img width="450" alt="Screen Shot 2019-09-04 at 10 49 17 AM" src="https://user-images.githubusercontent.com/2810519/64278524-d0697580-cf01-11e9-985e-3322abbf738c.png">
* Verify that `/google-my-business/stats/:siteSlug` matches the before screenshot above on WordPress.com and the after screenshot on the branch
