### PR TITLE
Calypso-build: Remove esm syntax

### DIFF
--- a/packages/calypso-build/.eslintrc.js
+++ b/packages/calypso-build/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+	parserOptions: {
+		sourceType: 'script', // force the cli to use require instead of import, which it should be to node compatible
+	},
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+- Replace esm import/export with `require`.
+
 # 4.0.0
 
 - Move `jest.config.js` to `jest-preset.js` so it can be used as a jest preset.

--- a/packages/calypso-build/jest/setup.js
+++ b/packages/calypso-build/jest/setup.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+const { configure } = require( 'enzyme' );
+const Adapter = require( 'enzyme-adapter-react-16' );
 
 configure( { adapter: new Adapter() } );

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",


### PR DESCRIPTION
v4.0.0 was published including some esm `import` syntax. Replace with `require` which would fail when the jest preset was used.

Prep 4.0.1 with a fix
