### PR TITLE
Checkout: remove ebanx to paygate fallback

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -28,7 +28,6 @@ import {
 	isEbanxCreditCardProcessingEnabledForCountry,
 	translatedEbanxError,
 } from 'lib/checkout/processor-specific';
-import analytics from 'lib/analytics';
 import {
 	createStripePaymentMethod,
 	confirmStripePaymentIntent,
@@ -469,14 +468,12 @@ function getEbanxParameters( cardDetails ) {
 	};
 }
 
-export function createCardToken( requestType, cardDetails, callback, forcedPaygate = false ) {
-	if ( ! forcedPaygate && isEbanxCreditCardProcessingEnabledForCountry( cardDetails.country ) ) {
+export function createCardToken( requestType, cardDetails, callback ) {
+	if ( isEbanxCreditCardProcessingEnabledForCountry( cardDetails.country ) ) {
 		return createEbanxToken( requestType, cardDetails ).then(
 			result => callback( null, result ),
-			function( reason ) {
-				analytics.mc.bumpStat( 'cc_token_fallback', 'ebanx_to_paygate' );
-				debug( 'Error creating EBANX token, falling back to paygate', reason );
-				return createCardToken( requestType, cardDetails, callback, true );
+			function( errorMsg ) {
+				return callback( new Error( errorMsg ) );
 			}
 		);
 	}


### PR DESCRIPTION
The fallback was introduced with #29551 - if CC tokenization failed with ebanx, we were attempting to tokenize with paygate. While this may have enabled a few successful transactions, we are deprecating Paygate, and the fallback is no longer wanted.

#### Changes proposed in this Pull Request

* Remove fallback

#### Testing instructions

* To test, you'll need a user account with currency set to **BRL**
* In the checkout form, set the country to **Brazil** to enable processing with EBANX.
* All fields are mandatory, with loose validation, except for the CPF (tax id), where you can enter `527.137.415-72`.
* Test a card that will fail tokenization `3566002020360505`, with a 3 digit CVV and any valid future expiry date. You should get an error message.
* Test with a valid test card, ie `555 555555554444` - (with a 3 digit CVV and any valid future expiry date). Payment should succeed, and you should be redirected to the success page.
