### PR TITLE
Fix: Open up G Suite access to Domain-Only accounts

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -159,7 +159,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	clientRender( reactContext );
 }
 
-function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
+function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParams ) {
 	const allPaths = [
 		domainManagementContactsPrivacy,
 		domainManagementDns,
@@ -177,7 +177,13 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
 		emailManagementForwarding,
 	];
 
-	let domainManagementPaths = allPaths.map( pathFactory => pathFactory( slug, slug ) );
+	let domainManagementPaths = allPaths.map( pathFactory => {
+		if ( pathFactory === emailManagementNewGSuiteAccount ) {
+			// `emailManagementNewGSuiteAccount` takes `planType` from `context.params`, otherwise path comparisons won't work well.
+			return emailManagementNewGSuiteAccount( slug, slug, contextParams.planType );
+		}
+		return pathFactory( slug, slug );
+	} );
 
 	if ( primaryDomain && slug !== primaryDomain.name ) {
 		domainManagementPaths = domainManagementPaths.concat(
@@ -225,7 +231,12 @@ function onSelectedSiteAvailable( context, basePath ) {
 	const primaryDomain = getPrimaryDomainBySiteId( state, selectedSite.ID );
 	if (
 		isDomainOnlySite( state, selectedSite.ID ) &&
-		! isPathAllowedForDomainOnlySite( context.pathname, selectedSite.slug, primaryDomain )
+		! isPathAllowedForDomainOnlySite(
+			context.pathname,
+			selectedSite.slug,
+			primaryDomain,
+			context.params
+		)
 	) {
 		renderSelectedSiteIsDomainOnly( context, selectedSite );
 		return false;


### PR DESCRIPTION
### Summary

`isPathAllowedForDomainOnlySite` is a controller routine that determines which parts of Calypso Domain-Only accounts should have access to. It does this by comparing the request URLs mostly and sometimes by inspecting URL prefixes.

It compiles this URL whitelist by generating them on the fly using path helpers.

The problem was one of these helpers ( i.e. `emailManagementNewGSuiteAccount` ) requires three arguments, one more than the default two passed to each helper.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before** - It used to be that when you attempt to add G Suite to your account which is a Domain-Only account, you are redirected back to the welcome page.

Users are usually brought back to this welcome screen every time even after clicking on <kbd>Add Email</kbd>

<img width="798" alt="Screenshot 2019-09-04 at 11 45 15 PM" src="https://user-images.githubusercontent.com/277661/64298613-1bb96d80-cf6e-11e9-9894-5a0de47bdab2.png">

-----



**After**

* Run this branch in Calypso locally, or using alternate Calypso platforms that lets you run from a branch.
* Create a domain only account via [Domains](https://wordpress.com/domains/). You will need to grant yourself free credits in SA.
* Purchased a domain with your credits, and stall for say 10 mins to allow the name servers propagate.
* Once you have successfully purchased and you are logged in, attempt to purchase G Suite.
* Confirm that you are not redirected back to the welcome screen.
* Confirm that you can successfully add G Suite users to your account.


Fixes #

- Updated `isPathAllowedForDomainOnlySite` by adding `planType` from context params as final parameter to the `emailManagementNewGSuiteAccount` path builder.
Without this required parameter, `emailManagementNewGSuiteAccount` was generating bad urls, such that access to some paths were erroneously denied.
