### PR TITLE
FSE: prevent showing template parts on unsupported themes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -33,6 +33,13 @@ class Full_Site_Editing {
 	private $theme_slug = '';
 
 	/**
+	 * Instance of WP_Template class.
+	 *
+	 * @var WP_Template
+	 */
+	public $wp_template;
+
+	/**
 	 * Instance of WP_Template_Inserter class.
 	 *
 	 * @var WP_Template_Inserter
@@ -64,6 +71,7 @@ class Full_Site_Editing {
 
 		$this->theme_slug           = $this->normalize_theme_slug( get_stylesheet() );
 		$this->wp_template_inserter = new WP_Template_Inserter( $this->theme_slug );
+		$this->wp_template          = new WP_Template();
 	}
 
 	/**
@@ -158,6 +166,10 @@ class Full_Site_Editing {
 	 * Enqueue assets.
 	 */
 	public function enqueue_script_and_style() {
+		if ( ! $this->wp_template->has_page_template_parts() ) {
+			return;
+		}
+
 		$script_dependencies = json_decode(
 			file_get_contents(
 				plugin_dir_path( __FILE__ ) . 'dist/full-site-editing.deps.json'
@@ -198,6 +210,10 @@ class Full_Site_Editing {
 	 * Register blocks.
 	 */
 	public function register_blocks() {
+		if ( ! $this->wp_template->has_page_template_parts() ) {
+			return;
+		}
+
 		register_block_type(
 			'a8c/navigation-menu',
 			array(
@@ -344,8 +360,11 @@ class Full_Site_Editing {
 			return;
 		}
 
-		$template         = new WP_Template();
-		$template_content = $template->get_page_template_content();
+		if ( ! $this->wp_template->has_page_template_parts() ) {
+			return;
+		}
+
+		$template_content = $this->wp_template->get_page_template_content();
 
 		// Bail if the template has no post content block.
 		if ( ! has_block( 'a8c/post-content', $template_content ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -142,6 +142,22 @@ class WP_Template {
 	}
 
 	/**
+	 * Checks whether header and footer have been populated for current theme.
+	 *
+	 * @return bool
+	 */
+	public function has_page_template_parts() {
+		$header_id = $this->get_template_id( self::HEADER );
+		$footer_id = $this->get_template_id( self::FOOTER );
+
+		if ( $header_id && $footer_id ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns full page template content.
 	 *
 	 * We only support one page template for now with header at the top and footer at the bottom.
@@ -149,14 +165,18 @@ class WP_Template {
 	 * @return null|string
 	 */
 	public function get_page_template_content() {
-		$header_id = $this->get_template_id( self::HEADER );
-		$footer_id = $this->get_template_id( self::FOOTER );
-
 		/*
 		 * Bail if we are missing header or footer. Otherwise this would cause us to
 		 * always return some page template content and show template parts (with empty IDs),
 		 * even for themes that don't support FSE.
 		 */
+		if ( ! $this->has_page_template_parts() ) {
+			return null;
+		}
+
+		$header_id = $this->get_template_id( self::HEADER );
+		$footer_id = $this->get_template_id( self::FOOTER );
+
 		if ( ! $header_id || ! $footer_id ) {
 			return null;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -152,6 +152,15 @@ class WP_Template {
 		$header_id = $this->get_template_id( self::HEADER );
 		$footer_id = $this->get_template_id( self::FOOTER );
 
+		/*
+		 * Bail if we are missing header or footer. Otherwise this would cause us to
+		 * always return some page template content and show template parts (with empty IDs),
+		 * even for themes that don't support FSE.
+		 */
+		if ( ! $header_id || ! $footer_id ) {
+			return null;
+		}
+
 		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"className\":\"site-header site-branding\"} /-->" .
 				'<!-- wp:a8c/post-content /-->' .
 				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"className\":\"site-footer\"} /-->";
@@ -179,9 +188,10 @@ class WP_Template {
 		if ( ! $this->is_supported_template_type( $template_type ) ) {
 			return null;
 		}
+
 		/*
-		things that follow are from wp-includes/default-filters.php
-		not everything is appropriate for template content as opposed to post content
+		* Things that follow are from wp-includes/default-filters.php
+		* not everything is appropriate for template content as opposed to post content
 		*/
 
 		global $wp_embed;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously the template parts were visible with infinite spinner even
when the theme that doesn't support FSE was activate. The reason for that
was that we were always return page template content, even when we didn't
have appropriate header and footer for a given theme.

#### Testing instructions

1. Activate a theme that doesn't support FSE on your local test site.
2. Edit an existing page or create a new one and make sure that template parts with spinners are no longer shown.
3. Smoke test with a theme that supports FSE and make sure that everything still works as expected.

fixes https://github.com/Automattic/wp-calypso/issues/35950