### PR TITLE
Gutenberg: Fix E2E tests for Gutenberg 6.4.0-a8c

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -30,6 +30,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
 		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
+
+		// Temp fix: revert to these selectors once https://github.com/WordPress/gutenberg/issues/17264 is fixed
+		// this.publishPostTitleLink = By.css( '.post-publish-panel__postpublish-header a' );
+		// this.publishViewPostLink = By.css( '.post-publish-panel__postpublish-buttons a' );
+		this.publishPostTitleLink = By.css( '.components-snackbar a' );
+		this.publishViewPostLink = By.css( '.components-snackbar a' );
 	}
 
 	static async Expect( driver, editorType ) {
@@ -60,16 +66,27 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
+
+		// Temp fix: remove the four lines below once https://github.com/WordPress/gutenberg/issues/17264 is fixed
+		if (
+			await driverHelper.isElementPresent(
+				this.driver,
+				By.css(
+					'.editor-post-publish-panel__header button.components-button.components-icon-button'
+				)
+			)
+		) {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			await gEditorComponent.closePublishedPanel();
+		}
+
 		await this.waitForSuccessViewPostNotice();
-		const url = await this.driver
-			.findElement( By.css( '.post-publish-panel__postpublish-header a' ) )
-			.getAttribute( 'href' );
+		const url = await this.driver.findElement( this.publishPostTitleLink ).getAttribute( 'href' );
 
 		if ( visit ) {
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '.post-publish-panel__postpublish-buttons a' )
-			);
+			await driverHelper.clickWhenClickable( this.driver, this.publishViewPostLink );
+			// Temp fix: remove the line below once https://github.com/WordPress/gutenberg/issues/17264 is fixed
+			await driverHelper.acceptAlertIfPresent( this.driver );
 		}
 
 		return url;

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -308,7 +308,16 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const revertDraftSelector = By.css( 'button.editor-post-switch-to-draft' );
 		await driverHelper.clickWhenClickable( this.driver, revertDraftSelector );
 		const revertAlert = await this.driver.switchTo().alert();
-		return await revertAlert.accept();
+		await revertAlert.accept();
+		await this.waitForSuccessViewPostNotice();
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( 'button.editor-post-publish-panel__toggle' )
+		);
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( 'button.editor-post-switch-to-draft' )
+		);
 	}
 
 	async isDraft() {


### PR DESCRIPTION
Amend the E2E tests to work with the Gutenberg 6.4.0 upgrade.

See: https://github.com/Automattic/wp-calypso/issues/35825