### PR TITLE
FSE: prevent loading on unsupported themes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -26,6 +26,13 @@ class Full_Site_Editing {
 	private $template_post_types = [ 'wp_template' ];
 
 	/**
+	 * Array of supported themes.
+	 *
+	 * @var array
+	 */
+	private $supported_themes = [ 'modern-business', 'maywood' ];
+
+	/**
 	 * Current theme slug.
 	 *
 	 * @var string
@@ -43,6 +50,10 @@ class Full_Site_Editing {
 	 * Full_Site_Editing constructor.
 	 */
 	private function __construct() {
+		if ( ! $this->is_supported_theme() ) {
+			return;
+		}
+
 		add_action( 'init', [ $this, 'register_blocks' ], 100 );
 		add_action( 'init', [ $this, 'register_template_post_types' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_script_and_style' ], 100 );
@@ -91,7 +102,7 @@ class Full_Site_Editing {
 	public function is_supported_theme( $theme_slug = null ) {
 		// phpcs:enable
 		// now in reality is_current_theme_supported.
-		return current_theme_supports( 'full-site-editing' );
+		return in_array( $this->normalize_theme_slug( get_stylesheet() ), $this->supported_themes, true );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -115,6 +115,20 @@ class WP_Template {
 	}
 
 	/**
+	 * Checks whether header and footer have been populated for current theme.
+	 *
+	 * @return bool
+	 */
+	public function has_page_template_parts() {
+		$header_id = $this->get_template_id( self::HEADER );
+		$footer_id = $this->get_template_id( self::FOOTER );
+		if ( $header_id && $footer_id ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Returns template content for given template type.
 	 *
 	 * @param string $template_type String representing the template type.
@@ -149,6 +163,10 @@ class WP_Template {
 	 * @return null|string
 	 */
 	public function get_page_template_content() {
+		if ( ! $this->has_page_template_parts() ) {
+			return;
+		}
+
 		$header_id = $this->get_template_id( self::HEADER );
 		$footer_id = $this->get_template_id( self::FOOTER );
 
@@ -179,9 +197,10 @@ class WP_Template {
 		if ( ! $this->is_supported_template_type( $template_type ) ) {
 			return null;
 		}
+
 		/*
-		things that follow are from wp-includes/default-filters.php
-		not everything is appropriate for template content as opposed to post content
+		* Things that follow are from wp-includes/default-filters.php
+		* not everything is appropriate for template content as opposed to post content
 		*/
 
 		global $wp_embed;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Alternative take at https://github.com/Automattic/wp-calypso/pull/35989.

Previously the template parts were visible with infinite spinner even
when the theme that doesn't support FSE was activate. The reason for that
was that we were always return page template content, even when we didn't
have appropriate header and footer for a given theme.

#### Testing instructions

1. Activate a theme that doesn't support FSE on your local test site.
2. Edit an existing page or create a new one and make sure that template parts with spinners are no longer shown.
3. Smoke test with a theme that supports FSE and make sure that everything still works as expected.

Fixes #35950