### PR TITLE
Fix container styling issues in Jetpack connect/install step

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -33,6 +33,6 @@
 
 	@include breakpoint( '<480px' ) {
 		margin: 0;
-		padding: 0 20px 24px 0;
+		padding: 0 20px 24px;
 	}
 }

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -5,7 +5,6 @@
 import classnames from 'classnames';
 import React, { Component, Fragment } from 'react';
 import config from 'config';
-import Gridicon from 'components/gridicon';
 import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight, includes } from 'lodash';
@@ -21,6 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormattedHeader from 'components/formatted-header';
 import FormPasswordInput from 'components/forms/form-password-input';
+import Gridicon from 'components/gridicon';
 import HelpButton from './help-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import JetpackRemoteInstallNotices from './jetpack-remote-install-notices';

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -5,7 +5,7 @@
 import classnames from 'classnames';
 import React, { Component, Fragment } from 'react';
 import config from 'config';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight, includes } from 'lodash';
@@ -146,11 +146,7 @@ export class OrgCredentialsForm extends Component {
 				'for this site. Your credentials will not be stored and are used for the purpose ' +
 				'of installing Jetpack securely. You can also skip this step entirely and install Jetpack manually.'
 		);
-		return (
-			<span className="jetpack-connect__install-step jetpack-connect__creds-form">
-				{ subheader }
-			</span>
-		);
+		return <span className="jetpack-connect__creds-form">{ subheader }</span>;
 	}
 
 	getError( installError ) {
@@ -350,7 +346,7 @@ export class OrgCredentialsForm extends Component {
 					</div>
 				) }
 				{ ( this.isInvalidCreds() || ! installError ) && (
-					<div>
+					<div className="jetpack-connect__site-url-entry-container">
 						{ this.renderHeadersText() }
 						<Card className="jetpack-connect__site-url-input-container">
 							{ this.isInvalidCreds() && (

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -146,7 +146,7 @@ export class OrgCredentialsForm extends Component {
 				'for this site. Your credentials will not be stored and are used for the purpose ' +
 				'of installing Jetpack securely. You can also skip this step entirely and install Jetpack manually.'
 		);
-		return <span className="jetpack-connect__creds-form">{ subheader }</span>;
+		return <span>{ subheader }</span>;
 	}
 
 	getError( installError ) {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -225,10 +225,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	@include breakpoint( '>660px' ) {
 		margin: 0 8px 16px;
 	}
-
-	&.jetpack-connect__creds-form {
-		margin-left: 20px;
-	}
 }
 
 .jetpack-connect__install-step-title {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix styling issues in the Jetpack connect/install step: http://calypso.localhost:3000/jetpack/connect/install, including:
* Remove class on the sub-header text that was forcing the header text to overflow on mobile screen widths.
* Add in existing `jetpack-connect__site-url-entry-container` class to set the maximum width of the container for the form and header, and center-align it, to be consistent with the previous step's styling.
* Fix issue introduced in #33973 where it looks like the left padding for `.formatted-header__subtitle` was accidentally set to 0 on mobile.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are a few steps to getting up and running for testing this one:

1. Create a new WordPress site at https://jurrassic.ninja
2. Once the site is created, log in and deactivate and remove the Jetpack plugin. This is so that we can attempt to install it from the Calypso side. Make a note of the new site's URL.
3. Log into Calypso, and go to http://calypso.localhost:3000/
4. From the My Sites menu, click Add New Site
5. From the Add a New Site screen (http://calypso.localhost:3000/jetpack/new) pop your new WordPress site's URL into the `Add an existing WordPress site with Jetpack` url field, and click Continue.
6. You should now be taken to: http://calypso.localhost:3000/jetpack/connect/install — compare the styling you see with the screenshots below
7. Click the Back button at the bottom of this step to go to the previous step http://calypso.localhost:3000/jetpack/connect — the white form should be the same width as on the connect/install step.
8. Test on mobile screen widths and Chrome, FF, Safari, IE11

Additional checks:

* Double-check that other instances of the `.formatted-header__subtitle` still look correct on mobile, for example the sub header at the top of the Checklist in Calypso:

![image](https://user-images.githubusercontent.com/14988353/64306330-c153f780-cfd5-11e9-9ff4-5da4fa50f01c.png)

## Before

![image](https://user-images.githubusercontent.com/14988353/64305795-d6c82200-cfd3-11e9-8057-f563ea0c6bed.png)

## After

![image](https://user-images.githubusercontent.com/14988353/64305817-ee9fa600-cfd3-11e9-9dba-02b5f4338f47.png)
