### PR TITLE
FSE: Improve/fse eligibility active check v2

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -95,14 +95,11 @@ function is_site_eligible_for_full_site_editing() {
 	/**
 	 * Can be used to disable Full Site Editing functionality.
 	 *
-	 * By default, we should disable FSE for sites which don't
-	 * specifically allow support.
-	 *
 	 * @since 0.2
 	 *
 	 * @param bool true if Full Site Editing should be disabled, false otherwise.
 	 */
-	return ! apply_filters( 'a8c_disable_full_site_editing', true );
+	return ! apply_filters( 'a8c_disable_full_site_editing', false );
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -53,6 +53,27 @@ function load_full_site_editing() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
 
 /**
+ * Whether or not FSE is active.
+ * If false, FSE functionality can be disabled.
+ *
+ * @returns bool True if FSE is active, false otherwise.
+ */
+function is_full_site_editing_active() {
+	return is_site_eligible_for_full_site_editing() && current_theme_supports( 'full-site-editing' );
+}
+
+/**
+ * Whether or not the site is eligible for FSE.
+ * This is essentially a feature gate to disable FSE
+ * on some sites which could theoretically otherwise use it.
+ *
+ * @returns bool True if current site is eligible for FSE, false otherwise.
+ */
+function is_site_eligible_for_full_site_editing() {
+	return ! apply_filters( 'a8c_disable_full_site_editing', false );
+}
+
+/**
  * Load Posts List Block.
  */
 function load_posts_list_block() {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -23,8 +23,6 @@ namespace A8C\FSE;
 define( 'PLUGIN_VERSION', '0.6.1' );
 
 // Themes which are supported by Full Site Editing (not the same as the SPT themes).
-// We includ public API since API requests have that as their stylesheet and we need
-// theme to work for Gutenberg.
 const SUPPORTED_THEMES = [ 'maywood' ];
 
 /**
@@ -59,8 +57,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
  * @returns bool True if FSE is active, false otherwise.
  */
 function is_full_site_editing_active() {
-	return is_site_eligible_for_full_site_editing() &&
-			( is_theme_supported() || in_array( get_theme_slug(), SUPPORTED_THEMES, true ) );
+	return is_site_eligible_for_full_site_editing() && is_theme_supported();
 }
 
 /**
@@ -73,7 +70,19 @@ function is_full_site_editing_active() {
  * @return string Normalized theme slug.
  */
 function get_theme_slug() {
-	$theme_slug = get_stylesheet();
+	/**
+	 * Used to get the correct theme in certain contexts.
+	 *
+	 * For example, in the wpcom API context, the theme slug is a8c/public-api, so we need
+	 * to grab the correct one with the filter.
+	 *
+	 * @since 0.7
+	 *
+	 * @param string current theme slug is the default if nothing overrides it.
+	 */
+	$theme_slug = apply_filters( 'a8c_fse_get_theme_slug', get_stylesheet() );
+
+	// Normalize the theme slug.
 	if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
 		$theme_slug = substr( $theme_slug, 4 );
 	}
@@ -104,21 +113,12 @@ function is_site_eligible_for_full_site_editing() {
 }
 
 /**
- * Whether or not current theme is FSE enabled.
- * This is to allow the checking of theme support to be abstracted
- * to the context in which the plugin is running.
+ * Whether or not current theme is enabled for FSE.
  *
  * @return bool True if current theme supports FSE, false otherwise.
  */
 function is_theme_supported() {
-	/**
-	 * Can be used to enable Full Site Editing theme support in certian contexts.
-	 *
-	 * @since 0.7
-	 *
-	 * @param bool true if Full Site Editing is available for current theme, false otherwise.
-	 */
-	return apply_filters( 'a8c_fse_enable_theme_support', false );
+	return in_array( get_theme_slug(), SUPPORTED_THEMES, true );
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -59,7 +59,30 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
  * @returns bool True if FSE is active, false otherwise.
  */
 function is_full_site_editing_active() {
-	return is_site_eligible_for_full_site_editing() && current_theme_supports( 'full-site-editing' );
+	$supported_themes = [ 'maywood' ];
+	return is_site_eligible_for_full_site_editing() && in_array( get_theme_slug(), $supported_themes, true );
+}
+
+/**
+ * Returns normalized theme slug for the current theme.
+ *
+ * Normalize WP.com theme slugs that differ from those that we'll get on self hosted sites.
+ * For example, we will get 'modern-business-wpcom' when retrieving theme slug on self hosted sites,
+ * but due to WP.com setup, on Simple sites we'll get 'pub/modern-business' for the theme.
+ *
+ * @return string Normalized theme slug.
+ */
+function get_theme_slug() {
+	$theme_slug = get_stylesheet();
+	if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
+		$theme_slug = substr( $theme_slug, 4 );
+	}
+
+	if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
+		$theme_slug = substr( $theme_slug, 0, -6 );
+	}
+
+	return $theme_slug;
 }
 
 /**
@@ -70,7 +93,8 @@ function is_full_site_editing_active() {
  * @returns bool True if current site is eligible for FSE, false otherwise.
  */
 function is_site_eligible_for_full_site_editing() {
-	return ! apply_filters( 'a8c_disable_full_site_editing', false );
+	// By default, sites are not eligible for FSE.
+	return ! apply_filters( 'a8c_disable_full_site_editing', true );
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -28,14 +28,9 @@ const SUPPORTED_THEMES = [ 'maywood', 'a8c/public-api' ];
  * Load Full Site Editing.
  */
 function load_full_site_editing() {
-	/**
-	 * Can be used to disable Full Site Editing functionality.
-	 *
-	 * @since 0.2
-	 *
-	 * @param bool true if Full Site Editing should be disabled, false otherwise.
-	 */
-	if ( apply_filters( 'a8c_disable_full_site_editing', false ) ) {
+	// Bail if FSE should not be active on the site. We do not
+	// want to load FSE functionality on non-supported sites!
+	if ( ! is_full_site_editing_active() ) {
 		return;
 	}
 
@@ -95,6 +90,13 @@ function get_theme_slug() {
  */
 function is_site_eligible_for_full_site_editing() {
 	// By default, sites are not eligible for FSE.
+		/**
+	 * Can be used to disable Full Site Editing functionality.
+	 *
+	 * @since 0.2
+	 *
+	 * @param bool true if Full Site Editing should be disabled, false otherwise.
+	 */
 	return ! apply_filters( 'a8c_disable_full_site_editing', true );
 }
 
@@ -171,7 +173,7 @@ register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data'
  * post_content yet.
  */
 function enqueue_coblocks_gallery_scripts() {
-	if ( ! function_exists( 'CoBlocks' ) ) {
+	if ( ! function_exists( 'CoBlocks' ) || ! is_full_site_editing_active() ) {
 		return;
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -22,6 +22,8 @@ namespace A8C\FSE;
  */
 define( 'PLUGIN_VERSION', '0.6.1' );
 
+const SUPPORTED_THEMES = [ 'maywood', 'a8c/public-api' ];
+
 /**
  * Load Full Site Editing.
  */
@@ -59,8 +61,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
  * @returns bool True if FSE is active, false otherwise.
  */
 function is_full_site_editing_active() {
-	$supported_themes = [ 'maywood' ];
-	return is_site_eligible_for_full_site_editing() && in_array( get_theme_slug(), $supported_themes, true );
+	return is_site_eligible_for_full_site_editing() && in_array( get_theme_slug(), SUPPORTED_THEMES, true );
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -104,11 +104,11 @@ function is_site_eligible_for_full_site_editing() {
 }
 
 /**
- * Whether or not the site is eligible for FSE.
- * This is essentially a feature gate to disable FSE
- * on some sites which could theoretically otherwise use it.
+ * Whether or not current theme is FSE enabled.
+ * This is to allow the checking of theme support to be abstracted
+ * to the context in which the plugin is running.
  *
- * @return bool True if current site is eligible for FSE, false otherwise.
+ * @return bool True if current theme supports FSE, false otherwise.
  */
 function is_theme_supported() {
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -25,7 +25,7 @@ define( 'PLUGIN_VERSION', '0.6.1' );
 // Themes which are supported by Full Site Editing (not the same as the SPT themes).
 // We includ public API since API requests have that as their stylesheet and we need
 // theme to work for Gutenberg.
-const SUPPORTED_THEMES = [ 'maywood', 'a8c/public-api' ];
+const SUPPORTED_THEMES = [ 'maywood' ];
 
 /**
  * Load Full Site Editing.
@@ -59,7 +59,8 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
  * @returns bool True if FSE is active, false otherwise.
  */
 function is_full_site_editing_active() {
-	return is_site_eligible_for_full_site_editing() && in_array( get_theme_slug(), SUPPORTED_THEMES, true );
+	return is_site_eligible_for_full_site_editing() &&
+			( is_theme_supported() || in_array( get_theme_slug(), SUPPORTED_THEMES, true ) );
 }
 
 /**
@@ -100,6 +101,24 @@ function is_site_eligible_for_full_site_editing() {
 	 * @param bool true if Full Site Editing should be disabled, false otherwise.
 	 */
 	return ! apply_filters( 'a8c_disable_full_site_editing', false );
+}
+
+/**
+ * Whether or not the site is eligible for FSE.
+ * This is essentially a feature gate to disable FSE
+ * on some sites which could theoretically otherwise use it.
+ *
+ * @return bool True if current site is eligible for FSE, false otherwise.
+ */
+function is_theme_supported() {
+	/**
+	 * Can be used to enable Full Site Editing theme support in certian contexts.
+	 *
+	 * @since 0.7
+	 *
+	 * @param bool true if Full Site Editing is available for current theme, false otherwise.
+	 */
+	return apply_filters( 'a8c_fse_enable_theme_support', false );
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -22,6 +22,9 @@ namespace A8C\FSE;
  */
 define( 'PLUGIN_VERSION', '0.6.1' );
 
+// Themes which are supported by Full Site Editing (not the same as the SPT themes).
+// We includ public API since API requests have that as their stylesheet and we need
+// theme to work for Gutenberg.
 const SUPPORTED_THEMES = [ 'maywood', 'a8c/public-api' ];
 
 /**
@@ -86,12 +89,14 @@ function get_theme_slug() {
  * This is essentially a feature gate to disable FSE
  * on some sites which could theoretically otherwise use it.
  *
- * @returns bool True if current site is eligible for FSE, false otherwise.
+ * @return bool True if current site is eligible for FSE, false otherwise.
  */
 function is_site_eligible_for_full_site_editing() {
-	// By default, sites are not eligible for FSE.
-		/**
+	/**
 	 * Can be used to disable Full Site Editing functionality.
+	 *
+	 * By default, we should disable FSE for sites which don't
+	 * specifically allow support.
 	 *
 	 * @since 0.2
 	 *

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -45,7 +45,7 @@ class Full_Site_Editing {
 	private function __construct() {
 		// Bail if FSE should not be active on the site. We do not
 		// want to load FSE functionality on non-supported sites!
-		if ( ! self::is_active() ) {
+		if ( ! is_full_site_editing_active() ) {
 			return;
 		}
 		add_action( 'init', [ $this, 'register_blocks' ], 100 );
@@ -82,28 +82,6 @@ class Full_Site_Editing {
 		}
 
 		return self::$instance;
-	}
-
-
-	/**
-	 * Whether or not FSE is active.
-	 * If false, FSE functionality is disabled in the constructor.
-	 *
-	 * @returns bool True if FSE is active, false otherwise.
-	 */
-	public static function is_active() {
-		return self::is_eligible() && current_theme_supports( 'full-site-editing' );
-	}
-
-	/**
-	 * Whether or not the site is eligible for FSE.
-	 * This is essentially a feature gate to disable FSE
-	 * on some sites which could theoretically otherwise use it.
-	 *
-	 * @returns bool True if current site is eligible for FSE, false otherwise.
-	 */
-	public static function is_eligible() {
-		return ! apply_filters( 'a8c_disable_full_site_editing', false );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -43,11 +43,7 @@ class Full_Site_Editing {
 	 * Full_Site_Editing constructor.
 	 */
 	private function __construct() {
-		// Bail if FSE should not be active on the site. We do not
-		// want to load FSE functionality on non-supported sites!
-		if ( ! is_full_site_editing_active() ) {
-			return;
-		}
+
 		add_action( 'init', [ $this, 'register_blocks' ], 100 );
 		add_action( 'init', [ $this, 'register_template_post_types' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_script_and_style' ], 100 );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -43,6 +43,11 @@ class Full_Site_Editing {
 	 * Full_Site_Editing constructor.
 	 */
 	private function __construct() {
+		// Bail if FSE should not be active on the site. We do not
+		// want to load FSE functionality on non-supported sites!
+		if ( ! self::is_active() ) {
+			return;
+		}
 		add_action( 'init', [ $this, 'register_blocks' ], 100 );
 		add_action( 'init', [ $this, 'register_template_post_types' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_script_and_style' ], 100 );
@@ -77,6 +82,28 @@ class Full_Site_Editing {
 		}
 
 		return self::$instance;
+	}
+
+
+	/**
+	 * Whether or not FSE is active.
+	 * If false, FSE functionality is disabled in the constructor.
+	 *
+	 * @returns bool True if FSE is active, false otherwise.
+	 */
+	public static function is_active() {
+		return self::is_eligible() && current_theme_supports( 'full-site-editing' );
+	}
+
+	/**
+	 * Whether or not the site is eligible for FSE.
+	 * This is essentially a feature gate to disable FSE
+	 * on some sites which could theoretically otherwise use it.
+	 *
+	 * @returns bool True if current site is eligible for FSE, false otherwise.
+	 */
+	public static function is_eligible() {
+		return ! apply_filters( 'a8c_disable_full_site_editing', false );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -43,7 +43,6 @@ class Full_Site_Editing {
 	 * Full_Site_Editing constructor.
 	 */
 	private function __construct() {
-
 		add_action( 'init', [ $this, 'register_blocks' ], 100 );
 		add_action( 'init', [ $this, 'register_template_post_types' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_script_and_style' ], 100 );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -152,6 +152,15 @@ class WP_Template {
 		$header_id = $this->get_template_id( self::HEADER );
 		$footer_id = $this->get_template_id( self::FOOTER );
 
+		/*
+		 * Bail if we are missing header or footer. Otherwise this would cause us to
+		 * always return some page template content and show template parts (with empty IDs),
+		 * even for themes that don't support FSE.
+		 */
+		if ( ! $header_id || ! $footer_id ) {
+			return null;
+		}
+
 		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"className\":\"site-header site-branding\"} /-->" .
 				'<!-- wp:a8c/post-content /-->' .
 				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"className\":\"site-footer\"} /-->";
@@ -179,11 +188,9 @@ class WP_Template {
 		if ( ! $this->is_supported_template_type( $template_type ) ) {
 			return null;
 		}
-		/*
-		things that follow are from wp-includes/default-filters.php
-		not everything is appropriate for template content as opposed to post content
-		*/
 
+		// Things that follow are from wp-includes/default-filters.php
+		// not everything is appropriate for template content as opposed to post content.
 		global $wp_embed;
 		$content = $this->get_template_content( $template_type );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a filter for grabbing the theme. We need this to override the api theme in the API context
* Bail on merging templates if header and footer templates empty

#### Testing instructions

* Apply D32454-code to your sandbox
* Checkout this patch, build FSE plugin and sync with your sandbox
* Sandbox API
* Make sure FSE templates display on supported theme on WP.com and not on unsupported theme
* Check same thing on local install

Fixes #35950
