### PR TITLE
Customer Home: Remove the feature flag from the development config file

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -37,7 +37,6 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,
-		"customer-home": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #35864 the `customer-home` feature flag was removed to put the feature live, but it was left in the development configuration file. This is a simple fix to remove it.

#### Testing instructions

A quick check that you can view the Customer Home page.
