### PR TITLE
jetpack checklist – thank you modal: remove color overrides and fix image width

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -39,7 +39,6 @@
 
 .current-plan-thank-you__illustration {
 	margin-right: 32px;
-	width: 35%;
 
 	@include breakpoint( '<660px' ) {
 		display: none;

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -27,20 +27,12 @@
 	}
 
 	.button {
-		background-color: var( --color-primary );
-		border-color: var( --color-primary-dark );
 		padding-right: 80px;
 		padding-left: 80px;
 
 		@include breakpoint( '<660px' ) {
 			text-align: center;
 			width: 100%;
-		}
-
-		&:hover,
-		&:focus {
-			background-color: var( --color-primary-400 );
-			border-color: var( --color-primary-dark );
 		}
 	}
 }


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/35123

#### Changes proposed in this Pull Request

* Remove color overrides for the button
* Fix image width in Firefox. In Chrome, image works fine already before the change.

#### Testing instructions

- Have a jetpack site
- Open `http://calypso.localhost:3000/plans/my-plan/SITE_SLUG?thank-you`

**Before (in Firefox)**

<img width="801" alt="Screenshot 2019-09-05 at 10 11 39" src="https://user-images.githubusercontent.com/87168/64319907-1b4cc100-cfc6-11e9-870b-d20b9c94ebfa.png">


**After**

<img width="797" alt="Screenshot 2019-09-05 at 10 12 51" src="https://user-images.githubusercontent.com/87168/64319937-2142a200-cfc6-11e9-8502-b73a4c620049.png">
<img width="328" alt="Screenshot 2019-09-05 at 10 13 12" src="https://user-images.githubusercontent.com/87168/64319943-23a4fc00-cfc6-11e9-90f6-71f7b4e980b2.png">

