### PR TITLE
Full Site Editing: Avoid double wrapper on fallback Navigation block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -35,9 +35,7 @@ function render_navigation_menu_block() {
 			<span class="hide-visually expanded-text"><?php esc_html_e( 'expanded', 'full-site-editing' ); ?></span>
 			<span class="hide-visually collapsed-text"><?php esc_html_e( 'collapsed', 'full-site-editing' ); ?></span>
 		</label>
-		<div class="menu-primary-container">
-			<?php echo $menu ? $menu : get_fallback_navigation_menu(); ?>
-		</div>
+		<?php echo $menu ? $menu : get_fallback_navigation_menu(); ?>
 	</nav>
 	<!-- #site-navigation -->
 	<?php
@@ -71,5 +69,7 @@ function get_fallback_navigation_menu() {
 	$original_classes    = [ 'children', 'page_item_has_sub-menu' ];
 	$replacement_classes = [ 'sub-menu', 'menu-item-has-children' ];
 
-	return str_replace( $original_classes, $replacement_classes, $menu );
+	return '<div class="menu-primary-container">'
+		. str_replace( $original_classes, $replacement_classes, $menu )
+		. '</div>';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Requires https://github.com/Automattic/themes/pull/1398

In a previous commit I've added a wrapper to the menu in the Navigation block to make it consistent with the Varia theme.
What I didn't realize is that the wrapper is only required for the fallback menu, used if there is no menu assigned to the `menu-1` ("Primary") location.
If there is an actual menu assigned, the wrapper is automatically output by the WP menu function, and so it's not needed, as it breaks some CSS rules.

@apeatling IIRC you got this issue at some point, this should fix it.

| | Before | After |
| - | - | - |
| Header (desktop) | ![Screenshot 2019-09-05 at 14 33 08](https://user-images.githubusercontent.com/2070010/64347180-6200e200-cfeb-11e9-8bd3-81466e2a8a1f.png) | ![Screenshot 2019-09-05 at 14 31 02](https://user-images.githubusercontent.com/2070010/64347195-67f6c300-cfeb-11e9-9f2e-107384ea1ec5.png) |
| Footer (desktop) | ![Screenshot 2019-09-05 at 14 33 16](https://user-images.githubusercontent.com/2070010/64347230-780ea280-cfeb-11e9-87eb-280d354daa7f.png) | ![Screenshot 2019-09-05 at 14 31 08](https://user-images.githubusercontent.com/2070010/64347248-7d6bed00-cfeb-11e9-9c5a-c758db4cb9df.png) |
| Header (mobile) | ![Screenshot 2019-09-05 at 14 33 26](https://user-images.githubusercontent.com/2070010/64347283-8c529f80-cfeb-11e9-9693-aaf87b34841b.png) | ![Screenshot 2019-09-05 at 14 31 27](https://user-images.githubusercontent.com/2070010/64347266-865cbe80-cfeb-11e9-83fa-858c6b4ec570.png) |
| Footer (mobile) | ![Screenshot 2019-09-05 at 14 33 31](https://user-images.githubusercontent.com/2070010/64347303-94124400-cfeb-11e9-9484-3c996859fda1.png) | ![Screenshot 2019-09-05 at 14 31 33](https://user-images.githubusercontent.com/2070010/64347307-970d3480-cfeb-11e9-88d7-b521af04f7c2.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this and https://github.com/Automattic/themes/pull/1398 on an FSE site with Varia and Maywood.
* Activate Maywood.
* Visit `/wp-admin/nav-menus.php`.
* If needed, create a menu, add some items, and assign it to the "Primary" display location.
* Check on the front end and in the editors that it looks as in the "after" screens.
* Head back to the Menu screen, remove the menu from the "Primary" display location.
* Check on the front end and in the editors that the fallback menu looks as expected.