### PR TITLE
Full Site Editing: Add alignment options to the FSE blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -1,4 +1,4 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -6,17 +6,17 @@
 /**
  * WordPress dependencies
  */
-import { ServerSideRender } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
 import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 
-const NavigationMenuEdit = ( { attributes } ) => {
+const NavigationMenuEdit = () => {
 	return (
 		<Fragment>
-			<ServerSideRender attributes={ attributes } block="a8c/navigation-menu" />
+			<ServerSideRender block="a8c/navigation-menu" />
 		</Fragment>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */
@@ -23,8 +24,15 @@ registerBlockType( 'a8c/navigation-menu', {
 	icon,
 	category: 'layout',
 	supports: {
+		align: [ 'wide', 'full' ],
 		html: false,
 		reusable: false,
+	},
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'wide',
+		},
 	},
 	edit,
 	save: () => null,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -10,9 +10,10 @@ namespace A8C\FSE;
 /**
  * Render the navigation menu.
  *
+ * @param array $attributes Block attributes.
  * @return string
  */
-function render_navigation_menu_block() {
+function render_navigation_menu_block( $attributes ) {
 	$menu = wp_nav_menu(
 		[
 			'echo'           => false,
@@ -23,10 +24,15 @@ function render_navigation_menu_block() {
 		]
 	);
 
+	$align = ' alignwide';
+	if ( isset( $attributes['align'] ) ) {
+		$align = empty( $attributes['align'] ) ? '' : ' align' . $attributes['align'];
+	}
+
 	ob_start();
 	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	?>
-	<nav class="main-navigation wp-block-a8c-navigation-menu">
+	<nav class="main-navigation wp-block-a8c-navigation-menu<?php echo esc_attr( $align ); ?>">
 		<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
 		<label for="toggle" id="toggle-menu" class="button">
 			<?php esc_html_e( 'Menu', 'full-site-editing' ); ?>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */
@@ -21,9 +22,16 @@ registerBlockType( 'a8c/site-description', {
 	),
 	category: 'layout',
 	supports: {
+		align: [ 'wide', 'full' ],
 		html: false,
 		multiple: false,
 		reusable: false,
+	},
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'wide',
+		},
 	},
 	edit,
 	save: () => null,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -21,6 +21,12 @@ function render_site_description_block( $attributes ) {
 		$class .= ' ' . $attributes['className'];
 	}
 
+	$align = ' alignwide';
+	if ( isset( $attributes['align'] ) ) {
+		$align = empty( $attributes['align'] ) ? '' : ' align' . $attributes['align'];
+	}
+	$class .= $align;
+
 	?>
 	<p class="<?php echo esc_attr( $class ); ?>">
 		<?php bloginfo( 'description' ); ?>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */
@@ -16,9 +17,16 @@ registerBlockType( 'a8c/site-title', {
 	icon: 'layout',
 	category: 'layout',
 	supports: {
+		align: [ 'wide', 'full' ],
 		html: false,
 		multiple: false,
 		reusable: false,
+	},
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'wide',
+		},
 	},
 	edit,
 	save: () => null,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.php
@@ -21,6 +21,12 @@ function render_site_title_block( $attributes ) {
 		$class .= ' ' . $attributes['className'];
 	}
 
+	$align = ' alignwide';
+	if ( isset( $attributes['align'] ) ) {
+		$align = empty( $attributes['align'] ) ? '' : ' align' . $attributes['align'];
+	}
+	$class .= $align;
+
 	?>
 	<h1 class="<?php echo esc_attr( $class ); ?>">
 		<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `a8c/site-title`, `a8c/site-description`, and `a8c/navigation-menu` to support `wide` and `full` alignment.
* Default the alignment to `wide`.

In theory, FSE template blocks (header and footer) should be all automatically wide and so all their content.
Though, in order to fully support the Gutenberg flexibility, I've chosen to not force a blanket alignment, but instead have the template block full-width (exactly like a normal post content), and let the user decide the width of each block.

This PR lets the user chose between default, `wide`, and `full` alignment on all the FSE blocks, defaulting them to `wide`.
Kind of the best of both worlds?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR on an FSE site (preferably with Varia or Maywood).
* Open a page and then a template editor (for example edit the header).
* Make sure that the FSE blocks (site title, description, and navigation) all are automatically `wide`.
* Try poking their alignment: make one `wide`, one `full`, and one leaving the alignment unspecified.
* Save and look at it on the front end.
* Inspect the FSE blocks: they should have, respectively an `alignwide` and `alignfull` class added, or nothing if the alignment was unspecified.
* Check the elements footprint and make sure they are in fact as wide as their alignment suggest.