### PR TITLE
Email: Fix custom domain image migration

### DIFF
--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -45,6 +45,11 @@ import QuerySiteDomains from 'components/data/query-site-domains';
  */
 import './style.scss';
 
+/**
+ * Image dependencies
+ */
+import customDomainImage from 'assets/images/illustrations/custom-domain.svg';
+
 class EmailManagement extends React.Component {
 	static propTypes = {
 		domains: PropTypes.array.isRequired,
@@ -143,7 +148,7 @@ class EmailManagement extends React.Component {
 			};
 		}
 		Object.assign( emptyContentProps, {
-			illustration: '/calypso/images/illustrations/custom-domain.svg',
+			illustration: customDomainImage,
 			action: translate( 'Add a Custom Domain' ),
 			actionURL: '/domains/add/' + selectedSiteSlug,
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes introduced in #34867 broke this image because it was moved but not migrated to webpack in this instance. This PR follows the same process for migration.

![screencapture-calypso-localhost-3000-email-sixhourssandbox-wordpress-com-2019-09-05-11_14_55](https://user-images.githubusercontent.com/2124984/64355275-e7c26480-cfce-11e9-85bf-4154b8689638.png)

#### Testing instructions

* Switch to this PR, navigate to `/email` on a site that does not have email configured yet.
* You should see the image shown in the screenshot above, not broken, regardless of production/development environments.