### PR TITLE
Private by Default: Pull out AB Test & enable for 100% of relevant flows

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,15 +124,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	privateByDefault: {
-		datestamp: '20190730',
-		variations: {
-			selected: 90,
-			control: 10,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	removeBlogFlow: {
 		datestamp: '20190813',
 		variations: {

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getCurrentFlowName } from 'state/signup/flow/selectors';
@@ -19,5 +18,5 @@ export default function shouldNewSiteBePrivateByDefault( state: object ): boolea
 		return false;
 	}
 
-	return abtest( 'privateByDefault' ) === 'selected';
+	return true;
 }

--- a/client/state/selectors/test/should-new-site-be-private-by-default.js
+++ b/client/state/selectors/test/should-new-site-be-private-by-default.js
@@ -3,10 +3,6 @@
  */
 import shouldNewSiteBePrivateByDefault from '../should-new-site-be-private-by-default';
 
-jest.mock( 'lib/abtest', () => ( {
-	abtest: testName => ( testName === 'privateByDefault' ? 'selected' : '' ),
-} ) );
-
 describe( 'shouldNewSiteBePrivateByDefault()', () => {
 	test( 'should be true with no input', () => {
 		expect( shouldNewSiteBePrivateByDefault() ).toBe( true );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Remove the AB Test config
* Update `shouldNewSiteBePrivateByDefault` to return `true` (unless specifically excepted)
* Update the test file to pull out `abtest` mock

#### Testing instructions

##### Manual tests

* Run this branch
* `/start`
* The `privateByDefault` test should not show up in the list under the "Environment Badge"
* Create a site using any vertical except for Online Store / eCommerce.
* The new site should be private & unlaunched

##### Automated tests
`npm run test-client "(should-new-site-be-private-by-default|get-new-site-public-setting)"`
