### PR TITLE
Full Site Editing: Fix full-width blocks inside the Post Content block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -19,12 +20,19 @@ registerBlockType( 'a8c/post-content', {
 	icon: 'layout',
 	category: 'layout',
 	supports: {
+		align: [ 'full' ],
 		anchor: false,
 		customClassName: false,
 		html: false,
 		inserter: false,
 		multiple: false,
 		reusable: false,
+	},
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'full',
+		},
 	},
 	edit,
 	save,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -34,6 +34,13 @@
 	}
 }
 
+// Fix the size and positioning full-width blocks inside the Post Content block
+// TODO: Replace the magic numbers!
+.post-content-block .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] {
+	max-width: calc( 100vw - 81px );
+	margin-left: 3px;
+}
+
 /* Hide the content slot block UI */
 .block-editor-block-list__layout {
 	.post-content__block {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -39,6 +39,7 @@
 .post-content-block .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] {
 	max-width: calc( 100vw - 81px );
 	margin-left: 3px;
+	margin-right: 3px;
 }
 
 /* Hide the content slot block UI */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Default the Post Content block to full alignment.
* Reposition the full-width blocks to fit the FSE editor frame.

| Before | After |
| - | - |
| ![Screenshot 2019-09-05 at 21 05 18](https://user-images.githubusercontent.com/2070010/64376794-f9ccf300-d020-11e9-8e6a-8c58e33ad8d7.png) | ![Screenshot 2019-09-05 at 21 04 24](https://user-images.githubusercontent.com/2070010/64376805-fcc7e380-d020-11e9-8d22-13a8a70645af.png) |