### PR TITLE
Signup: Add exception for connect-in-place flow for Google

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import AppleLoginButton from 'components/social-buttons/apple';
 import config from 'config';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -70,8 +71,14 @@ class SocialSignupForm extends Component {
 	}
 
 	render() {
+		const { currentRoute } = this.props;
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
-		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
+		let redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
+
+		// For the Jetpack Connect-in-place flow - see p1HpG7-7nj-p2 for more information.
+		if ( window && window.opener && '/jetpack/connect/authorize' === currentRoute ) {
+			redirectUri = window.location.href;
+		}
 
 		return (
 			<div className="signup-form__social">
@@ -99,6 +106,8 @@ class SocialSignupForm extends Component {
 }
 
 export default connect(
-	null,
+	state => ( {
+		currentRoute: getCurrentRoute( state ),
+	} ),
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );


### PR DESCRIPTION
This PR will alter the URL we redirect to after signing up with Google to the current URL, so the Jetpack authorization can continue. It will only work for the Jetpack authorize screen, and only when opened in a popup. 

Originally, this would redirect to `/start` after authenticating with Google, which breaks the Jetpack "connect in place" flow, dropping the user to the WP.com site creation flow, which doesn't make sense.

See p1HpG7-7nj-p2 for more context, and feel free to ping @Automattic/poseidon if you have any questions.

#### Changes proposed in this Pull Request

* Signup: Add exception for connect-in-place flow for Google account creation.

#### Testing instructions

* Checkout this branch locally and build Calypso (`npm start`).
* Use your Jetpack dev environment, a JN site or just a random Jetpack site you have access to.
* Make sure your Jetpack site runs the latest `master`. 
* Add this to your Jetpack site's wp-config.php to ensure you're going to see the connect-in-place flow: `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
* Add this to your Jetpack site's wp-config.php to point your Jetpack site to use the local Calypso: `define( 'CALYPSO_ENV', 'development' );`
* Make sure the site is currently disconnected.
* Make sure you're logged out of WP.com.
* Navigate to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Click on the "Set up Jetpack" button and wait for a little.
* Click the "Connect using WordPress.com" button - a popup will be opened, with the Jetpack Connect login screen.
* Click the "Create a new account" link.
* Click the "Continue with Google" button.
* You should see a 400 error screen - that's expected
* Verify that the error message says: "Invalid parameter value for redirect_uri: Non-public domains not allowed: http://calypso.localhost:3000/jetpack/connect/authorize...."
* Now test the same flow with the Calypso `master`.
* You'll notice that the error message says: "Invalid parameter value for redirect_uri: Non-public domains not allowed: http://calypso.localhost:3000/start".
* Verify the Google signup flow still works as expected when going through the Jetpack Connect original flow
* Verify the Google signup flow still works as expected when signing up for a WP.com site.
