### PR TITLE
Support: Update GM Closure notice dates

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -534,9 +534,9 @@ class HelpContact extends React.Component {
 					<GMClosureNotice
 						compact={ compact }
 						displayAt="2019-08-31 00:00Z"
-						basicChatClosesAt="2019-09-06 23:00Z"
+						basicChatClosesAt="2019-09-07 00:00Z"
 						basicChatReopensAt="2019-09-23 04:00Z"
-						priorityChatClosesAt="2019-09-09 23:00Z"
+						priorityChatClosesAt="2019-09-10 00:00Z"
 						priorityChatReopensAt="2019-09-19 04:00Z"
 					/>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the closure notice dates as requested

> Business plan and eCommerce plan:
> Chat closes: September 10th at 00:00 UTC
>
> Personal and Premium plan:
> Chat closes: September 7th at 00:00 UTC

[request]: https://github.com/Automattic/hg/issues/663#issuecomment-528180405

#### Testing instructions

- Go to http://calypso.localhost:3000/help/contact
- Observe the dates in the notice reflect the correct date/time for your given timezone.

