### PR TITLE
Fix first click does not work when linking existing wpcom account to social

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -11,7 +11,7 @@ import React, { Component, Fragment } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import { stringify } from 'qs';
 
 /**

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -11,7 +11,7 @@ import React, { Component, Fragment } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { stringify } from 'qs';
 
 /**
@@ -118,9 +118,8 @@ export class LoginForm extends Component {
 			this.props.socialAccountIsLinking !== nextProps.socialAccountIsLinking &&
 			nextProps.socialAccountIsLinking
 		) {
-			if ( ! this.state.usernameOrEmail ) {
-				this.setState( { usernameOrEmail: nextProps.socialAccountLinkEmail } );
-			}
+			this.setState( { usernameOrEmail: nextProps.socialAccountLinkEmail } );
+			this.props.getAuthAccountType( nextProps.socialAccountLinkEmail );
 		}
 
 		if ( this.props.hasAccountTypeLoaded && ! nextProps.hasAccountTypeLoaded ) {


### PR DESCRIPTION
This PR updates the login screen to fetch the account type immediately when user is trying to connect to an existing wpcom account with a social (apple, google) account. Doing so will make sure the account type is loaded when [user submits the form](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/login/login-form.jsx#L219).

#### Testing instructions

- Checkout this PR locally and boot http://calypso.localhost:3000/log-in
- Connect with google or apple using an email for which you already have a wpcom account
- You should see the connect screen "We found a WordPress.com account with the email address .... Log in to this account to connect it ..."
- Enter your password and click Log In
- It should log you in immediately

Fixes https://github.com/Automattic/wp-calypso/issues/35904
