### PR TITLE
Full Site Editing: Add image filters to the template content output

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -204,9 +204,11 @@ class WP_Template {
 		// 10 priority
 		$content = wptexturize( $content );
 		// @todo maybe look at WPCOM_Responsive_Images for WPCom responsive image handling
-
 		// 11 priority
 		$content = do_shortcode( $content );
+
+		$content = prepend_attachment( $content );
+		$content = wp_make_content_images_responsive( $content );
 
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $content;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -203,12 +203,18 @@ class WP_Template {
 
 		// 10 priority
 		$content = wptexturize( $content );
-		// @todo maybe look at WPCOM_Responsive_Images for WPCom responsive image handling
+
 		// 11 priority
 		$content = do_shortcode( $content );
 
 		$content = prepend_attachment( $content );
-		$content = wp_make_content_images_responsive( $content );
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && class_exists( '\WPCOM_Responsive_Images' ) ) {
+			$wpcom_responsive_images_instance = new \WPCOM_Responsive_Images();
+			$content                          = $wpcom_responsive_images_instance->make_content_images_responsive( $content );
+		} else {
+			$content = wp_make_content_images_responsive( $content );
+		}
 
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $content;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -209,12 +209,7 @@ class WP_Template {
 
 		$content = prepend_attachment( $content );
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && class_exists( '\WPCOM_Responsive_Images' ) ) {
-			$wpcom_responsive_images_instance = new \WPCOM_Responsive_Images();
-			$content                          = $wpcom_responsive_images_instance->make_content_images_responsive( $content );
-		} else {
-			$content = wp_make_content_images_responsive( $content );
-		}
+		$content = apply_filters( 'a8c_fse_make_content_images_responsive', $content );
 
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $content;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -209,7 +209,11 @@ class WP_Template {
 
 		$content = prepend_attachment( $content );
 
-		$content = apply_filters( 'a8c_fse_make_content_images_responsive', $content );
+		if ( has_filter( 'a8c_fse_make_content_images_responsive' ) ) {
+			$content = apply_filters( 'a8c_fse_make_content_images_responsive', $content );
+		} else {
+			$content = wp_make_content_images_responsive( $content );
+		}
 
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $content;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add more `the_content` filter functions to the template content output in order to fix how the manually resized images in the template part look on the front end.

| Before | After |
| - | - |
| ![Screenshot 2019-09-06 at 11 47 28](https://user-images.githubusercontent.com/2070010/64422750-b6b06580-d09c-11e9-91e9-9275b1172515.png) | ![Screenshot 2019-09-06 at 11 33 46](https://user-images.githubusercontent.com/2070010/64422757-bb751980-d09c-11e9-8981-da106590bdb9.png) |

These are the [default `the_content` filters](https://github.com/WordPress/WordPress/blob/699c6001fd6afabc8060acfd3b2a663093d33727/wp-includes/default-filters.php#L172-L178) that we should roughly use in FSE, and here are the [`prepend_attachment`](https://github.com/WordPress/WordPress/blob/699c6001fd6afabc8060acfd3b2a663093d33727/wp-includes/post-template.php#L1647) and [`wp_make_content_images_responsive`](https://github.com/WordPress/WordPress/blob/699c6001fd6afabc8060acfd3b2a663093d33727/wp-includes/media.php#L1402) functions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Either:
  * Apply D33228-code and sandbox a WPCOM FSE site with Maywood.
  * Or just open a non-WPCOM FSE site with Maywood.
* Add an image to the header, and resize it using the resize handles (not the size selector in the sidebar).
* Preview the image: the size should be the same.
* Repeat the test on the post content, and make sure the image size is the same in both editor and front end.

Fixes #36020
