### PR TITLE
Revert "Signup: Add exception for connect-in-place flow for Google"

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import AppleLoginButton from 'components/social-buttons/apple';
 import config from 'config';
-import getCurrentRoute from 'state/selectors/get-current-route';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -71,14 +70,8 @@ class SocialSignupForm extends Component {
 	}
 
 	render() {
-		const { currentRoute } = this.props;
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
-		let redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
-
-		// For the Jetpack Connect-in-place flow - see p1HpG7-7nj-p2 for more information.
-		if ( window && window.opener && '/jetpack/connect/authorize' === currentRoute ) {
-			redirectUri = window.location.href;
-		}
+		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
 			<div className="signup-form__social">
@@ -106,8 +99,6 @@ class SocialSignupForm extends Component {
 }
 
 export default connect(
-	state => ( {
-		currentRoute: getCurrentRoute( state ),
-	} ),
+	null,
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#36007 because we're getting:

![](https://cldup.com/fVqP7VD966.png)