### PR TITLE
Temporarily dial down concierge upsell nudge to zero

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -83,8 +83,8 @@ export default {
 		//this test is used to dial down the upsell offer
 		datestamp: '20190429',
 		variations: {
-			offer: 0,
-			noOffer: 100,
+			offer: 100,
+			noOffer: 0,
 		},
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -83,8 +83,8 @@ export default {
 		//this test is used to dial down the upsell offer
 		datestamp: '20190429',
 		variations: {
-			offer: 100,
-			noOffer: 0,
+			offer: 0,
+			noOffer: 100,
 		},
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,8 +118,8 @@ export default {
 	showPlanUpsellConcierge: {
 		datestamp: '20190805',
 		variations: {
-			variantShowPlanBump: 50,
-			control: 50,
+			variantShowPlanBump: 100,
+			control: 0,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -425,7 +425,7 @@ export class Checkout extends React.Component {
 			/*if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellConcierge' ) ) {
 				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
 			}*/
-			// Showing the plan bump to all users, for the GM week.
+			// Temporarily showing the plan bump to all users
 			return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
 		}
 
@@ -480,9 +480,11 @@ export class Checkout extends React.Component {
 
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
-			if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
+
+			//We are commenting out this code to temporaritly not show the concierge upsell to any user
+			/*if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
 				return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ selectedSiteSlug }`;
-			}
+			}*/
 		}
 
 		return;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -420,9 +420,13 @@ export class Checkout extends React.Component {
 		const { cart, selectedSiteSlug } = this.props;
 
 		if ( hasPersonalPlan( cart ) ) {
-			if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellConcierge' ) ) {
+			// The plan bump vs concierge test is having some discrepancies,
+			// we will comment this out till a fix is found. Check pa1C6h-z7-p2.
+			/*if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellConcierge' ) ) {
 				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
-			}
+			}*/
+			// Showing the plan bump to all users, for the GM week.
+			return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
 		}
 
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In view of the upcoming GM, we will not show the concierge upsell nudge to users. Instead, we will show the plan bump offer to 100% of users who buy or upgrade to a Personal plan

#### Testing instructions

1. Go through signup flow from /start
2. Purchase a personal plan
3. Verify that you are shown the Premium plan upgrade upsell nudge. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

