### PR TITLE
Signup: Add exception for connect-in-place flow for Google (take 2)

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import AppleLoginButton from 'components/social-buttons/apple';
 import config from 'config';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -70,8 +71,14 @@ class SocialSignupForm extends Component {
 	}
 
 	render() {
+		const { currentRoute } = this.props;
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
-		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
+		let redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
+
+		// For the Jetpack Connect-in-place flow - see p1HpG7-7nj-p2 for more information.
+		if ( window && window.opener && '/jetpack/connect/authorize' === currentRoute ) {
+			redirectUri = window.location.href;
+		}
 
 		return (
 			<div className="signup-form__social">
@@ -99,6 +106,8 @@ class SocialSignupForm extends Component {
 }
 
 export default connect(
-	null,
+	state => ( {
+		currentRoute: getCurrentRoute( state ),
+	} ),
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -77,7 +77,8 @@ class SocialSignupForm extends Component {
 
 		// For the Jetpack Connect-in-place flow - see p1HpG7-7nj-p2 for more information.
 		if ( window && window.opener && '/jetpack/connect/authorize' === currentRoute ) {
-			redirectUri = window.location.href;
+			// We mask the client ID to allow usage of Jetpack Connect authorization URLs as Google oAuth2 redirect URI.
+			redirectUri = window.location.href.replace( 'client_id=', 'jetpack_client_id=' );
 		}
 
 		return (

--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -4,7 +4,6 @@ export const authorizeQueryDataSchema = {
 	required: [
 		'_wp_nonce',
 		'blogname',
-		'client_id',
 		'home_url',
 		'redirect_uri',
 		'scope',
@@ -12,6 +11,14 @@ export const authorizeQueryDataSchema = {
 		'site',
 		'site_url',
 		'state',
+	],
+	oneOf: [
+		{
+			required: [ 'client_id' ],
+		},
+		{
+			required: [ 'jetpack_client_id' ],
+		},
 	],
 	properties: {
 		_ui: { type: 'string' },
@@ -21,6 +28,7 @@ export const authorizeQueryDataSchema = {
 		auth_approved: { type: 'string' },
 		blogname: { type: 'string' },
 		client_id: { pattern: '^\\d+$', type: 'string' },
+		jetpack_client_id: { pattern: '^\\d+$', type: 'string' },
 		close_window_after_login: { type: 'string' },
 		from: { type: 'string' },
 		home_url: { type: 'string' },

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -16,7 +16,7 @@ import { addQueryArgs, untrailingslashit } from 'lib/route';
 export function authQueryTransformer( queryObject ) {
 	return {
 		// Required
-		clientId: parseInt( queryObject.client_id, 10 ),
+		clientId: parseInt( queryObject.client_id || queryObject.jetpack_client_id, 10 ),
 		closeWindowAfterLogin: !! queryObject.close_window_after_login,
 		homeUrl: queryObject.home_url,
 		nonce: queryObject._wp_nonce,


### PR DESCRIPTION
This PR will alter the URL we redirect to after signing up with Google to the current URL, so the Jetpack authorization can continue. It will only work for the Jetpack authorize screen, and only when opened in a popup. 

Originally, this would redirect to `/start` after authenticating with Google, which breaks the Jetpack "connect in place" flow, dropping the user to the WP.com site creation flow, which doesn't make sense.

This is take 2 - see #36007 for take 1. In this take, in addition to take 1, we mask the `client_id` parameter as `jetpack_client_id` to allow Jetpack Connect authorize URLs to be used as Google oAuth2 redirect URIs, working around errors like this:

![](https://cldup.com/fVqP7VD966.png)

See p1HpG7-7nj-p2 for more context, and feel free to ping @Automattic/poseidon if you have any questions.

#### Changes proposed in this Pull Request

* Signup: Add exception for connect-in-place flow for Google account creation.

#### Testing instructions

Due to limitations with the Google oAuth2 flow, the full flow can't be tested with development Calypso and can only be tested in production.

* Checkout this branch locally and build Calypso (`npm start`).
* Use your Jetpack dev environment, a JN site or just a random Jetpack site you have access to.
* Make sure your Jetpack site runs the latest `master`. 
* Add this to your Jetpack site's wp-config.php to ensure you're going to see the connect-in-place flow: `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
* Add this to your Jetpack site's wp-config.php to point your Jetpack site to use the local Calypso: `define( 'CALYPSO_ENV', 'development' );`
* Make sure the site is currently disconnected.
* Make sure you're logged out of WP.com.
* Navigate to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Click on the "Set up Jetpack" button and wait for a little.
* Click the "Connect using WordPress.com" button - a popup will be opened, with the Jetpack Connect login screen.
* Click the "Create a new account" link.
* Click the "Continue with Google" button.
* You should see a 400 error screen - that's expected
* Verify that the error message says: "Invalid parameter value for redirect_uri: Non-public domains not allowed: http://calypso.localhost:3000/jetpack/connect/authorize...."
* Now test the same flow with the Calypso `master`.
* You'll notice that the error message says: "Invalid parameter value for redirect_uri: Non-public domains not allowed: http://calypso.localhost:3000/start".
* Verify the Google signup flow still works as expected when going through the Jetpack Connect original flow
* Verify the Google signup flow still works as expected when signing up for a WP.com site.
