### PR TITLE
Revert "Signup: Add exception for connect-in-place flow for Google (take 2)"

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import AppleLoginButton from 'components/social-buttons/apple';
 import config from 'config';
-import getCurrentRoute from 'state/selectors/get-current-route';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -71,15 +70,8 @@ class SocialSignupForm extends Component {
 	}
 
 	render() {
-		const { currentRoute } = this.props;
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
-		let redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
-
-		// For the Jetpack Connect-in-place flow - see p1HpG7-7nj-p2 for more information.
-		if ( window && window.opener && '/jetpack/connect/authorize' === currentRoute ) {
-			// We mask the client ID to allow usage of Jetpack Connect authorization URLs as Google oAuth2 redirect URI.
-			redirectUri = window.location.href.replace( 'client_id=', 'jetpack_client_id=' );
-		}
+		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
 			<div className="signup-form__social">
@@ -107,8 +99,6 @@ class SocialSignupForm extends Component {
 }
 
 export default connect(
-	state => ( {
-		currentRoute: getCurrentRoute( state ),
-	} ),
+	null,
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );

--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -4,6 +4,7 @@ export const authorizeQueryDataSchema = {
 	required: [
 		'_wp_nonce',
 		'blogname',
+		'client_id',
 		'home_url',
 		'redirect_uri',
 		'scope',
@@ -11,14 +12,6 @@ export const authorizeQueryDataSchema = {
 		'site',
 		'site_url',
 		'state',
-	],
-	oneOf: [
-		{
-			required: [ 'client_id' ],
-		},
-		{
-			required: [ 'jetpack_client_id' ],
-		},
 	],
 	properties: {
 		_ui: { type: 'string' },
@@ -28,7 +21,6 @@ export const authorizeQueryDataSchema = {
 		auth_approved: { type: 'string' },
 		blogname: { type: 'string' },
 		client_id: { pattern: '^\\d+$', type: 'string' },
-		jetpack_client_id: { pattern: '^\\d+$', type: 'string' },
 		close_window_after_login: { type: 'string' },
 		from: { type: 'string' },
 		home_url: { type: 'string' },

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -16,7 +16,7 @@ import { addQueryArgs, untrailingslashit } from 'lib/route';
 export function authQueryTransformer( queryObject ) {
 	return {
 		// Required
-		clientId: parseInt( queryObject.client_id || queryObject.jetpack_client_id, 10 ),
+		clientId: parseInt( queryObject.client_id, 10 ),
 		closeWindowAfterLogin: !! queryObject.close_window_after_login,
 		homeUrl: queryObject.home_url,
 		nonce: queryObject._wp_nonce,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#36036 because now we get:

![](https://cldup.com/K66wTfApod.png)

In take 3 we should address the `state` var the same way.