### PR TITLE
Climate strike setting

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -354,14 +354,23 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	handleClimateToggle = () => {
+		const { fields, submitForm, trackEvent, updateFields } = this.props;
+		const climatestrike = ! fields.climatestrike;
+		this.props.recordTracksEvent( 'calypso_general_settings_climatestrike_updated', {
+			climatestrike: climatestrike,
+		} );
+		updateFields( { climatestrike: climatestrike }, () => {
+			submitForm();
+			trackEvent( 'Toggled Climate Strike Toggle' );
+		} );
+	};
+
 	climateStrikeOption() {
 		const {
 			fields,
 			isRequestingSettings,
 			translate,
-			handleToggle,
-			handleSubmitForm,
-			isSavingSettings,
 		} = this.props;
 
 		const today = moment(),
@@ -373,23 +382,13 @@ export class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<div>
-				<SettingsSectionHeader title={ translate( 'Climate Strike 2019' ) }>
-					<Button
-						compact={ true }
-						onClick={ handleSubmitForm }
-						primary={ true }
-						type="submit"
-						disabled={ isRequestingSettings || isSavingSettings }
-					>
-						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
-					</Button>
-				</SettingsSectionHeader>
+				<SettingsSectionHeader title={ translate( 'Climate Strike 2019' ) } />
 				<Card>
 					<FormFieldset>
 						<CompactFormToggle
 							checked={ !! fields.climatestrike }
 							disabled={ isRequestingSettings }
-							onChange={ handleToggle( 'climatestrike' ) }
+							onChange={ this.handleClimateToggle }
 						>
 							{ translate(
 								'This September, millions of us will walk out of our workplaces and homes to join ' +

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -44,6 +44,7 @@ import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { launchSite } from 'state/sites/launch/actions';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {
@@ -353,6 +354,74 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	climateStrikeOption() {
+		const {
+			fields,
+			isRequestingSettings,
+			translate,
+			handleToggle,
+			handleSubmitForm,
+			isSavingSettings,
+		} = this.props;
+
+		const today = moment(),
+			lastDay = moment( { year: 2019, month: 9, day: 21 } );
+
+		if ( today.isAfter( lastDay, 'day' ) ) {
+			return null;
+		}
+
+		return (
+			<div>
+				<SettingsSectionHeader title={ translate( 'Climate Strike 2019' ) }>
+					<Button
+						compact={ true }
+						onClick={ handleSubmitForm }
+						primary={ true }
+						type="submit"
+						disabled={ isRequestingSettings || isSavingSettings }
+					>
+						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+					</Button>
+				</SettingsSectionHeader>
+				<Card>
+					<FormFieldset>
+						<CompactFormToggle
+							checked={ !! fields.climatestrike }
+							disabled={ isRequestingSettings }
+							onChange={ handleToggle( 'climatestrike' ) }
+						>
+							{ translate(
+								'This September, millions of us will walk out of our workplaces and homes to join ' +
+									'young climate strikers on the streets and {{climateStrikeLink}}demand an end to the age ' +
+									'of fossil fuels{{/climateStrikeLink}}. Show your solidarity with a {{digitalClimateStrikeLink}}digital ' +
+									'climate strike banner{{/digitalClimateStrikeLink}} that will appear on your website on September 20th.',
+								{
+									components: {
+										climateStrikeLink: (
+											<a
+												target="_blank"
+												rel="noopener noreferrer"
+												href={ 'https://globalclimatestrike.net' }
+											/>
+										),
+										digitalClimateStrikeLink: (
+											<a
+												target="_blank"
+												rel="noopener noreferrer"
+												href={ 'https://digital.globalclimatestrike.net' }
+											/>
+										),
+									},
+								}
+							) }
+						</CompactFormToggle>
+					</FormFieldset>
+				</Card>
+			</div>
+		);
+	}
+
 	Timezone() {
 		const { fields, isRequestingSettings, translate } = this.props;
 		const guessedTimezone = moment.tz.guess();
@@ -506,6 +575,8 @@ export class SiteSettingsFormGeneral extends Component {
 		return (
 			<div className={ classNames( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
+
+				{ ! siteIsJetpack && this.climateStrikeOption() }
 
 				<SettingsSectionHeader
 					data-tip-target="settings-site-profile-save"

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -395,7 +395,7 @@ export class SiteSettingsFormGeneral extends Component {
 								'This September, millions of us will walk out of our workplaces and homes to join ' +
 									'young climate strikers on the streets and {{climateStrikeLink}}demand an end to the age ' +
 									'of fossil fuels{{/climateStrikeLink}}. Show your solidarity with a {{digitalClimateStrikeLink}}digital ' +
-									'climate strike banner{{/digitalClimateStrikeLink}} that will appear on your website on September 20th.',
+									'climate strike banner{{/digitalClimateStrikeLink}}. On September 20th the banner will expand to a dissmissable overlay.',
 								{
 									components: {
 										climateStrikeLink: (

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -693,6 +693,7 @@ const getFormSettings = settings => {
 		timezone_string: '',
 		blog_public: '',
 		admin_url: '',
+		climatestrike: false,
 	};
 
 	if ( ! settings ) {
@@ -706,6 +707,7 @@ const getFormSettings = settings => {
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
 		timezone_string: settings.timezone_string,
+		climatestrike: settings.climatestrike
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -387,10 +387,11 @@ export class SiteSettingsFormGeneral extends Component {
 							onChange={ this.handleClimateToggle }
 						>
 							{ translate(
-								'This September, millions of us will walk out of our workplaces and homes to join ' +
-									'young climate strikers on the streets and {{climateStrikeLink}}demand an end to the age ' +
-									'of fossil fuels{{/climateStrikeLink}}. Show your solidarity with a {{digitalClimateStrikeLink}}digital ' +
-									'climate strike banner{{/digitalClimateStrikeLink}}. On September 20th the banner will expand to a dismissible overlay.',
+								'This September, millions of us will take to the streets to {{climateStrikeLink}}demand an end to the age ' +
+									'of fossil fuels{{/climateStrikeLink}}. Show your solidarity on your site by displaying a ' +
+									'{{digitalClimateStrikeLink}}digital climate strike banner{{/digitalClimateStrikeLink}} for the month. ' +
+									'On September 20th, the day of the Global Climate Strike, the banner will expand to a full-screen overlay ' +
+									'that site visitors can dismiss.',
 								{
 									components: {
 										climateStrikeLink: (

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { flowRight, get, has } from 'lodash';
 import moment from 'moment-timezone';
 
@@ -367,11 +367,7 @@ export class SiteSettingsFormGeneral extends Component {
 	};
 
 	climateStrikeOption() {
-		const {
-			fields,
-			isRequestingSettings,
-			translate,
-		} = this.props;
+		const { fields, isRequestingSettings, translate } = this.props;
 
 		const today = moment(),
 			lastDay = moment( { year: 2019, month: 9, day: 21 } );
@@ -706,7 +702,7 @@ const getFormSettings = settings => {
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
 		timezone_string: settings.timezone_string,
-		climatestrike: settings.climatestrike
+		climatestrike: settings.climatestrike,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -395,7 +395,7 @@ export class SiteSettingsFormGeneral extends Component {
 								'This September, millions of us will walk out of our workplaces and homes to join ' +
 									'young climate strikers on the streets and {{climateStrikeLink}}demand an end to the age ' +
 									'of fossil fuels{{/climateStrikeLink}}. Show your solidarity with a {{digitalClimateStrikeLink}}digital ' +
-									'climate strike banner{{/digitalClimateStrikeLink}}. On September 20th the banner will expand to a dissmissable overlay.',
+									'climate strike banner{{/digitalClimateStrikeLink}}. On September 20th the banner will expand to a dismissible overlay.',
 								{
 									components: {
 										climateStrikeLink: (

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -381,7 +381,7 @@ export class SiteSettingsFormGeneral extends Component {
 		}
 
 		return (
-			<div>
+			<>
 				<SettingsSectionHeader title={ translate( 'Climate Strike 2019' ) } />
 				<Card>
 					<FormFieldset>
@@ -417,7 +417,7 @@ export class SiteSettingsFormGeneral extends Component {
 						</CompactFormToggle>
 					</FormFieldset>
 				</Card>
-			</div>
+			</>
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

![Screenshot_2019-09-10 Site Settings ‹ Jack Lenox — WordPress com](https://user-images.githubusercontent.com/751476/64636161-6c631780-d401-11e9-910b-d85d88fa0e17.png)

Introduce a new setting for controlling the climate strike banner (pb6Nl-d71-p2).

Copy review in progress.

#### Testing instructions

**Dependencies**

D32643-code
D32647-code

With both the API and plugin in place and your site and the API sandboxed, you can test this PR on any WordPress.com site. The setting will not show for Jetpack sites which can install the [plugin directly](https://href.li/?https://wordpress.org/plugins/digital-climate-strike-wp/). 
