### PR TITLE
Add stripZeros option to formatCurrency function

### DIFF
--- a/packages/format-currency/src/index.js
+++ b/packages/format-currency/src/index.js
@@ -20,6 +20,7 @@ export { CURRENCIES } from './currencies';
  * @param   {String}     options.grouping    thousands separator
  * @param   {Number}     options.precision   decimal digits
  * @param   {String}     options.symbol      currency symbol e.g. 'A$'
+ * @param   {Boolean}    options.stripZeros  whether to remove trailing zero cents
  * @returns {?String}                        A formatted string.
  */
 export default function formatCurrency( number, code, options = {} ) {
@@ -29,11 +30,16 @@ export default function formatCurrency( number, code, options = {} ) {
 	}
 	const { decimal, grouping, precision, symbol } = { ...currencyDefaults, ...options };
 	const sign = number < 0 ? '-' : '';
-	const value = numberFormat( Math.abs( number ), {
+	let value = numberFormat( Math.abs( number ), {
 		decimals: precision,
 		thousandsSep: grouping,
 		decPoint: decimal,
 	} );
+
+	if ( options.stripZeros ) {
+		value = stripZeros( value, decimal );
+	}
+
 	return `${ sign }${ symbol }${ value }`;
 }
 
@@ -76,4 +82,16 @@ export function getCurrencyObject( number, code, options = {} ) {
 		integer,
 		fraction,
 	};
+}
+
+/**
+ * Remove trailing zero cents
+ * @param {String}  number  formatted number
+ * @param {String}  decimal decimal symbol
+ * @returns {String}
+ */
+
+function stripZeros( number, decimal ) {
+	const regex = new RegExp( `\\${ decimal }0+$` );
+	return number.replace( regex, '' );
 }

--- a/packages/format-currency/test/index.js
+++ b/packages/format-currency/test/index.js
@@ -15,6 +15,9 @@ describe( 'formatCurrency', () => {
 	test( 'handles zero', () => {
 		const money = formatCurrency( 0, 'USD' );
 		expect( money ).toBe( '$0.00' );
+
+		const money2 = formatCurrency( 0, 'USD', { stripZeros: true } );
+		expect( money2 ).toBe( '$0' );
 	} );
 	test( 'handles negative values', () => {
 		const money = formatCurrency( -1234.56789, 'USD' );
@@ -23,6 +26,19 @@ describe( 'formatCurrency', () => {
 	test( 'unknown currency codes return default', () => {
 		const money = formatCurrency( 9800900.32, {} );
 		expect( money ).toBe( '$9,800,900.32' );
+	} );
+
+	test( 'returns trailing zero cents when stripZeros set to true', () => {
+		const money = formatCurrency( 9800900, 'USD', { precision: 2 } );
+		expect( money ).toBe( '$9,800,900.00' );
+
+		// Trailing zero cents should be removed.
+		const money2 = formatCurrency( 9800900, 'USD', { precision: 2, stripZeros: true } );
+		expect( money2 ).toBe( '$9,800,900' );
+
+		// It should not strip non-zero cents.
+		const money3 = formatCurrency( 9800900.32, 'USD', { precision: 2, stripZeros: true } );
+		expect( money3 ).toBe( '$9,800,900.32' );
 	} );
 
 	describe( 'supported currencies', () => {

--- a/packages/format-currency/test/index.js
+++ b/packages/format-currency/test/index.js
@@ -18,6 +18,12 @@ describe( 'formatCurrency', () => {
 
 		const money2 = formatCurrency( 0, 'USD', { stripZeros: true } );
 		expect( money2 ).toBe( '$0' );
+
+		const money3 = formatCurrency( 0, 'EUR' );
+		expect( money3 ).toBe( '€0,00' );
+
+		const money4 = formatCurrency( 0, 'EUR', { stripZeros: true } );
+		expect( money4 ).toBe( '€0' );
 	} );
 	test( 'handles negative values', () => {
 		const money = formatCurrency( -1234.56789, 'USD' );
@@ -28,7 +34,7 @@ describe( 'formatCurrency', () => {
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
-	test( 'returns trailing zero cents when stripZeros set to true', () => {
+	test( 'returns no trailing zero cents when stripZeros set to true (USD)', () => {
 		const money = formatCurrency( 9800900, 'USD', { precision: 2 } );
 		expect( money ).toBe( '$9,800,900.00' );
 
@@ -39,6 +45,19 @@ describe( 'formatCurrency', () => {
 		// It should not strip non-zero cents.
 		const money3 = formatCurrency( 9800900.32, 'USD', { precision: 2, stripZeros: true } );
 		expect( money3 ).toBe( '$9,800,900.32' );
+	} );
+
+	test( 'returns no trailing zero cents when stripZeros set to true (EUR)', () => {
+		const money = formatCurrency( 9800900, 'EUR', { precision: 2 } );
+		expect( money ).toBe( '€9.800.900,00' );
+
+		// Trailing zero cents should be removed.
+		const money2 = formatCurrency( 9800900, 'EUR', { precision: 2, stripZeros: true } );
+		expect( money2 ).toBe( '€9.800.900' );
+
+		// It should not strip non-zero cents.
+		const money3 = formatCurrency( 9800900.32, 'EUR', { precision: 2, stripZeros: true } );
+		expect( money3 ).toBe( '€9.800.900,32' );
 	} );
 
 	describe( 'supported currencies', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Allows `formatCurrency` function to strip trailing zero cents. Prices with trailing zero cents are not displayed in a consistent way, as you see in the following screenshot. To keep the PR small, the inconsistency will be handled in follow-up PRs once the new option is adopted.

<img width="981" alt="screenshot_2019-06-26-plans-e280b9-site-title-e28094-wordpress-com_png__1280×2654_" src="https://user-images.githubusercontent.com/212034/64442109-33c5f400-d10a-11e9-8504-ba562f753e76.png">

To understand the background, see Victor's first comment in p8Eqe3-FT-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Move to the package root and run the test suites.
   ```
   cd packages/format-currency && npx jest -c ./jest.config.js .
   ```
* All tests should be passed.