### PR TITLE
Full Site Editing: Only reposition full width blocks in Post Content on large screens

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -37,9 +37,16 @@
 // Fix the size and positioning full-width blocks inside the Post Content block
 // TODO: Replace the magic numbers!
 .post-content-block .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] {
-	max-width: calc( 100vw - 81px );
-	margin-left: 3px;
-	margin-right: 3px;
+	@media ( max-width: 768px ) {
+		.block-editor-block-mover {
+			left: 60px;
+		}
+	}
+	@media ( min-width: 768px ) {
+		max-width: calc( 100vw - 81px );
+		margin-left: 3px;
+		margin-right: 3px;
+	}
 }
 
 /* Hide the content slot block UI */

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -38,6 +38,10 @@
 // TODO: Replace the magic numbers!
 .post-content-block .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] {
 	@media ( max-width: 768px ) {
+		max-width: 768px;
+		margin-left: 0;
+		margin-right: 0;
+
 		.block-editor-block-mover {
 			left: 60px;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -1,5 +1,9 @@
 .post-content-block.alignfull {
 	padding: 0 12px;
+
+	@media ( max-width: 768px ) {
+		overflow-x: hidden;
+	}
 }
 
 .post-content-block__selector {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -26,12 +26,13 @@
 	}
 
 	.edit-post-layout__content .edit-post-visual-editor {
+		box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 		flex: none;
 		margin: 36px 32px;
-		box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 
 		@media ( max-width: 768px ) {
 			margin: 0;
+			overflow-x: hidden;
 		}
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -21,18 +21,15 @@
 }
 
 .post-type-page, .post-type-wp_template {
-	.edit-post-layout__content {
-		background: #eee;
-	}
+	@media ( min-width: 768px ) {
+		.edit-post-layout__content {
+			background: #eee;
+		}
 
-	.edit-post-layout__content .edit-post-visual-editor {
-		box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
-		flex: none;
-		margin: 36px 32px;
-
-		@media ( max-width: 768px ) {
-			margin: 0;
-			overflow-x: hidden;
+		.edit-post-layout__content .edit-post-visual-editor {
+			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
+			flex: none;
+			margin: 36px 32px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/36005

* Full-width blocks in the Post Content block are now only repositioned on large screen.
* On small screens, move the block mover in a visible position.

| Before | After |
| - | - |
| ![Screenshot 2019-09-06 at 17 33 49](https://user-images.githubusercontent.com/2070010/64445194-cac08b00-d0cd-11e9-94df-dc8b59b09536.png) | ![Screenshot 2019-09-06 at 17 38 58](https://user-images.githubusercontent.com/2070010/64445202-cdbb7b80-d0cd-11e9-9bd9-df86ab317f6f.png) |