### PR TITLE
Empty Cart: Add Border Radius

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -193,6 +193,7 @@
 
 .cart-empty {
 	background: var( --color-white );
+	border-radius: 30px;
 	padding: 30px;
 	text-align: center;
 	font-size: 14px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a border radius to the empty cart popover, which is necessary due to the increased padding being set with the background colour.

#### Testing instructions

Compare the screenshots or follow the instructions in the original issue.

**Before (note the top corners of the popover):**

<img width="746" alt="Screenshot 2019-09-06 at 18 19 28" src="https://user-images.githubusercontent.com/43215253/64447632-c4351200-d0d3-11e9-858d-d1d9c3f0847a.png">

**After:**

<img width="812" alt="Screenshot 2019-09-06 at 18 22 25" src="https://user-images.githubusercontent.com/43215253/64447646-cdbe7a00-d0d3-11e9-921c-f7aa49aff3e2.png">

Fixes #36012
