### PR TITLE
Themes: Remove Try & Customize action in theme menu

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -183,7 +183,6 @@ const ALL_THEME_OPTIONS = {
 	purchase,
 	upgradePlan,
 	activate,
-	tryandcustomize,
 	deleteTheme,
 	signup,
 	separator,

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -15,7 +15,6 @@ import { has, identity, mapValues, pickBy } from 'lodash';
 import config from 'config';
 import {
 	activate as activateAction,
-	tryAndCustomize as tryAndCustomizeAction,
 	confirmDelete,
 	showThemePreview as themePreview,
 } from 'state/themes/actions';
@@ -114,25 +113,6 @@ const customize = {
 	hideForTheme: ( state, themeId, siteId ) =>
 		! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
 		! isThemeActive( state, themeId, siteId ),
-};
-
-const tryandcustomize = {
-	label: i18n.translate( 'Try & Customize' ),
-	extendedLabel: i18n.translate( 'Try & Customize' ),
-	header: i18n.translate( 'Try & Customize on:', {
-		comment: 'label in the dialog for opening the Customizer with the theme in preview',
-	} ),
-	action: tryAndCustomizeAction,
-	hideForTheme: ( state, themeId, siteId ) =>
-		! getCurrentUser( state ) ||
-		( siteId &&
-			( ! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
-				( isJetpackSite( state, siteId ) && isJetpackSiteMultiSite( state, siteId ) ) ) ) ||
-		isThemeActive( state, themeId, siteId ) ||
-		( isThemePremium( state, themeId ) &&
-			isJetpackSite( state, siteId ) &&
-			! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
-		( isJetpackSite( state, siteId ) && ! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ),
 };
 
 const preview = {

--- a/test/e2e/specs/wp-theme-multisite-spec.js
+++ b/test/e2e/specs/wp-theme-multisite-spec.js
@@ -68,36 +68,6 @@ describe( `[${ host }] Themes: All sites (${ screenSize })`, function() {
 				const displayed = await this.themesPage.popOverMenuDisplayed();
 				assert( displayed, 'Popover menu not displayed' );
 			} );
-
-			describe( 'when "Try & Customize" is clicked', function() {
-				step( 'click try and customize popover', async function() {
-					await this.themesPage.clickPopoverItem( 'Try & Customize' );
-					this.siteSelector = await SiteSelectorComponent.Expect( driver );
-				} );
-
-				step( 'should show the site selector', async function() {
-					const siteSelectorShown = await this.siteSelector.displayed();
-					return assert( siteSelectorShown, 'The site selector was not shown' );
-				} );
-
-				describe( 'when a site is selected, and Customize is clicked', function() {
-					step( 'select first site', async function() {
-						await this.siteSelector.selectFirstSite();
-						await this.siteSelector.ok();
-					} );
-
-					step( 'should open the customizer with the selected site and theme', async function() {
-						this.customizerPage = await CustomizerPage.Expect( driver );
-						const url = await driver.getCurrentUrl();
-						assert( url.indexOf( this.siteSelector.selectedSiteDomain ) > -1, 'Wrong site domain' );
-						assert( url.indexOf( this.themeSearchName ) > -1, 'Wrong theme' );
-					} );
-
-					after( async function() {
-						await this.customizerPage.close();
-					} );
-				} );
-			} );
 		} );
 	} );
 

--- a/test/e2e/specs/wp-theme-multisite-spec.js
+++ b/test/e2e/specs/wp-theme-multisite-spec.js
@@ -14,7 +14,6 @@ import * as dataHelper from '../lib/data-helper';
 
 import ThemeDetailPage from '../lib/pages/theme-detail-page.js';
 import ThemesPage from '../lib/pages/themes-page.js';
-import CustomizerPage from '../lib/pages/customizer-page.js';
 
 import SidebarComponent from '../lib/components/sidebar-component';
 import SiteSelectorComponent from '../lib/components/site-selector-component';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove "Try & Customize" as an option in the theme showcase. 50% of our theme switches are now template first Gutenberg themes, and using the try and customize option does not accurately reflect what you will get once the theme is activated. It also sends users to the customizer, which is not where they are going to get the best editing experience.

The theme demo sites now accurately reflect this as your site will look like the demo. This also greatly reduces the complexity of activating a theme, you look at the demo, and then you choose to activate or not.

#### Before

<img width="547" alt="Screen Shot 2019-09-06 at 2 02 21 PM" src="https://user-images.githubusercontent.com/1464705/64460338-00a24700-d0af-11e9-83db-9d9aad1a7bb2.png">

#### After

<img width="521" alt="Screen Shot 2019-09-06 at 2 03 03 PM" src="https://user-images.githubusercontent.com/1464705/64460361-0ef06300-d0af-11e9-8fd7-cc8dc9515545.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/themes
* Hit the three dots menu next to any theme, confirm that the "Try & Customize" options is no longer present.
* Try activating a theme and confirm this still works correctly.
