### PR TITLE
[SIGNUP]: clear the state after launching a site

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -360,10 +360,6 @@ class Signup extends React.Component {
 			isNew7DUserSite,
 		} );
 
-		if ( 'launch-site' === this.props.flowName ) {
-			this.signupFlowController.reset();
-		}
-
 		this.handleLogin( dependencies, destination );
 	};
 
@@ -379,6 +375,7 @@ class Signup extends React.Component {
 		if ( userIsLoggedIn ) {
 			// don't use page.js for external URLs (eg redirect to new site after signup)
 			if ( /^https?:\/\//.test( destination ) ) {
+				this.signupFlowController.reset();
 				return ( window.location.href = destination );
 			}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -360,6 +360,10 @@ class Signup extends React.Component {
 			isNew7DUserSite,
 		} );
 
+		if ( 'launch-site' === this.props.flowName ) {
+			this.signupFlowController.reset();
+		}
+
 		this.handleLogin( dependencies, destination );
 	};
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

If the successful flow is `launch-site`, we clear the signup state. 

We must do this to avoid a bug in which a user launches a site, then wishes to launch another in quick succession: because there's already progress in the state, the app thinks, for some reason, that the launch is ready and throws the user into the processing screen. 

And then the app does nada, leaving the user to contemplate their existence while staring at the never-ceasing floaties on the signup processing screen. 

![Sep-07-2019 10-55-35](https://user-images.githubusercontent.com/6458278/64467672-2f2b2b00-d15e-11e9-8928-04a608374175.gif)

## Open questions

This is a quick fix to squish the bug, but I suspect this problem is indicative of a deeper issue within the app. 

We've essentially nestled the launch site flow into the warm bosom of the signup flow architecture, so many of the paradigms might need to be extracted.

For example, and this is at the lower end of the _maybe-we-should-investigate-further_ scale, we fire the same signup tracks events during the signup flow. 

Unnecessary? Inappropriate?

## Testing instructions

Clear your cache or go incognito :shipit: 

Create a couple of sites. Maybe a few. 

Launch one (from the checklist, which will redirect to the current dev/calypso.live domain and not wordpress.com)

Then the other.

Can you launch the second?

Can you launch a third?

Is 🥑  too expensive in your part of the world?

