### PR TITLE
Site Address Changer: Update Margins

### DIFF
--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -6,12 +5,12 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
  */
 import Dialog from 'components/dialog';
+import Gridicon from 'components/gridicon';
 import FormLabel from 'components/forms/form-label';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import TrackComponentView from 'lib/analytics/track-component-view';
@@ -101,7 +100,7 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 							'this site address will no longer be available for future use.'
 					) }
 				</p>
-				<div className="site-address-changer__confirmation-detail">
+				<div className="site-address-changer__confirmation-detail is-former-address">
 					<Gridicon
 						icon="cross-circle"
 						size={ 18 }
@@ -114,7 +113,7 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 						{ translate( 'Will be removed and unavailable for use.' ) }
 					</p>
 				</div>
-				<div className="site-address-changer__confirmation-detail">
+				<div className="site-address-changer__confirmation-detail is-new-address">
 					<Gridicon
 						icon="checkmark-circle"
 						size={ 18 }
@@ -127,7 +126,9 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 						{ translate( 'Will be your new site address.' ) }
 					</p>
 				</div>
-				<h1>{ translate( 'Check the box to confirm' ) }</h1>
+				<h1 className="site-address-changer__confirmation-heading">
+					{ translate( 'Check the box to confirm' ) }
+				</h1>
 				<FormLabel>
 					<FormInputCheckbox
 						checked={ this.state.isConfirmationChecked }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -1,4 +1,3 @@
-
 .site-address-changer__dialog {
 	text-align: left;
 	max-width: 400px;
@@ -72,6 +71,7 @@
 
 	.gridicon {
 		float: left;
+		margin-top: 2.5px;
 
 		@include breakpoint( '<660px' ) {
 			display: none;
@@ -131,6 +131,11 @@
 }
 
 .site-address-changer__confirmation-detail {
+	
+	&.is-former-address {
+		margin-bottom: 8px;
+	}
+	
 	.gridicon {
 		float: left;
 
@@ -146,4 +151,8 @@
 			margin-left: 24px;
 		}
 	}
+}
+
+.site-address-changer__confirmation-heading {
+	margin-top: 28px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This just updates some of the margins with the Site Address Changer, and uses the correct Gridicons import.

#### Testing instructions

Go to Settings and click "Change site address", then pick one to see the confirmation dialog.

Note the improved alignment of the Gridicon, and the larger space between the heading and the text, along with each of the two paragraphs. 

**Before:**

<img width="563" alt="Screenshot 2019-09-07 at 17 54 47" src="https://user-images.githubusercontent.com/43215253/64477895-9f56a280-d198-11e9-87d7-5024b04d69e5.png">

**After:**

<img width="583" alt="Screenshot 2019-09-07 at 17 51 01" src="https://user-images.githubusercontent.com/43215253/64477882-83eb9780-d198-11e9-8e5d-5260adee6d3a.png">

Fixes #36009 and fixes #36010
