### PR TITLE
Update: fixes an issue where a valid alternate email does not pass validation

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -722,7 +722,7 @@ export function needsExplicitAlternateEmailForGSuite( cart, contactDetails ) {
 export function hasInvalidAlternateEmailDomain( cart, contactDetails ) {
 	return some(
 		cart.products,
-		isSameDomainAsProductMeta( getDomainPartFromEmail( contactDetails.email ) )
+		isSameDomainAsProductMeta( getDomainPartFromEmail( contactDetails.alternateEmail ) )
 	);
 }
 


### PR DESCRIPTION
### Summary

When a user is about to add G Suite to a domain or buy additional licences, they are presented a a form to update/confirm their contact details.

This form provides a field for an alternate email if [necessary](https://github.com/Automattic/wp-calypso/pull/35920) 

 Problem is the email that doesn't pass being compared to itself, rather than the `alternateEmail`.

- Related to current change: #35920

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The instructions for #35920 works, but additionally, ensure that valid alternate email addresses work.

Fixes #
* Now compares `email` of the contact details to the `alternateEmail`

