### PR TITLE
Add Social Login ToS

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -188,6 +188,12 @@ class SocialLoginForm extends Component {
 						responseHandler={ this.handleAppleResponse }
 						onClick={ this.trackLogin.bind( null, 'apple' ) }
 					/>
+
+					<p className="login__social-tos">
+						If you continue with Google or Apple and don't already have a WordPress.com account, you
+						are creating an account and you agree to our{' '}
+						<a href="https://wordpress.com/tos">Terms of Service</a>.
+					</p>
 				</div>
 
 				{ this.props.isSocialAccountCreating && (

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -6,7 +6,12 @@
 	display: flex;
 	flex-direction: column;
 
-	.social-buttons__button:not(:first-of-type) {
+	.social-buttons__button:not( :first-of-type ) {
 		margin-top: 10px;
 	}
+}
+
+.login__social-tos {
+	margin: 1.5em 0 0;
+	text-align: center;
 }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -92,6 +92,12 @@ class SocialSignupForm extends Component {
 						responseHandler={ this.handleAppleResponse }
 						onClick={ () => this.trackSocialLogin( 'apple' ) }
 					/>
+
+					<p>
+						If you continue with Google or Apple and don't already have a WordPress.com account, you
+						are creating an account and you agree to our{' '}
+						<a href="https://wordpress.com/tos">Terms of Service</a>.
+					</p>
 				</div>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a copy under the social login and signup buttons with a link to the ToS

#### Testing instructions

* Via the live link load the sign up page
* Observe the ToS copy under the Social Sign up buttons
* Observe that link to ToS works
* Goto Log in page
* Observe the ToS copy under the Social log in buttons
* Observe that link to ToS works

Todo:

Link colour on Sign up page

<img width="443" alt="Screen Shot 2019-09-09 at 11 30 10 AM" src="https://user-images.githubusercontent.com/6817400/64545007-02118080-d2f6-11e9-8962-c109372c1b12.png">
<img width="517" alt="Screen Shot 2019-09-09 at 11 29 47 AM" src="https://user-images.githubusercontent.com/6817400/64545008-02118080-d2f6-11e9-8ca2-cdec158e086a.png">

