### PR TITLE
Checkout: Use Context for Stripe data

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -23,7 +23,12 @@ import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'lib/url/support';
 import getCountries from 'state/selectors/get-countries';
 import QueryPaymentCountries from 'components/data/query-countries/payments';
 import { localizeUrl } from 'lib/i18n-utils';
-import { createStripeSetupIntent, StripeSetupIntentError, StripeValidationError } from 'lib/stripe';
+import {
+	createStripeSetupIntent,
+	StripeSetupIntentError,
+	StripeValidationError,
+	useStripe,
+} from 'lib/stripe';
 import {
 	getInitializedFields,
 	camelCaseFormFields,
@@ -57,12 +62,8 @@ export function CreditCardForm( {
 	heading,
 	onCancel,
 	translate,
-	stripe,
-	stripeConfiguration,
-	isStripeLoading,
-	stripeLoadingError,
-	setStripeError,
 } ) {
+	const { stripe, stripeConfiguration, setStripeError } = useStripe();
 	const [ formSubmitting, setFormSubmitting ] = useState( false );
 	const [ formFieldValues, setFormFieldValues ] = useState( getInitializedFields( initialValues ) );
 	const [ touchedFormFields, setTouchedFormFields ] = useState( {} );
@@ -158,9 +159,6 @@ export function CreditCardForm( {
 				<CreditCardFormFields
 					card={ kebabCaseFormFields( formFieldValues ) }
 					countriesList={ countriesList }
-					stripe={ stripe }
-					isStripeLoading={ isStripeLoading }
-					stripeLoadingError={ stripeLoadingError }
 					eventFormName="Edit Card Details Form"
 					onFieldChange={ onFieldChange }
 					getErrorMessage={ getErrorMessage }
@@ -204,10 +202,6 @@ CreditCardForm.propTypes = {
 	autoFocus: PropTypes.bool,
 	heading: PropTypes.string,
 	onCancel: PropTypes.func,
-	stripe: PropTypes.object,
-	isStripeLoading: PropTypes.bool,
-	stripeLoadingError: PropTypes.object,
-	setStripeError: PropTypes.func,
 	translate: PropTypes.func.isRequired,
 };
 

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -23,6 +23,7 @@ import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-spec
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { abtest } from 'lib/abtest';
+import { useStripe } from 'lib/stripe';
 
 const CardNumberElementWithValidation = withStripeElementValidation( CardNumberElement );
 const CardExpiryElementWithValidation = withStripeElementValidation( CardExpiryElement );
@@ -105,15 +106,8 @@ StripeElementErrors.propTypes = {
 	fieldName: PropTypes.string.isRequired,
 };
 
-function CreditCardNumberField( {
-	translate,
-	stripe,
-	isStripeLoading,
-	stripeLoadingError,
-	createField,
-	getErrorMessage,
-	card,
-} ) {
+function CreditCardNumberField( { translate, createField, getErrorMessage, card } ) {
+	const { stripe, isStripeLoading, stripeLoadingError } = useStripe();
 	const cardNumberLabel = translate( 'Card Number', {
 		comment: 'Card number label on credit card form',
 	} );
@@ -155,21 +149,11 @@ CreditCardNumberField.propTypes = {
 	translate: PropTypes.func.isRequired,
 	createField: PropTypes.func.isRequired,
 	getErrorMessage: PropTypes.func.isRequired,
-	stripe: PropTypes.object,
 	card: PropTypes.object.isRequired,
-	isStripeLoading: PropTypes.bool,
-	stripeLoadingError: PropTypes.object,
 };
 
-function CreditCardExpiryAndCvvFields( {
-	translate,
-	stripe,
-	isStripeLoading,
-	stripeLoadingError,
-	createField,
-	getErrorMessage,
-	card,
-} ) {
+function CreditCardExpiryAndCvvFields( { translate, createField, getErrorMessage, card } ) {
+	const { stripe, isStripeLoading, stripeLoadingError } = useStripe();
 	if ( stripeLoadingError && ! shouldRenderAdditionalCountryFields( card.country ) ) {
 		notices.error( stripeLoadingError.message || 'Error loading Stripe' );
 	}
@@ -253,9 +237,6 @@ CreditCardExpiryAndCvvFields.propTypes = {
 	createField: PropTypes.func.isRequired,
 	getErrorMessage: PropTypes.func.isRequired,
 	card: PropTypes.object.isRequired,
-	stripe: PropTypes.object,
-	isStripeLoading: PropTypes.bool,
-	stripeLoadingError: PropTypes.object,
 };
 
 export class CreditCardFormFields extends React.Component {
@@ -267,9 +248,6 @@ export class CreditCardFormFields extends React.Component {
 		getErrorMessage: PropTypes.func,
 		autoFocus: PropTypes.bool,
 		isNewTransaction: PropTypes.bool,
-		stripe: PropTypes.object,
-		isStripeLoading: PropTypes.bool,
-		stripeLoadingError: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -377,9 +355,6 @@ export class CreditCardFormFields extends React.Component {
 				<div className="credit-card-form-fields__field number">
 					<CreditCardNumberField
 						translate={ this.props.translate }
-						stripe={ this.props.stripe }
-						isStripeLoading={ this.props.isStripeLoading }
-						stripeLoadingError={ this.props.stripeLoadingError }
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }
@@ -389,9 +364,6 @@ export class CreditCardFormFields extends React.Component {
 				<div className={ creditCardFormFieldsExtrasClassNames }>
 					<CreditCardExpiryAndCvvFields
 						translate={ this.props.translate }
-						stripe={ this.props.stripe }
-						isStripeLoading={ this.props.isStripeLoading }
-						stripeLoadingError={ this.props.stripeLoadingError }
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
@@ -19,9 +19,7 @@ import CreditCardForm from 'blocks/credit-card-form';
 import { addStoredCard } from 'state/stored-cards/actions';
 import { createCardToken } from 'lib/store-transactions';
 import analytics from 'lib/analytics';
-import { withStripe } from 'lib/stripe';
-
-const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
+import { StripeHookProvider } from 'lib/stripe';
 
 function AddCardDialog( {
 	siteId,
@@ -41,15 +39,17 @@ function AddCardDialog( {
 			isVisible={ isVisible }
 			onClose={ onClose }
 		>
-			<CreditCardFormWithStripe
-				createCardToken={ createCardAddToken }
-				recordFormSubmitEvent={ recordFormSubmitEvent }
-				saveStoredCard={ saveStoredCard }
-				successCallback={ onClose }
-				showUsedForExistingPurchasesInfo={ true }
-				heading={ translate( 'Add credit card' ) }
-				onCancel={ onClose }
-			/>
+			<StripeHookProvider configurationArgs={ { needs_intent: true } }>
+				<CreditCardForm
+					createCardToken={ createCardAddToken }
+					recordFormSubmitEvent={ recordFormSubmitEvent }
+					saveStoredCard={ saveStoredCard }
+					successCallback={ onClose }
+					showUsedForExistingPurchasesInfo={ true }
+					heading={ translate( 'Add credit card' ) }
+					onCancel={ onClose }
+				/>
+			</StripeHookProvider>
 		</Dialog>
 	);
 }

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -344,7 +344,7 @@ export function useStripe() {
 }
 
 /**
- * HOC to use for components that cannot use useStripe
+ * HOC for components that cannot use useStripe
  *
  * Adds several props to the wrapped component. See docs of useStripe for
  * details of the properties it provides.
@@ -356,9 +356,6 @@ export function withStripeProps( WrappedComponent ) {
 	const StripeInjectedWrappedComponent = injectStripe( WrappedComponent );
 	return props => {
 		const stripeData = useStripe();
-		if ( ! stripeData.stripe ) {
-			return <WrappedComponent { ...props } />;
-		}
 		const newProps = { ...props, ...stripeData };
 		return <StripeInjectedWrappedComponent { ...newProps } />;
 	};

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -345,3 +345,21 @@ export function useStripe() {
 	}
 	return stripeData;
 }
+
+/**
+ * HOC to use for components that cannot use useStripe
+ *
+ * Adds several props to the wrapped component. See docs of useStripe for
+ * details of the properties it provides.
+ *
+ * @param {object} WrappedComponent The component to wrap
+ * @return {object} WrappedComponent
+ */
+export function withStripeProps( WrappedComponent ) {
+	const StripeInjectedWrappedComponent = injectStripe( WrappedComponent );
+	return props => {
+		const stripeData = useStripe();
+		const newProps = { ...props, ...stripeData };
+		return <StripeInjectedWrappedComponent { ...newProps } />;
+	};
+}

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -353,10 +353,9 @@ export function useStripe() {
  * @return {object} WrappedComponent
  */
 export function withStripeProps( WrappedComponent ) {
-	const StripeInjectedWrappedComponent = injectStripe( WrappedComponent );
 	return props => {
 		const stripeData = useStripe();
 		const newProps = { ...props, ...stripeData };
-		return <StripeInjectedWrappedComponent { ...newProps } />;
+		return <WrappedComponent { ...newProps } />;
 	};
 }

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -21,9 +21,7 @@ import Main from 'components/main';
 import titles from 'me/purchases/titles';
 import { billingHistory } from 'me/purchases/paths';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { withStripe } from 'lib/stripe';
-
-const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
+import { StripeHookProvider } from 'lib/stripe';
 
 function AddCreditCard( props ) {
 	const createAddCardToken = ( ...args ) => createCardToken( 'card_add', ...args );
@@ -37,13 +35,15 @@ function AddCreditCard( props ) {
 			<DocumentHead title={ concatTitle( titles.purchases, titles.addCreditCard ) } />
 
 			<HeaderCake onClick={ goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>
-			<CreditCardFormWithStripe
-				createCardToken={ createAddCardToken }
-				recordFormSubmitEvent={ recordFormSubmitEvent }
-				saveStoredCard={ props.addStoredCard }
-				successCallback={ goToBillingHistory }
-				showUsedForExistingPurchasesInfo={ true }
-			/>
+			<StripeHookProvider configurationArgs={ { needs_intent: true } }>
+				<CreditCardForm
+					createCardToken={ createAddCardToken }
+					recordFormSubmitEvent={ recordFormSubmitEvent }
+					saveStoredCard={ props.addStoredCard }
+					successCallback={ goToBillingHistory }
+					showUsedForExistingPurchasesInfo={ true }
+				/>
+			</StripeHookProvider>
 		</Main>
 	);
 }

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -27,9 +27,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { withStripe } from 'lib/stripe';
-
-const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
+import { StripeHookProvider } from 'lib/stripe';
 
 function AddCardDetails( props ) {
 	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
@@ -76,14 +74,16 @@ function AddCardDetails( props ) {
 				{ titles.addCardDetails }
 			</HeaderCake>
 
-			<CreditCardFormWithStripe
-				apiParams={ { purchaseId: props.purchase.id } }
-				createCardToken={ createCardUpdateToken }
-				purchase={ props.purchase }
-				recordFormSubmitEvent={ recordFormSubmitEvent }
-				siteSlug={ props.siteSlug }
-				successCallback={ successCallback }
-			/>
+			<StripeHookProvider configurationArgs={ { needs_intent: true } }>
+				<CreditCardForm
+					apiParams={ { purchaseId: props.purchase.id } }
+					createCardToken={ createCardUpdateToken }
+					purchase={ props.purchase }
+					recordFormSubmitEvent={ recordFormSubmitEvent }
+					siteSlug={ props.siteSlug }
+					successCallback={ successCallback }
+				/>
+			</StripeHookProvider>
 		</Main>
 	);
 }

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -29,9 +29,7 @@ import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-
 import { isRequestingSites } from 'state/sites/selectors';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { withStripe } from 'lib/stripe';
-
-const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
+import { StripeHookProvider } from 'lib/stripe';
 
 function EditCardDetails( props ) {
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
@@ -81,15 +79,17 @@ function EditCardDetails( props ) {
 				{ titles.editCardDetails }
 			</HeaderCake>
 
-			<CreditCardFormWithStripe
-				apiParams={ { purchaseId: props.purchase.id } }
-				createCardToken={ createCardUpdateToken }
-				initialValues={ props.card }
-				purchase={ props.purchase }
-				recordFormSubmitEvent={ recordFormSubmitEvent }
-				siteSlug={ props.siteSlug }
-				successCallback={ successCallback }
-			/>
+			<StripeHookProvider configurationArgs={ { needs_intent: true } }>
+				<CreditCardForm
+					apiParams={ { purchaseId: props.purchase.id } }
+					createCardToken={ createCardUpdateToken }
+					initialValues={ props.card }
+					purchase={ props.purchase }
+					recordFormSubmitEvent={ recordFormSubmitEvent }
+					siteSlug={ props.siteSlug }
+					successCallback={ successCallback }
+				/>
+			</StripeHookProvider>
 		</Main>
 	);
 }

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -31,7 +31,7 @@ import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
 import RecentRenewals from './recent-renewals';
 import CheckoutTerms from './checkout-terms';
-import { injectStripe } from 'react-stripe-elements';
+import { withStripeProps } from 'lib/stripe';
 import { setStripeObject } from 'lib/upgrades/actions';
 
 function isFormSubmitting( transactionStep ) {
@@ -235,5 +235,5 @@ class CreditCardPaymentBox extends React.Component {
 
 export { CreditCardPaymentBox };
 
-const InjectedStripeCreditCardPaymentBox = injectStripe( CreditCardPaymentBox );
+const InjectedStripeCreditCardPaymentBox = withStripeProps( CreditCardPaymentBox );
 export default InjectedStripeCreditCardPaymentBox;

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -12,9 +12,9 @@ import { find, defer } from 'lodash';
 import analytics from 'lib/analytics';
 import CreditCard from 'components/credit-card';
 import NewCardForm from './new-card-form';
-
 import { newCardPayment, newStripeCardPayment, storedCardPayment } from 'lib/store-transactions';
 import { setPayment } from 'lib/upgrades/actions';
+import { withStripeProps } from 'lib/stripe';
 
 class CreditCardSelector extends React.Component {
 	constructor( props ) {
@@ -81,9 +81,6 @@ class CreditCardSelector extends React.Component {
 					transaction={ this.props.transaction }
 					hasStoredCards={ this.props.cards.length > 0 }
 					selected={ selected }
-					stripe={ this.props.stripe }
-					isStripeLoading={ this.props.isStripeLoading }
-					stripeLoadingError={ this.props.stripeLoadingError }
 				/>
 			</CreditCard>
 		);
@@ -116,4 +113,4 @@ class CreditCardSelector extends React.Component {
 	};
 }
 
-export default CreditCardSelector;
+export default withStripeProps( CreditCardSelector );

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -23,9 +23,6 @@ class NewCardForm extends Component {
 		hasStoredCards: PropTypes.bool.isRequired,
 		transaction: PropTypes.object.isRequired,
 		selected: PropTypes.bool,
-		stripe: PropTypes.object,
-		isStripeLoading: PropTypes.bool,
-		stripeLoadingError: PropTypes.object,
 	};
 
 	getErrorMessage = fieldName => {
@@ -42,9 +39,6 @@ class NewCardForm extends Component {
 				eventFormName="Checkout Form"
 				onFieldChange={ this.handleFieldChange }
 				getErrorMessage={ this.getErrorMessage }
-				stripe={ this.props.stripe }
-				isStripeLoading={ this.props.isStripeLoading }
-				stripeLoadingError={ this.props.stripeLoadingError }
 			/>
 		);
 	};

--- a/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
@@ -10,9 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CreditCardPaymentBox from './credit-card-payment-box';
-import { withStripe } from 'lib/stripe';
-
-const CreditCardPaymentBoxWithStripe = withStripe( CreditCardPaymentBox );
+import { StripeHookProvider } from 'lib/stripe';
 
 export function StripeElementsPaymentBox( {
 	translate,
@@ -27,20 +25,22 @@ export function StripeElementsPaymentBox( {
 	cards,
 } ) {
 	return (
-		<CreditCardPaymentBoxWithStripe
-			translate={ translate }
-			cards={ cards }
-			transaction={ transaction }
-			cart={ cart }
-			countriesList={ countriesList }
-			initialCard={ initialCard }
-			selectedSite={ selectedSite }
-			onSubmit={ onSubmit }
-			transactionStep={ transaction.step }
-			presaleChatAvailable={ presaleChatAvailable }
-		>
-			{ children }
-		</CreditCardPaymentBoxWithStripe>
+		<StripeHookProvider>
+			<CreditCardPaymentBox
+				translate={ translate }
+				cards={ cards }
+				transaction={ transaction }
+				cart={ cart }
+				countriesList={ countriesList }
+				initialCard={ initialCard }
+				selectedSite={ selectedSite }
+				onSubmit={ onSubmit }
+				transactionStep={ transaction.step }
+				presaleChatAvailable={ presaleChatAvailable }
+			>
+				{ children }
+			</CreditCardPaymentBox>
+		</StripeHookProvider>
 	);
 }
 export default localize( StripeElementsPaymentBox );

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -36,6 +36,7 @@ import RecentRenewals from './recent-renewals';
 import PaymentRequestButton from './payment-request-button';
 import SubscriptionText from './subscription-text';
 import { useDebounce } from 'blocks/credit-card-form/helpers';
+import { useStripe } from 'lib/stripe';
 
 const debug = debugFactory( 'calypso:checkout:payment:web-payment-box' );
 
@@ -159,20 +160,11 @@ WebPaymentBox.propTypes = {
 	disablePostalCodeDebounce: PropTypes.bool,
 };
 
-function WebPayButton( {
-	stripe,
-	isStripeLoading,
-	stripeConfiguration,
-	countryCode,
-	postalCode,
-	cart,
-	onSubmit,
-	paymentType,
-	translate,
-} ) {
+function WebPayButton( { countryCode, postalCode, cart, onSubmit, paymentType, translate } ) {
 	const { currency, total_cost_integer, sub_total_integer, total_tax_integer } = cart;
 	const isRenewal = hasRenewalItem( cart );
 	const shouldDisplayItems = shouldShowTax( cart );
+	const { stripe, stripeConfiguration, isStripeLoading } = useStripe();
 	useEffect( () => {
 		stripe && setStripeObject( stripe, stripeConfiguration );
 	}, [ stripe, stripeConfiguration ] );
@@ -218,7 +210,6 @@ function WebPayButton( {
 }
 
 WebPayButton.propTypes = {
-	stripe: PropTypes.object,
 	countryCode: PropTypes.string,
 	postalCode: PropTypes.string,
 	cart: PropTypes.shape( {

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -35,7 +35,6 @@ import PaymentChatButton from './payment-chat-button';
 import RecentRenewals from './recent-renewals';
 import PaymentRequestButton from './payment-request-button';
 import SubscriptionText from './subscription-text';
-import { withStripe } from 'lib/stripe';
 import { useDebounce } from 'blocks/credit-card-form/helpers';
 
 const debug = debugFactory( 'calypso:checkout:payment:web-payment-box' );
@@ -46,8 +45,6 @@ const PAYMENT_REQUEST_OPTIONS = {
 	requestPayerEmail: false,
 	requestShipping: false,
 };
-
-const WebPayButtonWithStripe = withStripe( WebPayButton );
 
 export function WebPaymentBox( {
 	cart,
@@ -119,7 +116,7 @@ export function WebPaymentBox( {
 				<span className={ 'payment-box__payment-buttons' }>
 					<span className="pay-button">
 						<span className="payment-request-button">
-							<WebPayButtonWithStripe
+							<WebPayButton
 								countryCode={ countryCode }
 								postalCode={ disablePostalCodeDebounce ? postalCode : debouncedPostalCode }
 								cart={ cart }

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -36,7 +36,7 @@ import RecentRenewals from './recent-renewals';
 import PaymentRequestButton from './payment-request-button';
 import SubscriptionText from './subscription-text';
 import { useDebounce } from 'blocks/credit-card-form/helpers';
-import { useStripe } from 'lib/stripe';
+import { useStripe, StripeHookProvider } from 'lib/stripe';
 
 const debug = debugFactory( 'calypso:checkout:payment:web-payment-box' );
 
@@ -117,14 +117,16 @@ export function WebPaymentBox( {
 				<span className={ 'payment-box__payment-buttons' }>
 					<span className="pay-button">
 						<span className="payment-request-button">
-							<WebPayButton
-								countryCode={ countryCode }
-								postalCode={ disablePostalCodeDebounce ? postalCode : debouncedPostalCode }
-								cart={ cart }
-								onSubmit={ onSubmit }
-								paymentType={ paymentType }
-								translate={ translate }
-							/>
+							<StripeHookProvider>
+								<WebPayButton
+									countryCode={ countryCode }
+									postalCode={ disablePostalCodeDebounce ? postalCode : debouncedPostalCode }
+									cart={ cart }
+									onSubmit={ onSubmit }
+									paymentType={ paymentType }
+									translate={ translate }
+								/>
+							</StripeHookProvider>
 						</span>
 						<SubscriptionText cart={ cart } />
 					</span>


### PR DESCRIPTION
Right now we load the Stripe configuration via a React custom Hook, then load and initialize Stripe via a another hook, and then wrap the components which use Stripe in an HOC.

This works, but as the HOC has evolved, it has created many different variables (`stripe`, `isStripeLoading`, `stripeConfiguration`, `stripeLoadingError`, and `setStripeError`) which might be consumed by the children of that HOC. In order to provide these options where they are needed, all of those variables must be passed down through the children, and their children, as extra props. This becomes a very leaky abstraction when there are many layers of children between the HOC and the consumer.

```js
const StripeWrappedComponent = withStripe( CheckoutParent );
function TopLevel() {
  return <CheckoutParent />;
}

function CheckoutParent({stripe, isStripeLoading, stripeLoadingError, setStripeError}) {
  return <CheckoutChild stripe={stripe} isStripeLoading={isStripeLoading} stripeLoadingError={stripeLoadingError} setStripeError={setStripeError} />;
} 

function CheckoutChild({stripe, isStripeLoading, stripeLoadingError, setStripeError}) {
  //...
}
```

A better technique would be to use React Context to pass those variables down invisibly.

This PR creates a new custom hook (and an HOC for non-functional components) that provides all the above variables and could provide new ones in the future. Instead of passing those variables down through many components that don't need them, instead we just wrap the top-level component in the provider and the hook will provide just what's needed when it's needed.

```js
function TopLevel() {
  return (
    <StripeHookProvider>
      <CheckoutParent />
    </StripeHookProvider>
  );
}

function CheckoutParent() {
  return <CheckoutChild />;
} 

function CheckoutChild() {
  const { stripe, isStripeLoading } = useStripe();
  //...
}
```

At some point, Stripe itself may provide a hook like this, but they are trying to support the legacy context API (see https://github.com/stripe/react-stripe-elements/issues/317) and so it may be some time before that's available. Once it is, it should be relatively easy to convert this system to use those hooks instead.

#### Testing instructions

Visit all the routes that use Stripe and make sure they work as expected. Here's PRs with testing instructions for each of them.

- [x] Plan checkout: #34469
- [x] Add Card: #34848
- [x] Add Card Details: #35351
- [x] Update Card: #35262
- [x] Apple Pay: #35636
- [x] Woo Add Card: #35390