### PR TITLE
Login form: Fix typo

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -192,7 +192,7 @@ class SocialLoginForm extends Component {
 					<p className="login__social-tos">
 						{ this.props.translate(
 							"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-								'are creating an account and you agree to our' +
+								' are creating an account and you agree to our' +
 								' {{a}}Terms of Service{{/a}}.',
 							{
 								components: {

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -96,7 +96,7 @@ class SocialSignupForm extends Component {
 					<p className="signup-form__social-buttons-tos">
 						{ this.props.translate(
 							"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-								'are creating an account and you agree to our' +
+								' are creating an account and you agree to our' +
 								' {{a}}Terms of Service{{/a}}.',
 							{
 								components: {


### PR DESCRIPTION
This PR fixes a typo introduced in #36053

### Before
<img width="403" alt="Screenshot 2019-09-12 at 17 51 47" src="https://user-images.githubusercontent.com/184938/64823673-bb0ae000-d5c0-11e9-8dc2-f3c852148704.png">


### After
<img width="404" alt="Screenshot 2019-09-12 at 17 51 55" src="https://user-images.githubusercontent.com/184938/64823681-bf36fd80-d5c0-11e9-8748-5d021d3219be.png">
