### PR TITLE
Don't check for atomic when transferring

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -34,8 +34,7 @@ import {
 	emailManagementAddGSuiteUsers,
 	emailManagementForwarding,
 } from 'my-sites/email/paths';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { decodeURIComponentIfValid } from 'lib/url';
 
 export default {
@@ -261,15 +260,6 @@ export default {
 	},
 
 	domainManagementTransferToOtherUser( pageContext, next ) {
-		const state = pageContext.store.getState();
-		const siteId = getSelectedSiteId( state );
-		const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
-		if ( isAutomatedTransfer ) {
-			const siteSlug = getSelectedSiteSlug( state );
-			page.redirect( `/domains/manage/${ siteSlug }` );
-			return;
-		}
-
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementTransferToAnotherUser( ':site', ':domain' ) }

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -50,7 +50,7 @@ function Transfer( props ) {
 				<VerticalNavItem path={ domainManagementTransferOut( slug, selectedDomainName ) }>
 					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
-				{ ! isAtomic && ! isDomainOnly && (
+				{ ! isDomainOnly && (
 					<VerticalNavItem
 						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
 					>

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { includes, head, omit, find } from 'lodash';
+import { find, get, head, includes, omit } from 'lodash';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 
@@ -29,6 +29,7 @@ import SectionHeader from 'components/section-header';
 import Dialog from 'components/dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import DesignatedAgentNotice from 'my-sites/domains/domain-management/components/designated-agent-notice';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -41,6 +42,7 @@ class TransferOtherUser extends React.Component {
 	static propTypes = {
 		currentUser: PropTypes.object.isRequired,
 		domains: PropTypes.array.isRequired,
+		isAtomic: PropTypes.bool.isRequired,
 		isRequestingSiteDomains: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
@@ -53,7 +55,7 @@ class TransferOtherUser extends React.Component {
 
 		const defaultUser = head( this.filterAvailableUsers( props.users ) );
 		this.state = {
-			selectedUserId: defaultUser ? defaultUser.ID : '',
+			selectedUserId: defaultUser ? this.getWpcomUserId( defaultUser ) : '',
 			showConfirmationDialog: false,
 			disableDialogButtons: false,
 		};
@@ -64,11 +66,19 @@ class TransferOtherUser extends React.Component {
 		this.handleConfirmTransferDomain = this.handleConfirmTransferDomain.bind( this );
 	}
 
+	getWpcomUserId = user => {
+		if ( this.props.isAtomic ) {
+			return get( user, 'linked_user_ID', '' );
+		}
+
+		return user.ID;
+	};
+
 	componentWillUpdate( nextProps, nextState ) {
 		if ( nextState && ! nextState.selectedUserId ) {
 			const defaultUser = head( this.filterAvailableUsers( nextProps.users ) );
 			if ( defaultUser ) {
-				this.setState( { selectedUserId: defaultUser.ID } );
+				this.setState( { selectedUserId: this.getWpcomUserId( defaultUser ) } );
 			}
 		}
 	}
@@ -130,11 +140,13 @@ class TransferOtherUser extends React.Component {
 	getSelectedUserDisplayName() {
 		const selectedUser = find(
 			this.props.users,
-			user => user.ID === Number( this.state.selectedUserId )
+			user => this.getWpcomUserId( user ) === Number( this.state.selectedUserId )
 		);
+
 		if ( ! selectedUser ) {
 			return '';
 		}
+
 		return this.getUserDisplayName( selectedUser );
 	}
 
@@ -237,11 +249,15 @@ class TransferOtherUser extends React.Component {
 							value={ this.state.selectedUserId }
 						>
 							{ availableUsers.length ? (
-								availableUsers.map( user => (
-									<option key={ user.ID } value={ user.ID }>
-										{ this.getUserDisplayName( user ) }
-									</option>
-								) )
+								availableUsers.map( user => {
+									const userId = this.getWpcomUserId( user );
+
+									return (
+										<option key={ userId } value={ userId }>
+											{ this.getUserDisplayName( user ) }
+										</option>
+									);
+								} )
 							) : (
 								<option value="">{ translate( '-- Site has no other administrators --' ) }</option>
 							) }
@@ -265,7 +281,9 @@ class TransferOtherUser extends React.Component {
 
 	filterAvailableUsers( users ) {
 		return users.filter(
-			user => includes( user.roles, 'administrator' ) && user.ID !== this.props.currentUser.ID
+			user =>
+				includes( user.roles, 'administrator' ) &&
+				this.getWpcomUserId( user ) !== this.props.currentUser.ID
 		);
 	}
 
@@ -275,7 +293,10 @@ class TransferOtherUser extends React.Component {
 }
 
 export default connect(
-	state => ( { currentUser: getCurrentUser( state ) } ),
+	( state, ownProps ) => ( {
+		currentUser: getCurrentUser( state ),
+		isAtomic: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
+	} ),
 	{
 		successNotice,
 		errorNotice,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Allow users to transfer domain ownership to a different user

The problem we're solving here is that the `user.ID`s we get for an Atomic site is the internal Users objects. We need the WPCOM user ID to transfer subs to.

#### Testing instructions

- Create an Atomic site
- Add another admin user
- Transfer domain to that user
- All works :)