### PR TITLE
Atomic: Allow transferring a domain between atomic sites

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -53,12 +53,9 @@ export class TransferToOtherSite extends React.Component {
 	}
 
 	isSiteEligible = site => {
-		// check if it's an Atomic site from the site options
-		const isAtomic = get( site, 'options.is_automated_transfer', false );
-
 		return (
 			site.capabilities.manage_options &&
-			! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
+			! site.jetpack && // Simple and Atomic sites. Not Jetpack sites.
 			! get( site, 'options.is_domain_only', false ) &&
 			! (
 				this.props.domainsWithPlansOnly && isWpComFreePlan( get( site, 'plan.product_slug' ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We disabled domain transfer between atomic sites 2 years ago,
but all of the stuff works now, so... Re-enable!

#### Testing instructions

- Log in as a user who has 2 Atomic sites
- Transfer domain between the sites
- Confirm all the stuff works!
- Jetpack connection, domains resolve properly
