### PR TITLE
Blogger Importer: remove the inline help dialog and replace with link.

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -10,6 +10,7 @@ import { filter, head, orderBy, values } from 'lodash';
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import InlineSupportLink from 'components/inline-support-link';
 
 function getConfig( { siteTitle = '' } = {} ) {
@@ -66,7 +67,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				'to start importing into {{b}}%(siteTitle)s{{/b}}. ' +
 				'A %(importerName)s export file is an XML file ' +
 				'containing your page and post content. ' +
-				'Need help {{inlineSupportLink/}}?',
+				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
 			{
 				args: {
 					importerName: 'Blogger',
@@ -74,13 +75,8 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 				components: {
 					b: <strong />,
-					inlineSupportLink: (
-						<InlineSupportLink
-							supportPostId={ 66764 }
-							supportLink={ 'https://en.support.wordpress.com/import/coming-from-blogger/#import' }
-							text={ translate( 'exporting your content' ) }
-							showIcon={ false }
-						/>
+					ExternalLink: (
+						<ExternalLink href="https://en.support.wordpress.com/import/import-from-blogger/" />
 					),
 				},
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the inline help dialog from the Blogger importer page.
* Update the translation to be properly wrapped (the link text is no longer translated as a separate string)
* Link to the support documentation with an inline link.

Before:
![image](https://user-images.githubusercontent.com/363749/64870050-90e10e80-d610-11e9-9ddc-ac18ab2f5a4d.png)

After:
Clicking on the link opens the help dialog.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/import` and select your site.
* Select "Blogger" from the list of importers.
* Verify that the link in "Need help exporting your content?" now links directly to the support document as opposed to opening the document inline.

![image](https://user-images.githubusercontent.com/363749/64870332-19f84580-d611-11e9-81fe-d8b9489d3a5f.png)

Fixes #33388 
