### PR TITLE
Wrap copy with preventWidows in several places

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -92,24 +92,28 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isPlan( primaryPurchase ) ) {
-			return translate(
-				'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
-					"It's doing somersaults in excitement!",
-				{
-					args: { productName: primaryPurchase.productName },
-					components: { strong: <strong /> },
-				}
+			return preventWidows(
+				translate(
+					'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
+						"It's doing somersaults in excitement!",
+					{
+						args: { productName: primaryPurchase.productName },
+						components: { strong: <strong /> },
+					}
+				)
 			);
 		}
 
 		if ( isDomainRegistration( primaryPurchase ) ) {
-			return translate(
-				'Your new domain {{strong}}%(domainName)s{{/strong}} is ' +
-					'being set up. Your site is doing somersaults in excitement!',
-				{
-					args: { domainName: primaryPurchase.meta },
-					components: { strong: <strong /> },
-				}
+			return preventWidows(
+				translate(
+					'Your new domain {{strong}}%(domainName)s{{/strong}} is ' +
+						'being set up. Your site is doing somersaults in excitement!',
+					{
+						args: { domainName: primaryPurchase.meta },
+						components: { strong: <strong /> },
+					}
+				)
 			);
 		}
 
@@ -139,13 +143,15 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isGoogleApps( primaryPurchase ) ) {
-			return translate(
-				'Your domain {{strong}}%(domainName)s{{/strong}} is now set up to use G Suite. ' +
-					"It's doing somersaults in excitement!",
-				{
-					args: { domainName: primaryPurchase.meta },
-					components: { strong: <strong /> },
-				}
+			return preventWidows(
+				translate(
+					'Your domain {{strong}}%(domainName)s{{/strong}} is now set up to use G Suite. ' +
+						"It's doing somersaults in excitement!",
+					{
+						args: { domainName: primaryPurchase.meta },
+						components: { strong: <strong /> },
+					}
+				)
 			);
 		}
 
@@ -171,13 +177,15 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isSiteRedirect( primaryPurchase ) ) {
-			return translate(
-				'Your site is now redirecting to {{strong}}%(domainName)s{{/strong}}. ' +
-					"It's doing somersaults in excitement!",
-				{
-					args: { domainName: primaryPurchase.meta },
-					components: { strong: <strong /> },
-				}
+			return preventWidows(
+				translate(
+					'Your site is now redirecting to {{strong}}%(domainName)s{{/strong}}. ' +
+						"It's doing somersaults in excitement!",
+					{
+						args: { domainName: primaryPurchase.meta },
+						components: { strong: <strong /> },
+					}
+				)
 			);
 		}
 
@@ -208,8 +216,8 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isChargeback( primaryPurchase ) ) {
-			return translate(
-				'Your chargeback fee is paid. Your site is doing somersaults in excitement!'
+			return preventWidows(
+				translate( 'Your chargeback fee is paid. Your site is doing somersaults in excitement!' )
 			);
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR wraps several statements on the completion page of purchase flows in `preventWidows` so as not to widow single words.

#### Testing instructions

Complete the checkout process and take note of the copy on the completion step.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start on a plan lower than Premium
* Upgrade to premium plan
* View success page

Fixes #36029
