### PR TITLE
Cart: Remove white background from empty cart

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -192,7 +192,6 @@
 }
 
 .cart-empty {
-	background: var( --color-white );
 	padding: 30px;
 	text-align: center;
 	font-size: 14px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the white background set to the `cart-empty` class, since this was making visible the square corners on that layer over the rounded corners of the popover layer.

There is no need for setting a white background (it is not set in the `cart-items` class either, the class used when the cart is not empty), as the popover layer already sets a white background.

| Before | After |
|---|---|
| <img width="368" alt="Screen Shot 2019-09-13 at 10 21 48" src="https://user-images.githubusercontent.com/1233880/64870477-59269680-d611-11e9-9adc-ee5aa33c05e6.png"> | <img width="375" alt="Screen Shot 2019-09-13 at 10 20 40" src="https://user-images.githubusercontent.com/1233880/64870488-5fb50e00-d611-11e9-8b84-80734fda8057.png"> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Domains or Plans page, so you can find the cart.
* Remove any existing item from the cart.
* Make sure the empty cart is rendered with rounded corners.

Fixes #36012
