### PR TITLE
Underline link when mapping domain

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -61,11 +61,12 @@ function getAvailabilityNotice( domain, error, errorData ) {
 		case domainAvailability.REGISTERED_OTHER_SITE_SAME_USER:
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is already registered on your site %(site)s. Do you want to move it to this site? ' +
-					'{{a}}Yes, move it to this site.{{/a}}',
+					'{{u}}{{a}}Yes, move it to this site.{{/a}}{{/u}}',
 				{
 					args: { domain, site },
 					components: {
 						strong: <strong />,
+						u: <u />,
 						a: (
 							<a
 								rel="noopener noreferrer"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

an alternative could be to update the `a` to wrap the `u` tag around it with just `{{a}}` but I thought that would be a little misleading from just looking at `{{a}}`

* Use `u` tag around link to underline text

#### Testing instructions

Please follow instructions in #36033, ensure link is now underlined like so

<img width="1176" alt="Screen Shot 2019-09-13 at 10 44 42 AM" src="https://user-images.githubusercontent.com/6520461/64871597-8a07cb00-d613-11e9-9ab0-20d8f38adf8e.png">


*

Fixes #36033

