### PR TITLE
Editor: Fix low contrast of featured image block

### DIFF
--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -77,7 +77,11 @@
 		background-color: var( --color-accent-light );
 	}
 
-	.drop-zone__content {
-		color: var( --color-text );
+	.drop-zone__content-icon svg g {
+		fill: var( --color-white );
+	}
+
+	.drop-zone__content-text {
+		color: var( --color-white );
 	}
 }


### PR DESCRIPTION
This pull request seeks to address https://github.com/Automattic/wp-calypso/issues/31888 by changing the color of the `Set as Featured Image` text and icon to white when ones drags an image hover it:
 
![screenshot](https://user-images.githubusercontent.com/594356/64872815-d7853780-d615-11e9-9d9d-ebcd0c1757f8.png)

> Note this only affects the former post editor - this issue is **already fixed in Gutenberg**.

#### Testing instructions
 
1. Run `git checkout fix/featured-image-contrast` and start your server, or open a [live branch](https://calypso.live/?branch=fix/featured-image-contrast)
2. Open the [`Post` page](http://calypso.localhost:3000/post)
3. Expand the `Featured Image` section in the sidebar
4. Drag an image to the `Set Featured Image` block
5. Assert that the `Set as Featured Image` text and icon are now white