### PR TITLE
Import: Update WordPress, Medium, and Squarespace help links to use external link instead of modal

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -12,6 +12,7 @@ import { filter, head, orderBy, values } from 'lodash';
  */
 import ExternalLink from 'components/external-link';
 import InlineSupportLink from 'components/inline-support-link';
+import ExternalLink from 'components/external-link';
 
 function getConfig( { siteTitle = '' } = {} ) {
 	const importerConfig = {};
@@ -28,19 +29,14 @@ function getConfig( { siteTitle = '' } = {} ) {
 				'importing into {{b2}}%(title)s{{/b2}}. A WordPress export is ' +
 				'an XML file with your page and post content, or a zip archive ' +
 				'containing several XML files. ' +
-				'Need help {{inlineSupportLink/}}?',
+				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
 			{
 				args: { title: siteTitle },
 				components: {
 					b: <strong />,
 					b2: <strong />,
-					inlineSupportLink: (
-						<InlineSupportLink
-							supportPostId={ 2087 }
-							supportLink={ 'https://en.support.wordpress.com/export/' }
-							text={ translate( 'exporting your content' ) }
-							showIcon={ false }
-						/>
+					ExternalLink: (
+						<ExternalLink href="https://en.support.wordpress.com/coming-from-self-hosted/" />
 					),
 				},
 			}

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -11,7 +11,6 @@ import { filter, head, orderBy, values } from 'lodash';
  * Internal dependencies
  */
 import ExternalLink from 'components/external-link';
-import InlineSupportLink from 'components/inline-support-link';
 
 function getConfig( { siteTitle = '' } = {} ) {
 	const importerConfig = {};
@@ -141,7 +140,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				'to start importing into {{b}}%(siteTitle)s{{/b}}. ' +
 				'A %(importerName)s export file is an XML file ' +
 				'containing your page and post content. ' +
-				'Need help {{inlineSupportLink/}}?',
+				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
 			{
 				args: {
 					importerName: 'Squarespace',
@@ -149,12 +148,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 				components: {
 					b: <strong />,
-					inlineSupportLink: (
-						<InlineSupportLink
-							supportPostId={ 87696 }
-							supportLink={ 'https://en.support.wordpress.com/import/import-from-squarespace' }
-							text={ translate( 'exporting your content' ) }
-							showIcon={ false }
+					ExternalLink: (
+						<ExternalLink
+							href={ 'https://en.support.wordpress.com/import/import-from-squarespace' }
 						/>
 					),
 				},

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -12,7 +12,6 @@ import { filter, head, orderBy, values } from 'lodash';
  */
 import ExternalLink from 'components/external-link';
 import InlineSupportLink from 'components/inline-support-link';
-import ExternalLink from 'components/external-link';
 
 function getConfig( { siteTitle = '' } = {} ) {
 	const importerConfig = {};
@@ -106,7 +105,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 			'Upload your {{b}}%(importerName)s export file{{/b}} to start importing into ' +
 				'{{b}}%(siteTitle)s{{/b}}. A %(importerName)s export file is a ZIP ' +
 				'file containing several HTML files with your stories. ' +
-				'Need help {{inlineSupportLink/}}?',
+				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
 			{
 				args: {
 					importerName: 'Medium',
@@ -114,13 +113,8 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 				components: {
 					b: <strong />,
-					inlineSupportLink: (
-						<InlineSupportLink
-							supportPostId={ 93180 }
-							supportLink={ 'https://en.support.wordpress.com/import/import-from-medium/' }
-							text={ translate( 'exporting your content' ) }
-							showIcon={ false }
-						/>
+					ExternalLink: (
+						<ExternalLink href={ 'https://en.support.wordpress.com/import/import-from-medium/' } />
 					),
 				},
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the inline help dialog from the WordPress, Medium, and Squarespace importer pages.
* Update the translation to be properly wrapped (the link text is no longer translated as a separate string)
* Link to the support documentation with an inline link.

Before:
<img width="1022" alt="ScreenCapture at Fri Sep 13 11:02:39 EDT 2019" src="https://user-images.githubusercontent.com/2098816/64872967-292dc200-d616-11e9-9671-8c3b9b1d8e82.png">

After:
Clicking on the link opens the help dialog.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/import` and select your site.
* Select "WordPress", "Medium", or "Squarespace" from the list of importers.
* Verify that the link in "Need help exporting your content?" now links directly to the support document as opposed to opening the document inline.

<img width="743" alt="ScreenCapture at Fri Sep 13 11:04:11 EDT 2019" src="https://user-images.githubusercontent.com/2098816/64873072-5a0df700-d616-11e9-9d22-9586d0cad806.png">

Fixes #33386 
Fixes #33389
Fixes #33390 
