### PR TITLE
Fixed the site address changer link so that it opens in new window instead of same page.

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { debounce, get, flow, inRange, isEmpty } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**
@@ -338,7 +338,7 @@ export class SiteAddressChanger extends Component {
 											args: { currentDomainName },
 										}
 									) }{' '}
-									<a href={ ADDRESS_CHANGE_SUPPORT_URL }>
+									<a href={ ADDRESS_CHANGE_SUPPORT_URL } target="_blank" rel="noopener noreferrer">
 										{ translate(
 											'Before you confirm the change, please read this important information.'
 										) }


### PR DESCRIPTION


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Domains -> Click on the default WordPress.com URL -> Scroll down to `Change Site Address`  https://cloudup.com/cYF8jxfrIVd

The hyperlink to the guide should open in new tab.

Fixes # https://github.com/Automattic/wp-calypso/issues/36054
