### PR TITLE
Domains: Use color variable for included/sale price in search

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -65,14 +65,10 @@
 		line-height: 1.7;
 		margin-top: 2px;
 
-		small {
-			opacity: 1;
-		}
-
 		.domain-product-price__price,
 		.domain-product-price__renewal-price {
 			font-size: 80%;
-			opacity: 0.6;
+			color: var( --color-text-subtle );
 		}
 
 		@include breakpoint( '>660px' ) {


### PR DESCRIPTION
Color variables are used to keep consistency, and to ensure contrast for accessibility. Fixes #36013 

**Screenshots**

<img width="422" alt="Screen Shot 2019-09-13 at 11 08 27 AM" src="https://user-images.githubusercontent.com/541093/64873436-110a7280-d617-11e9-9a3d-80fa41a55b77.png">

**Testing Instructions**

- Pick a site with a domain credit
- Go to Domains -> Add Domain
- Look at the search results