### PR TITLE
Enhance the specificity of the <Notice> content related selectors

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -95,41 +95,41 @@
 	font-size: 12px;
 	flex-grow: 1;
 
+	.notice__text {
+		a,
+		a:visited,
+		button.is-link {
+			text-decoration: underline;
+			color: var( --color-white );
+
+			&:hover {
+				color: var( --color-white );
+				text-decoration: none;
+			}
+		}
+
+		ul {
+			margin-bottom: 0;
+			margin-left: 0;
+		}
+
+		li {
+			margin-left: 2em;
+			margin-top: 0.5em;
+		}
+
+		p {
+			margin-bottom: 0;
+			margin-top: 0.5em;
+
+			&:first-child {
+				margin-top: 0;
+			}
+		}
+	}
+
 	@include breakpoint( '>480px' ) {
 		font-size: 14px;
-	}
-}
-
-.notice__text {
-	a,
-	a:visited,
-	button.is-link {
-		text-decoration: underline;
-		color: var( --color-white );
-
-		&:hover {
-			color: var( --color-white );
-			text-decoration: none;
-		}
-	}
-
-	ul {
-		margin-bottom: 0;
-		margin-left: 0;
-	}
-
-	li {
-		margin-left: 2em;
-		margin-top: 0.5em;
-	}
-
-	p {
-		margin-bottom: 0;
-		margin-top: 0.5em;
-
-		&:first-child {
-			margin-top: 0;
-		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to resolve https://github.com/Automattic/wp-calypso/issues/36034. The originally reported issue is stated for the notices for the domain warnings, but it is actually a more general issue applying for all notices. For example, if we hardcode a notice with an anchor under [me/profile](https://github.com/Automattic/wp-calypso/blob/master/client/me/profile/index.jsx#L66) :
```
render() {
        const gravatarProfileLink =
            'https://gravatar.com/' + this.props.userSettings.getSetting( 'user_login' );

        return (
            <Main className="profile">
                <Notice status="is-warning">  // What we add
                    <span>
                        { 'Just a test' }{' '}
                        <a href="aaaaa">{ 'HAHAHAHA' }</a>
                    </span>
                </Notice>
                <PageViewTracker path="/me" title="Me > My Profile" />
                <MeSidebarNavigation />
```

It will look like this:
<img width="809" alt="螢幕快照 2019-09-13 上午11 00 45" src="https://user-images.githubusercontent.com/1842898/64873661-8ece7e00-d617-11e9-8a1a-c2bcdd55aec0.png">

The problem is that `.notice__text a` is nothing more specific than `.layout__content a`, so it cannot guarantee to override the latter, which contains `text-decoration: none`.

This PR moves the whole section of `.notice__text` under `.notce__content` so that it will guarantee to override.

<i>update:</i>
It also fixes #36033

#### Testing instructions

1. Put the same hard-coded notice like the above and the underline should appear:
![image](https://user-images.githubusercontent.com/1842898/64873843-f4226f00-d617-11e9-8b6c-a5f748bebcaa.png)
1. Make sure the reported issue has been fixed as well.
