### PR TITLE
Remove /all-about-domains support link

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -10,7 +10,6 @@ const root = localizeUrl( 'https://en.support.wordpress.com/' ).replace( /\/$/, 
 export const ACCOUNT_RECOVERY = `${ root }/account-recovery`;
 export const ADDING_GOOGLE_APPS_TO_YOUR_SITE = `${ root }/adding-g-suite-to-your-site`;
 export const ADDING_USERS = `${ root }/adding-users`;
-export const ALL_ABOUT_DOMAINS = `${ root }/all-about-domains`;
 export const AUTO_RENEWAL = `${ root }/auto-renewal`;
 export const BANDPAGE_WIDGET = `${ root }/widgets/bandpage-widget`;
 export const CATEGORIES_VS_TAGS = `${ root }/posts/categories-vs-tags`;

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -22,7 +22,6 @@ import { type as domainTypes, transferStatus, gdprConsentStatus } from 'lib/doma
 import { hasPendingGSuiteUsers } from 'lib/gsuite';
 import { isSubdomain } from 'lib/domains';
 import {
-	ALL_ABOUT_DOMAINS,
 	CHANGE_NAME_SERVERS,
 	DOMAINS,
 	DOMAIN_HELPER_PREFIX,
@@ -46,9 +45,6 @@ import './style.scss';
 
 const debug = _debug( 'calypso:domain-warnings' );
 
-const allAboutDomainsLink = (
-	<a href={ ALL_ABOUT_DOMAINS } target="_blank" rel="noopener noreferrer" />
-);
 const domainsLink = <a href={ DOMAINS } target="_blank" rel="noopener noreferrer" />;
 const pNode = <p />;
 
@@ -562,8 +558,8 @@ export class DomainWarnings extends React.PureComponent {
 				text = translate(
 					'We are setting up your new domains for you. They should start working immediately, ' +
 						'but may be unreliable during the first 72 hours. ' +
-						'{{allAboutDomainsLink}}Learn more{{/allAboutDomainsLink}}.',
-					{ components: { allAboutDomainsLink } }
+						'{{domainsLink}}Learn more{{/domainsLink}}.',
+					{ components: { domainsLink } }
 				);
 			}
 		} else {
@@ -592,12 +588,12 @@ export class DomainWarnings extends React.PureComponent {
 				text = translate(
 					'We are setting up {{strong}}%(domainName)s{{/strong}} for you. ' +
 						'It should start working immediately, but may be unreliable during the first 72 hours. ' +
-						'{{allAboutDomainsLink}}Learn more{{/allAboutDomainsLink}} about your new domain, or ' +
+						'{{domainsLink}}Learn more{{/domainsLink}} about your new domain, or ' +
 						'{{tryNowLink}} try it now{{/tryNowLink}}.',
 					{
 						args: { domainName: domain.name },
 						components: {
-							allAboutDomainsLink,
+							domainsLink,
 							tryNowLink: (
 								<a href={ `http://${ domain.name }` } target="_blank" rel="noopener noreferrer" />
 							),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There is no page https://en.support.wordpress.com/all-about-domains. However, https://en.support.wordpress.com/domains/all-about-domains redirects to https://en.support.wordpress.com/domains.

Replace both uses of https://en.support.wordpress.com/all-about-domains with https://en.support.wordpress.com/domains.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new wordpress.com site
* Choose a custom domain
* Pay with credits
* Go to http://calypso.localhost:3000/domains/manage/{new domain}
* Set the primary domain back to the *.wordpress.com domain (this will display the warning that is being fixed)

Expected:
* The _learn more_ link in the warning should link to https://en.support.wordpress.com/domains/

**Don't forget to cancel the domain once you are finished testing!**

<img width="979" alt="Screenshot 2019-09-13 at 11 34 57" src="https://user-images.githubusercontent.com/7767559/64875290-c985e580-d61a-11e9-994a-7364337cc61e.png">


Fixes #36031
