### PR TITLE
Domains: Adjust domain mapping copy notes

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -90,9 +90,9 @@ class MapDomainStep extends React.Component {
 				{ this.notice() }
 				<form className="map-domain-step__form card" onSubmit={ this.handleFormSubmit }>
 					<div className="map-domain-step__domain-heading">
-						{ translate( "Map this domain to use it as your site's address.", {
+						{ translate( 'Map this domain to use it as your site address.', {
 							context: 'Upgrades: Description in domain registration',
-							comment: "Explains how you could use a new domain name for your site's address.",
+							comment: 'Explains how you could use a new domain name for your site address.',
 						} ) }
 					</div>
 
@@ -134,7 +134,7 @@ class MapDomainStep extends React.Component {
 
 					<div className="map-domain-step__domain-text">
 						{ translate(
-							"We'll add your domain and help you change its settings so it points to your site. Keep your domain renewed with your current provider. (They'll remind you when it's time.) {{a}}Learn more about adding a domain{{/a}}.",
+							"We'll add your domain and help you change its settings so it points to your site. Keep your domain renewed with your current provider. (They'll remind you when it's time.) {{a}}Learn more about mapping a domain{{/a}}.",
 							{
 								components: {
 									a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adjusts domain mapping copy notes

#### Testing instructions

* Navigate to Domains -> Add Domain -> Use a domain I own -> Map Your Domain
* Should read `Map this domain to use it as your site address` instead of `Map this domain to use it as your site's address`
* Should read `Learn more about mapping a domain` instead of `Learn more about adding a domain`


Fixes #36032

#### Screenshots

<img width="1362" alt="Screen Shot 2019-09-13 at 11 22 53" src="https://user-images.githubusercontent.com/1620929/64874541-39936c00-d619-11e9-9802-8b771841a3e1.png">
