### PR TITLE
Try to sort post status absolutely

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -159,6 +159,11 @@ export class PostTypeFilter extends Component {
 		const isSingleSite = !! siteId;
 
 		const navItems = this.getNavItems();
+		const sortOrder = [ 'filter-publish', 'filter-draft', 'filter-trash' ];
+		navItems.sort( ( a, b ) =>
+			sortOrder.indexOf( a.key ) > sortOrder.indexOf( b.key ) ? 1 : -1
+		);
+
 		const selectedItem = find( navItems, 'selected' ) || {};
 
 		const scopes = {

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -27,7 +27,7 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import AuthorSegmented from './author-segmented';
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -159,7 +159,7 @@ export class PostTypeFilter extends Component {
 		const isSingleSite = !! siteId;
 
 		const navItems = this.getNavItems();
-		const sortOrder = [ 'filter-publish', 'filter-draft', 'filter-trash' ];
+		const sortOrder = [ 'filter-publish', 'filter-draft', 'filter-future', 'filter-trash' ];
 		navItems.sort( ( a, b ) =>
 			sortOrder.indexOf( a.key ) > sortOrder.indexOf( b.key ) ? 1 : -1
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In an attempt to solve #35785, this PR orders the post statuses absolutely in the `PostTypeFilter` component. I'm not sure this is great, but I think it will be okay given that the component is really only used in one place ... with that said, I've been largely unsuccessful in reproducing the original issue, and could use input.

#### Testing instructions

Load up the Calypso posts page for a site with several different post statuses. You should see the statuses appear in the component in the following order:

`Published > Draft > Future > Trashed`

Fixes https://github.com/Automattic/wp-calypso/issues/35785
