### PR TITLE
Plans: Remove pinned items space from navbar on pages without cart icon

### DIFF
--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -65,12 +65,12 @@ class PlansNavigation extends React.Component {
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 		const canManageDomain = userCanManageOptions && ( isATEnabled( site ) || ! isJetpack );
 		const pathsWithoutCartIcon = [ '/plans/my-plan', '/email' ];
-		const hadPinnedItems = isMobile() && ! pathsWithoutCartIcon.includes( path );
+		const hasPinnedItems = isMobile() && ! pathsWithoutCartIcon.includes( path );
 
 		return (
 			site && (
 				<SectionNav
-					hasPinnedItems={ hadPinnedItems }
+					hasPinnedItems={ hasPinnedItems }
 					selectedText={ sectionTitle }
 					onMobileNavPanelOpen={ this.onMobileNavPanelOpen }
 				>

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -64,7 +64,8 @@ class PlansNavigation extends React.Component {
 		const sectionTitle = this.getSectionTitle( path );
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 		const canManageDomain = userCanManageOptions && ( isATEnabled( site ) || ! isJetpack );
-		const hadPinnedItems = isMobile() && path !== '/plans/my-plan'; // My Plan doesn't show the cart icon.
+		const pathsWithoutCartIcon = [ '/plans/my-plan', '/email' ];
+		const hadPinnedItems = isMobile() && ! pathsWithoutCartIcon.includes( path );
 
 		return (
 			site && (

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -64,8 +64,7 @@ class PlansNavigation extends React.Component {
 		const sectionTitle = this.getSectionTitle( path );
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 		const canManageDomain = userCanManageOptions && ( isATEnabled( site ) || ! isJetpack );
-		const pathsWithoutCartIcon = [ '/plans/my-plan', '/email' ];
-		const hasPinnedItems = isMobile() && ! pathsWithoutCartIcon.includes( path );
+		const hasPinnedItems = isMobile() && this.cartToggleButton();
 
 		return (
 			site && (

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -64,11 +64,12 @@ class PlansNavigation extends React.Component {
 		const sectionTitle = this.getSectionTitle( path );
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 		const canManageDomain = userCanManageOptions && ( isATEnabled( site ) || ! isJetpack );
+		const hadPinnedItems = isMobile() && path !== '/plans/my-plan'; // My Plan doesn't show the cart icon.
 
 		return (
 			site && (
 				<SectionNav
-					hasPinnedItems={ isMobile() }
+					hasPinnedItems={ hadPinnedItems }
 					selectedText={ sectionTitle }
 					onMobileNavPanelOpen={ this.onMobileNavPanelOpen }
 				>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensures there are no space in the navigation bar for any pinned item like the cart icon when visiting "My Plan" or "Email" on a mobile device.

Previously, we were assuming that any page under the "Plans" section would display the cart icon, leaving space for it on mobile viewports. But that's not true for "My Plan" (only visible when the site has a plan active) or "Email".

| Before | After |
|---|---|
| <img width="295" alt="Screen Shot 2019-09-13 at 11 04 29" src="https://user-images.githubusercontent.com/1233880/64875043-351b8300-d61a-11e9-87c4-4a75d27f2e5c.png"> | <img width="315" alt="Screen Shot 2019-09-13 at 11 03 35" src="https://user-images.githubusercontent.com/1233880/64875030-2cc34800-d61a-11e9-8f85-3ccfe7ca9c3d.png"> |

#### Testing instructions

* Make sure you test with a mobile viewport. In Chrome you can easily simulate it by opening the browser devtools and toggling the device toolbar:
<img width="1230" alt="Screen Shot 2019-09-13 at 11 34 51" src="https://user-images.githubusercontent.com/1233880/64875213-9ba0a100-d61a-11e9-8b83-eb01ceddc272.png">

* Go to `http://calypso.localhost:3000/plans/my-plan/:site` (note that your site should currently have a plan).
* Confirm there is no extra space after the chevron icon.
* Switch to the "Email" page and confirm the is no extra space as well.
* Switch to either "Plans" or "Domains" and make sure the cart icon still appears on the right, with the chevron icon next to it.

Fixes #35501
