### PR TITLE
Update Primary domain flag style

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -19,8 +19,14 @@
 	overflow: hidden;
 
 	.domain__primary-flag {
-		vertical-align: middle;
 		margin-left: 8px;
+		background: var( --sidebar-menu-hover-background );
+		color: var( --sidebar-menu-hover-color );
+		font-size: 12px;
+		border-radius: 12px;
+		display: inline-block;
+		padding: 2px 10px;
+		vertical-align: baseline;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -19,14 +19,13 @@
 	overflow: hidden;
 
 	.domain__primary-flag {
+		vertical-align: middle;
 		margin-left: 8px;
 		background: var( --sidebar-menu-hover-background );
 		color: var( --sidebar-menu-hover-color );
-		font-size: 12px;
 		border-radius: 12px;
 		display: inline-block;
 		padding: 2px 10px;
-		vertical-align: baseline;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the style of the Primary domain flag to have more of a Pill like layout

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to Manage -> Domains and when looking at the site's primary address.

* Before 

<img width="658" alt="64382006-83b99380-d002-11e9-9a31-8166c781fd5c" src="https://user-images.githubusercontent.com/6520461/64876284-cc81d580-d61c-11e9-9681-e23bbf80220d.png">


After

<img width="661" alt="64382005-83b99380-d002-11e9-8eb9-5c7eb2468065" src="https://user-images.githubusercontent.com/6520461/64876298-d7d50100-d61c-11e9-8f78-d7e5b1553590.png">


Fixes #36011
