### PR TITLE
Fix Overflow Fade In Stats Page "Post Published" Overflow

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -434,18 +434,11 @@ $y-axis-padding: 0 20px 0 10px;
 			min-width: 0;
 
 			&::before {
-				content: '';
+				@include long-content-fade( $color: var( --color-primary-rgb ) );
 				position: relative;
-				background-image: linear-gradient(
-					to right,
-					rgba( 61, 89, 109, 0 ) 0%,
-					rgba( 61, 89, 109, 0.5 ),
-					rgba( 61, 89, 109, 1 )
-				);
 				left: -30px;
 				width: 30px;
 				height: 24px;
-				display: block;
 			}
 		}
 	}

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -434,7 +434,7 @@ $y-axis-padding: 0 20px 0 10px;
 			min-width: 0;
 
 			&::before {
-				@include long-content-fade( $color: var( --color-primary-rgb ) );
+				@include long-content-fade( $color: var( --color-neutral-600-rgb ) );
 				position: relative;
 				left: -30px;
 				width: 30px;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -434,7 +434,7 @@ $y-axis-padding: 0 20px 0 10px;
 			min-width: 0;
 
 			&::before {
-				@include long-content-fade( $color: var( --color-neutral-600-rgb ) );
+				@include long-content-fade( $color: var( --color-neutral-60-rgb ) );
 				position: relative;
 				left: -30px;
 				width: 30px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use color scheme in post title fade on stats page

#### Testing instructions
1. Navigate to `/stats/day` on WordPress.com with a more unconventional color scheme set ( Nightfall, Sakura, etc. )
2. Confirm the fade on the posts titles when mousing over a day in the bar chart with posts are a WordPress-y blue
<img width="300" alt="Screen Shot 2019-09-13 at 11 48 13 AM" src="https://user-images.githubusercontent.com/2810519/64876313-ddcae200-d61c-11e9-9aa4-0067d4672519.png">
3. Repeat steps one and two on the branch
4. Confirm the title now blends into the background as it overflows <img width="392" alt="Screen Shot 2019-09-13 at 2 10 19 PM" src="https://user-images.githubusercontent.com/2810519/64884759-74ed6500-d630-11e9-881f-ebe3a50829dd.png">




Fixes #34365
