### PR TITLE
Domains: Fix domain not shown on Transfer Restriction page

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -380,6 +380,8 @@ class TransferDomainStep extends React.Component {
 				domain: null,
 				inboundTransferStatus: {},
 				precheck: false,
+				notice: null,
+				searchQuery: '',
 				supportsPrivacy: false,
 			} );
 		} else {
@@ -484,7 +486,10 @@ class TransferDomainStep extends React.Component {
 			this.setState( prevState => {
 				const { submittingAvailability, submittingWhois } = prevState;
 
-				return { precheck: prevState.domain && ! submittingAvailability && ! submittingWhois };
+				return {
+					domain,
+					precheck: prevState.domain && ! submittingAvailability && ! submittingWhois
+				};
 			} );
 
 			if ( this.props.isSignupStep && this.state.domain && ! this.transferIsRestricted() ) {

--- a/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
@@ -88,7 +88,7 @@ class TransferRestrictionMessage extends React.PureComponent {
 					'%(daysAgoRegistered)s days ago, and can be transferred starting %(transferEligibleDate)s.',
 				{
 					args: {
-						domain: domain,
+						domain,
 						daysAgoRegistered: moment().diff( moment( creationDate ), 'days' ),
 						transferEligibleDate: transferEligibleMoment.format( 'LL' ),
 					},


### PR DESCRIPTION
This pull request addresses https://github.com/Automattic/wp-calypso/issues/36043 by displaying the domain being transferred on the `Transfer Restriction` page:
 
![screenshot](https://user-images.githubusercontent.com/594356/64876432-5cd90e00-d64f-11e9-8814-83fad529479e.png)

It also redirects users back to the `Transfer a Domain` page when clicking the `Transfer different domain` button. Previously they would be redirected to the `Domain Search` page.

#### Testing instructions
 
1. Run `git checkout fix/domain-transfer-restriction-page` and start your server, or open a [live branch](https://calypso.live/?branch=fix/domain-transfer-restriction-page)
2. Open the [`Use Your Own Domain` page](http://calypso.localhost:3000/domains/add/use-your-domain)
3. Click the `Transfer to WordPress.com` button
4. Enter `calobee-testing.club` in the form, and click the `Transfer` button
5. Assert that the domain name now shows up in the heading and second sentence
6. Click the `Transfer different domain` button
7. Assert that you were redirected to the `Transfer a Domain` page