### PR TITLE
changed message text to make sure it uses the same word as used in the error message.

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { debounce, get, flow, inRange, isEmpty } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**
@@ -225,7 +225,7 @@ export class SiteAddressChanger extends Component {
 		const serverValidationMessage = get( validationError, 'message' );
 
 		return isAvailable
-			? translate( 'Good news, this site address is available!' )
+			? translate( 'Good news, that site address is available!' )
 			: validationMessage || serverValidationMessage;
 	}
 


### PR DESCRIPTION


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Domains -> Click on a site address -> Go to Change Site Address at the bottom of the screen.

The message shown when the domain is available should be: `Good news, that site address is available.`

https://cloudup.com/cuzK2VvmeVN

*The error message pointed in the reported issue is coming from the server: https://cloudup.com/cTGCROxJ8yt This is why it is not possible to edit that one. 

Fixes # https://github.com/Automattic/wp-calypso/issues/36008
