### PR TITLE
Domains: Fix Change Site Address modal content alignment

### DIFF
--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -131,6 +131,8 @@
 }
 
 .site-address-changer__confirmation-detail {
+	margin-bottom: 1em;
+
 	.gridicon {
 		float: left;
 		margin-top: 4px;

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -133,6 +133,7 @@
 .site-address-changer__confirmation-detail {
 	.gridicon {
 		float: left;
+		margin-top: 4px;
 
 		@include breakpoint( '<660px' ) {
 			display: none;


### PR DESCRIPTION
Fixes the alignment in the "Change Site Address" dialog. Fixes #36010, fixes #36009, and supersedes #36050 which I only saw after fixing the other issues. This approach is simpler, and only requires the CSS change.

Before:

<img width="472" alt="Screen Shot 2019-09-13 at 12 09 12 PM" src="https://user-images.githubusercontent.com/541093/64877384-52068500-d61f-11e9-8f0b-b6515f304436.png">

After:

<img width="469" alt="Screen Shot 2019-09-13 at 12 04 16 PM" src="https://user-images.githubusercontent.com/541093/64877209-ecb29400-d61e-11e9-806a-259b19c5ef69.png">

**Testing instructions**

- Go to Domains -> Click on a site -> Scroll to Change Site Address.
- Input an available site address and click the button Change Site Address.
- The modal will appear.