### PR TITLE
My plan: Make CTAs full width only below 480px

### DIFF
--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -66,11 +66,11 @@
 	width: 100%;
 
 	.button {
-		@include breakpoint( '<660px' ) {
-			width: 80%;
+		@include breakpoint( '<480px' ) {
+			display: block;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint( '>480px' ) {
 
 			&:first-of-type {
 				margin-right: 16px;
@@ -83,7 +83,7 @@
 		padding-bottom: 11px;
 		padding-top: 2px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint( '<480px' ) {
 			margin-top: 16px;
 		}
 	}

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -9,7 +9,7 @@
 		border-bottom: none;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( '>480px' ) {
 		border-radius: 3px;
 		max-width: 700px;
 		margin: 16px auto;
@@ -69,7 +69,7 @@
 }
 
 .purchase-detail__button {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint( '<480px' ) {
 		display: block;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make CTA buttons on https://wordpress.com/plans/my-plan/ page for a paid WordPress.com site full width only below 480px.
* Fix CTA buttons width inconsistency between [`happiness-support`](https://github.com/Automattic/wp-calypso/tree/master/client/components/happiness-support) & [`purchase-detail`](https://github.com/Automattic/wp-calypso/tree/master/client/components/purchase-detail) components

#### Testing instructions

1. Go to https://wordpress.com/plans/my-plan/ page (for a paid WordPress.com site)
2. Check the CTA buttons width below & above the 480px breakpoint

- Before: 

   CTA buttons width is 100% (80% for the `happiness-support` component) up to 660px breakpoint making them look inconsistent & rather long. 

   `<660px`:

   <img width="494" alt="Screenshot 2019-09-13 12 13 04" src="https://user-images.githubusercontent.com/1451471/64877804-1d46fd80-d620-11e9-9338-604dfe99ca26.png">

- After:
   CTA buttons are 100% wide only below 480px breakpoint.

   `<=480px`

   <img width="359" alt="Screenshot 2019-09-13 12 14 14" src="https://user-images.githubusercontent.com/1451471/64877868-39e33580-d620-11e9-9894-c9860f632421.png">

   `>480px`

   <img width="493" alt="Screenshot 2019-09-13 12 13 45" src="https://user-images.githubusercontent.com/1451471/64877910-51222300-d620-11e9-88c6-e854a3e7faf3.png">

Fixes #35542 

