### PR TITLE
Improve whitespace between row header and data when editing domain

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/property/style.scss
+++ b/client/my-sites/domains/domain-management/edit/card/property/style.scss
@@ -9,12 +9,12 @@
 
 	& > strong {
 		float: left;
-		width: 50%;
+		margin-right: 5px;
 	}
 
 	& > span {
-		float: right;
-		text-align: right;
+		float: left;
+		text-align: left;
 		width: 50%;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before 

<img width="743" alt="64378631-1ce4ac00-cffb-11e9-9e35-37263366fcc7" src="https://user-images.githubusercontent.com/6520461/64880167-84b37c00-d625-11e9-9eaf-d55d04280a5b.png">

After

<img width="669" alt="64379392-ced0a800-cffc-11e9-9c45-6d703a6ac200" src="https://user-images.githubusercontent.com/6520461/64880176-8a10c680-d625-11e9-8e12-8fe424b3b096.png">


Fixes #36006
