### PR TITLE
Fix: Remove Plugin Upgrade nudge for VIP sites

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -37,6 +37,7 @@ import {
 	isRequestingSites,
 	canJetpackSiteManage,
 } from 'state/sites/selectors';
+import isVipSite from 'state/selectors/is-vip-site';
 import NonSupportedJetpackVersionNotice from 'my-sites/plugins/not-supported-jetpack-version';
 import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
 import HeaderButton from 'components/header-button';
@@ -540,6 +541,7 @@ export class PluginsBrowser extends Component {
 		if (
 			! this.props.selectedSiteId ||
 			! this.props.sitePlan ||
+			this.props.isVipSite ||
 			this.props.isJetpackSite ||
 			this.props.hasBusinessPlan
 		) {
@@ -631,6 +633,7 @@ export default flow(
 				hasPremiumPlan,
 				hasBusinessPlan,
 				isJetpackSite: isJetpackSite( state, selectedSiteId ),
+				isVipSite: isVipSite( state, selectedSiteId ),
 				hasJetpackSites: hasJetpackSites( state ),
 				jetpackManageError:
 					!! isJetpackSite( state, selectedSiteId ) &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request


Before: 
<img width="1447" alt="Screen Shot 2019-09-13 at 9 09 58 PM" src="https://user-images.githubusercontent.com/115071/64888293-e6e2a000-d66a-11e9-8515-20e7a57283d0.png">

After: 
<img width="1464" alt="Screen Shot 2019-09-13 at 9 10 32 PM" src="https://user-images.githubusercontent.com/115071/64888404-37f29400-d66b-11e9-81b7-07e741d3115a.png">



#### Testing instructions

1. Add yourself to a VIP site
and visit http://calypso.localhost:3000/plugins/examplevip.com Notice that you don't see upgrade nudge. 

2. Visit a regular WordPress site that doesn't have the business plan and notice that the nudge is still there!

Fixes https://github.com/Automattic/wp-calypso/issues/28928
