### PR TITLE
Refactor Stats Bar Chart X Axis Component & Fix Weird Initial Render

### DIFF
--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -4,91 +4,69 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useLayoutEffect, useState, useRef } from 'react';
 import { numberFormat } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import afterLayoutFlush from 'lib/after-layout-flush';
 import Label from './label';
 
-export default class ChartXAxis extends React.PureComponent {
-	static displayName = 'ModuleChartXAxis';
+const ModuleChartXAxis = ( { data, isRtl, labelWidth } ) => {
+	const axisRef = useRef( null );
+	const axisSpacerRef = useRef( null );
+	const dataCount = data.length || 1;
 
-	static propTypes = {
-		data: PropTypes.array.isRequired,
-		isRtl: PropTypes.bool,
-		labelWidth: PropTypes.number.isRequired,
-	};
+	const [ spacing, setSpacing ] = useState( labelWidth );
+	// the divisor determines how many labels are rendered, start very conservative
+	const [ divisor, setDivisor ] = useState( 1 );
 
-	axisRef = React.createRef();
-	axisSpacerRef = React.createRef();
+	useLayoutEffect( () => {
+		const resize = () => {
+			const width = axisRef.current.clientWidth - axisSpacerRef.current.clientWidth;
+			const newSpacing = width / dataCount;
 
-	state = {
-		divisor: 1,
-		spacing: this.props.labelWidth,
-	};
+			setSpacing( newSpacing );
+			setDivisor( Math.ceil( labelWidth / newSpacing ) );
+		};
 
-	// Add listener for window resize
-	componentDidMount() {
-		this.resize = afterLayoutFlush( this.resize );
-		window.addEventListener( 'resize', this.resize );
-		this.resize();
-	}
+		resize();
 
-	// Remove listener
-	componentWillUnmount() {
-		if ( this.resize.cancel ) {
-			this.resize.cancel();
+		window.addEventListener( 'resize', resize );
+
+		return () => {
+			window.removeEventListener( 'resize', resize );
+		};
+	}, [ dataCount, labelWidth ] );
+
+	const labels = data.map( function( item, index ) {
+		const x = index * spacing + ( spacing - labelWidth ) / 2,
+			rightIndex = data.length - index - 1;
+		let label;
+
+		if ( rightIndex % divisor === 0 ) {
+			label = (
+				<Label isRtl={ isRtl } key={ index } label={ item.label } width={ labelWidth } x={ x } />
+			);
 		}
-		window.removeEventListener( 'resize', this.resize );
-	}
 
-	componentDidUpdate() {
-		this.resize();
-	}
+		return label;
+	} );
 
-	resize = () => {
-		const width = this.axisRef.current.clientWidth - this.axisSpacerRef.current.clientWidth;
-		const dataCount = this.props.data.length || 1;
-		const spacing = width / dataCount;
-		const labelWidth = this.props.labelWidth;
-		const divisor = Math.ceil( labelWidth / spacing );
-
-		this.setState( { divisor, spacing } );
-	};
-
-	render() {
-		const data = this.props.data;
-
-		const labels = data.map( function( item, index ) {
-			const x = index * this.state.spacing + ( this.state.spacing - this.props.labelWidth ) / 2,
-				rightIndex = data.length - index - 1;
-			let label;
-
-			if ( rightIndex % this.state.divisor === 0 ) {
-				label = (
-					<Label
-						isRtl={ this.props.isRtl }
-						key={ index }
-						label={ item.label }
-						width={ this.props.labelWidth }
-						x={ x }
-					/>
-				);
-			}
-
-			return label;
-		}, this );
-
-		return (
-			<div ref={ this.axisRef } className="chart__x-axis">
-				{ labels }
-				<div ref={ this.axisSpacerRef } className="chart__x-axis-label chart__x-axis-width-spacer">
-					{ numberFormat( 100000 ) }
-				</div>
+	return (
+		<div ref={ axisRef } className="chart__x-axis">
+			{ labels }
+			<div ref={ axisSpacerRef } className="chart__x-axis-label chart__x-axis-width-spacer">
+				{ numberFormat( 100000 ) }
 			</div>
-		);
-	}
-}
+		</div>
+	);
+};
+
+ModuleChartXAxis.propTypes = {
+	data: PropTypes.array.isRequired,
+	isRtl: PropTypes.bool,
+	labelWidth: PropTypes.number.isRequired,
+};
+
+export default ModuleChartXAxis;

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -18,7 +18,7 @@ const ModuleChartXAxis = ( { data, isRtl, labelWidth } ) => {
 	const dataCount = data.length || 1;
 
 	const [ spacing, setSpacing ] = useState( labelWidth );
-	// the divisor determines how many labels are rendered, start very conservative
+
 	const [ divisor, setDivisor ] = useState( 1 );
 
 	useLayoutEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor stats bar chart x axis as functional component
* Use `useLayoutEffect` to hold render until axis is fixed

**BEFORE**
<img width="1336" alt="Screen Shot 2019-09-13 at 12 16 37 PM" src="https://user-images.githubusercontent.com/2810519/64888856-f7c6ed80-d639-11e9-9ef0-bfcba74a2f96.png">

**AFTER**
<img width="1263" alt="Screen Shot 2019-09-13 at 12 15 53 PM" src="https://user-images.githubusercontent.com/2810519/64888891-0a412700-d63a-11e9-91ba-3e3b1a8b1513.png">


#### Testing instructions
1. Navigate to `/stats/day` with a wide-ish browser width
2. Confirm the initial x axis does _not_ match the "BEFORE" screenshot above

Fixes #36089


