### PR TITLE
Removes assignmentMethod as an option to abtest

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -36,7 +36,6 @@ There are also several optional configuration settings available:
 Don't forget: any test that runs for locales other than English means strings will need to be translated.
 * `localeExceptions` - Allow tests to run for all locales except the specified. `localeTargets: ['en']`
 * `countryCodeTargets` - (array) Only run tests for users from specific countries. You'll need to pass the current user country to the abtest method when calling it.
-* `assignmentMethod` - By default, test variations are assigned using a random number generator. You can also assign test variations using the 'userId'. Using the userId to assign test variations will still assign a random assignment; however, it ensures the user is assigned the same assignment in the event their local storage gets cleared or is compromised. This includes cases where they manually clear their local storage, use multiple devices, or use an incognito window (storageless browser). This assignment method should not be used if a user does not have a userId by the time the AB test starts.
 
 Next, in your code, import the `abtest` method from the `abtest` module:
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -149,7 +149,6 @@ export default {
 			hide: 50,
 		},
 		defaultVariation: 'hide',
-		assignmentMethod: 'userId',
 	},
 	signupEscapeHatch: {
 		datestamp: '20190826',

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -94,8 +94,6 @@ ABTest.prototype.init = function( name, geoLocation ) {
 	}
 
 	const variationDetails = testConfig.variations;
-	const assignmentMethod =
-		typeof testConfig.assignmentMethod !== 'undefined' ? testConfig.assignmentMethod : 'default';
 	const variationNames = keys( variationDetails );
 	if ( ! variationDetails || variationNames.length === 0 ) {
 		throw new Error( 'No A/B test variations found for ' + name );
@@ -147,7 +145,6 @@ ABTest.prototype.init = function( name, geoLocation ) {
 	this.variationDetails = variationDetails;
 	this.defaultVariation = testConfig.defaultVariation;
 	this.variationNames = variationNames;
-	this.assignmentMethod = assignmentMethod;
 	this.experimentId = name + '_' + variationDatestamp;
 
 	if ( testConfig.countryCodeTargets ) {
@@ -314,11 +311,7 @@ ABTest.prototype.assignVariation = function() {
 		0
 	);
 
-	if ( this.assignmentMethod === 'userId' && ! isNaN( +userId ) ) {
-		randomAllocationAmount = Number( user.data.ID ) % allocationsTotal;
-	} else {
-		randomAllocationAmount = Math.random() * allocationsTotal;
-	}
+	randomAllocationAmount = Math.random() * allocationsTotal;
 
 	for ( variationName in this.variationDetails ) {
 		sum += this.variationDetails[ variationName ];


### PR DESCRIPTION
We cannot prove that the assignment test variations by a hashed userid is allocating expected percentages.