### PR TITLE
Update upgrade thank you page CTA button copy

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -282,7 +282,7 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isPlan( primaryPurchase ) ) {
-			return translate( 'View my plan' );
+			return translate( 'View my new features' );
 		}
 
 		if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After upgrade purchase, the 'Thank You' page's primary CTA takes the customer to their plan. In this PR I've updated the button copy from "View my plan" to "View my new features" to put the focus on the features they just paid for, and less on the plan itself.

#### Testing instructions

No testing needed. This is a one line copy fix.

Fixes #35371
