### PR TITLE
Posts, Testimonials and Portfolio Projects: Expand search scope from one tab to all tabs

### DIFF
--- a/client/blocks/post-item/README.md
+++ b/client/blocks/post-item/README.md
@@ -25,3 +25,13 @@ The component does not render a [query component](https://github.com/Automattic/
 </table>
 
 The global ID of the post to be displayed. If omitted, it's assumed that the post is currently loading, and a post with placeholder styling will be shown instead.
+
+### `showPublishedStatus`
+
+<table>
+	<tr><th>Type</th><td>Bool</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td>false</td></tr>
+</table>
+
+If true, statuses will be shown for scheduled, trashed, drafted, and published posts.

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -142,6 +142,7 @@ class PostItem extends React.Component {
 			isAllSitesModeSelected,
 			translate,
 			multiSelectEnabled,
+			showPublishedStatus,
 			hasExpandedContent,
 			isTypeWpBlock,
 		} = this.props;
@@ -208,7 +209,7 @@ class PostItem extends React.Component {
 							<span className="post-item__meta-time-status">
 								<a href={ enabledPostLink } className="post-item__time-status-link">
 									<PostTime globalId={ globalId } />
-									<PostStatus globalId={ globalId } showAll={ true } />
+									<PostStatus globalId={ globalId } showAll={ showPublishedStatus } />
 								</a>
 							</span>
 							<PostActionCounts globalId={ globalId } />
@@ -246,6 +247,7 @@ PostItem.propTypes = {
 	singleUserQuery: PropTypes.bool,
 	className: PropTypes.string,
 	compact: PropTypes.bool,
+	showPublishedStatus: PropTypes.bool,
 	hideActiveSharePanel: PropTypes.func,
 	hasExpandedContent: PropTypes.bool,
 	isTypeWpBlock: PropTypes.bool,

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -208,7 +208,7 @@ class PostItem extends React.Component {
 							<span className="post-item__meta-time-status">
 								<a href={ enabledPostLink } className="post-item__time-status-link">
 									<PostTime globalId={ globalId } />
-									<PostStatus globalId={ globalId } />
+									<PostStatus globalId={ globalId } showAll={ true } />
 								</a>
 							</span>
 							<PostActionCounts globalId={ globalId } />

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -17,7 +17,6 @@ import { isJetpackSite, isSingleUserSite, getSiteSlug } from 'state/sites/select
 import { getNormalizedMyPostCounts, getNormalizedPostCounts } from 'state/posts/counts/selectors';
 import { isMultiSelectEnabled } from 'state/ui/post-type-list/selectors';
 import { toggleMultiSelect } from 'state/ui/post-type-list/actions';
-import { mapPostStatus } from 'lib/route';
 import { isEnabled } from 'config';
 import urlSearch from 'lib/url-search';
 import QueryPostCounts from 'components/data/query-post-counts';
@@ -51,7 +50,7 @@ export class PostTypeFilter extends Component {
 	};
 
 	getNavItems() {
-		const { query, siteId, siteSlug, jetpack, counts } = this.props;
+		const { query, siteId, siteSlug, statusSlug, jetpack, counts } = this.props;
 
 		return reduce(
 			counts,
@@ -109,7 +108,7 @@ export class PostTypeFilter extends Component {
 						pathStatus,
 						siteSlug,
 					] ).join( '/' ),
-					selected: mapPostStatus( pathStatus ) === query.status,
+					selected: pathStatus === statusSlug,
 					children: label,
 				} );
 			},

--- a/client/my-sites/post-type-list/README.md
+++ b/client/my-sites/post-type-list/README.md
@@ -28,3 +28,13 @@ export default function MyComponent() {
 </table>
 
 The post type for which posts should be queried.
+
+### `showPublishedStatus`
+
+<table>
+	<tr><th>Type</th><td>Bool</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td>false</td></tr>
+</table>
+
+If true, statuses will be shown for scheduled, trashed, drafted, and published posts.

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -247,6 +247,7 @@ class PostTypeList extends Component {
 		const { query, siteId, isRequestingPosts, translate } = this.props;
 		const { maxRequestedPage, recentViewIds } = this.state;
 		const posts = this.props.posts || [];
+		const postStatuses = query.status.split( ',' );
 		const isLoadedAndEmpty = query && ! posts.length && ! isRequestingPosts;
 		const classes = classnames( 'post-type-list', {
 			'is-empty': isLoadedAndEmpty,
@@ -256,7 +257,7 @@ class PostTypeList extends Component {
 			posts.length > 10 &&
 			query &&
 			( query.type === 'post' || ! query.type ) &&
-			query.status === 'publish,private';
+			( postStatuses.includes( 'publish' ) || postStatuses.includes( 'private' ) );
 
 		return (
 			<div className={ classes }>

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -47,6 +47,7 @@ class PostTypeList extends Component {
 	static propTypes = {
 		// Props
 		query: PropTypes.object,
+		showPublishedStatus: PropTypes.bool,
 		scrollContainer: PropTypes.object,
 
 		// Connected props
@@ -232,13 +233,14 @@ class PostTypeList extends Component {
 
 	renderPost( post ) {
 		const globalId = post.global_ID;
-		const { query } = this.props;
+		const { query, showPublishedStatus } = this.props;
 
 		return (
 			<PostItem
 				key={ globalId }
 				globalId={ globalId }
 				singleUserQuery={ query && !! query.author }
+				showPublishedStatus={ showPublishedStatus }
 			/>
 		);
 	}

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -64,10 +64,10 @@ class PostsMain extends React.Component {
 			order: status === 'future' ? 'ASC' : 'DESC',
 			search,
 			site_visibility: ! siteId ? 'visible' : undefined,
-			// Search across all statuses so the user can always find what they
-			// are looking for, regardless of what tab they are on. (The API
-			// accepts "any" but this would exclude trashed posts, so use
-			// POST_STATUSES instead.)
+			// When searching, search across all statuses so the user can
+			// always find what they are looking for, regardless of what tab
+			// the search was initiated from. Use POST_STATUSES rather than
+			// "any" to do this, since the latter excludes trashed posts.
 			status: search ? POST_STATUSES.join( ',' ) : status,
 			tag,
 			type: 'post',

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -15,6 +15,7 @@ import PostTypeList from 'my-sites/post-type-list';
 import PostTypeBulkEditBar from 'my-sites/post-type-list/bulk-edit-bar';
 import titlecase from 'to-title-case';
 import Main from 'components/main';
+import { POST_STATUSES } from 'state/posts/constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { mapPostStatus } from 'lib/route';
 
@@ -63,7 +64,11 @@ class PostsMain extends React.Component {
 			order: status === 'future' ? 'ASC' : 'DESC',
 			search,
 			site_visibility: ! siteId ? 'visible' : undefined,
-			status,
+			// Search across all statuses so the user can always find what they
+			// are looking for, regardless of what tab they are on. (The API
+			// accepts "any" but this would exclude trashed posts, so use
+			// POST_STATUSES instead.)
+			status: search ? POST_STATUSES.join( ',' ) : status,
 			tag,
 			type: 'post',
 		};

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -72,6 +72,9 @@ class PostsMain extends React.Component {
 			tag,
 			type: 'post',
 		};
+		// Since searches are across all statuses, the status needs to be shown
+		// next to each post.
+		const showPublishedStatus = Boolean( query.search );
 
 		return (
 			<Main className="posts">
@@ -79,7 +82,11 @@ class PostsMain extends React.Component {
 				<SidebarNavigation />
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />
 				{ siteId && <PostTypeBulkEditBar /> }
-				<PostTypeList query={ query } scrollContainer={ document.body } />
+				<PostTypeList
+					query={ query }
+					showPublishedStatus={ showPublishedStatus }
+					scrollContainer={ document.body }
+				/>
 			</Main>
 		);
 	}

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -18,19 +18,24 @@ export function redirect() {
 
 export function list( context, next ) {
 	const search = context.query.s;
+	// When searching, search across all statuses so the user can always find
+	// what they are looking for, regardless of what tab the search was
+	// initiated from. Use POST_STATUSES rather than "any" to do this, since
+	// the latter excludes trashed posts.
+	const status = search ? POST_STATUSES.join( ',' ) : mapPostStatus( context.params.status );
+	// Since searches are across all statuses, the status needs to be shown
+	// next to each post.
+	const showPublishedStatus = Boolean( search );
+
 	context.primary = (
 		<Types
 			query={ {
 				type: context.params.type,
-				// When searching, search across all statuses so the user can
-				// always find what they are looking for, regardless of what
-				// tab the search was initiated from. Use POST_STATUSES rather
-				// than "any" to do this, since the latter excludes trashed
-				// posts.
-				status: search ? POST_STATUSES.join( ',' ) : mapPostStatus( context.params.status ),
+				status,
 				search,
 			} }
 			statusSlug={ context.params.status }
+			showPublishedStatus={ showPublishedStatus }
 		/>
 	);
 

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -10,19 +10,27 @@ import page from 'page';
  */
 import Types from './main';
 import { mapPostStatus } from 'lib/route';
+import { POST_STATUSES } from 'state/posts/constants';
 
 export function redirect() {
 	page.redirect( '/posts' );
 }
 
 export function list( context, next ) {
+	const search = context.query.s;
 	context.primary = (
 		<Types
 			query={ {
 				type: context.params.type,
-				status: mapPostStatus( context.params.status ),
-				search: context.query.s,
+				// When searching, search across all statuses so the user can
+				// always find what they are looking for, regardless of what
+				// tab the search was initiated from. Use POST_STATUSES rather
+				// than "any" to do this, since the latter excludes trashed
+				// posts.
+				status: search ? POST_STATUSES.join( ',' ) : mapPostStatus( context.params.status ),
+				search,
 			} }
+			statusSlug={ context.params.status }
 		/>
 	);
 

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -24,7 +24,15 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostType, isPostTypeSupported } from 'state/post-types/selectors';
 
-function Types( { siteId, query, postType, postTypeSupported, userCanEdit, statusSlug } ) {
+function Types( {
+	siteId,
+	query,
+	postType,
+	postTypeSupported,
+	userCanEdit,
+	statusSlug,
+	showPublishedStatus,
+} ) {
 	return (
 		<Main>
 			<DocumentHead title={ get( postType, 'label' ) } />
@@ -40,6 +48,7 @@ function Types( { siteId, query, postType, postTypeSupported, userCanEdit, statu
 					<PostTypeList
 						key="list"
 						query={ userCanEdit ? query : null }
+						showPublishedStatus={ showPublishedStatus }
 						scrollContainer={ document.body }
 					/>,
 				] }
@@ -56,6 +65,7 @@ Types.propTypes = {
 	postTypeSupported: PropTypes.bool,
 	userCanEdit: PropTypes.bool,
 	statusSlug: PropTypes.string,
+	showPublishedStatus: PropTypes.bool,
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -24,7 +24,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostType, isPostTypeSupported } from 'state/post-types/selectors';
 
-function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
+function Types( { siteId, query, postType, postTypeSupported, userCanEdit, statusSlug } ) {
 	return (
 		<Main>
 			<DocumentHead title={ get( postType, 'label' ) } />
@@ -32,7 +32,11 @@ function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 			<SidebarNavigation />
 			{ false !== userCanEdit &&
 				false !== postTypeSupported && [
-					<PostTypeFilter key="filter" query={ userCanEdit ? query : null } />,
+					<PostTypeFilter
+						key="filter"
+						query={ userCanEdit ? query : null }
+						statusSlug={ statusSlug }
+					/>,
 					<PostTypeList
 						key="list"
 						query={ userCanEdit ? query : null }
@@ -51,6 +55,7 @@ Types.propTypes = {
 	postType: PropTypes.object,
 	postTypeSupported: PropTypes.bool,
 	userCanEdit: PropTypes.bool,
+	statusSlug: PropTypes.string,
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/state/posts/constants.js
+++ b/client/state/posts/constants.js
@@ -26,3 +26,6 @@ export const DEFAULT_NEW_POST_VALUES = {
 	format: 'default',
 	featured_image: '',
 };
+
+// All post statuses displayed in Calypso.
+export const POST_STATUSES = [ 'publish', 'draft', 'pending', 'private', 'future', 'trash' ];

--- a/client/state/posts/counts/selectors.js
+++ b/client/state/posts/counts/selectors.js
@@ -7,9 +7,10 @@
 import { get } from 'lodash';
 
 /**
- * Constants
+ * Internal dependencies
  */
-const POST_STATUSES = [ 'publish', 'draft', 'pending', 'private', 'future', 'trash' ];
+
+import { POST_STATUSES } from '../constants';
 
 /**
  * Returns true if post counts request is in progress, or false otherwise.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When searching for posts, the search is currently limited to those with the same status as the tab you're currently visiting.  (In other words, if you start on the Published tab and enter the search interface from there, no draft posts will ever be returned in the search results, only published ones.)

Instead, users should always be able to search for any post regardless of status (as proposed by @lcollette in https://github.com/Automattic/wp-calypso/issues/36057).  This pull request makes that change.  (It also fixes it for testimonials and portfolio projects, since those share a fair amount of code with posts.)

Because the search results can now display posts with a mix of statuses, we also need to display the status next to the post in the search results.  (I used an existing option to the `PostStatus` component to do that, since it's already built and styled.)  In regular listings, when no search is active, the status will not be shown, same as the current behavior.

#### Testing instructions

Create some posts with a mix of statuses (published, draft, scheduled, trashed) and a common word in the title.  Then, search for that word at http://calypso.localhost:3000/posts/[site].  Ensure that all matching results are returned, regardless of what tab you started from (Published, Drafts, etc).

You can repeat the above with testimonials (at http://calypso.localhost:3000/types/jetpack-testimonial/[site]) and portfolio projects (at http://calypso.localhost:3000/types/jetpack-portfolio/[site]) also, and it should behave the same.

#### Screenshots

Before:

![post-search-before](https://user-images.githubusercontent.com/235183/64894009-a07b4a00-d646-11e9-9386-e184a017adec.png)

After:

![post-search-after](https://user-images.githubusercontent.com/235183/64894010-a07b4a00-d646-11e9-989f-623e0b7896f7.png)

#### Followups

1. (filed at https://github.com/Automattic/wp-calypso/issues/36121) Extend this search behavior to the other content listings (pages, etc).
2. (filed at https://github.com/Automattic/wp-calypso/issues/36147) Change the search placeholder text to say "Search Posts..." rather than just "Search..." (and similar for the other content types).

Fixes #36057 