### PR TITLE
Theme Sheet: Use Masterbar Colour

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -23,11 +23,6 @@ $autobar-height: 20px;
 		background: var( --studio-orange );
 		border-bottom: 1px solid var( --studio-orange-60 );
 	}
-
-	.is-section-theme &,
-	.is-section-themes.has-no-sidebar & {
-		border: none;
-	}
 }
 
 .pride .masterbar {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -3,7 +3,7 @@
 }
 
 .theme__sheet-bar {
-	background-color: var( --color-masterbar-background );
+	background-color: var( --color-masterbar-item-hover-background );
 	color: white;
 	height: 180px;
 	padding: 0;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -3,7 +3,7 @@
 }
 
 .theme__sheet-bar {
-	background-color: var( --color-primary );
+	background-color: var( --color-masterbar-background );
 	color: white;
 	height: 180px;
 	padding: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's three reasons why I'd argue it's better to use the masterbar colour in this scenario:

- I believe that it's identical to how it was like before the colour update in #35949, and the colours were the same (I might be wrong tho, I can't exactly recall, but a brief look at the code seems like they both were using `--color-primary`
- It means that in the normal scheme, the WordPress blue will be used, as mentioned in the issue 
- The colour will still look good in all schemes 

#### Testing instructions

Compare the two, you can access this by opening a theme in the Theme Directory:

**Before:**

<img width="1519" alt="Screenshot 2019-09-13 at 22 51 30" src="https://user-images.githubusercontent.com/43215253/64896824-1b5d5880-d679-11e9-80b8-0143314f39d7.png">

**After:**

<img width="1513" alt="Screenshot 2019-09-13 at 22 51 56" src="https://user-images.githubusercontent.com/43215253/64896829-1e584900-d679-11e9-967d-156b2adaa25d.png">


Fixes #36096
