### PR TITLE
Sidebar navigation: remove unneeded package.json and CSS class

### DIFF
--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -22,7 +22,7 @@ class MySitesNavigation extends React.Component {
 
 	render() {
 		return (
-			<div className="sites-navigation">
+			<div>
 				<SitePicker
 					allSitesPath={ this.props.allSitesPath }
 					siteBasePath={ this.props.siteBasePath }

--- a/client/my-sites/navigation/package.json
+++ b/client/my-sites/navigation/package.json
@@ -1,6 +1,0 @@
-{
-	"name": "my sites navigation",
-	"version": "0.0.0",
-	"private": true,
-	"main": "navigation.jsx"
-}


### PR DESCRIPTION
The `sites-navigation` CSS class is unused (no CSS styling for it). Also removed the redundant `package.json`.