### PR TITLE
Fix: poor contrast on subheadings in /plans page

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -432,7 +432,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__targeted-description-heading {
 	display: block;
-	color: var( --color-neutral-40 );
+	color: var( --color-text-subtle );
 }
 
 .plan-features__item {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix poor contrast on the subheadings in  /plans page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plans page as a logged in user.
* Check if the subheadings on each plan use the `--color-text-subtle` CSS var for the text color.

<img width="365" alt="Plans_‹_Taggon_on_wordpress_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/64909313-a15cbc00-d6d8-11e9-89df-615970ecfda8.png">

Fixes #35095
