### PR TITLE
Fix site cloning for Pressable sites

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -5,7 +5,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -192,8 +191,7 @@ export default connect( state => {
 		purchasesError: getPurchasesError( state ),
 		cloneUrl,
 		showChangeAddress: ! isJetpack && ! isVip,
-		showClone:
-			'active' === rewindState.state && ! find( rewindState.credentials, { type: 'managed' } ),
+		showClone: 'active' === rewindState.state && ! isAtomic,
 		showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
 		showDeleteContent: ! isJetpack && ! isVip,
 		showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,


### PR DESCRIPTION
Since moving to Atomic v2 infrastructure, Pressable-hosted sites now have credentials of type "managed", just like other Atomic sites. This means that the "Clone site" option in site tools is no longer being shown (cloning is not enabled for Atomic sites for business reasons).

#### Changes proposed in this Pull Request

Change the logic that excludes Atomic sites from cloning to use `! isAtomic` so that the clone option displays for Pressable-hosted sites.

/cc @thingalon when we want to enable cloning for Atomic sites, we can remove the `! isAtomic` check.

**Before**

<img width="744" alt="Screenshot 2019-09-14 at 10 10 51" src="https://user-images.githubusercontent.com/7767559/64909314-a3bf1600-d6d8-11e9-87d9-68a54baca87f.png">

**After**

<img width="740" alt="Screenshot 2019-09-14 at 10 15 32" src="https://user-images.githubusercontent.com/7767559/64909315-a9b4f700-d6d8-11e9-80b8-7610047b3f52.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/settings/general/{site} for a Pressable hosted site. You should see the "Clone" option in "Site Tools".


