### PR TITLE
Fix lint error from Gridicon import in PostTypeFilter component

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -27,7 +27,7 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import AuthorSegmented from './author-segmented';
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This just fixes a lint error in the `PostTypeFilter` component.  It's causing the automated checks on https://github.com/Automattic/wp-calypso/pull/36109 (the actual change I'm trying to make) to fail, even though it's a preexisting problem.  So I'm just fixing it separately here.

#### Testing instructions

Visit http://calypso.localhost:3000/posts, click between the tabs, and make sure nothing breaks.