### PR TITLE
Fix: Use higher contrast text color for feature card headings on my plan

### DIFF
--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -9,7 +9,7 @@
 .happiness-support.is-placeholder {
 	.happiness-support__heading,
 	.happiness-support__text {
-		@include placeholder( --color-neutral-10 );
+		@include placeholder( --color-text-subtle );
 	}
 
 	.happiness-support__heading {
@@ -32,7 +32,7 @@
 }
 
 .happiness-support__heading {
-	color: var( --color-neutral-40 );
+	color: var( --color-text-subtle );
 	clear: none;
 	font-size: 21px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set higher contrast text color to feature card headings on my plan

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/my-plan/YOUR_SITE` where your site is on any dotcom paid plan.
* Check if the feature card headings use the `--color-text-subtle` CSS var as text color.

Fixes #35098
