### PR TITLE
Site Indicator: use underline decoration instead of fake border.

### DIFF
--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -110,14 +110,12 @@
 	vertical-align: middle;
 
 	// Links within the action message
-	a,
+	a:link,
 	a:visited,
 	.button.is-borderless.is-scary,
 	.site-indicator__action-button {
-		border-bottom: 1px solid rgba( 255, 255, 255, 0.6 );
-		border-radius: 0;
 		color: var( --color-text-inverted );
-		text-decoration: none;
+		text-decoration: underline;
 	}
 
 	a > .gridicons-external {


### PR DESCRIPTION
Switches site indicator to use regular text underline rather than a pseudo-underline made of a bottom border property.

Before:
![image](https://user-images.githubusercontent.com/548849/64909686-88a2d500-d6dd-11e9-8ee2-68af02df52d4.png)

After:
![image](https://user-images.githubusercontent.com/548849/64909693-935d6a00-d6dd-11e9-801c-bd44fd0b5231.png)

Closes #36118.