### PR TITLE
Update Jetpack Connect Colors

### DIFF
--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -3,11 +3,11 @@
 	--color-accent: var( --studio-jetpack-green-30 );
 	--color-accent-light: var( --studio-jetpack-green-20 );
 	--color-accent-dark: var( --studio-jetpack-green-50 );
+	--color-accent-60: var( --studio-jetpack-green-40 );
 
 	// Override global colors with accent variables
 	--color-primary: var( --color-accent-dark );
 	--color-primary-light: var( --color-accent-light );
-	--color-accent-60: var( --color-accent-dark );
 
 	::selection {
 		color: var( --color-text-inverted );

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1,4 +1,4 @@
-@import './colors.scss';
+@import 'colors';
 
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
@@ -293,7 +293,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	left: 0;
 	padding: 9px 16px;
 	text-align: right;
-	background-color: #f3f3f3;
+	background-color: var( --color-neutral-0 );
 }
 
 .example-components__install-plugin-footer-button {
@@ -302,23 +302,23 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	padding: 7px 14px;
 	line-height: 1;
 	color: var( --color-text-inverted );
-	background-color: #008ec2; // wp-admin button blue
-	border: 1px solid #006799;
+	background-color: var( --color-wp-admin-button-background ); // wp-admin button blue
+	border: 1px solid var( --color-wp-admin-button-border );
 	border-radius: 3px;
 }
 
 .example-components__activate-jetpack {
-	background-color: #f1f1f1;
+	background-color: var( --color-neutral-0 );
 }
 
 .example-components__connect-jetpack {
-	background-color: #f1f1f1;
+	background-color: var( --color-neutral-0 );
 }
 
 .example-components__content-wp-admin-masterbar {
 	width: 100%;
 	padding-bottom: 6%;
-	background-color: #23282d;
+	background-color: var( --color-neutral-90 );
 }
 
 .example-components__content-wp-admin-sidebar {
@@ -326,7 +326,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	width: 15%;
 	padding-bottom: 44%;
 	line-height: 0;
-	background-color: #23282d;
+	background-color: var( --color-neutral-90 );
 }
 
 .example-components__content-wp-admin-main {
@@ -355,8 +355,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		line-height: 1;
 		color: var( --color-text-inverted );
 		border-radius: 3px;
-		background-color: #00be28;
-		border: 2px #00a523 solid;
+		background-color: var( --studio-jetpack-green-30 );
+		border: 1px solid var( --studio-jetpack-green-40 );
 		border-width: 1px 1px 2px;
 	}
 }
@@ -366,7 +366,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		margin: 10px;
 		padding: 12px 10px 16px;
 		text-align: right;
-		background-color: #81a844;
+		background-color: var( --studio-jetpack-green-20 );
 		border-left: 0;
 	}
 
@@ -376,10 +376,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		line-height: 1;
 		padding: 11px 10px;
 		color: var( --color-text-inverted );
-		background-color: #518d2a;
-		border-color: #518d2a;
+		background-color: var( --studio-jetpack-green-40 );
+		border-color: var( --studio-jetpack-green-40 );
 		border-radius: 4px;
-		box-shadow: 0 2px 3px 0 rgba( 0, 0, 0, 0.2 ), 0 4px 0 0 #3e6c20;
+		box-shadow: 0 2px 3px 0 rgba( var( --color-neutral-100 ), 0.2 ),
+		            0 4px 0 0 var( --studio-jetpack-green-60 );
 	}
 }
 
@@ -395,7 +396,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .example-components__content-wp-admin-plugin-activate-link {
 	font-size: 12px;
-	color: #0073aa;
+	color: var( --studio-blue-50 );
 }
 
 .example-components__content-wp-admin-activate-view {
@@ -408,8 +409,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	padding: 7px 14px;
 	line-height: 1;
 	color: var( --color-text-inverted );
-	background-color: #008ec2; // wp-admin button blue
-	border: 1px solid #006799;
+	background-color: var( --color-wp-admin-button-background ); // wp-admin button blue
+	border: 1px solid var( --color-wp-admin-button-border );
 	border-radius: 3px;
 }
 
@@ -503,9 +504,9 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	max-width: 360px;
 	margin: 0 auto 16px;
 	border-radius: 3px;
-	box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2 ),
-				0 8px 10px 1px rgba( 0, 0, 0, 0.14 ),
-				0 3px 14px 2px rgba( 0, 0, 0, 0.12 );
+	box-shadow: 0 5px 5px -3px rgba( var( --color-neutral-100 ), 0.2 ),
+	            0 8px 10px 1px rgba( var( --color-neutral-100 ), 0.14 ),
+	            3px 14px 2px rgba( var( --color-neutral-100 ), 0.12 );
 }
 
 .jetpack-connect__sso-terms-dialog {
@@ -786,7 +787,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.formatted-header__subtitle,
 	.payment-methods,
 	.jetpack-connect__help-button {
-		color: var( --color-primary-10 );
+		color: var( --color-neutral-10 );
 	}
 
 	.site__title::after,

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.0.1
+
+* Included WP Admin button colors.
+
 ## 2.0.0
 
 This update brings backwards-incompatible changes to the package. The most notable ones include:

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -315,4 +315,8 @@
 
 	--color-email: var( --studio-gray-0 );
 	--color-podcasting: #9b4dd5;
+
+	/* WP Admin */
+	--color-wp-admin-button-background: #008ec2;
+	--color-wp-admin-button-border: #006799;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following #35949, this updates Jetpack Connect colors to the theme properties and Jetpack Green values.

#### Testing instructions

* Set up a new Jetpack site using [jurassic.ninja](https://jurassic.ninja).
* Follow the setup instructions until you get to the plan selection screen.

Fixes #36095.