### PR TITLE
Reader: Use unstable editor is ready if available for more reliable press this block insertion

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -157,11 +157,13 @@ function handlePressThis( calypsoPort ) {
 		const unsubscribe = subscribe( () => {
 			// Calypso sends the message as soon as the iframe is loaded, so we
 			// need to be sure that the editor is initialized and the core blocks
-			// registered. There is no specific hook or selector for that, so we use
-			// `isCleanNewPost` which is triggered when everything is initialized if
-			// the post is new.
-			const isCleanNewPost = select( 'core/editor' ).isCleanNewPost();
-			if ( ! isCleanNewPost ) {
+			// registered. There is an unstable selector for that, so we use
+			// `isCleanNewPost` otherwise which is triggered when everything is
+			// initialized if the post is new.
+			const editorIsReady = select( 'core/editor' ).__unstableIsEditorReady
+				? select( 'core/editor' ).__unstableIsEditorReady()
+				: select( 'core/editor' ).isCleanNewPost();
+			if ( ! editorIsReady ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/35755

This PR fixes a regression where reader share content did not populate. It does this by providing a more reliable isEditor ready check, so we can insert reader share content at the appropriate time. 

| Before  | After |
| ------------- | ------------- |
| ![63629872-1e10e480-c5ca-11e9-85df-f3d0dc91db3b](https://user-images.githubusercontent.com/1270189/64910084-1af8a800-d6e1-11e9-8234-05f2b9015c41.gif) | ![Sep-14-2019 11-43-05](https://user-images.githubusercontent.com/1270189/64910474-dec74680-d6e4-11e9-9d16-e2baf4cc359f.gif)|

### Testing Instructions
- On a wpcom sandbox apply D32800-code
- Sandbox widgets.wp.com
- Visit WordPress.com and share an article in the reader
- Verify that both the title, and content like images and excepts look correct.
