### PR TITLE
Update banner icons on performance settings page

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -122,12 +122,11 @@
 .banner__icon-plan {
 	display: flex;
 	margin-right: 16px;
-	flex-direction: column;
-	justify-content: center;
+	flex-shrink: 0;
 
 	.plan-icon {
 		height: 32px;
-		max-width: 32px;
+		width: 32px;
 	}
 
 	@include breakpoint( '>480px' ) {

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -122,10 +122,12 @@
 .banner__icon-plan {
 	display: flex;
 	margin-right: 16px;
+	flex-direction: column;
+	justify-content: center;
 
 	.plan-icon {
 		height: 32px;
-		width: 32px;
+		max-width: 32px;
 	}
 
 	@include breakpoint( '>480px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates CSS to keep banner icons on performance settings page centered and not squashed. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before 

<img width="743" alt="64531263-b66fce80-d317-11e9-90a0-ebc7cedfdd22" src="https://user-images.githubusercontent.com/6520461/64910105-44b1cf00-d6e1-11e9-893e-b6fb8260f8a4.png">

<img width="819" alt="Screen Shot 2019-09-14 at 11 18 08 AM" src="https://user-images.githubusercontent.com/6520461/64910127-92c6d280-d6e1-11e9-971e-a7d0c7783688.png">

<img width="497" alt="Screen Shot 2019-09-14 at 11 18 28 AM" src="https://user-images.githubusercontent.com/6520461/64910164-98241d00-d6e1-11e9-987f-81e38ce27a62.png">

* After

<img width="554" alt="after 1" src="https://user-images.githubusercontent.com/6520461/64910189-a114ee80-d6e1-11e9-960e-bc54db66be45.png">

<img width="849" alt="after 2" src="https://user-images.githubusercontent.com/6520461/64910190-a5d9a280-d6e1-11e9-8800-5d9cc70bb5ae.png">


Fixes #36101 
