### PR TITLE
Fix: Several low contrast text areas on Stats

### DIFF
--- a/client/my-sites/stats/stats-error/style.scss
+++ b/client/my-sites/stats/stats-error/style.scss
@@ -5,7 +5,7 @@
 
 	// Error messages
 	&.is-error {
-		color: var( --color-neutral-light );
+		color: var( --color-text-subtle );
 
 		.stats-module.is-showing-error & {
 			display: inline-block;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -589,7 +589,7 @@ ul.module-content-list-legend {
 .module-content-list-legend .module-content-list-item .module-content-list-item-label {
 	@extend %placeholder;
 
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-weight: bold;
 
 	// Limit width when loading for placeholders to take less visual space

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -192,7 +192,7 @@
 		// Low state ('disabled')
 		.is-low,
 		&.is-low a .value {
-			color: var( --color-neutral-light );
+			color: var( --color-text-subtle );
 		}
 
 		// Individual tab loading state


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix several low constrast text areas on Stats page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/stats/day/YOUR_SITE`
* Check if the following 3 text areas use the `--color-text-subtle` CSS var for the text.
<img src="https://user-images.githubusercontent.com/2124984/62387960-178ed000-b52a-11e9-9e91-80a73f60b7cd.png">
<img src="https://user-images.githubusercontent.com/2124984/62387961-18276680-b52a-11e9-9a68-7a8a9c36ca11.png">
<img src="https://user-images.githubusercontent.com/2124984/62387963-18276680-b52a-11e9-9e3c-d287c93b02e5.png">

Fixes #35101
