### PR TITLE
Fix/remove upgrader nudge for vip sites in calypso

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import canCurrentUser from 'state/selectors/can-current-user';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
+import isVipSite from 'state/selectors/is-vip-site';
 import DocumentHead from 'components/data/document-head';
 import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -38,6 +39,7 @@ export const Sharing = ( {
 	showConnections,
 	showTraffic,
 	siteId,
+	isVip,
 	siteSlug,
 	translate,
 } ) => {
@@ -99,12 +101,14 @@ export const Sharing = ( {
 					</NavTabs>
 				</SectionNav>
 			) }
-			<UpgradeNudge
-				event="sharing_no_ads"
-				feature={ FEATURE_NO_ADS }
-				message={ translate( 'Prevent ads from showing on your site.' ) }
-				title={ translate( 'No Ads with WordPress.com Premium' ) }
-			/>
+			{ ! isVip && (
+				<UpgradeNudge
+					event="sharing_no_ads"
+					feature={ FEATURE_NO_ADS }
+					message={ translate( 'Prevent ads from showing on your site.' ) }
+					title={ translate( 'No Ads with WordPress.com Premium' ) }
+				/>
+			) }
 			{ contentComponent }
 		</Main>
 	);
@@ -112,6 +116,7 @@ export const Sharing = ( {
 
 Sharing.propTypes = {
 	canManageOptions: PropTypes.bool,
+	isVipSite: PropTypes.bool,
 	contentComponent: PropTypes.node,
 	path: PropTypes.string,
 	showButtons: PropTypes.bool,
@@ -133,6 +138,7 @@ export default connect( state => {
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
 		showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
 		showTraffic: canManageOptions && !! siteId,
+		isVip: isVipSite( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, includes, some } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize, moment } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -40,6 +40,7 @@ import { isBusiness, isEcommerce, isEnterprise } from 'lib/products-values';
 import { addSiteFragment } from 'lib/route';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import isVipSite from 'state/selectors/is-vip-site';
 import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-active';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import QueryEligibility from 'components/data/query-atat-eligibility';
@@ -588,6 +589,10 @@ export class PluginMeta extends Component {
 
 	renderUpsell() {
 		const { translate, slug } = this.props;
+
+		if ( this.props.isVipSite ) {
+			return null;
+		}
 		const bannerURL = `/checkout/${ slug }/business`;
 		const plan = findFirstSimilarPlanKey( this.props.selectedSite.plan.product_slug, {
 			type: TYPE_BUSINESS,
@@ -699,6 +704,7 @@ const mapStateToProps = state => {
 		atEnabled: isATEnabled( selectedSite ),
 		isTransferring: isAutomatedTransferActive( state, siteId ),
 		automatedTransferSite: isSiteAutomatedTransfer( state, siteId ),
+		isVipSite: isVipSite( state, siteId ),
 		slug: getSiteSlug( state, siteId ),
 	};
 };

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -19,6 +19,7 @@ import QueryPosts from 'components/data/query-posts';
 import QueryRecentPostViews from 'components/data/query-stats-recent-post-views';
 import { DEFAULT_POST_QUERY } from 'lib/query-manager/post/constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import isVipSite from 'state/selectors/is-vip-site';
 import {
 	isRequestingPostsForQueryIgnoringPage,
 	getPostsForQueryIgnoringPage,
@@ -48,6 +49,7 @@ class PostTypeList extends Component {
 		// Props
 		query: PropTypes.object,
 		scrollContainer: PropTypes.object,
+		isVipSite: PropTypes.bool,
 
 		// Connected props
 		siteId: PropTypes.number,
@@ -253,6 +255,7 @@ class PostTypeList extends Component {
 		} );
 		const showUpgradeNudge =
 			siteId &&
+			! this.props.isVipSite &&
 			posts.length > 10 &&
 			query &&
 			( query.type === 'post' || ! query.type ) &&
@@ -299,6 +302,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		siteId,
 		posts: getPostsForQueryIgnoringPage( state, siteId, ownProps.query ),
+		isVipSite: isVipSite( state, siteId ),
 		isRequestingPosts: isRequestingPostsForQueryIgnoringPage( state, siteId, ownProps.query ),
 		totalPostCount: getPostsFoundForQuery( state, siteId, ownProps.query ),
 		totalPageCount,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -40,6 +40,7 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import isVipSite from 'state/selectors/is-vip-site';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { launchSite } from 'state/sites/launch/actions';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
@@ -557,6 +558,7 @@ export class SiteSettingsFormGeneral extends Component {
 			isSavingSettings,
 			site,
 			siteIsJetpack,
+			siteIsVip,
 			siteSlug,
 			translate,
 		} = this.props;
@@ -615,7 +617,7 @@ export class SiteSettingsFormGeneral extends Component {
 								</Button>
 							</div>
 						</CompactCard>
-						{ site && ! isBusiness( site.plan ) && (
+						{ site && ! isBusiness( site.plan ) && ! siteIsVip && (
 							<Banner
 								feature={ FEATURE_NO_BRANDING }
 								plan={ PLAN_BUSINESS }
@@ -670,6 +672,7 @@ const connectComponent = connect(
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
+			siteIsVip: isVipSite( state, siteId ),
 			siteSlug: getSelectedSiteSlug( state ),
 			selectedSite,
 			isPaidPlan: isCurrentPlanPaid( state, siteId ),

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -22,18 +22,20 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import isVipSite from 'state/selectors/is-vip-site';
 
 const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const {
 		hasUnlimitedPremiumThemes,
 		requestingSitePlans,
 		siteId,
+		isVip,
 		siteSlug,
 		translate,
 		isJetpack,
 	} = props;
 
-	const displayUpsellBanner = ! requestingSitePlans && ! hasUnlimitedPremiumThemes;
+	const displayUpsellBanner = ! requestingSitePlans && ! hasUnlimitedPremiumThemes && ! isVip;
 	const bannerLocationBelowSearch = ! isJetpack;
 
 	const upsellUrl = `/plans/${ siteSlug }`;
@@ -87,6 +89,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 
 export default connect( ( state, { siteId } ) => ( {
 	isJetpack: isJetpackSite( state, siteId ),
+	isVip: isVipSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
 	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes most upgrade nudges for VIP sites that ask them to upgrade to a plan. 
Currently we show a number of nudges to VIP sites asking them to update. 

**Single Plugin screen.** 
Before
<img width="856" alt="Screen Shot 2019-09-13 at 9 28 39 PM" src="https://user-images.githubusercontent.com/115071/64910226-ecc79800-d6e1-11e9-8ba4-e93ff6699760.png">
After: 
<img width="865" alt="Screen Shot 2019-09-13 at 9 33 20 PM" src="https://user-images.githubusercontent.com/115071/64910232-fb15b400-d6e1-11e9-8877-9eab69108ef2.png">

**Marketing screen**
Before:
<img width="1088" alt="Screen Shot 2019-09-13 at 9 47 48 PM" src="https://user-images.githubusercontent.com/115071/64910244-213b5400-d6e2-11e9-8052-ec1be7c44fda.png">
After:
<img width="1084" alt="Screen Shot 2019-09-13 at 9 49 02 PM" src="https://user-images.githubusercontent.com/115071/64910245-213b5400-d6e2-11e9-9b9e-754169d214a1.png">

**Posts List View**
Before:
<img width="832" alt="Screen Shot 2019-09-13 at 4 02 01 PM" src="https://user-images.githubusercontent.com/115071/64910267-62cbff00-d6e2-11e9-9d70-4b7e2a6e5449.png">
After:
<img width="834" alt="Screen Shot 2019-09-13 at 4 02 21 PM" src="https://user-images.githubusercontent.com/115071/64910268-62cbff00-d6e2-11e9-9395-d368be1662a7.png">

**Themes List**
Before:
<img width="1365" alt="Screen Shot 2019-09-13 at 4 16 02 PM" src="https://user-images.githubusercontent.com/115071/64910280-81ca9100-d6e2-11e9-9803-03174daf813d.png">
After:
<img width="1377" alt="Screen Shot 2019-09-13 at 4 19 19 PM" src="https://user-images.githubusercontent.com/115071/64910281-81ca9100-d6e2-11e9-9e53-b37cd10aa6bd.png">


**Settings Screen**
Before:
<img width="774" alt="Screen Shot 2019-09-13 at 4 39 18 PM" src="https://user-images.githubusercontent.com/115071/64910257-47f98a80-d6e2-11e9-8cc6-8921d043a663.png">
After:
<img width="729" alt="Screen Shot 2019-09-13 at 4 47 10 PM" src="https://user-images.githubusercontent.com/115071/64910258-47f98a80-d6e2-11e9-95b0-4e1219198795.png">



#### Testing instructions
On a vip site load up calypso. 

1. Go to the single plugin screen ( Tools -> Plugins -> click on plugin) 
Notice that the nudge is not there. 
2. Go to Marketing screen ( Tools -> Marketing )
Notice that the nudge is not there.
3. Go to list posts view ( Site -> Posts) 
Notice that the nudge is not there.
4. Go to themes view ( Design -> Themes)
Notice that the nudge is not here. 
5. Go to setting screen. ( Manage -> Settings) 
Notice that nudge is not there any more. 

6. On a free WordPress site. 
Do the same steps 1-5. notice the nudge to upgrade is gone.



