### PR TITLE
Remove "Blog Post" Title from Callout

### DIFF
--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -96,6 +96,7 @@ class BlogPostsPage extends React.Component {
 
 		return (
 			<span>
+				<Gridicon icon="info-outline" size={ 18 } className="blog-posts-page__info-icon" />
 				{ translate( '"%(pageTitle)s" page is showing your latest posts.', {
 					args: {
 						pageTitle: this.getPageTitle( this.props.postsPage ),
@@ -106,7 +107,7 @@ class BlogPostsPage extends React.Component {
 	}
 
 	render() {
-		const { isFullSiteEditing, translate } = this.props;
+		const { isFullSiteEditing } = this.props;
 
 		if ( isFullSiteEditing ) {
 			return null;
@@ -127,14 +128,6 @@ class BlogPostsPage extends React.Component {
 				className="blog-posts-page"
 			>
 				<div className="blog-posts-page__details">
-					<div
-						className={ classNames( {
-							'blog-posts-page__title': true,
-							'is-disabled': isStaticHomePageWithNoPostsPage,
-						} ) }
-					>
-						{ translate( 'Blog Posts' ) }
-					</div>
 					<div
 						className={ classNames( {
 							'blog-posts-page__info': true,

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -116,6 +116,10 @@ class BlogPostsPage extends React.Component {
 			this.props.frontPageType === 'page' && ! this.props.postsPage;
 		const isCurrentlySetAsHomepage = this.props.frontPageType === 'posts';
 
+		if ( ! isCurrentlySetAsHomepage ) {
+			return null;
+		}
+
 		return (
 			<Card
 				href={ this.getPostsPageLink( {

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -68,7 +68,7 @@ class BlogPostsPage extends React.Component {
 			return (
 				<span>
 					<Gridicon size={ 12 } icon="not-visible" className="blog-posts-page__not-used-icon" />
-					{ this.props.translate( 'Not in use.' ) + ' ' }
+					{ this.props.translate( 'Posts page not in use.' ) + ' ' }
 					{ // Prevent displaying '"Untitled" is the homepage.' while the settings are loading.
 					!! this.props.frontPage &&
 						this.props.translate( '"%(pageTitle)s" is the homepage.', {
@@ -112,7 +112,6 @@ class BlogPostsPage extends React.Component {
 		if ( isFullSiteEditing ) {
 			return null;
 		}
-
 		const isStaticHomePageWithNoPostsPage =
 			this.props.frontPageType === 'page' && ! this.props.postsPage;
 		const isCurrentlySetAsHomepage = this.props.frontPageType === 'posts';

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -40,4 +40,8 @@
 	&.is-disabled {
 		color: var( --color-neutral-20 );
 	}
+
+	.blog-posts-page__info-icon {
+		margin: 0 4px -4px 0;
+	}
 }

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -80,15 +80,15 @@ function PageCardInfo( {
 			<div>
 				{ showTimestamp && renderTimestamp() }
 				{ isFront && (
-					<span className="page-card-info__item">
-						<Gridicon icon="house" size={ ICON_SIZE } className="page-card-info__item-icon" />
-						<span className="page-card-info__item-text">{ translate( 'Homepage' ) }</span>
+					<span className="page-card-info__badge">
+						<Gridicon icon="house" size={ ICON_SIZE } className="page-card-info__badge-icon" />
+						<span className="page-card-info__badge-text">{ translate( 'Homepage' ) }</span>
 					</span>
 				) }
 				{ isPosts && (
-					<span className="page-card-info__item">
-						<Gridicon icon="posts" size={ ICON_SIZE } className="page-card-info__item-icon" />
-						<span className="page-card-info__item-text">{ translate( 'Your latest posts' ) }</span>
+					<span className="page-card-info__badge">
+						<Gridicon icon="posts" size={ ICON_SIZE } className="page-card-info__badge-icon" />
+						<span className="page-card-info__badge-text">{ translate( 'Your latest posts' ) }</span>
 					</span>
 				) }
 				{ ! isFront && theme && (

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -29,3 +29,17 @@
 .page-card-info__site-url {
 	font-style: italic;
 }
+
+.page-card-info__badge {
+	background: var( --color-neutral-0 );
+	border-radius: 12px;
+	color: var( --color-neutral );
+	display: inline-block;
+	padding: 2px 10px;
+	vertical-align: middle;
+
+	.page-card-info__badge-icon {
+		margin-right: 4px;
+		margin-bottom: -1px;
+	}
+}

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -325,7 +325,7 @@ class Pages extends Component {
 			: this.renderChronological( { pages, site } );
 	}
 
-	renderHierarchical( { pages, site } ) {
+	renderHierarchical( { pages } ) {
 		pages = sortPagesHierarchically( pages );
 		const rows = pages.map( function( page ) {
 			return (
@@ -343,7 +343,6 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
-				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 				{ this.renderSectionHeader() }
 				{ rows }
 				{ this.renderListEnd() }

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -325,7 +325,7 @@ class Pages extends Component {
 			: this.renderChronological( { pages, site } );
 	}
 
-	renderHierarchical( { pages } ) {
+	renderHierarchical( { pages, site } ) {
 		pages = sortPagesHierarchically( pages );
 		const rows = pages.map( function( page ) {
 			return (
@@ -343,6 +343,7 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
+				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 				{ this.renderSectionHeader() }
 				{ rows }
 				{ this.renderListEnd() }


### PR DESCRIPTION
This PR removes the "Blog Post" Title from the latest post callout at
the top of the "Pages" page. It was previously confusing depending on
naming of pages for blog posts page.

Before:
https://d.pr/i/3hJoUQ

After:
https://d.pr/i/NUseZE

Fixes #36023
