### PR TITLE
Issue/33071 update banner fix

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { noop, size } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicons';
 
 /**
  * Internal dependencies

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -58,6 +58,7 @@ export class Banner extends Component {
 		siteSlug: PropTypes.string,
 		target: PropTypes.string,
 		title: PropTypes.string.isRequired,
+		customerType: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -69,9 +70,12 @@ export class Banner extends Component {
 	};
 
 	getHref() {
-		const { canUserUpgrade, feature, href, plan, siteSlug } = this.props;
+		const { canUserUpgrade, feature, href, plan, siteSlug, customerType } = this.props;
 
 		if ( ! href && siteSlug && canUserUpgrade ) {
+			if ( customerType ) {
+				return `/plans/${ siteSlug }?customerType=${ customerType }`;
+			}
 			const baseUrl = `/plans/${ siteSlug }`;
 			if ( feature || plan ) {
 				return addQueryArgs(

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { noop, size } from 'lodash';
-import Gridicon from 'components/gridicons';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -43,6 +43,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 			upsellBanner = (
 				<Banner
 					plan={ PLAN_PREMIUM }
+					customerType="business"
 					className="themes__showcase-banner"
 					title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
 					event="themes_plans_free_personal"


### PR DESCRIPTION
Based on the comment [here](https://github.com/Automattic/wp-calypso/issues/33071#issuecomment-505119867), this PR adds logic to open the Business Sites and Online Stores TAB when clicking in `View plans` button in the Themes page.

#### Testing instructions
- Click on the the Themes page and try to upload a theme without a Business plan.
- Notice the Business plan upgrade nudge banner.
- The Business Plan upgrade nudge brings you to the Blogs and Personal Sites section of the Plans page.
- Notice that it opens the `Blogs` TAB by default.
- Pull changes from this PR and test the above steps again. 
- Notice that it opens the `Business Sites and Online Stores` TAB by default.


#### Before
<img width="1030" alt="Screen Shot 2019-05-15 at 12 35 24 PM" src="https://user-images.githubusercontent.com/2124984/57792842-f75f2a00-770d-11e9-8ecb-6d308dccb98d.png">

#### After
<img  src="https://user-images.githubusercontent.com/22608780/64910654-a0cb2200-d6e6-11e9-8a4d-e850846d275e.gif">

Fixes #33071 