### PR TITLE
Add/gm19 webauthn -- challenge & response pieces

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'component/gridicons';
 import { capitalize, findLast, get, includes, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -42,6 +42,7 @@ import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
+import SecurityKeyForm from './two-factor-authentication/security-key-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
 
 /**
@@ -345,6 +346,14 @@ class Login extends Component {
 			socialServiceResponse,
 			disableAutoFocus,
 		} = this.props;
+
+		if ( twoFactorEnabled && includes( [ 'u2f' ], twoFactorAuthType ) ) {
+			return (
+				<div>
+					<SecurityKeyForm twoFactorAuthType={ 'u2f' } onSuccess={ this.handleValid2FACode } />
+				</div>
+			);
+		}
 
 		let poller;
 		if ( twoFactorEnabled && twoFactorAuthType && twoFactorNotificationSent === 'push' ) {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -346,10 +346,10 @@ class Login extends Component {
 			socialServiceResponse,
 			disableAutoFocus,
 		} = this.props;
-		console.log( twoFactorAuthType, typeof twoFactorAuthType );
+
 		if (
 			twoFactorEnabled &&
-			( typeof twoFactorAuthType === 'undefined' || includes( [ 'u2f' ], twoFactorAuthType ) )
+			( typeof twoFactorAuthType === 'undefined' || twoFactorAuthType === 'u2f' )
 		) {
 			return (
 				<div>

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'component/gridicons';
+import Gridicon from 'gridicons';
 import { capitalize, findLast, get, includes, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -346,8 +346,11 @@ class Login extends Component {
 			socialServiceResponse,
 			disableAutoFocus,
 		} = this.props;
-
-		if ( twoFactorEnabled && includes( [ 'u2f' ], twoFactorAuthType ) ) {
+		console.log( twoFactorAuthType, typeof twoFactorAuthType );
+		if (
+			twoFactorEnabled &&
+			( typeof twoFactorAuthType === 'undefined' || includes( [ 'u2f' ], twoFactorAuthType ) )
+		) {
 			return (
 				<div>
 					<SecurityKeyForm twoFactorAuthType={ 'u2f' } onSuccess={ this.handleValid2FACode } />

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -1,0 +1,131 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormButton from 'components/forms/form-button';
+import { localize } from 'i18n-calypso';
+import { getTwoFactorAuthRequestError } from 'state/login/selectors';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import { formUpdate, loginUserWithHardwareKey, sendSmsCode } from 'state/login/actions';
+import TwoFactorActions from './two-factor-actions';
+
+/**
+ * Style dependencies
+ */
+import './verification-code-form.scss';
+
+class SecurityKeyForm extends Component {
+	static propTypes = {
+		formUpdate: PropTypes.func.isRequired,
+		loginUserWithHardwareKey: PropTypes.func.isRequired,
+		onSuccess: PropTypes.func.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		sendSmsCode: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+		twoFactorAuthRequestError: PropTypes.object,
+		twoFactorAuthType: PropTypes.string.isRequired,
+	};
+
+	state = {
+		twoStepCode: '',
+		isDisabled: true,
+	};
+
+	componentDidMount() {
+		// eslint-disable-next-line react/no-did-mount-set-state
+		this.setState( { isDisabled: false }, () => {} );
+	}
+
+	componentWillReceiveProps = nextProps => {
+		// Resets the verification code input field when switching pages
+		if ( this.props.twoFactorAuthType !== nextProps.twoFactorAuthType ) {
+			this.setState( { twoStepCode: '' } );
+		}
+	};
+
+	onChangeField = event => {
+		const { name, value = '' } = event.target;
+
+		this.props.formUpdate();
+
+		this.setState( { [ name ]: value } );
+	};
+
+	onSubmitForm = event => {
+		event.preventDefault();
+
+		const { onSuccess, twoFactorAuthType } = this.props;
+		const { twoStepCode } = this.state;
+
+		this.props
+			.loginUserWithHardwareKey()
+			.then( () => onSuccess() )
+			.catch( error => {
+				this.setState( { isDisabled: false } );
+
+				this.props.recordTracksEvent( 'calypso_login_two_factor_verification_code_failure', {
+					error_code: error.code,
+					error_message: error.message,
+				} );
+			} );
+	};
+
+	saveRef = input => {
+		this.input = input;
+	};
+
+	render() {
+		const { translate, twoFactorAuthRequestError: requestError, twoFactorAuthType } = this.props;
+
+		let smallPrint;
+
+		return (
+			<form onSubmit={ this.onSubmitForm }>
+				<Card compact className="two-factor-authentication__verification-code-form">
+					<p>
+						{ translate( '{{strong}}Use your security key to finish logging in.{{/strong}}', {
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</p>
+					<p>
+						{ translate(
+							'Insert your security key into your USB port. Then tap the button or gold disc.'
+						) }
+					</p>
+
+					<FormButton primary disabled={ this.state.isDisabled }>
+						{ translate( 'Continue' ) }
+					</FormButton>
+
+					{ smallPrint }
+				</Card>
+
+				<TwoFactorActions twoFactorAuthType={ twoFactorAuthType } />
+			</form>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),
+	} ),
+	{
+		formUpdate,
+		loginUserWithHardwareKey,
+		recordTracksEvent,
+		sendSmsCode,
+	}
+)( localize( SecurityKeyForm ) );

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -14,9 +14,8 @@ import React, { Component } from 'react';
 import Card from 'components/card';
 import FormButton from 'components/forms/form-button';
 import { localize } from 'i18n-calypso';
-import { getTwoFactorAuthRequestError } from 'state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import { formUpdate, loginUserWithHardwareKey, sendSmsCode } from 'state/login/actions';
+import { formUpdate, loginUserWithSecurityKey } from 'state/login/actions';
 import TwoFactorActions from './two-factor-actions';
 
 /**
@@ -27,17 +26,13 @@ import './verification-code-form.scss';
 class SecurityKeyForm extends Component {
 	static propTypes = {
 		formUpdate: PropTypes.func.isRequired,
-		loginUserWithHardwareKey: PropTypes.func.isRequired,
+		loginUserWithSecurityKey: PropTypes.func.isRequired,
 		onSuccess: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
-		sendSmsCode: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
-		twoFactorAuthRequestError: PropTypes.object,
-		twoFactorAuthType: PropTypes.string.isRequired,
 	};
 
 	state = {
-		twoStepCode: '',
 		isDisabled: true,
 	};
 
@@ -46,29 +41,13 @@ class SecurityKeyForm extends Component {
 		this.setState( { isDisabled: false }, () => {} );
 	}
 
-	componentWillReceiveProps = nextProps => {
-		// Resets the verification code input field when switching pages
-		if ( this.props.twoFactorAuthType !== nextProps.twoFactorAuthType ) {
-			this.setState( { twoStepCode: '' } );
-		}
-	};
-
-	onChangeField = event => {
-		const { name, value = '' } = event.target;
-
-		this.props.formUpdate();
-
-		this.setState( { [ name ]: value } );
-	};
-
 	onSubmitForm = event => {
 		event.preventDefault();
 
-		const { onSuccess, twoFactorAuthType } = this.props;
-		const { twoStepCode } = this.state;
+		const { onSuccess } = this.props;
 
 		this.props
-			.loginUserWithHardwareKey()
+			.loginUserWithSecurityKey()
 			.then( () => onSuccess() )
 			.catch( error => {
 				this.setState( { isDisabled: false } );
@@ -80,12 +59,8 @@ class SecurityKeyForm extends Component {
 			} );
 	};
 
-	saveRef = input => {
-		this.input = input;
-	};
-
 	render() {
-		const { translate, twoFactorAuthRequestError: requestError, twoFactorAuthType } = this.props;
+		const { translate } = this.props;
 
 		let smallPrint;
 
@@ -112,20 +87,17 @@ class SecurityKeyForm extends Component {
 					{ smallPrint }
 				</Card>
 
-				<TwoFactorActions twoFactorAuthType={ twoFactorAuthType } />
+				<TwoFactorActions twoFactorAuthType={ 'u2f' } />
 			</form>
 		);
 	}
 }
 
 export default connect(
-	state => ( {
-		twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),
-	} ),
+	state => {},
 	{
 		formUpdate,
-		loginUserWithHardwareKey,
+		loginUserWithSecurityKey,
 		recordTracksEvent,
-		sendSmsCode,
 	}
 )( localize( SecurityKeyForm ) );

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -53,6 +53,10 @@ class TwoFactorActions extends Component {
 
 		page( login( { isNative: true, twoFactorAuthType: 'authenticator' } ) );
 	};
+	recordSecurityKey = event => {
+		event.preventDefault();
+		page( login( { isNative: true, twoFactorAuthType: 'u2f' } ) );
+	};
 
 	render() {
 		const { isAuthenticatorSupported, isSmsSupported, translate, twoFactorAuthType } = this.props;
@@ -67,6 +71,9 @@ class TwoFactorActions extends Component {
 
 		return (
 			<Card className="two-factor-authentication__actions">
+				<Button n data-e2e-link="2fa-sms-link" onClick={ this.recordSecurityKey }>
+					{ translate( 'Continue with your security\u00A0key' ) }
+				</Button>
 				{ isSmsAvailable && (
 					<Button data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
 						{ translate( 'Send code via\u00A0text\u00A0message' ) }

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -29,6 +29,7 @@ import './two-factor-actions.scss';
 class TwoFactorActions extends Component {
 	static propTypes = {
 		isAuthenticatorSupported: PropTypes.bool.isRequired,
+		isSecurityKeySupported: PropTypes.bool.isRequired,
 		isSmsSupported: PropTypes.bool.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		sendSmsCode: PropTypes.func.isRequired,
@@ -59,21 +60,31 @@ class TwoFactorActions extends Component {
 	};
 
 	render() {
-		const { isAuthenticatorSupported, isSmsSupported, translate, twoFactorAuthType } = this.props;
+		const {
+			isAuthenticatorSupported,
+			isSecurityKeySupported,
+			isSmsSupported,
+			translate,
+			twoFactorAuthType,
+		} = this.props;
 
 		const isSmsAvailable = isSmsSupported && twoFactorAuthType !== 'sms';
 		const isAuthenticatorAvailable =
 			isAuthenticatorSupported && twoFactorAuthType !== 'authenticator';
+		const isSecurityKeyAvailable = isSecurityKeySupported && twoFactorAuthType !== 'u2f';
 
-		if ( ! isSmsAvailable && ! isAuthenticatorAvailable ) {
+		if ( ! isSmsAvailable && ! isAuthenticatorAvailable && ! isSecurityKeyAvailable ) {
 			return null;
 		}
 
 		return (
 			<Card className="two-factor-authentication__actions">
-				<Button n data-e2e-link="2fa-sms-link" onClick={ this.recordSecurityKey }>
-					{ translate( 'Continue with your security\u00A0key' ) }
-				</Button>
+				{ isSecurityKeyAvailable && (
+					<Button n data-e2e-link="2fa-sms-link" onClick={ this.recordSecurityKey }>
+						{ translate( 'Continue with your security\u00A0key' ) }
+					</Button>
+				) }
+
 				{ isSmsAvailable && (
 					<Button data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
 						{ translate( 'Send code via\u00A0text\u00A0message' ) }
@@ -94,6 +105,7 @@ export default connect(
 	state => ( {
 		isAuthenticatorSupported: isTwoFactorAuthTypeSupported( state, 'authenticator' ),
 		isSmsSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
+		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'u2f' ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -80,7 +80,7 @@ class TwoFactorActions extends Component {
 		return (
 			<Card className="two-factor-authentication__actions">
 				{ isSecurityKeyAvailable && (
-					<Button n data-e2e-link="2fa-sms-link" onClick={ this.recordSecurityKey }>
+					<Button n data-e2e-link="2fa-security-key-link" onClick={ this.recordSecurityKey }>
 						{ translate( 'Continue with your security\u00A0key' ) }
 					</Button>
 				) }

--- a/client/lib/webauthn/index.js
+++ b/client/lib/webauthn/index.js
@@ -249,4 +249,11 @@ function authenticate( wpcom_user_id, nonce ) {
 		} );
 }
 
-export default { isSupported, register, authenticate };
+export default {
+	isSupported,
+	register,
+	authenticate,
+	strToBin,
+	binToStr,
+	credentialListConversion,
+};

--- a/client/lib/webauthn/index.js
+++ b/client/lib/webauthn/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
+import config from 'config';
 
 let _backend;
 
@@ -40,7 +41,7 @@ function credentialListConversion( list ) {
 	} );
 }
 
-function wpcomRequestPromise( path, _data, method ) {
+function wpcomApiRequest( path, _data, method ) {
 	const data = _data || {};
 	if ( process.env.NODE_ENV === 'development' ) {
 		data.hostname = window.location.hostname;
@@ -89,7 +90,7 @@ function isSupported() {
 }
 
 function register() {
-	return wpcomRequestPromise( '/me/two-step/security-key/registration_challenge' )
+	return wpcomApiRequest( '/me/two-step/security-key/registration_challenge' )
 		.then( options => {
 			const makeCredentialOptions = {};
 			makeCredentialOptions.rp = options.rp;
@@ -138,7 +139,7 @@ function register() {
 			response.attestationObject = binToStr( attestation.response.attestationObject );
 			publicKeyCredential.response = response;
 
-			return wpcomRequestPromise(
+			return wpcomApiRequest(
 				'/me/two-step/security-key/registration_validate',
 				{
 					data: JSON.stringify( publicKeyCredential ),
@@ -147,7 +148,70 @@ function register() {
 			);
 		} );
 }
+function wpcomLoginRequest( action, form ) {
+	form.append( 'client_id', config( 'wpcom_signup_id' ) );
+	form.append( 'client_secret', config( 'wpcom_signup_key' ) );
+	if ( process.env.NODE_ENV === 'development' ) {
+		form.append( 'dev_hostname', window.location.hostname );
+	}
+	return fetch( `https://wordpress.com/wp-login.php?action=${ action }`, {
+		method: 'POST',
+		body: form,
+		credentials: 'include',
+	} ).then( response => response.json() );
+}
 
-function authenticate() {}
+function authenticate( wpcom_user_id, nonce ) {
+	let form = new FormData();
+	form.append( 'user_id', wpcom_user_id );
+	form.append( 'two_step_nonce', nonce );
+	form.append( 'auth_type', 'u2f' );
+
+	return wpcomLoginRequest( 'u2f-challenge-endpoint', form )
+		.then( response => {
+			const parameters = response.data;
+			const requestOptions = {};
+
+			requestOptions.challenge = strToBin( parameters.challenge );
+			requestOptions.timeout = 6000;
+			if ( 'rpId' in parameters ) {
+				requestOptions.rpId = parameters.rpId;
+			}
+			if ( 'allowCredentials' in parameters ) {
+				requestOptions.allowCredentials = credentialListConversion( parameters.allowCredentials );
+			}
+			return navigator.credentials.get( { publicKey: requestOptions } );
+		} )
+		.then( assertion => {
+			const publicKeyCredential = {};
+			if ( 'id' in assertion ) {
+				publicKeyCredential.id = assertion.id;
+			}
+			if ( 'type' in assertion ) {
+				publicKeyCredential.type = assertion.type;
+			}
+			if ( 'rawId' in assertion ) {
+				publicKeyCredential.rawId = binToStr( assertion.rawId );
+			}
+			if ( ! assertion.response ) {
+				throw "Get assertion response lacking 'response' attribute";
+			}
+
+			const _response = assertion.response;
+			publicKeyCredential.response = {
+				clientDataJSON: binToStr( _response.clientDataJSON ),
+				authenticatorData: binToStr( _response.authenticatorData ),
+				signature: binToStr( _response.signature ),
+			};
+			if ( _response.userHandle ) {
+				publicKeyCredential.response.userHandle = binToStr( _response.userHandle );
+			}
+			form = new FormData();
+			form.append( 'user_id', wpcom_user_id );
+			form.append( 'client_data', JSON.stringify( publicKeyCredential ) );
+
+			return wpcomLoginRequest( 'u2f-authentication-endpoint', form );
+		} );
+}
 
 export default { isSupported, register, authenticate };

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -37,7 +37,7 @@ export default router => {
 	if ( config.isEnabled( 'login/wp-login' ) ) {
 		router(
 			[
-				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/${ lang }`,
+				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|u2f)/${ lang }`,
 				`/log-in/:flow(social-connect|private-site)/${ lang }`,
 				`/log-in/:socialService(google)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -51,6 +51,7 @@ import wpcom from 'lib/wp';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import 'state/data-layer/wpcom/login-2fa';
 import 'state/data-layer/wpcom/users/auth-options';
+import webauthn from 'lib/webauthn';
 
 /**
  * Creates a promise that will be rejected after a given timeout
@@ -173,6 +174,15 @@ export const updateNonce = ( nonceType, twoStepNonce ) => ( {
 	nonceType,
 	twoStepNonce,
 } );
+
+export const loginUserWithHardwareKey = () => ( dispatch, getState ) => {
+	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
+
+	return webauthn.authenticate(
+		getTwoFactorUserId( getState() ),
+		getTwoFactorAuthNonce( getState(), 'u2f' )
+	);
+};
 
 /**
  * Logs a user in with a two factor verification code.

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -175,7 +175,7 @@ export const updateNonce = ( nonceType, twoStepNonce ) => ( {
 	twoStepNonce,
 } );
 
-export const loginUserWithHardwareKey = () => ( dispatch, getState ) => {
+export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 	const twoFactorAuthType = 'u2f';
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 	const loginParams = {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -167,6 +167,7 @@ const twoFactorProperties = [
 	'two_step_nonce_sms',
 	'two_step_nonce_authenticator',
 	'two_step_nonce_push',
+	'two_step_nonce_u2f',
 	'user_id',
 ];
 


### PR DESCRIPTION
Targeting the branch in #36069

#### Changes proposed in this Pull Request

* Client-side pieces for calling the challenge and authenticate endpoints 

#### Testing instructions

* Register at least one hardware key using this branch (or the one in #36069)
* Run this branch
* Log out if you're not already
* Log in with your test user's user_id & password, (but don't submit a two-factor OTP code if one is set for the account)
* Click the button to use a hardware key
* Press the button on your hardware key
  * It should log you in

---

* Repeat the above with an unregistered key
  * It should not log you in
