### PR TITLE
Invite Form: Don't attempt to submit when form hasn't been updated.

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -81,7 +81,7 @@ const resetAnalyticsData = () => {
 class SignupForm extends Component {
 	static propTypes = {
 		className: PropTypes.string,
-		disableEmailExplanation: PropTypes.bool,
+		disableEmailExplanation: PropTypes.string,
 		disableEmailInput: PropTypes.bool,
 		disabled: PropTypes.bool,
 		displayNameInput: PropTypes.bool,

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -52,11 +52,15 @@ class InviteAcceptLoggedOut extends React.Component {
 		window.location = signInLink;
 	};
 
-	submitForm = ( form, userData ) => {
+	submitForm = ( form, userData, analyticsData, callback ) => {
+		if ( form.username.value === '' ) {
+			// If user hasn't entered anything, don't try to submit
+			callback();
+			return;
+		}
 		this.setState( { submitting: true } );
 		debug( 'Storing invite_accepted: ' + JSON.stringify( this.props.invite ) );
 		store.set( 'invite_accepted', this.props.invite );
-
 		const createAccountCallback = ( error, bearerToken ) => {
 			debug( 'Create account error: ' + JSON.stringify( error ) );
 			debug( 'Create account bearerToken: ' + bearerToken );
@@ -159,6 +163,7 @@ class InviteAcceptLoggedOut extends React.Component {
 					submitButtonText={ this.submitButtonText() }
 					footerLink={ this.renderFooterLink() }
 					email={ this.props.invite.sentTo }
+					suggestedUsername=""
 					disableEmailInput={ this.props.forceMatchingEmail }
 					disableEmailExplanation={ this.props.translate(
 						'This invite is only valid for %(email)s.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Invite Form: Don't attempt to submit the form if no information has been added. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Invite a new user to a site (there should not be a WordPress.com account connected to the email address)
* Visit the invite link from the email in a private browser window (to access on staging, use `https://calypso.live/accept-invite/{unique-string-from-email-url}?branch=signup-unhelpful-error-message`
* Without interacting with any other part of the form, click on `Sign Up & View`
* It should not submit
* Click in form and enter information
* The form should be validated and, if valid, the account should be created

#### Screenshots

Previous behavior:

![](https://cld.wthms.co/OD4Fev+)
Image Link: https://cld.wthms.co/OD4Fev

Expected behavior with PR:

![](https://cld.wthms.co/q0lSiS+)
Image Link: https://cld.wthms.co/q0lSiS

Fixes: #32549
