### PR TITLE
Plugins/Themes: update messaging from "upload" to "install"

### DIFF
--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**
@@ -58,7 +58,7 @@ class UploadDropZone extends Component {
 
 	render() {
 		const { translate, disabled } = this.props;
-		const dropText = translate( 'Drop files or click here to upload' );
+		const dropText = translate( 'Drop files or click here to install' );
 		const uploadInstructionsText = translate( 'Only single .zip files are accepted.' );
 
 		const className = classNames( 'upload-drop-zone', {

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicon';
+import Gridicon from 'gridicons';
 import classNames from 'classnames';
 
 /**

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -513,7 +513,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_UPLOAD_THEMES ]: {
 		getSlug: () => constants.FEATURE_UPLOAD_THEMES,
-		getTitle: () => i18n.translate( 'Upload Themes' ),
+		getTitle: () => i18n.translate( 'Install Themes' ),
 		getDescription: () => i18n.translate( 'Upload custom themes on your site.' ),
 	},
 

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -362,7 +362,7 @@ export default {
 				}
 				break;
 			case 'PLUGIN_UPLOAD':
-				return i18n.translate( "You've successfully uploaded the %(plugin)s plugin.", {
+				return i18n.translate( "You've successfully installed the %(plugin)s plugin.", {
 					args: translateArg,
 				} );
 		}

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -71,9 +71,9 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			/>
 
 			<FAQItem
-				question={ translate( 'Can I upload my own theme?' ) }
+				question={ translate( 'Can I install my own theme?' ) }
 				answer={ translate(
-					"Yes! With the WordPress.com Business plan you can upload any theme you'd like." +
+					"Yes! With the WordPress.com Business plan you can install any theme you'd like." +
 						' All plans give you access to our {{a}}directory of free and premium themes{{/a}}.' +
 						' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
 					{

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -148,7 +148,7 @@ class PluginUpload extends React.Component {
 			<Main>
 				<PageViewTracker path="/plugins/upload/:site" title="Plugins > Upload" />
 				<QueryEligibility siteId={ siteId } />
-				<HeaderCake onClick={ this.back }>{ translate( 'Upload plugin' ) }</HeaderCake>
+				<HeaderCake onClick={ this.back }>{ translate( 'Install plugin' ) }</HeaderCake>
 				{ upgradeJetpack && (
 					<JetpackManageErrorPage
 						template="updateJetpack"

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -475,8 +475,8 @@ export class PluginsBrowser extends Component {
 		return (
 			<HeaderButton
 				icon="cloud-upload"
-				label={ translate( 'Upload Plugin' ) }
-				aria-label={ translate( 'Upload Plugin' ) }
+				label={ translate( 'Install Plugin' ) }
+				aria-label={ translate( 'Install Plugin' ) }
 				href={ uploadUrl }
 				onClick={ this.handleUploadPluginButtonClick }
 			/>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { compact, pickBy } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -246,7 +246,7 @@ class ThemeShowcase extends React.Component {
 							href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
 						>
 							<Gridicon icon="cloud-upload" />
-							{ translate( 'Upload Theme' ) }
+							{ translate( 'Install Theme' ) }
 						</Button>
 					) }
 					<ThemesSelection

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { compact, pickBy } from 'lodash';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { compact, pickBy } from 'lodash';
-import Gridicon from 'gridicon';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -136,14 +136,14 @@ class Upload extends React.Component {
 		debug( 'Error', { error } );
 
 		const errorCauses = {
-			exists: translate( 'Upload problem: Theme already installed on site.' ),
-			already_installed: translate( 'Upload problem: Theme already installed on site.' ),
-			'too large': translate( 'Upload problem: Theme zip must be under 10MB.' ),
-			incompatible: translate( 'Upload problem: Incompatible theme.' ),
-			unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
+			exists: translate( 'Install problem: Theme already installed on site.' ),
+			already_installed: translate( 'Install problem: Theme already installed on site.' ),
+			'too large': translate( 'Install problem: Theme zip must be under 10MB.' ),
+			incompatible: translate( 'Install problem: Incompatible theme.' ),
+			unsupported_mime_type: translate( 'Install problem: Not a valid zip file' ),
 			initiate_failure: translate(
-				'Upload problem: Theme may not be valid. Check that your zip file contains only the theme ' +
-					'you are trying to upload.'
+				'Install problem: Theme may not be valid. Check that your zip file contains only the theme ' +
+					'you are trying to install.'
 			),
 		};
 
@@ -153,7 +153,7 @@ class Upload extends React.Component {
 		} );
 
 		const unknownCause = error.error ? `: ${ error.error }` : '';
-		notices.error( cause || translate( 'Problem uploading theme' ) + unknownCause );
+		notices.error( cause || translate( 'Problem installing theme' ) + unknownCause );
 	}
 
 	renderProgressBar() {
@@ -267,7 +267,7 @@ class Upload extends React.Component {
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }
 				<ThanksModal source="upload" />
-				<HeaderCake backHref={ backPath }>{ translate( 'Upload theme' ) }</HeaderCake>
+				<HeaderCake backHref={ backPath }>{ translate( 'Install theme' ) }</HeaderCake>
 				{ upgradeJetpack && (
 					<JetpackManageErrorPage
 						template="updateJetpack"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updated messaging from "upload" to "install" for the following cases:
* Plugins
  - Install page title and success notice
  - Plugin browser page
* Themes
  - Plans page for theme features and FAQ
  - Theme showcase page
  - Theme install page title and error notice

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

scenario | before | after
-- | -- | --
Plugin browser page | <img width="1552" alt="Screen Shot 2019-09-14 at 11 00 13 AM" src="https://user-images.githubusercontent.com/1945542/64910812-b5101e80-d6e8-11e9-84f3-c4c034a88f02.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 07 55 AM" src="https://user-images.githubusercontent.com/1945542/64910813-b5101e80-d6e8-11e9-997e-477b2931d980.png">
Plugin install page | <img width="1552" alt="Screen Shot 2019-09-14 at 12 24 24 PM" src="https://user-images.githubusercontent.com/1945542/64911015-b3475a80-d6ea-11e9-90d3-f7099160f045.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 17 57 AM" src="https://user-images.githubusercontent.com/1945542/64911014-b3475a80-d6ea-11e9-8813-f6dad8c7047a.png">
Plugin install success notice | <img width="1552" alt="Screen Shot 2019-09-14 at 11 23 08 AM" src="https://user-images.githubusercontent.com/1945542/64910839-e8eb4400-d6e8-11e9-8aa1-21802dd06f00.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 28 00 AM" src="https://user-images.githubusercontent.com/1945542/64910840-e8eb4400-d6e8-11e9-8e5b-57fd1650ee06.png">
Theme showcase page | <img width="1552" alt="Screen Shot 2019-09-14 at 11 46 14 AM" src="https://user-images.githubusercontent.com/1945542/64910866-2780fe80-d6e9-11e9-8e3f-218d9785c59f.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 47 31 AM" src="https://user-images.githubusercontent.com/1945542/64910867-2780fe80-d6e9-11e9-9591-94f2bbf343f8.png">
Theme install page | <img width="1552" alt="Screen Shot 2019-09-14 at 11 47 42 AM" src="https://user-images.githubusercontent.com/1945542/64910895-6a42d680-d6e9-11e9-8f1f-f95a00e5ab1c.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 52 55 AM" src="https://user-images.githubusercontent.com/1945542/64910904-7464d500-d6e9-11e9-919d-90c4d9ff38c5.png">
Theme install error (e.g. invalid file type) | <img width="1552" alt="Screen Shot 2019-09-14 at 11 48 55 AM" src="https://user-images.githubusercontent.com/1945542/64910908-85154b00-d6e9-11e9-96fb-33dc17dc6310.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 53 06 AM" src="https://user-images.githubusercontent.com/1945542/64910912-8a729580-d6e9-11e9-9c1c-05eb34e458f4.png">
Plans > theme install FAQ | <img width="1552" alt="Screen Shot 2019-09-14 at 11 36 11 AM" src="https://user-images.githubusercontent.com/1945542/64910930-aece7200-d6e9-11e9-9af8-a2fc57d4eaba.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 52 38 AM" src="https://user-images.githubusercontent.com/1945542/64910931-aece7200-d6e9-11e9-996a-aa01748c21b4.png">
Plans > theme feature list | <img width="1552" alt="Screen Shot 2019-09-14 at 11 36 15 AM" src="https://user-images.githubusercontent.com/1945542/64910941-d9202f80-d6e9-11e9-8a2a-03820e3d8018.png"> | <img width="1552" alt="Screen Shot 2019-09-14 at 11 52 30 AM" src="https://user-images.githubusercontent.com/1945542/64910942-d9202f80-d6e9-11e9-8e52-9ec3750e8b77.png">


Fixes #33062