### PR TITLE
Make the "Business plan required" nudges point directly to the checkout

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -10,17 +10,18 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, includes, noop, partition } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
 
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
+import { findFirstSimilarPlanKey } from 'lib/plans';
+import { FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES, TYPE_BUSINESS } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
+import { getSitePlan, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Banner from 'components/banner';
 import Button from 'components/button';
@@ -45,6 +46,7 @@ export const EligibilityWarnings = ( {
 	onProceed,
 	onCancel,
 	siteId,
+	sitePlan,
 	siteSlug,
 	translate,
 } ) => {
@@ -65,7 +67,9 @@ export const EligibilityWarnings = ( {
 			'Also get unlimited themes, advanced customization, no ads, live chat support, and more.'
 		);
 		const title = translate( 'Business plan required' );
-		const plan = PLAN_BUSINESS;
+		const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
+			type: TYPE_BUSINESS,
+		} );
 		let feature = null;
 		let event = null;
 
@@ -76,6 +80,8 @@ export const EligibilityWarnings = ( {
 			feature = FEATURE_UPLOAD_THEMES;
 			event = 'calypso-theme-eligibility-upgrade-nudge';
 		}
+
+		const bannerURL = `/checkout/${ siteSlug }/business`;
 		businessUpsellBanner = (
 			<Banner
 				description={ description }
@@ -83,6 +89,7 @@ export const EligibilityWarnings = ( {
 				event={ event }
 				plan={ plan }
 				title={ title }
+				href={ bannerURL }
 			/>
 		);
 	}
@@ -175,6 +182,7 @@ const mapStateToProps = state => {
 	const hasBusinessPlan = ! includes( eligibilityHolds, 'NO_BUSINESS_PLAN' );
 	const isJetpack = isJetpackSite( state, siteId );
 	const dataLoaded = !! eligibilityData.lastUpdate;
+	const sitePlan = getSitePlan( state, siteId );
 
 	return {
 		eligibilityData,
@@ -184,6 +192,7 @@ const mapStateToProps = state => {
 		isPlaceholder: ! dataLoaded,
 		siteId,
 		siteSlug,
+		sitePlan,
 	};
 };
 


### PR DESCRIPTION
Fixes #33071

In #33071, the main issue was that following the "Business Plan Required" nudge when trying to upload a theme redirects the user to the Blogger/Personal/Premium "Plans" page. That's no longer true, it must have been fixed in the last few months, because I see the Premium/Business/eCommerce plans tab. If this is an acceptable behaviour, we can close this PR.

However, a better solution is to direct the user straight to the checkout, with the Business plan in the shopping cart. That's the same approach that was taken in #33824 for a different nudge. This PR does exactly that.

To test:
- On a site that has a Free, Blogger, or Premium plan, go to the Themes screen.
- Click "Upload Theme".
- You'll see a notice that tells you "Business plan required".
- Clicking that notice will send you directly to the checkout.
- The same behaviour is expected when trying to upload a plugin.