### PR TITLE
Build: Fix server file-loader imports

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { capitalize, findLast, get, includes, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,5 +1,6 @@
-[UNRELEASED]
+# _unreleased_
 
+- Add config options to file-loader
 - Add `enzyme-to-json` serializer to `jest-preset.js`.
 - Make Jest ignore transpiled files in `dist/`.
 

--- a/packages/calypso-build/webpack/file-loader.js
+++ b/packages/calypso-build/webpack/file-loader.js
@@ -1,9 +1,10 @@
 /**
  * Return a Webpack loader configuration object for files / images.
  *
- * @return {Object} Webpack loader object
+ * @param  {object} options File loader options
+ * @return {object}         Webpack loader object
  */
-module.exports.loader = () => ( {
+module.exports.loader = options => ( {
 	test: /\.(?:gif|jpg|jpeg|png|svg)$/i,
 	use: [
 		{
@@ -11,6 +12,7 @@ module.exports.loader = () => ( {
 			options: {
 				name: '[name]-[hash].[ext]',
 				outputPath: 'images/',
+				...options,
 			},
 		},
 	],

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -23,11 +23,15 @@ const bundleEnv = config( 'env' );
 const { workerCount } = require( './webpack.common' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
 const nodeExternals = require( 'webpack-node-externals' );
+const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
 
 /**
  * Internal variables
  */
 const isDevelopment = bundleEnv === 'development';
+const fileLoader = FileConfig.loader( {
+	emitFile: false, // On the server side, don't actually copy files
+} );
 
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
@@ -42,9 +46,17 @@ function getExternals() {
 		// Don't bundle any node_modules, both to avoid a massive bundle, and problems
 		// with modules that are incompatible with webpack bundling.
 		//
-		// `@automattic/calypso-ui` is forced to be webpack-ed because it has SCSS and other
-		// non-JS asset imports that couldn't be processed by Node.js at runtime.
-		nodeExternals( { whitelist: [ '@automattic/calypso-ui' ] } ),
+		nodeExternals( {
+			whitelist: [
+				// `@automattic/calypso-ui` is forced to be webpack-ed because it has SCSS and other
+				// non-JS asset imports that couldn't be processed by Node.js at runtime.
+				'@automattic/calypso-ui',
+
+				// Ensure that file-loader files imported from packages in node_modules are
+				// _not_ externalized and can be processed by the fileLoader.
+				fileLoader.test,
+			],
+		} ),
 		// Don't bundle webpack.config, as it depends on absolute paths (__dirname)
 		'webpack.config',
 		// Exclude hot-reloader, as webpack will try and resolve this in production builds,
@@ -86,19 +98,7 @@ const webpackConfig = {
 				cacheIdentifier,
 				exclude: /(node_modules|devdocs[/\\]search-index)/,
 			} ),
-			{
-				test: /\.(?:gif|jpg|jpeg|png|svg)$/,
-				use: [
-					{
-						loader: 'file-loader',
-						options: {
-							emitFile: false, // On the server side, don't actually copy files
-							name: '[name].[ext]',
-							outputPath: 'images/',
-						},
-					},
-				],
-			},
+			fileLoader,
 			{
 				test: /\.(sc|sa|c)ss$/,
 				loader: 'ignore-loader',

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -1,7 +1,5 @@
 /**
  * **** WARNING: No ES6 modules here. Not transpiled! ****
- *
- * @format
  */
 
 /* eslint-disable import/no-nodejs-modules */
@@ -9,7 +7,6 @@
 /**
  * External dependencies
  */
-const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const _ = require( 'lodash' );


### PR DESCRIPTION
Fix file-loader imports in the server build.

It was discovered that when an svg from node_modules was imported as part of the server build, the file-loader was not being applied and the build was broken at runtime. This was due to externalization by `webpack-node-externals`.

This PR does a few things:
- Use the same file-loader config for client and server.
- Accept options in file-loader in order to permit the above while maintaining the existing `{emitFile: false}` option on the server.
- Use `fileLoader.test` as a whitelist for `webpack-node-externals`. This is the critical piece which ensure that imports which should be handled by file-loader are not treated as externals.
- Fixes the lint rule in `client/blocks/login/index.jsx` which was discovered to cause the issue.

## Testing

Does the app build and run?