### PR TITLE
export individual functions from webauthn lib

### DIFF
--- a/client/lib/webauthn/index.js
+++ b/client/lib/webauthn/index.js
@@ -64,7 +64,7 @@ function wpcomApiRequest( path, _data, method ) {
 	} );
 }
 
-export function isSupported() {
+export function isWebauthnSupported() {
 	if ( ! _backend ) {
 		_backend = new Promise( function( resolve ) {
 			function notSupported() {
@@ -90,7 +90,7 @@ export function isSupported() {
 	return _backend.then( backend => !! backend.webauthn );
 }
 
-export function register( keyName = null ) {
+export function registerSecurityKey( keyName = null ) {
 	return wpcomApiRequest( '/me/two-step/security-key/registration_challenge' )
 		.then( options => {
 			const makeCredentialOptions = {};

--- a/client/lib/webauthn/index.js
+++ b/client/lib/webauthn/index.js
@@ -9,14 +9,14 @@ let _backend;
 
 const POST = 'POST';
 
-function strToBin( str ) {
+export function strToBin( str ) {
 	str = str.replace( /[-_]/g, function( m ) {
 		return m[ 0 ] === '-' ? '+' : '/';
 	} );
 	return Uint8Array.from( atob( str ), c => c.charCodeAt( 0 ) );
 }
 
-function binToStr( bin ) {
+export function binToStr( bin ) {
 	return btoa( new Uint8Array( bin ).reduce( ( s, byte ) => s + String.fromCharCode( byte ), '' ) );
 }
 
@@ -29,7 +29,7 @@ function isBrowser() {
 	return true;
 }
 
-function credentialListConversion( list ) {
+export function credentialListConversion( list ) {
 	return list.map( item => {
 		const cred = {
 			type: item.type,
@@ -64,7 +64,7 @@ function wpcomApiRequest( path, _data, method ) {
 	} );
 }
 
-function isSupported() {
+export function isSupported() {
 	if ( ! _backend ) {
 		_backend = new Promise( function( resolve ) {
 			function notSupported() {
@@ -90,7 +90,7 @@ function isSupported() {
 	return _backend.then( backend => !! backend.webauthn );
 }
 
-function register( keyName = null ) {
+export function register( keyName = null ) {
 	return wpcomApiRequest( '/me/two-step/security-key/registration_challenge' )
 		.then( options => {
 			const makeCredentialOptions = {};
@@ -184,11 +184,3 @@ function register( keyName = null ) {
 			}
 		} );
 }
-
-export default {
-	isSupported,
-	register,
-	strToBin,
-	binToStr,
-	credentialListConversion,
-};

--- a/client/me/security-2fa-key/add.jsx
+++ b/client/me/security-2fa-key/add.jsx
@@ -12,7 +12,7 @@ import debugFactory from 'debug';
  */
 import Card from 'components/card';
 import { errorNotice, warningNotice } from 'state/notices/actions';
-import { register } from 'lib/webauthn';
+import { registerSecurityKey } from 'lib/webauthn';
 import Spinner from 'components/spinner';
 import Security2faKeyAddName from './name';
 
@@ -31,7 +31,7 @@ class Security2faKeyAdd extends React.Component {
 
 	registerKey = securityKeyName => {
 		this.setState( { securityKeyName } );
-		register( securityKeyName )
+		registerSecurityKey( securityKeyName )
 			.then( data => {
 				debug( 'registered key with data', data );
 				this.keyRegistered();

--- a/client/me/security-2fa-key/add.jsx
+++ b/client/me/security-2fa-key/add.jsx
@@ -12,7 +12,7 @@ import debugFactory from 'debug';
  */
 import Card from 'components/card';
 import { errorNotice, warningNotice } from 'state/notices/actions';
-import webauthn from 'lib/webauthn';
+import { register } from 'lib/webauthn';
 import Spinner from 'components/spinner';
 import Security2faKeyAddName from './name';
 
@@ -31,8 +31,7 @@ class Security2faKeyAdd extends React.Component {
 
 	registerKey = securityKeyName => {
 		this.setState( { securityKeyName } );
-		webauthn
-			.register( securityKeyName )
+		register( securityKeyName )
 			.then( data => {
 				debug( 'registered key with data', data );
 				this.keyRegistered();

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -16,7 +16,7 @@ import SectionHeader from 'components/section-header';
 import Security2faKeyAdd from './add';
 import Security2faKeyList from './list';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import webauthn from 'lib/webauthn';
+import { isSupported } from 'lib/webauthn';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 
@@ -33,7 +33,7 @@ class Security2faKey extends React.Component {
 
 	componentDidMount = () => {
 		this.getKeysFromServer();
-		webauthn.isSupported().then( this.setSupported );
+		isSupported().then( this.setSupported );
 	};
 
 	getClickHandler = ( action, callback ) => {

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -16,7 +16,7 @@ import SectionHeader from 'components/section-header';
 import Security2faKeyAdd from './add';
 import Security2faKeyList from './list';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import { isSupported } from 'lib/webauthn';
+import { isWebauthnSupported } from 'lib/webauthn';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 
@@ -33,7 +33,7 @@ class Security2faKey extends React.Component {
 
 	componentDidMount = () => {
 		this.getKeysFromServer();
-		isSupported().then( this.setSupported );
+		isWebauthnSupported().then( this.setSupported );
 	};
 
 	getClickHandler = ( action, callback ) => {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -51,7 +51,7 @@ import wpcom from 'lib/wp';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import 'state/data-layer/wpcom/login-2fa';
 import 'state/data-layer/wpcom/users/auth-options';
-import webauthn from 'lib/webauthn';
+import { binToStr, strToBin, credentialListConversion } from 'lib/webauthn';
 
 /**
  * Creates a promise that will be rejected after a given timeout
@@ -200,7 +200,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				dispatch( updateNonce( twoFactorAuthType, twoStepNonce ) );
 			}
 
-			requestOptions.challenge = webauthn.strToBin( parameters.challenge );
+			requestOptions.challenge = strToBin( parameters.challenge );
 			requestOptions.timeout = 6000;
 			if ( 'rpId' in parameters ) {
 				if ( parameters.rpId !== window.location.hostname ) {
@@ -209,9 +209,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				requestOptions.rpId = parameters.rpId;
 			}
 			if ( 'allowCredentials' in parameters ) {
-				requestOptions.allowCredentials = webauthn.credentialListConversion(
-					parameters.allowCredentials
-				);
+				requestOptions.allowCredentials = credentialListConversion( parameters.allowCredentials );
 			}
 			return navigator.credentials.get( { publicKey: requestOptions } );
 		} )
@@ -224,7 +222,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				publicKeyCredential.type = assertion.type;
 			}
 			if ( 'rawId' in assertion ) {
-				publicKeyCredential.rawId = webauthn.binToStr( assertion.rawId );
+				publicKeyCredential.rawId = binToStr( assertion.rawId );
 			}
 			if ( ! assertion.response ) {
 				throw "Get assertion response lacking 'response' attribute";
@@ -232,12 +230,12 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 
 			const _response = assertion.response;
 			publicKeyCredential.response = {
-				clientDataJSON: webauthn.binToStr( _response.clientDataJSON ),
-				authenticatorData: webauthn.binToStr( _response.authenticatorData ),
-				signature: webauthn.binToStr( _response.signature ),
+				clientDataJSON: binToStr( _response.clientDataJSON ),
+				authenticatorData: binToStr( _response.authenticatorData ),
+				signature: binToStr( _response.signature ),
 			};
 			if ( _response.userHandle ) {
-				publicKeyCredential.response.userHandle = webauthn.binToStr( _response.userHandle );
+				publicKeyCredential.response.userHandle = binToStr( _response.userHandle );
 			}
 
 			return postLoginRequest( 'u2f-authentication-endpoint', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Instead of importing and exporting an object from the webauthn library, just expose the relevant functions.

This slightly reduced bundle size & makes it a bit more dev friendly otherwise (exporting is declared at the function level instead of separated at the bottom of the file, usages are just a single function call instead of `webauthn.whatever`, etc.)

#### Testing instructions

This should function identically to the branch in #36069
