### PR TITLE
Separate Upload Button from Plugin Nav/Search Bar

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -493,11 +493,11 @@ export class PluginsBrowser extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="plugins-browser__main-header">
-				{ navigation }
 				<div className="plugins__header-buttons">
 					{ this.renderManageButton() }
 					{ this.renderUploadPluginButton() }
 				</div>
+				<div className="plugins__header-navigation">{ navigation }</div>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { concat, find, flow, get, flatMap, includes } from 'lodash';
 import PropTypes from 'prop-types';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -40,7 +41,7 @@ import {
 import isVipSite from 'state/selectors/is-vip-site';
 import NonSupportedJetpackVersionNotice from 'my-sites/plugins/not-supported-jetpack-version';
 import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
-import HeaderButton from 'components/header-button';
+import Button from 'components/button';
 import { isBusiness, isEcommerce, isEnterprise, isPremium } from 'lib/products-values';
 import { TYPE_BUSINESS } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
@@ -449,13 +450,14 @@ export class PluginsBrowser extends Component {
 			return null;
 		}
 
-		const site = this.props.siteSlug ? '/' + this.props.siteSlug : '';
+		const { siteSlug, translate } = this.props;
+		const site = siteSlug ? '/' + siteSlug : '';
+
 		return (
-			<HeaderButton
-				icon="cog"
-				label={ this.props.translate( 'Manage Plugins' ) }
-				href={ '/plugins/manage' + site }
-			/>
+			<Button className="plugins-browser__button" compact href={ '/plugins/manage' + site }>
+				<Gridicon icon="cog" />
+				<span className="plugins-browser__button-text">{ translate( 'Manage Plugins' ) }</span>
+			</Button>
 		);
 	}
 
@@ -473,13 +475,15 @@ export class PluginsBrowser extends Component {
 		const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
 
 		return (
-			<HeaderButton
-				icon="cloud-upload"
-				label={ translate( 'Install Plugin' ) }
-				aria-label={ translate( 'Install Plugin' ) }
-				href={ uploadUrl }
+			<Button
+				className="plugins-browser__button"
+				compact
 				onClick={ this.handleUploadPluginButtonClick }
-			/>
+				href={ uploadUrl }
+			>
+				<Gridicon icon="cloud-upload" />
+				<span className="plugins-browser__button-text">{ translate( 'Install Plugin' ) }</span>
+			</Button>
 		);
 	}
 
@@ -492,12 +496,14 @@ export class PluginsBrowser extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="plugins-browser__main-header">
-				<div className="plugins__header-buttons">
+			<div className="plugins-browser__main">
+				<div className="plugins-browser__main-header">
+					<div className="plugins__header-navigation">{ navigation }</div>
+				</div>
+				<div className="plugins-browser__main-buttons">
 					{ this.renderManageButton() }
 					{ this.renderUploadPluginButton() }
 				</div>
-				<div className="plugins__header-navigation">{ navigation }</div>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,6 +1,5 @@
 .plugins-browser__main-header {
 	background: var( --color-surface );
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
 	flex-direction: column;
 	display: flex;
 	margin-bottom: 9px;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -21,3 +21,41 @@
 		border-width: 0 1px 0 0;
 	}
 }
+
+.plugins-browser__main-buttons {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 9px;
+	width: 100%;
+
+	@include breakpoint( '>480px' ) {
+		margin-bottom: 17px;
+	}
+
+	.plugins-browser__button {
+		&:not( :last-child ) {
+			margin-right: 10px;
+		}
+
+		&:last-child {
+			@include breakpoint( '<480px' ) {
+				margin-right: 15px;
+			}
+		}
+
+		.gridicon {
+			margin-right: 0;
+			@include breakpoint( '>480px' ) {
+				margin-right: 4px;
+			}
+		}
+
+		.plugins-browser__button-text {
+			display: none;
+			@include breakpoint( '>480px' ) {
+				display: inline-block;
+			}
+		}
+	}
+}
+

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -36,16 +36,13 @@
 }
 
 .plugins__header-buttons {
+	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
 	display: flex;
+	margin: 0 10px 0 0;
 
 	.header-button {
 		flex: auto;
 		flex-basis: 0;
-
-		&:not( :last-child ) {
-			border-right: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
-		}
-
 		.gridicon {
 			margin-top: 4px;
 		}
@@ -54,6 +51,11 @@
 			flex: none;
 		}
 	}
+}
+
+.plugins__header-navigation {
+	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
+	width: 100%;
 }
 
 .plugins__more-header {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -36,13 +36,16 @@
 }
 
 .plugins__header-buttons {
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
 	display: flex;
-	margin: 0 10px 0 0;
 
 	.header-button {
 		flex: auto;
 		flex-basis: 0;
+
+		&:not( :last-child ) {
+			border-right: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
+		}
+
 		.gridicon {
 			margin-top: 4px;
 		}


### PR DESCRIPTION
This PR separates the Upload button from the Navigation/Search bar at
the top of the Plugins page. It also moves the button to the left of the
header nav/search to draw attention to search functionality.

Previously the placement of the layout of this header buried the search
functionality. Moving the Upload button to the left here makes it easier
to identify both Search and Upload.

Before:
https://d.pr/i/qsbCPX

After:
https://d.pr/i/5f1mZg

Fixes #33061
