### PR TITLE
Gutenberg: Update e2e tests for v6.5.0.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Full Site Editing
+ * Plugin Name: Full Site Editing Test
  * Description: Enhances your page creation workflow within the Block Editor.
  * Version: 0.7
  * Author: Automattic

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Full Site Editing Test
+ * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
  * Version: 0.7
  * Author: Automattic

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -55,21 +55,17 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async publish( { visit = false } = {} ) {
+		const snackBarNoticeLinkSelector = By.css( '.components-snackbar__content a' );
 		await driverHelper.clickWhenClickable( this.driver, this.prePublishButtonSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishHeaderSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
 		await this.waitForSuccessViewPostNotice();
-		const url = await this.driver
-			.findElement( By.css( '.post-publish-panel__postpublish-header a' ) )
-			.getAttribute( 'href' );
+		const url = await this.driver.findElement( snackBarNoticeLinkSelector ).getAttribute( 'href' );
 
 		if ( visit ) {
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '.post-publish-panel__postpublish-buttons a' )
-			);
+			await driverHelper.clickWhenClickable( this.driver, snackBarNoticeLinkSelector );
 		}
 
 		return url;

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -68,6 +68,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			await driverHelper.clickWhenClickable( this.driver, snackBarNoticeLinkSelector );
 		}
 
+		await driverHelper.acceptAlertIfPresent( this.driver );
 		return url;
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -61,6 +61,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
+		await this.closePublishedPanel();
 		await this.waitForSuccessViewPostNotice();
 		const url = await this.driver.findElement( snackBarNoticeLinkSelector ).getAttribute( 'href' );
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -30,13 +30,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
 		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
-
-		// Temp fix: Because of https://github.com/WordPress/gutenberg/issues/17264, the post publish sidebar is
-		// automatically hidden, so we need to retrieve the post links from the snackbar notices.
-		// this.publishPostTitleLink = By.css( '.post-publish-panel__postpublish-header a' );
-		// this.publishViewPostLink = By.css( '.post-publish-panel__postpublish-buttons a' );
-		this.publishPostTitleLink = By.css( '.components-snackbar a' );
-		this.publishViewPostLink = By.css( '.components-snackbar a' );
 	}
 
 	static async Expect( driver, editorType ) {
@@ -67,12 +60,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
-
-		// Temp fix: Because of https://github.com/WordPress/gutenberg/issues/17264, we retrieve the post links from
-		// the snackbar notices, so we need to ensure they are visible by hiding the publish sidebar if present.
-		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
-		await gEditorComponent.closePublishedPanel();
-
 		await this.waitForSuccessViewPostNotice();
 		const url = await this.driver
 			.findElement( By.css( '.post-publish-panel__postpublish-header a' ) )
@@ -271,12 +258,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closePublishedPanel() {
-		const closePublishSidebarSelector = By.css(
-			'.editor-post-publish-panel__header button.components-button.components-icon-button'
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-publish-panel__header button.components-button.components-icon-button' )
 		);
-		if ( await driverHelper.isElementPresent( this.driver, closePublishSidebarSelector ) ) {
-			return await driverHelper.clickWhenClickable( this.driver, closePublishSidebarSelector );
-		}
 	}
 
 	async ensureSaved() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -275,7 +275,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( driverManager.currentScreenSize() === 'mobile' ) {
 			// potentially close out the publish sidebar, as the snackbar won't show up in mobile views
 			if (
-				await driverHelper.isElementPresent( this.driver, By.css( '.editor-post-publish-panel' ) )
+				await driverHelper.isElementPresent(
+					this.driver,
+					By.css(
+						'.editor-post-publish-panel__header button.components-button.components-icon-button'
+					)
+				)
 			) {
 				await this.closePublishedPanel();
 			}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -30,6 +30,13 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.prePublishButtonSelector = By.css( '.editor-post-publish-panel__toggle' );
 		this.publishHeaderSelector = By.css( '.editor-post-publish-panel__header' );
 		this.editoriFrameSelector = By.css( '.calypsoify.is-iframe iframe' );
+
+		// Temp fix: Because of https://github.com/WordPress/gutenberg/issues/17264, the post publish sidebar is
+		// automatically hidden, so we need to retrieve the post links from the snackbar notices.
+		// this.publishPostTitleLink = By.css( '.post-publish-panel__postpublish-header a' );
+		// this.publishViewPostLink = By.css( '.post-publish-panel__postpublish-buttons a' );
+		this.publishPostTitleLink = By.css( '.components-snackbar a' );
+		this.publishViewPostLink = By.css( '.components-snackbar a' );
 	}
 
 	static async Expect( driver, editorType ) {
@@ -60,6 +67,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
+
+		// Temp fix: Because of https://github.com/WordPress/gutenberg/issues/17264, we retrieve the post links from
+		// the snackbar notices, so we need to ensure they are visible by hiding the publish sidebar if present.
+		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+		await gEditorComponent.closePublishedPanel();
+
 		await this.waitForSuccessViewPostNotice();
 		const url = await this.driver
 			.findElement( By.css( '.post-publish-panel__postpublish-header a' ) )
@@ -258,10 +271,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closePublishedPanel() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.editor-post-publish-panel__header button.components-button.components-icon-button' )
+		const closePublishSidebarSelector = By.css(
+			'.editor-post-publish-panel__header button.components-button.components-icon-button'
 		);
+		if ( await driverHelper.isElementPresent( this.driver, closePublishSidebarSelector ) ) {
+			return await driverHelper.clickWhenClickable( this.driver, closePublishSidebarSelector );
+		}
 	}
 
 	async ensureSaved() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -272,6 +272,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		// FIXME: Temporary hack to make sure it works with both 6.1 and core's Gutenberg (WP 5.2)
 		const noticeSelector =
 			getJetpackHost() === 'WPCOM' ? '.components-snackbar' : '.components-notice.is-success';
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			// potentially close out the publish sidebar, as the snackbar won't show up in mobile views
+			if (
+				await driverHelper.isElementPresent( this.driver, By.css( '.editor-post-publish-panel' ) )
+			) {
+				await this.closePublishedPanel();
+			}
+		}
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( noticeSelector ) );
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -272,19 +272,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		// FIXME: Temporary hack to make sure it works with both 6.1 and core's Gutenberg (WP 5.2)
 		const noticeSelector =
 			getJetpackHost() === 'WPCOM' ? '.components-snackbar' : '.components-notice.is-success';
-		if ( driverManager.currentScreenSize() === 'mobile' ) {
-			// potentially close out the publish sidebar, as the snackbar won't show up in mobile views
-			if (
-				await driverHelper.isElementPresent(
-					this.driver,
-					By.css(
-						'.editor-post-publish-panel__header button.components-button.components-icon-button'
-					)
-				)
-			) {
-				await this.closePublishedPanel();
-			}
-		}
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( noticeSelector ) );
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -295,7 +295,16 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const revertDraftSelector = By.css( 'button.editor-post-switch-to-draft' );
 		await driverHelper.clickWhenClickable( this.driver, revertDraftSelector );
 		const revertAlert = await this.driver.switchTo().alert();
-		return await revertAlert.accept();
+		await revertAlert.accept();
+		await this.waitForSuccessViewPostNotice();
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( 'button.editor-post-publish-panel__toggle' )
+		);
+		return await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( 'button.editor-post-switch-to-draft' )
+		);
 	}
 
 	async isDraft() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1108,8 +1108,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can publish the post', async function() {
 				const gHeaderComponent = await GutenbergEditorComponent.Expect( driver );
-				await gHeaderComponent.publish();
-				return await gHeaderComponent.closePublishedPanel();
+				return await gHeaderComponent.publish();
 			} );
 		} );
 


### PR DESCRIPTION
Update e2e tests for v6.5.0.

Our version of 6.5.0 includes cherry-picks of:
- de6df895c718e56e39f21d171207f1e64647b67f
- fa5a64edc26461288b0f1de8641aa693f4a122c4
- d9adf3b781fb7fbccc2b1c6e068adc27deb8dfac
- 20b30e044b6738b53a8262574278957ebf7465c1
- 00c6d183620e8384b856e0c48110c1df749d14c1