### PR TITLE
<SidebarMenu> should use <ul> instead of <li>

### DIFF
--- a/client/layout/sidebar/menu.jsx
+++ b/client/layout/sidebar/menu.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 const SidebarMenu = ( { children, className } ) => (
-	<li className={ classNames( 'sidebar__menu', className ) }>{ children }</li>
+	<ul className={ classNames( 'sidebar__menu', className ) }>{ children }</ul>
 );
 
 export default SidebarMenu;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when we first arrives My Sites tab, the illegally-nested <li> warning pops up:
<img width="1188" alt="螢幕快照 2019-09-15 上午10 16 05" src="https://user-images.githubusercontent.com/1842898/64923264-3bd70100-d7a6-11e9-9452-b19b25bf3d17.png">

Looking into the usage of <SidebarMenu>, it is mainly used as a wrapping elements for listed items, so there doesn't seem obvious reason that it has to be `<li>`. This PR updates it as `<ul>` so the warning is eliminated and the markup structure seems more adequate.

#### Testing instructions

Visit the My Sites tab and make sure the warning doesn't show up, and all the expandable menus still work as expected.
