### PR TITLE
Gridicons: Update import to component/gridicon

### DIFF
--- a/client/auth/connect.jsx
+++ b/client/auth/connect.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/auth/self-hosted-instructions.jsx
+++ b/client/auth/self-hosted-instructions.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default function SelfHostedInstructions( { onClickClose } ) {
 	const translate = useTranslate();

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { identity, noop, sample } from 'lodash';
 import store from 'store';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import debugModule from 'debug';
 
 /**

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { noop, pick } from 'lodash';
 

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -11,7 +11,7 @@ import { isNull, noop, omitBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { getPostTotalCommentsCount } from 'state/comments/selectors';
 
 /**

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 import { noop } from 'lodash';
 

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 
 /**

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { get, noop, some, flatMap } from 'lodash';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 
 /**

--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 
 /***

--- a/client/blocks/conversation-follow-button/button.jsx
+++ b/client/blocks/conversation-follow-button/button.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class ConversationFollowButton extends React.Component {
 	static propTypes = {

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { camelCase, values } from 'lodash';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import debugFactory from 'debug';
 
 /**

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import { get, defer } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { noop, flow } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/ecommerce-manage-nudge/index.js
+++ b/client/blocks/ecommerce-manage-nudge/index.js
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import path from 'path';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { noop, values as objectValues } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEqual, uniq } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, isUndefined, omitBy } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -8,7 +8,7 @@ import { flowRight as compose, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/like-button/icons.jsx
+++ b/client/blocks/like-button/icons.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent, Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { intersection } from 'lodash';
 import PropTypes from 'prop-types';
 

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { get, includes, map, concat } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { current as currentPage } from 'page';
 
 /**

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/post-share/sharing-preview-modal.jsx
+++ b/client/blocks/post-share/sharing-preview-modal.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/post-status/index.jsx
+++ b/client/blocks/post-status/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/post-status/test/index.jsx
+++ b/client/blocks/post-status/test/index.jsx
@@ -4,7 +4,7 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { identity } from 'lodash';
 import React from 'react';
 

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/blocks/reader-feed-header/badge.jsx
+++ b/client/blocks/reader-feed-header/badge.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 const ReaderFeedHeaderSiteBadge = ( { site } ) => {
 	/* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { keys, trim } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { get, map, take, values } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { map, partial, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 /**
  * Internal Dependencies

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import ReaderPopoverMenu from 'reader/components/reader-popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import SocialLogo from 'components/social-logo';
 import * as stats from 'reader/stats';
 import { preload } from 'sections-helper';

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -11,7 +11,7 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import ReaderPopover from 'reader/components/reader-popover';
 import SegmentedControl from 'components/segmented-control';
 import FormToggle from 'components/forms/form-toggle';

--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 

--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { flowRight as compose, get } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, isUndefined } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/term-tree-selector/add-term.jsx
+++ b/client/blocks/term-tree-selector/add-term.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/term-tree-selector/search.jsx
+++ b/client/blocks/term-tree-selector/search.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';

--- a/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
+++ b/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
@@ -42,11 +42,9 @@ exports[`UpworkBanner renders correctly 1`] = `
       width={18}
       xmlns="http://www.w3.org/2000/svg"
     >
-      <g>
-        <path
-          d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"
-        />
-      </g>
+      <use
+        xlinkHref="gridicons.svg#gridicons-cross-small"
+      />
     </svg>
   </button>
   <img

--- a/client/blocks/upwork-stats-nudge/index.js
+++ b/client/blocks/upwork-stats-nudge/index.js
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/accordion/status.jsx
+++ b/client/components/accordion/status.jsx
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -6,7 +6,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 import { shallow } from 'enzyme';
 

--- a/client/components/accordion/test/status.jsx
+++ b/client/components/accordion/test/status.jsx
@@ -8,7 +8,7 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 import sinon from 'sinon';
 

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 
 /**

--- a/client/components/back-button/index.jsx
+++ b/client/components/back-button/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { noop } from 'lodash';
 
 /**

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { noop, size } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/components/button-group/docs/example.jsx
+++ b/client/components/button-group/docs/example.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import Card from 'components/card';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class Buttons extends React.PureComponent {
 	static displayName = 'ButtonGroup';

--- a/client/components/button/README.md
+++ b/client/components/button/README.md
@@ -1,12 +1,11 @@
-Button
-===
+# Button
 
 Buttons express what action will occur when the user clicks or taps it. Buttons are used to trigger an action, and they can be used for any type of action, including navigation.
 
 ## Usage
 
 ```jsx
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicons';
 import Button from 'components/button';
 
 export default function RockOnButton() {
@@ -20,30 +19,30 @@ export default function RockOnButton() {
 
 ### Props
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`compact` | `bool` | false | Decreases the size of the button
-`primary` | `bool` | false | Provides extra visual weight and identifies the primary action in a set of buttons
-`borderless` | `bool` | false | Renders a button without borders
-`scary` | `bool` | false | Indicates a dangerous or potentially negative action
-`busy` | `bool` | false | Indicates activity while a background action is being performed
-`href` | `string` | null | If provided, renders `a` instead of `button`
+| Name         | Type     | Default | Description                                                                        |
+| ------------ | -------- | ------- | ---------------------------------------------------------------------------------- |
+| `compact`    | `bool`   | false   | Decreases the size of the button                                                   |
+| `primary`    | `bool`   | false   | Provides extra visual weight and identifies the primary action in a set of buttons |
+| `borderless` | `bool`   | false   | Renders a button without borders                                                   |
+| `scary`      | `bool`   | false   | Indicates a dangerous or potentially negative action                               |
+| `busy`       | `bool`   | false   | Indicates activity while a background action is being performed                    |
+| `href`       | `string` | null    | If provided, renders `a` instead of `button`                                       |
 
 ### Button types
 
-* **Primary**: Use to highlight the most important actions in any experience. Don’t use more than one primary button in a section or screen to avoid overwhelming customers.
-* **Secondary**: Used most in the interface. Only use another style if a button requires more or less visual weight.
-* **Button with icon**: When words are not enough, icons can be used in buttons to better communicate what the button does.
-* **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
-* **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
-* **Busy**: Use when a button has been pressed and the associated action is in progress.
+- **Primary**: Use to highlight the most important actions in any experience. Don’t use more than one primary button in a section or screen to avoid overwhelming customers.
+- **Secondary**: Used most in the interface. Only use another style if a button requires more or less visual weight.
+- **Button with icon**: When words are not enough, icons can be used in buttons to better communicate what the button does.
+- **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
+- **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
+- **Busy**: Use when a button has been pressed and the associated action is in progress.
 
 #### Icon buttons
 
 To use an icon button, insert a Gridicon so that it displays to the left of the text (displaying the `external` icon to the right of the text is the exception). Wrap the text in a `span` or some other element for spacing purposes. You may also create an icon button without text, but use sparingly because it may reduce clarity.
 
 ```jsx
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicons';
 import Button from 'components/button';
 
 export default function RockOnButton() {
@@ -58,13 +57,13 @@ export default function RockOnButton() {
 
 ### General guidelines
 
-* Use clear and accurate labels. Use sentence-style capitalization.
-* Lead with strong, concise, and actionable verbs.
-* When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
-* Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.
+- Use clear and accurate labels. Use sentence-style capitalization.
+- Lead with strong, concise, and actionable verbs.
+- When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
+- Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.
 
 ## Related components
 
-* To group buttons together, use the [ButtonGroup](./button-group) component.
-* To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
-* To display a loading spinner with a button, use the [SpinnerButton](./spinner-button) component.
+- To group buttons together, use the [ButtonGroup](./button-group) component.
+- To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
+- To display a loading spinner with a button, use the [SpinnerButton](./spinner-button) component.

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -4,7 +4,7 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 
 /**

--- a/client/components/chart/bar-tooltip.jsx
+++ b/client/components/chart/bar-tooltip.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default class ChartBarTooltip extends React.PureComponent {
 	static propTypes = {

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';

--- a/client/components/community-translator/translatable.jsx
+++ b/client/components/community-translator/translatable.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/date-picker/event.jsx
+++ b/client/components/date-picker/event.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -8,7 +8,7 @@ import { noop, isNil, isNull, has } from 'lodash';
 import { DateUtils } from 'react-day-picker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize, moment } from 'i18n-calypso';
 
 /**

--- a/client/components/date-range/test/__snapshots__/index.js.snap
+++ b/client/components/date-range/test/__snapshots__/index.js.snap
@@ -41,11 +41,10 @@ exports[`DateRange should render 1`] = `
           className="date-range__info"
           role="status"
         >
-          <t
+          <Memo([object Object])
             aria-hidden="true"
             icon="info"
             key="interpolation-child-1/.0"
-            size={24}
           />
            Please select the 
           <em

--- a/client/components/date-range/trigger.js
+++ b/client/components/date-range/trigger.js
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize, moment } from 'i18n-calypso';
 
 /**

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get, isNumber, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import page from 'page';
 

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { isEqual, pick } from 'lodash';
 

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -5,7 +5,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React, { Component } from 'react';
 import { includes, isEqual, pick } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 
 /**

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { endsWith, get, isEmpty, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import page from 'page';
 import { stringify } from 'qs';
 import formatCurrency from '@automattic/format-currency';

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { identity, includes, noop, without } from 'lodash';
 

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { string, node } from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { assign, omit } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/components/external-link/test/index.js
+++ b/client/components/external-link/test/index.js
@@ -5,7 +5,7 @@
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 
 /**

--- a/client/components/focusable/docs/example.jsx
+++ b/client/components/focusable/docs/example.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { noop } from 'lodash';
 
 /**

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -15,7 +15,7 @@ import { noop } from 'lodash';
  */
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import ScreenReaderText from 'components/screen-reader-text';
 
 /**

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { find, get } from 'lodash';
 
 /**

--- a/client/components/forms/form-input-validation/index.jsx
+++ b/client/components/forms/form-input-validation/index.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { omit } from 'lodash';
 

--- a/client/components/forms/range/docs/example.jsx
+++ b/client/components/forms/range/docs/example.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/forms/range/test/index.jsx
+++ b/client/components/forms/range/test/index.jsx
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import ReactDom from 'react-dom';

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 import { assign, findIndex, fromPairs, noop } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -10,7 +10,7 @@ import page from 'page';
 import { identity, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 
 /**

--- a/client/components/happychat/title.jsx
+++ b/client/components/happychat/title.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import GridIcon from 'gridicons';
+import GridIcon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/header-button/index.jsx
+++ b/client/components/header-button/index.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { throttle } from 'lodash';
 
 /**

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/jetpack-header/partner-logo-group.jsx
+++ b/client/components/jetpack-header/partner-logo-group.jsx
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/components/list-end/index.js
+++ b/client/components/list-end/index.js
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import { localizeUrl } from 'lib/i18n-utils';
 import safeProtocolUrl from 'lib/safe-protocol-url';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/mobile-back-to-sidebar/index.jsx
+++ b/client/components/mobile-back-to-sidebar/index.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 // which makes Calypso mysteriously crash at the moment.
 //
 // eslint-disable-next-line no-restricted-imports
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/pagination/pagination-page.jsx
+++ b/client/components/pagination/pagination-page.jsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';

--- a/client/components/phone-input/country-flag.jsx
+++ b/client/components/phone-input/country-flag.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/components/plans/plans-skip-button/index.jsx
+++ b/client/components/plans/plans-skip-button/index.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/plans/plans-skip-button/test/__snapshots__/index.jsx.snap
+++ b/client/components/plans/plans-skip-button/test/__snapshots__/index.jsx.snap
@@ -8,7 +8,7 @@ exports[`PlansSkipButton should render 1`] = `
     type="button"
   >
     Start with free
-    <t
+    <Memo([object Object])
       icon="arrow-right"
       size={18}
     />

--- a/client/components/podcast-indicator/index.jsx
+++ b/client/components/podcast-indicator/index.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { noop, omit } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/post-schedule/header-controls.jsx
+++ b/client/components/post-schedule/header-controls.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Globals

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { noop } from 'lodash';
 
 /**

--- a/client/components/purchase-detail/tip-info.jsx
+++ b/client/components/purchase-detail/tip-info.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { times } from 'lodash';
 import classNames from 'classnames';
 

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';

--- a/client/components/remove-button/test/index.js
+++ b/client/components/remove-button/test/index.js
@@ -4,7 +4,7 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { identity, noop } from 'lodash';
 import React from 'react';
 import { spy } from 'sinon';

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -20,7 +20,7 @@ import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import QueryRewindState from 'components/data/query-rewind-state';
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
 import { getSiteSlug } from 'state/sites/selectors';

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { debounce, noop, uniqueId } from 'lodash';
 import i18n from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { includes } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -5,7 +5,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { filter, find, get, noop } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/sidebar-navigation/README.md
+++ b/client/components/sidebar-navigation/README.md
@@ -1,5 +1,4 @@
-Sidebar Navigation
-==================
+# Sidebar Navigation
 
 This component is used to display the mobile sidebar navigation header at the top of content sections. It sets `layout-focus` to `sidebar`.
 
@@ -9,7 +8,7 @@ Put the component in your `Main` component, and wrap it around any components yo
 
 ```js
 import SidebarNavigation from 'components/sidebar-navigation';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicons';
 
 
 render() {

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { noop, get } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/sub-masterbar-nav/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/dropdown.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import Item from './item';
 
 const OptionShape = PropTypes.shape( {

--- a/client/components/sub-masterbar-nav/item.jsx
+++ b/client/components/sub-masterbar-nav/item.jsx
@@ -12,7 +12,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export const Item = props => {
 	const { isSelected, onClick, label, icon, href } = props;

--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import Item from './item';
 
 const SIDE_PADDING = 50;

--- a/client/components/sub-masterbar-nav/test/item.jsx
+++ b/client/components/sub-masterbar-nav/test/item.jsx
@@ -5,7 +5,7 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 
 /**

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { escapeRegExp, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/thank-you-card/index.jsx
+++ b/client/components/thank-you-card/index.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { get, isEmpty, isEqual, noop, some } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import photon from 'photon';
 

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isFunction, map } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/tinymce/plugins/contact-form/dialog/field-edit-button.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-edit-button.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/tinymce/plugins/contact-form/dialog/field-remove-button.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-remove-button.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -25,11 +25,9 @@ exports[`TokenField render should render tokens 1`] = `
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <g>
-          <path
-            d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"
-          />
-        </g>
+        <use
+          href="gridicons.svg#gridicons-cross-small"
+        />
       </svg>
     </span>
     <span
@@ -48,11 +46,9 @@ exports[`TokenField render should render tokens 1`] = `
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <g>
-          <path
-            d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"
-          />
-        </g>
+        <use
+          href="gridicons.svg#gridicons-cross-small"
+        />
       </svg>
     </span>
     <input

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/components/version/index.jsx
+++ b/client/components/version/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -12,7 +12,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { partial } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { useTranslate } from 'i18n-calypso';
 
 /**

--- a/client/devdocs/design/component-playground.jsx
+++ b/client/devdocs/design/component-playground.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-export { default as Gridicon } from 'gridicons';
+export { default as Gridicon } from 'components/gridicon';
 
 /**
  * Docs examples

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isNaN } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';

--- a/client/extensions/woocommerce/app/order/header.js
+++ b/client/extensions/woocommerce/app/order/header.js
@@ -4,7 +4,7 @@
  */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';

--- a/client/extensions/woocommerce/app/order/order-activity-log/event.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/event.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import formatCurrency from '@automattic/format-currency';

--- a/client/extensions/woocommerce/app/order/order-created/index.js
+++ b/client/extensions/woocommerce/app/order/order-created/index.js
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 import { withLocalizedMoment } from 'components/localized-moment';

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -5,7 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { every, find, findIndex, get, isNaN, noop } from 'lodash';
 import formatCurrency from '@automattic/format-currency';

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -8,7 +8,7 @@ import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { first, includes } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { isNumber, head, isNull } from 'lodash';
 

--- a/client/extensions/woocommerce/app/product-categories/header.js
+++ b/client/extensions/woocommerce/app/product-categories/header.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isObject } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { debounce, find } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { isNumber, noop } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { head } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isObject } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isObject, noop } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/reviews/review-actions-bar.js
+++ b/client/extensions/woocommerce/app/reviews/review-actions-bar.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 

--- a/client/extensions/woocommerce/app/reviews/review-card.js
+++ b/client/extensions/woocommerce/app/reviews/review-card.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/reviews/review-reply.js
+++ b/client/extensions/woocommerce/app/reviews/review-reply.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/getting-started.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/getting-started.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/log-into-mailchimp.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/log-into-mailchimp.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 
 /**

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { isNumber } from 'lodash';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isEmpty, startsWith } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -10,7 +10,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { find, isEmpty, round } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isArray } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -8,7 +8,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { every, find, isEmpty, trim } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/components/bulk-select/index.js
+++ b/client/extensions/woocommerce/components/bulk-select/index.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 const BulkSelect = ( {
 	className,

--- a/client/extensions/woocommerce/components/dashboard-widget/index.js
+++ b/client/extensions/woocommerce/components/dashboard-widget/index.js
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isUndefined, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { includes } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { noop, omit } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 import { getCurrencyObject } from '@automattic/format-currency';

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { head, find, noop, trim, uniqueId } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/components/table/docs/example.js
+++ b/client/extensions/woocommerce/components/table/docs/example.js
@@ -13,7 +13,7 @@ import Button from 'components/button';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 
 class Example extends Component {

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import Site from 'blocks/site';
 
 const StoreGroundControl = ( { site, translate } ) => {

--- a/client/extensions/woocommerce/woocommerce-services/components/checkbox/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/checkbox/index.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { omit } from 'lodash';
 
 const Checkbox = props => {

--- a/client/extensions/woocommerce/woocommerce-services/components/field-error/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/field-error/index.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 const FieldError = ( { text, type = 'input-validation' } ) => {
 	return (

--- a/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/index.js
@@ -5,7 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -10,7 +10,7 @@ import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { find, isBoolean } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { concat, difference, flatten, map } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/packages-list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/packages-list-item.js
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { trim } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 const PackagesListItem = ( {

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { snakeCase } from 'lodash';
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 const TRACKING_URL_MAP = {
 	usps: tracking => `https://tools.usps.com/go/TrackConfirmAction.action?tLabels=${ tracking }`,

--- a/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { pick } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/extensions/wp-super-cache/components/easy/index.jsx
+++ b/client/extensions/wp-super-cache/components/easy/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { flowRight, get, isEmpty, pick } from 'lodash';
 
 /**

--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -5,7 +5,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 

--- a/client/jetpack-connect/skip-button.js
+++ b/client/jetpack-connect/skip-button.js
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class SkipButton extends PureComponent {

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugModule from 'debug';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { flowRight, get, map } from 'lodash';

--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { localizeUrl } from 'lib/i18n-utils';
 

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { get, map, noop, without } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import i18n, { localize } from 'i18n-calypso';
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 

--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { useTranslate } from 'i18n-calypso';
 
 // Returns React component with a localized label and optional icon

--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-about-page-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour/index.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour/index.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-domain-register-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-domain-register-tour/index.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour/index.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { delay, negate as not } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour/index.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/editor-basics-tour/index.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour/index.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/guided-tours/tours/simple-payments-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { isFunction, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import TranslatableString from 'components/translatable/proptype';
 
 class MasterbarItem extends Component {

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isFunction } from 'lodash';
 
 /**

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -23,7 +23,7 @@ import {
 	enhanceWithSiteType,
 } from 'state/analytics/actions';
 import { withEnhancers } from 'state/utils';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class EmailedLoginLinkSuccessfully extends React.Component {
 	static propTypes = {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -31,7 +31,7 @@ import { withEnhancers } from 'state/utils';
 import Main from 'components/main';
 import RequestLoginEmailForm from './request-login-email-form';
 import GlobalNotices from 'components/global-notices';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { startCase } from 'lodash';

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -6,7 +6,7 @@
 
 import page from 'page';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import page from 'page';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classnames from 'classnames';

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -10,7 +10,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';

--- a/client/me/help/help-contact-confirmation/index.jsx
+++ b/client/me/help/help-contact-confirmation/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { debounce, isEqual, find, isEmpty, isArray } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { decodeEntities } from 'lib/formatting';
 
 /**

--- a/client/me/help/help-teaser-button.jsx
+++ b/client/me/help/help-teaser-button.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -20,7 +20,7 @@ import QueryMembershipsSubscriptions from 'components/data/query-memberships-sub
 import HeaderCake from 'components/header-cake';
 import { purchasesRoot } from '../purchases/paths';
 import Site from 'blocks/site';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import CompactCard from 'components/card/compact';
 import { requestSubscriptionStop } from 'state/memberships/subscriptions/actions';
 import Notice from 'components/notice';

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { countBy, map, omit, values, flatten } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */

--- a/client/me/notification-settings/blogs-settings/placeholder.jsx
+++ b/client/me/notification-settings/blogs-settings/placeholder.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/notification-settings/settings-form/stream-header.jsx
+++ b/client/me/notification-settings/settings-form/stream-header.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { localize, moment } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';

--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -42,7 +42,7 @@ import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '..
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getCanonicalTheme } from 'state/themes/selectors';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
 import {
 	isPersonal,

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -32,7 +32,7 @@ import {
 } from 'lib/products-values';
 import Notice from 'components/notice';
 import PlanIcon from 'components/plans/plan-icon';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { managePurchase } from '../paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { getPlanTermLabel } from 'lib/plans';

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -7,7 +7,7 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import Clipboard from 'clipboard';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { saveAs } from 'browser-filesaver';
 import { flowRight as compose } from 'lodash';
 

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-progress' );
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default class extends React.Component {
 	static displayName = 'Security2faProgressItem';

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -13,7 +13,7 @@ import React from 'react';
  */
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormButton from 'components/forms/form-button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class SecurityAccountRecoveryManageContactButtons extends React.Component {
 	static displayName = 'SecurityAccountRecoveryManageContactButtons';

--- a/client/my-sites/activity/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/error-banner.jsx
@@ -14,7 +14,7 @@ import { isUndefined } from 'lodash';
 import ActivityLogBanner from './index';
 import Button from 'components/button';
 import HappychatButton from 'components/happychat/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';

--- a/client/my-sites/activity/activity-log-banner/index.jsx
+++ b/client/my-sites/activity/activity-log-banner/index.jsx
@@ -14,7 +14,7 @@ import { noop } from 'lodash';
  */
 import Card from 'components/card';
 import ScreenReaderText from 'components/screen-reader-text';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { flowRight as compose } from 'lodash';
 
 /**

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -14,7 +14,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import FormLabel from 'components/forms/form-label';
 import FormCheckbox from 'components/forms/form-checkbox';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import HappychatButton from 'components/happychat/button';
 import { recordTracksEvent } from 'state/analytics/actions';
 

--- a/client/my-sites/activity/activity-log-item/activity-actor-icon.jsx
+++ b/client/my-sites/activity/activity-log-item/activity-actor-icon.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default class ActivityActorIcon extends PureComponent {
 	static propTypes = {

--- a/client/my-sites/activity/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/activity/activity-log-item/activity-icon.jsx
@@ -5,7 +5,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default class ActivityIcon extends PureComponent {
 	static propTypes = {

--- a/client/my-sites/activity/activity-log-item/activity-media.jsx
+++ b/client/my-sites/activity/activity-log-item/activity-media.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default class ActivityMedia extends PureComponent {
 	static propTypes = {

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -20,7 +20,7 @@ import ActivityMedia from './activity-media';
 import ActivityIcon from './activity-icon';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import EllipsisMenu from 'components/ellipsis-menu';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import HappychatButton from 'components/happychat/button';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { concat, without, isEmpty, find } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -6,7 +6,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isEmpty, flowRight as compose } from 'lodash';
 import { DateUtils } from 'react-day-picker';
 

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';

--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Children, Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 import { getCurrencyObject } from '@automattic/format-currency';
 

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -10,7 +10,7 @@ import createReactClass from 'create-react-class';
 import { reject } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop, overSome, some } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
@@ -12,7 +12,7 @@ import { get, map, reduce } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import {
 	getDomainRegistrations,
 	getDomainTransfers,

--- a/client/my-sites/checkout/checkout/domain-registration-hsts.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-hsts.jsx
@@ -11,7 +11,7 @@ import { isEmpty, join, merge, reduce } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { getDomainRegistrations, getDomainTransfers } from 'lib/cart-values/cart-items';
 import { HTTPS_SSL } from 'lib/url/support';
 import { getProductsList } from 'state/products-list/selectors';

--- a/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import { REFUNDS } from 'lib/url/support';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { hasDomainBeingUsedForPlan, hasDomainRegistration } from 'lib/cart-values/cart-items';
 
 class DomainRegistrationRefundPolicy extends React.Component {

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { snakeCase, includes } from 'lodash';
 
 /**

--- a/client/my-sites/checkout/checkout/payment-chat-button.jsx
+++ b/client/my-sites/checkout/checkout/payment-chat-button.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -7,7 +7,7 @@
 import { localize } from 'i18n-calypso';
 import { assign, overSome, some } from 'lodash';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/checkout/pending-payment-blocker.jsx
+++ b/client/my-sites/checkout/checkout/pending-payment-blocker.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -6,7 +6,7 @@
 import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { snakeCase, map, zipObject, isEmpty, mapValues, overSome, some } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/checkout/terms-of-service.jsx
+++ b/client/my-sites/checkout/checkout/terms-of-service.jsx
@@ -15,7 +15,7 @@ import {
 	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,
 	MANAGE_PURCHASES_FAQ_CANCELLING,
 } from 'lib/url/support';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localizeUrl } from 'lib/i18n-utils';
 
 class TermsOfService extends React.Component {

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import config from 'config';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import debugFactory from 'debug';
 import { overSome, some } from 'lodash';
 

--- a/client/my-sites/checkout/checkout/wechat-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-box.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { each, get, includes, isEqual, isUndefined, map } from 'lodash';
 

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { get, includes, isEqual, isUndefined, noop } from 'lodash';
 

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 
 /**

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get, isEqual } from 'lodash';
 
 /**

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 
 /**

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -6,7 +6,7 @@ import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get, noop, pick } from 'lodash';
 
 /**

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 
 /**

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Fragment, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';

--- a/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
+++ b/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get } from 'lodash';

--- a/client/my-sites/domains/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { endsWith } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -7,7 +7,7 @@
  */
 import { connect } from 'react-redux';
 import { find, findIndex, get, identity, noop, times } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import page from 'page';
 import React from 'react';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/my-sites/email/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-item.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/client/my-sites/email/email-forwarding/test/__snapshots__/email-forwarding-item.js.snap
+++ b/client/my-sites/email/email-forwarding/test/__snapshots__/email-forwarding-item.js.snap
@@ -14,11 +14,9 @@ exports[`EmailForwardingItem it renders EmailForwardingItem correctly 1`] = `
       width={24}
       xmlns="http://www.w3.org/2000/svg"
     >
-      <g>
-        <path
-          d="M6.187 8h11.625l-.695 11.125C17.05 20.18 16.177 21 15.12 21H8.88c-1.057 0-1.93-.82-1.997-1.875L6.187 8zM19 5v2H5V5h3V4c0-1.105.895-2 2-2h4c1.105 0 2 .895 2 2v1h3zm-9 0h4V4h-4v1z"
-        />
-      </g>
+      <use
+        xlinkHref="gridicons.svg#gridicons-trash"
+      />
     </svg>
   </button>
   <button
@@ -34,11 +32,9 @@ exports[`EmailForwardingItem it renders EmailForwardingItem correctly 1`] = `
       width={24}
       xmlns="http://www.w3.org/2000/svg"
     >
-      <g>
-        <path
-          d="M20 4H4c-1.105 0-2 .895-2 2v12c0 1.105.895 2 2 2h16c1.105 0 2-.895 2-2V6c0-1.105-.895-2-2-2zm0 4.236l-8 4.882-8-4.882V6h16v2.236z"
-        />
-      </g>
+      <use
+        xlinkHref="gridicons.svg#gridicons-mail"
+      />
     </svg>
   </button>
   <span>

--- a/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
@@ -39,11 +39,9 @@ exports[`GSuiteUserItem renders user item with manage correctly 1`] = `
       width={18}
       xmlns="http://www.w3.org/2000/svg"
     >
-      <g>
-        <path
-          d="M19 13v6c0 1.105-.895 2-2 2H5c-1.105 0-2-.895-2-2V7c0-1.105.895-2 2-2h6v2H5v12h12v-6h2zM13 3v2h4.586l-7.793 7.793 1.414 1.414L19 6.414V11h2V3h-8z"
-        />
-      </g>
+      <use
+        xlinkHref="gridicons.svg#gridicons-external"
+      />
     </svg>
     <span
       className="screen-reader-text"

--- a/client/my-sites/exporter/guided-transfer-card/in-progress.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/in-progress.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';

--- a/client/my-sites/feature-upsell/feature.jsx
+++ b/client/my-sites/feature-upsell/feature.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { noop } from 'lodash';
 
 /**

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { flowRight } from 'lodash';
 import { getCurrencyObject } from '@automattic/format-currency';
 

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { getCurrencyObject } from '@automattic/format-currency';
 
 /**

--- a/client/my-sites/google-my-business/location/index.js
+++ b/client/my-sites/google-my-business/location/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -5,7 +5,7 @@
  */
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';

--- a/client/my-sites/guided-transfer/transfer-unavailable-card.jsx
+++ b/client/my-sites/guided-transfer/transfer-unavailable-card.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { defer } from 'lodash';
 

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { defer, flow, get, includes, noop, truncate } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/marketing/buttons/preview-action.jsx
+++ b/client/my-sites/marketing/buttons/preview-action.jsx
@@ -12,7 +12,7 @@ import { omit, startsWith, endsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 const SharingButtonsPreviewAction = props => {
 	const { active, position, icon, children } = props;

--- a/client/my-sites/marketing/buttons/preview-placeholder.jsx
+++ b/client/my-sites/marketing/buttons/preview-placeholder.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/marketing/connections/account-dialog-account.jsx
+++ b/client/my-sites/marketing/connections/account-dialog-account.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/marketing/connections/service-placeholder.jsx
+++ b/client/my-sites/marketing/connections/service-placeholder.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
-import GridIcon from 'gridicons';
+import GridIcon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/marketing/connections/service-tip.jsx
+++ b/client/my-sites/marketing/connections/service-tip.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { identity, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Module constants

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { find, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { debounce } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/media-library/list-item-file-details.jsx
+++ b/client/my-sites/media-library/list-item-file-details.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -12,7 +12,7 @@ import photon from 'photon';
  * Internal dependencies
  */
 import ListItemFileDetails from './list-item-file-details';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { MEDIA_IMAGE_THUMBNAIL } from 'lib/media/constants';
 
 /**

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { debounce, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { noop } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 /**

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { flowRight, isEqual, size, without } from 'lodash';
 
 /**

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -15,7 +15,7 @@ import { flow, get, includes, noop, partial } from 'lodash';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Notice from 'components/notice';

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -15,7 +15,7 @@ import { connect } from 'react-redux';
 import Card from 'components/card';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -10,7 +10,7 @@ import React, { Component } from 'react';
 import deterministicStringify from 'json-stable-stringify';
 import { omit } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 
 /**

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/plan-compare-card/index.jsx
+++ b/client/my-sites/plan-compare-card/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plan-compare-card/item.jsx
+++ b/client/my-sites/plan-compare-card/item.jsx
@@ -7,7 +7,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default class PlanCompareCardItem extends React.Component {
 	static propTypes = {

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { clamp, inRange, range, round } from 'lodash';
 import classNames from 'classnames';
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { parse as parseUrl } from 'url';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React, { Component, Fragment } from 'react';
 
 /**

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get, isEmpty } from 'lodash';
 
 /**

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import titleCase from 'to-title-case';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -12,7 +12,7 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PluginsActions from 'lib/plugins/actions';
 
 /**

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { flowRight as compose, includes } from 'lodash';
 
 /**

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -11,7 +11,7 @@ import { times } from 'lodash';
  */
 import PluginBrowserItem from 'my-sites/plugins/plugins-browser-item';
 import Card from 'components/card';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import SectionHeader from 'components/section-header';
 
 /**

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { withLocalizedMoment } from 'components/localized-moment';
 
 /**

--- a/client/my-sites/post-selector/search.jsx
+++ b/client/my-sites/post-selector/search.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class PostSelectorSearch extends React.Component {
 	static displayName = 'PostSelectorSearch';

--- a/client/my-sites/post-type-list/bulk-edit-bar.jsx
+++ b/client/my-sites/post-type-list/bulk-edit-bar.jsx
@@ -16,7 +16,7 @@ import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
 import { isMultiSelectEnabled, getSelectedPostsCount } from 'state/ui/post-type-list/selectors';
 import { toggleMultiSelect } from 'state/ui/post-type-list/actions';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -21,7 +21,7 @@ import getEditorUrl from 'state/selectors/get-editor-url';
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import {
 	showInlineHelpPopover,

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import config from 'config';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -10,7 +10,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import FoldableCard from 'components/foldable-card';
 import CompactCard from 'components/card/compact';
 import RewindCredentialsForm from 'components/rewind-credentials-form';

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-start.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-start.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 const SetupStart = ( { goToNextStep, translate } ) => (
 	<CompactCard className="credentials-setup-flow__setup-start" onClick={ goToNextStep }>

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import Button from 'components/button';
 import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
 import getRewindState from 'state/selectors/get-rewind-state';

--- a/client/my-sites/site-settings/manage-connection/ownership-information.jsx
+++ b/client/my-sites/site-settings/manage-connection/ownership-information.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
+++ b/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import PressThisLink from './link';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -19,7 +19,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import { getSelectedSiteId } from 'state/ui/selectors';

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { get, isUndefined } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/info-panel/index.jsx
+++ b/client/my-sites/stats/info-panel/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-detail-months/index.jsx
+++ b/client/my-sites/stats/stats-detail-months/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-list/action-follow.jsx
+++ b/client/my-sites/stats/stats-list/action-follow.jsx
@@ -18,7 +18,7 @@ const debug = debugFactory( 'calypso:stats:action-follow' );
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 const StatsActionFollow = createReactClass( {
 	displayName: 'StatsActionFollow',

--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-list/action-page.jsx
+++ b/client/my-sites/stats/stats-list/action-page.jsx
@@ -14,7 +14,7 @@ const debug = debugFactory( 'calypso:stats:action-page' );
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class StatsActionPage extends React.Component {
 	static displayName = 'StatsActionPage';

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -15,7 +15,7 @@ const debug = debugFactory( 'calypso:stats:action-spam' );
  */
 import wpcom from 'lib/wp';
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class StatsActionSpam extends React.Component {
 	static displayName = 'StatsActionSpam';

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import page from 'page';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/stats/stats-module/availability-warning.tsx
+++ b/client/my-sites/stats/stats-module/availability-warning.tsx
@@ -3,7 +3,7 @@
  */
 import React, { FunctionComponent } from 'react';
 import moment from 'moment';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize, LocalizeProps } from 'i18n-calypso';
 
 interface Props {

--- a/client/my-sites/stats/stats-module/header.jsx
+++ b/client/my-sites/stats/stats-module/header.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-overview-placeholder/index.jsx
+++ b/client/my-sites/stats/stats-overview-placeholder/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import qs from 'qs';
 

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 class StatsTabsTab extends React.Component {
 	static displayName = 'StatsTabsTab';

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import PropTypes from 'prop-types';
 import Card from 'components/card';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getWordAdsEarnings } from 'state/wordads/earnings/selectors';
 import QueryWordadsEarnings from 'components/data/query-wordads-earnings';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import i18n, { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import titlecase from 'to-title-case';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { head, split } from 'lodash';
 import photon from 'photon';
 import page from 'page';

--- a/client/my-sites/theme/theme-download-card/index.jsx
+++ b/client/my-sites/theme/theme-download-card/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/current-theme/button.jsx
+++ b/client/my-sites/themes/current-theme/button.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 export default class extends React.Component {
 	static displayName = 'CurrentThemeButton';

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
 import { translate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { compact, pickBy } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/themes-banner/index.jsx
+++ b/client/my-sites/themes/themes-banner/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -10,7 +10,7 @@ import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import { intersection, difference, includes, flowRight as compose } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop, intersection } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-action-bar/view-link.jsx
+++ b/client/post-editor/editor-action-bar/view-link.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { get, isNull } from 'lodash';
 
 /**

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { debounce, filter, first, flow, get, has, last, map, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-drawer-well/index.jsx
+++ b/client/post-editor/editor-drawer-well/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies

--- a/client/post-editor/editor-featured-image/dropzone.jsx
+++ b/client/post-editor/editor-featured-image/dropzone.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { head, uniqueId } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
 

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, some } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -8,7 +8,7 @@ import { identity, noop, get, findLast } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { get, map, reduce, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { Env } from 'tinymce/tinymce';
 
 /**

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-page-slug/index.jsx
+++ b/client/post-editor/editor-page-slug/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import { get, map } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -10,7 +10,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { intersection } from 'lodash';
 
 /**

--- a/client/post-editor/editor-revisions-list/navigation.jsx
+++ b/client/post-editor/editor-revisions-list/navigation.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import { includes } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { includes, map } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { flow } from 'lodash';
 
 /**

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-term-selector/add-term.jsx
+++ b/client/post-editor/editor-term-selector/add-term.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { find, get } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { flowRight, get, includes, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import url from 'url';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/media-modal/detail/detail-preview-document.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-document.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
 export default class extends React.Component {

--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import { reject } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { values, noop, some, every, flow, partial, pick } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 
 /**

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { take, times } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 
 /**

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { map, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal Dependencies

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { sample } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { noop, filter, get, flatMap } from 'lodash';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { get, findLast, findIndex } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 
 /**

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -10,19 +9,17 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { NavigationLink } from '../';
-import EMPTY_COMPONENT from 'components/empty-component';
+import Gridicon from 'components/gridicon';
 
 jest.mock( 'signup/utils', () => ( {
 	getStepUrl: jest.fn(),
 	getFilteredSteps: jest.fn(),
 } ) );
-jest.mock( 'gridicons', () => require( 'components/empty-component' ) );
 
 const signupUtils = require( 'signup/utils' );
 const { getStepUrl, getFilteredSteps } = signupUtils;
 
 describe( 'NavigationLink', () => {
-	const Gridicon = EMPTY_COMPONENT;
 	const props = {
 		flowName: 'test:flow',
 		stepName: 'test:step2',

--- a/client/signup/steps/import-preview/index.jsx
+++ b/client/signup/steps/import-preview/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { isEmpty } from 'lodash';
 
 /**

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
 import { find, get } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/docs/component-readme-template.md
+++ b/docs/component-readme-template.md
@@ -1,5 +1,4 @@
-Component Documentation Template
-===
+# Component Documentation Template
 
 _Use this as a README.md template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point. See the [Button documentation](../design/buttons) for a good example._
 
@@ -13,7 +12,7 @@ Example:
 First, display a `jsx` code block to show an example of usage, including import statements and a React component.
 
 ```jsx
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicons';
 import Button from 'components/button';
 
 export default function RockOnButton() {
@@ -31,39 +30,39 @@ Props are displayed as a table with Name, Type, Default, and Description as head
 
 **Required props are marked with `*`.**
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`compact` | `bool` | `0` | Decreases the size of the button
-`primary`* | `bool` | `0` | Provides extra visual weight and identifies the primary action in a set of buttons
-`borderless` | `bool` | `0` | Renders a button without borders
-`scary` | `bool` | `0` | Indicates a dangerous or potentially negative action
-`busy`* | `bool` | `0` | Indicates activity while a background action is being performed
-`href` | `string` | `0` | If provided, renders `a` instead of `button`
+| Name         | Type     | Default | Description                                                                        |
+| ------------ | -------- | ------- | ---------------------------------------------------------------------------------- |
+| `compact`    | `bool`   | `0`     | Decreases the size of the button                                                   |
+| `primary`\*  | `bool`   | `0`     | Provides extra visual weight and identifies the primary action in a set of buttons |
+| `borderless` | `bool`   | `0`     | Renders a button without borders                                                   |
+| `scary`      | `bool`   | `0`     | Indicates a dangerous or potentially negative action                               |
+| `busy`\*     | `bool`   | `0`     | Indicates activity while a background action is being performed                    |
+| `href`       | `string` | `0`     | If provided, renders `a` instead of `button`                                       |
 
 ### Additional usage information
 
 If the component has many states, or if a technical aspect needs more explanation, use this section. Example:
 
-* **Primary**: Use to highlight the most important actions in any experience. Don’t use more than one primary button in a section or screen to avoid overwhelming customers.
-* **Secondary**: Used most in the interface. Only use another style if a button requires more or less visual weight.
-* **Button with icon**: When words are not enough, icons can be used in buttons to better communicate what the button does.
-* **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
-* **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
-* **Busy**: Use when a button has been pressed and the associated action is in progress.
+- **Primary**: Use to highlight the most important actions in any experience. Don’t use more than one primary button in a section or screen to avoid overwhelming customers.
+- **Secondary**: Used most in the interface. Only use another style if a button requires more or less visual weight.
+- **Button with icon**: When words are not enough, icons can be used in buttons to better communicate what the button does.
+- **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
+- **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
+- **Busy**: Use when a button has been pressed and the associated action is in progress.
 
 ### General guidelines
 
 General guidelines should be a list of tips and best practices. Example:
 
-* Use clear and accurate labels. Use sentence-style capitalization.
-* Lead with strong, concise, and actionable verbs.
-* When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
-* Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.
+- Use clear and accurate labels. Use sentence-style capitalization.
+- Lead with strong, concise, and actionable verbs.
+- When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
+- Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.
 
 ## Related components
 
 This is an unordered list of components that are related in some way. Components are linked to the detail page of that component. Example:
 
-* To group buttons together, use the [ButtonGroup](./button-group) component.
-* To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
-* To display a loading spinner with a button, use the [SpinnerButton](../design/spinner-button) component.
+- To group buttons together, use the [ButtonGroup](./button-group) component.
+- To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
+- To display a loading spinner with a button, use the [SpinnerButton](../design/spinner-button) component.

--- a/packages/calypso-ui/src/screen-reader-text/README.md
+++ b/packages/calypso-ui/src/screen-reader-text/README.md
@@ -1,17 +1,16 @@
-ScreenReaderText (JSX)
-====================
+# ScreenReaderText (JSX)
 
 ScreenReaderText is a component that is invisible on screen, but read out to screen readers. Use this to add context to inputs, buttons, or sections that might be obvious from visual cues but not to a screen reader user.
 
 This idea was pulled from WordPress core, for more background & technical details, see [Hiding text for screen readers with WordPress Core](https://make.wordpress.org/accessibility/2015/02/09/hiding-text-for-screen-readers-with-wordpress-core/)
 
--------
+---
 
 #### How to use:
 
 ```js
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicons';
 import ScreenReaderText from 'components/screen-reader-text';
 
 function ScreenReaderTextExample() {


### PR DESCRIPTION
Rewrites imports to satisfy a new lint rule where

```js
import Gridicon from 'gridicons'
```

becomes 

```js
import Gridicon from 'components/gridicon'
```

## Testing
- Smoke test gridicons in the app.
- [Full e2e tests are passing](https://github.com/Automattic/wp-calypso/pull/36150#issuecomment-531778763)