### PR TITLE
Make the post search placeholder be "Search [POST_TYPE]..."

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { compact, find, flow, includes, reduce } from 'lodash';
+import { compact, find, flow, get, includes, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import { compact, find, flow, includes, reduce } from 'lodash';
 import areAllSitesSingleUser from 'state/selectors/are-all-sites-single-user';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite, getSiteSlug } from 'state/sites/selectors';
+import { getPostType } from 'state/post-types/selectors';
 import { getNormalizedMyPostCounts, getNormalizedPostCounts } from 'state/posts/counts/selectors';
 import { isMultiSelectEnabled } from 'state/ui/post-type-list/selectors';
 import { toggleMultiSelect } from 'state/ui/post-type-list/actions';
@@ -27,7 +28,7 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import AuthorSegmented from './author-segmented';
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -45,6 +46,7 @@ export class PostTypeFilter extends Component {
 			status: PropTypes.string,
 			type: PropTypes.string.isRequired,
 		} ),
+		typeLabel: PropTypes.string,
 		jetpack: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		counts: PropTypes.object,
@@ -146,6 +148,7 @@ export class PostTypeFilter extends Component {
 			siteId,
 			statusSlug,
 			isMultiSelectEnabled: isMultiSelectButtonEnabled,
+			typeLabel,
 		} = this.props;
 
 		if ( ! query ) {
@@ -198,7 +201,11 @@ export class PostTypeFilter extends Component {
 							pinned
 							fitsContainer
 							onSearch={ this.props.doSearch }
-							placeholder={ this.props.translate( 'Search…' ) }
+							placeholder={ this.props.translate( 'Search %(postTypes)s…', {
+								args: {
+									postTypes: typeLabel,
+								},
+							} ) }
 							delaySearch={ true }
 						/>
 					) }
@@ -241,6 +248,7 @@ export default flow(
 
 			return {
 				...props,
+				typeLabel: get( getPostType( state, siteId, query.type ), 'labels.name' ),
 				counts: query.author
 					? getNormalizedMyPostCounts( state, siteId, query.type )
 					: getNormalizedPostCounts( state, siteId, query.type ),


### PR DESCRIPTION
Fixes #36147

Updated the search bar placeholder text to be context-dependent:
- In the "Posts" screen: `Search Posts...`
- In the "Pages" screen: `Search Published/Drafts/etc...` (unchanged, will be updated after https://github.com/Automattic/wp-calypso/issues/36121)
- In the "Testimonials" screen (Testimonials post type needs to be enabled in Jetpack): `Search Testimonials...` 
- In the "Portfolio" screen (Portfolio post type needs to be enabled in Jetpack): `Search Projects...`

Example:
<img width="655" alt="Screenshot 2019-09-15 at 11 28 04" src="https://user-images.githubusercontent.com/1715800/64923865-367cb500-d7ac-11e9-974e-8a6f02a84c03.png">
