### PR TITLE
Reader: Clearer link for Discover and site titles

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -35,7 +35,7 @@
 
 	.reader-feed-header__site-title-link,
 	.reader-feed-header__site-title-link:visited {
-		color: var( --color-neutral-70 );
+		color: var( --color-primary );
 	}
 
 	&::after {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #33747 it was requested that the 'Discover' title should be made to look like a link for clearer discoverability. This PR changes the colour of the title to match the other link colour used within the current theme. 

This also impacts the titles for sites/blogs that appear in the reader.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to WordPress.com
* On the reader page, click "discover"
* On the discover page, does the "Discover" title now look like something you can click?
* Once clicked it goes to https://discover.wordpress.com

Fixes #33747 

Before:

See issue.

After:

<img width="1439" alt="Screenshot 2019-09-15 at 11 27 00" src="https://user-images.githubusercontent.com/411945/64923907-b73bb100-d7ac-11e9-9b34-fa61526b647d.png">

<img width="1438" alt="Screenshot 2019-09-15 at 11 27 28" src="https://user-images.githubusercontent.com/411945/64923908-bdca2880-d7ac-11e9-97d8-a5a7107f2082.png">

<img width="1439" alt="Screenshot 2019-09-15 at 11 34 26" src="https://user-images.githubusercontent.com/411945/64923918-d9353380-d7ac-11e9-9872-2f769f19b194.png">


