### PR TITLE
Update Posts, Pages and Post types to have the full width Main Column

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -101,7 +101,7 @@ class PagesMain extends React.Component {
 			} ),
 		};
 		return (
-			<Main classname="pages">
+			<Main wideLayout classname="pages">
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<DocumentHead title={ translate( 'Site Pages' ) } />
 				<SidebarNavigation />

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -69,7 +69,7 @@ class PostsMain extends React.Component {
 		};
 
 		return (
-			<Main className="posts">
+			<Main wideLayout className="posts">
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<SidebarNavigation />
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -26,7 +26,7 @@ import { getPostType, isPostTypeSupported } from 'state/post-types/selectors';
 
 function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 	return (
-		<Main>
+		<Main wideLayout>
 			<DocumentHead title={ get( postType, 'label' ) } />
 			<PageViewTracker path={ siteId ? '/types/:site' : '/types' } title="Custom Post Type" />
 			<SidebarNavigation />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the width of the main column to be more consistent with the other section in calypso. 

**Posts**
Before:
<img width="1023" alt="Screen Shot 2019-09-15 at 11 25 55 AM" src="https://user-images.githubusercontent.com/115071/64923882-66c45380-d7ac-11e9-86e0-b8231a984ea1.png">
After:
<img width="1052" alt="Screen Shot 2019-09-15 at 11 32 05 AM" src="https://user-images.githubusercontent.com/115071/64923890-822f5e80-d7ac-11e9-87e6-1940cf3d35dc.png">

**Pages**
Before:
<img width="1059" alt="Screen Shot 2019-09-15 at 11 33 16 AM" src="https://user-images.githubusercontent.com/115071/64923915-c7ec2700-d7ac-11e9-8358-de2f20788df2.png">
After:
<img width="942" alt="Screen Shot 2019-09-15 at 11 33 28 AM" src="https://user-images.githubusercontent.com/115071/64923910-c15daf80-d7ac-11e9-8271-839dd3cea17b.png">

**Post types**
Before:
<img width="832" alt="Screen Shot 2019-09-15 at 11 39 23 AM" src="https://user-images.githubusercontent.com/115071/64923982-8c9e2800-d7ad-11e9-882e-7caabc764053.png">

After:
<img width="1044" alt="Screen Shot 2019-09-15 at 11 39 32 AM" src="https://user-images.githubusercontent.com/115071/64923981-8a3bce00-d7ad-11e9-979a-cb4462fb36e9.png">



#### Testing instructions

Go to the posts, pages and custom post type list views in calypso. 


