### PR TITLE
Login form: remove autocorrection

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -11,7 +9,7 @@ import React, { Component, Fragment } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { stringify } from 'qs';
 
 /**
@@ -323,6 +321,9 @@ export class LoginForm extends Component {
 						</label>
 
 						<TextControl
+							autoCapitalize="off"
+							autoCorrect="off"
+							spellCheck="false"
 							label={ this.props.translate( 'Email Address or Username' ) }
 							disabled={ isFormDisabled || this.isPasswordView() }
 							id="usernameOrEmail"
@@ -487,6 +488,8 @@ export class LoginForm extends Component {
 
 						<FormTextInput
 							autoCapitalize="off"
+							autoCorrect="off"
+							spellCheck="false"
 							className={ classNames( {
 								'is-error': requestError && requestError.field === 'usernameOrEmail',
 							} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On the main WordPress.com login form, turn off autocorrection and spelling suggestions.

![autocorrect 2019-09-15 11_50_22](https://user-images.githubusercontent.com/17325/64924164-7ee9a200-d7af-11e9-83fd-3905237d98a2.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Start logged out of WordPress.com at http://calypso.localhost:3000. On an iOS device or in Simulator, try entering the username "bluefuton" and ensure no spelling corrections are offered.

Fixes #36094.
