### PR TITLE
webauthn: Rename all instances of u2f to webauthn

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -99,7 +99,7 @@ class Login extends Component {
 		if ( this.props.twoFactorEnabled ) {
 			let defaultAuthType;
 			if ( this.props.isSecurityKeySupported && this.props.twoFactorNotificationSent !== 'push' ) {
-				defaultAuthType = 'u2f';
+				defaultAuthType = 'webauthn';
 			} else {
 				defaultAuthType = this.props.twoFactorNotificationSent.replace( 'none', 'authenticator' );
 			}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -349,10 +349,10 @@ class Login extends Component {
 			disableAutoFocus,
 		} = this.props;
 
-		if ( twoFactorEnabled && twoFactorAuthType === 'u2f' ) {
+		if ( twoFactorEnabled && twoFactorAuthType === 'webauthn' ) {
 			return (
 				<div>
-					<SecurityKeyForm twoFactorAuthType={ 'u2f' } onSuccess={ this.handleValid2FACode } />
+					<SecurityKeyForm twoFactorAuthType={ 'webauthn' } onSuccess={ this.handleValid2FACode } />
 				</div>
 			);
 		}
@@ -430,7 +430,7 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 		isLinking: getSocialAccountIsLinking( state ),
 		isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
-		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'u2f' ),
+		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'webauthn' ),
 		linkingSocialService: getSocialAccountLinkService( state ),
 		partnerSlug: getPartnerSlugFromQuery( state ),
 		isJetpackWooCommerceFlow:

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -77,7 +77,7 @@ class SecurityKeyForm extends Component {
 					) }
 				</Card>
 
-				<TwoFactorActions twoFactorAuthType={ 'u2f' } />
+				<TwoFactorActions twoFactorAuthType={ 'webauthn' } />
 			</form>
 		);
 	}

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -56,7 +56,7 @@ class TwoFactorActions extends Component {
 	};
 	recordSecurityKey = event => {
 		event.preventDefault();
-		page( login( { isNative: true, twoFactorAuthType: 'u2f' } ) );
+		page( login( { isNative: true, twoFactorAuthType: 'webauthn' } ) );
 	};
 
 	render() {
@@ -71,7 +71,7 @@ class TwoFactorActions extends Component {
 		const isSmsAvailable = isSmsSupported && twoFactorAuthType !== 'sms';
 		const isAuthenticatorAvailable =
 			isAuthenticatorSupported && twoFactorAuthType !== 'authenticator';
-		const isSecurityKeyAvailable = isSecurityKeySupported && twoFactorAuthType !== 'u2f';
+		const isSecurityKeyAvailable = isSecurityKeySupported && twoFactorAuthType !== 'webauthn';
 
 		if ( ! isSmsAvailable && ! isAuthenticatorAvailable && ! isSecurityKeyAvailable ) {
 			return null;
@@ -105,7 +105,7 @@ export default connect(
 	state => ( {
 		isAuthenticatorSupported: isTwoFactorAuthTypeSupported( state, 'authenticator' ),
 		isSmsSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
-		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'u2f' ),
+		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'webauthn' ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -37,7 +37,7 @@ export default router => {
 	if ( config.isEnabled( 'login/wp-login' ) ) {
 		router(
 			[
-				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|u2f)/${ lang }`,
+				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 				`/log-in/:flow(social-connect|private-site)/${ lang }`,
 				`/log-in/:socialService(google)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -176,7 +176,7 @@ export const updateNonce = ( nonceType, twoStepNonce ) => ( {
 } );
 
 export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
-	const twoFactorAuthType = 'u2f';
+	const twoFactorAuthType = 'webauthn';
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 	const loginParams = {
 		user_id: getTwoFactorUserId( getState() ),
@@ -187,7 +187,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 	if ( process.env.NODE_ENV === 'development' ) {
 		loginParams.dev_hostname = 'calypso.localhost';
 	}
-	return postLoginRequest( 'u2f-challenge-endpoint', {
+	return postLoginRequest( 'webauthn-challenge-endpoint', {
 		...loginParams,
 		two_step_nonce: getTwoFactorAuthNonce( getState(), twoFactorAuthType ),
 	} )
@@ -238,7 +238,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				publicKeyCredential.response.userHandle = binToStr( _response.userHandle );
 			}
 
-			return postLoginRequest( 'u2f-authentication-endpoint', {
+			return postLoginRequest( 'webauthn-authentication-endpoint', {
 				...loginParams,
 				client_data: JSON.stringify( publicKeyCredential ),
 			} );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -167,7 +167,7 @@ const twoFactorProperties = [
 	'two_step_nonce_sms',
 	'two_step_nonce_authenticator',
 	'two_step_nonce_push',
-	'two_step_nonce_u2f',
+	'two_step_nonce_webauthn',
 	'user_id',
 ];
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`s/u2f/webauthn/` for the route, various slugs, endpoint names, & expected server responses

#### Testing instructions

* Apply D32775-code
* Sandbox `public-api.wordpress.com` & `wordpress.com`
* Run this branch
* Complete the add, edit, delete key flow
* Complete the login flow using a hardware key

No new errors or brokenness should happen as a result of this change.