### PR TITLE
Gutenberg: Decrease width of snackbar notices in mobile screens

### DIFF
--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -3,6 +3,10 @@
 	.is-iframed #wpbody {
 		padding-top: 0;
 	}
+
+	.is-iframed .components-editor-notices__snackbar {
+		padding-right: 80px;
+	}
 }
 
 @media ( min-width: 600px ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Decreases the width of the snackbar notices when the block editor is viewed from a mobile device, so it doesn't overlap with the inline help.

| Before | After |
|---|---|
| <img width="294" alt="Screen Shot 2019-09-15 at 12 44 28" src="https://user-images.githubusercontent.com/1233880/64924827-ac861980-d7b6-11e9-93ce-831d3b6367e7.png"> | <img width="183" alt="Screen Shot 2019-09-15 at 12 39 58" src="https://user-images.githubusercontent.com/1233880/64924830-b6a81800-d7b6-11e9-8a50-8eb064674dc5.png"> |

#### Testing instructions

* Apply D32840-code to your sandbox.
* Sandbox `widgets.wp.com`.
* Open an existing post with the block editor.
* Make sure your browser width matches a mobile viewport.
* Add some edits and publish the post.
* Make sure the snackbar notice doesn't overlap with the inline help.
* Make sure the snackbar has a full width when the editor is no iframed (WP Admin)

Fixes #35426
