### PR TITLE
Fix site clone point styling

### DIFF
--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -312,6 +312,7 @@
 
 .activity-log-item__action {
 	display: flex;
+	justify-content: flex-end;
 
 	@include breakpoint( '<480px' ) {
 		margin-top: 16px;
@@ -331,6 +332,10 @@
 			transform: translateY( -50% );
 		}
 	}
+}
+
+.activity-log-item__clone-action {
+	flex-shrink: 0;
 }
 
 .activity-log-item__help-action {

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -12,6 +12,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { applySiteOffset } from 'lib/site/timezone';
+import Card from 'components/card';
 import ActivityLogItem from 'my-sites/activity/activity-log-item';
 import Pagination from 'components/pagination';
 import QuerySites from 'components/data/query-sites';
@@ -103,35 +104,37 @@ class ClonePointStep extends Component {
 
 		return (
 			<div>
-				<QuerySites siteId={ siteId } />
-				<QuerySiteSettings siteId={ siteId } />
-				<section className="clone-point__wrapper">
-					{ theseLogs.map( log => (
-						<Fragment key={ log.activityId }>
-							{ timePeriod( log ) }
-							<ActivityLogItem
-								key={ log.activityId }
-								siteId={ siteId }
-								activity={ log }
-								cloneOnClick={ this.selectedPoint }
-								disableRestore
-								disableBackup
-								hideRestore
-								enableClone
-							/>
-						</Fragment>
-					) ) }
-				</section>
-				<Pagination
-					className="clone-point__pagination"
-					key="clone-point-pagination"
-					nextLabel={ translate( 'Older' ) }
-					page={ this.state.currentPage }
-					pageClick={ this.changePage }
-					perPage={ PAGE_SIZE }
-					prevLabel={ translate( 'Newer' ) }
-					total={ logs.length }
-				/>
+				<Card className="clone-point__card">
+					<QuerySites siteId={ siteId } />
+					<QuerySiteSettings siteId={ siteId } />
+					<section className="clone-point__wrapper">
+						{ theseLogs.map( log => (
+							<Fragment key={ log.activityId }>
+								{ timePeriod( log ) }
+								<ActivityLogItem
+									key={ log.activityId }
+									siteId={ siteId }
+									activity={ log }
+									cloneOnClick={ this.selectedPoint }
+									disableRestore
+									disableBackup
+									hideRestore
+									enableClone
+								/>
+							</Fragment>
+						) ) }
+					</section>
+					<Pagination
+						className="clone-point__pagination"
+						key="clone-point-pagination"
+						nextLabel={ translate( 'Older' ) }
+						page={ this.state.currentPage }
+						pageClick={ this.changePage }
+						perPage={ PAGE_SIZE }
+						prevLabel={ translate( 'Newer' ) }
+						total={ logs.length }
+					/>
+				</Card>
 			</div>
 		);
 	}

--- a/client/signup/steps/clone-point/style.scss
+++ b/client/signup/steps/clone-point/style.scss
@@ -1,3 +1,7 @@
+.clone-point__card {
+	background: var( --color-surface-backdrop );
+}
+
 .clone-point__wrapper {
 	position: relative;
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

**Before**
<img width="800" alt="Screenshot 2019-09-15 at 12 50 52" src="https://user-images.githubusercontent.com/7767559/64924904-890f9e80-d7b7-11e9-8e95-a3e96d008753.png">

**After**
<img width="800" alt="Screenshot 2019-09-15 at 12 47 17" src="https://user-images.githubusercontent.com/7767559/64924908-8f9e1600-d7b7-11e9-8c3c-3e07b0c8f3bb.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a non-Atomic site that has Jetpack Backup, for example a Pressable hosted site
* On WordPress.com, go to Settings -> General -> Site Tools -> Clone
* Create a new Jurassic Ninja site at https://jurassic.ninja/create
* Use the Jurassic Ninja site credentials for the clone target
* After saving the credentials in the cloning flow, choose _Clone Previous State_

Expected: the styling should match the screen shot above

**This change affects Activity Log styling, so check that the Activity Log on this branch matches master, specifically the "Action" position on the right of each activity:**
<img width="980" alt="Screenshot 2019-09-15 at 12 58 01 copy" src="https://user-images.githubusercontent.com/7767559/64925007-abee8280-d7b8-11e9-9bb8-4b9a2e372288.png">


