### PR TITLE
Update: is vip check fixes for #36127

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -22,6 +22,7 @@ import { FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES, TYPE_BUSINESS } from 'li
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { getSitePlan, isJetpackSite } from 'state/sites/selectors';
+import isVipSite from 'state/selectors/is-vip-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Banner from 'components/banner';
 import Button from 'components/button';
@@ -42,6 +43,7 @@ export const EligibilityWarnings = ( {
 	hasBusinessPlan,
 	isEligible,
 	isJetpack,
+	isVip,
 	isPlaceholder,
 	onProceed,
 	onCancel,
@@ -62,7 +64,7 @@ export const EligibilityWarnings = ( {
 	} );
 
 	let businessUpsellBanner = null;
-	if ( ! hasBusinessPlan && ! isJetpack ) {
+	if ( ! hasBusinessPlan && ! isJetpack && ! isVip ) {
 		const description = translate(
 			'Also get unlimited themes, advanced customization, no ads, live chat support, and more.'
 		);
@@ -181,6 +183,7 @@ const mapStateToProps = state => {
 	const eligibilityHolds = get( eligibilityData, 'eligibilityHolds', [] );
 	const hasBusinessPlan = ! includes( eligibilityHolds, 'NO_BUSINESS_PLAN' );
 	const isJetpack = isJetpackSite( state, siteId );
+	const isVip = isVipSite( state, siteId );
 	const dataLoaded = !! eligibilityData.lastUpdate;
 	const sitePlan = getSitePlan( state, siteId );
 
@@ -189,6 +192,7 @@ const mapStateToProps = state => {
 		hasBusinessPlan,
 		isEligible,
 		isJetpack,
+		isVip,
 		isPlaceholder: ! dataLoaded,
 		siteId,
 		siteSlug,

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -21,6 +21,7 @@ import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
+import isVipSite from 'state/selectors/is-vip-site';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 
@@ -87,9 +88,11 @@ export class UpgradeNudge extends React.Component {
 			site,
 			title,
 			translate,
+			isVip,
 		} = this.props;
 
 		const shouldNotDisplay =
+			isVip ||
 			! canManageSite ||
 			( ! site || typeof site !== 'object' || typeof site.jetpack !== 'boolean' ) ||
 			( feature && planHasFeature ) ||
@@ -155,6 +158,7 @@ export default connect(
 			site: getSite( state, siteId ),
 			planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 			canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
+			isVip: isVipSite( state, siteId ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -50,7 +50,6 @@ class PostTypeList extends Component {
 		query: PropTypes.object,
 		showPublishedStatus: PropTypes.bool,
 		scrollContainer: PropTypes.object,
-		isVipSite: PropTypes.bool,
 
 		// Connected props
 		siteId: PropTypes.number,
@@ -59,6 +58,7 @@ class PostTypeList extends Component {
 		totalPostCount: PropTypes.number,
 		totalPageCount: PropTypes.number,
 		lastPageToRequest: PropTypes.number,
+		isVip: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -248,7 +248,7 @@ class PostTypeList extends Component {
 	}
 
 	render() {
-		const { query, siteId, isRequestingPosts, translate } = this.props;
+		const { query, siteId, isRequestingPosts, translate, isVip } = this.props;
 		const { maxRequestedPage, recentViewIds } = this.state;
 		const posts = this.props.posts || [];
 		const postStatuses = query.status.split( ',' );
@@ -258,8 +258,8 @@ class PostTypeList extends Component {
 		} );
 		const showUpgradeNudge =
 			siteId &&
-			! this.props.isVipSite &&
 			posts.length > 10 &&
+			! isVip &&
 			query &&
 			( query.type === 'post' || ! query.type ) &&
 			( postStatuses.includes( 'publish' ) || postStatuses.includes( 'private' ) );
@@ -305,7 +305,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		siteId,
 		posts: getPostsForQueryIgnoringPage( state, siteId, ownProps.query ),
-		isVipSite: isVipSite( state, siteId ),
+		isVip: isVipSite( state, siteId ),
 		isRequestingPosts: isRequestingPostsForQueryIgnoringPage( state, siteId, ownProps.query ),
 		totalPostCount: getPostsFoundForQuery( state, siteId, ownProps.query ),
 		totalPageCount,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -29,6 +29,7 @@ import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import isVipSite from 'state/selectors/is-vip-site';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isUserPaid } from 'state/purchases/selectors';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -601,6 +602,7 @@ class ThemeSheet extends React.Component {
 			retired,
 			isPremium,
 			isJetpack,
+			isVip,
 			translate,
 			hasUnlimitedPremiumThemes,
 			previousRoute,
@@ -646,7 +648,7 @@ class ThemeSheet extends React.Component {
 		}
 
 		let pageUpsellBanner, previewUpsellBanner;
-		const hasUpsellBanner = ! isJetpack && isPremium && ! hasUnlimitedPremiumThemes;
+		const hasUpsellBanner = ! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip;
 		if ( hasUpsellBanner ) {
 			pageUpsellBanner = (
 				<Banner
@@ -784,6 +786,7 @@ export default connect(
 			isLoggedIn: !! currentUserId,
 			isActive: isThemeActive( state, id, siteId ),
 			isJetpack: isJetpackSite( state, siteId ),
+			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import i18n, { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import titlecase from 'to-title-case';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import { head, split } from 'lodash';
 import photon from 'photon';
 import page from 'page';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes changes found in code review on https://github.com/Automattic/wp-calypso/pull/36127 as well as removes the banner in the install theme and plugin views.

**Install Plugin** 

Before: 
<img width="774" alt="Screen Shot 2019-09-15 at 12 30 40 PM" src="https://user-images.githubusercontent.com/115071/64924937-d724a200-d7b7-11e9-9458-8a29e7062a64.png">
After:
<img width="796" alt="Screen Shot 2019-09-15 at 12 30 22 PM" src="https://user-images.githubusercontent.com/115071/64924935-d68c0b80-d7b7-11e9-8357-5a8e73317394.png">


**Install theme**
Before: 

<img width="792" alt="Screen Shot 2019-09-15 at 12 30 52 PM" src="https://user-images.githubusercontent.com/115071/64924938-d724a200-d7b7-11e9-9be5-1bb5a3b90875.png">

After:
<img width="801" alt="Screen Shot 2019-09-15 at 12 30 30 PM" src="https://user-images.githubusercontent.com/115071/64924936-d724a200-d7b7-11e9-94c6-09db2608a0f6.png">

**Single Theme:**
Before: 
<img width="873" alt="Screen Shot 2019-09-15 at 2 26 41 PM" src="https://user-images.githubusercontent.com/115071/64925950-c24f0b00-d7c5-11e9-9ed3-47513b8baaa2.png">
After:
<img width="935" alt="Screen Shot 2019-09-15 at 2 30 13 PM" src="https://user-images.githubusercontent.com/115071/64925952-c5e29200-d7c5-11e9-82b2-82bc29089cc7.png">


#### Testing instructions

_Select a VIP site_ 
Go to Manage -> Plugins -> Install Plugin ( click button in the tab bar)  
Notice that the banner is not there any more. 

Go to Design -> Themes -> Install Theme (click button under the filers)
Notice that the banner is not there any more. 

Go to Design -> Theme -> View a premium Theme. 
Notice that the banner is not there any more.

On a regular WordPress free site notice the Banner is still there.

