### PR TITLE
Tests: Fix Jest file-loader imports

### DIFF
--- a/test/server/jest.config.js
+++ b/test/server/jest.config.js
@@ -16,7 +16,9 @@ module.exports = {
 			'@automattic/calypso-build/jest/transform/asset.js'
 		),
 	},
-	transformIgnorePatterns: [ 'node_modules[\\/\\\\](?!redux-form|draft-js)' ],
+	transformIgnorePatterns: [
+		'node_modules[\\/\\\\](?!redux-form|draft-js)(?!.*\\.(?:gif|jpg|jpeg|png|svg|scss|sass|css))',
+	],
 	testMatch: [ '<rootDir>/server/**/test/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	timers: 'fake',
 	setupFiles: [ 'regenerator-runtime/runtime' ], // some NPM-published packages depend on the global


### PR DESCRIPTION
Similar to the issue addressed by #36139, Jest was ignoring `node_modules` file-loader imports rather than transforming them as expected. Fix this to transform `node_modules` file-loader imports.

## Testing
- Server tests pass in #36150  (cherry-picked from there)
- Server tests pass here