### PR TITLE
Calypso color schemes: Fix published SASS

### DIFF
--- a/packages/calypso-color-schemes/.npmignore
+++ b/packages/calypso-color-schemes/.npmignore
@@ -1,4 +1,3 @@
 .eslintrc.js
 bin
 screenshot@2x.png
-src/__color-studio

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
SASS in the published package depends on `src/__color-studio`. Ensure it is published.

## Testing
The published package should include the mentioned directory.