### PR TITLE
SignupForm: Validate username field always

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -237,7 +237,7 @@ class SignupForm extends Component {
 		const fieldsForValidation = filter( [
 			'email',
 			this.state.focusPassword && 'password',
-			this.props.displayUsernameInput && this.state.focusUsername && 'username',
+			this.props.displayUsernameInput && 'username',
 			this.props.displayNameInput && 'firstName',
 			this.props.displayNameInput && 'lastName',
 		] );

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -52,12 +52,7 @@ class InviteAcceptLoggedOut extends React.Component {
 		window.location = signInLink;
 	};
 
-	submitForm = ( form, userData, analyticsData, callback ) => {
-		if ( form.username.value === '' ) {
-			// If user hasn't entered anything, don't try to submit
-			callback();
-			return;
-		}
+	submitForm = ( form, userData ) => {
 		this.setState( { submitting: true } );
 		debug( 'Storing invite_accepted: ' + JSON.stringify( this.props.invite ) );
 		store.set( 'invite_accepted', this.props.invite );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes previous code to bypass error checking when username is empty
* Checks username whether it has focus or not

While reviewing the behavior of `/accept-invite` vs. `/start`, I found that the error displayed `/start` came from a call to `/rest/v1.1/signups/validation/user/` with a blank email address, but the same API was called from `/accept-invite` **with** an email address. All the fieldds should be sent to the API when validating, so I updated `SignupForm` to verify the username, whether or not it has focus.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Invite a new user to a site (there should not be a WordPress.com account connected to the email address)
* Visit the invite link from the email in a private browser window. [This link is one that will work on staging to test](https://calypso.live/accept-invite/144093467/b9d470b12f441f7cd62fd8474e8be304?branch=invite-error-message))
* Without interacting with any other part of the form, click on Sign Up & View 
* Make sure errors display properly
* Ensure error checking and newly invited user behavior has not otherwise been changed
* Ensure signup behavior on `/start` still behaves correctly

Fixes #36146
