### PR TITLE
P2 Autocomplete: Improve search by searching suffixes of name

### DIFF
--- a/apps/o2-blocks/src/p2-autocomplete/editor.js
+++ b/apps/o2-blocks/src/p2-autocomplete/editor.js
@@ -10,29 +10,27 @@ import { map, unescape } from 'lodash';
  */
 import './editor.scss';
 
-/*
- * This is a workaround for the way Gutenberg autocomplete works. It only looks for
- * beginnings of words and something like "teamabcp2" won't be found if you search "abc".
- * Adding spaces around the word solves the problem.
- */
-const COMMON_PREFIXES = /(team|a8c|woo|happiness)/i;
-const stripCommonWords = str => str.replace( COMMON_PREFIXES, ' ' );
+function substrings( name, subs = [ name ] ) {
+	if ( name.length === 0 ) {
+		return subs;
+	}
+
+	const [ , ...t ] = [ ...name ]; // don't accidentally split characters
+	const next = t.join( '' );
+
+	subs.push( next );
+
+	return substrings( next, subs );
+}
 
 const p2s = apiFetch( {
 	path: '/internal/P2s',
 } ).then( result =>
-	map( result.list, ( p2, subdomain ) => {
-		const keywords = [ subdomain ];
-		const stripped = stripCommonWords( subdomain );
-		if ( subdomain !== stripped ) {
-			keywords.push( stripped );
-		}
-		return {
-			...p2,
-			subdomain,
-			keywords,
-		};
-	} )
+	map( result.list, ( p2, subdomain ) => ( {
+		...p2,
+		subdomain,
+		keywords: substrings( subdomain ),
+	} ) )
 );
 
 const p2Completer = {


### PR DESCRIPTION
The first iteration fo the P2 autocomplete only searches the beginning
of the P2 subdomain which leads to oddities like not finding "something"
when searching "thing".

In this iteration we're searching through all suffixes of the name so
that we can find P2s as in this use-case while not resorting to specific
compromises like stripping away a small set of common prefixes.

**Testing**

I have not tested this and I wasn't sure how to test it based on the
instructions in #36092. It would be helpful to have someone help
with this PR by making the testing instructions clearer.

Personally I tested outside of this PR by manually creating the
altered copy of the autocompleter on a local dev sandbox.