### PR TITLE
Build/colors: Update color schemes and SASS pipeline

### DIFF
--- a/client/assets/stylesheets/shared/_utils.scss
+++ b/client/assets/stylesheets/shared/_utils.scss
@@ -1,5 +1,4 @@
 @import '../shared/functions/functions'; // sass functions for z-index, etc.
-@import '~@automattic/calypso-color-schemes/src/shared/colors'; // import all of our wpcom colors
 @import '../shared/typography'; // all the typographic rules, variables, etc.
 @import '../shared/variables'; // other variables
 @import '../shared/mixins/mixins'; // sass mixins for gradients, bordius radii, etc.


### PR DESCRIPTION
This attempt addresses some issues introduced by #35949 by removing the CSS properties imports from the `_utils.scss` stylesheet. This prevents the CSS properties from being repeatedly prepended to each stylesheet.

## Testing
- Test color schemes in calypso https://calypso.live/?branch=update/colors-sass-pipeline-fix
- Test the color scheme picker [in devdocs](https://calypso.live/devdocs/design/color-scheme-picker?branch=update/colors-sass-pipeline-fix)
- I'm not sure whether there are other places that need to be tested. 