### PR TITLE
Hide apple connected account email address in social login settings page on mobile

### DIFF
--- a/client/me/social-login/style.scss
+++ b/client/me/social-login/style.scss
@@ -19,6 +19,12 @@
 	p {
 		margin-bottom: 0;
 	}
+
+	@include breakpoint( '<960px' ) {
+		p {
+			display: none;
+		}
+	}
 }
 .social-login__header-icon {
 	height: 30px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In this PR we hide the email address for mobile users on the social login page to avoid displaying too much information which may push the connect/disconnect button out of the screen.

| Before | After |
| ------- | ----- |
|![Screenshot 2019-09-18 at 18 15 39](https://user-images.githubusercontent.com/230230/65166133-693edb80-da40-11e9-84f7-ae585def49ff.png)|![image](https://user-images.githubusercontent.com/230230/65166278-b15dfe00-da40-11e9-9595-1d893088c916.png)|



#### Testing instructions

* Apply patch or try with calypso.live
* Check that issue #36181 is fixed

Fixes #36181
