### PR TITLE
Fix/36174 search cursor placement

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -95,7 +95,6 @@
 		position: relative;
 		flex: 1 1 auto;
 		display: flex;
-		align-items: center;
 	}
 
 	.search__input[type='search'] {
@@ -105,7 +104,7 @@
 }
 
 .search__input[type='search'] {
-	line-height: 1.5;
+	line-height: 3;
 	flex: 1 1 auto;
 	display: none;
 	z-index: z-index( '.search', '.search__input' );
@@ -155,7 +154,7 @@
 	}
 
 	.search__input {
-		display: flex;
+		display: block;
 	}
 
 	.search__input-fade {

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -95,6 +95,7 @@
 		position: relative;
 		flex: 1 1 auto;
 		display: flex;
+		align-items: center;
 	}
 
 	.search__input[type='search'] {
@@ -104,13 +105,13 @@
 }
 
 .search__input[type='search'] {
+	line-height: 1.5;
 	flex: 1 1 auto;
 	display: none;
 	z-index: z-index( '.search', '.search__input' );
 	top: 0;
 	border: none;
 	border-radius: inherit;
-	height: 100%;
 	background: var( --color-surface );
 	appearance: none;
 	box-sizing: border-box;
@@ -154,10 +155,12 @@
 	}
 
 	.search__input {
-		display: block;
+		display: flex;
 	}
 
 	.search__input-fade {
+		display: flex;
+		align-items: center;
 		flex: 1 1 auto;
 		height: 100%;
 		position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I removed the height: 100% property on the input.  Changed the parent container to flex with center alignment to keep the input in the center of the div.  I also increased the line height of the input to 3 so that a user can still click anywhere in the search box to type in the input instead of having to click directly on the placeholder text.

#### Testing instructions

here is the original link to the issue.  You can run this code and see that the cursor does land where you expect it to on a click.

https://github.com/Automattic/wp-calypso/issues/36174

