### PR TITLE
Update the Looka URL to a better landing page

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -267,7 +267,7 @@ class Home extends Component {
 								iconSrc="/calypso/images/customer-home/images.svg"
 							/>
 							<ActionBox
-								href="https://logojoy.grsm.io/looka"
+								href="https://looka.com/make-a-logo"
 								onClick={ () => trackAction( 'my_site', 'design_logo' ) }
 								label={ translate( 'Design a logo' ) }
 								iconSrc="/calypso/images/customer-home/logo.svg"

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -77,7 +77,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					<Button
 						compact
 						onClick={ handleCreateALogoClick }
-						href="http://logojoy.grsm.io/looka"
+						href="https://looka.com/make-a-logo"
 						target="_blank"
 					>
 						{ translate( 'Create A Logo' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Looka URL is still pointing at the LogoJoy domain. Also a test was
run and it was found that a new landing page converted better. This
change updates the URL to the new one on the two promo cards that refer
to it.

#### Testing instructions

 - Check out and run this branch
 - Place yourself in the customerHome A/B test using the menu in the environment badge, either using the dev environment or wpcalypso. The test group is show.
 - With a site created after the 6th August 2019 go to the go to the 'My Home' page by following the link in the sidebar and check the 'Design a logo' button links to https://looka.com/make-a-logo
 - Go to Tools > Marketing, and check that the 'Create a Logo' button links to the same place
