### PR TITLE
Signup: Better description for site creation flow on the first step

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -98,9 +98,7 @@ class StepWrapper extends Component {
 				return this.props.subHeaderText;
 			}
 
-			return this.props.translate(
-				"Create an account and answer a few questions about what you want to build. We'll start you off with a new site tailored to your choices."
-			);
+			return this.props.translate( 'Welcome to the best place for your WordPress website.' );
 		}
 
 		if ( this.props.fallbackSubHeaderText !== undefined ) {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -99,7 +99,7 @@ class StepWrapper extends Component {
 			}
 
 			return this.props.translate(
-				"Create and account and answer a few questions about what you want to build. We'll start your off with a new site tailored to your choices."
+				"Create an account and answer a few questions about what you want to build. We'll start you off with a new site tailored to your choices."
 			);
 		}
 

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -84,7 +84,7 @@ class StepWrapper extends Component {
 				return this.props.headerText;
 			}
 
-			return this.props.translate( "Let's get started" );
+			return this.props.translate( 'Start your site with WordPress.com' );
 		}
 
 		if ( this.props.fallbackHeaderText !== undefined ) {
@@ -98,7 +98,9 @@ class StepWrapper extends Component {
 				return this.props.subHeaderText;
 			}
 
-			return this.props.translate( 'Welcome to the best place for your WordPress website.' );
+			return this.props.translate(
+				"Create and account and answer a few questions about what you want to build. We'll start your off with a new site tailored to your choices."
+			);
 		}
 
 		if ( this.props.fallbackSubHeaderText !== undefined ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -160,7 +160,7 @@ export class UserStep extends Component {
 
 		if ( positionInFlow === 0 && flowName === 'onboarding' ) {
 			subHeaderText = translate(
-				"Create an account and answer a few questions about what you want to build. We'll start you off with a new site tailored to your choices."
+				'Create an account and answer a few questions about what you want to build, so we can start you off with a custom site.'
 			);
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -159,7 +159,9 @@ export class UserStep extends Component {
 		}
 
 		if ( positionInFlow === 0 && flowName === 'onboarding' ) {
-			subHeaderText = translate( 'First, create your WordPress.com account.' );
+			subHeaderText = translate(
+				"Create an account and answer a few questions about what you want to build. We'll start you off with a new site tailored to your choices."
+			);
 		}
 
 		this.setState( { subHeaderText } );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -137,7 +137,8 @@ body.is-section-signup .layout.gravatar .formatted-header {
 	}
 
 	.formatted-header__subtitle {
-		margin: 0;
+		margin: 0 auto;
+		max-width: 560px;
 		font-size: 15px;
 		color: var( --color-text-inverted );
 	}


### PR DESCRIPTION
This PR changes the title and subtitle of the first step of signup to make for a better introduction to the entire flow. Instead of a generic heading and a subheading specific to the current step, the new heading refers to creating a new site and the subheading describes the entire flow, not just the current step.

Before | After
------ | ------
![screencapture-wordpress-start-user-2019-10-10-15_36_46](https://user-images.githubusercontent.com/426518/66570697-c8db6300-eb76-11e9-8d18-d4392e1a8605.png) | ![screencapture-hash-eb5bc990c97517d0a638aaaad7cf993943806b17-calypso-live-start-user-2019-10-10-15_52_51](https://user-images.githubusercontent.com/426518/66570707-cbd65380-eb76-11e9-80c0-50ffe6f2aa2f.png)


The actual copy changes:

Before:

> Let's get started
>
> First, create your WordPress.com account.

After:

> Start your site with WordPress.com
> 
> Create an account and answer a few questions about what you want to build. We'll start you off with a new site tailored to your choices.

To accommodate the longer subtitle, I also added some CSS to set a `max-width` on the element.

---

See also #36295 which changes the action button and terms, at the bottom of the screen. This is what this screen will look like with changes from both PRs:

Before | After
------ | ------
![before](https://user-images.githubusercontent.com/426518/66303964-e3a6a100-e904-11e9-99f1-7e145536d0fb.png) | ![after](https://user-images.githubusercontent.com/426518/66303969-e5706480-e904-11e9-9a08-aaac63101783.png)
