### PR TITLE
Add Payments team to GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,37 @@
 # Gutenberg editor (Gutenframe)
 /client/gutenberg @Automattic/serenity @Automattic/cylon @Automattic/ajax
 
+# Payments
+/client/blocks/credit-card-form/ @Automattic/payments
+/client/blocks/payment-methods/ @Automattic/payments
+/client/blocks/subscription-length-picker/ @Automattic/payments
+/client/components/credit-card/ @Automattic/payments
+/client/components/credit-card-form-fields/ @Automattic/payments
+/client/components/payment-country-select/ @Automattic/payments
+/client/components/payment-logo/ @Automattic/payments
+/client/lib/cart/ @Automattic/payments
+/client/lib/cart-values/ @Automattic/payments
+/client/lib/checkout/ @Automattic/payments
+/client/lib/siftscience/ @Automattic/payments
+/client/lib/simple-payments/ @Automattic/payments
+/client/lib/store-transactions/ @Automattic/payments
+/client/lib/stripe/ @Automattic/payments
+/client/lib/transaction/ @Automattic/payments
+/client/lib/upgrades/ @Automattic/payments
+/client/me/billing-history/ @Automattic/payments
+/client/me/memberships/ @Automattic/payments
+/client/me/pending-payments/ @Automattic/payments
+/client/me/purchases/ @Automattic/payments
+/client/my-sites/checkout/ @Automattic/payments
+/client/state/billing-transactions/ @Automattic/payments
+/client/state/memberships/ @Automattic/payments
+/client/state/order-transactions/ @Automattic/payments
+/client/state/plans/ @Automattic/payments
+/client/state/receipts/ @Automattic/payments
+/client/state/simple-payments/ @Automattic/payments
+/client/state/stored-cards/ @Automattic/payments
+/client/state/sites/plans/ @Automattic/payments
+
 # Reader
 /client/reader @Automattic/reader
 /client/blocks/reader-* @Automattic/reader


### PR DESCRIPTION
The @Automattic/payments team would like to be aware of Calypso changes that affect billing/checkout/payments/etc.

To accomplish that, this pull request adds the team as GitHub "code owners" for a variety of code paths related to those topics.

We don't expect to actually review and provide feedback on all Calypso changes affecting these code paths, but we would at least like to be notified about them, and the GitHub CODEOWNERS file is the perfect vehicle for that.