### PR TITLE
SSR: Fix file-loader assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -156,7 +156,7 @@ const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
 const fileLoader = FileConfig.loader( {
 	outputPath: path.join( __dirname, 'public', 'images' ),
-	publicPath: '../images/',
+	publicPath: '/calypso/images/',
 	emitFile: browserslistEnv === 'evergreen', // Only output files once.
 } );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,6 +154,12 @@ if ( isDevelopment || isDesktop ) {
 const cssFilename = cssNameFromFilename( outputFilename );
 const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
+const fileLoader = FileConfig.loader( {
+	outputPath: path.join( __dirname, 'public', 'images' ),
+	publicPath: '../images/',
+	emitFile: browserslistEnv === 'evergreen', // Only output files once.
+} );
+
 const webpackConfig = {
 	bail: ! isDevelopment,
 	context: __dirname,
@@ -228,7 +234,7 @@ const webpackConfig = {
 				test: /\.html$/,
 				loader: 'html-loader',
 			},
-			FileConfig.loader(),
+			fileLoader,
 			{
 				include: require.resolve( 'tinymce/tinymce' ),
 				use: 'exports-loader?window=tinymce',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -155,9 +155,11 @@ const cssFilename = cssNameFromFilename( outputFilename );
 const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
 const fileLoader = FileConfig.loader( {
-	outputPath: path.join( __dirname, 'public', 'images' ),
+	// File-loader does not understand absolute paths so __dirname won't work.
+	// Build off `output.path` for a result like `/…/public/evergreen/../images/`.
+	outputPath: path.join( '..', 'images' ),
 	publicPath: '/calypso/images/',
-	emitFile: browserslistEnv === 'evergreen', // Only output files once.
+	emitFile: browserslistEnv === defaultBrowserslistEnv, // Only output files once.
 } );
 
 const webpackConfig = {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -26,6 +26,7 @@ const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
  * Internal variables
  */
 const isDevelopment = bundleEnv === 'development';
+
 const fileLoader = FileConfig.loader( {
 	emitFile: false, // On the server side, don't actually copy files
 } );

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -26,7 +26,6 @@ const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
  * Internal variables
  */
 const isDevelopment = bundleEnv === 'development';
-
 const fileLoader = FileConfig.loader( {
 	publicPath: '/calypso/images/',
 	emitFile: false, // On the server side, don't actually copy files

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -28,6 +28,7 @@ const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
 const isDevelopment = bundleEnv === 'development';
 
 const fileLoader = FileConfig.loader( {
+	publicPath: '/calypso/images/',
 	emitFile: false, // On the server side, don't actually copy files
 } );
 


### PR DESCRIPTION
Output `file-loader` files once and share the output files across builds.

Currently, SSR does not show any icons because of a path mismatch.

I suspect this was a regression from https://github.com/Automattic/wp-calypso/pull/30768 which started to affect icons after https://github.com/Automattic/wp-calypso/pull/32763

Reported by @michaeldcain 

## Screens
### Before

#### SSR

Paths like `images/file.ext#id`

![Screen Shot 2019-09-20 at 09 42 00](https://user-images.githubusercontent.com/841763/65308770-0e65cb00-db8b-11e9-9ad5-d01ab0739785.png)

#### Rendered

Paths like `/calypso/evergreen/images/file.ext#id`

![Screen Shot 2019-09-20 at 09 42 49](https://user-images.githubusercontent.com/841763/65308777-1160bb80-db8b-11e9-9b74-827f201e7b88.png)

### After

#### SSR

Paths like `/calypso/images/file.ext#id`

![Screen Shot 2019-09-20 at 12 06 34](https://user-images.githubusercontent.com/841763/65319157-4840cc80-db9f-11e9-9e84-901d314f0cd2.png)

#### Rendered

Paths like `/calypso/images/file.ext#id`
![Screen Shot 2019-09-20 at 12 10 28](https://user-images.githubusercontent.com/841763/65319334-a8377300-db9f-11e9-964b-5bbd957bfa84.png)


## Testing instructions

* Visit https://calypso.live/themes?branch=update/fix-ssr-files logged out with JavaScript disabled. You should see icons.
* ~Repeat with a legacy browser (ensure JavaScript assets are coming from the fallback URL).~ Some legacy browsers are rendered without external SVG support so they rely on JavaScript to render icons. Just trust that they work 😅 
* The same behavior in production results in missing icons.
