### PR TITLE
Add is-popup to layout div when opening login form in a popup

### DIFF
--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -21,10 +21,10 @@ export const authorizeQueryDataSchema = {
 		auth_approved: { type: 'string' },
 		blogname: { type: 'string' },
 		client_id: { pattern: '^\\d+$', type: 'string' },
-		close_window_after_login: { type: 'string' },
+		close_window_after_login: { type: 'string' }, // '1' if true
 		from: { type: 'string' },
 		home_url: { type: 'string' },
-		is_popup: { type: 'string' },
+		is_popup: { type: 'string' }, // '1' if true
 		jp_version: { type: 'string' },
 		partner_id: { pattern: '^\\d+$', type: 'string' },
 		redirect_after_auth: { type: 'string' },

--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -24,6 +24,7 @@ export const authorizeQueryDataSchema = {
 		close_window_after_login: { type: 'string' },
 		from: { type: 'string' },
 		home_url: { type: 'string' },
+		is_popup: { type: 'string' },
 		jp_version: { type: 'string' },
 		partner_id: { pattern: '^\\d+$', type: 'string' },
 		redirect_after_auth: { type: 'string' },

--- a/client/jetpack-connect/test/__snapshots__/utils.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/utils.js.snap
@@ -9,6 +9,7 @@ Object {
   "closeWindowAfterLogin": false,
   "from": "[unknown]",
   "homeUrl": "https://yourjetpack.blog",
+  "isPopup": false,
   "jpVersion": null,
   "nonce": "foobar",
   "redirectAfterAuth": null,

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -75,7 +75,7 @@ describe( 'parseAuthorizationQuery', () => {
 			_wp_nonce: 'foobar',
 			blogname: 'Just Another WordPress.com Site',
 			client_id: '12345',
-			closeWindowAfterLogin: false,
+			close_window_after_login: '0',
 			home_url: 'https://yourjetpack.blog',
 			redirect_uri: 'https://yourjetpack.blog/wp-admin/admin.php',
 			scope: 'administrator:34579bf2a3185a47d1b31aab30125d',
@@ -87,6 +87,46 @@ describe( 'parseAuthorizationQuery', () => {
 		const result = parseAuthorizationQuery( data );
 		expect( result ).not.toBeNull();
 		expect( result ).toMatchSnapshot();
+	} );
+
+	test( 'isPopup, closeWindowAfterLogin should be true if string is truthy', () => {
+		const data = {
+			_wp_nonce: 'foobar',
+			blogname: 'Just Another WordPress.com Site',
+			client_id: '12345',
+			close_window_after_login: '1',
+			home_url: 'https://yourjetpack.blog',
+			is_popup: 'true',
+			redirect_uri: 'https://yourjetpack.blog/wp-admin/admin.php',
+			scope: 'administrator:34579bf2a3185a47d1b31aab30125d',
+			secret: '640fdbd69f96a8ca9e61',
+			site: 'https://yourjetpack.blog',
+			site_url: 'https://yourjetpack.blog',
+			state: '1',
+		};
+		const result = parseAuthorizationQuery( data );
+		expect( result.isPopup ).toBe( true );
+		expect( result.closeWindowAfterLogin ).toBe( true );
+	} );
+
+	test( 'isPopup, closeWindowAfterLogin should be false if string is falsy', () => {
+		const data = {
+			_wp_nonce: 'foobar',
+			blogname: 'Just Another WordPress.com Site',
+			client_id: '12345',
+			close_window_after_login: '0',
+			home_url: 'https://yourjetpack.blog',
+			is_popup: 'FALSE',
+			redirect_uri: 'https://yourjetpack.blog/wp-admin/admin.php',
+			scope: 'administrator:34579bf2a3185a47d1b31aab30125d',
+			secret: '640fdbd69f96a8ca9e61',
+			site: 'https://yourjetpack.blog',
+			site_url: 'https://yourjetpack.blog',
+			state: '1',
+		};
+		const result = parseAuthorizationQuery( data );
+		expect( result.isPopup ).toBe( false );
+		expect( result.closeWindowAfterLogin ).toBe( false );
 	} );
 
 	test( 'should return null data on valid input', () => {

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -89,14 +89,14 @@ describe( 'parseAuthorizationQuery', () => {
 		expect( result ).toMatchSnapshot();
 	} );
 
-	test( 'isPopup, closeWindowAfterLogin should be true if string is truthy', () => {
+	test( 'isPopup, closeWindowAfterLogin should be true if string is 1', () => {
 		const data = {
 			_wp_nonce: 'foobar',
 			blogname: 'Just Another WordPress.com Site',
 			client_id: '12345',
 			close_window_after_login: '1',
 			home_url: 'https://yourjetpack.blog',
-			is_popup: 'true',
+			is_popup: '1',
 			redirect_uri: 'https://yourjetpack.blog/wp-admin/admin.php',
 			scope: 'administrator:34579bf2a3185a47d1b31aab30125d',
 			secret: '640fdbd69f96a8ca9e61',
@@ -109,7 +109,7 @@ describe( 'parseAuthorizationQuery', () => {
 		expect( result.closeWindowAfterLogin ).toBe( true );
 	} );
 
-	test( 'isPopup, closeWindowAfterLogin should be false if string is falsy', () => {
+	test( 'isPopup, closeWindowAfterLogin should be false if string is not 1', () => {
 		const data = {
 			_wp_nonce: 'foobar',
 			blogname: 'Just Another WordPress.com Site',

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -19,6 +19,7 @@ export function authQueryTransformer( queryObject ) {
 		clientId: parseInt( queryObject.client_id, 10 ),
 		closeWindowAfterLogin: !! queryObject.close_window_after_login,
 		homeUrl: queryObject.home_url,
+		isPopup: !! queryObject.is_popup,
 		nonce: queryObject._wp_nonce,
 		redirectUri: queryObject.redirect_uri,
 		scope: queryObject.scope,

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -14,13 +14,12 @@ import { head, includes, isEmpty, split } from 'lodash';
 import { addQueryArgs, untrailingslashit } from 'lib/route';
 
 export function authQueryTransformer( queryObject ) {
-	const truthy = [ 'true', 'True', 'TRUE', '1' ];
 	return {
 		// Required
 		clientId: parseInt( queryObject.client_id, 10 ),
-		closeWindowAfterLogin: -1 !== truthy.indexOf( queryObject.close_window_after_login ),
+		closeWindowAfterLogin: '1' === queryObject.close_window_after_login,
 		homeUrl: queryObject.home_url,
-		isPopup: -1 !== truthy.indexOf( queryObject.is_popup ),
+		isPopup: '1' === queryObject.is_popup,
 		nonce: queryObject._wp_nonce,
 		redirectUri: queryObject.redirect_uri,
 		scope: queryObject.scope,

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -14,12 +14,13 @@ import { head, includes, isEmpty, split } from 'lodash';
 import { addQueryArgs, untrailingslashit } from 'lib/route';
 
 export function authQueryTransformer( queryObject ) {
+	const truthy = [ 'true', 'True', 'TRUE', '1' ];
 	return {
 		// Required
 		clientId: parseInt( queryObject.client_id, 10 ),
-		closeWindowAfterLogin: !! queryObject.close_window_after_login,
+		closeWindowAfterLogin: -1 !== truthy.indexOf( queryObject.close_window_after_login ),
 		homeUrl: queryObject.home_url,
-		isPopup: !! queryObject.is_popup,
+		isPopup: -1 !== truthy.indexOf( queryObject.is_popup ),
 		nonce: queryObject._wp_nonce,
 		redirectUri: queryObject.redirect_uri,
 		scope: queryObject.scope,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -39,6 +39,7 @@ const hasSidebar = section => {
 const LayoutLoggedOut = ( {
 	currentRoute,
 	isJetpackLogin,
+	isPopup,
 	isJetpackWooCommerceFlow,
 	wccomFrom,
 	masterbarIsHidden,
@@ -60,6 +61,7 @@ const LayoutLoggedOut = ( {
 		'has-no-sidebar': ! hasSidebar( section ),
 		'has-no-masterbar': masterbarIsHidden,
 		'is-jetpack-login': isJetpackLogin,
+		'is-popup': isPopup,
 		'is-jetpack-woocommerce-flow':
 			config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow,
 		'is-wccom-oauth-flow':
@@ -132,8 +134,9 @@ LayoutLoggedOut.propTypes = {
 export default connect( state => {
 	const section = getSection( state );
 	const currentRoute = getCurrentRoute( state );
-	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
+    const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const noMasterbarForRoute = startsWith( currentRoute, '/log-in/jetpack' );
+	const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 	const isJetpackWooCommerceFlow =
 		'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' );
@@ -142,6 +145,7 @@ export default connect( state => {
 	return {
 		currentRoute,
 		isJetpackLogin,
+		isPopup,
 		isJetpackWooCommerceFlow,
 		wccomFrom,
 		masterbarIsHidden:

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -134,9 +134,9 @@ LayoutLoggedOut.propTypes = {
 export default connect( state => {
 	const section = getSection( state );
 	const currentRoute = getCurrentRoute( state );
-    const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
+	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const noMasterbarForRoute = startsWith( currentRoute, '/log-in/jetpack' );
-	const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+	const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 	const isJetpackWooCommerceFlow =
 		'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' );


### PR DESCRIPTION
We want to add this class so we can re-style the connection when it's open during the wp-admin connect flow.

#### Changes proposed in this Pull Request

* Add `is-popup` to the `layout` div when showing the login or create account screens during Jetpack's "wp-admin" connect flow.

Example div classes: `layout is-section-login focus-content has-no-sidebar has-no-masterbar is-jetpack-login is-popup`

#### Testing instructions

* Got through the wp-admin connect flow from a recent Jetpack master build ( you will need to set `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );` in `wp-config.php`)
* When the popup opens, you should see `is-popup` as a class on the `layout` div inside the `wpcom` div.

* Setting `calypso_env` for the wp-admin connect flow is part of a separate patch (ping @gravityrail )