### PR TITLE
Signup: Explain what happens when choosing a site type

### DIFF
--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -109,7 +109,7 @@ class SiteType extends Component {
 
 		const headerText = translate( 'What kind of site are you building?' );
 		const subHeaderText = translate(
-			"We'll add a few recommended pages to your site based on your choices."
+			"We'll add a few recommended pages to your site based on your choices. You can add or change pages later on."
 		);
 
 		return (

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -109,7 +109,7 @@ class SiteType extends Component {
 
 		const headerText = translate( 'What kind of site are you building?' );
 		const subHeaderText = translate(
-			"We'll add a few recommended pages to your site based on your choices. You can add or change pages later on."
+			"We'll add a few recommended pages to your site based on your choice. You can add or change pages later on."
 		);
 
 		return (

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -109,7 +109,7 @@ class SiteType extends Component {
 
 		const headerText = translate( 'Where do you want to start?' );
 		const subHeaderText = translate(
-			'We’ll add a few recommended pages to your site based on your choices.'
+			"We'll add a few recommended pages to your site based on your choices."
 		);
 
 		return (

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -107,7 +107,7 @@ class SiteType extends Component {
 			hasInitializedSitesBackUrl,
 		} = this.props;
 
-		const headerText = translate( 'Where do you want to start?' );
+		const headerText = translate( 'What kind of site are you building?' );
 		const subHeaderText = translate(
 			"We'll add a few recommended pages to your site based on your choices."
 		);

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -107,9 +107,9 @@ class SiteType extends Component {
 			hasInitializedSitesBackUrl,
 		} = this.props;
 
-		const headerText = translate( 'What kind of site are you building?' );
+		const headerText = translate( 'Where do you want to start?' );
 		const subHeaderText = translate(
-			'This is just a starting point. You can add or change features later.'
+			'We’ll add a few recommended pages to your site based on your choices.'
 		);
 
 		return (

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -137,7 +137,8 @@ body.is-section-signup .layout.gravatar .formatted-header {
 	}
 
 	.formatted-header__subtitle {
-		margin: 0;
+		margin: 0 auto;
+		max-width: 560px;
 		font-size: 15px;
 		color: var( --color-text-inverted );
 	}


### PR DESCRIPTION
This PR changes the subheading on the Site Type step of signup, to better explain what choosing a site type means. Instead of a vague and generic message to say that this will be the site's starting point, the new subheading explains exactly what the choice means.

Before | After
------ | ------
![site type - before](https://user-images.githubusercontent.com/426518/66576341-4061c000-eb80-11e9-8b37-261b843fe1d5.png) | ![site type - after](https://user-images.githubusercontent.com/426518/66578142-3bead680-eb83-11e9-9343-c1ef838f0d18.png)

The actual copy changes:

Before

> This is just a starting point. You can add or change features later.

After

> We'll add a few recommended pages to your site based on your choice. You can add or change features later on.

To accommodate the longer subtitle, I also added some CSS to set a `max-width` on the element and center it.