### PR TITLE
Allow icloud.com iframes in Reader

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -249,7 +249,7 @@
 		display: none;
 	}
 
-	// iCloud embeds - force a min width because they're 100% height by default, making them a bit slender
+	// iCloud embeds - force a min height because they're a bit slender by default
 	.wp-block-embed__wrapper iframe[src*='icloud.com'] {
 		min-height: 300px;
 	}

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -80,7 +80,8 @@
 		}
 	}
 
-	audio, video {
+	audio,
+	video {
 		display: block;
 		width: 100%;
 		margin: 24px auto;
@@ -246,6 +247,11 @@
 
 	.wp-block-cover-image {
 		display: none;
+	}
+
+	// iCloud embeds - force a min width because they're 100% height by default, making them a bit slender
+	.wp-block-embed__wrapper iframe[src*='icloud.com'] {
+		min-height: 300px;
 	}
 }
 

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -180,6 +180,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'gfycat.com',
 		'scribd.com',
 		'megaphone.fm',
+		'icloud.com',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When you embed a Keynote document in a post, Reader show allow the resulting iframe to display in Reader.

This PR adds `icloud.com` to the list of acceptable sources.


Before:

<img width="720" alt="Screen Shot 2019-09-23 at 15 56 47" src="https://user-images.githubusercontent.com/17325/65401277-379c8a80-de1b-11e9-8a49-665507b7e580.png">

After:

<img width="754" alt="Screen Shot 2019-09-23 at 16 23 21" src="https://user-images.githubusercontent.com/17325/65401803-7e3fb400-de1e-11e9-8445-4487e25b1ab6.png">

Sidenote: the embed is 100% height by default, which means it ended up being a bit slender (but still usable). I've added a targeted style to make the iframe a min-height of 300px when the src contains `icloud.com`.

#### Testing instructions

Embed a Keynote slide deck into a post using these instructions:

https://support.apple.com/en-us/HT207738

Load up the post in Reader and verify that a preview of the slides is shown.

Alternatively, internal users can check out http://calypso.localhost:3000/read/feeds/77519677/posts/2422849206 which contains two Keynote embeds.
