### PR TITLE
Prevent long domain names from overflowing the DomainSuggestion component

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -18,12 +18,14 @@
 
 	.is-section-signup & {
 		@include breakpoint( '>660px' ) {
+			padding-left: 1em;
 			padding-right: 2em;
 		}
 	}
 
 	.is-section-domains & {
 		@include breakpoint( '>800px' ) {
+			padding-left: 1em;
 			padding-right: 2em;
 		}
 	}

--- a/client/components/domains/domain-skip-suggestion/style.scss
+++ b/client/components/domains/domain-skip-suggestion/style.scss
@@ -14,6 +14,10 @@
 		width: 75%;
 	}
 
+	h3 {
+		word-break: break-all;
+	}
+
 	p {
 		color: var( --color-neutral-70 );
 		font-size: 12px;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -133,6 +133,7 @@
 
 	.domain-registration-suggestion__title {
 		width: auto;
+		max-width: 100%;
 		padding-right: 0.2em;
 	}
 
@@ -149,6 +150,7 @@
 
 .domain-registration-suggestion__title {
 	font-size: 16px;
+	word-break: break-all;
 
 	@include breakpoint( '>480px' ) {
 		align-self: center;


### PR DESCRIPTION
Longer domains in signup currently overflow the viewport on mobile screen sizes (#36024). This PR proposes to set `word-break: break-all` so that longer domain names wrap within the domain step. This isn't necessarily _pretty_, but is preferable to the text running off the side of the screen, resulting in a horizontal scrollbar.

The proposed styling more closely matches the styling for long domain titles in the signup flow in the mobile app on iOS.

## Screenshot of "before"

![word-break-before](https://user-images.githubusercontent.com/14988353/65402808-053b5f00-de14-11e9-8caf-c02b43c30a6d.png)

## Screenshot of "after"

![image](https://user-images.githubusercontent.com/14988353/65403357-97446700-de16-11e9-9da5-4d3d8ba32c12.png)

#### Changes proposed in this Pull Request

* Add `word-break: break-all` to the domain registration suggestion titles, used in the DomainSuggestion component.
* Set the maximum width of the the domain suggestion titles to 100% to fix an issue with Flexbox where it doesn't automatically respect the word-break property and instead allows the element to be wider than the container width.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/start` and go to create a new site until you reach the `domains` step.
* Enter a long domain name, e.g. `mytestsitewithareallylongdomainname20190923`.
* Resize to mobile screen width, e.g. 375px wide or iPhone 6/7/8 size, and the domain name should wrap, without overflowing the screen width
* Complete creating a site
* After creating the site, go to launch the site and check that the skip suggestion at the bottom of the `domains-launch` step also wraps the domain text:

![image](https://user-images.githubusercontent.com/14988353/65403097-b55d9780-de15-11e9-8efd-875bb3e8a4ce.png)

* Test adding a domain to an existing site by going to Plan > Domains > Add Domain (http://calypso.localhost:3000/domains/add/mysite.wordpress.com), and the suggested domains should all wrap as above, also.

* Test on Chrome, Firefox, Safari, IE11
* Test on a real mobile device (Android / iOS)

Note that short domain names should still display a two-column featured domain name suggestion on desktop screen widths. E.g.

![image](https://user-images.githubusercontent.com/14988353/65402895-9d394880-de14-11e9-96cd-310c44f02046.png)

Fixes #36024