### PR TITLE
Signup: add basic site onboarding skip button AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -125,6 +125,15 @@ export default {
 		defaultVariation: 'hide',
 		assignmentMethod: 'userId',
 	},
+	signupWithBasicSite: {
+		datestamp: '20190923',
+		variations: {
+			variant: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 	placesApiInCheckout: {
 		datestamp: '20190923',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -126,7 +126,7 @@ export default {
 		assignmentMethod: 'userId',
 	},
 	signupWithBasicSite: {
-		datestamp: '20190923',
+		datestamp: '20190930',
 		variations: {
 			variant: 50,
 			control: 50,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -120,6 +120,13 @@ export function generateFlows( {
 			lastModified: '2019-06-20',
 		},
 
+		'get-started': {
+			steps: [ 'user', 'site-type', 'domains', 'plans' ],
+			destination: getSignupDestination,
+			description: 'A blank slate flow used with the `signupEscapeHatch` AB test',
+			lastModified: '2019-09-23',
+		},
+
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -40,19 +40,8 @@ class SiteType extends Component {
 	};
 
 	// This function is to support the A/B test `signupWithBasicSite`
-	// by prefilling the vertical with 'travel'
-	handleBasicSiteButtonClick = () => {
-		const { translate } = this.props;
-		// prefill the vertical values to inform headstart of which vertical template to use.
-		this.props.setSiteVertical( {
-			isUserInput: false,
-			name: translate( 'Travel' ),
-			slug: 'Travel',
-			id: 'p2v7',
-			parentId: 'p2',
-		} );
-		this.submitStep( 'business', 'get-started' );
-	};
+	// by using a flow that does not include intermediary steps before 'domain'
+	handleBasicSiteButtonClick = () => this.submitStep( 'business', 'get-started' );
 
 	submitStep = ( siteTypeValue, flowName ) => {
 		this.props.submitSiteType( siteTypeValue );

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import Button from 'components/button';
@@ -17,9 +18,11 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
+	'get-started': 'get-started',
 	'online-store': 'ecommerce-onboarding',
 };
 
@@ -36,11 +39,30 @@ class SiteType extends Component {
 		this.submitStep( 'import' );
 	};
 
-	submitStep = siteTypeValue => {
+	// This function is to support the A/B test `signupWithBasicSite`
+	// by prefilling the vertical with 'travel'
+	handleBasicSiteButtonClick = () => {
+		const { translate } = this.props;
+		// prefill the vertical values to inform headstart of which vertical template to use.
+		this.props.setSiteVertical( {
+			isUserInput: false,
+			name: translate( 'Travel' ),
+			slug: 'Travel',
+			id: 'p2v7',
+			parentId: 'p2',
+		} );
+		this.submitStep( 'business', 'get-started' );
+	};
+
+	submitStep = ( siteTypeValue, flowName ) => {
 		this.props.submitSiteType( siteTypeValue );
 
+		if ( flowName ) {
+			this.props.goToNextStep( flowName );
+			return;
+		}
+
 		// Modify the flowname if the site type matches an override.
-		let flowName;
 		if ( 'import-onboarding' === this.props.flowName ) {
 			flowName = siteTypeToFlowname[ siteTypeValue ] || 'onboarding';
 		} else {
@@ -64,6 +86,20 @@ class SiteType extends Component {
 		);
 	}
 
+	renderStartWithBasicSiteButton() {
+		if ( 'variant' !== abtest( 'signupWithBasicSite' ) ) {
+			return null;
+		}
+
+		return (
+			<div className="site-type__basic-site">
+				<Button borderless onClick={ this.handleBasicSiteButtonClick }>
+					{ this.props.translate( 'Skip setup and start with a basic website.' ) }
+				</Button>
+			</div>
+		);
+	}
+
 	renderStepContent() {
 		const { siteType } = this.props;
 
@@ -74,6 +110,7 @@ class SiteType extends Component {
 					submitForm={ this.submitStep }
 					siteType={ siteType }
 				/>
+				{ this.renderStartWithBasicSiteButton() }
 				{ this.renderImportButton() }
 			</Fragment>
 		);
@@ -116,5 +153,5 @@ export default connect(
 		siteType: getSiteType( state ) || 'blog',
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
-	{ recordTracksEvent, saveSignupStep, submitSiteType }
+	{ recordTracksEvent, saveSignupStep, submitSiteType, setSiteVertical }
 )( localize( SiteType ) );

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -85,6 +85,7 @@
 	}
 }
 
+.site-type__basic-site,
 .site-type__import-button {
 	text-align: center;
 	margin-top: 20px;


### PR DESCRIPTION
## Changes proposed in this Pull Request

In this PR we're replacing the blank canvas skip setup functionality we introduced in https://github.com/Automattic/wp-calypso/pull/35273 with a 'starter site', consisting of the default 'business' segment theme (`pub/maywood`).

The idea is to provide the user with a quick way to set up a starter site, that is, a site that contains stuff.

See: p8Eqe3-KU-p2#comment-2274

## To do

- [x] Roll back D31408-code
- [x] Create marketing data post / update the escape hatch post - p8Eqe3-PR-p2
- [x] Create a wpcom happiness post - p7DVsv-7of-p2
- [x] Create an A/B hypothesis

## Testing instructions

1. Set the A/B `signupWithBasicSite` to `variant`
2. At the site type step, select **Skip setup and start with a basic website**. 
3. Complete the signup flow
4. Behold your new `pub/maywood` site!
5. Accept Elvis as your saviour.

<img width="462" alt="Screen Shot 2019-09-27 at 10 05 23 am" src="https://user-images.githubusercontent.com/6458278/65732728-8b0a2380-e10e-11e9-8dae-7e4a706c6483.png">

