### PR TITLE
Signup: Explain what happens when choosing a site topic

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -32,7 +32,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			siteTopicHeader: i18n.translate( 'What is your site about?' ),
 			siteTopicLabel: i18n.translate( 'What is your site about?' ),
 			siteTopicSubheader: i18n.translate(
-				"Choose the closest matching option. We’ll add relevant images and text to your site based on your choices."
+				'Choose the closest matching option. We’ll add relevant images and text to your site based on your choice. You can change everything later on.'
 			),
 			siteTopicInputPlaceholder: i18n.translate( 'Enter a topic or choose one from below.' ),
 			// Domains step
@@ -97,7 +97,7 @@ export function getAllSiteTypes( siteTypeIds = allowedSiteTypeIds ) {
 			siteTopicHeader: i18n.translate( 'What is your blog about?' ),
 			siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
 			siteTopicSubheader: i18n.translate(
-				"Choose the closest matching option. We’ll add relevant images and text to your site based on your choices."
+				'Choose the closest matching option. We’ll add relevant images and text to your site based on your choices.'
 			),
 			siteMockupHelpTipCopy: i18n.translate(
 				'Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.'

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -97,7 +97,7 @@ export function getAllSiteTypes( siteTypeIds = allowedSiteTypeIds ) {
 			siteTopicHeader: i18n.translate( 'What is your blog about?' ),
 			siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
 			siteTopicSubheader: i18n.translate(
-				'Choose the closest matching option. We’ll add relevant images and text to your site based on your choices.'
+				'Choose the closest matching option. We’ll add relevant images and text to your blog based on your choice. You can change everything later on.'
 			),
 			siteMockupHelpTipCopy: i18n.translate(
 				'Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.'

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -32,7 +32,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			siteTopicHeader: i18n.translate( 'What is your site about?' ),
 			siteTopicLabel: i18n.translate( 'What is your site about?' ),
 			siteTopicSubheader: i18n.translate(
-				"We'll add relevant content to your site to help you get started."
+				"Choose the closest matching option. We’ll add relevant images and text to your site based on your choices."
 			),
 			siteTopicInputPlaceholder: i18n.translate( 'Enter a topic or choose one from below.' ),
 			// Domains step
@@ -97,7 +97,7 @@ export function getAllSiteTypes( siteTypeIds = allowedSiteTypeIds ) {
 			siteTopicHeader: i18n.translate( 'What is your blog about?' ),
 			siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
 			siteTopicSubheader: i18n.translate(
-				"We'll add relevant content to your blog to help you get started."
+				"Choose the closest matching option. We’ll add relevant images and text to your site based on your choices."
 			),
 			siteMockupHelpTipCopy: i18n.translate(
 				'Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.'

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -137,7 +137,8 @@ body.is-section-signup .layout.gravatar .formatted-header {
 	}
 
 	.formatted-header__subtitle {
-		margin: 0;
+		margin: 0 auto;
+		max-width: 560px;
 		font-size: 15px;
 		color: var( --color-text-inverted );
 	}


### PR DESCRIPTION
This PR changes the subheading on the Site Topic step of signup, to better explain what choosing a site topic means. 

Before | After
------ | ------
![site topic - before](https://user-images.githubusercontent.com/426518/66578312-8b310700-eb83-11e9-86f2-b2b472f711ee.png) | ![site topic - after](https://user-images.githubusercontent.com/426518/66578314-8b310700-eb83-11e9-8e36-42017839784d.png)



The actual copy changes:

Before

> We'll add relevant content to your site to help you get started.

After

> Choose the closest matching option. We’ll add relevant images and text to your site based on your choice. You can change everything later on. 

To accommodate the longer subtitle, I also added some CSS to set a max-width on the element and center it.