### PR TITLE
Full Site Editing: Replace temporary template block injection from `core/template` to `core/group`

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 /* global fullSiteEditing */
 /**
@@ -62,7 +63,7 @@ const TemplateEdit = compose(
 				}
 
 				const templateBlocks = parse( get( template, [ 'content', 'raw' ], '' ) );
-				const templateBlock = createBlock( 'core/template', {}, templateBlocks );
+				const templateBlock = createBlock( 'core/group', {}, templateBlocks );
 
 				receiveBlocks( [ templateBlock ] );
 				setState( { templateClientId: templateBlock.clientId } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `core/template` block will be [removed](https://github.com/WordPress/gutenberg/pull/14367) in Gutenberg 6.5. (Props to @glendaviesnz for finding out about this!)
Full Site Editing uses it to group the content (blocks) of FSE templates before feeding them to their `BlockEdit` components inside the page editor.

This PR simply uses `core/group` as grouping block instead of `core/template`.

After some tests, it doesn't seem to me there are any differences with the previous approach, but I wasn't around when we decided to use `core/template`, and there might be edge cases (e.g. with the template locking, which is not clear to me how it works) that I haven't considered.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an FSE test site, update Gutenberg to 6.5 (or build from master).
* Try opening an FSE page, and observe that the template blocks are broken because the `core/template` block doesn't exist anymore.
* Apply this PR.
* Reload the FSE page (make sure it didn't autosave without the template blocks, in which case restore a previous revision).
* Make sure the template blocks look as expected.
* Save and view the page in the front end.
* Make sure the page looks as expected.

Fixes #36217