### PR TITLE
Upgrade Prettier to v1.18.2 of the WP fork

### DIFF
--- a/apps/notifications/src/standalone/auth-wrapper.jsx
+++ b/apps/notifications/src/standalone/auth-wrapper.jsx
@@ -80,9 +80,7 @@ export const AuthWrapper = Wrapped =>
 
 			const baseUrl = 'https://public-api.wordpress.com/oauth2/authorize';
 			const redirectUri = `${ window.location.origin }${ this.props.redirectPath }`;
-			const uri = `${ baseUrl }?client_id=${
-				this.props.clientId
-			}&redirect_uri=${ redirectUri }&response_type=token&scope=global`;
+			const uri = `${ baseUrl }?client_id=${ this.props.clientId }&redirect_uri=${ redirectUri }&response_type=token&scope=global`;
 
 			const auth = getTokenFromUrl();
 			if ( auth ) {

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -17,7 +17,7 @@ import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 import wpcom from 'lib/wp';
-import Dialog from 'components/dialog'
+import Dialog from 'components/dialog';
 import { fetchUserSettings } from 'state/user-settings/actions';
 import getUserSettings from 'state/selectors/get-user-settings';
 
@@ -106,15 +106,15 @@ export class AppPromo extends React.Component {
 	};
 
 	sendMagicLink = () => {
-		this.recordClickEvent()
+		this.recordClickEvent();
 
 		const email = this.props.userSettings.user_email;
 		wpcom.undocumented().requestMagicLoginEmail( {
 			email,
-			'infer': true,
-			'scheme': 'wordpress',
-		} )
-		
+			infer: true,
+			scheme: 'wordpress',
+		} );
+
 		this.onShowDialog();
 
 		return false;
@@ -127,8 +127,8 @@ export class AppPromo extends React.Component {
 	onCloseDialog = () => {
 		this.setState( { showDialog: false } );
 	};
-	
-	desktopPromo = ( promoItem ) => {
+
+	desktopPromo = promoItem => {
 		const { location, translate } = this.props;
 
 		return (
@@ -159,14 +159,12 @@ export class AppPromo extends React.Component {
 					{ promoItem.message }
 				</a>
 			</div>
-		)
-	}
-	
+		);
+	};
+
 	mobilePromo = () => {
 		const { translate } = this.props;
-		const buttons = [
-			{ action: 'cancel', label: translate( 'OK' ) },
-		];
+		const buttons = [ { action: 'cancel', label: translate( 'OK' ) } ];
 
 		return (
 			<div className="app-promo">
@@ -192,20 +190,29 @@ export class AppPromo extends React.Component {
 					/>
 					{ 'WordPress.com in the palm of your hands — download the mobile app.' }
 				</button>
-				<Dialog className="app-promo__dialog" isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
+				<Dialog
+					className="app-promo__dialog"
+					isVisible={ this.state.showDialog }
+					buttons={ buttons }
+					onClose={ this.onCloseDialog }
+				>
 					<h1>{ translate( 'Check your mail!' ) }</h1>
-					<p>{ translate( "We've sent you an email with links to download and effortlessly log in to the mobile app. Be sure to use them from your mobile device!" ) }</p>
+					<p>
+						{ translate(
+							"We've sent you an email with links to download and effortlessly log in to the mobile app. Be sure to use them from your mobile device!"
+						) }
+					</p>
 				</Dialog>
 			</div>
-		)
-	}
+		);
+	};
 
 	render() {
 		if ( ! this.state.showPromo ) {
 			return null;
 		}
 		const { promoItem } = this.state;
-		return ( promoItem.type === 'mobile' ) ? this.mobilePromo() : this.desktopPromo( promoItem );
+		return promoItem.type === 'mobile' ? this.mobilePromo() : this.desktopPromo( promoItem );
 	}
 }
 

--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -60,28 +60,24 @@ function sendMagicLink( email ) {
 	//Actions must be plain objects. Use custom middleware for async actions.
 	// https://stackoverflow.com/questions/46765896/react-redux-actions-must-be-plain-objects-use-custom-middleware-for-async-acti
 	return function( dispatch ) {
-		const duration = { duration: 4000 }
+		const duration = { duration: 4000 };
 		dispatch( infoNotice( i18n.translate( 'Sending email' ), duration ) );
 
 		return wpcom
 			.undocumented()
 			.requestMagicLoginEmail( {
 				email,
-				'infer': true,
-				'scheme': 'wordpress',
+				infer: true,
+				scheme: 'wordpress',
 			} )
 			.then( () => {
-				dispatch(
-					successNotice( i18n.translate( 'Email Sent. Check your mail app!' ), duration )
-				);
+				dispatch( successNotice( i18n.translate( 'Email Sent. Check your mail app!' ), duration ) );
 			} )
 			.catch( error => {
-				dispatch(
-					errorNotice( i18n.translate( 'Sorry, we couldn’t send the email.' ), duration )
-				);
+				dispatch( errorNotice( i18n.translate( 'Sorry, we couldn’t send the email.' ), duration ) );
 				return Promise.reject( error );
 			} );
-	}
+	};
 }
 
 class MobileDownloadCard extends React.Component {
@@ -284,14 +280,13 @@ class MobileDownloadCard extends React.Component {
 						<p>
 							<strong>{ translate( 'Instantly log in to the mobile app' ) }</strong>
 							<br />
-							{ translate( 'Send yourself links to download the app and instantly log in on your mobile device.' ) }
+							{ translate(
+								'Send yourself links to download the app and instantly log in on your mobile device.'
+							) }
 						</p>
 					</div>
 					<div className="get-apps__link-button-wrapper">
-						<Button
-							className="get-apps__magic-link-button"
-							onClick={ this.onSubmitLink }
-						>
+						<Button className="get-apps__magic-link-button" onClick={ this.onSubmitLink }>
 							{ translate( 'Email me a log in link' ) }
 						</Button>
 					</div>
@@ -326,8 +321,8 @@ class MobileDownloadCard extends React.Component {
 	onSubmitLink = () => {
 		this.props.recordTracksEvent( 'calypso_get_apps_magic_link_button_click' );
 		const email = this.props.userSettings.user_email;
-		this.props.sendMagicLink( email )
-	}
+		this.props.sendMagicLink( email );
+	};
 }
 
 export default connect(

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -117,7 +117,9 @@ export class ImageEditorToolbar extends Component {
 		const items = [
 			{
 				action: AspectRatios.FREE,
-				label: translate( 'Freeform', {context: 'Option in image editor used to crop images using freeform aspect ratio'} ),
+				label: translate( 'Freeform', {
+					context: 'Option in image editor used to crop images using freeform aspect ratio',
+				} ),
 			},
 			{
 				action: AspectRatios.ORIGINAL,

--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -114,7 +114,7 @@ export class ImageSelector extends Component {
 					labels={ { confirm: multiple ? translate( 'Set images' ) : translate( 'Set image' ) } }
 					enabledFilters={ [ 'images' ] }
 					galleryViewEnabled={ false }
-					{ ...! multiple && { single: true } }
+					{ ...( ! multiple && { single: true } ) }
 				/>
 			</MediaLibrarySelectedData>
 		);

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -58,9 +58,7 @@ class PostShareExample extends Component {
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
-						text={ `Keep in mind that you are able to share the '${
-							post.title
-						}' post now. Be careful!` }
+						text={ `Keep in mind that you are able to share the '${ post.title }' post now. Be careful!` }
 					/>
 				) }
 

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -36,7 +36,7 @@ export const UpgradeToPremiumNudgePure = props => {
 			translate( 'Unlimited premium themes.' ),
 		];
 	}
-	
+
 	if ( ! canUserUpgrade ) {
 		return null;
 	}

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -65,7 +65,7 @@ describe( 'UpgradeToPremiumNudgePure basic tests', () => {
 		const comp = shallow( <UpgradeToPremiumNudgePure { ...props } /> );
 		expect( comp.find( 'Banner' ).length ).toBe( 1 );
 	} );
-	
+
 	test( 'hide when user cannot upgrade', () => {
 		const props = {
 			translate: x => x,

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -104,7 +104,9 @@ export default connect( ( state, { siteId } ) => {
 			siteId
 		),
 		isStore: isSiteStore( state, siteId ),
-		isWordAds: getSiteOption( state, siteId, 'wordads' ) && canCurrentUser( state, siteId, 'manage_options' ),
+		isWordAds:
+			getSiteOption( state, siteId, 'wordads' ) &&
+			canCurrentUser( state, siteId, 'manage_options' ),
 		siteId,
 	};
 } )( StatsNavigation );

--- a/client/blocks/upgrade-nudge/test/index.js
+++ b/client/blocks/upgrade-nudge/test/index.js
@@ -75,7 +75,7 @@ describe( 'UpgradeNudge', () => {
 
 			expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 		} );
-		
+
 		describe( 'with feature prop', () => {
 			test( 'should not display when plan has feature', () => {
 				const props = createProps( {

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -100,7 +100,7 @@ function Chart( {
 	const maxBars = Math.floor( width / minWidth );
 
 	// Memoize data calculations to avoid performing them too often.
-	const { chartData, isEmptyChart, yMax } = useMemo(() => {
+	const { chartData, isEmptyChart, yMax } = useMemo( () => {
 		if ( ! hasResized ) {
 			return {};
 		}
@@ -113,7 +113,7 @@ function Chart( {
 			isEmptyChart: Boolean( nextVals.length && ! nextVals.some( a => a > 0 ) ),
 			yMax: getYAxisMax( nextVals ),
 		};
-	}, [ data, maxBars, hasResized ]);
+	}, [ data, maxBars, hasResized ] );
 
 	// If we don't have any sizing info yet, render an empty chart with the ref.
 	if ( ! hasResized ) {

--- a/client/components/community-translator/test/utils.js
+++ b/client/components/community-translator/test/utils.js
@@ -100,9 +100,7 @@ describe( 'Community Translator', () => {
 
 		test( 'should return valid url with correct params for root language', () => {
 			expect( getTranslationPermaLink( '123', languagesMock[ 0 ] ) ).toBe(
-				`${ GP_BASE_URL }/projects/${ GP_PROJECT }/${
-					languagesMock[ 0 ].langSlug
-				}/default?filters[original_id]=123`
+				`${ GP_BASE_URL }/projects/${ GP_PROJECT }/${ languagesMock[ 0 ].langSlug }/default?filters[original_id]=123`
 			);
 		} );
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1022,9 +1022,7 @@ class RegisterDomainStep extends React.Component {
 		const pageNumber = this.state.pageNumber + 1;
 
 		debug(
-			`Showing page ${ pageNumber } with query "${ this.state.lastQuery }" in section "${
-				this.props.analyticsSection
-			}"`
+			`Showing page ${ pageNumber } with query "${ this.state.lastQuery }" in section "${ this.props.analyticsSection }"`
 		);
 
 		this.props.recordShowMoreResults(

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -488,7 +488,7 @@ class TransferDomainStep extends React.Component {
 
 				return {
 					domain,
-					precheck: prevState.domain && ! submittingAvailability && ! submittingWhois
+					precheck: prevState.domain && ! submittingAvailability && ! submittingWhois,
 				};
 			} );
 

--- a/client/components/draggable/index.tsx
+++ b/client/components/draggable/index.tsx
@@ -36,7 +36,7 @@ interface State {
 
 interface MinimalTouchList {
 	readonly length: number;
-	[index: number]: HasPageCoords;
+	[ index: number ]: HasPageCoords;
 }
 interface HasTouches {
 	readonly touches: MinimalTouchList;
@@ -83,7 +83,7 @@ export default class Draggable extends Component< Props & DivProps, State > {
 	relativePos: { x: number; y: number } | null = null;
 	mousePos: { x: number; y: number } | null = null;
 
-	static getDerivedStateFromProps( props: Draggable['props'], state: State ) {
+	static getDerivedStateFromProps( props: Draggable[ 'props' ], state: State ) {
 		if ( state.x !== props.x || state.y !== props.y ) {
 			return {
 				x: props.x,
@@ -125,8 +125,8 @@ export default class Draggable extends Component< Props & DivProps, State > {
 		const coords = isEventWithTouches( event ) ? event.touches[ 0 ] : event;
 
 		// draggingStartedHandler populates `relativePos` and it should not be undefined.
-		const x = coords.pageX - ( this.relativePos as NonNullable< Draggable['relativePos'] > ).x;
-		const y = coords.pageY - ( this.relativePos as NonNullable< Draggable['relativePos'] > ).y;
+		const x = coords.pageX - ( this.relativePos as NonNullable< Draggable[ 'relativePos' ] > ).x;
+		const y = coords.pageY - ( this.relativePos as NonNullable< Draggable[ 'relativePos' ] > ).y;
 
 		this.mousePos = { x, y };
 	};

--- a/client/components/infinite-scroll/index.js
+++ b/client/components/infinite-scroll/index.js
@@ -123,6 +123,6 @@ class InfiniteScrollWithScrollEvent extends React.Component {
 	}
 }
 
-export default ( hasIntersectionObserver
+export default hasIntersectionObserver
 	? InfiniteScrollWithIntersectionObserver
-	: InfiniteScrollWithScrollEvent );
+	: InfiniteScrollWithScrollEvent;

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -226,9 +226,7 @@ export function formatNumber( inputNumber, country ) {
 
 	if ( pattern ) {
 		debug(
-			`Will replace "${ nationalNumber }" with "${ pattern.match }" and "${
-				pattern.replace
-			}" with prefix "${ prefix }"`
+			`Will replace "${ nationalNumber }" with "${ pattern.match }" and "${ pattern.replace }" with prefix "${ prefix }"`
 		);
 		return prefix + nationalNumber.replace( new RegExp( pattern.match ), pattern.replace );
 	}

--- a/client/components/plans/plan-pill/index.jsx
+++ b/client/components/plans/plan-pill/index.jsx
@@ -9,8 +9,4 @@ import React from 'react';
  */
 import './style.scss';
 
-export default props => (
-	<div className="plan-pill">
-		{ props.children }
-	</div>
-);
+export default props => <div className="plan-pill">{ props.children }</div>;

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -30,7 +30,12 @@ import { TERM_ANNUALLY, TYPE_BUSINESS } from 'lib/plans/constants';
 import './style.scss';
 import upgradeNudgeImage from './preview-upgrade-nudge.png';
 
-export const SeoPreviewNudge = ( { canCurrentUserUpgrade, translate, site, isJetpack = false } ) => {
+export const SeoPreviewNudge = ( {
+	canCurrentUserUpgrade,
+	translate,
+	site,
+	isJetpack = false,
+} ) => {
 	return (
 		<div className="preview-upgrade-nudge">
 			<QueryPlans />
@@ -44,9 +49,13 @@ export const SeoPreviewNudge = ( { canCurrentUserUpgrade, translate, site, isJet
 						...( isJetpack ? { term: TERM_ANNUALLY } : {} ),
 					} )
 				}
-				title={ canCurrentUserUpgrade ? translate( 'Upgrade to a Business plan to unlock the power of our SEO tools!' ) 
-						: translate ( "Unlock powerful SEO tools! Contact your site's administrator to upgrade to a Business plan." ) 
-					  }
+				title={
+					canCurrentUserUpgrade
+						? translate( 'Upgrade to a Business plan to unlock the power of our SEO tools!' )
+						: translate(
+								"Unlock powerful SEO tools! Contact your site's administrator to upgrade to a Business plan."
+						  )
+				}
 				event="site_preview_seo_plan_upgrade"
 				className="preview-upgrade-nudge__banner"
 			/>

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -201,6 +201,6 @@ class StickyPanelWithScrollEvent extends React.Component {
 	}
 }
 
-export default ( hasIntersectionObserver
+export default hasIntersectionObserver
 	? StickyPanelWithIntersectionObserver
-	: StickyPanelWithScrollEvent );
+	: StickyPanelWithScrollEvent;

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -494,7 +494,13 @@ class SimplePaymentsDialog extends Component {
 					illustration="/calypso/images/illustrations/type-e-commerce.svg"
 					illustrationWidth={ 300 }
 					title={ translate( 'Want to add a payment button to your site?' ) }
-					line={ ! canCurrentUserUpgrade ? translate ( "Contact your site's administrator to upgrade to the Premium, Business, or eCommerce Plan." ) : false }
+					line={
+						! canCurrentUserUpgrade
+							? translate(
+									"Contact your site's administrator to upgrade to the Premium, Business, or eCommerce Plan."
+							  )
+							: false
+					}
 					action={
 						<UpgradeNudge
 							className="editor-simple-payments-modal__nudge-nudge"

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -112,7 +112,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	conversionPort: MessagePort | null = null;
 	mediaSelectPort: MessagePort | null = null;
 	revisionsPort: MessagePort | null = null;
-	templatePorts: [T.PostId, MessagePort][] = [];
+	templatePorts: [ T.PostId, MessagePort ][] = [];
 
 	componentDidMount() {
 		MediaStore.on( 'change', this.updateImageBlocks );

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -32,8 +32,10 @@ export function canAccessWordads( site ) {
 }
 
 export function canAccessAds( site ) {
-	return ( canAccessWordads( site ) || canUpgradeToUseWordAds( site ) ) 
-	&& userCan( 'manage_options', site )
+	return (
+		( canAccessWordads( site ) || canUpgradeToUseWordAds( site ) ) &&
+		userCan( 'manage_options', site )
+	);
 }
 
 export function isWordadsInstantActivationEligible( site ) {

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -116,7 +116,7 @@ const clearPreviousErrors = ( users: GSuiteNewUser[] ) => {
  */
 const validateNewUserMailboxIsUnique = (
 	{ value: mailBox, error: previousError }: GSuiteNewUserField,
-	mailboxesByCount: { [mailbox: string]: number }
+	mailboxesByCount: { [ mailbox: string ]: number }
 ) => ( {
 	value: mailBox,
 	error:
@@ -129,7 +129,7 @@ const validateNewUserMailboxIsUnique = (
  * Adds a duplicate error to each mailBox with a duplicate mailbox
  */
 const validateNewUsersAreUnique = ( users: GSuiteNewUser[] ) => {
-	const mailboxesByCount: { [mailbox: string]: number } = countBy(
+	const mailboxesByCount: { [ mailbox: string ]: number } = countBy(
 		users.map( ( { mailBox: { value: mailBox } } ) => mailBox )
 	);
 
@@ -241,7 +241,7 @@ const getItemsForCart = (
 	productSlug: string,
 	users: GSuiteNewUser[]
 ) => {
-	const usersGroupedByDomain: { [domain: string]: GSuiteProductUser[] } = mapValues(
+	const usersGroupedByDomain: { [ domain: string ]: GSuiteProductUser[] } = mapValues(
 		groupBy( users, 'domain.value' ),
 		groupedUsers => groupedUsers.map( transformUserForCart )
 	);

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -81,7 +81,7 @@ export const protectForm = < P extends ProtectedFormProps >(
 				<WrappedComponent
 					markChanged={ this.markChanged }
 					markSaved={ this.markSaved }
-					{ ...this.props as P }
+					{ ...( this.props as P ) }
 				/>
 			);
 		}

--- a/client/lib/route/index.ts
+++ b/client/lib/route/index.ts
@@ -17,7 +17,7 @@ const appendQueryString = ( basepath: string, querystring: string ): string =>
 	basepath + ( querystring ? '?' + querystring : '' );
 
 interface QueryArgs {
-	[key: string]: Primitive;
+	[ key: string ]: Primitive;
 }
 export const addQueryArgs = ( args: QueryArgs, url: URL ): URL => {
 	if ( 'object' !== typeof args ) {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -35,7 +35,7 @@ import { resetSignup, updateDependencies } from 'state/signup/actions';
 import { completeSignupStep, invalidateStep, processStep } from 'state/signup/progress/actions';
 
 interface Dependencies {
-	[other: string]: any;
+	[ other: string ]: any;
 }
 
 interface Flow {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -448,9 +448,7 @@ export class Checkout extends React.Component {
 				if ( domainsForGSuite.length ) {
 					return (
 						this.maybeShowPlanBumpOfferGSuite( pendingOrReceiptId ) ||
-						`/checkout/${ selectedSiteSlug }/with-gsuite/${
-							domainsForGSuite[ 0 ].meta
-						}/${ pendingOrReceiptId }`
+						`/checkout/${ selectedSiteSlug }/with-gsuite/${ domainsForGSuite[ 0 ].meta }/${ pendingOrReceiptId }`
 					);
 				}
 			}

--- a/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
+++ b/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
@@ -20,7 +20,7 @@ export class SignupSiteCreatedNotice extends PureComponent {
 		if ( hasPlanInCart ) {
 			hintText = translate( 'Complete your plan purchase to upgrade.' );
 		}
-		
+
 		if ( hasPlanInCart && bundledDomain ) {
 			hintText = translate(
 				"Once you've upgraded, your new site address will be {{strong}}%(bundledDomain)s{{/strong}}",
@@ -48,14 +48,11 @@ export class SignupSiteCreatedNotice extends PureComponent {
 				/>
 				<div className="checkout__site-created-copy">
 					<div>
-						{ translate(
-							"{{em}}%(siteSlug)s{{/em}} is up and running!",
-							{
-								components: { em: <em /> },
-								args: { siteSlug: selectedSite.slug },
-								comment: '`siteSlug` is the WordPress.com site, e.g., testsite.wordpress.com',
-							} )
-						}
+						{ translate( '{{em}}%(siteSlug)s{{/em}} is up and running!', {
+							components: { em: <em /> },
+							args: { siteSlug: selectedSite.slug },
+							comment: '`siteSlug` is the WordPress.com site, e.g., testsite.wordpress.com',
+						} ) }
 					</div>
 					<div>{ this.getUpgradeText() }</div>
 				</div>

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -77,15 +77,19 @@ function PendingGSuiteTosNoticeDialog( props ) {
 				setPassword( data.password );
 			},
 			() => {
-				props.errorNotice( translate( 'There was a problem resetting the password for %(gsuiteEmail)s. Please {{link}}contact support{{/link}}.', {
-						args: {
-							gsuiteEmail: props.user,
-						},
-						components: {
-							link: <a href={ CALYPSO_CONTACT } />,
-						},
-					}
-				) );
+				props.errorNotice(
+					translate(
+						'There was a problem resetting the password for %(gsuiteEmail)s. Please {{link}}contact support{{/link}}.',
+						{
+							args: {
+								gsuiteEmail: props.user,
+							},
+							components: {
+								link: <a href={ CALYPSO_CONTACT } />,
+							},
+						}
+					)
+				);
 
 				setOpenTracked( false );
 				props.onClose();

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -38,9 +38,7 @@ const WpcomDomain = createReactClass( {
 		return (
 			<VerticalNav>
 				<VerticalNavItem
-					path={ `https://${ this.props.domain.name }/wp-admin/index.php?page=my-blogs#blog_row_${
-						this.props.selectedSite.ID
-					}` }
+					path={ `https://${ this.props.domain.name }/wp-admin/index.php?page=my-blogs#blog_row_${ this.props.selectedSite.ID }` }
 					external={ true }
 					onClick={ this.handleEditSiteAddressClick }
 				>

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -267,9 +267,7 @@ class MembershipsSection extends Component {
 				<PopoverMenuItem
 					target="_blank"
 					rel="noopener norefferer"
-					href={ `https://dashboard.stripe.com/test/search?query=metadata%3A${
-						subscriber.user.ID
-					}` }
+					href={ `https://dashboard.stripe.com/test/search?query=metadata%3A${ subscriber.user.ID }` }
 				>
 					<Gridicon size={ 18 } icon={ 'external' } />
 					{ this.props.translate( 'See transactions in Stripe Dashboard' ) }

--- a/client/my-sites/marketing/tools/header.tsx
+++ b/client/my-sites/marketing/tools/header.tsx
@@ -14,9 +14,7 @@ interface Props {
 	handleButtonClick: () => void;
 }
 
-const MarketingToolsHeader: FunctionComponent< Props > = ( {
-	handleButtonClick,
-} ) => {
+const MarketingToolsHeader: FunctionComponent< Props > = ( { handleButtonClick } ) => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -48,7 +48,7 @@ const SiteSettingsTraffic = ( {
 } ) => (
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 	<Main className="settings-traffic site-settings" wideLayout>
-    <PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
+		<PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
 		<DocumentHead title={ translate( 'Site Settings' ) } />
 		{ ! isAdmin && (
 			<EmptyContent
@@ -66,9 +66,9 @@ const SiteSettingsTraffic = ( {
 				fields={ fields }
 			/>
 		) }
-		{ isAdmin && ( <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> ) }
-		{ isAdmin && ( <SeoSettingsMain /> ) }
-		{ isAdmin && ( 
+		{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
+		{ isAdmin && <SeoSettingsMain /> }
+		{ isAdmin && (
 			<RelatedPosts
 				onSubmitForm={ handleSubmitForm }
 				handleAutosavingToggle={ handleAutosavingToggle }
@@ -76,8 +76,8 @@ const SiteSettingsTraffic = ( {
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
-		 ) }
-				
+		) }
+
 		{ isJetpack && (
 			<JetpackSiteStats
 				handleAutosavingToggle={ handleAutosavingToggle }
@@ -87,7 +87,7 @@ const SiteSettingsTraffic = ( {
 				fields={ fields }
 			/>
 		) }
-		{ isAdmin && ( <AnalyticsSettings /> ) }
+		{ isAdmin && <AnalyticsSettings /> }
 		{ isJetpack && (
 			<Shortlinks
 				handleAutosavingRadio={ handleAutosavingRadio }
@@ -98,14 +98,14 @@ const SiteSettingsTraffic = ( {
 				onSubmitForm={ handleSubmitForm }
 			/>
 		) }
-		{ isAdmin && ( 
+		{ isAdmin && (
 			<Sitemaps
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
-			/> 
+			/>
 		) }
-		{ isAdmin && ( <SiteVerification /> ) }
+		{ isAdmin && <SiteVerification /> }
 	</Main>
 );
 

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -26,7 +26,7 @@ import './list-item.scss';
 interface MediaObject {
 	transient?: boolean;
 	file?: string;
-	[propName: string]: any;
+	[ propName: string ]: any;
 }
 type Media = string | MediaObject;
 // END TODO

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -52,25 +52,31 @@ class MediaLibraryListPlanPromo extends React.Component {
 		switch ( this.props.filter ) {
 			case 'videos':
 				return preventWidows(
-					this.props.canUpgrade ?
-					this.props.translate( 'To upload video files to your site, upgrade your plan.', {
-						textOnly: true,
-						context: 'Media upgrade promo',
-					} )
-					: this.props.translate( "Uploading video requires a paid plan." )
-					+ " " + this.props.translate( 'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.' ),
+					this.props.canUpgrade
+						? this.props.translate( 'To upload video files to your site, upgrade your plan.', {
+								textOnly: true,
+								context: 'Media upgrade promo',
+						  } )
+						: this.props.translate( 'Uploading video requires a paid plan.' ) +
+								' ' +
+								this.props.translate(
+									'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
+								),
 					2
 				);
 
 			case 'audio':
 				return preventWidows(
-					this.props.canUpgrade ?
-					this.props.translate( 'To upload audio files to your site, upgrade your plan.', {
-						textOnly: true,
-						context: 'Media upgrade promo',
-					} )
-					: this.props.translate( "Uploading audio requires a paid plan." )
-					+ " " + this.props.translate( 'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.' ),
+					this.props.canUpgrade
+						? this.props.translate( 'To upload audio files to your site, upgrade your plan.', {
+								textOnly: true,
+								context: 'Media upgrade promo',
+						  } )
+						: this.props.translate( 'Uploading audio requires a paid plan.' ) +
+								' ' +
+								this.props.translate(
+									'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
+								),
 					2
 				);
 
@@ -114,7 +120,7 @@ class MediaLibraryListPlanPromo extends React.Component {
 	}
 }
 
-export default connect( ( state ) => {
+export default connect( state => {
 	return {
 		canUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 	};

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -131,7 +131,7 @@ export class JetpackProductInstall extends Component< Props, State > {
 			return;
 		}
 
-		const installerPositionalArguments: ['akismet', 'vaultpress'] = [ 'akismet', 'vaultpress' ];
+		const installerPositionalArguments: [ 'akismet', 'vaultpress' ] = [ 'akismet', 'vaultpress' ];
 		const startJetpackProductInstallArgs = installerPositionalArguments.map( slug =>
 			// Installation hasn't been initiated for the plugin
 			! this.state.initiatedInstalls.has( slug ) &&
@@ -163,7 +163,7 @@ export class JetpackProductInstall extends Component< Props, State > {
 			this.props.startJetpackProductInstall(
 				siteId,
 				.../* We know this array will include exactly 2 items */
-				( startJetpackProductInstallArgs as [string | null, string | null] )
+				( startJetpackProductInstallArgs as [ string | null, string | null ] )
 			);
 		}
 	}
@@ -337,7 +337,7 @@ export class JetpackProductInstall extends Component< Props, State > {
 
 interface ConnectedProps {
 	siteId: SiteId | null;
-	pluginKeys: { [key in PluginSlug]: string } | null;
+	pluginKeys: { [ key in PluginSlug ]: string } | null;
 	progressComplete: ReturnType< typeof getJetpackProductInstallProgress >;
 	requestedInstalls: PluginSlug[];
 	status: ReturnType< typeof getJetpackProductInstallStatus >;

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -44,7 +44,13 @@ class PostActionsEllipsisMenuShare extends Component {
 	}
 
 	render() {
-		const { canShare, translate, status, type, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
+		const {
+			canShare,
+			translate,
+			status,
+			type,
+			isPublicizeEnabled: isPublicizeEnabledForSite,
+		} = this.props;
 		if ( 'publish' !== status || ! isPublicizeEnabledForSite || 'post' !== type || ! canShare ) {
 			return null;
 		}

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -151,9 +151,13 @@ class WordAds extends Component {
 				{ ! canAccessAds && (
 					<EmptyContent
 						illustration="/calypso/images/illustrations/illustration-404.svg"
-						title={ ! isAdmin ? translate( 'You are not authorized to view this page' ) : translate( 'WordAds is not enabled on your site' ) }
+						title={
+							! isAdmin
+								? translate( 'You are not authorized to view this page' )
+								: translate( 'WordAds is not enabled on your site' )
+						}
 						action={ isAdmin ? translate( 'Explore WordAds' ) : false }
-						actionURL={ "/earn/ads-settings/" + slug }
+						actionURL={ '/earn/ads-settings/' + slug }
 					/>
 				) }
 				{ canAccessAds && (

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -42,9 +42,7 @@ class SignupThemesList extends Component {
 	}
 
 	getScreenshotUrl( theme ) {
-		return `https://i1.wp.com/s0.wp.com/wp-content/themes/${ theme.repo }/${
-			theme.slug
-		}/screenshot.png?w=660`;
+		return `https://i1.wp.com/s0.wp.com/wp-content/themes/${ theme.repo }/${ theme.slug }/screenshot.png?w=660`;
 	}
 
 	render() {

--- a/client/state/data-getters/wpcom/jetpack-blogs/keys/index.ts
+++ b/client/state/data-getters/wpcom/jetpack-blogs/keys/index.ts
@@ -16,7 +16,7 @@ interface ResponseData {
 
 export function requestPluginKeys(
 	siteId: SiteId,
-	options: Parameters< typeof requestHttpData >[2] = {}
+	options: Parameters< typeof requestHttpData >[ 2 ] = {}
 ) {
 	requestHttpData(
 		dataKey( siteId ),

--- a/client/state/data-layer/http-data.ts
+++ b/client/state/data-layer/http-data.ts
@@ -131,8 +131,8 @@ const onError = ( action: HttpDataAction, error: unknown ) => {
 	return { type: HTTP_DATA_TICK };
 };
 
-type SuccessfulParse = [undefined, ReturnType< ResponseParser >];
-type FailedParse = [unknown, undefined];
+type SuccessfulParse = [ undefined, ReturnType< ResponseParser > ];
+type FailedParse = [ unknown, undefined ];
 type ParseResult = SuccessfulParse | FailedParse;
 
 /**
@@ -219,7 +219,7 @@ export const enhancer = ( next: StoreEnhancerStoreCreator ) => (
 	return store;
 };
 
-type ResourcePair = [DataId, any];
+type ResourcePair = [ DataId, any ];
 type ResponseParser = ( apiData: any ) => ResourcePair[];
 
 interface RequestHttpDataOptions {
@@ -266,10 +266,10 @@ export const requestHttpData = (
 };
 
 interface Query {
-	[key: string]: Lazy< Resource >;
+	[ key: string ]: Lazy< Resource >;
 }
 
-type Results< T extends Query > = { [P in keyof T]: ReturnType< T[P] > };
+type Results< T extends Query > = { [ P in keyof T ]: ReturnType< T[ P ] > };
 
 /**
  * Blocks execution until requested data has been fulfilled
@@ -315,7 +315,7 @@ export const waitForData = < T extends Query >(
 						allDone && ( value.state === DataState.Success || value.state === DataState.Failure ),
 					];
 				},
-				[ {}, true, true ] as [Results< T >, boolean, boolean]
+				[ {}, true, true ] as [ Results< T >, boolean, boolean ]
 			);
 
 		const listener = () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js
@@ -24,9 +24,7 @@ export const cancelConciergeAppointment = action => {
 		http(
 			{
 				method: 'POST',
-				path: `/concierge/schedules/${ action.scheduleId }/appointments/${
-					action.appointmentId
-				}/cancel`,
+				path: `/concierge/schedules/${ action.scheduleId }/appointments/${ action.appointmentId }/cancel`,
 				apiNamespace: 'wpcom/v2',
 				body: {},
 			},

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
@@ -28,9 +28,7 @@ describe( 'wpcom-api', () => {
 				http(
 					{
 						method: 'POST',
-						path: `/concierge/schedules/${ action.scheduleId }/appointments/${
-							action.appointmentId
-						}/cancel`,
+						path: `/concierge/schedules/${ action.scheduleId }/appointments/${ action.appointmentId }/cancel`,
 						apiNamespace: 'wpcom/v2',
 						body: {},
 					},

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
@@ -28,9 +28,7 @@ describe( 'wpcom-api', () => {
 				http(
 					{
 						method: 'GET',
-						path: `/concierge/schedules/${ action.scheduleId }/appointments/${
-							action.appointmentId
-						}/detail`,
+						path: `/concierge/schedules/${ action.scheduleId }/appointments/${ action.appointmentId }/detail`,
 						apiNamespace: 'wpcom/v2',
 						retryPolicy: noRetry(),
 					},

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js
@@ -20,9 +20,7 @@ export const rescheduleConciergeAppointment = action => {
 		http(
 			{
 				method: 'POST',
-				path: `/concierge/schedules/${ action.scheduleId }/appointments/${
-					action.appointmentId
-				}/reschedule`,
+				path: `/concierge/schedules/${ action.scheduleId }/appointments/${ action.appointmentId }/reschedule`,
 				apiNamespace: 'wpcom/v2',
 				body: toApi( action ),
 			},

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
@@ -31,9 +31,7 @@ describe( 'wpcom-api', () => {
 				http(
 					{
 						method: 'POST',
-						path: `/concierge/schedules/${ action.scheduleId }/appointments/${
-							action.appointmentId
-						}/reschedule`,
+						path: `/concierge/schedules/${ action.scheduleId }/appointments/${ action.appointmentId }/reschedule`,
 						apiNamespace: 'wpcom/v2',
 						body: toApi( action ),
 					},

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -23,9 +23,7 @@ export const requestBlogStickerRemove = action =>
 	http(
 		{
 			method: 'POST',
-			path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${
-				action.payload.stickerName
-			}`,
+			path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${ action.payload.stickerName }`,
 			body: {}, // have to have an empty body to make wpcom-http happy
 			apiVersion: '1.1',
 		},

--- a/client/state/logstash/actions.ts
+++ b/client/state/logstash/actions.ts
@@ -19,7 +19,7 @@ interface LogToLogstashParams {
 	message: string;
 	extra?: any;
 	site_id?: number;
-	[key: string]: any;
+	[ key: string ]: any;
 }
 
 /**

--- a/client/types.ts
+++ b/client/types.ts
@@ -27,6 +27,6 @@ export type CommentId = number;
 
 // Language stuff
 export type Lazy< T > = () => T;
-export type TimeoutMS = NonUndefined< Parameters< typeof setTimeout >[1] >;
+export type TimeoutMS = NonUndefined< Parameters< typeof setTimeout >[ 1 ] >;
 export type TimestampMS = ReturnType< typeof Date.now >;
 export type TimerHandle = ReturnType< typeof setTimeout >;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18150,8 +18150,8 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz",
-			"integrity": "sha512-T6Ya21PFyCgcrTDvMe8pNx9kMpg6nm5KG6ohAx7UzDdcTClsH0X83pNjdQ3AuVJwStz6fhIBW8Wo9P3BEHqFLQ==",
+			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
+			"integrity": "sha512-MZWjD8vE5xFscQxZsBQgNyxqkQbRMWildoUUKm0TNAbuCLjswU6UMtPDLRL1iTkyhWMvJISibVvasqC8PnJPuA==",
 			"dev": true
 		},
 		"pretty-error": {

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
 		"ncp": "2.0.0",
 		"nock": "10.0.6",
 		"npm-merge-driver": "2.3.5",
-		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz",
+		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
 		"react-test-renderer": "16.8.6",
 		"readline-sync": "1.4.9",
 		"replace": "1.1.0",

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -21,10 +21,10 @@ declare namespace i18nCalypso {
 	export type Substitutions =
 		| Substitution
 		| Substitution[]
-		| { [placeholder: string]: Substitution };
+		| { [ placeholder: string ]: Substitution };
 
 	export interface ComponentInterpolations {
-		[placeholder: string]: React.ReactElement;
+		[ placeholder: string ]: React.ReactElement;
 	}
 
 	export interface TranslateOptions {

--- a/packages/webpack-extensive-lodash-replacement-plugin/index.js
+++ b/packages/webpack-extensive-lodash-replacement-plugin/index.js
@@ -104,9 +104,7 @@ class ExtensiveLodashReplacementPlugin {
 			// Output compilation warning.
 			this.compilation.warnings.push(
 				new Error(
-					`${ relativePath }\n  ${ packageName } version ${ importVersion } cannot be replaced by lodash-es version ${
-						this.baseLodashESVersion
-					}`
+					`${ relativePath }\n  ${ packageName } version ${ importVersion } cannot be replaced by lodash-es version ${ this.baseLodashESVersion }`
 				)
 			);
 		}

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
 	"packageRules": [
 		{
 			"paths": [ "packages/**" ],
-			"packagePatterns": ["*"],
+			"packagePatterns": [ "*" ],
 			"groupName": "calypso-packages",
 			"rangeStrategy": "replace"
 		},

--- a/server/bundler/sections-loader.js
+++ b/server/bundler/sections-loader.js
@@ -17,9 +17,7 @@ function addModuleImportToSections( { sections, shouldSplit, onlyIsomorphic } ) 
 			return;
 		}
 
-		const loaderFunction = `function() { return require( /* webpackChunkName: '${
-			section.name
-		}' */ '${ section.module }'); }`;
+		const loaderFunction = `function() { return require( /* webpackChunkName: '${ section.name }' */ '${ section.module }'); }`;
 
 		section.load = shouldSplit ? loaderFunction.replace( 'require', 'import' ) : loaderFunction;
 	} );

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -46,9 +46,7 @@ export function clickWhenClickable( driver, selector, waitOverride ) {
 			);
 		},
 		timeoutWait,
-		`Timed out waiting for element with ${ selector.using } of '${
-			selector.value
-		}' to be clickable`
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be clickable`
 	);
 }
 
@@ -132,9 +130,7 @@ export function waitTillPresentAndDisplayed( driver, selector, waitOverride ) {
 			);
 		},
 		timeoutWait,
-		`Timed out waiting for element with ${ selector.using } of '${
-			selector.value
-		}' to be present and displayed`
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be present and displayed`
 	);
 }
 
@@ -256,9 +252,7 @@ export function waitForFieldClearable( driver, selector ) {
 			);
 		},
 		explicitWaitMS,
-		`Timed out waiting for element with ${ selector.using } of '${
-			selector.value
-		}' to be clearable`
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be clearable`
 	);
 }
 
@@ -290,9 +284,7 @@ export function setWhenSettable(
 			return actualValue === value;
 		},
 		explicitWaitMS,
-		`Timed out waiting for element with ${ selector.using } of '${
-			selector.value
-		}' to be settable to: '${ logValue }'`
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to be settable to: '${ logValue }'`
 	);
 }
 
@@ -327,9 +319,7 @@ export function waitTillNotPresent( driver, selector, waitOverride ) {
 			} );
 		},
 		timeoutWait,
-		`Timed out waiting for element with ${ selector.using } of '${
-			selector.value
-		}' to NOT be present`
+		`Timed out waiting for element with ${ selector.using } of '${ selector.value }' to NOT be present`
 	);
 }
 

--- a/test/e2e/lib/override-abtest.js
+++ b/test/e2e/lib/override-abtest.js
@@ -36,9 +36,7 @@ export async function setOverriddenABTests( driver, name, variation ) {
 		if ( test === name ) {
 			return `"${ test }_${ abTestList[ test ].datestamp }":"${ variation }"`;
 		}
-		return `"${ test }_${ abTestList[ test ].datestamp }":"${
-			abTestList[ test ].defaultVariation
-		}"`;
+		return `"${ test }_${ abTestList[ test ].datestamp }":"${ abTestList[ test ].defaultVariation }"`;
 	} );
 	return await writeABTests( driver, expectedABTestValue );
 }

--- a/test/e2e/lib/pages/frontend/comments-area-component.js
+++ b/test/e2e/lib/pages/frontend/comments-area-component.js
@@ -39,9 +39,7 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 	async reply( commentObj, depth = 2 ) {
 		const replyButton = By.css( '.comment-reply-link' );
 		const replyContent = By.xpath(
-			`//li[contains(@class,'depth-${ depth }')]//div[@class='comment-content']/p[.='${
-				commentObj.comment
-			}']`
+			`//li[contains(@class,'depth-${ depth }')]//div[@class='comment-content']/p[.='${ commentObj.comment }']`
 		);
 		await driverHelper.clickWhenClickable( this.driver, replyButton );
 		await this._postComment( commentObj );

--- a/test/e2e/lib/pages/my-plan-page.js
+++ b/test/e2e/lib/pages/my-plan-page.js
@@ -25,6 +25,9 @@ export default class MyPlanPage extends AsyncBaseContainer {
 	}
 
 	async isPremium() {
-		return await driverHelper.isEventuallyPresentAndDisplayed( this.driver, By.css( 'img.is-premium-plan' ) );
+		return await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( 'img.is-premium-plan' )
+		);
 	}
 }

--- a/test/e2e/lib/reporter/magellan-reporter.js
+++ b/test/e2e/lib/reporter/magellan-reporter.js
@@ -88,13 +88,7 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 
 													slackClient.send( {
 														icon_emoji: ':a8c:',
-														text: `Build <https://circleci.com/gh/${
-															process.env.CIRCLE_PROJECT_USERNAME
-														}/${ process.env.CIRCLE_PROJECT_REPONAME }/${
-															process.env.CIRCLE_BUILD_NUM
-														}|#${
-															process.env.CIRCLE_BUILD_NUM
-														}> Upload to slack failed: '${ err }'`,
+														text: `Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${ process.env.CIRCLE_PROJECT_REPONAME }/${ process.env.CIRCLE_BUILD_NUM }|#${ process.env.CIRCLE_BUILD_NUM }> Upload to slack failed: '${ err }'`,
 														username: 'e2e Test Runner',
 													} );
 												}
@@ -118,13 +112,7 @@ Reporter.prototype.listenTo = function( testRun, test, source ) {
 				if ( test.attempts > 0 ) {
 					slackClient.send( {
 						icon_emoji: ':a8c:',
-						text: `FYI - The following test failed, retried, and passed: (${
-							process.env.BROWSERSIZE
-						}) ${ testObject.title } - Build <https://circleci.com/gh/${
-							process.env.CIRCLE_PROJECT_USERNAME
-						}/${ process.env.CIRCLE_PROJECT_REPONAME }/${ process.env.CIRCLE_BUILD_NUM }|#${
-							process.env.CIRCLE_BUILD_NUM
-						}>`,
+						text: `FYI - The following test failed, retried, and passed: (${ process.env.BROWSERSIZE }) ${ testObject.title } - Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${ process.env.CIRCLE_PROJECT_REPONAME }/${ process.env.CIRCLE_BUILD_NUM }|#${ process.env.CIRCLE_BUILD_NUM }>`,
 						username: 'e2e Test Runner',
 					} );
 				}
@@ -183,11 +171,7 @@ function copyReports( slackClient, reportDir, reportPath, guid ) {
 				}
 				slackClient.send( {
 					icon_emoji: ':a8c:',
-					text: `Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${
-						process.env.CIRCLE_PROJECT_REPONAME
-					}/${ process.env.CIRCLE_BUILD_NUM }|#${
-						process.env.CIRCLE_BUILD_NUM
-					}> Moving file to /reports failed: '${ moveErr }'`,
+					text: `Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${ process.env.CIRCLE_PROJECT_REPONAME }/${ process.env.CIRCLE_BUILD_NUM }|#${ process.env.CIRCLE_BUILD_NUM }> Moving file to /reports failed: '${ moveErr }'`,
 					username: 'e2e Test Runner',
 				} );
 			}
@@ -206,11 +190,7 @@ function copyScreenshots( slackClient, dir, path, finalScreenshotDir ) {
 			}
 			slackClient.send( {
 				icon_emoji: ':a8c:',
-				text: `Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${
-					process.env.CIRCLE_PROJECT_REPONAME
-				}/${ process.env.CIRCLE_BUILD_NUM }|#${
-					process.env.CIRCLE_BUILD_NUM
-				}> Moving file to screenshots directory failed: '${ moveErr }'`,
+				text: `Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${ process.env.CIRCLE_PROJECT_REPONAME }/${ process.env.CIRCLE_BUILD_NUM }|#${ process.env.CIRCLE_BUILD_NUM }> Moving file to screenshots directory failed: '${ moveErr }'`,
 				username: 'e2e Test Runner',
 			} );
 		} );
@@ -264,11 +244,7 @@ function sendFailureNotif( slackClient, reportDir, testRun ) {
 
 	slackClient.send( {
 		icon_emoji: ':a8c:',
-		text: `<!subteam^S0G7K98MB|flow-patrol-squad-team> Test Run Failed - Build <https://circleci.com/gh/${
-			process.env.CIRCLE_PROJECT_USERNAME
-		}/${ process.env.CIRCLE_PROJECT_REPONAME }/${ process.env.CIRCLE_BUILD_NUM }|#${
-			process.env.CIRCLE_BUILD_NUM
-		}>`,
+		text: `<!subteam^S0G7K98MB|flow-patrol-squad-team> Test Run Failed - Build <https://circleci.com/gh/${ process.env.CIRCLE_PROJECT_USERNAME }/${ process.env.CIRCLE_PROJECT_REPONAME }/${ process.env.CIRCLE_BUILD_NUM }|#${ process.env.CIRCLE_BUILD_NUM }>`,
 		fields: fieldsObj,
 		username: 'e2e Test Runner',
 	} );

--- a/test/e2e/lib/slack-notifier.js
+++ b/test/e2e/lib/slack-notifier.js
@@ -28,11 +28,7 @@ export function warn( message, { suppressDuplicateMessages = false } = {} ) {
 			config.get( 'reportWarningsToSlack' ) === true
 		) {
 			const currentScreenSize = driverManager.currentScreenSize();
-			const detailedMessage = `${ message } - encountered on '${
-				global.browserName
-			}' at screen size '${ currentScreenSize }' in CircleCI build #${
-				process.env.CIRCLE_BUILD_NUM
-			} on branch '${ process.env.CIRCLE_BRANCH }'`;
+			const detailedMessage = `${ message } - encountered on '${ global.browserName }' at screen size '${ currentScreenSize }' in CircleCI build #${ process.env.CIRCLE_BUILD_NUM } on branch '${ process.env.CIRCLE_BRANCH }'`;
 			const slackClient = slack( slackHook );
 			slackClient.send( {
 				icon_emoji: ':a8c:',


### PR DESCRIPTION
Two significant changes:

Formatting template literals doesn't do line breaks that don't look good, it rather prefers the line to go over the maximum length.

No longer this:
```js
`This is a string with ${
  first.param
} and ${
  second.param
}`
```

But do this:
```js
`This is a string with ${ first.param } and ${ second.param }`
```

The second change is a lot of spacing bugfixes in TypeScript, at places where square brackets are involved (indexed access, tuples, ...). These are bugfixes in the fork rather than the upstream, adding spaces where appropriate:
```ts
interface QueryArgs {
  [ key: string ]: Primitive;
}

function Component( props: Draggable[ 'props' ] ) {}

const installerPositionalArguments: [ 'akismet', 'vaultpress' ] = [ 'akismet', 'vaultpress' ];
```