### PR TITLE
Packages: Use esm for esm builds

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,19 +7,7 @@ const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
 // We implicitly use browserslist configuration in package.json for build targets.
 
 const config = {
-	presets: [
-		[
-			'@babel/env',
-			{
-				modules,
-				useBuiltIns: 'entry',
-				corejs: 2,
-				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-				exclude: [ 'transform-typeof-symbol' ],
-			},
-		],
-		'@automattic/calypso-build/babel/default',
-	],
+	presets: [ [ '@automattic/calypso-build/babel/default', { modules } ] ],
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
 	env: {
 		build_pot: {

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.2.0
+- Support CommonJS/ESM compilation by adding a `modules` option (and `MODULES` env variable) to the `babel/default` preset.
+
 # 4.1.0
 
 - Add config options to file-loader.

--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -120,6 +120,16 @@ module.exports = {
 };
 ```
 
+The `default` preset has a `modules` option that specifies whether we want to transpile ESM `import` and `export` statements. Most common values are `false`, which keeps these statements intact and results in ES modules as output, and `'commonjs'`, which transpiles the module to the CommonJS format. See the [@babel/preset-env documentation](https://babeljs.io/docs/en/babel-preset-env#modules) for more details.
+
+```js
+presets: [
+	[ '@automattic/calypso-build/babel/default', { modules: 'commonjs' } ]
+]
+```
+
+Another way to set the `modules` option is to set the `MODULES` environment variable to `'esm'` (maps to `false`) or any other valid value. That's convenient for running Babel from command line, where specifying options for presets (`--presets=...`) is not supported.
+
 ## Jest
 
 Use the provided Jest configuration via a preset. In your `jest.config.js` set the following:

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -1,10 +1,16 @@
+const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
+
+// Use commonjs for Node
+const modules = isBrowser ? false : 'commonjs';
+
 module.exports = () => ( {
 	presets: [
 		[
 			require.resolve( '@babel/preset-env' ),
 			{
-				useBuiltIns: 'entry',
 				corejs: 2,
+				modules,
+				useBuiltIns: 'entry',
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
 				exclude: [ 'transform-typeof-symbol' ],
 			},

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -1,16 +1,23 @@
 // @babel/preset-env modules option. `false` for ECMAScript modules.
-let modules = 'commonjs'; // Default
-if ( typeof process.env.MODULES !== 'undefined' ) {
-	modules = process.env.MODULES === 'esm' ? false : process.env.MODULES;
+function modulesOption( opts ) {
+	if ( opts && opts.modules !== undefined ) {
+		return opts.modules;
+	}
+
+	if ( typeof process.env.MODULES !== 'undefined' ) {
+		return process.env.MODULES === 'esm' ? false : process.env.MODULES;
+	}
+
+	return false; // Default
 }
 
-module.exports = () => ( {
+module.exports = ( api, opts ) => ( {
 	presets: [
 		[
 			require.resolve( '@babel/preset-env' ),
 			{
 				corejs: 2,
-				modules,
+				modules: modulesOption( opts ),
 				useBuiltIns: 'entry',
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
 				exclude: [ 'transform-typeof-symbol' ],

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -1,7 +1,8 @@
-const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
-
-// Use commonjs for Node
-const modules = isBrowser ? false : 'commonjs';
+// @babel/preset-env modules option. `false` for ECMAScript modules.
+let modules = 'commonjs'; // Default
+if ( typeof process.env.MODULES !== 'undefined' ) {
+	modules = process.env.MODULES === 'esm' ? false : process.env.MODULES;
+}
 
 module.exports = () => ( {
 	presets: [

--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -19,11 +19,11 @@ console.log( 'Building %s', dir );
 const baseCommand = `npx babel --presets="${ babelPresetFile }" --extensions='.js,.jsx,.ts,.tsx'`;
 
 execSync( `${ baseCommand } -d "${ outputDirEsm }" "${ inputDir }"`, {
-	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults', MODULES: 'esm' } ),
+	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults' } ),
 	cwd: root,
 } );
 
 execSync( `${ baseCommand } -d "${ outputDirCommon }" "${ inputDir }"`, {
-	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults' } ),
+	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults', MODULES: 'commonjs' } ),
 	cwd: root,
 } );

--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -19,11 +19,11 @@ console.log( 'Building %s', dir );
 const baseCommand = `npx babel --presets="${ babelPresetFile }" --extensions='.js,.jsx,.ts,.tsx'`;
 
 execSync( `${ baseCommand } -d "${ outputDirEsm }" "${ inputDir }"`, {
-	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults' } ),
+	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults', MODULES: 'esm' } ),
 	cwd: root,
 } );
 
 execSync( `${ baseCommand } -d "${ outputDirCommon }" "${ inputDir }"`, {
-	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'server' } ),
+	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults' } ),
 	cwd: root,
 } );


### PR DESCRIPTION
esm build of packages were not using esm! Fix that.

Discovered in #36186 

<details>

<summary>Comparison of output</summary>

This is the result of transpiling `@automattic/calypso-ui` `ScreenReaderText` component.

```sh
npm run clean:packages && npm run build-packages
```

### CommonJS

#### Before

```js
"use strict";

var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.default = ScreenReaderText;

var _react = _interopRequireDefault(require("react"));

require("./style.scss");

/**
 * External dependencies
 */

/**
 * Style dependencies
 */
function ScreenReaderText(_ref) {
  var children = _ref.children;
  return _react.default.createElement("span", {
    className: "screen-reader-text"
  }, children);
}
```

#### After

```js
"use strict";

var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.default = ScreenReaderText;

var _react = _interopRequireDefault(require("react"));

require("./style.scss");

/**
 * External dependencies
 */

/**
 * Style dependencies
 */
function ScreenReaderText(_ref) {
  var children = _ref.children;
  return _react.default.createElement("span", {
    className: "screen-reader-text"
  }, children);
}
```

### ECMAScript Modules

#### Before

**It's not ESM!**

```js
"use strict";

var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.default = ScreenReaderText;

var _react = _interopRequireDefault(require("react"));

require("./style.scss");

/**
 * External dependencies
 */

/**
 * Style dependencies
 */
function ScreenReaderText(_ref) {
  var children = _ref.children;
  return _react.default.createElement("span", {
    className: "screen-reader-text"
  }, children);
}
```

#### After

```js
/**
 * External dependencies
 */
import React from 'react';
/**
 * Style dependencies
 */

import './style.scss';
export default function ScreenReaderText(_ref) {
  var children = _ref.children;
  return React.createElement("span", {
    className: "screen-reader-text"
  }, children);
}
```

</details>

## Testing
1. Build packages: `npm run clean:packages && npm run build-packages`
1. Check the output of packages be inspecting the output in the `dist` directory.
1. Smoke test calypso.