### PR TITLE
G Suite: Stop submit button A/B test on Add Users page

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
@@ -11,7 +11,6 @@ import React, { useState } from 'react';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import { areAllUsersValid, getItemsForCart, newUsers } from 'lib/gsuite/new-users';
@@ -68,6 +67,7 @@ const GSuiteUpsellCard = ( {
 
 	const handleSkipClick = () => {
 		recordClickEvent( `calypso_checkout_gsuite_upgrade_skip_button_click` );
+
 		onSkipClick();
 	};
 
@@ -80,17 +80,14 @@ const GSuiteUpsellCard = ( {
 
 	const handleUsersChange = changedUsers => {
 		recordUsersChangedEvent( users, changedUsers );
+
 		setUsers( changedUsers );
 	};
-
-	const renderAddEmailButtonText = () =>
-		abtest( 'gSuiteContinueButtonCopy' ) === 'purchase'
-			? translate( 'Purchase G Suite' )
-			: translate( 'Yes, Add Email \u00BB' );
 
 	return (
 		<div className="gsuite-upsell-card__form">
 			<QueryProducts />
+
 			<CompactCard>
 				<header className="gsuite-upsell-card__header">
 					<h2 className="gsuite-upsell-card__title">
@@ -100,11 +97,13 @@ const GSuiteUpsellCard = ( {
 							},
 						} ) }
 					</h2>
+
 					<h5 className="gsuite-upsell-card__no-setup-required">
 						{ translate( 'No setup or software required. Easy to manage from your dashboard.' ) }
 					</h5>
 				</header>
 			</CompactCard>
+
 			<CompactCard>
 				<GSuiteUpsellProductDetails
 					domain={ domain }
@@ -112,6 +111,7 @@ const GSuiteUpsellCard = ( {
 					currencyCode={ currencyCode }
 					plan={ gSuiteProductSlug }
 				/>
+
 				<GSuiteNewUserList
 					extraValidation={ user => user }
 					selectedDomainName={ domain }
@@ -130,7 +130,7 @@ const GSuiteUpsellCard = ( {
 							disabled={ ! canContinue }
 							onClick={ handleAddEmailClick }
 						>
-							{ renderAddEmailButtonText() }
+							{ translate( 'Purchase G Suite' ) }
 						</Button>
 					</div>
 				</GSuiteNewUserList>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -62,14 +62,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	gSuiteContinueButtonCopy: {
-		datestamp: '20190307',
-		variations: {
-			purchase: 50,
-			original: 50,
-		},
-		defaultVariation: 'original',
-	},
 	pageBuilderMVP: {
 		datestamp: '20190419',
 		variations: {


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/31282 which ends the A/B test. The new variation will be retained.

#### Testing instructions

1. Run `git checkout remove/gsuite-button-label-test` and start your server, or open a [live branch](https://calypso.live/?branch=remove/gsuite-button-label-test)
2. Open the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
3. Select any domain suggested
4. Assert that `Purchase G Suite` is displayed for the submit button
5. Assert that you can add G Suite to the shopping cart