### PR TITLE
Fix emitting calypso_login_social_button_click when user clicks on the Apple login button

### DIFF
--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -7,6 +7,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,8 +30,14 @@ class AppleLoginButton extends Component {
 		responseHandler: PropTypes.func.isRequired,
 	};
 
+	static defaultProps = {
+		onClick: noop,
+	};
+
 	handleClick = event => {
 		event.preventDefault();
+
+		this.props.onClick( event );
 
 		requestExternalAccess( connectUrl, this.props.responseHandler );
 	};


### PR DESCRIPTION
This fixes event `calypso_login_social_button_click` emitted on "Continue with Apple" click on login and signup.

#### Changes proposed in this Pull Request

* Call the `onClick` props from `AppleLoginButton` before opening the oauth2 popup

#### Testing instructions

Try applying this patch and check that you see the event in tracks
