### PR TITLE
Editor: Improve Featured Image Dropzone Colours

### DIFF
--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -74,14 +74,15 @@
 	border: 6px solid var( --color-accent-dark );
 
 	&.is-dragging-over-element {
-		background-color: var( --color-accent-light );
+		background-color: var( --color-accent-dark );
+		border-color: var( --color-accent-80 );
 	}
 
 	.drop-zone__content-icon svg g {
-		fill: var( --color-white );
+		fill: var( --color-text-inverted );
 	}
 
 	.drop-zone__content-text {
-		color: var( --color-white );
+		color: var( --color-text-inverted );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes two things:

1. the dropzone is using `--color-white`, that doesn't exist anymore as of #35949 I think. that's causing the gridicon to use an odd colour
2. the hover contrast was previously too low

#### Testing instructions

In the Classic Editor, you can access this feature by dragging an image over the document and over the dropzone in the sidebar.

**Current experience:**

_Hovering image over document_
<img width="275" alt="Screenshot 2019-09-23 at 19 22 51" src="https://user-images.githubusercontent.com/43215253/65451922-0aaaa080-de38-11e9-9391-8501b0008320.png">

_Hovering image over dropzone_
<img width="292" alt="Screenshot 2019-09-23 at 19 23 02" src="https://user-images.githubusercontent.com/43215253/65451958-17c78f80-de38-11e9-96a4-d08ceec88dec.png">


**Proposed experience:**

_Hovering image over document_
<img width="300" alt="Screenshot 2019-09-23 at 19 23 15" src="https://user-images.githubusercontent.com/43215253/65451970-20b86100-de38-11e9-998e-0337b9af2b51.png">

_Hovering image over dropzone_
<img width="299" alt="Screenshot 2019-09-23 at 19 23 25" src="https://user-images.githubusercontent.com/43215253/65451972-244be800-de38-11e9-8959-fe27de11fa35.png">

Basically, the colour change still reflects that the image is being hovered over the dropzone, it just becomes darker instead of lighter.

Fixes #36239
