### PR TITLE
e2e: Increase wait time for calypso.live

### DIFF
--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -3,8 +3,8 @@
 sha=$CIRCLE_SHA1
 
 COUNT=0
-RESETCOUNT=60 # 5sec retry = Reset the branch after 5 minutes
-MAXCOUNT=120  # 5sec retry = Cancel after 10 minutes
+RESETCOUNT=120 # 5sec retry = Reset the branch after 5 minutes
+MAXCOUNT=240  # 5sec retry = Cancel after 10 minutes
 SITEWAITCOUNT=30 # 5sec retry = Stop waiting after 2.5 minutes
 
 STATUS=$(curl https://hash-$sha.calypso.live/status 2>/dev/null)


### PR DESCRIPTION
Our e2e job waits for 5 minutes for a calypso.live branch to be build, then _resets_ the branch and tries again. I suspect calypso.live is averaging more than 5 minutes for _any_ initial build, so resetting the branch too early is wasting a lot of calypso.live time and a lot of CircleCI container time.

Double the wait times for the first reset and the overall failure time to 10 and 20 minutes.

#### Testing instructions

* With luck, this branch will build and pass on the first run of `wait-calypso-live`.