### PR TITLE
Media Library: Change Delete Button Depending on Selection Count

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -269,7 +269,7 @@ class Media extends Component {
 				}
 			},
 			selectedCount < 2
-				? translate( 'Delete 1 item' )
+				? translate( 'Delete item' )
 				: translate( 'Delete %(selectedCount)s items', {
 						args: {
 							selectedCount: selectedCount,

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -167,13 +167,21 @@ class Media extends Component {
 			return null;
 		}
 
-		const { translate } = this.props;
+		const { selectedSite, translate } = this.props;
+		const selectedMediaCount = MediaLibrarySelectedStore.getAll( selectedSite.ID ).length;
 
 		return [
 			{
 				action: 'delete',
 				additionalClassNames: 'is-borderless is-scary',
-				label: translate( 'Delete' ),
+				label:
+					selectedMediaCount < 2
+						? translate( 'Delete item' )
+						: translate( 'Delete %(selectedMediaCount)s items', {
+								args: {
+									selectedMediaCount: selectedMediaCount,
+								},
+						  } ),
 				isPrimary: false,
 				disabled: false,
 				onClick: this.deleteMediaByItemDetail,
@@ -260,14 +268,13 @@ class Media extends Component {
 					callback();
 				}
 			},
-			selectedCount < 2 
-				? translate( 'Delete 1 item' ) 
+			selectedCount < 2
+				? translate( 'Delete 1 item' )
 				: translate( 'Delete %(selectedCount)s items', {
-					args: {
-						selectedCount: selectedCount,
-					},
-				}
-			),
+						args: {
+							selectedCount: selectedCount,
+						},
+				  } ),
 			null,
 			{
 				isScary: true,

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -260,7 +260,14 @@ class Media extends Component {
 					callback();
 				}
 			},
-			translate( 'Delete' ),
+			selectedCount < 2 
+				? translate( 'Delete 1 item' ) 
+				: translate( 'Delete %(selectedCount)s items', {
+					args: {
+						selectedCount: selectedCount,
+					},
+				}
+			),
 			null,
 			{
 				isScary: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This ensures that the "Delete" button in the Media Library updates the text depending on how many items are selected for removal. Currently, it just says "Delete" in all cases.

#### Testing instructions

1. Visit the `/media/site`
2. Select multiple images
3. Click the trash icon
4. Verify the scary button displays how many images are about to deleted

<img width="708" alt="Screenshot 2019-09-23 at 22 26 59" src="https://user-images.githubusercontent.com/43215253/65464348-777e6480-de51-11e9-83e8-36a64eb0a4e0.png">

Now try selecting just one image, verify that the plural of "item" is not used.

<img width="724" alt="Screenshot 2019-09-23 at 22 26 52" src="https://user-images.githubusercontent.com/43215253/65464408-967cf680-de51-11e9-81af-a13a62440eb5.png">

For comparison, here's what the button looks like currently in all cases.

<img width="706" alt="Screenshot 2019-09-23 at 22 29 34" src="https://user-images.githubusercontent.com/43215253/65464428-a85e9980-de51-11e9-9751-32a55680c234.png">

Fixes #31843
