### PR TITLE
Fix shadows produced by `elevation` mixin

### DIFF
--- a/client/assets/stylesheets/shared/mixins/_elevation.scss
+++ b/client/assets/stylesheets/shared/mixins/_elevation.scss
@@ -6,53 +6,53 @@
         box-shadow: none;
     }
     @else if $dp==1 {
-        box-shadow: 0 1px 1px 0 rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 2px 1px -1px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 1px 3px 0 rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 1px 1px 0 rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 2px 1px -1px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 1px 3px 0 rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==2 {
-        box-shadow: 0 2px 2px 0 rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 3px 1px -2px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 1px 5px 0 rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 2px 2px 0 rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 3px 1px -2px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 1px 5px 0 rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==3 {
-        box-shadow: 0 3px 4px 0 rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 3px 3px -2px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 1px 8px 0 rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 3px 4px 0 rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 3px 3px -2px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 1px 8px 0 rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==4 {
-        box-shadow: 0 4px 5px 0 rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 1px 10px 0 rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 2px 4px -1px rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 4px 5px 0 rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 1px 10px 0 rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 2px 4px -1px rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==6 {
-        box-shadow: 0 6px 10px 0 rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 1px 18px 0 rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 3px 5px -1px rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 6px 10px 0 rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 1px 18px 0 rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 3px 5px -1px rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==8 {
-        box-shadow: 0 8px 10px 1px rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 3px 14px 2px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 5px 5px -3px rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 8px 10px 1px rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 3px 14px 2px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 5px 5px -3px rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==9 {
-        box-shadow: 0 9px 12px 1px rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 3px 16px 2px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 5px 6px -3px rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 9px 12px 1px rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 3px 16px 2px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 5px 6px -3px rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==12 {
-        box-shadow: 0 12px 17px 2px rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 5px 22px 4px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 7px 8px -4px rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 12px 17px 2px rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 5px 22px 4px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 7px 8px -4px rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==16 {
-        box-shadow: 0 16px 24px 2px rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 6px 30px 5px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 8px 10px -5px rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 16px 24px 2px rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 6px 30px 5px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 8px 10px -5px rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
     @else if $dp==24 {
-        box-shadow: 0 24px 38px 3px rgba( var( --color-neutral-100 ), 0.14 ),
-                    0 9px 46px 8px rgba( var( --color-neutral-100 ), 0.12 ),
-                    0 11px 15px -7px rgba( var( --color-neutral-100 ), 0.2 );
+        box-shadow: 0 24px 38px 3px rgba( var( --color-neutral-100-rgb ), 0.14 ),
+                    0 9px 46px 8px rgba( var( --color-neutral-100-rgb ), 0.12 ),
+                    0 11px 15px -7px rgba( var( --color-neutral-100-rgb ), 0.2 );
     }
 }


### PR DESCRIPTION
Fixes the `elevation()` mixin which was unintentionally broken in a big refactor from the looks of it: 91d81829a56186344001eb45531cb7826e03be34
(there was a further rename in 22a75f5967028e4ec8a116dcea53312fabcd87c6, but that didn't change this bug).

The mixin should use the `-rgb` variation of the colour variable so that it produces a valid rgba code. Instead it used a colour variable that has a hex code.

I had a quick look at the commit and I didn't see any other places the `-rgb` was left off.

The mixin looks like it's primarily used in signup code, easy to miss.

### Testing instructions

#### Before applying the fix
<img width="467" alt="image" src="https://user-images.githubusercontent.com/1500769/65465988-b5ab7080-deb1-11e9-99ad-255d335edb8c.png">
<img width="508" alt="image" src="https://user-images.githubusercontent.com/1500769/65466066-f0ada400-deb1-11e9-8500-f6c34a11f755.png">

#### After applying the fix
<img width="467" alt="image" src="https://user-images.githubusercontent.com/1500769/65465963-a9bfae80-deb1-11e9-9916-d5ebf5500793.png">
<img width="508" alt="image" src="https://user-images.githubusercontent.com/1500769/65466093-015e1a00-deb2-11e9-83cb-8063b442258b.png">
