### PR TITLE
Reader: add read.amazon.com to trusted iframe hosts

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -181,6 +181,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'scribd.com',
 		'megaphone.fm',
 		'icloud.com',
+		'read.amazon.com',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/issues/36251, @katiebethbrown notes that Amazon Kindle embeds do not work correctly because the iframe is sandboxed.

This PR adds read.amazon.com to the trusted iframe hosts list.

#### Testing instructions

Starting at URL: https://wordpress.com/read/blogs/156768890/posts/170
View any post in the Reader with an Amazon/Kindle book embed.
Click any any of the areas in the Amazon Kindle Embed - the cover, the buy, share, or preview buttons

Fixes #36251.
