### PR TITLE
User bootstrap cookie-based support session

### DIFF
--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -54,6 +54,20 @@ function setup() {
 					)
 				);
 			}
+
+			// Use try/catch because config() will throw for missing keys in development mode,
+			// and we don't want an exception if `support_session_id_cookie` is undefined.
+			try {
+				const supportSessionIdCookie = config( 'support_session_id_cookie' );
+				if ( supportSessionIdCookie ) {
+					app.use( function( req, res, next ) {
+						if ( ! req.cookies.support_session_id ) {
+							req.cookies.support_session_id = supportSessionIdCookie;
+						}
+						next();
+					} );
+				}
+			} catch ( e ) {}
 		}
 	} else {
 		// setup logger

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -227,7 +227,7 @@ function getAcceptedLanguagesFromHeader( header ) {
  * all following handlers (including the locale and redirect ones) can rely on the context values.
  */
 function setupLoggedInContext( req, res, next ) {
-	const isSupportSession = !! req.get( 'x-support-session' );
+	const isSupportSession = !! req.get( 'x-support-session' ) || !! req.cookies.support_session_id;
 	const isLoggedIn = !! req.cookies.wordpress_logged_in;
 
 	req.context = {

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -17,6 +17,7 @@ import config from 'config';
 const debug = debugFactory( 'calypso:bootstrap' ),
 	API_KEY = config( 'wpcom_calypso_rest_api_key' ),
 	AUTH_COOKIE_NAME = 'wordpress_logged_in',
+	SUPPORT_SESSION_COOKIE_NAME = 'support_session_id',
 	/**
 	 * WordPress.com REST API /me endpoint.
 	 */
@@ -38,10 +39,19 @@ const debug = debugFactory( 'calypso:bootstrap' ),
 module.exports = async function( request ) {
 	const authCookieValue = request.cookies[ AUTH_COOKIE_NAME ];
 	const geoCountry = request.get( 'x-geoip-country-code' ) || '';
-	const supportSession = request.get( 'x-support-session' );
+	const supportSessionHeader = request.get( 'x-support-session' );
+	const supportSessionCookie = request.cookies[ SUPPORT_SESSION_COOKIE_NAME ];
 
 	if ( ! authCookieValue ) {
 		throw new Error( 'Cannot bootstrap without an auth cookie' );
+	}
+
+	if ( supportSessionHeader && supportSessionCookie ) {
+		// We don't expect to see a support session header and cookie at the same time.
+		// They are separate support session auth options.
+		throw new Error(
+			'Cannot bootstrap with both a support session header and support session cookie.'
+		);
 	}
 
 	const decodedAuthCookieValue = decodeURIComponent( authCookieValue );
@@ -50,9 +60,14 @@ module.exports = async function( request ) {
 	const req = superagent.get( url );
 	req.set( 'User-Agent', 'WordPress.com Calypso' );
 	req.set( 'X-Forwarded-GeoIP-Country-Code', geoCountry );
-	req.set( 'Cookie', AUTH_COOKIE_NAME + '=' + decodedAuthCookieValue );
 
-	if ( supportSession ) {
+	const cookies = [ `${ AUTH_COOKIE_NAME }=${ decodedAuthCookieValue }` ];
+	if ( supportSessionCookie ) {
+		cookies.push( `${ SUPPORT_SESSION_COOKIE_NAME }=${ supportSessionCookie }` );
+	}
+	req.set( 'Cookie', cookies.join( '; ' ) );
+
+	if ( supportSessionHeader ) {
 		if ( typeof SUPPORT_SESSION_API_KEY !== 'string' ) {
 			throw new Error(
 				'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
@@ -60,11 +75,11 @@ module.exports = async function( request ) {
 		}
 
 		const hmac = crypto.createHmac( 'md5', SUPPORT_SESSION_API_KEY );
-		hmac.update( supportSession );
+		hmac.update( supportSessionHeader );
 		const hash = hmac.digest( 'hex' );
 
 		req.set( 'Authorization', `X-WPCALYPSO-SUPPORT-SESSION ${ hash }` );
-		req.set( 'x-support-session', supportSession );
+		req.set( 'x-support-session', supportSessionHeader );
 	} else {
 		if ( typeof API_KEY !== 'string' ) {
 			throw new Error( 'Unable to boostrap user because of invalid API key in secrets.json' );


### PR DESCRIPTION
We are adding support for cookie-based support sessions, and this PR updates user-bootstrap to authenticate properly with them.

I've tested this with normal WordPress auth and cookie-based support session auth, but there have been some changes since I last tested. I plan to test all user bootstrap auth branches again in the morning.
