### PR TITLE
Wrap up removeBlogFlow abtest and remove /start/blog flow

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,15 +124,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	removeBlogFlow: {
-		datestamp: '20190813',
-		variations: {
-			remove: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	customerHomePage: {
 		datestamp: '20190903',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -83,13 +83,6 @@ export function generateFlows( {
 			lastModified: '2019-08-05',
 		},
 
-		blog: {
-			steps: [ 'user', 'blog-themes', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'Signup flow starting with blog themes',
-			lastModified: '2017-09-01',
-		},
-
 		'rebrand-cities': {
 			steps: [ 'rebrand-cities-welcome', 'user' ],
 			destination: function( dependencies ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -46,8 +46,6 @@ const stepNameToModuleName = {
 	'survey-user': 'survey-user',
 	test: 'test-step',
 	themes: 'theme-selection',
-	'website-themes': 'theme-selection',
-	'blog-themes': 'theme-selection',
 	'themes-site-selected': 'theme-selection',
 	user: 'user',
 	'oauth2-user': 'user',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -52,24 +52,6 @@ export function generateSteps( {
 			providesDependencies: [ 'themeSlugWithRepo' ],
 		},
 
-		'blog-themes': {
-			stepName: 'blog-themes',
-			props: {
-				designType: 'blog',
-			},
-			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'themeSlugWithRepo' ],
-		},
-
-		'website-themes': {
-			stepName: 'website-themes',
-			props: {
-				designType: 'page',
-			},
-			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'themeSlugWithRepo' ],
-		},
-
 		'portfolio-themes': {
 			stepName: 'portfolio-themes',
 			props: {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -38,7 +38,6 @@ import SignupHeader from 'signup/signup-header';
 import QuerySiteDomains from 'components/data/query-site-domains';
 
 // Libraries
-import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
@@ -163,12 +162,6 @@ class Signup extends React.Component {
 			const destinationStep = flows.getFlow( this.props.flowName ).steps[ 0 ];
 			this.setState( { resumingStep: destinationStep } );
 			return page.redirect( getStepUrl( this.props.flowName, destinationStep, this.props.locale ) );
-		}
-
-		if ( 'remove' === abtest( 'removeBlogFlow' ) && 'blog' === this.props.flowName ) {
-			const destinationStep = flows.getFlow( 'onboarding' ).steps[ 0 ];
-			this.setState( { resumingStep: destinationStep } );
-			return page.redirect( getStepUrl( 'onboarding', destinationStep, this.props.locale ) );
 		}
 
 		this.recordStep();


### PR DESCRIPTION
This PR will remove the `/start/blog` flow. More info: p8Eqe3-Lk-p2#comment-2303

The `blog` flow appears to no longer be actively used, so if accepted this PR will remove it. For the moment, I'll put this PR in "blocked" until I can confirm whether or not there are any objections to removing the flow. The original A/B test was created in: https://github.com/Automattic/wp-calypso/pull/35321

#### Changes proposed in this Pull Request

* Wrap up `removeBlogFlow` A/B test
* Remove `blog` flow from signup
* Remove unused `blog-themes` and `website-themes` steps

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/start/blog`
* This should redirect you to the main onboarding flow `http://calypso.localhost:3000/start/` and the first step in that flow (`user`, or if you're already logged in, `site-type`)
* Complete creating a site, ensuring that the signup flow still works
