### PR TITLE
tree-select: Fix getDependents returning a truthy primitive

### DIFF
--- a/packages/tree-select/src/index.js
+++ b/packages/tree-select/src/index.js
@@ -69,7 +69,7 @@ export default function treeSelect( getDependents, selector, options = {} ) {
 /*
  * This object will be used as a WeakMap key if a dependency is a falsy value (null, undefined, ...)
  */
-const STATIC_FALSY_KEY = {};
+const NULLISH_KEY = {};
 
 /*
  * First tries to get the value for the key.
@@ -79,7 +79,10 @@ const STATIC_FALSY_KEY = {};
  * The last map is a regular one because the the key for the last map is the string results of args.join().
  */
 function insertDependentKey( map, key, currentIndex, arr ) {
-	const weakMapKey = key || STATIC_FALSY_KEY;
+	if ( key != null && Object( key ) !== key ) {
+		throw new TypeError( 'key must be an object, `null`, or `undefined`' );
+	}
+	const weakMapKey = key || NULLISH_KEY;
 
 	const existingMap = map.get( weakMapKey );
 	if ( existingMap ) {

--- a/packages/tree-select/test/index.js
+++ b/packages/tree-select/test/index.js
@@ -221,13 +221,22 @@ describe( 'index', () => {
 			expect( afterClearResult ).not.toBe( firstResult );
 		} );
 
-		test( 'should memoize a falsy value returned by getDependents', () => {
-			const memoizedSelector = treeSelect( () => [ null ], () => [] );
+		test( 'should memoize a nullish value returned by getDependents', () => {
+			const memoizedSelector = treeSelect( () => [ null, undefined ], () => [] );
 			const state = {};
 
 			const firstResult = memoizedSelector( state );
 			const secondResult = memoizedSelector( state );
 			expect( firstResult ).toBe( secondResult );
+		} );
+
+		test( 'throws on a non-nullish primitive value returned by getDependents', () => {
+			[ true, 1, 'a', false, '', 0 ].forEach( primitive => {
+				const memoizedSelector = treeSelect( () => [ primitive ], () => [] );
+				const state = {};
+
+				expect( () => memoizedSelector( state ) ).toThrow();
+			} );
 		} );
 
 		test( 'accepts a getCacheKey option that enables object arguments', () => {


### PR DESCRIPTION
I noticed that the `tree-select` code is ensuring that falsy values returned by `getDependents` are not used as a `WeakMap` key (by falling back to a singleton object), but truthy primitives don't have this protection. Without this fix, `WeakMap` throws.

I chose to implement the same behavior as falsy values - but if something else is desired, I'm happy to alter it.