### PR TITLE
Update wp-prettier 1.18.2 distribution package

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18151,7 +18151,7 @@
 		},
 		"prettier": {
 			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
-			"integrity": "sha512-MZWjD8vE5xFscQxZsBQgNyxqkQbRMWildoUUKm0TNAbuCLjswU6UMtPDLRL1iTkyhWMvJISibVvasqC8PnJPuA==",
+			"integrity": "sha512-J9Bipqt0wEJ5t7X3ODqlY9d/+E4/co7PuCeFi8HqxQPZge/8v9NkwhyXce8PO2+e71Z1wjQM5H4iL8OZPDXsiA==",
 			"dev": true
 		},
 		"pretty-error": {


### PR DESCRIPTION
The tarball on GitHub has changed, to fix an issue with incorrect name of the Prettier binary (https://github.com/Automattic/wp-calypso/pull/36229#issuecomment-534431878).
That also changes the checksum in the lockfile.
