### PR TITLE
Prettier: install the wp-prettier fork as NPM alias rather than tarball download

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18150,8 +18150,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
-			"integrity": "sha512-J9Bipqt0wEJ5t7X3ODqlY9d/+E4/co7PuCeFi8HqxQPZge/8v9NkwhyXce8PO2+e71Z1wjQM5H4iL8OZPDXsiA==",
+			"version": "npm:wp-prettier@1.18.2",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.18.2.tgz",
+			"integrity": "sha512-OvmJZJ6j6KF+CqnNGPLRupSLt6zlFG8/D9dJL21eVJwad1HHEq5cGgeXqboloxE7DjtglkKd/6CEvO1dvqfQdA==",
 			"dev": true
 		},
 		"pretty-error": {

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
 		"ncp": "2.0.0",
 		"nock": "10.0.6",
 		"npm-merge-driver": "2.3.5",
-		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
+		"prettier": "npm:wp-prettier@1.18.2",
 		"react-test-renderer": "16.8.6",
 		"readline-sync": "1.4.9",
 		"replace": "1.1.0",


### PR DESCRIPTION
Since 6.9.0, NPM supports aliases in `package.json`. Let's use the new feature to install the `wp-prettier` fork from NPM and make it available in the project under the `prettier` name. Much nicer than a tarball download URL.

NPM 6.9.0 is the default version bundled with Node.js LTS since v10.16.0. As we force Calypso contributors to use the latest supported version, requiring 6.9.0 shouldn't cause issues for anyone.

See also:
- NPM 6.9.0 release notes: https://npm.community/t/release-npm-6-9-0/5911
- NPM aliases doc (RFC): https://github.com/npm/rfcs/blob/latest/implemented/0001-package-aliases.md

Ping @simison to update his Automattic/jetpack#13524 🚀 
Thanks @samouri for giving us ownership of the `wp-prettier` NPM package 💚 