### PR TITLE
Fix the Remaining RGBA Color Properties

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -212,8 +212,8 @@ $image-height: 47px;
 	.wp-login__site-return-link::after {
 		background: linear-gradient(
 			to right,
-			rgba( var( --color-jetpack-onboarding-background ), 0 ),
-			rgba( var( --color-jetpack-onboarding-background ), 1 ) 90%
+			rgba( var( --color-jetpack-onboarding-background-rgb ), 0 ),
+			var( --color-jetpack-onboarding-background ) 90%
 		);
 	}
 }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -123,7 +123,7 @@
 		}
 
 		.module-content-list-item-right::before {
-			background-image: linear-gradient( to right, rgba( var( --color-neutral-0 ), 0 ) 0%, var( --color-neutral-0 ) 90% );
+			background-image: linear-gradient( to right, rgba( var( --color-neutral-0-rgb ), 0 ) 0%, var( --color-neutral-0 ) 90% );
 		}
 
 		// Display hidden actions
@@ -157,7 +157,7 @@
 	}
 
 	.module-content-list-item-right::before {
-		background-image: linear-gradient( to right, rgba( var( --color-neutral-0 ), 0 ) 0%, var( --color-neutral-0 ) 90% );
+		background-image: linear-gradient( to right, rgba( var( --color-neutral-0-rgb ), 0 ) 0%, var( --color-neutral-0 ) 90% );
 	}
 
 	// Display hidden actions
@@ -748,7 +748,7 @@ ul.module-content-list-legend {
 	}
 
 	> .stats-list__module-content-list-item-wrapper .module-content-list-item-right::before {
-		background-image: linear-gradient( to right, rgba( var( --color-neutral-0 ), 0 ) 0%, var( --color-neutral-0 ) 90% );
+		background-image: linear-gradient( to right, rgba( var( --color-neutral-0-rgb ), 0 ) 0%, var( --color-neutral-0 ) 90% );
 	}
 
 	// Rotate toggle icon

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -3,10 +3,17 @@
 ## 2.1.0
 
 * Updated the color palette to the most recent version.
+* Added the following RGB counterparts of the existing properties:
+  * `--color-jetpack-onboarding-background-rgb`
+  * `--color-jetpack-onboarding-text-rgb`
 * Removed the following properties:
   * `--color-section-nav-item-background-hover`
   * `--color-themes-active-text`
   * `--color-themes-active-text-rgb`
+
+## 2.0.2
+
+* Included missing SCSS dependencies in the published package.
 
 ## 2.0.1
 
@@ -20,7 +27,7 @@ This update brings backwards-incompatible changes to the package. The most notab
 * Following the [files](https://github.com/Automattic/color-studio/blob/master/dist/color-properties.css) [generated](https://github.com/Automattic/color-studio/blob/master/dist/color-properties-rgb.css) by Color Studio, updated all properties to use consistent names (including index numbers).
 * Phased out all SCSS variables in favor of CSS custom properties.
 * Refactored the existing component-specific properties and prefixed all theme variables with `--color`.
-* Introduced `-inverted` properties.
+* Introduced semantic `-inverted` properties which are the successor to `--color-white`.
 * Split all color schemes into separate partial files.
 
 For more details, please refer to Calypso’s [color guide](https://github.com/Automattic/wp-calypso/blob/update/colors/docs/color.md) or the [default color scheme](https://github.com/Automattic/wp-calypso/blob/master/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss).

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -277,7 +277,9 @@
 	--color-sidebar-menu-hover-text: var( --studio-gray-90 );
 
 	--color-jetpack-onboarding-text: var( --studio-white );
+	--color-jetpack-onboarding-text-rgb: var( --studio-white-rgb );
 	--color-jetpack-onboarding-background: var( --studio-blue-100 );
+	--color-jetpack-onboarding-background-rgb: var( --studio-blue-100-rgb );
 
 	/* Brand Color Properties */
 	--color-automattic: var( --studio-blue-40 );


### PR DESCRIPTION
This is a cosmetic update. Following #36250, I looked for any other occurrences of `rgba` values that contain a `var` without the `-rgb` suffix. Found some and fixed them.

I also updated the color schemes’ changelog and bumped the version number which seem to have been overlooked in the recent round of pull requests.