### PR TITLE
SPT: adds confirm selection button to preview thumbnails

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,15 +1,19 @@
 /**
  * External dependencies
  */
+/* eslint-disable import/no-extraneous-dependencies */
 import { isEmpty, isArray, noop, map } from 'lodash';
+/* eslint-enable import/no-extraneous-dependencies */
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
+/* eslint-disable import/no-extraneous-dependencies */
 import { withInstanceId, compose } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
 import { memo } from '@wordpress/element';
+/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies
@@ -28,6 +32,8 @@ export const TemplateSelectorControl = ( {
 	onTemplateSelect = noop,
 	onTemplateFocus = noop,
 	siteInformation = {},
+	currentTemplate = '',
+	handleTemplateConfirmation = noop,
 } ) => {
 	if ( isEmpty( templates ) || ! isArray( templates ) ) {
 		return null;
@@ -57,12 +63,14 @@ export const TemplateSelectorControl = ( {
 							value={ slug }
 							label={ replacePlaceholders( title, siteInformation ) }
 							help={ help }
+							isSelected={ currentTemplate === slug }
 							onSelect={ onTemplateSelect }
 							onFocus={ onTemplateFocus }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
 							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }
 							useDynamicPreview={ useDynamicPreview }
+							handleTemplateConfirmation={ handleTemplateConfirmation }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -10,7 +10,8 @@ import { isNil, isEmpty } from 'lodash';
  */
 import BlockPreview from './block-template-preview';
 /* eslint-disable import/no-extraneous-dependencies */
-import { Disabled } from '@wordpress/components';
+import { Disabled, Button } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const TemplateSelectorItem = props => {
@@ -24,6 +25,8 @@ const TemplateSelectorItem = props => {
 		staticPreviewImg,
 		staticPreviewImgAlt = '',
 		blocks = [],
+		isSelected = false,
+		handleTemplateConfirmation,
 	} = props;
 
 	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
@@ -50,17 +53,28 @@ const TemplateSelectorItem = props => {
 	const labelId = `label-${ id }-${ value }`;
 
 	return (
-		<button
-			type="button"
-			className="template-selector-item__label"
-			value={ value }
-			onMouseEnter={ () => onFocus( value, label ) }
-			onClick={ () => onSelect( value, label ) }
-			aria-labelledby={ `${ id } ${ labelId }` }
-		>
-			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
-			<span id={ labelId }>{ label }</span>
-		</button>
+		<Fragment>
+			<button
+				type="button"
+				className="template-selector-item__label"
+				value={ value }
+				onMouseEnter={ () => onFocus( value, label ) }
+				onClick={ () => onSelect( value, label ) }
+				aria-labelledby={ `${ id } ${ labelId }` }
+			>
+				<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
+				<span id={ labelId }>{ label }</span>
+			</button>
+			{ isSelected && (
+				<Button
+					className="template-selector-item__confirm-selection"
+					isPrimary={ true }
+					onClick={ handleTemplateConfirmation }
+				>
+					Use { label } <span>template</span>
+				</Button>
+			) }
+		</Fragment>
 	);
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -7,7 +7,7 @@ import { isNil, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -100,7 +100,7 @@ const TemplateSelectorItem = props => {
 				disabled={ ! isSelected }
 				onClick={ () => handleTemplateConfirmation( value, label ) }
 			>
-				{ __( 'Use template', 'full-site-editing' ) }
+				{ sprintf( __( 'Use %s template', 'full-site-editing' ), label ) }
 			</Button>
 		</Fragment>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -55,6 +55,20 @@ const TemplateSelectorItem = props => {
 
 	const labelId = `label-${ id }-${ value }`;
 
+	/**
+	 * Determines (based on arbitary "mobile" breakpoint) whether or not
+	 * the Template selection UI interaction model should be select and confirm
+	 * or simply a single "tap to confirm". The reason for this is that on larger screens
+	 * the large preview is visible which necessitates the double interaction. Without this
+	 * then only a single tap is necessary.
+	 * @return {Function} the appropriate interaction handler function depending on the breakpoint match status
+	 */
+	const handleLabelClick = () => {
+		return window.matchMedia( '(min-width: 660px)' ).matches
+			? onSelect( value, label )
+			: handleTemplateConfirmation();
+	};
+
 	return (
 		<Fragment>
 			<button
@@ -62,7 +76,7 @@ const TemplateSelectorItem = props => {
 				className="template-selector-item__label"
 				value={ value }
 				onMouseEnter={ () => onFocus( value, label ) }
-				onClick={ () => onSelect( value, label ) }
+				onClick={ handleLabelClick }
 				aria-labelledby={ `${ id } ${ labelId }` }
 				aria-pressed={ isSelected }
 			>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -56,22 +56,25 @@ const TemplateSelectorItem = props => {
 	const labelId = `label-${ id }-${ value }`;
 
 	/**
-	 * Determines (based on arbitary "mobile" breakpoint) whether or not
-	 * the Template selection UI interaction model should be select and confirm
-	 * or simply a single "tap to confirm". The reason for this is that on larger screens
-	 * the large preview is visible which necessitates the double interaction. Without this
-	 * then only a single tap is necessary.
+	 * Determines (based on whether the large preview is able to be visible at the
+	 * current breakpoint) whether or not the Template selection UI interaction model
+	 * should be select _and_ confirm or simply a single "tap to confirm".
+	 * The reason for this is that on larger screens the large preview is visible
+	 * which necessitates the double interaction. Without this then only a single tap
+	 * is necessary.
 	 *
 	 * @param  {string} tplSlug template slug string from the button value attr
 	 * @param  {string} tplName template name string from the button text
 	 */
 	const handleLabelClick = ( tplSlug, tplName ) => {
+		const largeTplPreviewVisible = window.matchMedia( '(min-width: 660px)' ).matches;
+
 		// On both case set the template as being selected
 		onSelect( tplSlug, tplName );
 
 		// Only on screens where large preview is not visible immediately
 		// confirm the template with no further interaction step
-		if ( window.matchMedia( '(max-width: 660px)' ).matches ) {
+		if ( ! largeTplPreviewVisible ) {
 			handleTemplateConfirmation( tplSlug, tplName );
 		}
 	};

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -3,6 +3,7 @@
  */
 /* eslint-disable import/no-extraneous-dependencies */
 import { isNil, isEmpty } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -79,6 +80,12 @@ const TemplateSelectorItem = props => {
 		}
 	};
 
+	// Used to determine whether or not to apply a bottom border to the template preview
+	// Larger confirmation buttons will overlap the border which doesn't look good, so we
+	// disable the border in those cases.
+	const longLabelTextThreshold = 25;
+	const confirmButtonText = sprintf( __( 'Use %s template', 'full-site-editing' ), label );
+
 	return (
 		<Fragment>
 			<button
@@ -90,7 +97,14 @@ const TemplateSelectorItem = props => {
 				aria-labelledby={ `${ id } ${ labelId }` }
 				aria-pressed={ isSelected }
 			>
-				<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
+				<div
+					className={ classnames( 'template-selector-item__preview-wrap', {
+						'has-long-label': confirmButtonText.length > longLabelTextThreshold,
+						'is-selected': isSelected,
+					} ) }
+				>
+					{ innerPreview }
+				</div>
 				<span id={ labelId }>{ label }</span>
 			</button>
 
@@ -100,7 +114,7 @@ const TemplateSelectorItem = props => {
 				disabled={ ! isSelected }
 				onClick={ () => handleTemplateConfirmation( value, label ) }
 			>
-				{ sprintf( __( 'Use %s template', 'full-site-editing' ), label ) }
+				{ confirmButtonText }
 			</Button>
 		</Fragment>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -3,13 +3,16 @@
  */
 /* eslint-disable import/no-extraneous-dependencies */
 import { isNil, isEmpty } from 'lodash';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import BlockPreview from './block-template-preview';
-/* eslint-disable import/no-extraneous-dependencies */
 import { Disabled, Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 /* eslint-enable import/no-extraneous-dependencies */
@@ -61,19 +64,20 @@ const TemplateSelectorItem = props => {
 				onMouseEnter={ () => onFocus( value, label ) }
 				onClick={ () => onSelect( value, label ) }
 				aria-labelledby={ `${ id } ${ labelId }` }
+				aria-pressed={ isSelected }
 			>
 				<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
 				<span id={ labelId }>{ label }</span>
 			</button>
-			{ isSelected && (
-				<Button
-					className="template-selector-item__confirm-selection"
-					isPrimary={ true }
-					onClick={ handleTemplateConfirmation }
-				>
-					Use { label } <span>template</span>
-				</Button>
-			) }
+
+			<Button
+				className="template-selector-item__confirm-selection"
+				isPrimary={ true }
+				disabled={ ! isSelected }
+				onClick={ handleTemplateConfirmation }
+			>
+				{ __( 'Use template', 'full-site-editing' ) }
+			</Button>
 		</Fragment>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -61,12 +61,19 @@ const TemplateSelectorItem = props => {
 	 * or simply a single "tap to confirm". The reason for this is that on larger screens
 	 * the large preview is visible which necessitates the double interaction. Without this
 	 * then only a single tap is necessary.
-	 * @return {Function} the appropriate interaction handler function depending on the breakpoint match status
+	 *
+	 * @param  {string} tplSlug template slug string from the button value attr
+	 * @param  {string} tplName template name string from the button text
 	 */
-	const handleLabelClick = () => {
-		return window.matchMedia( '(min-width: 660px)' ).matches
-			? onSelect( value, label )
-			: handleTemplateConfirmation();
+	const handleLabelClick = ( tplSlug, tplName ) => {
+		// On both case set the template as being selected
+		onSelect( tplSlug, tplName );
+
+		// Only on screens where large preview is not visible immediately
+		// confirm the template with no further interaction step
+		if ( window.matchMedia( '(max-width: 660px)' ).matches ) {
+			handleTemplateConfirmation( tplSlug, tplName );
+		}
 	};
 
 	return (
@@ -76,7 +83,7 @@ const TemplateSelectorItem = props => {
 				className="template-selector-item__label"
 				value={ value }
 				onMouseEnter={ () => onFocus( value, label ) }
-				onClick={ handleLabelClick }
+				onClick={ () => handleLabelClick( value, label ) }
 				aria-labelledby={ `${ id } ${ labelId }` }
 				aria-pressed={ isSelected }
 			>
@@ -88,7 +95,7 @@ const TemplateSelectorItem = props => {
 				className="template-selector-item__confirm-selection"
 				isPrimary={ true }
 				disabled={ ! isSelected }
-				onClick={ handleTemplateConfirmation }
+				onClick={ () => handleTemplateConfirmation( value, label ) }
 			>
 				{ __( 'Use template', 'full-site-editing' ) }
 			</Button>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -7,9 +7,9 @@ import { isEmpty, reduce } from 'lodash';
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
-import { Button, Modal, Spinner } from '@wordpress/components';
+import { Modal, Spinner } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
@@ -193,19 +193,6 @@ class PageTemplateModal extends Component {
 							/>
 						</>
 					) }
-				</div>
-				<div className="page-template-modal__buttons">
-					<Button isDefault isLarge onClick={ this.closeModal }>
-						{ __( 'Cancel', 'full-site-editing' ) }
-					</Button>
-					<Button
-						isPrimary
-						isLarge
-						disabled={ isEmpty( this.state.slug ) || this.state.isLoading }
-						onClick={ this.handleConfirmation }
-					>
-						{ sprintf( __( 'Use %s template', 'full-site-editing' ), this.state.title ) }
-					</Button>
 				</div>
 			</Modal>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -121,7 +121,9 @@ class PageTemplateModal extends Component {
 		return this.props.shouldPrefetchAssets ? ensureAssets( blocks ) : Promise.resolve( blocks );
 	};
 
-	handleConfirmation = () => this.setTemplate( this.state.slug, this.state.title );
+	handleConfirmation = ( slug = this.state.slug, title = this.state.title ) => {
+		this.setTemplate( slug, title );
+	};
 
 	previewTemplate = ( slug, title ) => {
 		this.setState( { slug, title } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,24 +1,30 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
 import { isEmpty, reduce } from 'lodash';
+
+/**
+ * External dependencies
+ */
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
-import ensureAssets from './utils/ensure-assets';
+import { parse as parseBlocks } from '@wordpress/blocks';
 import '@wordpress/nux';
+/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies
  */
 import './styles/starter-page-templates-editor.scss';
+import ensureAssets from './utils/ensure-assets';
 import TemplateSelectorControl from './components/template-selector-control';
 import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
-import { parse as parseBlocks } from '@wordpress/blocks';
 import replacePlaceholders from './utils/replace-placeholders';
 
 // Load config passed from backend.
@@ -175,6 +181,8 @@ class PageTemplateModal extends Component {
 										onTemplateSelect={ this.previewTemplate }
 										useDynamicPreview={ false }
 										siteInformation={ siteInformation }
+										currentTemplate={ this.state.slug }
+										handleTemplateConfirmation={ this.handleConfirmation }
 									/>
 								</fieldset>
 							</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -125,9 +125,6 @@ class PageTemplateModal extends Component {
 
 	previewTemplate = ( slug, title ) => {
 		this.setState( { slug, title } );
-		if ( slug === 'blank' ) {
-			this.setTemplate( slug, title );
-		}
 	};
 
 	closeModal = event => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -148,6 +148,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	    margin: 5px;
 		display: block;
 
+		&:disabled {
+			@include screen-reader-text(); // visually hide the button but keep active for screen readers
+		}
+
 		> span {
 			@include screen-reader-text();
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -16,6 +16,7 @@ $template-selector-empty-background: #f6f6f6;
 $template-selector-modal-offset-right: 32px;
 $template-selector-modal-offset-bottom: 25px;
 $template-preview-height: 170px;
+$bp-template-large-preview-visible: 660px;
 
 // Modal Overlay
 .page-template-modal-screen-overlay {
@@ -89,7 +90,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		grid-template-columns: 1fr 1fr; // force 2 col on small screens to ensure blank isn't the only option visible on load
 		grid-gap: 1.75em;
 
-		@media screen and ( min-width: 660px ) {
+		@media screen and ( min-width: $bp-template-large-preview-visible ) {
 			margin-top: 0;
 			// stylelint-disable unit-whitelist
 			grid-template-columns: repeat(
@@ -214,7 +215,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 .page-template-modal__form {
-	@media screen and ( min-width: 660px ) {
+	@media screen and ( min-width: $bp-template-large-preview-visible ) {
 		max-width: 50%;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -15,6 +15,7 @@ $template-selector-border-color: #a1aab2;
 $template-selector-empty-background: #f6f6f6;
 $template-selector-modal-offset-right: 32px;
 $template-selector-modal-offset-bottom: 25px;
+$template-preview-height: 170px;
 
 // Modal Overlay
 .page-template-modal-screen-overlay {
@@ -112,6 +113,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		margin-bottom: 4px;
 	}
 
+	.template-selector-control__template {
+		position: relative; // positioning context for button placement 
+	}
+
 	.template-selector-item__label {
 		display: block;
 		width: 100%;
@@ -134,6 +139,20 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 	}
 
+	.template-selector-item__confirm-selection {
+	    position: absolute;
+	    top: $template-preview-height + 1px;
+	    left: 0;
+	    width: calc( 100% - 10px );
+	    height: 37px;
+	    margin: 5px;
+		display: block;
+
+		> span {
+			@include screen-reader-text();
+		}
+	}
+
 	.template-selector-item__preview-wrap {
 		width: 100%;
 		display: block;
@@ -142,7 +161,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
-		height: 170px;
+		height: $template-preview-height;
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -142,12 +142,17 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 	.template-selector-item__confirm-selection {
 	    position: absolute;
-	    top: $template-preview-height + 1px;
+	    bottom: 0;
 	    left: 0;
 	    width: calc( 100% - 10px );
-	    height: 37px;
+	    height: auto; // allow flexible height
+		line-height: 1.2;
+		padding-top: 10px;
+		padding-bottom: 10px;
 	    margin: 5px;
 		display: block;
+		white-space: normal; // allow text to wrap
+
 
 		&:disabled {
 			@include screen-reader-text(); // visually hide the button but keep active for screen readers
@@ -174,6 +179,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 		&.is-rendering {
 			opacity: 0.5;
+		}
+
+		&.is-selected.has-long-label {
+			border-bottom-color: transparent;
 		}
 
         .block-editor-block-list__layout,


### PR DESCRIPTION
This PR addresses https://github.com/Automattic/wp-calypso/issues/36235 and https://github.com/Automattic/wp-calypso/issues/35887 by adding an inner button to each Template thumbnail which appears once the Template has been selected for preview. Clicking on the inner button then triggers the "selection" of that Template and insertion into the Editor.

## Major changes

✅ Individual select & confirm UI interaction pattern for each Template.
✅ Removal of "global" select & confirm UI in favour of individual buttons on a per Template basis.
✅ The normalisation of interaction pattern between "blank" Template and all other Templates.

## Items not addressed here

As this PR forms part of a wider UI update, it's worth noting that the follow closely related issues are **_not_** addressed here

* Any UI update to the visual implementation of Modal itself.
* Change to what is shown for the full-size preview for the "Blank Template".
* Restyling of the individual Template preview thumbnails themselves.

## Important Notes

* The breakpoint where the interaction modal changes from one (mobile) to two (desktop) interactions depends on whether the large preview is visible or not. This itself depends on a CSS media query which makes it laborious to share between CSS and JS. We could parse it out of pseudo-element but this seems like a lot of work for little gain. 

## Testing instructions

* Check out PR 
* Start new Page
* See Template selector
* Click on Template preview (confirm that double / repeated clicking on preview thumbnail itself does not trigger insertion of template)
* See `primary` button appear on top of the Template name
* Click on button to insert Template.
* Confirm the same workflow using only your keyboard.

## Screenshots

#### Desktop

![Screen Capture on 2019-09-24 at 16-26-30](https://user-images.githubusercontent.com/444434/65525961-371df580-dee8-11e9-9cca-e9be8aa178f1.gif)


#### "Mobile" 

This term means "screens which don't have sufficient real estate to accommodate the large preview. 

![Screen Capture on 2019-09-24 at 16-18-52](https://user-images.githubusercontent.com/444434/65525266-2620b480-dee7-11e9-8cf2-734f454cc7b1.gif)
