### PR TITLE
Full Site Editing: Add data fetching monitoring

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -85,10 +85,11 @@ class WP_Template_Inserter {
 			do_action(
 				'a8c_fse_log',
 				'template_population_failure',
-				array(
-					'theme_slug' => $this->theme_slug,
+				[
 					'context'    => 'WP_Template_Inserter->fetch_template_parts',
-				)
+					'error'      => 'Fetch retry timeout',
+					'theme_slug' => $this->theme_slug,
+				]
 			);
 			$this->header_content = $this->get_default_header();
 			$this->footer_content = $this->get_default_footer();
@@ -167,14 +168,29 @@ class WP_Template_Inserter {
 	 * This function will be called on plugin activation hook.
 	 */
 	public function insert_default_template_data() {
-		do_action( 'full_site_editing_before_data_population', 'default_template_data' );
+		do_action(
+			'a8c_fse_log',
+			'before_template_population',
+			[
+				'context'    => 'WP_Template_Inserter->insert_default_template_data',
+				'theme_slug' => $this->theme_slug,
+			]
+		);
 
 		if ( $this->is_template_data_inserted() ) {
 			/*
 			 * Bail here to prevent inserting the FSE data twice for any given theme.
 			 * Multiple themes will still be able to insert different templates.
 			 */
-			do_action( 'full_site_editing_data_population_error', 'default_template_data', 'Default template data already exists' );
+			do_action(
+				'a8c_fse_log',
+				'template_population_failure',
+				[
+					'context'    => 'WP_Template_Inserter->insert_default_template_data',
+					'error'      => 'Data already exist',
+					'theme_slug' => $this->theme_slug,
+				]
+			);
 			return;
 		}
 
@@ -224,7 +240,14 @@ class WP_Template_Inserter {
 
 		add_option( $this->fse_template_data_option, true );
 
-		do_action( 'full_site_editing_data_population_success', 'default_template_data' );
+		do_action(
+			'a8c_fse_log',
+			'template_population_success',
+			[
+				'context'    => 'WP_Template_Inserter->insert_default_template_data',
+				'theme_slug' => $this->theme_slug,
+			]
+		);
 	}
 
 	/**
@@ -243,11 +266,26 @@ class WP_Template_Inserter {
 	 * with 'About' and 'Contact' titles already exist.
 	 */
 	public function insert_default_pages() {
-		do_action( 'full_site_editing_before_data_population', 'default_pages' );
+		do_action(
+			'a8c_fse_log',
+			'before_pages_population',
+			[
+				'context'    => 'WP_Template_Inserter->insert_default_pages',
+				'theme_slug' => $this->theme_slug,
+			]
+		);
 
 		// Bail if this data has already been inserted.
 		if ( $this->is_pages_data_inserted() ) {
-			do_action( 'full_site_editing_data_population_error', 'default_pages', 'Default pages already exist' );
+			do_action(
+				'a8c_fse_log',
+				'pages_population_failure',
+				[
+					'context'    => 'WP_Template_Inserter->insert_default_pages',
+					'error'      => 'Data already exist',
+					'theme_slug' => $this->theme_slug,
+				]
+			);
 			return;
 		}
 
@@ -261,7 +299,15 @@ class WP_Template_Inserter {
 		$response = $this->fetch_retry( $request_url );
 
 		if ( ! $response ) {
-			do_action( 'full_site_editing_data_population_error', 'default_pages', 'API error.', $request_url );
+			do_action(
+				'a8c_fse_log',
+				'pages_population_failure',
+				[
+					'context'    => 'WP_Template_Inserter->insert_default_pages',
+					'error'      => 'Fetch retry timeout',
+					'theme_slug' => $this->theme_slug,
+				]
+			);
 			return;
 		}
 
@@ -306,7 +352,14 @@ class WP_Template_Inserter {
 
 		update_option( $this->fse_page_data_option, true );
 
-		do_action( 'full_site_editing_data_population_success', 'default_pages' );
+		do_action(
+			'a8c_fse_log',
+			'pages_population_success',
+			[
+				'context'    => 'WP_Template_Inserter->insert_default_pages',
+				'theme_slug' => $this->theme_slug,
+			]
+		);
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -167,11 +167,17 @@ class WP_Template_Inserter {
 	 * This function will be called on plugin activation hook.
 	 */
 	public function insert_default_template_data() {
+		do_action( 'full_site_editing_before_insert_default_template_data' );
+
 		if ( $this->is_template_data_inserted() ) {
 			/*
 			 * Bail here to prevent inserting the FSE data twice for any given theme.
 			 * Multiple themes will still be able to insert different templates.
 			 */
+			do_action(
+				'full_site_editing_insert_default_template_data_error',
+				'Default template data already exists.'
+			);
 			return;
 		}
 
@@ -220,6 +226,8 @@ class WP_Template_Inserter {
 		wp_set_object_terms( $footer_id, "$this->theme_slug-footer", 'wp_template_type' );
 
 		add_option( $this->fse_template_data_option, true );
+
+		do_action( 'full_site_editing_insert_default_template_data_success' );
 	}
 
 	/**
@@ -238,8 +246,14 @@ class WP_Template_Inserter {
 	 * with 'About' and 'Contact' titles already exist.
 	 */
 	public function insert_default_pages() {
+		do_action( 'full_site_editing_before_insert_default_pages' );
+
 		// Bail if this data has already been inserted.
 		if ( $this->is_pages_data_inserted() ) {
+			do_action(
+				'full_site_editing_insert_default_pages_error',
+				'Default pages already exist.'
+			);
 			return;
 		}
 
@@ -253,6 +267,11 @@ class WP_Template_Inserter {
 		$response = $this->fetch_retry( $request_url );
 
 		if ( ! $response ) {
+			do_action(
+				'full_site_editing_insert_default_pages_error',
+				'API error.',
+				$request_url
+			);
 			return;
 		}
 
@@ -296,6 +315,8 @@ class WP_Template_Inserter {
 		}
 
 		update_option( $this->fse_page_data_option, true );
+
+		do_action( 'full_site_editing_insert_default_pages_success' );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -167,17 +167,14 @@ class WP_Template_Inserter {
 	 * This function will be called on plugin activation hook.
 	 */
 	public function insert_default_template_data() {
-		do_action( 'full_site_editing_before_insert_default_template_data' );
+		do_action( 'full_site_editing_before_data_population', 'default_template_data' );
 
 		if ( $this->is_template_data_inserted() ) {
 			/*
 			 * Bail here to prevent inserting the FSE data twice for any given theme.
 			 * Multiple themes will still be able to insert different templates.
 			 */
-			do_action(
-				'full_site_editing_insert_default_template_data_error',
-				'Default template data already exists.'
-			);
+			do_action( 'full_site_editing_data_population_error', 'default_template_data', 'Default template data already exists' );
 			return;
 		}
 
@@ -227,7 +224,7 @@ class WP_Template_Inserter {
 
 		add_option( $this->fse_template_data_option, true );
 
-		do_action( 'full_site_editing_insert_default_template_data_success' );
+		do_action( 'full_site_editing_data_population_success', 'default_template_data' );
 	}
 
 	/**
@@ -246,14 +243,11 @@ class WP_Template_Inserter {
 	 * with 'About' and 'Contact' titles already exist.
 	 */
 	public function insert_default_pages() {
-		do_action( 'full_site_editing_before_insert_default_pages' );
+		do_action( 'full_site_editing_before_data_population', 'default_pages' );
 
 		// Bail if this data has already been inserted.
 		if ( $this->is_pages_data_inserted() ) {
-			do_action(
-				'full_site_editing_insert_default_pages_error',
-				'Default pages already exist.'
-			);
+			do_action( 'full_site_editing_data_population_error', 'default_pages', 'Default pages already exist' );
 			return;
 		}
 
@@ -267,11 +261,7 @@ class WP_Template_Inserter {
 		$response = $this->fetch_retry( $request_url );
 
 		if ( ! $response ) {
-			do_action(
-				'full_site_editing_insert_default_pages_error',
-				'API error.',
-				$request_url
-			);
+			do_action( 'full_site_editing_data_population_error', 'default_pages', 'API error.', $request_url );
 			return;
 		}
 
@@ -316,7 +306,7 @@ class WP_Template_Inserter {
 
 		update_option( $this->fse_page_data_option, true );
 
-		do_action( 'full_site_editing_insert_default_pages_success' );
+		do_action( 'full_site_editing_data_population_success', 'default_pages' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to #35961.

* Add more `a8c_fse_log` action hooks to the `WP_Template_Inserter` class to be used in the MU plugin loader to call WPCOM analytics and error tracking (see D32445-code).

The interface would be: `do_action( 'a8c_fse_log', $message, $extra )`
`$extra` is an array containing `context` (the caller function), `theme_slug`, and for error logging an additional `error` message that could simplify the debugging.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the domain of a test FSE site you are about to create on Horizon with new user via `/start/test-fse`.
* Create a new FSE site with the domain name you sandboxed through the CfT flow.
* Check that a logstash log was added for the `before` and `success` by searching Kibana for `a8c_fse`.
* Temporarily change [domain name here](https://github.com/Automattic/wp-calypso/blob/5589ce100348b02bbd02ed5845cae6c63540cc48/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php#L76) to an invalid domain name, eg. `public-api-bogus.wordpress.com`.
* Repeat the test creating a new user and FSE site (remember to pre-sandbox its domain).
* Check that a logstash log was added for the `failure` by searching Kibana for `a8c_fse`.

Part of #35396 fixes