### PR TITLE
SPT: use <BlockPreview /> onReady() callback to set template title

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -23,7 +23,11 @@ const BlockTemplatePreview = ( { blocks = [], viewportWidth } ) => {
 		<div className="edit-post-visual-editor">
 			<div className="editor-styles-wrapper">
 				<div className="editor-writing-flow">
-					<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+					<BlockPreview
+						blocks={ blocks }
+						viewportWidth={ viewportWidth }
+						__experimentalScalingDelay={ 0 }
+					/>
 				</div>
 			</div>
 		</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -4,12 +4,13 @@
  * inherited from the Editor.
  *
  * @param {string} title Template title - transform css rule.
+ * @param {string} transform CSS transform rule.
  * @return {*} Component
  */
 
-const PreviewTemplateTitle = ( { title } ) => (
+const PreviewTemplateTitle = ( { title, transform } ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	<div className="editor-post-title">
+	<div className="editor-post-title" style={ { transform } }>
 		<div className="editor-post-title__block">
 			<textarea className="editor-post-title__input" value={ title } />
 		</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -7,9 +7,9 @@
  * @return {*} Component
  */
 
-const PreviewTemplateTitle = ( { title, transform } ) => (
+const PreviewTemplateTitle = ( { title } ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	<div className="editor-post-title" style={ { transform } }>
+	<div className="editor-post-title">
 		<div className="editor-post-title__block">
 			<textarea className="editor-post-title__input" value={ title } />
 		</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 /* eslint-disable import/no-extraneous-dependencies */
 import { isEmpty, isArray, debounce } from 'lodash';
 /* eslint-enable import/no-extraneous-dependencies */
@@ -12,7 +11,7 @@ import { isEmpty, isArray, debounce } from 'lodash';
 /* eslint-disable import/no-extraneous-dependencies */
 import { __ } from '@wordpress/i18n';
 import { Disabled } from '@wordpress/components';
-import { useState, useEffect, useLayoutEffect, useRef, useReducer } from '@wordpress/element';
+import { useState, useEffect, useReducer } from '@wordpress/element';
 /* eslint-enable import/no-extraneous-dependencies */
 
 /**
@@ -24,61 +23,16 @@ import BlockPreview from './block-preview';
 const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	const THRESHOLD_RESIZE = 300;
 
-	const previewElClasses = classnames( 'template-selector-preview', 'editor-styles-wrapper' );
-	const [ transform, setTransform ] = useState( 'none' );
 	const [ visibility, setVisibility ] = useState( 'hidden' );
-	const ref = useRef( null );
 
 	const [ recompute, triggerRecompute ] = useReducer( state => state + 1, 0 );
-
-	// TODO: we should remove this approach and use the onReady callback.
-	// There is Gutenberg PR which adds the onReady callback
-	// as a component property.
-	// The following approach can be easily replace calling this callback
-	// once the PR ships (finger-crossed)
-	// https://github.com/WordPress/gutenberg/pull/17242
-
-	const updateTemplateTitle = () => {
-		// Get DOM reference.
-		setTimeout( () => {
-			if ( ! ref || ! ref.current ) {
-				return;
-			}
-
-			// Try to get the preview content element.
-			const previewContainerEl = ref.current.querySelector(
-				'.block-editor-block-preview__content'
-			);
-			if ( ! previewContainerEl ) {
-				return;
-			}
-
-			// Try to get the `transform` css rule from the preview container element.
-			const elStyles = window.getComputedStyle( previewContainerEl );
-			if ( elStyles && elStyles.transform ) {
-				setTransform( elStyles.transform ); // apply the same transform css rule to template title.
-			}
-
-			setVisibility( 'visible' );
-		}, 300 );
-	};
-
-	useLayoutEffect( () => {
-		setVisibility( 'hidden' );
-		updateTemplateTitle();
-	}, [ blocks ] );
 
 	useEffect( () => {
 		if ( ! blocks || ! blocks.length ) {
 			return;
 		}
 
-		const rePreviewTemplate = () => {
-			updateTemplateTitle();
-			triggerRecompute();
-		};
-
-		const refreshPreview = debounce( rePreviewTemplate, THRESHOLD_RESIZE );
+		const refreshPreview = debounce( triggerRecompute, THRESHOLD_RESIZE );
 		window.addEventListener( 'resize', refreshPreview );
 
 		return () => {
@@ -88,7 +42,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 	if ( isEmpty( blocks ) || ! isArray( blocks ) ) {
 		return (
-			<div className={ previewElClasses }>
+			<div className="template-selector-preview editor-styles-wrapper">
 				<div className="template-selector-preview__placeholder">
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
@@ -98,12 +52,12 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		<div className={ previewElClasses }>
+		<div className="template-selector-preview editor-styles-wrapper">
 			<Disabled>
-				<div ref={ ref } className="edit-post-visual-editor">
+				<div className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper" style={ { visibility } }>
 						<div className="editor-writing-flow">
-							<PreviewTemplateTitle title={ title } transform={ transform } />
+							<PreviewTemplateTitle title={ title } />
 							<BlockPreview key={ recompute } blocks={ blocks } viewportWidth={ viewportWidth } />
 						</div>
 					</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -51,9 +51,9 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 		);
 	}
 
-	const setTemplateTitle = ( { styles } ) => {
+	const setTemplateTitle = ( { inlineStyles } ) => {
 		setVisibility( 'visible' );
-		setTitleTransform( styles.transform );
+		setTitleTransform( inlineStyles.transform );
 	};
 
 	return (
@@ -69,6 +69,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 								blocks={ blocks }
 								viewportWidth={ viewportWidth }
 								__experimentalOnReady={ setTemplateTitle }
+								__experimentalScalingDelay={ 0 }
 							/>
 						</div>
 					</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -24,6 +24,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	const THRESHOLD_RESIZE = 300;
 
 	const [ visibility, setVisibility ] = useState( 'hidden' );
+	const [ titleTransform, setTitleTransform ] = useState( 'scale(1)' );
 
 	const [ recompute, triggerRecompute ] = useReducer( state => state + 1, 0 );
 
@@ -50,6 +51,11 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 		);
 	}
 
+	const setTemplateTitle = ( { styles } ) => {
+		setVisibility( 'visible' );
+		setTitleTransform( styles.transform );
+	};
+
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<div className="template-selector-preview editor-styles-wrapper">
@@ -57,8 +63,13 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 				<div className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper" style={ { visibility } }>
 						<div className="editor-writing-flow">
-							<PreviewTemplateTitle title={ title } />
-							<BlockPreview key={ recompute } blocks={ blocks } viewportWidth={ viewportWidth } />
+							<PreviewTemplateTitle title={ title } transform={ titleTransform } />
+							<BlockPreview
+								key={ recompute }
+								blocks={ blocks }
+								viewportWidth={ viewportWidth }
+								__experimentalOnReady={ setTemplateTitle }
+							/>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## IMPORTANT
**This PR depends on https://github.com/WordPress/gutenberg/pull/17242**

## Changes proposed in this Pull Request

This PR replaces the current way used to set the scale for the template title. It depends on https://github.com/WordPress/gutenberg/pull/17242, which adds the `__experimentalOnReady()` property.

![transform-title](https://user-images.githubusercontent.com/77539/65537558-d1c40780-dedb-11e9-9723-7bf05d4e7276.gif)


#### Testing instructions

Apply the patch and check that the title scales as expected.

Fixes #36264
