### PR TITLE
Page Templates: Fix Blank title insertion, some code cleanup

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -26,7 +26,6 @@ export const TemplateSelectorControl = ( {
 	blocksByTemplates = {},
 	useDynamicPreview = false,
 	onTemplateSelect = noop,
-	onTemplateFocus = noop,
 	siteInformation = {},
 } ) => {
 	if ( isEmpty( templates ) || ! isArray( templates ) ) {
@@ -58,7 +57,6 @@ export const TemplateSelectorControl = ( {
 							label={ replacePlaceholders( title, siteInformation ) }
 							help={ help }
 							onSelect={ onTemplateSelect }
-							onFocus={ onTemplateFocus }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
 							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -17,7 +17,6 @@ const TemplateSelectorItem = props => {
 	const {
 		id,
 		value,
-		onFocus,
 		onSelect,
 		label,
 		useDynamicPreview = false,
@@ -54,8 +53,7 @@ const TemplateSelectorItem = props => {
 			type="button"
 			className="template-selector-item__label"
 			value={ value }
-			onMouseEnter={ () => onFocus( value, label ) }
-			onClick={ () => onSelect( value, label ) }
+			onClick={ () => onSelect( value ) }
 			aria-labelledby={ `${ id } ${ labelId }` }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/template-selector-control-test.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/template-selector-control-test.js
@@ -90,25 +90,6 @@ describe( 'TemplateSelectorControl', () => {
 	} );
 
 	describe( 'Event handlers', () => {
-		it( 'calls onTemplateFocus prop on mouseEnter over template', () => {
-			const onFocusSpy = jest.fn();
-
-			const { getByText } = render(
-				<TemplateSelectorControl
-					label="Select a Template..."
-					instanceId={ testUniqueId }
-					templates={ templatesFixture }
-					blocksByTemplates={ blocksByTemplatesFixture }
-					siteInformation={ siteInformation }
-					onTemplateFocus={ onFocusSpy }
-				/>
-			);
-
-			fireEvent.mouseEnter( getByText( 'Template 2' ) );
-
-			expect( onFocusSpy ).toHaveBeenCalled();
-		} );
-
 		it( 'calls onTemplateSelect prop when template is clicked', () => {
 			const onSelectSpy = jest.fn();
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -120,14 +120,7 @@ class PageTemplateModal extends Component {
 
 	handleConfirmation = () => this.setTemplate( this.state.previewedTemplate );
 
-	previewTemplate = slug => {
-		// Immediately confirm and close when 'blank' is selected.
-		if ( slug === 'blank' ) {
-			this.setTemplate( slug );
-			return;
-		}
-		this.setState( { previewedTemplate: slug } );
-	};
+	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
 
 	closeModal = event => {
 		// Check to see if the Blur event occurred on the buttons inside of the Modal.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -171,7 +171,7 @@ class PageTemplateModal extends Component {
 									<TemplateSelectorControl
 										label={ __( 'Template', 'full-site-editing' ) }
 										templates={ this.props.templates }
-										blocksBySlug={ this.state.blocks }
+										blocksByTemplates={ this.state.blocksBySlug }
 										onTemplateSelect={ this.previewTemplate }
 										useDynamicPreview={ false }
 										siteInformation={ siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -33,7 +33,7 @@ const {
 class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
-		selectedTemplate: null,
+		previewedTemplate: null,
 		blocksBySlug: {},
 		templatesBySlug: {},
 		error: null,
@@ -46,7 +46,7 @@ class PageTemplateModal extends Component {
 		this.state.isOpen = hasTemplates;
 		// Select the first template automatically.
 		if ( hasTemplates ) {
-			this.state.selectedTemplate = get( props.templates, [ 0, 'slug' ] );
+			this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
 			this.state.templatesBySlug = keyBy( props.templates, 'slug' );
 		}
 	}
@@ -117,7 +117,7 @@ class PageTemplateModal extends Component {
 		return this.props.shouldPrefetchAssets ? ensureAssets( blocks ) : Promise.resolve( blocks );
 	};
 
-	handleConfirmation = () => this.setTemplate( this.state.selectedTemplate );
+	handleConfirmation = () => this.setTemplate( this.state.previewedTemplate );
 
 	previewTemplate = slug => {
 		// Immediately confirm and close when 'blank' is selected.
@@ -125,7 +125,7 @@ class PageTemplateModal extends Component {
 			this.setTemplate( slug );
 			return;
 		}
-		this.setState( { selectedTemplate: slug } );
+		this.setState( { previewedTemplate: slug } );
 	};
 
 	closeModal = event => {
@@ -138,11 +138,11 @@ class PageTemplateModal extends Component {
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 
-	getBlocksBySlug( slug = this.state.selectedTemplate ) {
+	getBlocksBySlug( slug = this.state.previewedTemplate ) {
 		return get( this.state.blocksBySlug, [ slug ], [] );
 	}
 
-	getTitleBySlug( slug = this.state.selectedTemplate ) {
+	getTitleBySlug( slug = this.state.previewedTemplate ) {
 		return get( this.state.templatesBySlug, [ slug, 'title' ], '' );
 	}
 
@@ -193,7 +193,7 @@ class PageTemplateModal extends Component {
 					<Button
 						isPrimary
 						isLarge
-						disabled={ isEmpty( this.state.selectedTemplate ) || this.state.isLoading }
+						disabled={ isEmpty( this.state.previewedTemplate ) || this.state.isLoading }
 						onClick={ this.handleConfirmation }
 					>
 						{ sprintf( __( 'Use %s template', 'full-site-editing' ), this.getTitleBySlug() ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -34,7 +34,7 @@ class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
 		previewedTemplate: null,
-		blocksBySlug: {},
+		blocksByTemplateSlug: {},
 		templatesBySlug: {},
 		error: null,
 		isOpen: false,
@@ -57,7 +57,7 @@ class PageTemplateModal extends Component {
 		}
 
 		// Parse templates blocks and store them into the state.
-		const blocksBySlug = reduce(
+		const blocksByTemplateSlug = reduce(
 			templates,
 			( prev, { slug, content } ) => {
 				prev[ slug ] = content
@@ -69,7 +69,7 @@ class PageTemplateModal extends Component {
 		);
 
 		// eslint-disable-next-line react/no-did-mount-set-state
-		this.setState( { blocksBySlug } );
+		this.setState( { blocksByTemplateSlug } );
 	}
 
 	setTemplate = slug => {
@@ -78,8 +78,8 @@ class PageTemplateModal extends Component {
 		this.props.saveTemplateChoice( slug );
 
 		// Load content.
-		const blocks = this.getBlocksBySlug( slug );
-		const title = this.getTitleBySlug( slug );
+		const blocks = this.getBlocksByTemplateSlug( slug );
+		const title = this.getTitleByTemplateSlug( slug );
 
 		// Skip inserting if there's nothing to insert.
 		if ( ! blocks || ! blocks.length ) {
@@ -138,16 +138,19 @@ class PageTemplateModal extends Component {
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 
-	getBlocksBySlug( slug = this.state.previewedTemplate ) {
-		return get( this.state.blocksBySlug, [ slug ], [] );
+	getBlocksByTemplateSlug( slug ) {
+		return get( this.state.blocksByTemplateSlug, [ slug ], [] );
 	}
 
-	getTitleBySlug( slug = this.state.previewedTemplate ) {
+	getTitleByTemplateSlug( slug ) {
 		return get( this.state.templatesBySlug, [ slug, 'title' ], '' );
 	}
 
 	render() {
-		if ( ! this.state.isOpen ) {
+		const { previewedTemplate, isOpen, isLoading, blocksByTemplateSlug } = this.state;
+		const { templates } = this.props;
+
+		if ( ! isOpen ) {
 			return null;
 		}
 
@@ -159,7 +162,7 @@ class PageTemplateModal extends Component {
 				overlayClassName="page-template-modal-screen-overlay"
 			>
 				<div className="page-template-modal__inner">
-					{ this.state.isLoading ? (
+					{ isLoading ? (
 						<div className="page-template-modal__loading">
 							<Spinner />
 							{ __( 'Inserting template…', 'full-site-editing' ) }
@@ -170,8 +173,8 @@ class PageTemplateModal extends Component {
 								<fieldset className="page-template-modal__list">
 									<TemplateSelectorControl
 										label={ __( 'Template', 'full-site-editing' ) }
-										templates={ this.props.templates }
-										blocksByTemplates={ this.state.blocksBySlug }
+										templates={ templates }
+										blocksByTemplates={ blocksByTemplateSlug }
 										onTemplateSelect={ this.previewTemplate }
 										useDynamicPreview={ false }
 										siteInformation={ siteInformation }
@@ -179,9 +182,9 @@ class PageTemplateModal extends Component {
 								</fieldset>
 							</form>
 							<TemplateSelectorPreview
-								blocks={ this.getBlocksBySlug() }
+								blocks={ this.getBlocksByTemplateSlug( previewedTemplate ) }
 								viewportWidth={ 960 }
-								title={ this.getTitleBySlug() }
+								title={ this.getTitleByTemplateSlug( previewedTemplate ) }
 							/>
 						</>
 					) }
@@ -193,10 +196,13 @@ class PageTemplateModal extends Component {
 					<Button
 						isPrimary
 						isLarge
-						disabled={ isEmpty( this.state.previewedTemplate ) || this.state.isLoading }
+						disabled={ isEmpty( previewedTemplate ) || isLoading }
 						onClick={ this.handleConfirmation }
 					>
-						{ sprintf( __( 'Use %s template', 'full-site-editing' ), this.getTitleBySlug() ) }
+						{ sprintf(
+							__( 'Use %s template', 'full-site-editing' ),
+							this.getTitleByTemplateSlug( previewedTemplate )
+						) }
 					</Button>
 				</div>
 			</Modal>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, get, keyBy } from 'lodash';
+import { isEmpty, reduce, get, keyBy, mapValues } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner } from '@wordpress/components';
@@ -35,7 +35,7 @@ class PageTemplateModal extends Component {
 		isLoading: false,
 		previewedTemplate: null,
 		blocksByTemplateSlug: {},
-		templatesBySlug: {},
+		titlesByTemplateSlug: {},
 		error: null,
 		isOpen: false,
 	};
@@ -44,10 +44,11 @@ class PageTemplateModal extends Component {
 		super();
 		const hasTemplates = ! isEmpty( props.templates );
 		this.state.isOpen = hasTemplates;
-		// Select the first template automatically.
 		if ( hasTemplates ) {
+			// Select the first template automatically.
 			this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
-			this.state.templatesBySlug = keyBy( props.templates, 'slug' );
+			// Extract titles for faster lookup.
+			this.state.titlesByTemplateSlug = mapValues( keyBy( props.templates, 'slug' ), 'title' );
 		}
 	}
 
@@ -143,7 +144,7 @@ class PageTemplateModal extends Component {
 	}
 
 	getTitleByTemplateSlug( slug ) {
-		return get( this.state.templatesBySlug, [ slug, 'title' ], '' );
+		return get( this.state.titlesByTemplateSlug, [ slug ], '' );
 	}
 
 	render() {


### PR DESCRIPTION
Fixing the Blank title bug was connected to some other parts of code so I did a bit of a cleanup along the way.

#### Changes proposed in this Pull Request

* fix the bug when selecting a blank template would insert the title "Blank"
* removed long unused code for `onFocus` (which had nothing to do with a focus)
* removed multiple sources of truth and extraneous passing for template titles between components
* select the first template by default (Blank)

#### Testing instructions

* use inserter as normal, try switching between templates
* insert template with content - everything should work
* insert "Blank" - our plugin should close and you should see nothing being inserted into the editor - no title, no content

Fixes #36060