### PR TITLE
Search: Use a lower line height for shorter search boxes

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -104,7 +104,7 @@
 }
 
 .search__input[type='search'] {
-	line-height: 3;
+	line-height: 2;
 	flex: 1 1 auto;
 	display: none;
 	z-index: z-index( '.search', '.search__input' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a lesser line height property on the search component to account for narrower search fields. This is a temporary fix for #36261 that needs closer investigation, because this method still creates less notable visual issues in other areas (Pages search, for example).

**Before**

<img width="286" alt="Screen Shot 2019-09-24 at 4 00 29 PM" src="https://user-images.githubusercontent.com/2124984/65546147-e658cd80-dee4-11e9-8832-2d642d535be6.png">

**After**

<img width="284" alt="Screen Shot 2019-09-24 at 4 00 51 PM" src="https://user-images.githubusercontent.com/2124984/65546156-ebb61800-dee4-11e9-9d35-525c3cb76382.png">

#### Testing instructions

* Switch to this PR on a site with multiple sites
* Click Switch Site to open the site selector and note the search box at the top; there should be no overlap as shown in the above screenshot
* Also sign up for a new site from `/start/` and check out the search box on the domains step; there should be no visual issues there, either.

Fixes #36261