### PR TITLE
SPT: Pass theme slug to API endpoint

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -190,6 +190,7 @@ class Starter_Page_Templates {
 			$request_url = add_query_arg(
 				[
 					'_locale' => $this->get_iso_639_locale(),
+					'theme'   => get_stylesheet(),
 				],
 				'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates'
 			);


### PR DESCRIPTION
Lets the endpoint add the theme's homepage template to its response.

Test:
Apply D33133-code and pull up the template selector on a local installation. If your test site has a template-first theme active, it'll add a Home template to the selector.

See #36237.
