### PR TITLE
Pages: Remove unused logic

### DIFF
--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { identity } from 'lodash';
+import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
@@ -16,6 +16,7 @@ import classNames from 'classnames';
 import Card from 'components/card';
 import { getSiteFrontPageType, getSitePostsPage, getSiteFrontPage } from 'state/sites/selectors';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -25,40 +26,32 @@ import './style.scss';
 class BlogPostsPage extends React.Component {
 	static propTypes = {
 		site: PropTypes.object,
-		pages: PropTypes.array,
+		recordCalloutClick: PropTypes.func,
 	};
 
 	static defaultProps = {
 		translate: identity,
+		recordCalloutClick: noop,
 	};
 
-	getPageProperty( { pageId, property } ) {
-		return this.props.pages
-			.filter( page => page.ID === pageId )
-			.map( page => page[ property ] )
-			.shift();
-	}
-
-	getPostsPageLink( { isCurrentlySetAsHomepage } ) {
-		if ( ! isCurrentlySetAsHomepage ) {
-			return this.getPageProperty( { pageId: this.props.postsPage, property: 'URL' } );
-		}
-
+	getPostsPageLink() {
 		return this.props.site.URL;
 	}
 
-	renderPostsPageInfo( { isCurrentlySetAsHomepage } ) {
+	renderPostsPageInfo() {
 		const { translate } = this.props;
 
-		if ( isCurrentlySetAsHomepage ) {
-			return (
-				<span>
-					<Gridicon size={ 12 } icon="house" className="blog-posts-page__front-page-icon" />
-					{ translate( 'The homepage is showing your latest posts.' ) }
-				</span>
-			);
-		}
+		return (
+			<span>
+				<Gridicon size={ 12 } icon="house" className="blog-posts-page__front-page-icon" />
+				{ translate( 'The homepage is showing your latest posts.' ) }
+			</span>
+		);
 	}
+
+	recordCalloutClick = () => {
+		this.props.recordCalloutClick( this.props.site.ID );
+	};
 
 	render() {
 		const { isFullSiteEditing } = this.props;
@@ -75,12 +68,11 @@ class BlogPostsPage extends React.Component {
 
 		return (
 			<Card
-				href={ this.getPostsPageLink( {
-					isCurrentlySetAsHomepage,
-				} ) }
+				href={ this.getPostsPageLink() }
 				target="_blank"
 				rel="noopener noreferrer"
 				className="blog-posts-page"
+				onClick={ this.recordCalloutClick }
 			>
 				<div className="blog-posts-page__details">
 					<div
@@ -88,9 +80,7 @@ class BlogPostsPage extends React.Component {
 							'blog-posts-page__info': true,
 						} ) }
 					>
-						{ this.renderPostsPageInfo( {
-							isCurrentlySetAsHomepage,
-						} ) }
+						{ this.renderPostsPageInfo() }
 					</div>
 				</div>
 			</Card>
@@ -98,12 +88,21 @@ class BlogPostsPage extends React.Component {
 	}
 }
 
-export default connect( ( state, props ) => {
-	return {
-		frontPageType: getSiteFrontPageType( state, props.site.ID ),
-		isFrontPage: getSiteFrontPageType( state, props.site.ID ) === 'posts',
-		postsPage: getSitePostsPage( state, props.site.ID ),
-		frontPage: getSiteFrontPage( state, props.site.ID ),
-		isFullSiteEditing: isSiteUsingFullSiteEditing( state, props.site.ID ),
-	};
-} )( localize( BlogPostsPage ) );
+const mapDispatchToProps = dispatch => ( {
+	recordCalloutClick: siteId => {
+		dispatch( recordTracksEvent( 'calypso_pages_blog_posts_callout_click', { blog_id: siteId } ) );
+	},
+} );
+
+export default connect(
+	( state, props ) => {
+		return {
+			frontPageType: getSiteFrontPageType( state, props.site.ID ),
+			isFrontPage: getSiteFrontPageType( state, props.site.ID ) === 'posts',
+			postsPage: getSitePostsPage( state, props.site.ID ),
+			frontPage: getSiteFrontPage( state, props.site.ID ),
+			isFullSiteEditing: isSiteUsingFullSiteEditing( state, props.site.ID ),
+		};
+	},
+	mapDispatchToProps
+)( localize( BlogPostsPage ) );

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -39,16 +39,6 @@ class BlogPostsPage extends React.Component {
 			.shift();
 	}
 
-	getPageTitle = pageId => {
-		const pageTitle = this.getPageProperty( { pageId, property: 'title' } );
-		if ( pageTitle ) {
-			return pageTitle;
-		}
-		return pageId
-			? `${ this.props.translate( 'Untitled' ) } (#${ pageId })`
-			: this.props.translate( 'Untitled' );
-	};
-
 	getPostsPageLink( { isCurrentlySetAsHomepage } ) {
 		if ( ! isCurrentlySetAsHomepage ) {
 			return this.getPageProperty( { pageId: this.props.postsPage, property: 'URL' } );
@@ -68,22 +58,6 @@ class BlogPostsPage extends React.Component {
 				</span>
 			);
 		}
-
-		// Prevent displaying '"Untitled" page is showing your latest posts.' while the settings are loading.
-		if ( ! this.props.postsPage ) {
-			return null;
-		}
-
-		return (
-			<span>
-				<Gridicon icon="info-outline" size={ 18 } className="blog-posts-page__info-icon" />
-				{ translate( '"%(pageTitle)s" page is showing your latest posts.', {
-					args: {
-						pageTitle: this.getPageTitle( this.props.postsPage ),
-					},
-				} ) }
-			</span>
-		);
 	}
 
 	render() {

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -49,11 +49,7 @@ class BlogPostsPage extends React.Component {
 			: this.props.translate( 'Untitled' );
 	};
 
-	getPostsPageLink( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) {
-		if ( isStaticHomePageWithNoPostsPage ) {
-			return null;
-		}
-
+	getPostsPageLink( { isCurrentlySetAsHomepage } ) {
 		if ( ! isCurrentlySetAsHomepage ) {
 			return this.getPageProperty( { pageId: this.props.postsPage, property: 'URL' } );
 		}
@@ -61,24 +57,8 @@ class BlogPostsPage extends React.Component {
 		return this.props.site.URL;
 	}
 
-	renderPostsPageInfo( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) {
+	renderPostsPageInfo( { isCurrentlySetAsHomepage } ) {
 		const { translate } = this.props;
-
-		if ( isStaticHomePageWithNoPostsPage ) {
-			return (
-				<span>
-					<Gridicon size={ 12 } icon="not-visible" className="blog-posts-page__not-used-icon" />
-					{ this.props.translate( 'Posts page not in use.' ) + ' ' }
-					{ // Prevent displaying '"Untitled" is the homepage.' while the settings are loading.
-					!! this.props.frontPage &&
-						this.props.translate( '"%(pageTitle)s" is the homepage.', {
-							args: {
-								pageTitle: this.getPageTitle( this.props.frontPage ),
-							},
-						} ) }
-				</span>
-			);
-		}
 
 		if ( isCurrentlySetAsHomepage ) {
 			return (
@@ -112,8 +92,7 @@ class BlogPostsPage extends React.Component {
 		if ( isFullSiteEditing ) {
 			return null;
 		}
-		const isStaticHomePageWithNoPostsPage =
-			this.props.frontPageType === 'page' && ! this.props.postsPage;
+
 		const isCurrentlySetAsHomepage = this.props.frontPageType === 'posts';
 
 		if ( ! isCurrentlySetAsHomepage ) {
@@ -123,7 +102,6 @@ class BlogPostsPage extends React.Component {
 		return (
 			<Card
 				href={ this.getPostsPageLink( {
-					isStaticHomePageWithNoPostsPage,
 					isCurrentlySetAsHomepage,
 				} ) }
 				target="_blank"
@@ -134,11 +112,9 @@ class BlogPostsPage extends React.Component {
 					<div
 						className={ classNames( {
 							'blog-posts-page__info': true,
-							'is-disabled': isStaticHomePageWithNoPostsPage,
 						} ) }
 					>
 						{ this.renderPostsPageInfo( {
-							isStaticHomePageWithNoPostsPage,
 							isCurrentlySetAsHomepage,
 						} ) }
 					</div>

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -10,7 +10,9 @@
 
 .blog-posts-page__front-page-icon,
 .blog-posts-page__not-used-icon {
+	margin-top: -1px;
 	margin-right: 6px;
+	vertical-align: middle;
 }
 
 .blog-posts-page__details {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove logic and notification for cases where a static front page is used and the blog posts page is unassigned; the callout no longer showed due to changes in #36129, and it adds confusion to show this notification when there's no context given for what a "posts page" is.
* Remove logic and callout for cases where the blog posts page is set to a static page.
* Add tracking on the homepage callout click.
* Also includes a small CSS tweak for the vertical alignment of the homepage icon.

<img width="966" alt="Screen Shot 2019-09-24 at 6 23 24 PM" src="https://user-images.githubusercontent.com/2124984/65554825-a7347780-def8-11e9-9641-d2dd26f61be2.png">

#### Testing instructions

* Switch to this PR and navigate to Pages
* Open the site's Customizer settings in a new tab/window. Ensure Homepage Settings is set to "Your latest posts"
* You should see a callout like the one in the screenshot above on the Pages section.
* Change the Homepage Settings to use a static page. Do not assign a Posts page. Save settings and refresh the Pages section; you should no longer see a callout.