### PR TITLE
Customer Home: Hide the checklist banner

### DIFF
--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -21,6 +21,7 @@ import GSuiteStatsNudge from 'blocks/gsuite-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
 import isGSuiteStatsNudgeDismissed from 'state/selectors/is-gsuite-stats-nudge-dismissed';
 import isUpworkStatsNudgeDismissed from 'state/selectors/is-upwork-stats-nudge-dismissed';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import UpworkStatsNudge from 'blocks/upwork-stats-nudge';
 import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
@@ -105,7 +106,7 @@ class StatsBanners extends Component {
 	}
 
 	render() {
-		const { planSlug, siteId } = this.props;
+		const { isCustomerHomeEnabled, planSlug, siteId } = this.props;
 		if ( ! this.props.domains.length ) {
 			return null;
 		}
@@ -113,7 +114,10 @@ class StatsBanners extends Component {
 		return (
 			<Fragment>
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
-				{ 'ecommerce-bundle' !== planSlug && <WpcomChecklist viewMode="banner" /> }
+				{ /* Hide `WpcomChecklist` on the Customer Home because the checklist is displayed on the page. */ }
+				{ 'ecommerce-bundle' !== planSlug && ! isCustomerHomeEnabled && (
+					<WpcomChecklist viewMode="banner" />
+				) }
 				{ 'ecommerce-bundle' === planSlug && <ECommerceManageNudge siteId={ siteId } /> }
 				{ this.renderBanner() }
 			</Fragment>
@@ -130,5 +134,6 @@ export default connect( ( state, ownProps ) => {
 		),
 		isGSuiteStatsNudgeVisible: ! isGSuiteStatsNudgeDismissed( state, ownProps.siteId ),
 		isUpworkStatsNudgeVisible: ! isUpworkStatsNudgeDismissed( state, ownProps.siteId ),
+		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
 	};
 } )( localize( StatsBanners ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request

#35938 moved the Stats Banners to the top of the Customer Home (when enabled). Because the checklist is already displayed on the Customer Home, the checklist banner is redundant. Additionally and the "View Checklist" link appears to not function because it links to the page you are already on.

This PR hides the Checklist banner when Stats Banners are displayed on the Customer Home.

**Before**

<img width="1552" alt="Screen Shot 2019-09-24 at 17 07 28" src="https://user-images.githubusercontent.com/1699996/65555344-03e06400-def2-11e9-8509-1899194ba14b.png">

**After**

<img width="1552" alt="Screen Shot 2019-09-24 at 17 23 57" src="https://user-images.githubusercontent.com/1699996/65555356-0fcc2600-def2-11e9-91d0-59b3474da136.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start` and create a new site.
* Add your user to the `show` group of the `customerHomePage` a/b test.
* Visit the Customer Home (`/home/{site}`) and see that the checklist banner is not shown.
* Add your user to the `hide` group of the `customerHomePage` a/b test.
* Visit the stats page (`/stats/{site}`) and verify that the checkist banner is shown.
