### PR TITLE
Revert "Fix/36174 search cursor placement"

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -104,13 +104,13 @@
 }
 
 .search__input[type='search'] {
-	line-height: 3;
 	flex: 1 1 auto;
 	display: none;
 	z-index: z-index( '.search', '.search__input' );
 	top: 0;
 	border: none;
 	border-radius: inherit;
+	height: 100%;
 	background: var( --color-surface );
 	appearance: none;
 	box-sizing: border-box;
@@ -158,8 +158,6 @@
 	}
 
 	.search__input-fade {
-		display: flex;
-		align-items: center;
 		flex: 1 1 auto;
 		height: 100%;
 		position: relative;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#36190

The change caused a few UI regressions

See: https://github.com/Automattic/wp-calypso/issues/36261