### PR TITLE
G Suite: Hide misleading banner when user has active forwards or G Suite with others

### DIFF
--- a/client/lib/domains/email-forwarding/index.js
+++ b/client/lib/domains/email-forwarding/index.js
@@ -7,7 +7,7 @@ import emailValidator from 'email-validator';
 /**
  * Internal dependencies
  */
-import { hasGSuite } from 'lib/gsuite';
+import { hasGSuiteWithUs } from 'lib/gsuite';
 import { type as domainTypes } from 'lib/domains/constants';
 
 /**
@@ -36,11 +36,11 @@ function getEligibleEmailForwardingDomain( selectedDomainName, domains = [] ) {
  */
 function getEmailForwardingSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
-		const domainHasGSuite = hasGSuite( domain );
+		const domainHasGSuiteWithUs = hasGSuiteWithUs( domain );
 		const wpcomHosted =
 			includes( [ domainTypes.REGISTERED ], domain.type ) && domain.hasWpcomNameservers;
 		const mapped = includes( [ domainTypes.MAPPED ], domain.type );
-		return ( wpcomHosted || mapped ) && ! domainHasGSuite;
+		return ( wpcomHosted || mapped ) && ! domainHasGSuiteWithUs;
 	} );
 }
 

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -104,11 +104,11 @@ function getEligibleGSuiteDomain( selectedDomainName, domains ) {
  */
 function getGSuiteSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
-		if ( hasGSuiteOtherProvider( domain ) ) {
+		if ( hasGSuiteWithAnotherProvider( domain ) ) {
 			return false;
 		}
 
-		const isHostedOnWpcom = isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuite( domain ) );
+		const isHostedOnWpcom = isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuiteWithUs( domain ) );
 		const isMapped = isMappedDomain( domain );
 
 		return ( isHostedOnWpcom || isMapped ) && canDomainAddGSuite( domain.name );
@@ -155,24 +155,26 @@ function getGSuiteSettingsUrl( domainName ) {
 }
 
 /**
- * Given a domain object, does that domain have G Suite
+ * Given a domain object, does that domain have G Suite with us.
  *
- * @param {Object} domain - domain object
- * @returns {Boolean} - Does a domain have G Suite
+ * @param {Object} domain
+ * @returns {Boolean} - true if the domain is with under our management, false otherwise
  */
-function hasGSuite( domain ) {
+function hasGSuiteWithUs( domain ) {
 	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
+
 	return 'no_subscription' !== domainStatus && 'other_provider' !== domainStatus;
 }
 
 /**
- * Given a domain object, does that domain have G Suite with another provider
+ * Given a domain object, does that domain have G Suite with another provider.
  *
- * @param {Object} domain - domain object
- * @returns {Boolean} - Does a domain have G Suite with another provider
+ * @param {Object} domain
+ * @returns {Boolean} - true if the domain is with another provider, false otherwise
  */
-function hasGSuiteOtherProvider( domain ) {
+function hasGSuiteWithAnotherProvider( domain ) {
 	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
+
 	return 'other_provider' === domainStatus;
 }
 
@@ -215,9 +217,9 @@ export {
 	getGSuiteSupportedDomains,
 	getLoginUrlWithTOSRedirect,
 	getMonthlyPrice,
-	hasGSuite,
-	hasGSuiteOtherProvider,
 	hasGSuiteSupportedDomain,
+	hasGSuiteWithAnotherProvider,
+	hasGSuiteWithUs,
 	hasPendingGSuiteUsers,
 	isGSuiteRestricted,
 };

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -6,7 +6,7 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import { get, includes, some, endsWith } from 'lodash';
+import { get, includes, some, endsWith, find } from 'lodash';
 import { type as domainTypes } from 'lib/domains/constants';
 import userFactory from 'lib/user';
 
@@ -100,10 +100,22 @@ function getGSuiteSupportedDomains( domains ) {
 			includes( [ domainTypes.REGISTERED ], domain.type ) &&
 			( domain.hasWpcomNameservers || hasGSuite( domain ) );
 		const mapped = includes( [ domainTypes.MAPPED ], domain.type );
-		const notOtherProvidor =
+		const notOtherProvider =
 			domain.googleAppsSubscription && domain.googleAppsSubscription.status !== 'other_provider';
-		return ( wpcomHosted || mapped ) && canDomainAddGSuite( domain.name ) && notOtherProvidor;
+		return ( wpcomHosted || mapped ) && canDomainAddGSuite( domain.name ) && notOtherProvider;
 	} );
+}
+
+/**
+ * Returns the primary domain name if the domain name supports GSuite
+ *
+ * @param {Array} domains - list of domain objects
+ * @returns {String} - name of the domain if valid
+ */
+function getGSuiteSupportedPrimaryDomainName( domains ) {
+	const eligibleGSuiteDomains = getGSuiteSupportedDomains( domains );
+	const selectedGSuiteDomain = find( eligibleGSuiteDomains, 'isPrimary' );
+	return get( selectedGSuiteDomain, 'name' );
 }
 
 /**
@@ -157,12 +169,12 @@ function hasGSuite( domain ) {
 }
 
 /**
- * Given a domain object, does that domain have G Suite with another providor
+ * Given a domain object, does that domain have G Suite with another provider
  *
  * @param {Object} domain - domain object
- * @returns {Boolean} - Does a domain have G Suite with another providor
+ * @returns {Boolean} - Does a domain have G Suite with another provider
  */
-function hasGSuiteOtherProvidor( domain ) {
+function hasGSuiteOtherProvider( domain ) {
 	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
 	return 'other_provider' === domainStatus;
 }
@@ -204,10 +216,11 @@ export {
 	getEligibleGSuiteDomain,
 	getGSuiteSettingsUrl,
 	getGSuiteSupportedDomains,
+	getGSuiteSupportedPrimaryDomainName,
 	getLoginUrlWithTOSRedirect,
 	getMonthlyPrice,
 	hasGSuite,
-	hasGSuiteOtherProvidor,
+	hasGSuiteOtherProvider,
 	hasGSuiteSupportedDomain,
 	hasPendingGSuiteUsers,
 	isGSuiteRestricted,

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -78,7 +78,6 @@ function getAnnualPrice( cost, currencyCode ) {
  *
  *   - The domain from the site currently selected
  *   - The primary domain of the site
- *   - The first domain of the site
  *
  * @param {String} selectedDomainName - domain name for the site currently selected by the user
  * @param {Array} domains - list of domain objects
@@ -157,8 +156,8 @@ function getGSuiteSettingsUrl( domainName ) {
 /**
  * Given a domain object, does that domain have G Suite with us.
  *
- * @param {Object} domain
- * @returns {Boolean} - true if the domain is with under our management, false otherwise
+ * @param {Object} domain - domain object
+ * @returns {Boolean} - true if the domain is under our management, false otherwise
  */
 function hasGSuiteWithUs( domain ) {
 	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
@@ -169,7 +168,7 @@ function hasGSuiteWithUs( domain ) {
 /**
  * Given a domain object, does that domain have G Suite with another provider.
  *
- * @param {Object} domain
+ * @param {Object} domain - domain object
  * @returns {Boolean} - true if the domain is with another provider, false otherwise
  */
 function hasGSuiteWithAnotherProvider( domain ) {

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -5,8 +5,8 @@ import {
 	canDomainAddGSuite,
 	getEligibleGSuiteDomain,
 	getGSuiteSupportedDomains,
-	hasGSuite,
 	hasGSuiteSupportedDomain,
+	hasGSuiteWithUs,
 	hasPendingGSuiteUsers,
 	isGSuiteRestricted,
 } from 'lib/gsuite';
@@ -88,13 +88,13 @@ describe( 'index', () => {
 		} );
 	} );
 
-	describe( '#hasGSuite', () => {
+	describe( '#hasGSuiteWithUs', () => {
 		test( 'returns true if googleAppsSubscription has a value for status', () => {
-			expect( hasGSuite( { googleAppsSubscription: { status: 'blah' } } ) ).toEqual( true );
+			expect( hasGSuiteWithUs( { googleAppsSubscription: { status: 'blah' } } ) ).toEqual( true );
 		} );
 
 		test( 'returns true if googleAppsSubscription has no_subscription for status', () => {
-			expect( hasGSuite( { googleAppsSubscription: { status: 'no_subscription' } } ) ).toEqual(
+			expect( hasGSuiteWithUs( { googleAppsSubscription: { status: 'no_subscription' } } ) ).toEqual(
 				false
 			);
 		} );

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -14,7 +14,7 @@ import React from 'react';
  */
 import Button from 'components/button';
 import EmptyContent from 'components/empty-content';
-import { hasGSuite } from 'lib/gsuite';
+import { hasGSuiteWithUs } from 'lib/gsuite';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { domainManagementEdit } from 'my-sites/domains/paths';
 import { emailManagement } from 'my-sites/email/paths';
@@ -42,10 +42,10 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 	}
 
 	const domainName = primaryDomain.name;
-	const domainHasGSuite = hasGSuite( primaryDomain );
+	const domainHasGSuiteWithUs = hasGSuiteWithUs( primaryDomain );
 
 	const recordEmailClick = () => {
-		const tracksName = domainHasGSuite
+		const tracksName = domainHasGSuiteWithUs
 			? 'calypso_domain_only_gsuite_manage'
 			: 'calypso_domain_only_gsuite_cta';
 		recordTracks( tracksName, {
@@ -69,10 +69,10 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 				<Button
 					className="empty-content__action button"
 					href={ emailManagement( slug, domainName ) }
-					primary={ ! domainHasGSuite }
+					primary={ ! domainHasGSuiteWithUs }
 					onClick={ recordEmailClick }
 				>
-					{ domainHasGSuite ? translate( 'Manage Email' ) : translate( 'Add Email' ) }
+					{ domainHasGSuiteWithUs ? translate( 'Manage Email' ) : translate( 'Add Email' ) }
 				</Button>
 			</EmptyContent>
 

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -16,11 +16,11 @@ import Main from 'components/main';
 import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import {
-	hasGSuite,
-	isGSuiteRestricted,
-	hasGSuiteOtherProvider,
-	hasGSuiteSupportedDomain,
 	getEligibleGSuiteDomain,
+	hasGSuiteSupportedDomain,
+	hasGSuiteWithAnotherProvider,
+	hasGSuiteWithUs,
+	isGSuiteRestricted,
 } from 'lib/gsuite';
 import { getEligibleEmailForwardingDomain } from 'lib/domains/email-forwarding';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
@@ -99,7 +99,7 @@ class EmailManagement extends React.Component {
 		}
 		const domainList = selectedDomainName ? [ getSelectedDomain( this.props ) ] : domains;
 
-		if ( domainList.some( hasGSuite ) ) {
+		if ( domainList.some( hasGSuiteWithUs ) ) {
 			return this.googleAppsUsersCard();
 		} else if ( hasGSuiteSupportedDomain( domainList ) ) {
 			return this.addGSuiteCta();
@@ -123,7 +123,7 @@ class EmailManagement extends React.Component {
 						'to a professional custom domain.'
 				),
 			};
-		} else if ( selectedDomain && hasGSuiteOtherProvider( selectedDomain ) ) {
+		} else if ( selectedDomain && hasGSuiteWithAnotherProvider( selectedDomain ) ) {
 			emptyContentProps = {
 				title: translate( 'G Suite is not supported on this domain' ),
 				line: translate(

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -18,7 +18,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import {
 	hasGSuite,
 	isGSuiteRestricted,
-	hasGSuiteOtherProvidor,
+	hasGSuiteOtherProvider,
 	hasGSuiteSupportedDomain,
 	getEligibleGSuiteDomain,
 } from 'lib/gsuite';
@@ -123,7 +123,7 @@ class EmailManagement extends React.Component {
 						'to a professional custom domain.'
 				),
 			};
-		} else if ( selectedDomain && hasGSuiteOtherProvidor( selectedDomain ) ) {
+		} else if ( selectedDomain && hasGSuiteOtherProvider( selectedDomain ) ) {
 			emptyContentProps = {
 				title: translate( 'G Suite is not supported on this domain' ),
 				line: translate(

--- a/client/state/selectors/get-email-forwarding-type.js
+++ b/client/state/selectors/get-email-forwarding-type.js
@@ -6,6 +6,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { getEmailForwards } from 'state/selectors/get-email-forwards';
+
+/**
  * Retrieve the type of the email forwards
  *
  * @param  {Object} state    Global state tree
@@ -14,4 +19,26 @@ import { get } from 'lodash';
  */
 export default function getEmailForwardingType( state, domainName ) {
 	return get( state.emailForwarding, [ domainName, 'type' ], null );
+}
+
+/**
+ * Retrieve the type of the email forwards for domains
+ *
+ * @param  {Object} state    Global state tree
+ * @param  {Array}  domains domains to filter
+ * @param  {boolean} setPending set forward type to `pending` while waiting for a request to complete.
+ * @return {Object} an object containing the email forward type per domain. The type per domain could be null if it has not be retrieved yet
+ */
+export function getEmailForwardingTypeForDomains( state, domains, setPending = false ) {
+	return Object.fromEntries(
+		domains.map( domain => {
+			const requesting =
+				get( state.emailForwarding, [ domain.name, 'requesting' ], false ) === true;
+			let type =
+				setPending && requesting ? 'pending' : getEmailForwardingType( state, domain.name );
+			const forwards = getEmailForwards( state, domain.name );
+			type = 'forward' === type && 0 === forwards.length ? null : type;
+			return [ domain.name, type ];
+		} )
+	);
 }

--- a/client/state/selectors/get-email-forwarding-type.js
+++ b/client/state/selectors/get-email-forwarding-type.js
@@ -3,13 +3,7 @@
 /**
  * External dependencies
  */
-import { get, isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { getEmailForwards } from 'state/selectors/get-email-forwards';
-import isRequestingEmailForwards from 'state/selectors/is-requesting-email-forwards';
+import { get } from 'lodash';
 
 /**
  * Retrieve the type of the email forwards
@@ -20,24 +14,4 @@ import isRequestingEmailForwards from 'state/selectors/is-requesting-email-forwa
  */
 export default function getEmailForwardingType( state, domainName ) {
 	return get( state.emailForwarding, [ domainName, 'type' ], null );
-}
-
-/**
- * Retrieve the type of the email associated with a domain name
- *
- * @param  {Object} state    Global state tree
- * @param  {String}  domainName domains name to query
- * @return {String} the email type for the domain. It's set as `pending` if it has not been retrieved yet
- */
-export function getEmailTypeForDomainName( state, domainName ) {
-	// Set the type to `pending` if `requesting`
-	let type = isRequestingEmailForwards( state, domainName )
-		? 'pending'
-		: getEmailForwardingType( state, domainName );
-	const forwards = getEmailForwards( state, domainName );
-	// Explicitly set the type to null if type === `forward` but there are no active forwards
-	if ( 'forward' === type ) {
-		type = isEmpty( forwards ) ? null : type;
-	}
-	return type;
 }

--- a/client/state/selectors/is-gsuite-stats-nudge-visible.js
+++ b/client/state/selectors/is-gsuite-stats-nudge-visible.js
@@ -43,7 +43,7 @@ export default function isGSuiteStatsNudgeVisible( state, siteId, domains ) {
 
 	const forwards = getEmailForwards( state, eligibleDomain );
 
-	// Prevents the nudge from appearing until the list of email forwards has loaded
+	// Prevents the nudge from appearing until the list of email forwards has loaded to avoid flickering
 	if ( forwards === null ) {
 		return false;
 	}

--- a/client/state/selectors/is-gsuite-stats-nudge-visible.js
+++ b/client/state/selectors/is-gsuite-stats-nudge-visible.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getGSuiteSupportedPrimaryDomainName } from 'lib/gsuite';
+import { getEmailTypeForDomainName } from 'state/selectors/get-email-forwarding-type';
+import isGSuiteStatsNudgeDismissed from 'state/selectors/is-gsuite-stats-nudge-dismissed';
+
+/**
+ * Returns true if the G Suite nudge can shown for this site if:
+ *  - The GSuite stats nudge has not been dismissed
+ *  - The primary domain is eligible to add GSuite ( i.e. has no GSuite or forwards already )
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId The Id of the site
+ * @param  {Array} domains - list of domain objects
+ * @return {Boolean} true if the nudge should be visible
+ */
+export default function isGSuiteStatsNudgeVisible( state, siteId, domains ) {
+	const supportedPrimaryDomainName = getGSuiteSupportedPrimaryDomainName( domains );
+	const notDismissed = ! isGSuiteStatsNudgeDismissed( state, siteId );
+	const hasValidName = !! supportedPrimaryDomainName;
+	const domainCanAddGSuite =
+		hasValidName && ! getEmailTypeForDomainName( state, supportedPrimaryDomainName );
+	return notDismissed && domainCanAddGSuite;
+}

--- a/client/state/selectors/is-gsuite-stats-nudge-visible.js
+++ b/client/state/selectors/is-gsuite-stats-nudge-visible.js
@@ -1,27 +1,52 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import { getGSuiteSupportedPrimaryDomainName } from 'lib/gsuite';
-import { getEmailTypeForDomainName } from 'state/selectors/get-email-forwarding-type';
+import { getEligibleGSuiteDomain } from 'lib/gsuite';
+import { getEmailForwards } from 'state/selectors/get-email-forwards';
+import getEmailForwardingType from 'state/selectors/get-email-forwarding-type';
 import isGSuiteStatsNudgeDismissed from 'state/selectors/is-gsuite-stats-nudge-dismissed';
 
 /**
- * Returns true if the G Suite nudge can shown for this site if:
- *  - The GSuite stats nudge has not been dismissed
- *  - The primary domain is eligible to add GSuite ( i.e. has no GSuite or forwards already )
+ * Determines whether the G Suite nudge can be shown for this site. It will be displayed if:
  *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId The Id of the site
- * @param  {Array} domains - list of domain objects
+ *   - The GSuite stats nudge has not been dismissed
+ *   - A domain is eligible to GSuite (i.e. has not G Suite and no email forwards already)
+ *
+ * @param  {Object} state - Global state tree
+ * @param  {Number} siteId - The Id of the site
+ * @param  {Array}  domains - list of domain objects
  * @return {Boolean} true if the nudge should be visible
  */
 export default function isGSuiteStatsNudgeVisible( state, siteId, domains ) {
-	const supportedPrimaryDomainName = getGSuiteSupportedPrimaryDomainName( domains );
-	const notDismissed = ! isGSuiteStatsNudgeDismissed( state, siteId );
-	const hasValidName = !! supportedPrimaryDomainName;
-	const domainCanAddGSuite =
-		hasValidName && ! getEmailTypeForDomainName( state, supportedPrimaryDomainName );
-	return notDismissed && domainCanAddGSuite;
+	if ( isGSuiteStatsNudgeDismissed( state, siteId ) ) {
+		return false;
+	}
+
+	const eligibleDomain = getEligibleGSuiteDomain( null, domains );
+
+	if ( ! eligibleDomain ) {
+		return false;
+	}
+
+	const emailForwardingType = getEmailForwardingType( state, eligibleDomain );
+
+	if ( emailForwardingType !== null && emailForwardingType !== 'forward' ) {
+		return false;
+	}
+
+	const forwards = getEmailForwards( state, eligibleDomain );
+
+	// Prevents the nudge from appearing until the list of email forwards has loaded
+	if ( forwards === null ) {
+		return false;
+	}
+
+	return isEmpty( forwards );
 }


### PR DESCRIPTION
This proposed change fixes the issue where customers are shown the G Suite nudge when there are active forwards on the primary domain or the when the user has G Suite with another provider.

![Screenshot_20190418-190834](https://user-images.githubusercontent.com/43215253/56375184-82cbc500-620d-11e9-81c2-56f3378abb4d.jpg)

This is related to #32409

#### Testing instructions

##### Viewing the nudge
You can view the G Suite nudge in the stats page using the `Statistics` menu item on the side bar, or the `My Home` menu item if you are in the `customerHome` A/B test variation. 

##### Requirements
* A mapped domain with forwards only - **domainA**
* A domain with G Suite subscription with us - **domainB**
* A domain with G Suite subscription with another provider - **domainC**

##### Steps
* Apply D33465-code to your sandbox
* Point `public-api.wordpress.com` to your sandbox
* Run calypso in the dev environment
* Ensure that the **domainA** is the primary domain. If necessary go to: `domains/manage/<domainSlug>`.
* Add some forwarding address
* Go view the nudge and confirm that it's not shown for a mapped domain with forwards
* Delete all the forwarding addresses.
* Confirm that the nudge is then shown.
* Make **domainB** the primary domain
* Confirm the nudge is not shown
* Make **domainC** the primary domain
* Confirm the nudge is not shown



