### PR TITLE
Marketing: Show Connections tab for all Jetpack sites

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -136,7 +136,7 @@ export default connect( state => {
 
 	return {
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
-		showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
+		showConnections: ! siteId || ! isJetpack,
 		showTraffic: canManageOptions && !! siteId,
 		isVip: isVipSite( state, siteId ),
 		siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show "Connections" tab for all Jetpack sites, no matter if Publicize is enabled

#### Testing instructions


1. Start with connected Jetpack site
1. Make sure Publicize is enabled and Mailchimp mailing list is not configured for your site 
1. Start a new post in wp-admin and add a Mailchimp block, follow the link to set up the connection
1. Make sure you can see Mailchimp connection options, and the "Connections" tab is present
1. Repeat 1-4 but with Publicize disabled

Before:
<img width="836" alt="Sharing ‹ HelloWord — WordPress com 2019-09-25 10-18-28" src="https://user-images.githubusercontent.com/5654161/65578752-1ce32680-df7f-11e9-8d2c-d16e06044aba.png">

After:

<img width="855" alt="Sharing ‹ HelloWord — WordPress com 2019-09-25 10-27-14" src="https://user-images.githubusercontent.com/5654161/65578764-21a7da80-df7f-11e9-842b-29e82324595b.png">


Related to #34018
