### PR TITLE
Ignore test directories when transpiling/copying package sources

### DIFF
--- a/packages/calypso-build/bin/copy-styles.js
+++ b/packages/calypso-build/bin/copy-styles.js
@@ -14,7 +14,7 @@ const outputDirCommon = path.join( dir, 'dist', 'cjs' );
 
 const copyOptions = {
 	overwrite: true,
-	filter: '**/*.scss',
+	filter: [ '**/*.scss', '!**/test/**' ],
 	concurrency: 127,
 };
 

--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -14,9 +14,12 @@ const inputDir = path.join( dir, 'src' );
 const outputDirEsm = path.join( dir, 'dist', 'esm' );
 const outputDirCommon = path.join( dir, 'dist', 'cjs' );
 
-console.log( 'Building %s', dir );
+// If the pattern was just a relative path (**/test/**), Babel would resolve it against the
+// root directory (set as cwd) which isn't an ancestor of any of the source files.
+const testIgnorePattern = path.join( dir, '**/test/**' );
 
-const baseCommand = `npx babel --presets="${ babelPresetFile }" --extensions='.js,.jsx,.ts,.tsx'`;
+console.log( 'Building %s', dir );
+const baseCommand = `npx babel --presets="${ babelPresetFile }" --ignore "${ testIgnorePattern }" --extensions='.js,.jsx,.ts,.tsx'`;
 
 execSync( `${ baseCommand } -d "${ outputDirEsm }" "${ inputDir }"`, {
 	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults' } ),


### PR DESCRIPTION
When transpiling package JS sources or copying SCSS style files, ignore `test/` subdirectories and don't copy them to the `dist/` folder.

**How to test:**
Run `npm run build-packages` and verify that there is no `test` subdirectory in `packages/calypso-ui/dist/{cjs,esm}/card`.

Try to create a SCSS source file `packages/calypso-ui/src/card/test/test.scss` and verify that the package build doesn't copy it to the `dist` folder. That tests the change in `copy-styles`.
