### PR TITLE
Fix the upgrade nudge

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/README.md
+++ b/client/blocks/upgrade-nudge-expanded/README.md
@@ -14,7 +14,7 @@ It's meant to comprehensively describe a plan and give enough reasons to upgrade
 - *benefits* - array of strings explaining the benefits of the feature and upgradidng to the plan
 - *upgrade* - upgrade function. If not provided, default will be used.
 - *eventName* - event to record when nudge is shown. Default is `calypso_upgrade_nudge_impression` with properties cta_name: props.event, cta_size: expanded and cta_feature: props.highlightedFeature
-- *shouldDisplay* - Used to display the update nudge in devdocs.
+- *forceDisplay* - Used to display the update nudge in devdocs.
 
 
 ## Example - minimal

--- a/client/blocks/upgrade-nudge-expanded/README.md
+++ b/client/blocks/upgrade-nudge-expanded/README.md
@@ -14,6 +14,7 @@ It's meant to comprehensively describe a plan and give enough reasons to upgrade
 - *benefits* - array of strings explaining the benefits of the feature and upgradidng to the plan
 - *upgrade* - upgrade function. If not provided, default will be used.
 - *eventName* - event to record when nudge is shown. Default is `calypso_upgrade_nudge_impression` with properties cta_name: props.event, cta_size: expanded and cta_feature: props.highlightedFeature
+- *shouldDisplay* - Used to display the update nudge in devdocs.
 
 
 ## Example - minimal

--- a/client/blocks/upgrade-nudge-expanded/docs/example.jsx
+++ b/client/blocks/upgrade-nudge-expanded/docs/example.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/blocks/upgrade-nudge-expanded/docs/example.jsx
+++ b/client/blocks/upgrade-nudge-expanded/docs/example.jsx
@@ -26,7 +26,7 @@ const UpgradeNudgeExpandedExample = () => {
 						'Allow you to control how page titles will appear on Google search results, or when shared on social networks.',
 						'Modify front page meta data in order to customize how your site appears to search engines.',
 					] }
-					forceDisplay={ true }
+					forceDisplay
 				/>
 			</div>
 		</div>

--- a/client/blocks/upgrade-nudge-expanded/docs/example.jsx
+++ b/client/blocks/upgrade-nudge-expanded/docs/example.jsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import { stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +28,7 @@ const UpgradeNudgeExpandedExample = () => {
 						'Allow you to control how page titles will appear on Google search results, or when shared on social networks.',
 						'Modify front page meta data in order to customize how your site appears to search engines.',
 					] }
-					shouldDisplay={ stubTrue }
+					forceDisplay={ true }
 				/>
 			</div>
 		</div>

--- a/client/blocks/upgrade-nudge-expanded/docs/example.jsx
+++ b/client/blocks/upgrade-nudge-expanded/docs/example.jsx
@@ -1,0 +1,41 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { stubTrue } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
+import { PLAN_BUSINESS, FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
+
+const UpgradeNudgeExpandedExample = () => {
+	return (
+		<div>
+			<div>
+				<UpgradeNudgeExpanded
+					plan={ PLAN_BUSINESS }
+					title={ 'Upgrade to a Business Plan and Enable Advanced SEO' }
+					subtitle={
+						"By upgrading to a Business Plan you'll enable advanced SEO features on your site."
+					}
+					highlightedFeature={ FEATURE_ADVANCED_SEO }
+					benefits={ [
+						"Preview your site's posts and pages as they will appear when shared on Facebook, Twitter and the WordPress.com Reader.",
+						'Allow you to control how page titles will appear on Google search results, or when shared on social networks.',
+						'Modify front page meta data in order to customize how your site appears to search engines.',
+					] }
+					shouldDisplay={ stubTrue }
+				/>
+			</div>
+		</div>
+	);
+};
+
+UpgradeNudgeExpandedExample.displayName = 'UpgradeNudgeExpandedExample';
+
+export default UpgradeNudgeExpandedExample;

--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -54,7 +54,7 @@ class UpgradeNudgeExpanded extends Component {
 	}
 
 	render() {
-		if ( ! this.props.currentPlan ) {
+		if ( ! this.props.currentPlan && ! this.props.shouldDisplay ) {
 			return null;
 		}
 
@@ -149,6 +149,7 @@ UpgradeNudgeExpanded.propTypes = {
 	eventName: PropTypes.string,
 	event: PropTypes.string,
 	siteSlug: PropTypes.string,
+	shouldDisplay: PropTypes.bool,
 	recordTracksEvent: PropTypes.func.isRequired,
 };
 

--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -54,7 +54,7 @@ class UpgradeNudgeExpanded extends Component {
 	}
 
 	render() {
-		if ( ! this.props.currentPlan && ! this.props.shouldDisplay ) {
+		if ( ! this.props.currentPlan && ! this.props.forceDisplay ) {
 			return null;
 		}
 
@@ -149,7 +149,7 @@ UpgradeNudgeExpanded.propTypes = {
 	eventName: PropTypes.string,
 	event: PropTypes.string,
 	siteSlug: PropTypes.string,
-	shouldDisplay: PropTypes.bool,
+	forceDisplay: PropTypes.bool,
 	recordTracksEvent: PropTypes.func.isRequired,
 };
 

--- a/client/blocks/upgrade-nudge/README.md
+++ b/client/blocks/upgrade-nudge/README.md
@@ -27,6 +27,7 @@ Name | Type | Default | Description
 `compact` | `bool` | `false` | Decreases the size of the UpgradeNudge.
 `event` | `string` | `null` | An event to distinguish the nudge in tracks. Will be set as the `cta_name` event property.
 `feature` | `string` from `FEATURES_LIST` keys | `null` | The slug of the feature that will be provided as part of the proposed upgrade.
+`forceDisplay` | `bool` | `false` | Used to display the update nudge in devdocs.
 `href` | `string` | `null` | The URL/path that the UpgradeNudge redirects to if clicked.
 `icon` | `string` | `'star'` | The slug of the icon used on the UpgradeNudge.
 `jetpack` | `bool` | `false` | Indicates whether the proposed upgrade feature is a Jetpack feature.

--- a/client/blocks/upgrade-nudge/docs/example.jsx
+++ b/client/blocks/upgrade-nudge/docs/example.jsx
@@ -16,7 +16,7 @@ const UpgradeNudgeExample = () => {
 	return (
 		<div>
 			<div>
-				<UpgradeNudge feature={ FEATURE_CUSTOM_DOMAIN } href="#" forceDisplay={ true } />
+				<UpgradeNudge feature={ FEATURE_CUSTOM_DOMAIN } href="#" forceDisplay />
 			</div>
 			<div>
 				<UpgradeNudge

--- a/client/blocks/upgrade-nudge/docs/example.jsx
+++ b/client/blocks/upgrade-nudge/docs/example.jsx
@@ -23,7 +23,7 @@ const UpgradeNudgeExample = () => {
 					title="This is a title"
 					message="This is a custom message"
 					icon="customize"
-					forceDisplay={ true }
+					forceDisplay
 					compact
 				/>
 			</div>

--- a/client/blocks/upgrade-nudge/docs/example.jsx
+++ b/client/blocks/upgrade-nudge/docs/example.jsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import { stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,14 +16,14 @@ const UpgradeNudgeExample = () => {
 	return (
 		<div>
 			<div>
-				<UpgradeNudge feature={ FEATURE_CUSTOM_DOMAIN } href="#" shouldDisplay={ stubTrue } />
+				<UpgradeNudge feature={ FEATURE_CUSTOM_DOMAIN } href="#" forceDisplay={ true } />
 			</div>
 			<div>
 				<UpgradeNudge
 					title="This is a title"
 					message="This is a custom message"
 					icon="customize"
-					shouldDisplay={ stubTrue }
+					forceDisplay={ true }
 					compact
 				/>
 			</div>

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -42,6 +42,7 @@ export class UpgradeNudge extends React.Component {
 		compact: PropTypes.bool,
 		plan: PropTypes.string,
 		feature: PropTypes.string,
+		shouldDisplay: PropTypes.bool,
 		site: PropTypes.object,
 		translate: PropTypes.func,
 	};
@@ -85,6 +86,7 @@ export class UpgradeNudge extends React.Component {
 			icon,
 			jetpack,
 			message,
+			shouldDisplay,
 			site,
 			title,
 			translate,
@@ -100,7 +102,7 @@ export class UpgradeNudge extends React.Component {
 			( feature === FEATURE_NO_ADS && site.options.wordads ) ||
 			( ( ! jetpack && site.jetpack ) || ( jetpack && ! site.jetpack ) );
 
-		if ( shouldNotDisplay ) {
+		if ( shouldNotDisplay && ! shouldDisplay ) {
 			return null;
 		}
 

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -42,7 +42,7 @@ export class UpgradeNudge extends React.Component {
 		compact: PropTypes.bool,
 		plan: PropTypes.string,
 		feature: PropTypes.string,
-		shouldDisplay: PropTypes.bool,
+		forceDisplay: PropTypes.bool,
 		site: PropTypes.object,
 		translate: PropTypes.func,
 	};
@@ -80,13 +80,13 @@ export class UpgradeNudge extends React.Component {
 			className,
 			compact,
 			event,
+			forceDisplay,
 			plan,
 			planHasFeature,
 			feature,
 			icon,
 			jetpack,
 			message,
-			shouldDisplay,
 			site,
 			title,
 			translate,
@@ -102,7 +102,7 @@ export class UpgradeNudge extends React.Component {
 			( feature === FEATURE_NO_ADS && site.options.wordads ) ||
 			( ( ! jetpack && site.jetpack ) || ( jetpack && ! site.jetpack ) );
 
-		if ( shouldNotDisplay && ! shouldDisplay ) {
+		if ( shouldNotDisplay && ! forceDisplay ) {
 			return null;
 		}
 

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -42,6 +42,7 @@ import HappinessSupport from 'components/happiness-support/docs/example';
 import ThemesListExample from 'components/themes-list/docs/example';
 import PlanStorage from 'blocks/plan-storage/docs/example';
 import UpgradeNudge from 'blocks/upgrade-nudge/docs/example';
+import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded/docs/example';
 import PlanCompareCard from 'my-sites/plan-compare-card/docs/example';
 import DomainTip from 'blocks/domain-tip/docs/example';
 import PostItem from 'blocks/post-item/docs/example';
@@ -159,7 +160,8 @@ export default class AppComponents extends React.Component {
 					<SiteIcon readmeFilePath="site-icon" />
 					<Theme />
 					<ThemesListExample />
-					<UpgradeNudge readmeFilePath="upgrade-nudge-expanded" />
+					<UpgradeNudge readmeFilePath="upgrade-nudge" />
+					<UpgradeNudgeExpanded readmeFilePath="upgrade-nudge-expanded" />
 					<PlanCompareCard />
 					<DomainTip />
 					<RelatedPostCard />


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The upgrade nudge isn't displayed in devdocs:
- http://wpcalypso.wordpress.com/devdocs/blocks/upgrade-nudge
- http://wpcalypso.wordpress.com/devdocs/blocks/upgrade-nudge-expanded

#### Testing instructions
Checkout this branch and look in devdocs:
- http://calypso.localhost:3000/devdocs/blocks/upgrade-nudge
- http://calypso.localhost:3000/devdocs/blocks/upgrade-nudge-expanded

