### PR TITLE
i18n: Extract additional translatable strings using wp i18n

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,8 +294,8 @@ jobs:
       - run:
           name: Extract @wordpress/i18n strings
           command: |
-            wp i18n make-pot . merged.pot --slug=calypso  --ignore-domain --domain=default --exclude=build/,packages/,public/,test/ --merge=calypso-strings.pot
-            mv merged.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
+            wp i18n make-pot . calypso-strings.pot --slug=calypso --ignore-domain --domain=default --exclude=build/,packages/,public/,test/ --merge=translate.pot
+            mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - store-artifacts-and-test-results
 
   build-notifications:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,13 +245,12 @@ jobs:
       - run:
           name: Build calypso-strings.pot
           when: always
-          command: |
-            npm run translate
+          command: npm run translate
       - persist_to_workspace:
           root: '~'
           paths:
             - wp-calypso
-     - run:
+      - run:
           name: Build New Strings .pot
           when: always
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
     working_directory: ~/wp-calypso
     environment: *shared-environment
     docker:
-      - image: php:7-cli
+      - image: wordpress:cli
     parallelism: 1
     steps:
       - prepare
@@ -294,12 +294,7 @@ jobs:
       - run:
           name: Extract @wordpress/i18n strings
           command: |
-            # Get wp-cli
-            curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-            # Install wp i18n
-            php wp-cli.phar wp package install git@github.com:wp-cli/i18n-command.git
-            # Extract strings.
-            php wp-cli.phar wp i18n make-pot . merged.pot --slug=calypso  --ignore-domain --domain=default --exclude=build/,packages/,public/,test/ --merge=calypso-strings.pot
+            wp i18n make-pot . merged.pot --slug=calypso  --ignore-domain --domain=default --exclude=build/,packages/,public/,test/ --merge=calypso-strings.pot
             mv merged.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
       - store-artifacts-and-test-results
 
@@ -672,7 +667,7 @@ workflows:
             - setup
       - wp-i18n-extract-strings:
           requires:
-            - setup
+            - lint-and-translate
       - test-client:
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,6 +671,9 @@ workflows:
       - lint-and-translate:
           requires:
             - setup
+      - wp-i18n-extract-strings:
+          requires:
+            - setup
       - test-client:
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,8 +247,11 @@ jobs:
           when: always
           command: |
             npm run translate
-            mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
-      - run:
+      - persist_to_workspace:
+          root: '~'
+          paths:
+            - wp-calypso
+     - run:
           name: Build New Strings .pot
           when: always
           command: |
@@ -278,6 +281,28 @@ jobs:
                       "vcs_type": "github"
                     }
                   }'
+
+  wp-i18n-extract-strings:
+    working_directory: ~/wp-calypso
+    environment: *shared-environment
+    docker:
+      - image: php:7-cli
+    parallelism: 1
+    steps:
+      - prepare
+      - attach_workspace:
+          at: '~'
+      - run:
+          name: Extract @wordpress/i18n strings
+          command: |
+            # Get wp-cli
+            curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+            # Install wp i18n
+            php wp-cli.phar wp package install git@github.com:wp-cli/i18n-command.git
+            # Extract strings.
+            php wp-cli.phar wp i18n make-pot . merged.pot --slug=calypso  --ignore-domain --domain=default --exclude=build/,packages/,public/,test/ --merge=calypso-strings.pot
+            mv merged.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
+      - store-artifacts-and-test-results
 
   build-notifications:
     <<: *defaults

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
 		"test-server": "jest -c=test/server/jest.config.js",
 		"test-server:coverage": "npm run -s test-server -- --coverage",
 		"test-server:watch": "npm run -s test-server -- --watch",
-		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
+		"translate": "i18n-calypso --format pot --output-file ./translate.pot -k translate -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
 		"update-deps": "npx rimraf npm-shrinkwrap.json && npm run -s distclean && npm i && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
 		"postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
 		"test-server": "jest -c=test/server/jest.config.js",
 		"test-server:coverage": "npm run -s test-server -- --coverage",
 		"test-server:watch": "npm run -s test-server -- --watch",
-		"translate": "i18n-calypso --format pot --output-file ./translate.pot -k translate -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
+		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
 		"update-deps": "npx rimraf npm-shrinkwrap.json && npm run -s distclean && npm i && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
 		"postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
 		"test-server": "jest -c=test/server/jest.config.js",
 		"test-server:coverage": "npm run -s test-server -- --coverage",
 		"test-server:watch": "npm run -s test-server -- --watch",
-		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
+		"translate": "i18n-calypso --format pot --output-file ./translate.pot -k translate -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
 		"update-deps": "npx rimraf npm-shrinkwrap.json && npm run -s distclean && npm i && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
 		"postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",


### PR DESCRIPTION
Since we are started to get usage of `@wordpress/i18n` in the Calypso codebase, and long term we'd want to migrate there, we'll need to extract these strings as well.

We don't need a custom solution for extracting these since [wp-cli's i18n-command](https://github.com/wp-cli/i18n-command) supports this with it's `make-pot` command.

That command also has some nice features that we are able to make use of here, such as merging the newly extracted strings with another POT file. In this case we'll use it to augment the output of our `i18n-calypso` command.

#### Testing instructions

Extraction happens on CircleCI. As per @sirreal's suggestion, I've created a new job that re-uses the workspace that the `translate` job leaves behind and only then creates the artifact that we'll want to use for our translation pipeline on the Automattic servers.