### PR TITLE
Signup: Add exception for connect-in-place flow for Google (take 3)

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import AppleLoginButton from 'components/social-buttons/apple';
 import config from 'config';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -62,9 +63,17 @@ class SocialSignupForm extends Component {
 	};
 
 	shouldUseRedirectFlow() {
+		const { currentRoute } = this.props;
+
 		// If calypso is loaded in a popup, we don't want to open a second popup for social signup
 		// let's use the redirect flow instead in that case
-		const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+		let isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+
+		// Jetpack Connect-in-place auth flow contains special reserved args, so we want a popup for social signup.
+		// See p1HpG7-7nj-p2 for more information.
+		if ( isPopup && '/jetpack/connect/authorize' === currentRoute ) {
+			isPopup = false;
+		}
 
 		return isPopup;
 	}
@@ -112,6 +121,8 @@ class SocialSignupForm extends Component {
 }
 
 export default connect(
-	null,
+	state => ( {
+		currentRoute: getCurrentRoute( state ),
+	} ),
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );


### PR DESCRIPTION
This PR will force opening the Google signup flow in a popup for the connect in place flow. It will only work for the Jetpack authorize screen, and only when opened in a popup. 

Originally, this would redirect to `/start` after authenticating with Google, which breaks the Jetpack "connect in place" flow, dropping the user to the WP.com site creation flow, which doesn't make sense.

This is take 3 - see #36007 for take 1, and #36036 for take 2. In this take, we take a different approach and open a popup within the popup to get around the issues outlined in take 1 and 2.

See p1HpG7-7nj-p2 for more context, and feel free to ping @Automattic/poseidon if you have any questions.

#### Changes proposed in this Pull Request

* Signup: Add exception for connect-in-place flow for Google account creation.

#### Testing instructions

Due to limitations with the Google oAuth2 flow, the full flow can't be tested with development Calypso and can only be tested in production.

* Verify the Google signup flow still works as expected when going through the Jetpack Connect original flow
* Verify the Google signup flow still works as expected when signing up for a WP.com site.
* The rest can be tested in prod only.
