### PR TITLE
Threat Alerts: Ensure date displays properly

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -341,7 +341,7 @@ export class ThreatAlert extends Component {
 										{ this.renderTitle() }
 										<TimeSince
 											className="activity-log__threat-alert-time-since"
-											date={ threat.firstDetected }
+											date={ threat.first_detected }
 											dateFormat="ll"
 										/>
 									</span>


### PR DESCRIPTION
We're currently trying to access the date in the `threat` object from an invalid property. This PR updates the `ThreatAlert` component to get the date from the valid property, thereby ensuring the date in the UI is accurate instead of always showing "Just Now".

![Screen Shot 2019-09-25 at 11 25 36 AM](https://user-images.githubusercontent.com/5528445/65615397-41430100-df87-11e9-9599-24f655980bd1.png)

#### Testing instructions

Load up the activity log for a site with active threats. Observe the date for each threat and ensure that it display accurately for some older threats.

