### PR TITLE
eCommerce Plan: show the eCommerce manage nudge in stats banners

### DIFF
--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -30,9 +30,12 @@ import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 
 class StatsBanners extends Component {
 	static propTypes = {
+		domains: PropTypes.array.isRequired,
+		isCustomerHomeEnabled: PropTypes.bool.isRequired,
 		isGoogleMyBusinessStatsNudgeVisible: PropTypes.bool.isRequired,
 		isGSuiteStatsNudgeVisible: PropTypes.bool.isRequired,
 		isUpworkStatsNudgeVisible: PropTypes.bool.isRequired,
+		planSlug: PropTypes.string.isRequired,
 		siteId: PropTypes.number.isRequired,
 		slug: PropTypes.string.isRequired,
 	};
@@ -130,13 +133,13 @@ class StatsBanners extends Component {
 export default connect( ( state, ownProps ) => {
 	return {
 		domains: getDecoratedSiteDomains( state, ownProps.siteId ),
+		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
 		isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
 			state,
 			ownProps.siteId
 		),
 		isGSuiteStatsNudgeVisible: ! isGSuiteStatsNudgeDismissed( state, ownProps.siteId ),
 		isUpworkStatsNudgeVisible: ! isUpworkStatsNudgeDismissed( state, ownProps.siteId ),
-		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
 		planSlug: getSitePlanSlug( state, ownProps.siteId ),
 	};
 } )( localize( StatsBanners ) );

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -12,6 +12,7 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
+import { isEcommercePlan } from 'lib/plans';
 import config from 'config';
 import ECommerceManageNudge from 'blocks/ecommerce-manage-nudge';
 import { getSitePlanSlug } from 'state/sites/selectors';
@@ -116,10 +117,10 @@ class StatsBanners extends Component {
 			<Fragment>
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 				{ /* Hide `WpcomChecklist` on the Customer Home because the checklist is displayed on the page. */ }
-				{ 'ecommerce-bundle' !== planSlug && ! isCustomerHomeEnabled && (
+				{ ! isEcommercePlan( planSlug ) && ! isCustomerHomeEnabled && (
 					<WpcomChecklist viewMode="banner" />
 				) }
-				{ 'ecommerce-bundle' === planSlug && <ECommerceManageNudge siteId={ siteId } /> }
+				{ isEcommercePlan( planSlug ) && <ECommerceManageNudge siteId={ siteId } /> }
 				{ this.renderBanner() }
 			</Fragment>
 		);

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -14,6 +14,7 @@ import React, { Component, Fragment } from 'react';
 import { abtest } from 'lib/abtest';
 import config from 'config';
 import ECommerceManageNudge from 'blocks/ecommerce-manage-nudge';
+import { getSitePlanSlug } from 'state/sites/selectors';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import { getGSuiteSupportedDomains, hasGSuite } from 'lib/gsuite';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
@@ -135,5 +136,6 @@ export default connect( ( state, ownProps ) => {
 		isGSuiteStatsNudgeVisible: ! isGSuiteStatsNudgeDismissed( state, ownProps.siteId ),
 		isUpworkStatsNudgeVisible: ! isUpworkStatsNudgeDismissed( state, ownProps.siteId ),
 		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
+		planSlug: getSitePlanSlug( state, ownProps.siteId ),
 	};
 } )( localize( StatsBanners ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#31328 inadvertently hid the eCommerce Manage nudge that previously displayed in the Stats Banners ("Start managing your Store"). This PR displays that nudge for users who have an eCommerce plan (both 1 yr and 2 yr plans).

<img width="1007" alt="Screen Shot 2019-09-25 at 14 26 16" src="https://user-images.githubusercontent.com/1699996/65637279-8aa44800-dfa9-11e9-8eed-065589f51624.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note that there's an active a/b test running for the Customer Home with new sites. If you see "Home" in the sidebar, the nudge will display at the top of that page. Otherwise the nudge will display at the top of the Stats page.

* Visit `/start` and select "Online store" as the site type.
* Continue through the flow and select an eCommerce plan
* Complete the eCommerce setup wizard
* You probably now see a Calypsoified page with a checklist for setting up an online store... navigate back to "My Sites" to get back to Calypso (at the top left)
* Check on either the "Home" or "Stats" pages and you should see the eCommerce nudge that informs you of the Store link in the sidebar

* Visit `/start` and set up another new site that has any other plan, besides eCommerce
* Once the site is set up, visit "Home" or "Stats" and see that the eCommerce nudge is not displayed
