### PR TITLE
File-loader: Output file-loader files in development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,9 +157,9 @@ const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 const fileLoader = FileConfig.loader(
 	// The server bundler express middleware server assets from the hard-coded publicPath `/calypso/evergreen/`.
 	// This is required so that running calypso via `npm start` doesn't break.
-	isDevelopment && ! isDesktop
+	isDevelopment
 		? {
-				outputPath: 'images/',
+				outputPath: 'images',
 				publicPath: '/calypso/evergreen/images/',
 		  }
 		: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,13 +154,21 @@ if ( isDevelopment || isDesktop ) {
 const cssFilename = cssNameFromFilename( outputFilename );
 const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
-const fileLoader = FileConfig.loader( {
-	// File-loader does not understand absolute paths so __dirname won't work.
-	// Build off `output.path` for a result like `/…/public/evergreen/../images/`.
-	outputPath: path.join( '..', 'images' ),
-	publicPath: '/calypso/images/',
-	emitFile: isDevelopment || browserslistEnv === defaultBrowserslistEnv, // Only output files once.
-} );
+const fileLoader = FileConfig.loader(
+	// The server bundler express middleware server assets from the hard-coded publicPath `/calypso/evergreen/`.
+	// This is required so that running calypso via `npm start` doesn't break.
+	isDevelopment && ! isDesktop
+		? {
+				outputPath: 'images/',
+				publicPath: '/calypso/evergreen/images/',
+		  }
+		: {
+				// File-loader does not understand absolute paths so __dirname won't work.
+				// Build off `output.path` for a result like `/…/public/evergreen/../images/`.
+				outputPath: path.join( '..', 'images' ),
+				publicPath: '/calypso/images/',
+		  }
+);
 
 const webpackConfig = {
 	bail: ! isDevelopment,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -159,7 +159,7 @@ const fileLoader = FileConfig.loader( {
 	// Build off `output.path` for a result like `/…/public/evergreen/../images/`.
 	outputPath: path.join( '..', 'images' ),
 	publicPath: '/calypso/images/',
-	emitFile: browserslistEnv === defaultBrowserslistEnv, // Only output files once.
+	emitFile: isDevelopment || browserslistEnv === defaultBrowserslistEnv, // Only output files once.
 } );
 
 const webpackConfig = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -167,6 +167,7 @@ const fileLoader = FileConfig.loader(
 				// Build off `output.path` for a result like `/…/public/evergreen/../images/`.
 				outputPath: path.join( '..', 'images' ),
 				publicPath: '/calypso/images/',
+				emitFile: browserslistEnv === defaultBrowserslistEnv, // Only output files once.
 		  }
 );
 

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -8,6 +8,7 @@
  * External dependencies
  */
 const path = require( 'path' );
+// eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require( 'webpack' );
 const _ = require( 'lodash' );
 
@@ -26,8 +27,9 @@ const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
  * Internal variables
  */
 const isDevelopment = bundleEnv === 'development';
+
 const fileLoader = FileConfig.loader( {
-	publicPath: '/calypso/images/',
+	publicPath: isDevelopment ? '/calypso/evergreen/images/' : '/calypso/images/',
 	emitFile: false, // On the server side, don't actually copy files
 } );
 


### PR DESCRIPTION
Running `npm start` would result in file-loader requests 404ing. Reported in https://github.com/Automattic/wp-calypso/pull/36204#issuecomment-535047845.

This is due to the server bundler's webpack-dev-middleware, which hard codes a `/calypso/evergreen/` public path.

This change updates the file-loader in development to match the expected path.

#### Testing instructions

* Test on Calypso.live, ensure https://github.com/Automattic/wp-calypso/pull/36204 has not regressed (visit https://calypso.live/themes?branch=fix/file-loader-in-development while logged out and you should see gridicons).
* Test this PR in development and ensure gridicons are correctly rendered.
