### PR TITLE
Types: Add typecheck script and use latest TypeScript on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
       - run:
           name: TypeScript typecheck
           # Report but don't fail the build (`|| exit 0`)
-          command: npx --package=typescript tsc --noEmit || exit 0
+          command: npm run typecheck || exit 0
 
 
   lint-and-translate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
       - run:
           name: TypeScript typecheck
           # Report but don't fail the build (`|| exit 0`)
-          command: ./node_modules/.bin/tsc --noEmit || exit 0
+          command: npx --package=typescript tsc --noEmit || exit 0
 
 
   lint-and-translate:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -95,6 +95,12 @@
 					"requires": {
 						"lodash": "^4.17.12"
 					}
+				},
+				"typescript": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
+					"integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+					"dev": true
 				}
 			}
 		},
@@ -22569,9 +22575,9 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-			"integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
 			"dev": true
 		},
 		"ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
 		"test-server:coverage": "npm run -s test-server -- --coverage",
 		"test-server:watch": "npm run -s test-server -- --watch",
 		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
-		"typecheck": "npx --package=typescript tsc --noEmit",
+		"typecheck": "tsc --noEmit",
 		"update-deps": "npx rimraf npm-shrinkwrap.json && npm run -s distclean && npm i && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
 		"validate-fallback-es5": "npx eslint --env=es5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",

--- a/package.json
+++ b/package.json
@@ -279,6 +279,7 @@
 		"test-server:coverage": "npm run -s test-server -- --coverage",
 		"test-server:watch": "npm run -s test-server -- --watch",
 		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
+		"typecheck": "npx --package=typescript tsc --noEmit",
 		"update-deps": "npx rimraf npm-shrinkwrap.json && npm run -s distclean && npm i && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
 		"validate-fallback-es5": "npx eslint --env=es5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
 		"stylelint": "9.10.1",
 		"supertest": "3.4.2",
 		"svgstore-cli": "1.3.1",
+		"typescript": "3.6.4",
 		"webpack-hot-middleware": "2.25.0",
 		"webpack-node-externals": "1.7.2",
 		"whybundled": "1.4.2"


### PR DESCRIPTION
Instead of using the `tsc` bin from `node_modules`, use `npx` to install and run latest.
At the moment, we don't depend on TypeScript directly and this job is purely informative, but it does generate a few more errors than expected, for example missing `Omit` which should be globally available in recent versions of `tsc`.

Also adds a `typecheck` script so you can see the results locally by running `npm run typecheck`.

#### Testing instructions

* Compare the `typecheck` job with a [recent `typecheck` job on `master`](https://circleci.com/gh/Automattic/wp-calypso/436595). There should be fewer errors (142 on `master` vs 136 here).
* Run `npm run typecheck` on this branch to see the typecheck results.