### PR TITLE
Page Templates: Allow Blank to be previewed

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -120,14 +120,7 @@ class PageTemplateModal extends Component {
 
 	handleConfirmation = () => this.setTemplate( this.state.previewedTemplate );
 
-	previewTemplate = slug => {
-		// Immediately confirm and close when 'blank' is selected.
-		if ( slug === 'blank' ) {
-			this.setTemplate( slug );
-			return;
-		}
-		this.setState( { previewedTemplate: slug } );
-	};
+	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
 
 	closeModal = event => {
 		// Check to see if the Blur event occurred on the buttons inside of the Modal.


### PR DESCRIPTION
This builds on top of the #36270.

#### Changes proposed in this Pull Request

* This unifies the behavior of all templates to be previewable and inserted only through a confirmation
* Previously clicking the Blank tile immediately closed the modal

#### Testing instructions

1. Build plugin and open the editor
1. Try clicking all template tiles - all should preview, including Blank
1. The only case when modal close is the confirm/cancel/close buttons, no longer from the Blank tile alone

#### TODO

In this PR, the preview for Blank shows "Select a page template to preview." as pictured here:

<img width="1025" alt="Screenshot 2019-09-25 at 19 41 15" src="https://user-images.githubusercontent.com/156676/65647728-8722b800-dfcd-11e9-9211-1e944e85eaf9.png">

The mockup in #35883 suggest showing just the Blank title - I suggest doing that separately from this PR, as that might be quite complicated due to way titles are resized and tied directly to the block preview scaling.

Fixes #35883