### PR TITLE
Pipe Gutenframe errors to Calypso error handler

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -690,6 +690,20 @@ function getCloseButtonUrl( calypsoPort ) {
 	};
 }
 
+/**
+ * Passes uncaught errors in window.onerror to Calypso for logging.
+ *
+ * @param {MessagePort} calypsoPort Port used for communication with parent frame.
+ */
+function handleUncaughtErrors( calypsoPort ) {
+	window.onerror = ( ...error ) => {
+		calypsoPort.postMessage( {
+			action: 'logError',
+			payload: { error },
+		} );
+	};
+}
+
 function initPort( message ) {
 	if ( 'initPort' !== message.data.action ) {
 		return;
@@ -772,6 +786,8 @@ function initPort( message ) {
 		setupEditTemplateLinks( calypsoPort );
 
 		getCloseButtonUrl( calypsoPort );
+
+		handleUncaughtErrors( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -697,6 +697,13 @@ function getCloseButtonUrl( calypsoPort ) {
  */
 function handleUncaughtErrors( calypsoPort ) {
 	window.onerror = ( ...error ) => {
+		// Since none of Error's properties are enumerable, JSON.stringify does not work on it.
+		// We therefore stringify the error with a custom replacer containing the object's properties.
+		const errorObject = error[ 4 ]; // the 5th argument is the error object
+		error[ 4 ] =
+			errorObject && JSON.stringify( errorObject, Object.getOwnPropertyNames( errorObject ) );
+
+		// The other parameters don't need encoded since they are numbers or strings.
 		calypsoPort.postMessage( {
 			action: 'logError',
 			payload: { error },

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { endsWith, get, map, partial, pickBy, startsWith } from 'lodash';
+import { endsWith, get, map, partial, pickBy, startsWith, isArray } from 'lodash';
 import url from 'url';
 
 /**
@@ -95,6 +95,7 @@ enum EditorActions {
 	OpenCustomizer = 'openCustomizer',
 	GetTemplateEditorUrl = 'getTemplateEditorUrl',
 	GetCloseButtonUrl = 'getCloseButtonUrl',
+	LogError = 'logError',
 }
 
 class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
@@ -274,6 +275,12 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		if ( EditorActions.GetCloseButtonUrl === action ) {
 			const { closeUrl } = this.props;
 			ports[ 0 ].postMessage( `${ window.location.origin }${ closeUrl }` );
+		}
+
+		// Pipes errors in the iFrame context to the Calypso error handler if it exists:
+		if ( EditorActions.LogError === action ) {
+			const { error } = payload;
+			isArray( error ) && window.onerror && window.onerror( ...error );
 		}
 	};
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -280,7 +280,11 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		// Pipes errors in the iFrame context to the Calypso error handler if it exists:
 		if ( EditorActions.LogError === action ) {
 			const { error } = payload;
-			isArray( error ) && window.onerror && window.onerror( ...error );
+			if ( isArray( error ) && error.length > 4 && window.onerror ) {
+				const errorObject = error[ 4 ];
+				error[ 4 ] = errorObject && JSON.parse( errorObject );
+				window.onerror( ...error );
+			}
 		}
 	};
 


### PR DESCRIPTION
When an error occurs in window.onerror in Gutenframe, we now send a message to Calypso containing the error. That error is then passed to the Calypso window.onerror handler. Currently, Calypso has a library which consumes and logs those errors. This PR makes sure that errors in Gutenberg or FSE in the iFrame still get reported through that handler. (See https://github.com/Automattic/wp-calypso/issues/35396#issuecomment-534851364 for info about that handler.)

#### Changes proposed in this Pull Request

* Send window.onerror events to Calypso for reporting

#### Testing instructions

 _Setup:_
1. Change this line to `if ( true )` so that the error handling code loads on your test environment: https://github.com/Automattic/wp-calypso/blob/8b37f4c4a7ca911f49a117f02cae5a17b94447dd/client/boot/common.js#L276
1. Sandbox your test site, widgets.wp.com, and public-api.wordpress.com.
2. Pull this branch and run `npm start` to fire up the changes in your local testing environment.
3. Run `npx lerna run build --scope='@automattic/wpcom-block-editor' --stream -- -- --watch` to build the iframe server files. Sync them to your sandbox.

 _Testing:_
1. Now, navigate edit a post or page in calypso.localhost in the block editor.
2. Open the JS console and select the `post.php` context:
<img width="1016" alt="Screen Shot 2019-09-25 at 5 06 49 PM" src="https://user-images.githubusercontent.com/6265975/65648410-01940d80-dfb7-11e9-865e-b38e36ccd64f.png">

3. Run `window.onerror( 'Howdy', 'Not Howdy', 1, 2, new Error( 'Howdy Or Not' ) )` in the JS console. **Note: before this PR, this function was not defined in the post.php context, so this is another way to verify that it's working** 
4. Observe a warning in the console from the TraceKit library. This is the Calypso library handling errors, which means that you fired an event in the iFrame context, which got sent to Calypso for handling and everything is working!
<img width="1908" alt="Screen Shot 2019-09-25 at 5 10 12 PM" src="https://user-images.githubusercontent.com/6265975/65648525-77987480-dfb7-11e9-9c59-dbffde558527.png">


Partial resolution of https://github.com/Automattic/wp-calypso/issues/35396.