### PR TITLE
Page Templates: Explicit selected state for thumbnails

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -27,6 +27,7 @@ export const TemplateSelectorControl = ( {
 	useDynamicPreview = false,
 	onTemplateSelect = noop,
 	siteInformation = {},
+	selectedTemplate,
 } ) => {
 	if ( isEmpty( templates ) || ! isArray( templates ) ) {
 		return null;
@@ -61,6 +62,7 @@ export const TemplateSelectorControl = ( {
 							staticPreviewImgAlt={ previewAlt }
 							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }
 							useDynamicPreview={ useDynamicPreview }
+							isSelected={ slug === selectedTemplate }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -4,6 +4,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { isNil, isEmpty } from 'lodash';
 /* eslint-enable import/no-extraneous-dependencies */
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -23,6 +24,7 @@ const TemplateSelectorItem = props => {
 		staticPreviewImg,
 		staticPreviewImgAlt = '',
 		blocks = [],
+		isSelected,
 	} = props;
 
 	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
@@ -51,7 +53,9 @@ const TemplateSelectorItem = props => {
 	return (
 		<button
 			type="button"
-			className="template-selector-item__label"
+			className={ classnames( 'template-selector-item__label', {
+				'is-selected': isSelected,
+			} ) }
 			value={ value }
 			onClick={ () => onSelect( value ) }
 			aria-labelledby={ `${ id } ${ labelId }` }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/template-selector-control-test.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/template-selector-control-test.js
@@ -57,7 +57,23 @@ describe( 'TemplateSelectorControl', () => {
 			expect( document.querySelectorAll( 'button.template-selector-item__label' ) ).toHaveLength(
 				4
 			);
+			expect( document.querySelectorAll( 'button.is-selected' ) ).toHaveLength( 0 );
 			expect( container ).toMatchSnapshot();
+		} );
+
+		it( 'highlights the selected template', () => {
+			render(
+				<TemplateSelectorControl
+					label="Select a Template..."
+					instanceId={ testUniqueId }
+					templates={ templatesFixture }
+					blocksByTemplates={ blocksByTemplatesFixture }
+					siteInformation={ siteInformation }
+					selectedTemplate={ templatesFixture[ 0 ].slug }
+				/>
+			);
+
+			expect( document.querySelectorAll( 'button.is-selected' ) ).toHaveLength( 1 );
 		} );
 
 		it( 'does not render when missing templates prop', () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -172,6 +172,7 @@ class PageTemplateModal extends Component {
 										onTemplateSelect={ this.previewTemplate }
 										useDynamicPreview={ false }
 										siteInformation={ siteInformation }
+										selectedTemplate={ previewedTemplate }
 									/>
 								</fieldset>
 							</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -126,7 +126,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		overflow: hidden;
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&.is-selected {
 			border-color: #2562b7;
 			box-shadow: 0 0 0 1px #2562b7;
 			outline: 1px solid transparent;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -132,6 +132,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			box-shadow: 0 0 0 1px #2562b7;
 			outline: 1px solid transparent;
 			outline-offset: -1px;
+			color: inherit;
 		}
 	}
 


### PR DESCRIPTION
This builds on top of #36270 

#### Changes proposed in this Pull Request

We were using only `:active` pseudo class to highlight a selected item in the selector.

* This PR adds a new class `is-selected` that is added on currently selected tile. (using the same pattern for classname modifiers as core G: https://github.com/WordPress/gutenberg/search?q=is-selected&unscoped_q=is-selected)

##### A note about naming.

This involves some cascading prop passing. As a general pattern, deeper components should be less aware of their surroundings and that's what I did here.

`PageTemplateModal` is the most clever one and knows that the selected template is meant for controlling the preview - thus it has the state key named `previewedTemplate` with the template slug as the value.

`TemplateSelectorControl` is one level deeper and is just that - a selector. It knows what are the options available and which one is selected but doesn't care about the selection purpose (preview). That's why it's using a simpler prop name `selectedTemplate`, again with slug as a value.

`TemplateSelectorItem` is the most simple one. It only knows about itself and thus it has a bool prop `isSelected`.

#### Testing instructions

* Select a template and then click some whitespace inside the modal
* Blue border should stay visible on currently selected template
* Test with Safari and make sure #35885 (invisible text) is no longer reproducible there

Fixes #35884
Fixes #35885