### PR TITLE
[SIGNUP]: Reverting #35273 escape hatch A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -125,15 +125,6 @@ export default {
 		defaultVariation: 'hide',
 		assignmentMethod: 'userId',
 	},
-	signupEscapeHatch: {
-		datestamp: '20190826',
-		variations: {
-			variant: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	placesApiInCheckout: {
 		datestamp: '20190923',
 		variations: {

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -9,10 +9,6 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 
-// Default value for `siteTypeIds` argument in `getAllSiteTypes()`.
-// Allows for overriding to ensure we don't return site type definitions for segments we don't wish to render in the UI, e.g., when rendering the list on the site type step.
-const allowedSiteTypeIds = [ 1, 2, 3, 4, 6 ];
-
 const getSiteTypePropertyDefaults = propertyKey =>
 	get(
 		{
@@ -76,10 +72,9 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  *
  * Please don't modify the IDs for now until we can integrate the /segments API into Calypso.
  *
- * @param  {Array} siteTypeIds Optional array of segment ids so that we can return all, some or no site type definitions.
- * @return {Array}             current list of site types
+ * @return {Array} current list of site types
  */
-export function getAllSiteTypes( siteTypeIds = allowedSiteTypeIds ) {
+export function getAllSiteTypes() {
 	return [
 		{
 			id: 2, // This value must correspond with its sibling in the /segments API results
@@ -158,12 +153,5 @@ export function getAllSiteTypes( siteTypeIds = allowedSiteTypeIds ) {
 			purchaseRequired: true,
 			forcePublicSite: true,
 		},
-		{
-			id: 6, // This value must correspond with its sibling in the /segments API results
-			slug: 'blank-canvas',
-			label: i18n.translate( 'Start from scratch' ),
-			description: i18n.translate( 'Skip setup and start with a blank website.' ),
-			theme: 'pub/refresh-2019',
-		},
-	].filter( siteType => siteTypeIds.indexOf( siteType.id ) >= 0 );
+	];
 }

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -120,13 +120,6 @@ export function generateFlows( {
 			lastModified: '2019-06-20',
 		},
 
-		'blank-canvas': {
-			steps: [ 'user', 'site-type', 'domains', 'plans' ],
-			destination: getSignupDestination,
-			description: 'A blank slate flow used with the `signupEscapeHatch` AB test',
-			lastModified: '2019-08-09',
-		},
-
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -44,12 +44,11 @@ class SiteTypeForm extends Component {
 
 	render() {
 		const { showDescriptions, showPurchaseRequired, translate } = this.props;
-		// Specify which site types we'd like to render in the UI
-		const siteTypeDefinitions = getAllSiteTypes( [ 1, 2, 3, 4 ] );
+
 		return (
 			<>
 				<Card className="site-type__wrapper">
-					{ siteTypeDefinitions.map( siteTypeProperties => (
+					{ getAllSiteTypes().map( siteTypeProperties => (
 						<Card
 							className="site-type__option"
 							key={ siteTypeProperties.id }

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -21,7 +21,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
-	'blank-canvas': 'blank-canvas',
 	'online-store': 'ecommerce-onboarding',
 };
 
@@ -37,8 +36,6 @@ class SiteType extends Component {
 		} );
 		this.submitStep( 'import' );
 	};
-
-	handleBlankCanvasButtonClick = () => this.submitStep( 'blank-canvas' );
 
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
@@ -68,20 +65,6 @@ class SiteType extends Component {
 		);
 	}
 
-	renderStartWithBlankCanvasButton() {
-		if ( 'variant' !== abtest( 'signupEscapeHatch' ) ) {
-			return null;
-		}
-
-		return (
-			<div className="site-type__blank-canvas">
-				<Button borderless onClick={ this.handleBlankCanvasButtonClick }>
-					{ this.props.translate( 'Skip setup and start with a blank website.' ) }
-				</Button>
-			</div>
-		);
-	}
-
 	renderStepContent() {
 		const { siteType } = this.props;
 
@@ -92,7 +75,6 @@ class SiteType extends Component {
 					submitForm={ this.submitStep }
 					siteType={ siteType }
 				/>
-				{ this.renderStartWithBlankCanvasButton() }
 				{ this.renderImportButton() }
 			</Fragment>
 		);

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import Button from 'components/button';

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -85,7 +85,6 @@
 	}
 }
 
-.site-type__blank-canvas,
 .site-type__import-button {
 	text-align: center;
 	margin-top: 20px;
@@ -98,4 +97,3 @@
 		text-decoration: underline;
 	}
 }
-


### PR DESCRIPTION
## Changes proposed in this Pull Request

The escape hatch A/B we added in https://github.com/Automattic/wp-calypso/pull/35273 is finished up.

Let's revert the code so that it no longer runs, and in preparation for the [next test](https://github.com/Automattic/wp-calypso/pull/36221)

## Testing instructions

The `signupEscapeHatch` A/B should be terminated 🤖 

Create a site via the onboarding flow to make sure I didn't break anything. 

Thank you.
