### PR TITLE
Calypso build: Transpile to commonjs modules in Jest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,13 @@ references:
   restore-jest-cache: &restore-jest-cache
     name: Restore Jest cache
     keys:
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
   save-jest-cache: &save-jest-cache
     name: Save Jest cache
-    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/jest-cache
 

--- a/packages/calypso-build/jest/transform/babel.js
+++ b/packages/calypso-build/jest/transform/babel.js
@@ -5,7 +5,9 @@ const babelJest = require( 'babel-jest' );
 const path = require( 'path' );
 
 module.exports = babelJest.createTransformer( {
-	presets: [ path.join( __dirname, '..', '..', 'babel', 'default.js' ) ],
+	presets: [
+		[ path.join( __dirname, '..', '..', 'babel', 'default.js' ), { modules: 'commonjs' } ],
+	],
 	babelrc: false,
 	configFile: false,
 } );


### PR DESCRIPTION
Update the Calypso Build Jest preset to transpile to commonjs modules.
Bump the related caches in CircleCI.

https://github.com/Automattic/wp-calypso/pull/36230 updated defaults to target ECMAScript modules. That changed the behavior of the Jest preset which was overlooked.

Reported by @ljharb: https://github.com/Automattic/wp-calypso/pull/36230#issuecomment-535130604, https://github.com/Automattic/wp-calypso/pull/36256#issuecomment-535130392

#### Testing instructions

* Locally: `npm run test-packages -- --clearCache && npm run test-packages`
* `test-packages` job on CI should pass.