### PR TITLE
Login: Make social TOS style consistent

### DIFF
--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -12,6 +12,7 @@
 }
 
 .login__social-tos {
+	font-size: 11px;
 	margin: 1.5em 0 0;
 	text-align: center;
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -179,6 +179,7 @@ $image-height: 47px;
 	}
 
 	.login__form-terms a,
+	.login__social-tos a,
 	.form-input-validation a {
 		color: var( --color-accent-dark );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the social login TOS font size consistent with the other TOS on the same screen.
* Make the social login TOS link color consistent with the link color on the other TOS on the same screen.

#### Preview

General login - before
![](https://cldup.com/U6vw2QoOLl.png)

General login - after
![](https://cldup.com/gIqch6A2HH.png)

Jetpack login - before:
![](https://cldup.com/mETHRdd0pP.png)

Jetpack login - after:
![](https://cldup.com/wbGYj69rYf.png)

#### Testing instructions

* Checkout this branch or get it running on calypso.live.
* Go to http://calypso.localhost:3000/log-in/jetpack
* Verify the social TOS looks good and consistent with the other TOS above.
* Go to http://calypso.localhost:3000/log-in
* Verify the social TOS looks good and consistent with the other TOS above.