### PR TITLE
Login: Adapt username change link color to Jetpack color scheme

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -180,7 +180,8 @@ $image-height: 47px;
 
 	.login__form-terms a,
 	.login__social-tos a,
-	.form-input-validation a {
+	.form-input-validation a,
+	.login__form-change-username {
 		color: var( --color-accent-dark );
 
 		&:hover,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Login: Adapt username change link color to Jetpack color scheme

#### Preview

Before:
![](https://cldup.com/wyWS0N6_vi.png)

After:
![](https://cldup.com/rdWnwy434X.png)

#### Testing instructions

* Checkout this branch.
* Log out of WP.com.
* Go to http://calypso.localhost:3000/log-in/jetpack
* Input your valid WP.com email address.
* Verify the "change username" button color is the proper green one.
