### PR TITLE
Login: Fix button color on 2FA auth screen for Jetpack

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -190,6 +190,7 @@ $image-height: 47px;
 	}
 
 	.wp-login__links a,
+	.wp-login__links button,
 	.logged-out-form__links a,
 	.logged-out-form__link-item,
 	.translator-invite__content a {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Login: Fix button color on 2FA auth screen for Jetpack

#### Preview

Before:
![](https://cldup.com/bSQjDH6i0Z.png)

After:
![](https://cldup.com/mnozZqmnqz.png)

#### Testing instructions

* Checkout this branch.
* Log out of WP.com.
* Go to http://calypso.localhost:3000/log-in/jetpack
* Input the username/email of a user that has 2FA enabled.
* Input the password.
* On the 2FA pages, verify bottom links look good now, as shown on the screenshots.
