### PR TITLE
Login: Open social signup TOS link in new window

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -26,6 +26,7 @@ import {
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { InfoNotice } from 'blocks/global-notice';
+import { localizeUrl } from 'lib/i18n-utils';
 import { login } from 'lib/paths';
 
 /**
@@ -196,7 +197,13 @@ class SocialLoginForm extends Component {
 								' {{a}}Terms of Service{{/a}}.',
 							{
 								components: {
-									a: <a href="https://wordpress.com/tos" />,
+									a: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
 								},
 							}
 						) }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -15,6 +15,7 @@ import AppleLoginButton from 'components/social-buttons/apple';
 import config from 'config';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import GoogleLoginButton from 'components/social-buttons/google';
+import { localizeUrl } from 'lib/i18n-utils';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -109,7 +110,13 @@ class SocialSignupForm extends Component {
 								' {{a}}Terms of Service{{/a}}.',
 							{
 								components: {
-									a: <a href="https://wordpress.com/tos" />,
+									a: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
 								},
 							}
 						) }


### PR DESCRIPTION
In some locations, our TOS links open in new window. The social login/signup one doesn't, though. This might cause the user to break out of the current flow, without a good way to go back. This is also valid for the new Jetpack connect-in-place flow. So this PR updates those TOS links to open consistently in a new window.

An extra benefit is that the URL will now be localized, just like we do for other TOS links. This will ensure that the TOS page will be displayed in the proper language, when available.

#### Changes proposed in this Pull Request

* Login: Open social signup TOS link in new window

#### Testing instructions

* Checkout this branch.
* Log out of WP.com.
* Go to  http://calypso.localhost:3000/log-in/jetpack
* Click the "Terms of Service" link.
* Verify it opens in a new window.
* Bonus (non-required): test it with the Jetpack connect-in-place flow (if you know what that is).
