### PR TITLE
SPT: Implement design by removing modal appearance and overlaying Block Editor toolbar

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -61,7 +61,9 @@ const TemplateSelectorItem = props => {
 			aria-labelledby={ `${ id } ${ labelId }` }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
-			<span id={ labelId }>{ label }</span>
+			<span className="template-selector-item__template-title" id={ labelId }>
+				{ label }
+			</span>
 		</button>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -168,7 +168,9 @@ class PageTemplateModal extends Component {
 						<>
 							<form className="page-template-modal__form">
 								<fieldset className="page-template-modal__list">
-									<legend className="page-template-modal__form-title">Choose a template...</legend>
+									<legend className="page-template-modal__form-title">
+										{ __( 'Choose a template…', 'full-site-editing' ) }
+									</legend>
 									<TemplateSelectorControl
 										label={ __( 'Template', 'full-site-editing' ) }
 										templates={ templates }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -168,6 +168,7 @@ class PageTemplateModal extends Component {
 						<>
 							<form className="page-template-modal__form">
 								<fieldset className="page-template-modal__list">
+									<legend className="page-template-modal__form-title">Choose a template...</legend>
 									<TemplateSelectorControl
 										label={ __( 'Template', 'full-site-editing' ) }
 										templates={ templates }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,15 +1,17 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
 import { isEmpty, reduce, get, keyBy, mapValues } from 'lodash';
+import classnames from 'classnames';
+import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
-import ensureAssets from './utils/ensure-assets';
-import '@wordpress/nux';
+import { parse as parseBlocks } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -18,8 +20,9 @@ import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
 import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
-import { parse as parseBlocks } from '@wordpress/blocks';
 import replacePlaceholders from './utils/replace-placeholders';
+import ensureAssets from './utils/ensure-assets';
+/* eslint-enable import/no-extraneous-dependencies */
 
 // Load config passed from backend.
 const {
@@ -184,10 +187,11 @@ class PageTemplateModal extends Component {
 						</>
 					) }
 				</div>
-				<div className="page-template-modal__buttons">
-					<Button isDefault isLarge onClick={ this.closeModal }>
-						{ __( 'Cancel', 'full-site-editing' ) }
-					</Button>
+				<div
+					className={ classnames( 'page-template-modal__buttons', {
+						'is-visually-hidden': isEmpty( previewedTemplate ) || isLoading,
+					} ) }
+				>
 					<Button
 						isPrimary
 						isLarge

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -15,6 +15,10 @@ $template-selector-border-color: #a1aab2;
 $template-selector-empty-background: #f6f6f6;
 $template-selector-modal-offset-right: 32px;
 $template-selector-modal-offset-bottom: 25px;
+$template-large-preview-title-height: 117px;
+
+$wp-org-sidebar-reduced: 36px;
+$wp-org-sidebar-full: 160px;
 
 // Modal Overlay
 .page-template-modal-screen-overlay {
@@ -25,11 +29,11 @@ $template-selector-modal-offset-bottom: 25px;
 // When not in fullscreen mode allow space for WP.org sidebar
 body:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	@media screen and ( min-width: 783px ) {
-		left: 36px;
+		left: $wp-org-sidebar-reduced;
 	}
 
 	@media screen and ( min-width: 961px ) {
-		left: 160px;
+		left: $wp-org-sidebar-full;
 	}
 }
 
@@ -239,23 +243,22 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		display: none;
 	}
 
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	right: 0;
-	width: calc( 50% - 24px );
+	position: fixed;
+	top: 111px;
+	bottom: 24px;
+	right: 24px;
+	width: calc( 50% - 50px );
 	background: $template-selector-empty-background;
 	border-radius: 2px;
 	overflow-x: hidden;
 	overflow-y: auto;
-	max-height: 80vh; // avoid overflow off bottom of screen if no of thumbs is large
 	box-shadow: 0 0 13px rgba( 0, 0, 0, 0.2 );
 
 	.edit-post-visual-editor {
 		margin-top: 20px;
 	}
 
-	$template-large-preview-title-height: 117px;
+
 	.editor-styles-wrapper {
 		.editor-post-title {
 			transform-origin: top left;
@@ -277,6 +280,16 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		body.show-post-title-before-content & .block-editor-block-preview__content > .block-editor-block-list__layout {
 			margin-top: $template-large-preview-title-height;
 		}
+	}
+}
+
+body:not( .is-fullscreen-mode ) .template-selector-preview {
+	@media screen and ( min-width: 783px ) {
+		width: calc( 50% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
+	}
+
+	@media screen and ( min-width: 961px ) {
+		width: calc( 50% - #{$wp-org-sidebar-full } );
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -12,7 +12,7 @@
 }
 
 $template-selector-border-color: #a1aab2;
-$template-selector-empty-background: #f6f6f6;
+$template-selector-empty-background: #fff;
 $template-selector-modal-offset-right: 32px;
 $template-selector-modal-offset-bottom: 25px;
 $template-large-preview-title-height: 117px;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -19,6 +19,7 @@ $template-selector-modal-offset-bottom: 25px;
 // Modal Overlay
 .page-template-modal-screen-overlay {
 	animation: none;
+	background-color: transparent; // hide the overlay visually
 }
 
 // When not in fullscreen mode allow space for WP.org sidebar
@@ -45,17 +46,21 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .page-template-modal {
 	width: 100%;
 	height: 100vh;
-	max-width: 800px;
 	animation: none;
-
-	@media screen and ( min-width: 1200px ) {
-		width: 80%;
-		max-width: 1200px;
-	}
+	box-shadow: none; // cancel "modal" appearance
+	border: none; // cancel "modal" appearance
+	top: 0; // overlay the Block Editor toolbar
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transform: none;
+    max-width: none;
+    max-height: none;
+    background-color: #eeeeee;
 }
 
 .page-template-modal .components-modal__header-heading-container {
-	justify-content: center;
+	justify-content: flex-start;
 }
 
 .page-template-modal .components-modal__content {
@@ -124,6 +129,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		appearance: none;
 		padding: 0 0 14px;
 		overflow: hidden;
+		background-color: #fff;
 
 		&:hover,
 		&:focus,
@@ -225,7 +231,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		display: none;
 	}
 
-	position: fixed;
+	position: absolute;
 	top: 80px;
 	bottom: $template-selector-modal-offset-bottom + 50px;
 	right: $template-selector-modal-offset-right;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -134,11 +134,21 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		border: 1px solid $template-selector-border-color;
 		border-radius: 6px;
 		cursor: pointer;
-		background: none;
 		appearance: none;
-		padding: 0 0 14px;
+		padding: 0;
 		overflow: hidden;
 		background-color: #fff;
+		position: relative;
+
+		span {
+			width: 100%;
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			height: 40px;
+			line-height: 40px;
+			background-color: #fff;
+		}
 
 		&:hover,
 		&:focus,
@@ -154,11 +164,12 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	.template-selector-item__preview-wrap {
 		width: 100%;
 		display: block;
-		margin: 0 auto 14px;
+		margin: 0 auto;
 		background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
-		height: 170px;
+		height: 0;
+		padding-top: 100%; // Aspect radio boxes. It will take the 100% of width.
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;
@@ -230,7 +241,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     &.is-visually-hidden {
     	@include screen-reader-text();
     }
-	
+
 	.components-button {
 		height: 33px; // match to Gutenberg toolbar styles
 	    line-height: 32px; // match to Gutenberg toolbar styles

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -140,7 +140,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		background-color: #fff;
 		position: relative;
 
-		span {
+		.template-selector-item__template-title {
 			width: 100%;
 			position: absolute;
 			bottom: 0;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -60,7 +60,12 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 .page-template-modal .components-modal__header-heading-container {
-	justify-content: flex-start;
+	@include screen-reader-text();
+}
+
+// Close button
+.page-template-modal .components-modal__header .components-button {
+	left: 0;
 }
 
 .page-template-modal .components-modal__content {
@@ -69,6 +74,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 .page-template-modal__inner {
+	position: relative;
 	max-width: 720px;
 	margin: 0 auto;
 	padding: 0;
@@ -205,23 +211,22 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 .page-template-modal__buttons {
-	position: fixed;
-	right: $template-selector-modal-offset-right;
-	bottom: $template-selector-modal-offset-bottom;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 10;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    padding-right: 24px;
 
-	@media screen and ( max-width: 659px ) {
-		display: flex;
-		justify-content: flex-end;
-		right: 0;
-		left: 0;
-		bottom: 0;
-		padding: 15px;
-		background: white;
-		border-top: 1px solid $template-selector-border-color;
-	}
-
+    &.is-visually-hidden {
+    	@include screen-reader-text();
+    }
+	
 	.components-button {
-		margin-left: 10px;
+		height: 33px; // match to Gutenberg toolbar styles
+	    line-height: 32px; // match to Gutenberg toolbar styles
 	}
 }
 
@@ -232,10 +237,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	position: absolute;
-	top: 80px;
-	bottom: $template-selector-modal-offset-bottom + 50px;
-	right: $template-selector-modal-offset-right;
-	width: calc( 50% - 50px );
+	top: 0;
+	bottom: 0;
+	right: 0;
+	width: calc( 50% - 24px );
 	background: $template-selector-empty-background;
 	border: 1px solid $template-selector-border-color;
 	border-radius: 6px;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -263,7 +263,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	border-radius: 2px;
 	overflow-x: hidden;
 	overflow-y: auto;
-	box-shadow: 0 0 13px rgba( 0, 0, 0, 0.2 );
+	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 
 	.edit-post-visual-editor {
 		margin-top: 20px;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -151,7 +151,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		width: 100%;
 		display: block;
 		margin: 0 auto 14px;
-		border-bottom: 1px solid #a1aab2;
 		background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
@@ -209,6 +208,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 }
 
+.page-template-modal__form-title {
+	font-weight: bold;
+	margin-bottom: 1em;
+}
+
 .page-template-modal__buttons {
     position: absolute;
     right: 0;
@@ -241,11 +245,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	right: 0;
 	width: calc( 50% - 24px );
 	background: $template-selector-empty-background;
-	border: 1px solid $template-selector-border-color;
-	border-radius: 6px;
+	border-radius: 2px;
 	overflow-x: hidden;
 	overflow-y: auto;
 	max-height: 80vh; // avoid overflow off bottom of screen if no of thumbs is large
+	box-shadow: 0 0 13px rgba( 0, 0, 0, 0.2 );
 
 	.edit-post-visual-editor {
 		margin-top: 20px;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -75,7 +75,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 .page-template-modal__inner {
 	position: relative;
-	max-width: 720px;
 	margin: 0 auto;
 	padding: 0;
 
@@ -246,6 +245,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	border-radius: 6px;
 	overflow-x: hidden;
 	overflow-y: auto;
+	max-height: 80vh; // avoid overflow off bottom of screen if no of thumbs is large
 
 	.edit-post-visual-editor {
 		margin-top: 20px;


### PR DESCRIPTION
As per @obenland's request, aims to implement the design proposed in https://github.com/Automattic/wp-calypso/issues/36323 by altering the display of the modal to conform to the visuals.

This is definitely a non-optimal approach, but may allow us to ship this iteration. We can then circle back to the more complex custom editor approach once the team have had time to explore and understand the approach.

## Important Notes

~* This does not implement the "auto select Blank template" feature.~

## Screenshots

![image](https://user-images.githubusercontent.com/77539/65722033-c1e62800-e081-11e9-93d0-86d876ab76ef.png)


## Testing

Simply apply the changes purposed by the branch and confirm that it looks and behaves as expects.

