### PR TITLE
Change the publicPath to /calypso and add target prefixes to JS and CSS asset names

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -199,7 +199,7 @@ class Document extends React.Component {
 					 * this lets us have the performance benefit in prod, without breaking HMR in dev
 					 * since the manifest needs to be updated on each save
 					 */ }
-					{ env === 'development' && <script src="/calypso/evergreen/manifest.js" /> }
+					{ env === 'development' && <script src="/calypso/manifest.js" /> }
 					{ env !== 'development' && (
 						<script
 							nonce={ inlineScriptNonce }

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -100,8 +100,7 @@ function middleware( app ) {
 	app.use(
 		webpackMiddleware( compiler, {
 			mode: 'development',
-			// Development is always evergreen.
-			publicPath: '/calypso/evergreen/',
+			publicPath: '/calypso/',
 			stats: {
 				colors: true,
 				hash: true,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -168,7 +168,7 @@ const getFilesForChunk = ( chunkName, request ) => {
 
 const getFilesForEntrypoint = ( target, name ) => {
 	const entrypointAssets = getAssets( target ).entrypoints[ name ].assets.filter(
-		asset => ! asset.startsWith( 'manifest' )
+		asset => ! /(\/|^)manifest\.js$/.test( asset )
 	);
 	return groupAssetsByType( entrypointAssets );
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,25 +151,18 @@ if ( isDevelopment || isDesktop ) {
 	outputChunkFilename = '[name].js';
 }
 
+// Prefix the JS and CSS paths with the target (evergreen/fallback) in production mode
+if ( ! isDevelopment ) {
+	outputFilename = `${ extraPath }/${ outputFilename }`;
+	outputChunkFilename = `${ extraPath }/${ outputChunkFilename }`;
+}
+
 const cssFilename = cssNameFromFilename( outputFilename );
 const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
-const fileLoader = FileConfig.loader(
-	// The server bundler express middleware server assets from the hard-coded publicPath `/calypso/evergreen/`.
-	// This is required so that running calypso via `npm start` doesn't break.
-	isDevelopment
-		? {
-				outputPath: 'images',
-				publicPath: '/calypso/evergreen/images/',
-		  }
-		: {
-				// File-loader does not understand absolute paths so __dirname won't work.
-				// Build off `output.path` for a result like `/…/public/evergreen/../images/`.
-				outputPath: path.join( '..', 'images' ),
-				publicPath: '/calypso/images/',
-				emitFile: browserslistEnv === defaultBrowserslistEnv, // Only output files once.
-		  }
-);
+const fileLoader = FileConfig.loader( {
+	emitFile: browserslistEnv === defaultBrowserslistEnv, // Only output files once.
+} );
 
 const webpackConfig = {
 	bail: ! isDevelopment,
@@ -183,7 +176,7 @@ const webpackConfig = {
 	output: {
 		path: path.join( __dirname, 'public', extraPath ),
 		pathinfo: false,
-		publicPath: `/calypso/${ extraPath }/`,
+		publicPath: `/calypso/`,
 		filename: outputFilename,
 		chunkFilename: outputChunkFilename,
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -29,7 +29,7 @@ const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
 const isDevelopment = bundleEnv === 'development';
 
 const fileLoader = FileConfig.loader( {
-	publicPath: isDevelopment ? '/calypso/evergreen/images/' : '/calypso/images/',
+	publicPath: '/calypso/images/',
 	emitFile: false, // On the server side, don't actually copy files
 } );
 


### PR DESCRIPTION
Testing an alternative approach to structuring webpack `publicPath` and directories for `evergreen` and `fallback` JS and CSS and a separate `images` directory.
