### PR TITLE
Activity Log: Allow threat alerts in all environments

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -5,7 +5,6 @@
  */
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import config from 'config';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, get, includes, isEmpty, isEqual } from 'lodash';
@@ -410,9 +409,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 
-				{ config.isEnabled( 'rewind-alerts' ) && siteId && isJetpack && ! isAtomic && (
-					<RewindAlerts siteId={ siteId } />
-				) }
+				{ siteId && isJetpack && ! isAtomic && <RewindAlerts siteId={ siteId } /> }
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }

--- a/config/development.json
+++ b/config/development.json
@@ -134,7 +134,6 @@
 		"recommend-plugins": true,
 		"resume-editing": true,
 		"republicize": true,
-		"rewind-alerts": true,
 		"rewind/clone-site": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,6 @@
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,
-		"rewind-alerts": true,
 		"rewind/clone-site": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the feature flag restriction for threat alerts in all environments, thus allowing them to display for customers.

#### Testing instructions

Boot up Calypso and ensure there are no errors of any sort. Also for completeness, ensure that the Threat Alerts appear at the top of the activity log for a site with active threats.