### PR TITLE
Update/spt square up preview thumbs

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -59,7 +59,9 @@ const TemplateSelectorItem = props => {
 			aria-labelledby={ `${ id } ${ labelId }` }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
-			<span id={ labelId }>{ label }</span>
+			<span className="template-selector-item__template-title" id={ labelId }>
+				{ label }
+			</span>
 		</button>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -134,11 +134,21 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		border: 1px solid $template-selector-border-color;
 		border-radius: 6px;
 		cursor: pointer;
-		background: none;
 		appearance: none;
-		padding: 0 0 14px;
+		padding: 0;
 		overflow: hidden;
 		background-color: #fff;
+		position: relative;
+
+		span {
+			width: 100%;
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			height: 40px;
+			line-height: 40px;
+			background-color: #fff;
+		}
 
 		&:hover,
 		&:focus {
@@ -152,11 +162,12 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	.template-selector-item__preview-wrap {
 		width: 100%;
 		display: block;
-		margin: 0 auto 14px;
+		margin: 0 auto;
 		background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
-		height: 170px;
+		height: 0;
+		padding-top: 100%; // Aspect radio boxes. It will take the 100% of width.
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;
@@ -228,7 +239,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     &.is-visually-hidden {
     	@include screen-reader-text();
     }
-	
+
 	.components-button {
 		height: 33px; // match to Gutenberg toolbar styles
 	    line-height: 32px; // match to Gutenberg toolbar styles

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -140,7 +140,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		background-color: #fff;
 		position: relative;
 
-		span {
+		.template-selector-item__template-title {
 			width: 100%;
 			position: absolute;
 			bottom: 0;


### PR DESCRIPTION
### Depends (and cloned from) on #36355

#### Changes proposed in this Pull Request

Set square shape to the template thumbnails.
Just a note about the approach: It sets the height through of an aspect-radio-box technique, which means that the height will follow the width of the button, trying to guarantee the square shape.

#### Testing instructions

* Take a look at the current shape of thumbnails.

<img width="1139" alt="Screen Shot 2019-09-26 at 11 14 39 AM" src="https://user-images.githubusercontent.com/77539/65696009-e5dc4600-e04e-11e9-9041-f176ddec7369.png">


* Apply these changes. Confirm they are squares.
<img width="1051" alt="Screen Shot 2019-09-26 at 11 10 44 AM" src="https://user-images.githubusercontent.com/77539/65695679-5df63c00-e04e-11e9-8a59-0ba29d0a0060.png">



Fixes #36233

