### PR TITLE
Hosting Panel: Add routing

### DIFF
--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import config from 'config';
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import Hosting from './main';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export function redirectIfNotAtomic( context, next ) {
+	const { store } = context;
+	const state = store.getState();
+	const isAtomic = isSiteAutomatedTransfer( state, getSelectedSiteId( state ) );
+
+	if ( ! config.isEnabled( 'hosting' ) || ! isAtomic ) {
+		page.redirect( '/' );
+	}
+
+	next();
+}
+
+export function layout( context, next ) {
+	context.primary = React.createElement( Hosting );
+
+	next();
+}

--- a/client/my-sites/hosting/index.js
+++ b/client/my-sites/hosting/index.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { siteSelection, sites } from 'my-sites/controller';
+import { redirectIfNotAtomic, layout } from './controller';
+import { makeLayout, render as clientRender } from 'controller';
+
+export default function() {
+	page( '/hosting', siteSelection, sites, makeLayout, clientRender );
+	page( '/hosting/:site_id', siteSelection, redirectIfNotAtomic, layout, makeLayout, clientRender );
+}

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,0 +1,11 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+const Hosting = () => <p>Placeholder</p>;
+
+export default Hosting;

--- a/client/sections.js
+++ b/client/sections.js
@@ -463,6 +463,13 @@ const sections = [
 		secondary: true,
 		group: 'sites',
 	},
+	{
+		name: 'hosting',
+		paths: [ '/hosting' ],
+		module: 'my-sites/hosting',
+		secondary: true,
+		group: 'sites',
+	},
 ];
 
 for ( const extension of require( './extensions' ) ) {


### PR DESCRIPTION
### Summary

This PR adds routing for the hosting panel in Calypso.

### Testing

* Spin up a local Calypso dev environment.
* Go to `/hosting`.
     * Select a non-Atomic site. Make sure that you are re-directed to the root route.
     * Select an Atomic site. Make sure that you see the text "Placeholder".

Fixes #36278
