### PR TITLE
Signup: Override Gutenberg cover block height styles.

### DIFF
--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -109,7 +109,7 @@ export function getIframeSource(
 					*/
 					.entry .entry-content .wp-block-cover-image,
 					.entry .entry-content .wp-block-cover {
-						min-height: 500px !important;
+						height: 480px !important;
 					}
 				}
 


### PR DESCRIPTION
Gutenberg 6.5 added a `height: 100%` rule to the cover image, which breaks in our Signup iframe. This updates the styles to set a static height.

**Before:**
![Screenshot 2019-09-26 10 45 17](https://user-images.githubusercontent.com/942359/65717952-7f681f80-e070-11e9-8ad5-105dae405b54.png)

**After:**
<img width="1284" alt="Screen Shot 2019-09-26 at 3 14 41 PM" src="https://user-images.githubusercontent.com/942359/65717969-8727c400-e070-11e9-8e88-dbae6c1cb0a9.png">


**To Test:**
- head to /start/
- select the "business" segment
- select a vertical
- make sure that the cover image in the desktop preview is the correct height (not blurry, full-height)