### PR TITLE
Checkout: Give Ebanx its own _paymentHandler callback

### DIFF
--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -220,11 +220,7 @@ export const CART = deepFreeze( {
 	total_cost_display: '€0',
 	temporary: false,
 	credits: 0,
-	allowed_payment_methods: [
-		'WPCOM_Billing_PayPal_Express',
-		'WPCOM_Billing_MoneyPress_Paygate',
-		'WPCOM_Billing_Stripe_Source_Ideal',
-	],
+	allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express', 'WPCOM_Billing_Stripe_Source_Ideal' ],
 	create_new_blog: false,
 	messages: { errors: [], success: [] },
 	client_metadata: { last_server_response_date: '2017-10-19T11:45:21.862Z' },

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -201,16 +201,11 @@ CartStore.dispatchToken = Dispatcher.register( payload => {
 						postalCode = extractStoredCardMetaValue( action, 'card_zip' );
 						countryCode = extractStoredCardMetaValue( action, 'country_code' );
 						break;
-					case 'WPCOM_Billing_MoneyPress_Paygate': {
-						const paymentDetails = get( action, 'payment.newCardDetails', {} );
-						postalCode = paymentDetails[ 'postal-code' ];
-						countryCode = paymentDetails.country;
-						break;
-					}
 					case 'WPCOM_Billing_WPCOM':
 						postalCode = null;
 						countryCode = null;
 						break;
+					case 'WPCOM_Billing_Ebanx':
 					case 'WPCOM_Billing_Web_Payment':
 					case 'WPCOM_Billing_Stripe_Payment_Method': {
 						const paymentDetails = get( action, 'payment.newCardDetails', {} );

--- a/client/lib/cart/store/test/fixtures/actions.js
+++ b/client/lib/cart/store/test/fixtures/actions.js
@@ -64,7 +64,7 @@ export const payments = {
 		},
 	},
 	creditCard: {
-		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
+		paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
 		newCardDetails: {
 			country: 'US1',
 			name: 'Albert A. User',
@@ -91,7 +91,7 @@ export const payments = {
 		},
 	},
 	newCardNoPostalCode: {
-		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
+		paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
 		newCardDetails: {
 			country: 'AI',
 			name: 'Albert A. User',
@@ -102,7 +102,7 @@ export const payments = {
 		},
 	},
 	newCardNoCountryCode: {
-		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
+		paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
 		newCardDetails: {
 			name: 'Albert A. User',
 			'postal-code': '90314',

--- a/client/lib/purchases/test/assembler.js
+++ b/client/lib/purchases/test/assembler.js
@@ -35,7 +35,7 @@ describe( 'assembler', () => {
 				payment_details: 7890,
 				payment_expiry: '11/16',
 				payment_type: 'credit_card',
-				payment_card_processor: 'WPCOM_Billing_MoneyPress_Paygate',
+				payment_card_processor: 'WPCOM_Billing_Stripe_Payment_Method',
 				payment_name: 'My VISA',
 				payment_country_code: 'US',
 				payment_country_name: 'United States',
@@ -48,7 +48,7 @@ describe( 'assembler', () => {
 		expect( creditCard.id ).to.equal( 1234 );
 		expect( creditCard.number ).to.equal( 7890 );
 		expect( creditCard.type ).to.equal( 'visa' );
-		expect( creditCard.processor ).to.equal( 'WPCOM_Billing_MoneyPress_Paygate' );
+		expect( creditCard.processor ).to.equal( 'WPCOM_Billing_Stripe_Payment_Method' );
 		expect( payment.type ).to.equal( 'credit_card' );
 		expect( payment.countryCode ).to.equal( 'US' );
 		expect( payment.countryName ).to.equal( 'United States' );

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -167,6 +167,52 @@ TransactionFlow.prototype._paymentHandlers = {
 		);
 	},
 
+	WPCOM_Billing_Ebanx: function() {
+		const { newCardDetails } = this._initialData.payment;
+		const { successUrl, cancelUrl } = this._initialData;
+		const paymentType = newCardDetails.tokenized_payment_data ? 'token' : undefined;
+		const validation = validatePaymentDetails( newCardDetails, paymentType );
+
+		if ( ! isEmpty( validation.errors ) ) {
+			this._pushStep( {
+				name: INPUT_VALIDATION,
+				error: new ValidationError( 'invalid-card-details', validation.errors ),
+				first: true,
+				last: true,
+			} );
+			return;
+		}
+
+		this._pushStep( { name: INPUT_VALIDATION, first: true } );
+		debug( 'submitting transaction with new card (ebanx)' );
+
+		this._createCardToken( gatewayData => {
+			const { name, country, 'postal-code': zip } = newCardDetails;
+
+			// Ebanx payments require additional customer documentation.
+			// @see https://developers.ebanx.com/api-reference/ebanx-payment-api/ebanx-payment-guide/guide-create-a-payment/brazil/
+			const ebanxPaymentData = {
+				payment_method: gatewayData.paymentMethod,
+				payment_key: gatewayData.token,
+				name,
+				zip,
+				country,
+				successUrl,
+				cancelUrl,
+				state: newCardDetails.state,
+				city: newCardDetails.city,
+				address_1: newCardDetails[ 'address-1' ],
+				address_2: newCardDetails[ 'address-2' ],
+				street_number: newCardDetails[ 'street-number' ],
+				phone_number: newCardDetails[ 'phone-number' ],
+				document: newCardDetails.document,
+				device_id: gatewayData.deviceId,
+			};
+
+			this._submitWithPayment( ebanxPaymentData );
+		} );
+	},
+
 	WPCOM_Billing_WPCOM: function() {
 		this._pushStep( { name: INPUT_VALIDATION, first: true } );
 		this._submitWithPayment( { payment_method: 'WPCOM_Billing_WPCOM' } );

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -193,7 +193,7 @@ export class SecurePaymentForm extends Component {
 
 		const cardDetailsCountry = get( params.transaction, 'payment.newCardDetails.country', null );
 		if ( isEbanxCreditCardProcessingEnabledForCountry( cardDetailsCountry ) ) {
-			params.transaction.payment.paymentMethod = 'WPCOM_Billing_MoneyPress_Paygate';
+			params.transaction.payment.paymentMethod = 'WPCOM_Billing_Ebanx';
 		}
 
 		try {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently Ebanx payments reuse the `WPCOM_Billing_MoneyPress_Paygate` handler callback for historical reasons. This patch copies that logic to a dedicated ebanx handler in anticipation of paygate going away.
* Also removes Paygate references that don't (or shouldn't!) do anything -- mostly in tests.

Fixes: part of ongoing project to kill off paygate

#### Testing Instructions

* Set a test user's currency to BRL
* Make sure you are using local calypso and sandboxing the wpcom api, and have both the store and billing sandboxes on
* Attempt a purchase on wpcom with a new card. Set your country to Brazil, and use [fake customer info](https://developers.ebanx.com/guides/going-live/fake-customer-data/fake-brazilian-customer-data/) and a [test card number](https://developers.ebanx.com/guides/going-live/test-card-numbers/). (CEP is the postal code and CPF is the tax ID.)
