### PR TITLE
Signup: redirect user to editor after Signup

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -44,7 +44,7 @@ function getPostID( context ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 
-		return parseInt( getSiteOption( state, siteId, 'page_on_front' ) );
+		return parseInt( getSiteOption( state, siteId, 'page_on_front' ), 10 );
 	}
 
 	// both post and site are in the path

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -17,7 +17,7 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { addQueryArgs } from 'lib/route';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { requestSelectedEditor } from 'state/selected-editor/actions';
-import { getSiteUrl } from 'state/sites/selectors';
+import { getSiteUrl, getSiteOption } from 'state/sites/selectors';
 import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 import { isEnabled } from 'config';
 import { Placeholder } from './placeholder';
@@ -38,6 +38,13 @@ function determinePostType( context ) {
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
 		return null;
+	}
+
+	if ( 'home' === context.params.post ) {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+
+		return parseInt( getSiteOption( state, siteId, 'page_on_front' ) );
 	}
 
 	// both post and site are in the path

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -119,20 +119,6 @@ export function generateFlows( {
 			lastModified: '2019-06-20',
 		},
 
-		'onboarding-dev': {
-			steps: [
-				'user',
-				'site-type',
-				'site-topic-with-preview',
-				'site-title-with-preview',
-				'domains-with-preview',
-				'plans',
-			],
-			destination: getEditorDestination,
-			description: 'Testing flow for Gutenboarding.',
-			lastModified: '2019-09-26',
-		},
-
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,
@@ -332,9 +318,9 @@ export function generateFlows( {
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
 			steps: [ 'user', 'domains', 'plans' ],
-			destination: getSignupDestination,
+			destination: getEditorDestination,
 			description: 'User testing Signup flow for Full Site Editing',
-			lastModified: '2019-11-19',
+			lastModified: '2019-11-22',
 		};
 	}
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,6 +16,7 @@ export function generateFlows( {
 	getSignupDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
+	getEditorDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -116,6 +117,20 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2019-06-20',
+		},
+
+		'onboarding-dev': {
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getEditorDestination,
+			description: 'Testing flow for Gutenboarding.',
+			lastModified: '2019-09-26',
 		},
 
 		desktop: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -104,8 +104,8 @@ const Flows = {
 	 *
 	 * The returned flow is modified according to several filters.
 	 *
-	 * @param {String} flowName The name of the flow to return
-	 * @returns {Object} A flow object
+	 * @param {string} flowName The name of the flow to return
+	 * @returns {object} A flow object
 	 */
 	getFlow( flowName ) {
 		let flow = Flows.getFlows()[ flowName ];
@@ -141,7 +141,7 @@ const Flows = {
 	 * The main usage at the moment is to serve as a quick solution to remove steps that have been pre-fulfilled
 	 * without explicit user inputs, e.g. query arguments.
 	 *
-	 * @param {String} step Name of the step to be excluded.
+	 * @param {string} step Name of the step to be excluded.
 	 */
 	excludeStep( step ) {
 		step && Flows.excludedSteps.push( step );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -58,6 +58,9 @@ function getThankYouNoSiteDestination() {
 function getChecklistThemeDestination( dependencies ) {
 	return `/checklist/${ dependencies.siteSlug }?d=theme`;
 }
+function getEditorDestination( dependencies ) {
+	return `/block-editor/page/${ dependencies.siteSlug }/home`;
+}
 
 const flows = generateFlows( {
 	getSiteDestination,
@@ -65,6 +68,7 @@ const flows = generateFlows( {
 	getSignupDestination,
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
+	getEditorDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -58,6 +58,7 @@ function getThankYouNoSiteDestination() {
 function getChecklistThemeDestination( dependencies ) {
 	return `/checklist/${ dependencies.siteSlug }?d=theme`;
 }
+
 function getEditorDestination( dependencies ) {
 	return `/block-editor/page/${ dependencies.siteSlug }/home`;
 }

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -46,8 +46,9 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 		};
 	}
 
-	// Customer Home.
-	if ( doesRouteMatch( /^\/home\/?/ ) ) {
+	// If a user comes from Home or from a fresh page load (i.e. Signup),
+	// redirect to Customer Home.
+	if ( ! lastNonEditorRoute || doesRouteMatch( /^\/home\/?/ ) ) {
 		return {
 			url: `/home/${ getSiteSlug( state, siteId ) }`,
 			label: translate( 'Home' ),

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import getEditorCloseConfig from 'state/selectors/get-editor-close-config';
@@ -25,7 +20,7 @@ const checklistAction = { type: ROUTE_SET, path: checklistUrl };
 const customerHomeAction = { type: ROUTE_SET, path: customerHomeUrl };
 
 describe( 'getEditorCloseConfig()', () => {
-	test( 'should return URL for post type listings as default', () => {
+	test( 'should return URL for customer home as default when no previous route is given', () => {
 		const state = {
 			sites: {
 				items: {
@@ -35,9 +30,30 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: { selectedSiteId: siteId, actionLog: [] },
 		};
 
+		expect( getEditorCloseConfig( state, siteId, postType ).url ).toEqual( customerHomeUrl );
+	} );
+
+	test( 'should return URL for post type listings as default when previous route has no match', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			ui: {
+				route: {
+					path: {
+						previous: '/route-with-no-match',
+					},
+				},
+				selectedSiteId: siteId,
+				actionLog: [],
+			},
+		};
+
 		const allPostsUrl = getPostTypeAllPostsUrl( state, postType );
 
-		expect( getEditorCloseConfig( state, siteId, postType ).url ).to.equal( allPostsUrl );
+		expect( getEditorCloseConfig( state, siteId, postType ).url ).toEqual( allPostsUrl );
 	} );
 
 	test( 'should return parent URL if current post is a FSE template part', () => {
@@ -70,7 +86,7 @@ describe( 'getEditorCloseConfig()', () => {
 
 		const parentPostEditorUrl = getGutenbergEditorUrl( state, siteId, parentPostId, pagePostType );
 
-		expect( getEditorCloseConfig( state, siteId, templatePostType, parentPostId ).url ).to.equal(
+		expect( getEditorCloseConfig( state, siteId, templatePostType, parentPostId ).url ).toEqual(
 			parentPostEditorUrl
 		);
 	} );
@@ -93,7 +109,7 @@ describe( 'getEditorCloseConfig()', () => {
 			},
 		};
 
-		expect( getEditorCloseConfig( state, siteId, postType ).url ).to.equal( checklistUrl );
+		expect( getEditorCloseConfig( state, siteId, postType ).url ).toEqual( checklistUrl );
 	} );
 
 	test( 'should return URL for checklist if most recent non-editor nav was from the checklist', () => {
@@ -109,7 +125,7 @@ describe( 'getEditorCloseConfig()', () => {
 			},
 		};
 
-		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).to.equal( checklistUrl );
+		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( checklistUrl );
 	} );
 
 	test( 'should return URL for customer home if previous nav was from the customer home', () => {
@@ -130,7 +146,7 @@ describe( 'getEditorCloseConfig()', () => {
 			},
 		};
 
-		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).to.equal( customerHomeUrl );
+		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( customerHomeUrl );
 	} );
 
 	test( 'should return URL for customer home if most recent non-editor nav was from the customer home', () => {
@@ -146,6 +162,6 @@ describe( 'getEditorCloseConfig()', () => {
 			},
 		};
 
-		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).to.equal( customerHomeUrl );
+		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( customerHomeUrl );
 	} );
 } );


### PR DESCRIPTION
This redirects a user to their homepage editor after Signup is completed for the `/test-fse/` flow. It also updates the Gutenberg back button for that instance to return the user to the Customer Home.

**To Test:**
- visit `/start/test-fse/`
- create a new site
- verify that you're redirected to the editor for the site's homepage
- verify that the back button in the Editor is labeled "Home" and should takes the user back to the Customer Home