### PR TITLE
Login: Add exception for connect-in-place flow for Google

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -26,6 +26,7 @@ import FormPasswordInput from 'components/forms/form-password-input';
 import FormTextInput from 'components/forms/form-text-input';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import {
@@ -232,10 +233,17 @@ export class LoginForm extends Component {
 	};
 
 	shouldUseRedirectLoginFlow() {
-		const { oauth2Client } = this.props;
+		const { currentRoute, oauth2Client } = this.props;
 		// If calypso is loaded in a popup, we don't want to open a second popup for social login
 		// let's use the redirect flow instead in that case
-		const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+		let isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+
+		// Jetpack Connect-in-place auth flow contains special reserved args, so we want a popup for social login.
+		// See p1HpG7-7nj-p2 for more information.
+		if ( isPopup && '/log-in/jetpack' === currentRoute ) {
+			isPopup = false;
+		}
+
 		// disable for oauth2 flows for now
 		return ! oauth2Client && isPopup;
 	}
@@ -625,6 +633,7 @@ export default connect(
 
 		return {
 			accountType,
+			currentRoute: getCurrentRoute( state ),
 			hasAccountTypeLoaded: accountType !== null,
 			isFormDisabled: isFormDisabledSelector( state ),
 			isLoggedIn: Boolean( getCurrentUserId( state ) ),


### PR DESCRIPTION
This PR will force opening the Google signup flow in a popup for the connect in place flow when initiating from the login screen. It will only work for the Jetpack login screen, and only when opened in a popup. 

Originally, this would redirect to `/start` after signing up with Google, which breaks the Jetpack "connect in place" flow, dropping the user to the WP.com site creation flow, which doesn't make sense.

This is similar to what #36296 did, but for when we start from the login page (and not the account creation page).

See p1HpG7-7nj-p2 for more context, and feel free to ping @Automattic/poseidon if you have any questions.

#### Changes proposed in this Pull Request

* Login: Add exception for connect-in-place flow for Google.

#### Testing instructions

Due to limitations with the Google oAuth2 flow, the full flow can't be tested with development Calypso and can only be tested in production. The following steps can ensure it works properly though:

* Checkout this branch.
* Log out of WP.com.
* Go to http://calypso.localhost:3000/log-in/jetpack
* Click "Continue with Google".
* Verify a popup is open to select an account or login to Google.
* Now go through the connect in place flow by either:
  * Doing it locally on your Jetpack dev env, or:
  * Doing it with a JN site:
    * Start a new JN site with the latest bleeding edge Jetpack: https://jurassic.ninja/create?jetpack-beta
    * Enable the iframe constant from the constants settings page in your JN site.
    * SSH into the site using the command in the JN site admin notification.
    * Navigate to the WP installation dir by calling `cd DIR` where `DIR` is the path as specified in the JN site admin notification.
    * `vim wp-config.php`
    * `:i` to go to INSERT mode.
    * Add `define( 'CALYPSO_ENV', 'development );` somewhere where the other constants are.
    * Press `esc` key to leave INSERT mode.
    * `:w` to save.
    * `:q` to quit.
    * Make sure you're logged out of WP.com.
    * Go to `/wp-admin/admin.php?page=jetpack#/dashboard` in the JN site.
* Start connecting the site while logged out of WP.com.
* In the popup, click "Continue with Google".
* Verify it opens another popup.
* If you got here, this means it works well!
* The rest of the flow can only be tested once this gets to production.