### PR TITLE
Styling fixes for WooCommerce.com OAuth login

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -466,6 +466,10 @@
 		}
 	}
 
+	.layout__content {
+		padding-top: 85px;
+	}
+
 	.button.is-primary {
 		background-color: #a46497;
 		border-radius: 100px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -424,12 +424,17 @@
 		line-height: 83px;
 		margin: 0 auto;
 		z-index: 100;
+	}
 
-		nav {
-			box-sizing: border-box;
-			max-width: 1500px;
-			margin-left: auto;
-			margin-right: auto;
+	.masterbar__oauth-client nav {
+		box-sizing: border-box;
+		max-width: 1500px;
+		margin-left: auto;
+		margin-right: auto;
+		padding-left: 13px;
+		padding-right: 13px;
+
+		@include breakpoint( '>480px' ) {
 			padding-left: 55px;
 			padding-right: 13px;
 		}
@@ -451,9 +456,13 @@
 			color: #999;
 			font-size: 0.9em;
 			font-weight: bold;
-			padding: 32px;
+			padding: 32px 10px;
 			text-decoration: none;
 			text-transform: uppercase;
+
+			@include breakpoint( '>480px' ) {
+				padding: 32px;
+			}
 		}
 	}
 
@@ -540,8 +549,14 @@
 	.login__social-buttons {
 		margin-top: 0;
 
+		.login__social-tos {
+			margin: 2.5em auto 0;
+			max-width: 90%;
+		}
+
 		@include breakpoint( '>660px' ) {
 			flex-direction: row;
+			flex-wrap: wrap;
 
 			button:not( :first-of-type ) {
 				margin-top: 0;
@@ -562,6 +577,10 @@
 		box-shadow: none;
 		padding-left: 0;
 		padding-right: 0;
+	}
+
+	.wp-login__container {
+		margin-top: 50px;
 	}
 
 	.wp-login__container,


### PR DESCRIPTION
This PR fixes display issues for WooCommerce.com OAuth login page.

#### Testing instructions

1. Checkout `fix/sign-in-with-apple-button` and start your server.
1. Open the WooCommerce [Home page](https://woocommerce.com/) in an incognito window.
1. Click the `LOG IN WITH WORDPRESS.COM` link in the header.
1. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in the address bar, and reload.
1. Assert that the page looks like the screenshot below.

#### Desktop Screenshots

Before | After
------ | -----
![calypso localhost_3000_log-in_client_id=50916 redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D81227403991f5ea06888ed894027f94618b6588b2a95080089a1a79f172f7263% (4)](https://user-images.githubusercontent.com/78313/65786239-6ea6cf00-e180-11e9-8d03-086257f2fe17.png)|![calypso localhost_3000_log-in_client_id=50916 redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D81227403991f5ea06888ed894027f94618b6588b2a95080089a1a79f172f7263% (5)](https://user-images.githubusercontent.com/78313/65786255-78c8cd80-e180-11e9-94d1-ccc436043f8e.png)

#### Mobile Screenshots

Before | After
------ | -----
![calypso localhost_3000_log-in_client_id=50916 redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D81227403991f5ea06888ed894027f94618b6588b2a95080089a1a79f172f7263% (3)](https://user-images.githubusercontent.com/78313/65785994-e3c5d480-e17f-11e9-837d-588eb9c47189.png)|![calypso localhost_3000_log-in_client_id=50916 redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D81227403991f5ea06888ed894027f94618b6588b2a95080089a1a79f172f7263% (2)](https://user-images.githubusercontent.com/78313/65786014-ea544c00-e17f-11e9-8a8f-48e2759f9004.png)

