### PR TITLE
Adding GA to the Premium description in the plans list

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -226,6 +226,7 @@ const getPlanPremiumDetails = () => ( {
 		i18n.translate(
 			'{{strong}}Best for Freelancers:{{/strong}}' +
 				' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
+				' Google Analytics support,' +
 				' and the ability to monetize your site with ads.',
 			{
 				components: {
@@ -238,6 +239,7 @@ const getPlanPremiumDetails = () => ( {
 	getShortDescription: () =>
 		i18n.translate(
 			'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
+				' Google Analytics support,' +
 				' and the ability to monetize your site with ads.'
 		),
 	getPlanCompareFeatures: () =>
@@ -293,8 +295,7 @@ const getPlanBusinessDetails = () => ( {
 		i18n.translate(
 			'{{strong}}Best for Small Businesses:{{/strong}} Power your' +
 				' business website with custom plugins and themes, unlimited premium and business theme templates,' +
-				' Google Analytics support, 200 GB' +
-				' storage, and the ability to remove WordPress.com branding.',
+				' 200 GB storage, and the ability to remove WordPress.com branding.',
 			{
 				components: {
 					strong: (
@@ -306,8 +307,7 @@ const getPlanBusinessDetails = () => ( {
 	getShortDescription: () =>
 		i18n.translate(
 			'Power your business website with custom plugins and themes, unlimited premium and business theme templates,' +
-				' Google Analytics support, 200 GB' +
-				' storage, and the ability to remove WordPress.com branding.'
+				' 200 GB storage, and the ability to remove WordPress.com branding.'
 		),
 	getTagline: () =>
 		i18n.translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moved from #36367
* This updates the copy for the plans list components in /start, to list it in Premium.
* We also need to update it on:
https://wordpress.com/premium/
https://wordpress.com/create-blog/
https://wordpress.com/easy/
https://wordpress.com/create-website/
https://wordpress.com/built-for-business/
https://wordpress.com/business-everywhere/
https://wordpress.com/brand-everywhere/
https://wordpress.com/creativity-everywhere/
https://wordpress.com/everywhere/
https://wordpress.com/resolutions/
