### PR TITLE
Remove unused call to newCardPayment() in CreditCardSelector

### DIFF
--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -13,7 +13,7 @@ import analytics from 'lib/analytics';
 import CreditCard from 'components/credit-card';
 import NewCardForm from './new-card-form';
 
-import { newCardPayment, newStripeCardPayment, storedCardPayment } from 'lib/store-transactions';
+import { newStripeCardPayment, storedCardPayment } from 'lib/store-transactions';
 import { setPayment } from 'lib/upgrades/actions';
 
 class CreditCardSelector extends React.Component {
@@ -102,11 +102,7 @@ class CreditCardSelector extends React.Component {
 
 	savePayment = section => {
 		if ( 'new-card' === section ) {
-			if ( this.props.stripe ) {
-				return setPayment( newStripeCardPayment( this.props.transaction.newCardRawDetails ) );
-			}
-
-			return setPayment( newCardPayment( this.props.transaction.newCardRawDetails ) );
+			return setPayment( newStripeCardPayment( this.props.transaction.newCardRawDetails ) );
 		}
 		setPayment( storedCardPayment( this.getStoredCardDetails( section ) ) );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Default to stripe in the CreditCardSelector element.

#### Testing instructions

* Attempt to add a card from e.g. `/me/purchases/billing`

Part of ongoing removal of paygate from calypso.
