### PR TITLE
Primary Segmented Control: Use primary background color rather than primary light

### DIFF
--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -86,6 +86,7 @@
 
 				&:focus {
 					background-color: var( --color-primary-dark );
+					border-color: var( --color-primary-dark );
 				}
 			}
 

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -85,7 +85,7 @@
 				color: var( --color-text-inverted );
 
 				&:focus {
-					background-color: var( --color-primary );
+					background-color: var( --color-primary-dark );
 				}
 			}
 

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -85,7 +85,7 @@
 				color: var( --color-text-inverted );
 
 				&:focus {
-					background-color: var( --color-primary-light );
+					background-color: var( --color-primary );
 				}
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `focus` state for elements in the Primary Segmented Control does not pass WCAG AA standards; as a result, mobile devices and keyboard users see a much lighter focus style. This PR switches from `--color-primary-light` to `--color-primary-dark` for better contrast on focused elements.
* This doesn't completely resolve the issue in #32423 but I think it's a fair compromise and a bump for accessibility.

**Before**

<img width="411" alt="Screen Shot 2019-09-27 at 2 18 15 PM" src="https://user-images.githubusercontent.com/2124984/65792503-e4377e80-e131-11e9-8096-a50110d8f1f1.png">

**After**

<img width="416" alt="Screen Shot 2019-09-27 at 2 26 20 PM" src="https://user-images.githubusercontent.com/2124984/65792953-ce768900-e132-11e9-8c19-2acab02c3027.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/devdocs/design/segmented-control` and look at the "Primary version" of the Segmented Control. Click on one of the items, both on desktop and mobile.
* You should see the darker primary color as the focus style for each selected element.

Fixes #32423