### PR TITLE
Fix a bug where Popover is focused too early, before it's fully rendered

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import classNames from 'classnames';
 import clickOutside from 'click-outside';
-import { uniqueId } from 'lodash';
+import { defer, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -308,7 +308,7 @@ class Popover extends Component {
 
 		this.setPosition();
 
-		this.focusPopover();
+		defer( () => this.focusPopover() );
 	}
 
 	getPositionClass( position = this.props.position ) {


### PR DESCRIPTION
Fixes a regression introduced in #36297 where we started focusing all `Popover` elements right after they are rendered.

The focusing, however, happens in a ref callback, at a time when the element is not yet fully rendered (I don't understand the low-level details ATM) and focusing it scrolls to the top of the page.

A quick fix uses a `defer` call. That's in this patch. A correct patch would move the focus call to a lifecycle method (`componentDid{Mount,Update}`), but that's too much to ask on Friday evening.

**How to test:**
Open Reader feed and scroll down to a post with several likes. Hover over the like button (with star icon). Buggy behavior is that the window scrolls to the top immediately. Fixed behavior doesn't do that, but just shows a popover with the names of the likers.