### PR TITLE
WP.com Block Editor: Add front-end styles for text justify.

### DIFF
--- a/apps/wpcom-block-editor/src/common/rich-text.js
+++ b/apps/wpcom-block-editor/src/common/rich-text.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* global wpcomGutenberg */
 
 /**
@@ -78,6 +79,5 @@ registerFormatType( 'wpcom/justify', {
 	title: wpcomGutenberg.richTextToolbar.justify,
 	tagName: 'p',
 	className: null,
-	attributes: { style: 'style' },
 	edit: ConnectedRichTextJustifyButton,
 } );

--- a/apps/wpcom-block-editor/src/common/style-front-end.scss
+++ b/apps/wpcom-block-editor/src/common/style-front-end.scss
@@ -1,0 +1,3 @@
+.has-text-align-justify {
+	text-align: justify;
+}

--- a/apps/wpcom-block-editor/src/common/style-front-end.scss
+++ b/apps/wpcom-block-editor/src/common/style-front-end.scss
@@ -1,3 +1,0 @@
-.has-text-align-justify {
-	text-align: justify;
-}

--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -42,3 +42,7 @@
 .components-notice-list {
 	z-index: 29; // Ensure notices are placed behind the editor header (z-index: 30).
 }
+
+.has-text-align-justify {
+	text-align: justify;
+}


### PR DESCRIPTION
In Gutenberg 6.3, text align styles for blocks were [moved from inline to classes](https://github.com/WordPress/gutenberg/pull/16794), breaking our Justify text styles for Rich Text blocks. This PR updates our integration to use the new class-based method.

**Testing Instructions**

See D33289-code.

Fixes https://github.com/Automattic/wp-calypso/issues/36391