### PR TITLE
Full Site Editing: warn when switching to an unsupported theme

### DIFF
--- a/client/my-sites/themes/activate-confirm.js
+++ b/client/my-sites/themes/activate-confirm.js
@@ -16,22 +16,27 @@ export default function ActivateConfirm( { isVisible, onClose, themeName } ) {
 		args: { theme: themeName },
 	} );
 	const buttons = [
-		{ action: 'cancel', label: translate( 'Keep current theme' ), isPrimary: true },
 		{ action: 'confirm', label: confirmLabel },
+		{ action: 'cancel', label: translate( 'Keep current theme' ), isPrimary: true },
 	];
 	const props = { isVisible, onClose };
-	const message = translate(
-		'{{strong}}%(theme)s{{/strong}} does not fully support editing headers and footers. ' +
-			'Any changes you have made will not be displayed on your site. You will need to use ' +
-			'the legacy Customizer tool to edit some areas of your site.',
+	const first = translate(
+		'{{strong}}%(theme)s{{/strong}} does not fully support editing all parts of your site, such as headers and footers.',
 		{
 			components: { strong: <strong /> },
 			args: { theme: themeName },
 		}
 	);
+	const second = translate(
+		'If you activate this theme, you will still have limited site appearance control using the legacy Customizer tool.'
+	);
 	return (
 		<Dialog { ...props } buttons={ buttons }>
-			<p>{ message }</p>
+			<div style={ { maxWidth: '33em' } }>
+				<h1>{ translate( 'Warning' ) }</h1>
+				<p>{ first }</p>
+				<p>{ second }</p>
+			</div>
 		</Dialog>
 	);
 }

--- a/client/my-sites/themes/activate-confirm.js
+++ b/client/my-sites/themes/activate-confirm.js
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+
+export default function ActivationConfirm( { isVisible, onClose, themeName } ) {
+	const confirmLabel = translate( 'Activate %(theme)s', {
+		args: { theme: themeName },
+	} );
+	const buttons = [
+		{ action: 'cancel', label: translate( 'Keep current theme' ), isPrimary: true },
+		{ action: 'confirm', label: confirmLabel },
+	];
+	const props = { isVisible, onClose };
+	const message = translate(
+		'{{strong}}%(theme)s{{/strong}} does not fully support editing headers and footers. ' +
+			'Any changes you have made will not be displayed on your site. You will need to use ' +
+			'the legacy Customizer tool to edit some areas of your site.',
+		{
+			components: { strong: <strong /> },
+			args: { theme: themeName },
+		}
+	);
+	return (
+		<Dialog { ...props } buttons={ buttons }>
+			<p>{ message }</p>
+		</Dialog>
+	);
+}

--- a/client/my-sites/themes/activate-confirm.js
+++ b/client/my-sites/themes/activate-confirm.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import Dialog from 'components/dialog';
 
-export default function ActivationConfirm( { isVisible, onClose, themeName } ) {
+export default function ActivateConfirm( { isVisible, onClose, themeName } ) {
 	const confirmLabel = translate( 'Activate %(theme)s', {
 		args: { theme: themeName },
 	} );

--- a/client/state/themes/full-site-editing.js
+++ b/client/state/themes/full-site-editing.js
@@ -1,0 +1,19 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { includes } from 'lodash';
+
+const FULL_SITE_EDITING_THEMES = [ 'maywood' ];
+
+/**
+ * Checks to see if a theme supports Full Site Editing
+ *
+ * @param {string} theme A theme ID as returned by the REST API (no pub/ etc prefixes)
+ * @returns {bool} True if the theme supports Full Site Editing
+ */
+export function themeSupportsFullSiteEditing( theme ) {
+	return includes( FULL_SITE_EDITING_THEMES, theme );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a confirmation dialog when attempting to activate a theme that does not support Full Site Editing.

<img width="546" alt="image" src="https://user-images.githubusercontent.com/195089/65799932-e3571a80-e13a-11e9-8c86-8d710fa49b29.png">


#### Testing instructions

On a site with Full Site Editing active[^1], try the following:

1. Under Design → Themes, try activating any unsupported theme (only Maywood is currently supported). The two buttons should function as expected.
2. If an unsupported theme is activated, no further dialogs should be present when trying to enable any other theme.
3. On a single theme page, clicking "Activate this Design" should trigger the dialog also when FSE is active <img width="215" alt="image" src="https://user-images.githubusercontent.com/195089/65800127-4ea0ec80-e13b-11e9-94bf-ddccefa98553.png"> 

Non-FSE sites should not trigger any extra dialogs.

[^1]: FSE is active on sites created with a **new user** via https://horizon.wordpress.com/start/test-fse/ and with the Maywood theme activated.

Fixes #35646 
