### PR TITLE
SPT: Clear templates cache on theme switch

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -28,6 +28,7 @@ class Starter_Page_Templates {
 		add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_assets' ] );
 		add_action( 'delete_attachment', [ $this, 'clear_sideloaded_image_cache' ] );
+		add_action( 'switch_theme', [ $this, 'clear_templates_cache' ] );
 	}
 
 	/**
@@ -215,6 +216,23 @@ class Starter_Page_Templates {
 		if ( ! empty( $url ) ) {
 			delete_transient( 'fse_sideloaded_image_' . hash( 'crc32b', $url ) );
 		}
+	}
+
+	/**
+	 * Deletes cached templates data when theme switches.
+	 */
+	public function clear_templates_cache() {
+		$transient_key = implode(
+			'_',
+			[
+				'starter_page_templates',
+				PLUGIN_VERSION,
+				get_option( 'site_vertical', 'default' ),
+				get_locale(),
+			]
+		);
+
+		delete_transient( $transient_key );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -20,9 +20,26 @@ class Starter_Page_Templates {
 	private static $instance = null;
 
 	/**
+	 * Cache key for templates array.
+	 *
+	 * @var string
+	 */
+	public $templates_cache_key;
+
+	/**
 	 * Starter_Page_Templates constructor.
 	 */
 	private function __construct() {
+		$this->templates_cache_key = implode(
+			'_',
+			[
+				'starter_page_templates',
+				PLUGIN_VERSION,
+				get_option( 'site_vertical', 'default' ),
+				get_locale(),
+			]
+		);
+
 		add_action( 'init', [ $this, 'register_scripts' ] );
 		add_action( 'init', [ $this, 'register_meta_field' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );
@@ -182,12 +199,11 @@ class Starter_Page_Templates {
 	 * @return array Containing vertical name and template list or nothing if an error occurred.
 	 */
 	public function fetch_vertical_data() {
-		$vertical_id        = get_option( 'site_vertical', 'default' );
-		$transient_key      = implode( '_', [ 'starter_page_templates', PLUGIN_VERSION, $vertical_id, get_locale() ] );
-		$vertical_templates = get_transient( $transient_key );
+		$vertical_templates = get_transient( $this->templates_cache_key );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
 		if ( false === $vertical_templates || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
+			$vertical_id = get_option( 'site_vertical', 'default' );
 			$request_url = add_query_arg(
 				[
 					'_locale' => $this->get_iso_639_locale(),
@@ -200,7 +216,7 @@ class Starter_Page_Templates {
 				return [];
 			}
 			$vertical_templates = json_decode( wp_remote_retrieve_body( $response ), true );
-			set_transient( $transient_key, $vertical_templates, DAY_IN_SECONDS );
+			set_transient( $this->templates_cache_key, $vertical_templates, DAY_IN_SECONDS );
 		}
 
 		return $vertical_templates;
@@ -222,17 +238,7 @@ class Starter_Page_Templates {
 	 * Deletes cached templates data when theme switches.
 	 */
 	public function clear_templates_cache() {
-		$transient_key = implode(
-			'_',
-			[
-				'starter_page_templates',
-				PLUGIN_VERSION,
-				get_option( 'site_vertical', 'default' ),
-				get_locale(),
-			]
-		);
-
-		delete_transient( $transient_key );
+		delete_transient( $this->templates_cache_key );
 	}
 
 	/**


### PR DESCRIPTION
Fixes a bug where the previous theme's homepage template remains in the selector for 24h after a theme switch.

Test:
With `WP_DEBUG` set to false or not set, switch between template-first themes and double-check that the Home template updates.

See p7DVsv-7o5-p2#comment-23538
