### PR TITLE
FSE: Fix navigation to the template editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -132,6 +132,22 @@ const TemplateEdit = compose(
 			savePost();
 		};
 
+		/**
+		 * IMPORTANT: Be careful about changes to the overlay button. There is code in
+		 * iframe-bridge-server.js (setupEditTemplateLinks) which looks for two
+		 * elements matching '.template__block-container .template-block__overlay a'.
+		 * This code updates the href of the button to match the calypso URL (which is
+		 * sent through the iFrame port) since editTemplateUrl here will be the wpadmin URL.
+		 *
+		 * If you make changes to the button, navigation to the template editor MAY BREAK.
+		 *
+		 * For example, if the button does not exist in the DOM as the editor is loaded,
+		 * the links may not be updated in time, or an interval will continuously try to
+		 * find them (which is bad for performance).
+		 *
+		 * This has already broken several times, so be careful!
+		 */
+
 		return (
 			<div
 				className={ classNames( 'template-block', {

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -614,12 +614,19 @@ function openCustomizer( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function setupEditTemplateLinks( calypsoPort ) {
-	// We only want this when editing a full site page.
+	// We only want this when editing an FSE page.
 	if ( ! window.fullSiteEditing || 'page' !== window.fullSiteEditing.editorPostType ) {
 		return;
 	}
 
+	const handledLinks = [];
 	const handleNewTemplateLinks = link => {
+		// Don't do anything if we already saw this link:
+		if ( handledLinks.some( existingLink => existingLink.isSameNode( link ) ) ) {
+			return;
+		}
+
+		handledLinks.push( link );
 		const templateId = parseInt( getQueryArg( link.getAttribute( 'href' ), 'post' ), 10 );
 
 		const { port1, port2 } = new MessageChannel();
@@ -629,7 +636,7 @@ function setupEditTemplateLinks( calypsoPort ) {
 			link.setAttribute( 'href', data );
 		};
 
-		// Ask for another URl for the template:
+		// Ask for an updated URL for the button:
 		calypsoPort.postMessage(
 			{
 				action: 'getTemplateEditorUrl',
@@ -639,7 +646,7 @@ function setupEditTemplateLinks( calypsoPort ) {
 		);
 	};
 
-	subscribe( () => {
+	const unsubscribe = subscribe( () => {
 		const currentPost = select( 'core/editor' ).getCurrentPost();
 		const initialized = currentPost && currentPost.id;
 
@@ -647,24 +654,21 @@ function setupEditTemplateLinks( calypsoPort ) {
 			return;
 		}
 
-		// When the template block becomes selected, we want to change
-		// the link of the "edit template" button.
-		const selectedBlock = select( 'core/editor' ).getSelectedBlock();
+		unsubscribe();
 
-		if ( selectedBlock && 'a8c/template' === selectedBlock.name ) {
-			const getImpendingLinks = setInterval( () => {
-				const editTemplateLink = document.querySelector(
-					'[data-type="a8c/template"] .template-block__overlay a'
-				);
+		const getImpendingLinks = setInterval( () => {
+			const editTemplateLinks = document.querySelectorAll(
+				'.template__block-container .template-block__overlay a'
+			);
 
-				// Keep looking for it as the DOM may not have loaded yet:
-				if ( ! editTemplateLink ) {
-					return;
-				}
+			// We want to stop looking after the header/footer have been handled:
+			if ( handledLinks.length === 2 ) {
 				clearInterval( getImpendingLinks );
-				handleNewTemplateLinks( editTemplateLink );
-			} );
-		}
+			}
+
+			// Handle the links:
+			editTemplateLinks.forEach( handleNewTemplateLinks );
+		} );
 	} );
 }
 


### PR DESCRIPTION
We changed the structure of the hover UI for the "edit template" button in the page editor, so the iframe bridge server wasn't updating the hrefs with the correct Calypso URLs until the template blocks were focused in Gutenberg. This was valid before we changed the hover interaction, but caused bugs when clicking the button without focusing the block.

This code keeps breaking when we change the hover interaction, so I added a scary comment to the FSE code which touches it.

We really need a less artisanal solution, but I'd like to ship this for the 10% test. IMO, the correct solution would be a well-designed Calypso-iFrame navigation API that we can hook into through the iFrame bridge server. Occasionally, we have buttons in the block editor which need their hrefs changed from wpadmin URLs to Calypso URLs. Currently, we do manual DOM selection to handle this for a few cases, but this is obviously not a stable solution.

#### Changes proposed in this Pull Request
* Update the iframe bridge server to update the href on the "edit template" links correctly. 

#### Testing instructions
1. Apply this patch to your sandbox (the auto-generated iframe bridge server code): **D33303-code**
2. Sandbox the API and widgets.wp.com, as well as the site you're going to test.
3. On an FSE enabled site, open the page editor from Calypso. Hover over the "edit header" button. 
4. In the bottom-left corner of the browser, you should see the href of the button. It should match the format `.../block-editor/edit/wp_template/...`
<img width="1333" alt="Screen Shot 2019-09-27 at 5 11 48 PM" src="https://user-images.githubusercontent.com/6265975/65808590-210f6f80-e14a-11e9-9cc2-04a960234fc5.png">

5. Click on the button without focusing the header area and make sure that when the template editor loads, the browser URL updates to match the path above.
6. Click the back button in the template editor. It should load the previous page editor. It should not load the all pages list. 
7. Repeat steps 5 and 6 several times with the header/footer and make sure that it always goes to the template editor and back to the page editor without messing up. :) You're mainly trying to see if you can reproduce using the instructions in #36380

Fixes #36380