### PR TITLE
[SIGNUP]: correct wrong passwordless component prop value

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -918,7 +918,7 @@ class SignupForm extends Component {
 						flowName={ this.props.flowName }
 						goToNextStep={ this.props.goToNextStep }
 						renderTerms={ this.termsOfServiceLink }
-						getloginUrl={ this.getloginUrl() }
+						getloginUrl={ this.getloginUrl }
 					/>
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -22,12 +21,8 @@ import Notice from 'components/notice';
 import { submitSignupStep } from 'state/signup/progress/actions';
 
 export class PasswordlessSignupForm extends Component {
-	static propTypes = {
-		flowName: PropTypes.string.isRequired,
-		stepName: PropTypes.string.isRequired,
-		goToNextStep: PropTypes.func.isRequired,
-		getloginUrl: PropTypes.func.isRequired,
-		renderTerms: PropTypes.func.isRequired,
+	static defaultProps = {
+		locale: 'en',
 	};
 
 	state = {

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -21,8 +22,12 @@ import Notice from 'components/notice';
 import { submitSignupStep } from 'state/signup/progress/actions';
 
 export class PasswordlessSignupForm extends Component {
-	static defaultProps = {
-		locale: 'en',
+	static propTypes = {
+		flowName: PropTypes.string.isRequired,
+		stepName: PropTypes.string.isRequired,
+		goToNextStep: PropTypes.func.isRequired,
+		getloginUrl: PropTypes.func.isRequired,
+		renderTerms: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -32,7 +37,9 @@ export class PasswordlessSignupForm extends Component {
 	};
 
 	submitTracksEvent = ( isSuccessful, props ) => {
-		const tracksEventName = isSuccessful ? 'calypso_signup_actions_onboarding_passwordless_login_success' : 'calypso_signup_actions_onboarding_passwordless_login_error';
+		const tracksEventName = isSuccessful
+			? 'calypso_signup_actions_onboarding_passwordless_login_success'
+			: 'calypso_signup_actions_onboarding_passwordless_login_error';
 		this.props.recordTracksEvent( tracksEventName, {
 			...props,
 		} );


### PR DESCRIPTION
## Changes proposed in this Pull Request 

In https://github.com/Automattic/wp-calypso/pull/34768

I was passing the return value of `getloginUrl()` instead of the function itself. Not good!

<img width="630" alt="Screen Shot 2019-09-30 at 1 11 32 pm" src="https://user-images.githubusercontent.com/6458278/65847192-db3deb80-e383-11e9-9383-b3aba879e08a.png">


## Testing instructions

Sign up according to instructions in https://github.com/Automattic/wp-calypso/pull/34768

Use http://calypso.localhost:3000/start/user not the calypso live link. This is due to a strict whitelist on the endpoint.

Check that the type error doesn't occur on the first step!! :)


