### PR TITLE
BodySectionCssClass: remove class from body on unmount, rewrite to hooks

### DIFF
--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -7,40 +7,35 @@ import React from 'react';
  * React component that manages `is-section-*` and `is-group-*` class names on the <body>
  * element. When the `section` and `group` props get updated, it adds, removes and replaces
  * CSS classes accordingly.
+ *
  * TODO: reconsider if these classnames are really needed on <body> and whether having them
  * on `div.layout` could be sufficient to satisfy all theming and styling requirements.
  * `div.layout` has the advantage of being maintained by React, where class names can be
  * specified declaratively and the DOM diffing and patching is done by React itself.
  */
-const patchBodyClass = toClass => ( next = null, prev = null ) => {
-	if ( prev === next ) {
+const addBodyClass = toClass => value => () => {
+	// if value is empty-ish, don't add any CSS classes
+	if ( ! value ) {
 		return;
 	}
 
-	if ( prev ) {
-		document.body.classList.remove( toClass( prev ) );
-	}
+	// convert the value (section or group name) to a CSS class name
+	const className = toClass( value );
 
-	if ( next ) {
-		document.body.classList.add( toClass( next ) );
-	}
+	// add the CSS class to body when performing the effect
+	document.body.classList.add( className );
+
+	// remove the CSS class from body in the effect cleanup function
+	return () => document.body.classList.remove( className );
 };
 
-const patchGroupClass = patchBodyClass( g => `is-group-${ g }` );
-const patchSectionClass = patchBodyClass( s => `is-section-${ s }` );
+// two effect creators for groups and sections
+const addGroupClass = addBodyClass( g => `is-group-${ g }` );
+const addSectionClass = addBodyClass( s => `is-section-${ s }` );
 
-export default class BodySectionCssClass extends React.Component {
-	componentDidMount() {
-		patchGroupClass( this.props.group );
-		patchSectionClass( this.props.section );
-	}
+export default function BodySectionCssClass( { group, section } ) {
+	React.useEffect( addGroupClass( group ), [ group ] );
+	React.useEffect( addSectionClass( section ), [ section ] );
 
-	componentDidUpdate( prevProps ) {
-		patchGroupClass( this.props.group, prevProps.group );
-		patchSectionClass( this.props.section, prevProps.section );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }


### PR DESCRIPTION
Fixes a bug where `BodySectionCssClass` would not remove the old class name when being unmounted. That can happen when navigating from page that has `ReduxWrappedLayout` as its JSX root (e.g., signup) to a page that has `ReduxWrappedLoggedOutLayout` as its root (e.g., login). Because the components are not identical, all their children get unmounted and mounted again, although it's not strictly necessary. One place where the React diff algorithm takes a
shortcut in order to be efficient.

That leads to `BodySectionCssClass` being re-mounted when navigating from Signup to Login, e.g., when going through the "Connect with Google" flow. The result is Login styled as Signup, because `body` still has the `is-section-signup` class.

The Signup styling is actually desirable, but will need to be implemented in some reasonable way.

This bugfix is actually a complete rewrite of the component, using the `useEffect` hook. Adds the `body` classes when mounted, changes it (by removing and adding again) when a prop changes, and removes them all on unmount.