### PR TITLE
WooCommerce Onboarding: Fix CSS class names in signup route and fix cart display header

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -251,8 +251,8 @@ class Login extends Component {
 						{ 'cart' === wccomFrom ? (
 							<WooCommerceConnectCartHeader />
 						) : (
-							<div className="login__woocommerce-logo">
-								<div className={ classNames( 'connect-header' ) }>
+							<div className="login__woocommerce-wrapper">
+								<div className={ classNames( 'login__woocommerce-logo' ) }>
 									<svg width={ 200 } viewBox={ '0 0 1270 170' }>
 										<AsyncLoad
 											require="components/jetpack-header/woocommerce"

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -47,14 +47,14 @@
 		}
 	}
 
-	.login__woocommerce-logo {
+	.login__woocommerce-wrapper {
 		svg > g {
 			transform: translateX( 50% );
 		}
 	}
 
 	.jetpack-header,
-	.connect-header {
+	.login__woocommerce-logo {
 		margin: 0;
 		text-align: center;
 		margin-right: auto;
@@ -93,6 +93,11 @@
 	.login__form-action .form-button {
 		border: 0;
 		box-shadow: none;
+	}
+
+	.login__social-tos a {
+		color: var( --studio-gray-60 );
+		text-decoration: underline;
 	}
 
 	.jetpack-header__partner-logo-plus svg {

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
@@ -69,7 +69,7 @@ const WooCommercConnectCartHeader = ( { translate } ) => {
 						</div>
 						<div className="woocommerce-connect-cart-header__stepper-step-text">
 							<span className="woocommerce-connect-cart-header__stepper-step-label">
-								{ ( translate( 'Installation' ), { context: 'Navigation item' } ) }
+								{ translate( 'Installation', { context: 'Navigation item' } ) }
 							</span>
 						</div>
 					</div>

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
@@ -1,6 +1,6 @@
 .woocommerce-connect-cart-header {
 	height: 56px;
-	border-bottom: 1px solid var( --color-gray-50 );
+	border-bottom: 1px solid var( --studio-gray-5 );
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -19,7 +19,7 @@
 		width: 100%;
 		bottom: 0;
 		top: initial;
-		border-top: 1px solid var( --color-gray-50 );
+		border-top: 1px solid var( --studio-gray-5 );
 		border-bottom: none;
 	}
 }
@@ -66,14 +66,14 @@
 	height: 24px;
 	min-width: 24px;
 	margin-right: 12px;
-	background: var( --color-gray-50 );
-	color: var( --color-gray-600 );
+	background: var( --studio-gray-5 );
+	color: var( --studio-gray-60 );
 	border-radius: 50%;
 }
 
 .woocommerce-connect-cart-header__stepper-step.is-active .woocommerce-connect-cart-header__stepper-step-icon,
 .woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-icon {
-	background: var( --color-hot-purple-600 );
+	background: var( --studio-woocommerce-purple-60 );
 	color: var( --color-text-inverted );
 }
 
@@ -90,7 +90,7 @@
 }
 
 .woocommerce-connect-cart-header__stepper-step .woocommerce-connect-cart-header__stepper-step-label {
-	color: var( --color-gray-900 );
+	color: var( --studio-gray-90 );
 	line-height: 24px;
 	font-size: 16px;
 
@@ -101,15 +101,15 @@
 }
 
 .woocommerce-connect-cart-header__stepper-step .woocommerce-connect-cart-header__stepper-step-label {
-	color: var( --color-gray-800 );
+	color: var( --studio-gray-80 );
 }
 .woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-label {
-	color: var( --color-gray-900 );
+	color: var( --studio-gray-90 );
 }
 
 .woocommerce-connect-cart-header__stepper-step-divider {
 	align-self: flex-start;
 	flex-grow: 1;
-	border-bottom: 1px solid var( --color-gray-50 );
+	border-bottom: 1px solid var( --studio-gray-5 );
 	margin-top: 20px;
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -924,6 +924,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.formatted-header__subtitle {
+			color: var( --color-primary-10 );
 			margin-top: 1em;
 			font-size: 16px;
 			line-height: 24px;
@@ -986,6 +987,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			color: var( --color-neutral-60 );
 		}
 
+		.signup-form__terms-of-service-link a {
+			text-decoration: underline;
+		}
+
 		.logged-out-form__link-item {
 			text-align: center;
 			text-decoration: underline;
@@ -1000,10 +1005,21 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				font-size: 12px;
 			}
 
+			.signup-form__social-buttons-tos {
+				color: var( --studio-gray-60 );
+				margin-bottom: 16px;
+				a {
+					text-decoration: underline;
+					color: var( --studio-gray-60 );
+				}
+			}
+
 			.social-buttons__button {
 				border: 1px solid var( --studio-pink-50 );
 				color: var( --studio-pink-50 );
 				box-shadow: none;
+				max-width: 310px;
+				height: 48px;
 			}
 		}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -295,6 +295,14 @@ $image-height: 47px;
 		}
 	}
 
+	.login__social-tos a {
+		color: var( --studio-gray-60 );
+	}
+
+	.wp-login__site-return-link::after {
+		background: none;
+	}
+
 	.woocommerce-muriel-text-control,
 	.muriel-input-text {
 		border-color: var( --color-neutral-20 );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -245,8 +245,8 @@ export class UserStep extends Component {
 					{ 'cart' === wccomFrom ? (
 						<WooCommerceConnectCartHeader />
 					) : (
-						<div className={ classNames( 'login__woocommerce-logo' ) }>
-							<div className={ classNames( 'connect-header' ) }>
+						<div className={ classNames( 'signup-form__woocommerce-wrapper' ) }>
+							<div className={ classNames( 'signup-form__woocommerce-logo' ) }>
 								<svg width={ 200 } viewBox={ '0 0 1270 170' }>
 									<AsyncLoad
 										require="components/jetpack-header/woocommerce"
@@ -257,7 +257,7 @@ export class UserStep extends Component {
 							</div>
 						</div>
 					) }
-					<div className={ classNames( 'login__form-header' ) }>
+					<div className={ classNames( 'signup-form__woocommerce-heading' ) }>
 						{ translate( 'Create a WordPress.com account' ) }
 					</div>
 				</Fragment>

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -185,18 +185,6 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		}
 	}
 
-	.login__form-footer {
-		text-align: center;
-		.button {
-			max-width: 310px;
-			height: 48px;
-
-			&.is-primary {
-				border: 0;
-			}
-		}
-	}
-
 	.layout__content {
 		padding-top: 48px;
 	}
@@ -205,11 +193,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		display: none;
 	}
 
-	.wp-login__footer-links {
-		display: none;
-	}
-
-	.login__woocommerce-logo {
+	.signup-form__woocommerce-wrapper {
 		text-align: center;
 		border-bottom: 1px solid var( --color-neutral-50 );
 		position: absolute;
@@ -223,7 +207,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		}
 	}
 
-	.connect-header {
+	.signup-form__woocommerce-logo {
 		margin: 0;
 		text-align: center;
 		margin-right: auto;
@@ -239,7 +223,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		}
 	}
 
-	.login__form-header {
+	.signup-form__woocommerce-heading {
 		margin-top: 32px;
 	}
 
@@ -249,7 +233,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		margin-left: auto;
 
 		.formatted-header__subtitle {
-			color: var( --color-primary-100 );
+			color: var( --color-primary-10 );
 			margin-top: 1em;
 			font-size: 16px;
 			line-height: 24px;
@@ -264,14 +248,19 @@ body.is-section-signup .layout.gravatar .formatted-header {
 	.logged-out-form__link-item {
 		text-align: center;
 		text-decoration: underline;
-		color: var( --color-gray-600 );
+		color: var( --studio-gray-60 );
 		font-size: 14px;
 	}
 
-	.signup-form__terms-of-service-link,
-	.signup-form__terms-of-service-link a {
+	.signup-form__terms-of-service-link {
 		text-align: left;
-		color: var( --color-gray-600 );
+		color: var( --studio-gray-60 );
+	}
+
+	.signup-form__terms-of-service-link a,
+	.signup-form__social-buttons-tos a {
+		color: var( --studio-gray-60 );
+		text-decoration: underline;
 	}
 
 	.signup-form__social {
@@ -279,7 +268,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		margin-top: 16px;
 		p {
 			font-size: 12px;
-			color: var( --color-gray-600 );
+			color: var( --studio-gray-60 );
 		}
 
 		.social-buttons__button {


### PR DESCRIPTION
Note that the flows affected in this PR are currently behind a feature flag while onboarding work is ongoing in WooCommerce Core. Please see 22a33-pb for designs of these flows.

* This PR adjust some incorrect class names on the signup route. See https://github.com/Automattic/wp-calypso/pull/35193#issuecomment-535917270 and my follow up comment.
* Makes term of services links clearer and fixes display of updated social buttons.
* This PR also adjusts the colors of the 'cart header' that will display in certain WooCommerce.com OAuth flows.

#### Testing instructions

We are going to work on a test build of the onboarding code that will make testing things easier, but in the meantime the best way to load these is the following:

* `npm start` this branch
* Install WooCommerce
* Install WooCommerce Admin from GitHub (https://github.com/woocommerce/woocommerce-admin) and `npm run dev`.
* `define( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT', 'development' );` in your wp-config.php.
* `define( 'WP_DEBUG', true );` in your wp-config.php.
* Go to `/wp-admin/edit.php?post_type=shop_order` and click the Help Tab.
* Under Setup Wizard you should see `Quickly access the WooCommerce.com connection flow in Calypso.`. Click the connect button here.
* Visually inspect the signup and login pages.
* You can change `wccom-from` in the query string to `wccom-from=cart` to test the cart header display.

#### Screenshots

<img width="1543" alt="Screen Shot 2019-09-30 at 10 54 32 AM" src="https://user-images.githubusercontent.com/689165/65892538-78912380-e374-11e9-90bf-cf892fac6627.png">

<img width="1241" alt="Screen Shot 2019-09-30 at 10 54 42 AM" src="https://user-images.githubusercontent.com/689165/65892545-7e870480-e374-11e9-98fb-46ae8b6bd022.png">


