### PR TITLE
Wait for popover content before selecting "Private" option

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import webdriver from 'selenium-webdriver';
+import webdriver, { until } from 'selenium-webdriver';
 import config from 'config';
 import { forEach } from 'lodash';
 
@@ -551,4 +551,9 @@ export async function acceptAlertIfPresent( driver ) {
 	} catch ( error ) {
 		return false;
 	}
+}
+
+export async function waitForAlertPresent( driver ) {
+	console.log( this.explicitWaitMS );
+	return await driver.wait( until.alertIsPresent(), this.explicitWaitMS, 'Alert is not present.' );
 }

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -554,6 +554,5 @@ export async function acceptAlertIfPresent( driver ) {
 }
 
 export async function waitForAlertPresent( driver ) {
-	console.log( this.explicitWaitMS );
 	return await driver.wait( until.alertIsPresent(), this.explicitWaitMS, 'Alert is not present.' );
 }

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -223,15 +223,13 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			this.driver,
 			By.css( '.edit-post-post-visibility__toggle' )
 		);
-		await driverHelper.waitTillPresentAndDisplayed(
+		await this.driver.sleep( 1000 );
+		await driverHelper.setCheckbox(
 			this.driver,
-			By.css( '.editor-post-visibility__choice' )
+			By.css( 'input#editor-post-private-0[value="private"]' )
 		);
-		await driverHelper.selectElementByText(
-			this.driver,
-			By.css( '.editor-post-visibility__dialog-label' ),
-			'Private'
-		);
+
+		await driverHelper.waitForAlertPresent( this.driver );
 		const publishPrivateAlert = await this.driver.switchTo().alert();
 		return await publishPrivateAlert.accept();
 	}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -223,7 +223,7 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			this.driver,
 			By.css( '.edit-post-post-visibility__toggle' )
 		);
-		await this.driver.sleep( 1000 );
+		await this.driver.sleep( 1000 ); // wait for popover to be fully loaded
 		await driverHelper.setCheckbox(
 			this.driver,
 			By.css( 'input#editor-post-private-0[value="private"]' )

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -223,6 +223,10 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			this.driver,
 			By.css( '.edit-post-post-visibility__toggle' )
 		);
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.editor-post-visibility__choice' )
+		);
 		await driverHelper.selectElementByText(
 			this.driver,
 			By.css( '.editor-post-visibility__dialog-label' ),


### PR DESCRIPTION
We have a situation where, occasionally, tests `Calypso Gutenberg Editor: Private Posts` and `Calypso Gutenberg Editor: Private Pages` are failing with the error `no such alert` ([example](https://circleci.com/gh/Automattic/wp-calypso/442170)) when test user tries to make post/page private. 

[Steps are](https://github.com/Automattic/wp-calypso/blob/master/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js#L221-L233): Click on "Public" -> Wait for popover to load -> select "Private" -> Accept alert
It's strange that we are using the same `setVisibilityToPrivate` function for classic editor tests also, but this error has never happened there. 

<img width="268" alt="Screen Shot 2019-09-30 at 15 46 42" src="https://user-images.githubusercontent.com/7116222/65972769-9ccf2c00-e46a-11e9-9cc7-cb0f3679c926.png">

While testing this locally I found two issues here:
1. Clicking on "Private" doesn't happen because popover is loaded, but "Private" is not clickable yet. Test pass that step as it actually clicked on "private" but fails on the next step. I tried to avoid [adding `driver.sleep( 1000 );`](https://github.com/Automattic/wp-calypso/pull/36433/files#diff-04fc2edc6ef2941b15a504ffdc6afbbbR226) to wait for popover to load, but that was the only solution which I found to work. 
2. After clicking on "Private" option alert should pop up and test switch focus on it, but sometimes test switches to fast and cannot find the alert. [I added additional function](https://github.com/Automattic/wp-calypso/pull/36433/files#diff-04fc2edc6ef2941b15a504ffdc6afbbbR232) to wait for the alert to show up first.  