### PR TITLE
Checkout: Show error if no paypal url is returned in PayPal form

### DIFF
--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import { assign, overSome, some } from 'lodash';
 import React from 'react';
 import Gridicon from 'components/gridicon';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -29,6 +30,8 @@ import RecentRenewals from './recent-renewals';
 import CheckoutTerms from './checkout-terms';
 
 const wpcom = wp.undocumented();
+
+const debug = debugFactory( 'calypso:paypal-payment-box' );
 
 export class PaypalPaymentBox extends React.Component {
 	static displayName = 'PaypalPaymentBox';
@@ -92,32 +95,42 @@ export class PaypalPaymentBox extends React.Component {
 		} );
 
 		// get PayPal Express URL from rest endpoint
+		debug( 'submitting paypalExpress request', dataForApi );
 		wpcom.paypalExpressUrl(
 			dataForApi,
 			function( error, paypalExpressURL ) {
-				let errorMessage;
+				debug( 'paypalExpress request complete' );
 				if ( error ) {
-					if ( error.message ) {
-						errorMessage = error.message;
-					} else {
-						errorMessage = this.props.translate( 'Please specify a country and postal code' );
-					}
-
+					debug( 'paypalExpress request had an error', error );
+					const errorMessage =
+						error.message || this.props.translate( 'Please specify a country and postal code' );
 					this.setSubmitState( {
 						error: errorMessage,
 						disabled: false,
 					} );
+					return;
 				}
 
-				if ( paypalExpressURL ) {
+				if ( ! paypalExpressURL ) {
+					debug( 'paypalExpress request returned no url' );
+					const errorMessage = this.props.translate(
+						'An error occurred connecting to PayPal; please check your information and try again'
+					);
 					this.setSubmitState( {
-						info: this.props.translate( 'Redirecting you to PayPal' ),
-						disabled: true,
+						error: errorMessage,
+						disabled: false,
 					} );
-					analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Paypal Button' );
-					analytics.tracks.recordEvent( 'calypso_checkout_with_paypal' );
-					window.location = paypalExpressURL;
+					return;
 				}
+
+				debug( 'paypalExpress request successfully got a url', paypalExpressURL );
+				this.setSubmitState( {
+					info: this.props.translate( 'Redirecting you to PayPal' ),
+					disabled: true,
+				} );
+				analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Paypal Button' );
+				analytics.tracks.recordEvent( 'calypso_checkout_with_paypal' );
+				window.location = paypalExpressURL;
 			}.bind( this )
 		);
 	};


### PR DESCRIPTION
The `PaypalPaymentBox` sends its information to `wpcom.paypalExpressUrl()` with a callback. When the callback is called, it's supposed to be passed either an error or a URL for the PayPal Express redirect. However, it's possible for it to be passed nothing at all. In that case, the user will see the "Submitting" state forever.

This change shows a generic error in case the callback gets neither an error nor a URL. It's better than nothing.

See also D33357-code which begins addressing the issue that causes these errors on the server side.

#### Testing instructions

Cause the API endpoint `/rest/v1.1/me/paypal-express-url` to return an empty response. You can do this by applying D33473-code.

Next, add a plan to your cart, visit the checkout page, select the PayPal tab, then press the "Pay" button. You should shortly see an error message and be able to re-submit the form. Prior to this change you would see the "Sending" notice forever and the form would remain disabled.