### PR TITLE
People: Allow token field inputs to grow for right-clicks

### DIFF
--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -36,6 +36,7 @@
 // Token input
 input[type='text'].token-field__input {
 	display: inline-block;
+	flex-grow: 1;
 	width: auto;
 	max-width: 100%;
 	margin: 2px 0 2px 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `flex-grow: 1` for `input[type='text'].token-field__input` 
* Otherwise, right-click won't give the paste option unless clicking in the very small empty input field width.

#### Testing instructions

Before:

![before](https://user-images.githubusercontent.com/15803018/65928913-fc6efe00-e3bc-11e9-99b2-d73fb05ee9c2.gif)

After:

![after](https://user-images.githubusercontent.com/15803018/65928922-01cc4880-e3bd-11e9-8c51-6f5985f165a5.gif)

Fixes #35514 

CC: @porada Would this be an acceptable fix? There is still some padding from `token-field__input-container` that is not right-clickable, though this change should create much more success with right-clicking to paste.