### PR TITLE
Signup: Record event when user goes back to user step after si…

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import React, { Component } from 'react';
+import React, { Component, useEffect } from 'react';
 import { connect } from 'react-redux';
 import {
 	camelCase,
@@ -747,12 +744,16 @@ class SignupForm extends Component {
 			return this.globalNotice( this.state.notice );
 		}
 		if ( this.userCreationComplete() ) {
-			return this.globalNotice( {
-				info: true,
-				message: this.props.translate(
-					'Your account has already been created. You can change your email, username, and password later.'
-				),
-			} );
+			return (
+				<TrackRender eventName="calypso_signup_account_already_created_show">
+					{ this.globalNotice( {
+						info: true,
+						message: this.props.translate(
+							'Your account has already been created. You can change your email, username, and password later.'
+						),
+					} ) }
+				</TrackRender>
+			);
 		}
 		return false;
 	}
@@ -929,6 +930,14 @@ class SignupForm extends Component {
 			</div>
 		);
 	}
+}
+
+function TrackRender( { children, eventName } ) {
+	useEffect( () => {
+		analytics.tracks.recordEvent( eventName );
+	}, [] );
+
+	return children;
 }
 
 export default connect(

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -935,7 +935,7 @@ class SignupForm extends Component {
 function TrackRender( { children, eventName } ) {
 	useEffect( () => {
 		analytics.tracks.recordEvent( eventName );
-	}, [] );
+	}, [ eventName ] );
 
 	return children;
 }


### PR DESCRIPTION
Want a new event to track when the "Your account has already been created" notice is shown on the user step.

The logic for when this notice is shown is spread across a number of places (both in `render` and `getNotice`). So I've created a small utility component fires an event when a part of the UI is mounted. This way the track event is sharing the same logic as the rendering code.

Hoping this will help when analysing impact for for Automattic/zelda-private#164

p1569618088090200-slack-CCS1W9QVA

#### Changes proposed in this Pull Request

* Create `<TrackRender>` component that sends an event when a part of the UI is mounted.
* Wrap the "Your account has already been created" notice in `<TrackRender>`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Filter network tab by `calypso_signup_account_already_created_show`

* Create a new account with the happy path, event is not sent
* Create an account, before completing signup go back to the user step, event is sent
* Create an account, go forwards and back to the user step, event is sent multiple times
* Create a new account via crowdsignal, event is not sent
* `calypso_signup_account_already_created_show` events should appear in live view