### PR TITLE
Hosting Panel: Hook up UI to hosting panel API

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -20,6 +20,7 @@ import CardHeading from 'components/card-heading';
 import Button from 'components/button';
 import MaterialIcon from 'components/material-icon';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { requestAtomicSFTPDetails } from 'state/data-getters';
 
 /**
  * Style dependencies
@@ -86,8 +87,15 @@ const Hosting = ( { translate } ) => {
 	);
 };
 
-export default connect( state => ( {
-	site: getSelectedSite( state ),
-	siteId: getSelectedSiteId( state ),
-	siteSlug: getSelectedSiteSlug( state ),
-} ) )( localize( Hosting ) );
+export default connect( state => {
+    
+	const atomicSFTPDetails = requestAtomicSFTPDetails( getSelectedSiteId( state ) );
+
+	return {
+		atomicSFTPDetails,
+        site: getSelectedSite( state ),
+        siteId: getSelectedSiteId( state ),
+        siteSlug: getSelectedSiteSlug( state ),
+    };
+    
+} )( localize( Hosting ) );

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -5,7 +5,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,87 +14,33 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
-import Card from 'components/card';
-import CardHeading from 'components/card-heading';
-import Button from 'components/button';
-import MaterialIcon from 'components/material-icon';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { requestAtomicSFTPDetails } from 'state/data-getters';
+import SFTPCard from './sftp-card';
+import PhpMyAdminCard from './phpmyadmin-card';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const DataSection = ( { title, data } ) => {
-	return (
-		<tr>
-			<th>{ title }:</th>
-			<td>{ data }</td>
-		</tr>
-	);
-};
-
 const Hosting = ( { translate } ) => {
-	const dummyInfo = {
-		[ translate( 'URL' ) ]: 'sftp1.wordpress.com',
-		[ translate( 'Port' ) ]: 22,
-		[ translate( 'Username' ) ]: 'test',
-		[ translate( 'Password' ) ]: 'test',
-	};
-
 	return (
 		<Main className="hosting is-wide-layout">
 			<PageViewTracker path="hosting/:site" title="Hosting" />
 			<DocumentHead title={ translate( 'Hosting' ) } />
 			<SidebarNavigation />
 			<div className="hosting__cards">
-				<Card>
-					<div className="hosting__card-icon-col">
-						<MaterialIcon className="hosting__card-icon" icon="cloud" size={ 32 } />
-					</div>
-					<div className="hosting__card-col">
-						<CardHeading>{ translate( 'SFTP Information' ) }</CardHeading>
-						<p>
-							{ translate( "Access and edit your website's files directly using an FTP client." ) }
-						</p>
-						<table className="hosting__info-table">
-							<tbody>
-								{ map( dummyInfo, ( data, title ) => (
-									<DataSection key={ title } { ...{ data, title } } />
-								) ) }
-							</tbody>
-						</table>
-					</div>
-				</Card>
-				<Card>
-					<div className="hosting__card-icon-col">
-						<MaterialIcon className="hosting__card-icon" icon="dns" size={ 32 } />
-					</div>
-					<div className="hosting__card-col">
-						<CardHeading>{ translate( 'Database Access' ) }</CardHeading>
-						<p>
-							{ translate(
-								'Manage your databases with PHPMyAdmin and run a wide range of operations with MySQL.'
-							) }
-						</p>
-						<Button>{ translate( 'Access PHPMyAdmin' ) }</Button>
-					</div>
-				</Card>
+				<SFTPCard />
+				<PhpMyAdminCard />
 			</div>
 		</Main>
 	);
 };
 
 export default connect( state => {
-    
-	const atomicSFTPDetails = requestAtomicSFTPDetails( getSelectedSiteId( state ) );
-
 	return {
-		atomicSFTPDetails,
-        site: getSelectedSite( state ),
-        siteId: getSelectedSiteId( state ),
-        siteSlug: getSelectedSiteSlug( state ),
-    };
-    
+		site: getSelectedSite( state ),
+		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state ),
+	};
 } )( localize( Hosting ) );

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -34,19 +34,19 @@ const PhpMyAdminCard = ( { translate, siteId } ) => {
 
 	return (
 		<Card>
-			<div className="hosting__card-icon-col">
-				<MaterialIcon className="hosting__card-icon" icon="dns" size={ 32 } />
+			<div className="phpmyadmin-card__icon-col">
+				<MaterialIcon icon="dns" size={ 32 } />
 			</div>
-			<div className="hosting__card-col">
-				<CardHeading>
-					{ translate( 'Database Access' ) }
-				</CardHeading>
+			<div>
+				<CardHeading>{ translate( 'Database Access' ) }</CardHeading>
 				<p>
 					{ translate(
 						'Manage your databases with PHPMyAdmin and run a wide range of operations with MySQL.'
 					) }
 				</p>
-				<Button onClick={ handlePmaLogin } busy={ loading }>{ translate( 'Access PHPMyAdmin' ) }</Button>
+				<Button onClick={ handlePmaLogin } busy={ loading }>
+					{ translate( 'Access PHPMyAdmin' ) }
+				</Button>
 			</div>
 		</Card>
 	);
@@ -54,6 +54,6 @@ const PhpMyAdminCard = ( { translate, siteId } ) => {
 
 export default connect( state => {
 	return {
-		siteId: getSelectedSiteId( state )
+		siteId: getSelectedSiteId( state ),
 	};
 } )( localize( PhpMyAdminCard ) );

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CardHeading from 'components/card-heading';
+import MaterialIcon from 'components/material-icon';
+import Button from 'components/button';
+
+const PhpMyAdminCard = ( { translate } ) => {
+	return (
+		<Card>
+			<div className="hosting__card-icon-col">
+				<MaterialIcon className="hosting__card-icon" icon="dns" size={ 32 } />
+			</div>
+			<div className="hosting__card-col">
+				<CardHeading>{ translate( 'Database Access' ) }</CardHeading>
+				<p>
+					{ translate(
+						'Manage your databases with PHPMyAdmin and run a wide range of operations with MySQL.'
+					) }
+				</p>
+				<Button>{ translate( 'Access PHPMyAdmin' ) }</Button>
+			</div>
+		</Card>
+	);
+};
+
+export default localize( PhpMyAdminCard );

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -3,8 +3,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,24 +15,45 @@ import Card from 'components/card';
 import CardHeading from 'components/card-heading';
 import MaterialIcon from 'components/material-icon';
 import Button from 'components/button';
+import { requestPmaLink } from 'state/data-getters';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-const PhpMyAdminCard = ( { translate } ) => {
+const PhpMyAdminCard = ( { translate, siteId } ) => {
+	const [ request, setRequest ] = useState( null );
+
+	const pmaLink = get( request, 'data.pmaLink', null );
+	const loading = get( request, 'status', null ) === 'pending';
+
+	if ( pmaLink ) {
+		window.open( pmaLink );
+	}
+
+	const handlePmaLogin = () => {
+		setRequest( requestPmaLink( siteId ) );
+	};
+
 	return (
 		<Card>
 			<div className="hosting__card-icon-col">
 				<MaterialIcon className="hosting__card-icon" icon="dns" size={ 32 } />
 			</div>
 			<div className="hosting__card-col">
-				<CardHeading>{ translate( 'Database Access' ) }</CardHeading>
+				<CardHeading>
+					{ translate( 'Database Access' ) }
+				</CardHeading>
 				<p>
 					{ translate(
 						'Manage your databases with PHPMyAdmin and run a wide range of operations with MySQL.'
 					) }
 				</p>
-				<Button>{ translate( 'Access PHPMyAdmin' ) }</Button>
+				<Button onClick={ handlePmaLogin } busy={ loading }>{ translate( 'Access PHPMyAdmin' ) }</Button>
 			</div>
 		</Card>
 	);
 };
 
-export default localize( PhpMyAdminCard );
+export default connect( state => {
+	return {
+		siteId: getSelectedSiteId( state )
+	};
+} )( localize( PhpMyAdminCard ) );

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -59,7 +59,7 @@ const SFTPCard = ( { translate, username, password, errorCode, siteId, loading }
 				<table className={ classNames( 'hosting__info-table', { [ 'is-placeholder' ]: loading } ) }>
 					<tbody>
 						{ map( sftpData, ( data, title ) => (
-							<tr>
+							<tr key={ title } >
 								<th>{ title }:</th>
 								<td>
 									<span>{ ! loading && data }</span>

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -32,14 +32,14 @@ const SFTPCard = ( { translate, username, password, errorCode, siteId, loading }
 
 	return (
 		<Card>
-			<div className="hosting__icon-col">
-				<MaterialIcon className="hosting__card-icon" icon="cloud" size={ 32 } />
+			<div className="sftp-card__icon-col">
+				<MaterialIcon icon="cloud" size={ 32 } />
 			</div>
-			<div className="hosting__card-col">
+			<div>
 				<CardHeading>{ translate( 'SFTP Information' ) }</CardHeading>
 				<p>{ translate( "Access and edit your website's files directly using an FTP client." ) }</p>
 				{ password && (
-					<div className="hosting__callout-box">
+					<div className="sftp-card__callout-box">
 						<p>{ translate( 'Your new password for your sftp user is:' ) }</p>
 						<p>
 							<code>{ password }</code>
@@ -56,10 +56,12 @@ const SFTPCard = ( { translate, username, password, errorCode, siteId, loading }
 						Create SFTP User
 					</Button>
 				) }
-				<table className={ classNames( 'hosting__info-table', { [ 'is-placeholder' ]: loading } ) }>
+				<table
+					className={ classNames( 'sftp-card__info-table', { [ 'is-placeholder' ]: loading } ) }
+				>
 					<tbody>
 						{ map( sftpData, ( data, title ) => (
-							<tr key={ title } >
+							<tr key={ title }>
 								<th>{ title }:</th>
 								<td>
 									<span>{ ! loading && data }</span>

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -1,0 +1,99 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get, map } from 'lodash';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CardHeading from 'components/card-heading';
+import MaterialIcon from 'components/material-icon';
+import Button from 'components/button';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	requestAtomicSFTPDetails,
+	resetAtomicSFTPUserPassword,
+	createAtomicSFTPUser,
+} from 'state/data-getters';
+
+const SFTPCard = ( { translate, username, password, errorCode, siteId, loading } ) => {
+	const sftpData = {
+		[ translate( 'URL' ) ]: 'sftp1.wordpress.com',
+		[ translate( 'Port' ) ]: 22,
+		[ translate( 'Username' ) ]: username,
+	};
+
+	return (
+		<Card>
+			<div className="hosting__icon-col">
+				<MaterialIcon className="hosting__card-icon" icon="cloud" size={ 32 } />
+			</div>
+			<div className="hosting__card-col">
+				<CardHeading>{ translate( 'SFTP Information' ) }</CardHeading>
+				<p>{ translate( "Access and edit your website's files directly using an FTP client." ) }</p>
+				{ password && (
+					<div className="hosting__callout-box">
+						<p>{ translate( 'Your new password for your sftp user is:' ) }</p>
+						<p>
+							<code>{ password }</code>
+						</p>
+						<strong>
+							{ translate(
+								'Make sure to save this password in a safe place! You will need to reset this password if you lose it.'
+							) }
+						</strong>
+					</div>
+				) }
+				{ errorCode === 404 && (
+					<Button onClick={ createAtomicSFTPUser } primary>
+						Create SFTP User
+					</Button>
+				) }
+				<table className={ classNames( 'hosting__info-table', { [ 'is-placeholder' ]: loading } ) }>
+					<tbody>
+						{ map( sftpData, ( data, title ) => (
+							<tr>
+								<th>{ title }:</th>
+								<td>
+									<span>{ ! loading && data }</span>
+								</td>
+							</tr>
+						) ) }
+						<tr>
+							<th>{ translate( 'Password' ) }:</th>
+							<td>
+								<Button
+									onClick={ () => resetAtomicSFTPUserPassword( siteId ) }
+									disabled={ loading }
+								>
+									{ translate( 'Reset Password' ) }
+								</Button>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</Card>
+	);
+};
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const sftpDetails = requestAtomicSFTPDetails( siteId );
+	const username = get( sftpDetails, 'data.username', null );
+
+	return {
+		siteId,
+		username,
+		password: get( sftpDetails, 'data.password', null ),
+		errorCode: get( sftpDetails, 'error.status', null ),
+		loading: get( sftpDetails, 'status', null ) === 'pending' || ! username,
+	};
+} )( localize( SFTPCard ) );

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -18,7 +18,11 @@
         }
 
 		@include breakpoint( '>1280px' ) {
-			width: calc( 50% - 10px );
+            width: calc( 40% - 10px );
+            
+            &:first-child {
+                width: calc( 60% - 10px );
+            }
 		}
 	}
 }
@@ -30,6 +34,7 @@
 
 .hosting__info-table {
     border: 1px solid var( --color-border-subtle );
+    margin-top: 15px;
 
     th {
         text-align: right;
@@ -39,4 +44,15 @@
     th, td {
         padding: 10px;
     }
+
+    &.is-placeholder span {
+        padding: 0 35%;
+        background-color: var( --color-surface-backdrop );
+    }
+}
+
+.hosting__callout-box {
+    border: 1px solid var( --color-accent );
+    padding: 10px;
+    margin: 10px 0;
 }

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -27,12 +27,12 @@
 	}
 }
 
-.hosting__card-icon-col {
+.phpmyadmin-card__icon-col, .sftp-card__icon-col {
     margin-right: 24px;
     height: 100%;
 }
 
-.hosting__info-table {
+.sftp-card__info-table {
     border: 1px solid var( --color-border-subtle );
     margin-top: 15px;
 
@@ -51,7 +51,7 @@
     }
 }
 
-.hosting__callout-box {
+.sftp-card__callout-box {
     border: 1px solid var( --color-accent );
     padding: 10px;
     margin: 10px 0;

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -209,3 +209,21 @@ export const requestSiteAlerts = siteId => {
 		}
 	);
 };
+
+export const requestAtomicSFTPDetails = siteId =>
+	requestHttpData(
+		`atomic-hosting-data-${ siteId }`,
+		http(
+			{
+				method: 'GET',
+				path: `/sites/${ siteId }/hosting/sftp`,
+				apiNamespace: 'wpcom/v2',
+			},
+			{}
+		),
+		{
+			fromApi: () => data => {
+				return [ 'sftpData', data ];
+			},
+		}
+	);

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -268,18 +268,3 @@ export const createAtomicSFTPUser = siteId =>
 			freshness: 0,
 		}
 	);
-
-export const requestPmaLink = siteId => 
-	requestHttpData(
-		`pma-link-request-${ siteId }`,
-		http( {
-			method: 'GET',
-			path: `/sites/${ siteId }/hosting/pma`,
-			apiNamespace: 'wpcom/v2',
-		}, {} ),
-		{
-			fromApi: () => ( { pmaUrl } ) => { 
-				return [ [ `pma-link-request-${ siteId }`, { pmaUrl } ] ];
-			},
-		}
-	);

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -268,3 +268,18 @@ export const createAtomicSFTPUser = siteId =>
 			freshness: 0,
 		}
 	);
+
+export const requestPmaLink = siteId => 
+	requestHttpData(
+		`pma-link-request-${ siteId }`,
+		http( {
+			method: 'GET',
+			path: `/sites/${ siteId }/hosting/pma`,
+			apiNamespace: 'wpcom/v2',
+		}, {} ),
+		{
+			fromApi: () => ( { pmaUrl } ) => { 
+				return [ [ `pma-link-request-${ siteId }`, { pmaUrl } ] ];
+			},
+		}
+	);

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -216,14 +216,55 @@ export const requestAtomicSFTPDetails = siteId =>
 		http(
 			{
 				method: 'GET',
-				path: `/sites/${ siteId }/hosting/sftp`,
+				path: `/sites/${ siteId }/hosting/ssh`,
 				apiNamespace: 'wpcom/v2',
 			},
 			{}
 		),
 		{
-			fromApi: () => data => {
-				return [ 'sftpData', data ];
+			freshness: 5 * 60 * 1000,
+			fromApi: () => ( { username } ) => {
+				return [ `atomic-hosting-data-${ siteId }`, { username } ];
 			},
+		}
+	);
+
+export const resetAtomicSFTPUserPassword = siteId =>
+	requestHttpData(
+		`atomic-hosting-data-${ siteId }`,
+		http(
+			{
+				method: 'POST',
+				path: `/sites/${ siteId }/hosting/ssh/reset-password`,
+				apiNamespace: 'wpcom/v2',
+				body: {},
+			},
+			{}
+		),
+		{
+			fromApi: () => ( { username, password } ) => {
+				return [ `atomic-hosting-data-${ siteId }`, { username, password } ];
+			},
+			freshness: 0,
+		}
+	);
+
+export const createAtomicSFTPUser = siteId =>
+	requestHttpData(
+		`atomic-hosting-data-${ siteId }`,
+		http(
+			{
+				method: 'POST',
+				path: `/sites/${ siteId }/hosting/ssh`,
+				apiNamespace: 'wpcom/v2',
+				body: {},
+			},
+			{}
+		),
+		{
+			fromApi: () => ( { username, password } ) => {
+				return [ `atomic-hosting-data-${ siteId }`, { username, password } ];
+			},
+			freshness: 0,
 		}
 	);


### PR DESCRIPTION
### Summary

This PR hooks up the existing stubbed-out UI for the Atomic Hosting panel to the API provided by some in-progress diffs for manipulating STFP users and providing a log-in link for PHPMyAdmin.

<hr>

### User flows

* **A user visits the hosting panel for the first time.** An SFTP user does not yet exist, so they see (b), prompting them to create a new user.
    * After clicking the button to create a new SFTP user, they see (c), which displays their password and the other SFTP information. It warns them to save the password, because there is no way to recover it once they navigate away. The password callout is temporary and will disappear on navigation or page reload.
* **A user visits the hosting panel when they have already created an SFTP user.** They will see (d), showing their SFTP username and other information. The password for their SFTP user is not recoverable.
    * They can choose to reset the password for their SFTP user. When they click the "Reset Password" button, they will see (c), which will display a password callout letting them know what their new password is and warning them to save it because they will not see it again once navigating away.

For the PHPMyAdmin panel, the user clicks the button and a new tab is opened directing to PHPMyAdmin for their site.

## a) Loading state:
<img width="1115" alt="Screen Shot 2019-10-15 at 4 31 43 PM" src="https://user-images.githubusercontent.com/8892849/66867817-189c9e80-ef6a-11e9-9f3d-f2bad61b1e40.png">

## b) New interaction state
(When SFTP user doesn't exist yet.)

<img width="1071" alt="Screen Shot 2019-10-15 at 4 33 17 PM" src="https://user-images.githubusercontent.com/8892849/66867850-294d1480-ef6a-11e9-9580-7dd12d23c1ea.png">

## c) With password callout
(After creating a new SFTP user or resetting the user password. The only time the password is displayed.)

<img width="1062" alt="Screen Shot 2019-10-15 at 4 32 27 PM" src="https://user-images.githubusercontent.com/8892849/66867900-42ee5c00-ef6a-11e9-8e8f-48d0af9e3f35.png">

## d) Default state when an SFTP user exists
<img width="1110" alt="Screen Shot 2019-10-15 at 4 28 52 PM" src="https://user-images.githubusercontent.com/8892849/66867987-78934500-ef6a-11e9-8dbf-50fd2410320c.png">

<hr>

### Testing

* Apply D33899-code and D33970-code to your sandbox.
* Spin up this branch in a local calypso environment.
* Go to `http://calypso.localhost:3000/hosting/your.atomic.site`.
* **SFTP Card:**
    * When first viewing the page, a button should appear in the card prompting you to create a new SFTP user.
    * After clicking the button, the table in the SFTP card should show your SFTP user details and there should also be a password callout in the card.
    * After an SFTP user has been created, the card should display your SFTP user details, but not the password, on page load.
    * Clicking the 'Reset Password' button should show the password callout in the card again with your new password.
* **PHPMyAdmin Card:**
    * The card should display a button. Clicking the button should open a new tab with the PHPMyAdmin panel for your site.

Fixes #35452