### PR TITLE
SIWA: Add support for the redirect flow

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -108,11 +108,19 @@ class SocialLoginForm extends Component {
 	};
 
 	handleAppleResponse = response => {
-		const { onSuccess, redirectTo } = this.props;
+		const { onSuccess, socialService } = this.props;
+		let redirectTo = this.props.redirectTo;
 
 		if ( ! response.id_token ) {
 			return;
 		}
+
+		// load persisted redirect_to url from session storage, needed for redirect_to to work with apple redirect flow
+		if ( socialService === 'apple' && ! redirectTo ) {
+			redirectTo = window.sessionStorage.getItem( 'login_redirect_to' );
+		}
+
+		window.sessionStorage.removeItem( 'login_redirect_to' );
 
 		const user = response.user || {};
 
@@ -157,7 +165,7 @@ class SocialLoginForm extends Component {
 			...params,
 		} );
 
-	trackLogin = service => {
+	trackLoginAndRememberRedirect = service => {
 		this.recordEvent( 'calypso_login_social_button_click', service );
 
 		if ( this.props.redirectTo ) {
@@ -166,10 +174,13 @@ class SocialLoginForm extends Component {
 	};
 
 	getRedirectUrl = ( uxMode, service ) => {
-		return uxMode
-			? `https://${ ( typeof window !== 'undefined' && window.location.host ) +
-					login( { isNative: true, socialService: service } ) }`
-			: null;
+		const host = typeof window !== 'undefined' && window.location.host;
+
+		if ( ! host || uxMode !== 'redirect' ) {
+			return null;
+		}
+
+		return `https://${ host + login( { isNative: true, socialService: service } ) }`;
 	};
 
 	render() {
@@ -182,12 +193,21 @@ class SocialLoginForm extends Component {
 						responseHandler={ this.handleGoogleResponse }
 						uxMode={ uxMode }
 						redirectUri={ this.getRedirectUrl( uxMode, 'google' ) }
-						onClick={ this.trackLogin.bind( null, 'google' ) }
+						onClick={ this.trackLoginAndRememberRedirect.bind( null, 'google' ) }
+						socialServiceResponse={
+							this.props.socialService === 'google' ? this.props.socialServiceResponse : null
+						}
 					/>
 
 					<AppleLoginButton
+						clientId={ config( 'apple_oauth_client_id' ) }
 						responseHandler={ this.handleAppleResponse }
-						onClick={ this.trackLogin.bind( null, 'apple' ) }
+						uxMode="redirect"
+						redirectUri={ this.getRedirectUrl( uxMode, 'apple' ) }
+						onClick={ this.trackLoginAndRememberRedirect.bind( null, 'apple' ) }
+						socialServiceResponse={
+							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
+						}
 					/>
 
 					<p className="login__social-tos">

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -185,6 +185,8 @@ class SocialLoginForm extends Component {
 
 	render() {
 		const { redirectTo, uxMode } = this.props;
+		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : 'popup';
+
 		return (
 			<Card className="login__social">
 				<div className="login__social-buttons">
@@ -202,7 +204,7 @@ class SocialLoginForm extends Component {
 					<AppleLoginButton
 						clientId={ config( 'apple_oauth_client_id' ) }
 						responseHandler={ this.handleAppleResponse }
-						uxMode="redirect"
+						uxMode={ uxModeApple }
 						redirectUri={ this.getRedirectUrl( uxMode, 'apple' ) }
 						onClick={ this.trackLoginAndRememberRedirect.bind( null, 'apple' ) }
 						socialServiceResponse={

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -173,7 +173,7 @@ class SocialLoginForm extends Component {
 		}
 	};
 
-	getRedirectUrl = ( uxMode, service ) => {
+	getRedirectUrl = service => {
 		const host = typeof window !== 'undefined' && window.location.host;
 		return `https://${ host + login( { isNative: true, socialService: service } ) }`;
 	};
@@ -189,7 +189,7 @@ class SocialLoginForm extends Component {
 						clientId={ config( 'google_oauth_client_id' ) }
 						responseHandler={ this.handleGoogleResponse }
 						uxMode={ uxMode }
-						redirectUri={ this.getRedirectUrl( uxMode, 'google' ) }
+						redirectUri={ this.getRedirectUrl( 'google' ) }
 						onClick={ this.trackLoginAndRememberRedirect.bind( null, 'google' ) }
 						socialServiceResponse={
 							this.props.socialService === 'google' ? this.props.socialServiceResponse : null
@@ -200,7 +200,7 @@ class SocialLoginForm extends Component {
 						clientId={ config( 'apple_oauth_client_id' ) }
 						responseHandler={ this.handleAppleResponse }
 						uxMode={ uxModeApple }
-						redirectUri={ this.getRedirectUrl( uxMode, 'apple' ) }
+						redirectUri={ this.getRedirectUrl( 'apple' ) }
 						onClick={ this.trackLoginAndRememberRedirect.bind( null, 'apple' ) }
 						socialServiceResponse={
 							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -175,17 +175,12 @@ class SocialLoginForm extends Component {
 
 	getRedirectUrl = ( uxMode, service ) => {
 		const host = typeof window !== 'undefined' && window.location.host;
-
-		if ( ! host || uxMode !== 'redirect' ) {
-			return null;
-		}
-
 		return `https://${ host + login( { isNative: true, socialService: service } ) }`;
 	};
 
 	render() {
 		const { redirectTo, uxMode } = this.props;
-		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : 'popup';
+		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
 
 		return (
 			<Card className="login__social">

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -82,8 +82,8 @@ class SocialSignupForm extends Component {
 	render() {
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
 		const host = typeof window !== 'undefined' && window.location.host;
-		const redirectUri = host ? `https://${ host }/start/user` : null;
-		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : 'popup';
+		const redirectUri = `https://${ host }/start/user`;
+		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
 
 		return (
 			<div className="signup-form__social">

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -83,6 +83,7 @@ class SocialSignupForm extends Component {
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
 		const host = typeof window !== 'undefined' && window.location.host;
 		const redirectUri = host ? `https://${ host }/start/user` : null;
+		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : 'popup';
 
 		return (
 			<div className="signup-form__social">
@@ -105,7 +106,7 @@ class SocialSignupForm extends Component {
 					<AppleLoginButton
 						clientId={ config( 'apple_oauth_client_id' ) }
 						responseHandler={ this.handleAppleResponse }
-						uxMode="redirect"
+						uxMode={ uxModeApple }
 						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'apple' ) }
 						socialServiceResponse={

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -81,7 +81,8 @@ class SocialSignupForm extends Component {
 
 	render() {
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
-		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
+		const host = typeof window !== 'undefined' && window.location.host;
+		const redirectUri = host ? `https://${ host }/start/user` : null;
 
 		return (
 			<div className="signup-form__social">
@@ -93,14 +94,23 @@ class SocialSignupForm extends Component {
 					<GoogleLoginButton
 						clientId={ config( 'google_oauth_client_id' ) }
 						responseHandler={ this.handleGoogleResponse }
-						redirectUri={ redirectUri }
 						uxMode={ uxMode }
+						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'google' ) }
+						socialServiceResponse={
+							this.props.socialService === 'google' && this.props.socialServiceResponse
+						}
 					/>
 
 					<AppleLoginButton
+						clientId={ config( 'apple_oauth_client_id' ) }
 						responseHandler={ this.handleAppleResponse }
+						uxMode="redirect"
+						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'apple' ) }
+						socialServiceResponse={
+							this.props.socialService === 'apple' && this.props.socialServiceResponse
+						}
 					/>
 
 					<p className="signup-form__social-buttons-tos">

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -99,7 +99,7 @@ class SocialSignupForm extends Component {
 						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'google' ) }
 						socialServiceResponse={
-							this.props.socialService === 'google' && this.props.socialServiceResponse
+							this.props.socialService === 'google' ? this.props.socialServiceResponse : null
 						}
 					/>
 
@@ -110,7 +110,7 @@ class SocialSignupForm extends Component {
 						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'apple' ) }
 						socialServiceResponse={
-							this.props.socialService === 'apple' && this.props.socialServiceResponse
+							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
 						}
 					/>
 

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -22,6 +22,8 @@ import requestExternalAccess from 'lib/sharing';
 import './style.scss';
 import AppleIcon from 'components/social-icons/apple';
 
+const appleClientUrl =
+	'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js';
 const connectUrlPopupFLow =
 	'https://public-api.wordpress.com/connect/?magic=keyring&service=apple&action=request&for=connect';
 
@@ -69,19 +71,8 @@ class AppleLoginButton extends Component {
 				} );
 			}
 
-			// do not load the client for the popup flow as
-			// we won't have a valid redirectUri to give to the apple client
 			this.loadAppleClient();
 		}
-	}
-
-	async loadDependency() {
-		if ( ! window.AppleID ) {
-			await loadScript(
-				'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js'
-			);
-		}
-		return window.AppleID;
 	}
 
 	async loadAppleClient() {
@@ -89,20 +80,23 @@ class AppleLoginButton extends Component {
 			return this.appleClientLoaded;
 		}
 
-		const AppleID = await this.loadDependency();
+		if ( ! window.AppleID ) {
+			await loadScript( appleClientUrl );
+		}
+
 		const oauth2State = String( Math.floor( Math.random() * 10e9 ) );
 		window.sessionStorage.setItem( 'siwa_state', oauth2State );
 
-		AppleID.auth.init( {
+		window.AppleID.auth.init( {
 			clientId: this.props.clientId,
 			scope: this.props.scope,
 			redirectURI: this.props.redirectUri,
 			state: oauth2State,
 		} );
 
-		this.appleClientLoaded = AppleID;
+		this.appleClientLoaded = window.AppleID;
 
-		return AppleID;
+		return window.AppleID;
 	}
 
 	handleClick = event => {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -29,7 +29,7 @@ class AppleLoginButton extends Component {
 	static propTypes = {
 		clientId: PropTypes.string.isRequired,
 		isFormDisabled: PropTypes.bool,
-		redirectUri: PropTypes.string.isRequired,
+		redirectUri: PropTypes.string,
 		responseHandler: PropTypes.func.isRequired,
 		scope: PropTypes.string,
 		uxMode: PropTypes.oneOf( [ 'redirect', 'popup' ] ),
@@ -47,21 +47,24 @@ class AppleLoginButton extends Component {
 			return;
 		}
 
-		this.loadAppleClient();
+		if ( this.props.uxMode === 'redirect' ) {
+			// do not load the client for the popup flow as
+			// we won't have a valid redirectUri to give to the apple client
+			this.loadAppleClient();
 
-		if (
-			this.props.uxMode === 'redirect' &&
-			this.props.socialServiceResponse &&
-			this.props.socialServiceResponse.client_id === config( 'apple_oauth_client_id' )
-		) {
-			const user = {
-				email: this.props.socialServiceResponse.user_email,
-				name: this.props.socialServiceResponse.user_name,
-			};
-			this.props.responseHandler( {
-				id_token: this.props.socialServiceResponse.id_token,
-				user: user,
-			} );
+			if (
+				this.props.socialServiceResponse &&
+				this.props.socialServiceResponse.client_id === config( 'apple_oauth_client_id' )
+			) {
+				const user = {
+					email: this.props.socialServiceResponse.user_email,
+					name: this.props.socialServiceResponse.user_name,
+				};
+				this.props.responseHandler( {
+					id_token: this.props.socialServiceResponse.id_token,
+					user: user,
+				} );
+			}
 		}
 	}
 
@@ -79,7 +82,6 @@ class AppleLoginButton extends Component {
 			return this.appleClientLoaded;
 		}
 
-		this.setState( { error: '' } );
 		this.appleClientLoaded = this.loadDependency()
 			.then( AppleID =>
 				AppleID.auth.init( {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -44,6 +44,8 @@ class AppleLoginButton extends Component {
 		uxMode: 'popup',
 	};
 
+	appleClient = null;
+
 	componentDidMount() {
 		if ( ! config.isEnabled( 'sign-in-with-apple' ) ) {
 			return;
@@ -76,8 +78,8 @@ class AppleLoginButton extends Component {
 	}
 
 	async loadAppleClient() {
-		if ( this.appleClientLoaded ) {
-			return this.appleClientLoaded;
+		if ( this.appleClient ) {
+			return this.appleClient;
 		}
 
 		if ( ! window.AppleID ) {
@@ -94,9 +96,9 @@ class AppleLoginButton extends Component {
 			state: oauth2State,
 		} );
 
-		this.appleClientLoaded = window.AppleID;
+		this.appleClient = window.AppleID;
 
-		return window.AppleID;
+		return this.appleClient;
 	}
 
 	handleClick = event => {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import { loadScript } from '@automattic/load-script';
 
 /**
  * Internal dependencies
@@ -21,25 +22,97 @@ import requestExternalAccess from 'lib/sharing';
 import './style.scss';
 import AppleIcon from 'components/social-icons/apple';
 
-const connectUrl =
+const connectUrlPopupFLow =
 	'https://public-api.wordpress.com/connect/?magic=keyring&service=apple&action=request&for=connect';
 
 class AppleLoginButton extends Component {
 	static propTypes = {
+		clientId: PropTypes.string.isRequired,
 		isFormDisabled: PropTypes.bool,
+		redirectUri: PropTypes.string.isRequired,
 		responseHandler: PropTypes.func.isRequired,
+		scope: PropTypes.string,
+		uxMode: PropTypes.oneOf( [ 'redirect', 'popup' ] ),
+		socialServiceResponse: PropTypes.object,
 	};
 
 	static defaultProps = {
 		onClick: noop,
+		scope: 'name email',
+		uxMode: 'popup',
 	};
+
+	componentDidMount() {
+		if ( ! config.isEnabled( 'sign-in-with-apple' ) ) {
+			return;
+		}
+
+		this.loadAppleClient();
+
+		if (
+			this.props.uxMode === 'redirect' &&
+			this.props.socialServiceResponse &&
+			this.props.socialServiceResponse.client_id === config( 'apple_oauth_client_id' )
+		) {
+			const user = {
+				email: this.props.socialServiceResponse.user_email,
+				name: this.props.socialServiceResponse.user_name,
+			};
+			this.props.responseHandler( {
+				id_token: this.props.socialServiceResponse.id_token,
+				user: user,
+			} );
+		}
+	}
+
+	async loadDependency() {
+		if ( ! window.AppleID ) {
+			await loadScript(
+				'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js'
+			);
+		}
+		return window.AppleID;
+	}
+
+	loadAppleClient() {
+		if ( this.appleClientLoaded ) {
+			return this.appleClientLoaded;
+		}
+
+		this.setState( { error: '' } );
+		this.appleClientLoaded = this.loadDependency()
+			.then( AppleID =>
+				AppleID.auth.init( {
+					clientId: this.props.clientId,
+					scope: this.props.scope,
+					redirectURI: this.props.redirectUri,
+					state: '1',
+				} )
+			)
+			.catch( error => {
+				this.appleClientLoaded = null;
+				return Promise.reject( error );
+			} );
+
+		return this.appleClientLoaded;
+	}
 
 	handleClick = event => {
 		event.preventDefault();
 
-		this.props.onClick( event );
+		if ( this.props.onClick ) {
+			this.props.onClick( event );
+		}
 
-		requestExternalAccess( connectUrl, this.props.responseHandler );
+		if ( this.props.uxMode === 'popup' ) {
+			requestExternalAccess( connectUrlPopupFLow, this.props.responseHandler );
+			return;
+		}
+
+		if ( this.props.uxMode === 'redirect' ) {
+			this.loadDependency().then( AppleID => AppleID.auth.signIn() );
+			return;
+		}
 	};
 
 	render() {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -52,29 +52,32 @@ class AppleLoginButton extends Component {
 		}
 
 		if ( this.props.uxMode === 'redirect' ) {
-			if (
-				this.props.socialServiceResponse &&
-				this.props.socialServiceResponse.client_id === config( 'apple_oauth_client_id' )
-			) {
-				const storedOauth2State = window.sessionStorage.getItem( 'siwa_state' );
-				window.sessionStorage.removeItem( 'siwa_state' );
-
-				if ( this.props.socialServiceResponse.state !== storedOauth2State ) {
-					return;
-				}
-
-				const user = {
-					email: this.props.socialServiceResponse.user_email,
-					name: this.props.socialServiceResponse.user_name,
-				};
-				this.props.responseHandler( {
-					id_token: this.props.socialServiceResponse.id_token,
-					user: user,
-				} );
-			}
-
+			this.props.socialServiceResponse &&
+				this.handleSocialResponseFromRedirect( this.props.socialServiceResponse );
 			this.loadAppleClient();
 		}
+	}
+
+	handleSocialResponseFromRedirect( socialServiceResponse ) {
+		if ( socialServiceResponse.client_id !== config( 'apple_oauth_client_id' ) ) {
+			return;
+		}
+
+		const storedOauth2State = window.sessionStorage.getItem( 'siwa_state' );
+		window.sessionStorage.removeItem( 'siwa_state' );
+
+		if ( socialServiceResponse.state !== storedOauth2State ) {
+			return;
+		}
+
+		const user = {
+			email: socialServiceResponse.user_email,
+			name: socialServiceResponse.user_name,
+		};
+		this.props.responseHandler( {
+			id_token: socialServiceResponse.id_token,
+			user: user,
+		} );
 	}
 
 	async loadAppleClient() {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -32,6 +32,7 @@ class GoogleLoginButton extends Component {
 		isFormDisabled: PropTypes.bool,
 		onClick: PropTypes.func,
 		recordTracksEvent: PropTypes.func.isRequired,
+		redirectUri: PropTypes.string,
 		responseHandler: PropTypes.func.isRequired,
 		scope: PropTypes.string,
 		translate: PropTypes.func.isRequired,

--- a/client/lib/login/README.md
+++ b/client/lib/login/README.md
@@ -1,0 +1,4 @@
+login
+======================
+
+Utility functions for login and signup into WordPress.com

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+export function getSocialServiceFromClientId( clientId ) {
+	if ( ! clientId ) {
+		return null;
+	}
+
+	if ( clientId === config( 'google_oauth_client_id' ) ) {
+		return 'google';
+	}
+
+	if ( clientId === config( 'facebook_app_id' ) ) {
+		return 'facebook';
+	}
+
+	if ( clientId === config( 'apple_oauth_client_id' ) ) {
+		return 'apple';
+	}
+
+	return null;
+}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -28,8 +28,10 @@ const enhanceContextWithLogin = context => {
 	} = context;
 
 	const previousHash = context.state || {};
-	const { client_id, user_email, user_name, id_token } = previousHash;
-	const socialServiceResponse = client_id ? { client_id, user_email, user_name, id_token } : null;
+	const { client_id, user_email, user_name, id_token, state } = previousHash;
+	const socialServiceResponse = client_id
+		? { client_id, user_email, user_name, id_token, state }
+		: null;
 
 	context.primary = (
 		<WPLogin

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -27,13 +27,15 @@ const enhanceContextWithLogin = context => {
 		query,
 	} = context;
 
+	const socialServiceResponse = context.hash && context.hash.client_id ? context.hash : null;
+
 	context.primary = (
 		<WPLogin
 			isJetpack={ isJetpack === 'jetpack' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }
-			socialServiceResponse={ context.hash }
+			socialServiceResponse={ socialServiceResponse }
 			socialConnect={ flow === 'social-connect' }
 			privateSite={ flow === 'private-site' }
 			domain={ ( query && query.domain ) || null }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -27,7 +27,9 @@ const enhanceContextWithLogin = context => {
 		query,
 	} = context;
 
-	const socialServiceResponse = context.hash && context.hash.client_id ? context.hash : null;
+	const previousHash = context.state || {};
+	const { client_id, user_email, user_name, id_token } = previousHash;
+	const socialServiceResponse = client_id ? { client_id, user_email, user_name, id_token } : null;
 
 	context.primary = (
 		<WPLogin
@@ -53,6 +55,13 @@ export function login( context, next ) {
 	const {
 		query: { client_id, redirect_to },
 	} = context;
+
+	// Remove id_token from the address bar and push social connect args into the state instead
+	if ( context.hash && context.hash.client_id ) {
+		page.replace( context.path, context.hash );
+
+		return;
+	}
 
 	if ( client_id ) {
 		if ( ! redirect_to ) {

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -39,7 +39,7 @@ export default router => {
 			[
 				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 				`/log-in/:flow(social-connect|private-site)/${ lang }`,
-				`/log-in/:socialService(google)/callback/${ lang }`,
+				`/log-in/:socialService(google|apple)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push)/${ lang }`,
 				`/log-in/${ lang }`,

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -17,6 +17,7 @@ import accountPasswordData from 'lib/account-password-data';
 import SocialLoginComponent from 'me/social-login';
 import ConnectedAppsComponent from 'me/connected-applications';
 import AccountRecoveryComponent from 'me/security-account-recovery';
+import { getSocialServiceFromClientId } from 'lib/login';
 
 export function password( context, next ) {
 	if ( context.query && context.query.updated === 'password' ) {
@@ -62,9 +63,24 @@ export function accountRecovery( context, next ) {
 }
 
 export function socialLogin( context, next ) {
+	// Remove id_token from the address bar and push social connect args into the state instead
+	if ( context.hash && context.hash.client_id ) {
+		page.replace( context.path, context.hash );
+		return;
+	}
+
+	const previousHash = context.state || {};
+	const { client_id, user_email, user_name, id_token, state } = previousHash;
+	const socialServiceResponse = client_id
+		? { client_id, user_email, user_name, id_token, state }
+		: null;
+	const socialService = getSocialServiceFromClientId( client_id );
+
 	context.primary = React.createElement( SocialLoginComponent, {
-		userSettings: userSettings,
 		path: context.path,
+		socialService,
+		socialServiceResponse,
+		userSettings,
 	} );
 	next();
 }

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -121,7 +121,8 @@ class SocialLoginActionButton extends Component {
 
 		if ( service === 'apple' ) {
 			const uxMode = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : 'popup';
-			const redirectUri = window.location.origin + window.location.pathname;
+			const redirectUri =
+				typeof window !== 'undefined' ? window.location.origin + window.location.pathname : null;
 			return (
 				<AppleLoginButton
 					clientId={ config( 'apple_oauth_client_id' ) }

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -27,6 +27,7 @@ class SocialLoginActionButton extends Component {
 		translate: PropTypes.func.isRequired,
 		connectSocialUser: PropTypes.func.isRequired,
 		disconnectSocialUser: PropTypes.func.isRequired,
+		socialServiceResponse: PropTypes.object,
 	};
 
 	state = {
@@ -119,11 +120,15 @@ class SocialLoginActionButton extends Component {
 		}
 
 		if ( service === 'apple' ) {
+			const uxMode = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : 'popup';
+			const redirectUri = window.location.origin + window.location.pathname;
 			return (
 				<AppleLoginButton
 					clientId={ config( 'apple_oauth_client_id' ) }
-					uxMode="popup"
+					uxMode={ uxMode }
 					responseHandler={ this.handleSocialServiceResponse }
+					redirectUri={ redirectUri }
+					socialServiceResponse={ this.props.socialServiceResponse }
 				>
 					{ actionButton }
 				</AppleLoginButton>

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -120,7 +120,11 @@ class SocialLoginActionButton extends Component {
 
 		if ( service === 'apple' ) {
 			return (
-				<AppleLoginButton responseHandler={ this.handleSocialServiceResponse }>
+				<AppleLoginButton
+					clientId={ config( 'apple_oauth_client_id' ) }
+					uxMode="popup"
+					responseHandler={ this.handleSocialServiceResponse }
+				>
 					{ actionButton }
 				</AppleLoginButton>
 			);

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -35,6 +35,8 @@ class SocialLogin extends Component {
 	static propTypes = {
 		errorUpdatingSocialConnection: PropTypes.object,
 		path: PropTypes.string,
+		socialService: PropTypes.string,
+		socialServiceResponse: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -59,7 +61,13 @@ class SocialLogin extends Component {
 				<SocialLoginService service="google" icon={ <GoogleIcon /> } />
 
 				{ config.isEnabled( 'sign-in-with-apple' ) && (
-					<SocialLoginService service="apple" icon={ <AppleIcon /> } />
+					<SocialLoginService
+						service="apple"
+						icon={ <AppleIcon /> }
+						socialServiceResponse={
+							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
+						}
+					/>
 				) }
 			</div>
 		);

--- a/client/me/social-login/service.jsx
+++ b/client/me/social-login/service.jsx
@@ -12,7 +12,13 @@ import CompactCard from 'components/card/compact';
 import { getCurrentUser } from 'state/current-user/selectors';
 import SocialLoginActionButton from './action-button';
 
-const SocialLoginService = ( { service, icon, isConnected, socialConnectionEmail } ) => (
+const SocialLoginService = ( {
+	service,
+	icon,
+	isConnected,
+	socialConnectionEmail,
+	socialServiceResponse,
+} ) => (
 	<CompactCard>
 		<div className="social-login__header">
 			<div className="social-login__header-info">
@@ -22,7 +28,11 @@ const SocialLoginService = ( { service, icon, isConnected, socialConnectionEmail
 			</div>
 
 			<div className="social-login__header-action">
-				<SocialLoginActionButton service={ service } isConnected={ isConnected } />
+				<SocialLoginActionButton
+					service={ service }
+					isConnected={ isConnected }
+					socialServiceResponse={ socialServiceResponse }
+				/>
 			</div>
 		</div>
 	</CompactCard>

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -30,6 +30,7 @@ import store from 'store';
 import { setCurrentFlowName } from 'state/signup/flow/actions';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
+import { getCurrentFlowName } from 'state/signup/flow/selectors';
 import { login } from 'lib/paths';
 
 /**
@@ -82,10 +83,33 @@ export default {
 		const flowName = getFlowName( context.params );
 		const localeFromParams = getLocale( context.params );
 		const localeFromStore = store.get( 'signup-locale' );
-		context.store.dispatch( setCurrentFlowName( flowName ) );
-
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const signupProgress = getSignupProgress( context.store.getState() );
+
+		// Special case for the user step which may use oauth2 redirect flow
+		// Check if there is a valid flow in progress to resume
+		// We're limited in the number of redirect uris we can provide so we only have a single one at /start/user
+		if ( context.params.flowName === 'user' ) {
+			const alternativeFlowName = getCurrentFlowName( context.store.getState() );
+			if (
+				alternativeFlowName &&
+				alternativeFlowName !== flowName &&
+				canResumeFlow( alternativeFlowName, signupProgress )
+			) {
+				window.location =
+					getStepUrl(
+						alternativeFlowName,
+						getStepName( context.params ),
+						getStepSectionName( context.params ),
+						localeFromStore
+					) +
+					( context.querystring ? '?' + context.querystring : '' ) +
+					( context.hashstring ? '#' + context.hashstring : '' );
+				return;
+			}
+		}
+
+		context.store.dispatch( setCurrentFlowName( flowName ) );
 
 		if ( ! userLoggedIn && shouldForceLogin( flowName ) ) {
 			return page.redirect( login( { isNative: true, redirectTo: context.path } ) );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -26,26 +26,7 @@ import { WPCC } from 'lib/url/support';
 import config from 'config';
 import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
-
-function getSocialServiceFromClientId( clientId ) {
-	if ( ! clientId ) {
-		return null;
-	}
-
-	if ( clientId === config( 'google_oauth_client_id' ) ) {
-		return 'google';
-	}
-
-	if ( clientId === config( 'facebook_app_id' ) ) {
-		return 'facebook';
-	}
-
-	if ( clientId === config( 'apple_oauth_client_id' ) ) {
-		return 'apple';
-	}
-
-	return null;
-}
+import { getSocialServiceFromClientId } from 'lib/login';
 
 export class UserStep extends Component {
 	static propTypes = {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -40,6 +40,10 @@ function getSocialServiceFromClientId( clientId ) {
 		return 'facebook';
 	}
 
+	if ( clientId === config( 'apple_oauth_client_id' ) ) {
+		return 'apple';
+	}
+
 	return null;
 }
 

--- a/client/state/signup/flow/reducer.js
+++ b/client/state/signup/flow/reducer.js
@@ -3,11 +3,14 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { SIGNUP_CURRENT_FLOW_NAME_SET } from 'state/action-types';
+import { currentFlowNameSchema } from './schema';
 
-export const currentFlowName = ( state = '', { type, flowName } ) =>
-	type === SIGNUP_CURRENT_FLOW_NAME_SET ? flowName : state;
+export const currentFlowName = withSchemaValidation(
+	currentFlowNameSchema,
+	( state = '', { flowName, type } ) => ( type === SIGNUP_CURRENT_FLOW_NAME_SET ? flowName : state )
+);
 
 export default combineReducers( {
 	currentFlowName,

--- a/client/state/signup/flow/schema.js
+++ b/client/state/signup/flow/schema.js
@@ -1,0 +1,4 @@
+/** @format */
+export const currentFlowNameSchema = {
+	type: 'string',
+};

--- a/config/development.json
+++ b/config/development.json
@@ -141,6 +141,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
+		"sign-in-with-apple/redirect": true,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": true,
 		"signup/full-site-editing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,6 +106,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
+		"sign-in-with-apple/redirect": true,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
 		"signup/onboarding-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -118,6 +118,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
+		"sign-in-with-apple/redirect": true,
 		"signup/import": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -117,6 +117,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
+		"sign-in-with-apple": true,
 		"signup/import": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -26,7 +26,7 @@ module.exports = function() {
 		oauth( app );
 	}
 
-	if ( config.isEnabled( 'sign-in-with-apple' ) ) {
+	if ( config.isEnabled( 'sign-in-with-apple/redirect' ) ) {
 		signInWithApple( app );
 	}
 

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -10,7 +10,8 @@ const express = require( 'express' );
  */
 const version = require( '../../package.json' ).version,
 	config = require( 'config' ),
-	oauth = require( './oauth' );
+	oauth = require( './oauth' ),
+	signInWithApple = require( './sign-in-with-apple' );
 
 module.exports = function() {
 	const app = express();
@@ -23,6 +24,10 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'oauth' ) ) {
 		oauth( app );
+	}
+
+	if ( config.isEnabled( 'sign-in-with-apple' ) ) {
+		signInWithApple( app );
 	}
 
 	return app;

--- a/server/api/sign-in-with-apple.js
+++ b/server/api/sign-in-with-apple.js
@@ -56,6 +56,7 @@ function loginWithApple( request, response, next ) {
 		user_email: userEmail,
 		user_name: userName,
 		client_id: config( 'apple_oauth_client_id' ),
+		state: request.body.state,
 	} );
 
 	response.redirect( originalUrlPath + '#' + hashString );

--- a/server/api/sign-in-with-apple.js
+++ b/server/api/sign-in-with-apple.js
@@ -64,7 +64,7 @@ function loginWithApple( request, response, next ) {
 
 module.exports = function( app ) {
 	return app.post(
-		[ '/log-in/apple/callback', '/start/user' ],
+		[ '/log-in/apple/callback', '/start/user', '/me/security/social-login' ],
 		bodyParser.urlencoded(),
 		loginWithApple
 	);

--- a/server/api/sign-in-with-apple.js
+++ b/server/api/sign-in-with-apple.js
@@ -1,0 +1,70 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import bodyParser from 'body-parser';
+import qs from 'qs';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import wpcom from 'lib/wp';
+
+function loginEndpointData() {
+	return {
+		client_id: config( 'wpcom_signup_id' ),
+		client_secret: config( 'wpcom_signup_key' ),
+		service: 'apple',
+		signup_flow_name: 'no-signup',
+	};
+}
+
+function loginWithApple( request, response, next ) {
+	if ( ! request.body.id_token ) {
+		return next();
+	}
+
+	const idToken = request.body.id_token;
+	const user = request.body.user || {};
+	const userEmail = user.email;
+	const userName = user.name
+		? `${ user.name.firstName || '' } ${ user.name.lastName || '' }`.trim()
+		: undefined;
+
+	// An `id_token` is not enough to log a user in (one might have 2FA enabled or an existing account with the same email)
+	// Thus we need to return `id_token` to the front-end so it can handle all sign-up/sign-in cases.
+	// However Apple sends the user data only once,
+	// so let's query our sign-up endpoint with the `signup_flow_name=no-signup` to make sure the user data is saved
+	if ( userEmail ) {
+		wpcom
+			.undocumented()
+			.usersSocialNew( {
+				...loginEndpointData(),
+				id_token: idToken,
+				user_email: userEmail,
+				user_name: userName,
+			} )
+			.catch( () => {
+				// ignore errors
+			} );
+	}
+
+	const originalUrlPath = request.originalUrl.split( '#' )[ 0 ];
+	const hashString = qs.stringify( {
+		id_token: idToken,
+		user_email: userEmail,
+		user_name: userName,
+		client_id: config( 'apple_oauth_client_id' ),
+	} );
+
+	response.redirect( originalUrlPath + '#' + hashString );
+}
+
+module.exports = function( app ) {
+	return app.post(
+		[ '/log-in/apple/callback', '/start/user' ],
+		bodyParser.urlencoded(),
+		loginWithApple
+	);
+};


### PR DESCRIPTION
~Requires server patch D33371~ (deployed)

#### Changes proposed in this Pull Request

* Add support for the redirect flow for Sign In with Apple
* Switch to using the redirect flow on `wpcalypso` and `development`, maybe we want `staging` as well?

Using the redirect flow is required so our login is compatible with Safari on iOS 13 and macOS Catalina which bypass the oauth2 flow with a native UI. It seems this UI is not compatible with the popup flow for some unknown reason.

#### Testing instructions
If testing locally, you will need to use the wordpress.com hostname with HTTPS (need a valid redirect uri). You can use Charles proxy to do this (see FG documentation on the subject). Redirect all routes from `https://wordpress.com` to `http://calypso.localhost:3000` except for `/wp-login.php*` which needs to hit the wpcom server (`wordpress.com` or `wpcalypso.wordpress.com` or your sandbox url).

* Try signing in/up with the redirect flow
* Try connecting and disconnecting from Me > Security > Social Login
* Try adding 2FA to your account and sign in
* Try signing in from https://crowdsignal.com
* Try signing in from https://jetpack.com
* Try signing in from https://woocommerce.com
* Try signing in to a wordpress instance with Jetpack using your WPCOM account (Make sure "Allow users to log in to this site using WordPress.com accounts" is enabled in jetpack settings)
* Try linking your Jetpack site to WordPress.com
* Try signing up (if possible for all the flows above) with and without an existing email address in wpcom
* Try a signup flow where `user` is not the first step: Go to http://wordpress.com/themes while logged out, pick a theme, select "Pick this design", then pick a site address then a plan (free for each should do), then click on "Continue with Apple". After authenticating with apple you should come back to the `user` step and it should create your site and log you in
* Make sure we don't break production: set `sign-in-with-apple/redirect` to `false` in `config/development.json` and try signing in/up with Apple, it should work the same as on production.
* Optional: try with Safari on macos Catalina
* Optional: try with Safari on iOS 13 with Charles proxy

Once tested locally let's merge so we can do more tests on wpcalypso. Note that `calypso.live` won't work as the hostname is dynamic which is not supported as a redirect uri for external auth services.

TODO:
- [ ] Make sure we resume the `user` step in the signup flow for flows that don't have user as the first step. For instance starting from https://wordpress.com/start/with-theme