### PR TITLE
Domains: Suggestion provdier A\B test for EN locale.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -133,4 +133,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	domainSuggestionsEn: {
+		datestamp: '20191003',
+		variations: {
+			control: 50,
+			test: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -2,10 +2,14 @@
 /**
  * Internal dependencies
  */
-import { isUsingGivenLocales } from 'lib/abtest';
+import { abtest, isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
 	if ( isUsingGivenLocales( [ 'en' ] ) ) {
+		if ( abtest( 'domainSuggestionsEn' ) === 'test' ) {
+			return 'variation2_front';
+		}
+
 		return 'variation_front';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Check on conversion rates for different domain suggestion providers.

#### Testing instructions
* Visit http://calypso.localhost:3000/domains/add
* In the dev tools, switch variations for the test
* Make sure the /suggestions endpoint has the proper vendor