### PR TITLE
Update prettier integrity hash

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18151,7 +18151,7 @@
 		},
 		"prettier": {
 			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
-			"integrity": "sha512-MZWjD8vE5xFscQxZsBQgNyxqkQbRMWildoUUKm0TNAbuCLjswU6UMtPDLRL1iTkyhWMvJISibVvasqC8PnJPuA==",
+			"integrity": "sha512-J9Bipqt0wEJ5t7X3ODqlY9d/+E4/co7PuCeFi8HqxQPZge/8v9NkwhyXce8PO2+e71Z1wjQM5H4iL8OZPDXsiA==",
 			"dev": true
 		},
 		"pretty-error": {


### PR DESCRIPTION
Not sure what happened to `prettier`, but the pre-commit hook was broken on my side because it could not find it at `node_modules/.bin/prettier`. It seems calypso.live is also broken because of it.
- On calypso.live
```
Time=2019-10-01T13:27:12.433Z | npm
Time=2019-10-01T13:27:12.433Z |  WARN tarball tarball data for prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz (sha512-MZWjD8vE5xFscQxZsBQgNyxqkQbRMWildoUUKm0TNAbuCLjswU6UMtPDLRL1iTkyhWMvJISibVvasqC8PnJPuA==) seems to be corrupted. Trying one more time.
Time=2019-10-01T13:27:15.780Z | npm WARN tarball tarball data for prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz (sha512-MZWjD8vE5xFscQxZsBQgNyxqkQbRMWildoUUKm0TNAbuCLjswU6UMtPDLRL1iTkyhWMvJISibVvasqC8PnJPuA==) seems to be corrupted. Trying one more time.
Time=2019-10-01T13:27:15.829Z | npm ERR! code
Time=2019-10-01T13:27:15.830Z |  EINTEGRITY
Time=2019-10-01T13:27:15.831Z | npm ERR! Verification failed while extracting prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz:
npm ERR!
Time=2019-10-01T13:27:15.831Z |  Verification failed while extracting prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz:
npm ERR! sha512-MZWjD8vE5xFscQxZsBQgNyxqkQbRMWildoUUKm0TNAbuCLjswU6UMtPDLRL1iTkyhWMvJISibVvasqC8PnJPuA== integrity checksum failed when using sha512: wanted sha512-MZWjD8vE5xFscQxZsBQgNyxqkQbRMWildoUUKm0TNAbuCLjswU6UMtPDLRL1iTkyhWMvJISibVvasqC8PnJPuA== but got sha512-J9Bipqt0wEJ5t7X3ODqlY9d/+E4/co7PuCeFi8HqxQPZge/8v9NkwhyXce8PO2+e71Z1wjQM5H4iL8OZPDXsiA==. (2092945 bytes)
Time=2019-10-01T13:27:55.873Z | 
npm ERR! A complete log of this run can be found in:
npm ERR!
Time=2019-10-01T13:27:55.874Z |      /root/.npm/_logs/2019-10-01T13_27_15_849Z-debug.log
Time=2019-10-01T13:27:58.321Z | Removing intermediate container 1b62e9c92f92
```
- When running `git commit`:
```
Prettier formatting staged file: client/blocks/login/social.jsx
Prettier formatting staged file: client/components/social-buttons/apple.js
/bin/sh: ./node_modules/.bin/prettier: No such file or directory
child_process.js:669
    throw err;
    ^

Error: Command failed: ./node_modules/.bin/prettier --ignore-path .eslintignore --write client/blocks/login/social.jsx client/components/social-buttons/apple.js
/bin/sh: ./node_modules/.bin/prettier: No such file or directory
```

I had to reinstall `prettier`, running `npm install prettier` which updated the `npm-shrinkwrap.json` file. It seems the file has changed. We might want to investigate this before merging this fix.

#### Testing instructions

- Boot this branch on calypso.live and notice that it works.
- Check that the `prettier` dependency has the right checksum `curl -fLs https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz | shasum -a 512 | xxd -r -p | base64`