### PR TITLE
FSE: populate default pages with correct content

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -106,13 +106,8 @@ class Full_Site_Editing {
 			return;
 		}
 
-		if ( ! $this->wp_template_inserter->is_template_data_inserted() ) {
-			$this->wp_template_inserter->insert_default_template_data();
-		}
-
-		if ( ! $this->wp_template_inserter->is_pages_data_inserted() ) {
-			$this->wp_template_inserter->insert_default_pages();
-		}
+		$this->wp_template_inserter->insert_default_template_data();
+		$this->wp_template_inserter->insert_default_pages();
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -313,37 +313,25 @@ class WP_Template_Inserter {
 
 		$api_response = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		$about_page_content   = '';
-		$contact_page_content = '';
+		// Convert templates response to [ slug => content ] pairs to extract required content more easily.
+		$template_content_by_slug = wp_list_pluck( $api_response['templates'], 'content', 'slug' );
 
-		/*
-		 * Array of returned templates is not keyed by name, so we have to access it directly like this.
-		 * About page is at position 6 in the array, and Contact page at 1.
-		 */
-		if ( ! empty( $api_response['templates'][6]['content'] ) ) {
-			$about_page_content = $api_response['templates'][6]['content'];
-		}
-
-		if ( ! empty( $api_response['templates'][1]['content'] ) ) {
-			$contact_page_content = $api_response['templates'][1]['content'];
-		}
-
-		if ( empty( get_page_by_title( 'About' ) ) ) {
+		if ( empty( get_page_by_title( 'About' ) ) && ! empty( $template_content_by_slug['about'] ) ) {
 			wp_insert_post(
 				[
 					'post_title'   => _x( 'About', 'Default page title', 'full-site-editing' ),
-					'post_content' => $about_page_content,
+					'post_content' => $template_content_by_slug['about'],
 					'post_status'  => 'publish',
 					'post_type'    => 'page',
 				]
 			);
 		}
 
-		if ( empty( get_page_by_title( 'Contact' ) ) ) {
+		if ( empty( get_page_by_title( 'Contact' ) ) && ! empty( $template_content_by_slug['contact'] ) ) {
 			wp_insert_post(
 				[
 					'post_title'   => _x( 'Contact', 'Default page title', 'full-site-editing' ),
-					'post_content' => $contact_page_content,
+					'post_content' => $template_content_by_slug['contact'],
 					'post_status'  => 'publish',
 					'post_type'    => 'page',
 				]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previous implementation of extracting the template content was
fragile since it depended on directly specifying the index of
the required template in the response array. Now that response
has been modified to include a slug which can be used to extract
the needed template content in a more reliable fashion.

Fixes https://github.com/Automattic/wp-calypso/issues/36437

#### Testing instructions

1. Make sure that your test site doesn't have pages title `Contact` and `About` (including trash).
2. Delete `fse-page-data-v1` option if it was set or alternatively comment out this bail assertion https://github.com/Automattic/wp-calypso/blob/babd1b81a044b7412d0a96940014baaf62604a1a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php#L279
3. Switch to Maywood theme or toggle it if your test site was already using this theme.
4. Verify that Contact and About page have been created with correct content.

**Expected About page content:**

<img width="1126" alt="Screenshot 2019-10-01 at 16 30 04" src="https://user-images.githubusercontent.com/1182160/65973045-fcc5d280-e46a-11e9-9665-864241b9db00.png">


**Expected Contact page content:**

<img width="1120" alt="Screenshot 2019-10-01 at 16 30 16" src="https://user-images.githubusercontent.com/1182160/65973048-fd5e6900-e46a-11e9-8e50-633cb646744b.png">
