### PR TITLE
Settings Page: Use @wordpress/components for Antispam Settings

### DIFF
--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -4,6 +4,9 @@
 // Color Schemes
 @import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
 
+// WordPress Components
+@import '~@wordpress/components/build-style/style';
+
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined
 @import 'shared/animation'; // all UI animation

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -26,7 +26,6 @@ import isJetpackSettingsSaveFailure from 'state/selectors/is-jetpack-settings-sa
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
-import SpamFilteringSettings from './spam-filtering-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 import { isATEnabled } from 'lib/automated-transfer';
 import { FEATURE_SPAM_AKISMET_PLUS, PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
@@ -123,20 +122,24 @@ class SiteSettingsFormSecurity extends Component {
 								initialOpen={ true }
 							>
 								<PanelRow className="form-security__text-field-panel-row">
-									{ /* TODO: don't style this inline?  */ }
 									<div style={ { display: 'flex', flexDirection: 'column' } }>
 										<TextControl
 											className={ fieldStyle }
 											disabled={ inTransition || ! fields.akismet }
 											label={ translate( 'Your API Key' ) }
 											onChange={ apiKey => {
-												// TODO: this isn't the best pattern
 												const onChangeApiKey = onChangeField( 'wordpress_api_key' );
 												onChangeApiKey( { target: { value: apiKey } } );
 											} }
 											value={ fields.wordpress_api_key }
 										/>
-										{ ( isValidKey || isInvalidKey ) && ! inTransition && (
+										{ ! inTransition && isValidKey && (
+											<FormInputValidation
+												isError={ isInvalidKey }
+												text={ translate( 'Your Antispam key is valid.' ) }
+											/>
+										) }
+										{ ! inTransition && isInvalidKey && (
 											<FormInputValidation
 												isError={ isInvalidKey }
 												text={ translate( 'Please enter a valid Antispam API key.' ) }
@@ -154,26 +157,6 @@ class SiteSettingsFormSecurity extends Component {
 							</PanelBody>
 						) }
 					</Panel>
-				) }
-
-				{ ! isAtomic && (
-					<div>
-						<SettingsSectionHeader
-							disabled={ isRequestingSettings || isSavingSettings || disableSpamFiltering }
-							isSaving={ isSavingSettings }
-							onButtonClick={ handleSubmitForm }
-							showButton
-							title={ translate( 'Jetpack Anti-spam' ) }
-						/>
-						<SpamFilteringSettings
-							dirtyFields={ dirtyFields }
-							fields={ fields }
-							currentAkismetKey={ settings.wordpress_api_key }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							onChangeField={ onChangeField }
-						/>
-					</div>
 				) }
 
 				<SettingsSectionHeader title={ translate( 'WordPress.com log in' ) } />

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -54,7 +54,6 @@ class SiteSettingsFormSecurity extends Component {
 		const disableProtect = ! protectModuleActive || protectModuleUnavailable;
 		const disableSpamFiltering = ! fields.akismet || akismetUnavailable;
 
-		// *********************************************************************************************************
 		const inTransition = isRequestingSettings || isSavingSettings;
 		const isStoredKey = fields.wordpress_api_key === settings.wordpress_api_key;
 		const isDirty = includes( dirtyFields, 'wordpress_api_key' );
@@ -72,7 +71,6 @@ class SiteSettingsFormSecurity extends Component {
 		if ( ! inTransition && isInvalidKey ) {
 			fieldStyle = 'is-error';
 		}
-		// *********************************************************************************************************
 
 		return (
 			<form

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -524,3 +524,10 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	opacity: 0.33;
 	pointer-events: none;
 }
+
+.components-base-control.is-valid .components-base-control__field .components-text-control__input {
+	border-color: var( --color-success );
+}
+.components-base-control.is-error .components-base-control__field .components-text-control__input {
+	border-color: var( --color-error );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR explores the use of `@wordpress/components` in Calypso by building the 

This needs to be polished before it can be shipped:
1. Margins and alignment need to tweaked.
2. Help text needs to be added.
3. The various error states need to be tested (e.g. invalid but not saved, invalid after save, etc) 
4. The `Panel` should be extracted into its own component.

Current state of the component:
![wpcomponents_anti-spam_settings](https://user-images.githubusercontent.com/42627630/65978901-17cc1e80-e43a-11e9-9f7b-97ed394a515a.gif)

Before `@wordpress/components`:
![original_anti-spam_settings](https://user-images.githubusercontent.com/42627630/65978936-24507700-e43a-11e9-9f03-c3cf814d73fc.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TODO