### PR TITLE
SPT: Update visual appearance on small screens

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -32,6 +32,7 @@ export const TemplateSelectorControl = ( {
 	onTemplateSelect = noop,
 	siteInformation = {},
 	selectedTemplate,
+	handleTemplateConfirmation = noop,
 } ) => {
 	if ( isEmpty( templates ) || ! isArray( templates ) ) {
 		return null;
@@ -67,6 +68,7 @@ export const TemplateSelectorControl = ( {
 							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }
 							useDynamicPreview={ useDynamicPreview }
 							isSelected={ slug === selectedTemplate }
+							handleTemplateConfirmation={ handleTemplateConfirmation }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,15 +1,19 @@
 /**
  * External dependencies
  */
+/* eslint-disable import/no-extraneous-dependencies */
 import { isEmpty, isArray, noop, map } from 'lodash';
+/* eslint-enable import/no-extraneous-dependencies */
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
+/* eslint-disable import/no-extraneous-dependencies */
 import { withInstanceId, compose } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
 import { memo } from '@wordpress/element';
+/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -25,6 +25,7 @@ const TemplateSelectorItem = props => {
 		staticPreviewImgAlt = '',
 		blocks = [],
 		isSelected,
+		handleTemplateConfirmation,
 	} = props;
 
 	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
@@ -50,6 +51,21 @@ const TemplateSelectorItem = props => {
 
 	const labelId = `label-${ id }-${ value }`;
 
+	/**
+	 * Determines (based on whether the large preview is able to be visible at the
+	 * current breakpoint) whether or not the Template selection UI interaction model
+	 * should be select _and_ confirm or simply a single "tap to confirm".
+	 */
+	const handleLabelClick = () => {
+		const largeTplPreviewVisible = window.matchMedia( '(min-width: 660px)' ).matches;
+		// In both cases set the template as being selected
+		onSelect( value );
+		// Confirm the template when large preview isn't visible
+		if ( ! largeTplPreviewVisible ) {
+			handleTemplateConfirmation( value );
+		}
+	};
+
 	return (
 		<button
 			type="button"
@@ -57,7 +73,7 @@ const TemplateSelectorItem = props => {
 				'is-selected': isSelected,
 			} ) }
 			value={ value }
-			onClick={ () => onSelect( value ) }
+			onClick={ handleLabelClick }
 			aria-labelledby={ `${ id } ${ labelId }` }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -145,7 +145,9 @@ class PageTemplateModal extends Component {
 
 	render() {
 		const { previewedTemplate, isOpen, isLoading, blocksByTemplateSlug } = this.state;
+		/* eslint-disable no-shadow */
 		const { templates } = this.props;
+		/* eslint-enable no-shadow */
 
 		if ( ! isOpen ) {
 			return null;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -121,7 +121,7 @@ class PageTemplateModal extends Component {
 		return this.props.shouldPrefetchAssets ? ensureAssets( blocks ) : Promise.resolve( blocks );
 	};
 
-	handleConfirmation = () => this.setTemplate( this.state.previewedTemplate );
+	handleConfirmation = ( slug = this.state.previewedTemplate ) => this.setTemplate( slug );
 
 	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
 
@@ -181,6 +181,7 @@ class PageTemplateModal extends Component {
 										useDynamicPreview={ false }
 										siteInformation={ siteInformation }
 										selectedTemplate={ previewedTemplate }
+										handleTemplateConfirmation={ this.handleConfirmation }
 									/>
 								</fieldset>
 							</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -158,11 +158,13 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		&:hover,
 		&:focus,
 		&.is-selected {
-			border-color: #2562b7;
-			box-shadow: 0 0 0 1px #2562b7;
-			outline: 1px solid transparent;
-			outline-offset: -1px;
-			color: inherit;
+			@media screen and ( min-width: 660px ) {
+				border-color: #2562b7;
+				box-shadow: 0 0 0 1px #2562b7;
+				outline: 1px solid transparent;
+				outline-offset: -1px;
+				color: inherit;
+			}
 		}
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -264,7 +264,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     height: 56px;
     display: flex;
     align-items: center;
-    padding-right: 24px;
+	padding-right: 24px;
+	
+	@media screen and ( max-width: 659px ) {
+		display: none;
+	}
 
     &.is-visually-hidden {
     	@include screen-reader-text();

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -83,7 +83,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	padding: 0;
 
 	@media screen and ( max-width: 659px ) {
-		padding-bottom: 3em;
+		padding: 0 14% 3em;
 	}
 
 	@media screen and ( min-width: 1200px ) {
@@ -99,7 +99,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	.template-selector-control__options {
 		display: grid;
 		// stylelint-disable-next-line unit-whitelist
-		grid-template-columns: 1fr 1fr; // force 2 col on small screens to ensure blank isn't the only option visible on load
+		grid-template-columns: 1fr;
 		grid-gap: 1.75em;
 
 		@media screen and ( min-width: 660px ) {
@@ -175,6 +175,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		pointer-events: none;
 		opacity: 1;
 
+		@media screen and ( max-width: 659px ) {
+			padding-top: 120%;
+		}
+
 		&.is-rendering {
 			opacity: 0.5;
 		}
@@ -226,6 +230,9 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .page-template-modal__form-title {
 	font-weight: bold;
 	margin-bottom: 1em;
+	@media screen and ( max-width: 659px ) {
+		text-align: center;
+	}
 }
 
 .page-template-modal__buttons {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -15,6 +15,7 @@ $template-selector-border-color: #a1aab2;
 $template-selector-empty-background: #fff;
 $template-selector-modal-offset-right: 32px;
 $template-selector-modal-offset-bottom: 25px;
+$template-selector-blank-template-mobile-height: 70px;
 $template-large-preview-title-height: 117px;
 
 $wp-org-sidebar-reduced: 36px;
@@ -84,6 +85,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 	@media screen and ( max-width: 659px ) {
 		padding: 0 14% 3em;
+	}
+
+	@media screen and ( max-width: 440px ) {
+		padding: 0 15px 3em;
 	}
 
 	@media screen and ( min-width: 1200px ) {
@@ -195,6 +200,22 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		position: absolute;
 		top: 0;
 		left: 0;
+	}
+
+	// Blank template
+	.template-selector-control__template:first-child {
+		.template-selector-item__preview-wrap {
+			@media screen and ( max-width: 659px ) {
+				padding-top: 0%;
+				height: $template-selector-blank-template-mobile-height;
+			}
+		}
+		.template-selector-item__template-title {
+			@media screen and ( max-width: 659px ) {
+				height: $template-selector-blank-template-mobile-height;
+				line-height: $template-selector-blank-template-mobile-height;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION

This PR aims to update the visual appearance of the SPT selector on small screens as per the design suggestions made in this comment  https://github.com/Automattic/wp-calypso/issues/35887#issuecomment-536063212

This PR is related to https://github.com/Automattic/wp-calypso/issues/35887

![spt-mobile-update](https://user-images.githubusercontent.com/1562646/65986706-b5e4d680-e484-11e9-8188-cf5804218cae.gif)
