### PR TITLE
Billing History: Equalize padding for date and details

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -96,7 +96,8 @@
 
 .billing-history__transactions tbody .billing-history__date {
 	width: 150px;
-	padding: 12px;
+	padding-left: 12px;
+	padding-right: 12px;
 }
 
 .billing-history__transactions tbody .billing-history__trans-app {


### PR DESCRIPTION
The Billing History page contains a table with three columns: date,
details, and amount. Each column has a padding, but the paddings are not
the same.

The `td` in that table has a default top/bottom paddding of 16px, but
the date field is overridden to be 12px instead. This leads to uneven
content.

This commit changes the padding so that the date field does not override
the top and bottom padding, to keep them aligned.

Props to @daledupreez for finding this issue.

Before:

![history-padding-before](https://user-images.githubusercontent.com/2036909/65998632-b3c14e80-e469-11e9-93e3-2cd8b47dcbc8.png)

After:

![history-padding-after](https://user-images.githubusercontent.com/2036909/65998639-bae85c80-e469-11e9-8fc5-e58da253ad83.png)

#### Testing instructions

For a site with at least one purchase, visit http://calypso.localhost:3000/me/purchases/billing and examine the top alignment of the table cells. See the screenshots above.