### PR TITLE
Onboarding Checklist: Remove it for all Jetpack sites

### DIFF
--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -11,7 +11,6 @@ import moment from 'moment';
  */
 import getSiteOptions from 'state/selectors/get-site-options';
 import { isJetpackSite } from 'state/sites/selectors';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 /**
  * @param {Object} state Global state tree
@@ -21,7 +20,6 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
  */
 export default function isEligibleForDotcomChecklist( state, siteId ) {
 	const siteOptions = getSiteOptions( state, siteId );
-	const designType = get( siteOptions, 'design_type' );
 	const createdAt = get( siteOptions, 'created_at', '' );
 
 	// Checklist should not show up if the site is created before the feature was launched.
@@ -33,9 +31,5 @@ export default function isEligibleForDotcomChecklist( state, siteId ) {
 		return false;
 	}
 
-	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
-		return false;
-	}
-
-	return 'store' !== designType;
+	return ! isJetpackSite( state, siteId );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a PR based on a recent discussion about the check against a site's design type being unreliable. It was suggested by @michaeldcain that we shouldn't be using the checklist for any Atomic sites until private by default was available. p1569501077031000-slack-onboarding-exp

As we are planning on launching the Customer Home more widely soon, it would be good if we could sort this logic out, and so this change hides the checklist menu item for all Jetpack sites. There will be a number of Atomic sites that will have this disappear, but that could be seen as better than displaying a checklist that's not appropriate. 

It's up for discussion what the right thing to do is!

#### Testing instructions

Using this branch and selecting an Atomic site created after the 6th August, observe that there is no Checklist menu item in the sidebar.
