### PR TITLE
e2e: Add tests for our six CoBlocks.

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -156,6 +156,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	// return blockID - top level block id which is looks like `block-b91ce479-fb2d-45b7-ad92-22ae7a58cf04`. Should be used for further interaction with added block.
 	async addBlock( name ) {
 		name = name.charAt( 0 ).toUpperCase() + name.slice( 1 ); // Capitalize block name
+		let blockClass = name;
 		let prefix = '';
 		switch ( name ) {
 			case 'Instagram':
@@ -170,12 +171,23 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			case 'Markdown':
 				prefix = 'jetpack-';
 				break;
+			case 'Buttons':
+			case 'Click to Tweet':
+			case 'Hero':
+			case 'Logos':
+			case 'Pricing Table':
+				prefix = 'coblocks-';
+				break;
+			case 'Dynamic HR':
+				prefix = 'coblocks-';
+				blockClass = 'dynamic-separator';
+				break;
 		}
 		const inserterToggleSelector = By.css( '.edit-post-header .editor-inserter__toggle' );
 		const inserterMenuSelector = By.css( '.editor-inserter__menu' );
 		const inserterSearchInputSelector = By.css( 'input.editor-inserter__search' );
 		const inserterBlockItemSelector = By.css(
-			`li.editor-block-types-list__list-item button.editor-block-list-item-${ prefix }${ name
+			`li.editor-block-types-list__list-item button.editor-block-list-item-${ prefix }${ blockClass
 				.replace( /\s+/g, '-' )
 				.toLowerCase() }`
 		);

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -1,0 +1,202 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
+
+import * as driverManager from '../lib/driver-manager';
+import * as driverHelper from '../lib/driver-helper';
+import * as dataHelper from '../lib/data-helper';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+
+let driver;
+
+before( async function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, function() {
+	this.timeout( mochaTimeOut );
+
+	describe( 'Insert a Buttons block: @parallel', function() {
+		step( 'Can log in', async function() {
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can insert the Buttons block', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.addBlock( 'Buttons' );
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-buttons' )
+			);
+		} );
+
+		step( 'Can publish and view content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see the Buttons block in our published post', async function() {
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-buttons' )
+			);
+		} );
+	} );
+
+	// describe( 'Insert a Click to Tweet block: @parallel', function() {
+	// 	step( 'Can log in', async function() {
+	// 		this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+	// 		return await this.loginFlow.loginAndStartNewPost( null, true );
+	// 	} );
+
+	// 	step( 'Can insert the Click to Tweet block', async function() {
+	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+	// 		await gEditorComponent.addBlock( 'Click to Tweet' );
+	//         return await driverHelper.waitTillPresentAndDisplayed(
+	//             driver,
+	//             By.css( '.wp-block-coblocks-click-to-tweet' )
+	//         );
+	// 	} );
+
+	// 	step( 'Can publish and view content', async function() {
+	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+	// 		return await gEditorComponent.publish( { visit: true } );
+	// 	} );
+
+	// 	step( 'Can see the Click to Tweet block in our published post', async function() {
+	//         return await driverHelper.waitTillPresentAndDisplayed(
+	//             driver,
+	//             By.css( '.wp-block-coblocks-click-to-tweet' )
+	//         );
+	// 	} );
+	// } );
+
+	describe( 'Insert a Dynamic HR block: @parallel', function() {
+		step( 'Can log in', async function() {
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can insert the Dynamic HR block', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.addBlock( 'Dynamic HR' );
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-dynamic-separator' )
+			);
+		} );
+
+		step( 'Can publish and view content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see the Dynamic HR block in our published post', async function() {
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-dynamic-separator' )
+			);
+		} );
+	} );
+
+	describe( 'Insert a Hero block: @parallel', function() {
+		step( 'Can log in', async function() {
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can insert the Hero block', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.addBlock( 'Hero' );
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-hero' )
+			);
+		} );
+
+		step( 'Can publish and view content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see the Hero block in our published post', async function() {
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-hero' )
+			);
+		} );
+	} );
+
+	// describe( 'Insert a Logos & Badges block: @parallel', function() {
+	// 	step( 'Can log in', async function() {
+	// 		this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+	// 		return await this.loginFlow.loginAndStartNewPost( null, true );
+	// 	} );
+
+	// 	step( 'Can insert the Logos & Badges block', async function() {
+	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+	// 		await gEditorComponent.addBlock( 'Logos' );
+	//         return await driverHelper.waitTillPresentAndDisplayed(
+	//             driver,
+	//             By.css( '.wp-block-coblocks-logos' )
+	//         );
+	// 	} );
+
+	// 	step( 'Can publish and view content', async function() {
+	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+	// 		return await gEditorComponent.publish( { visit: true } );
+	// 	} );
+
+	// 	step( 'Can see the Logos & Badges block in our published post', async function() {
+	//         return await driverHelper.waitTillPresentAndDisplayed(
+	//             driver,
+	//             By.css( '.wp-block-coblocks-logos' )
+	//         );
+	// 	} );
+	// } );
+
+	describe( 'Insert a Pricing Table block: @parallel', function() {
+		step( 'Can log in', async function() {
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can insert the Pricing Table block', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.addBlock( 'Pricing Table' );
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-pricing-table' )
+			);
+		} );
+
+		step( 'Can publish and view content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see the Pricing Table block in our published post', async function() {
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-pricing-table' )
+			);
+		} );
+	} );
+} );

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -87,8 +87,29 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 		} );
 
 		step( 'Can publish and view content', async function() {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			return await gEditorComponent.publish( { visit: true } );
+			// FIXME: hack based on `gEditorComponent.publish()`, which was closing the sidebar too fast in this test
+			// We're basically removing the `this.closePublishedPanel()` call.
+			const snackBarNoticeLinkSelector = By.css( '.components-snackbar__content a' );
+			const publishSelector = By.css(
+				'.editor-post-publish-panel__header-publish-button button[aria-disabled=false]'
+			);
+			await driverHelper.clickWhenClickable(
+				driver,
+				By.css( '.editor-post-publish-panel__toggle' )
+			);
+			await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.editor-post-publish-panel__header' )
+			);
+			await driverHelper.waitTillPresentAndDisplayed( driver, publishSelector );
+			await driverHelper.clickWhenClickable( driver, publishSelector );
+			await driverHelper.waitTillNotPresent(
+				driver,
+				By.css( '.editor-post-publish-panel__content .components-spinner' )
+			);
+			await driverHelper.waitTillPresentAndDisplayed( driver, By.css( '.components-snackbar' ) );
+			await driverHelper.clickWhenClickable( driver, snackBarNoticeLinkSelector );
+			return await driverHelper.acceptAlertIfPresent( driver );
 		} );
 
 		step( 'Can see the Click to Tweet block in our published post', async function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -16,6 +16,7 @@ import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-componen
 import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
 import * as dataHelper from '../lib/data-helper';
+import * as mediaHelper from '../lib/media-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -60,33 +61,43 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 		} );
 	} );
 
-	// describe( 'Insert a Click to Tweet block: @parallel', function() {
-	// 	step( 'Can log in', async function() {
-	// 		this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-	// 		return await this.loginFlow.loginAndStartNewPost( null, true );
-	// 	} );
+	describe( 'Insert a Click to Tweet block: @parallel', function() {
+		step( 'Can log in', async function() {
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
 
-	// 	step( 'Can insert the Click to Tweet block', async function() {
-	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-	// 		await gEditorComponent.addBlock( 'Click to Tweet' );
-	//         return await driverHelper.waitTillPresentAndDisplayed(
-	//             driver,
-	//             By.css( '.wp-block-coblocks-click-to-tweet' )
-	//         );
-	// 	} );
+		step( 'Can insert the Click to Tweet block', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.addBlock( 'Click to Tweet' );
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-click-to-tweet' )
+			);
+		} );
 
-	// 	step( 'Can publish and view content', async function() {
-	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-	// 		return await gEditorComponent.publish( { visit: true } );
-	// 	} );
+		step( 'Can enter text to tweet', async function() {
+			const textSelector = By.css( '.wp-block-coblocks-click-to-tweet__text' );
+			await driverHelper.waitTillPresentAndDisplayed( driver, textSelector );
+			return await driver
+				.findElement( textSelector )
+				.sendKeys(
+					'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim'
+				);
+		} );
 
-	// 	step( 'Can see the Click to Tweet block in our published post', async function() {
-	//         return await driverHelper.waitTillPresentAndDisplayed(
-	//             driver,
-	//             By.css( '.wp-block-coblocks-click-to-tweet' )
-	//         );
-	// 	} );
-	// } );
+		step( 'Can publish and view content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see the Click to Tweet block in our published post', async function() {
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-click-to-tweet' )
+			);
+		} );
+	} );
 
 	describe( 'Insert a Dynamic HR block: @parallel', function() {
 		step( 'Can log in', async function() {
@@ -144,33 +155,60 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 		} );
 	} );
 
-	// describe( 'Insert a Logos & Badges block: @parallel', function() {
-	// 	step( 'Can log in', async function() {
-	// 		this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
-	// 		return await this.loginFlow.loginAndStartNewPost( null, true );
-	// 	} );
+	describe( 'Insert a Logos & Badges block: @parallel', function() {
+		let fileDetails;
 
-	// 	step( 'Can insert the Logos & Badges block', async function() {
-	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-	// 		await gEditorComponent.addBlock( 'Logos' );
-	//         return await driverHelper.waitTillPresentAndDisplayed(
-	//             driver,
-	//             By.css( '.wp-block-coblocks-logos' )
-	//         );
-	// 	} );
+		// Create image file for upload
+		before( async function() {
+			fileDetails = await mediaHelper.createFile();
+			return fileDetails;
+		} );
 
-	// 	step( 'Can publish and view content', async function() {
-	// 		const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-	// 		return await gEditorComponent.publish( { visit: true } );
-	// 	} );
+		step( 'Can log in', async function() {
+			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
 
-	// 	step( 'Can see the Logos & Badges block in our published post', async function() {
-	//         return await driverHelper.waitTillPresentAndDisplayed(
-	//             driver,
-	//             By.css( '.wp-block-coblocks-logos' )
-	//         );
-	// 	} );
-	// } );
+		step( 'Can insert the Logos & Badges block', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.addBlock( 'Logos' );
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-logos' )
+			);
+		} );
+
+		step( 'Can select an image as a logo', async function() {
+			await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.editor-media-placeholder' )
+			);
+			await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.components-form-file-upload ' )
+			);
+			const filePathInput = await driver.findElement(
+				By.css( '.components-form-file-upload input[type="file"]' )
+			);
+			await filePathInput.sendKeys( fileDetails.file );
+			return await driverHelper.waitTillNotPresent(
+				driver,
+				By.css( '.wp-block-image .components-spinner' )
+			);
+		} );
+
+		step( 'Can publish and view content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see the Logos & Badges block in our published post', async function() {
+			return await driverHelper.waitTillPresentAndDisplayed(
+				driver,
+				By.css( '.wp-block-coblocks-logos' )
+			);
+		} );
+	} );
 
 	describe( 'Insert a Pricing Table block: @parallel', function() {
 		step( 'Can log in', async function() {


### PR DESCRIPTION
We have a custom build of the CoBlocks plugin, which brings these six blocks to WordPress.com:

* Buttons
* Click to Tweet
* Hero
* Dynamic HR
* Logos & Badges
* Pricing Table

This PR adds basic add+display tests for all blocks.

#### Testing instructions

* Switch to this branch in your local Calypso repo.
* Run the following in your local e2e setup, from the `test/e2e` directory: `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-coblocks-spec.js`
