### PR TITLE
Remove media query for cover image block styling override in site preview

### DIFF
--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -102,15 +102,13 @@ export function getIframeSource(
 					pointer-events: none;
 				}
 
-				@media only screen and (min-width: 768px) {
-					/*
-						Some of the themes (business sophisticated) use js to dynamically set the height of the banner
-						Let's set a fixed max-height.
-					*/
-					.entry .entry-content .wp-block-cover-image,
-					.entry .entry-content .wp-block-cover {
-						height: 480px !important;
-					}
+				/*
+					Some of the themes (business sophisticated) use js to dynamically set the height of the banner
+					Let's set a fixed max-height.
+				*/
+				.entry .entry-content .wp-block-cover-image,
+				.entry .entry-content .wp-block-cover {
+					height: 480px !important;
 				}
 
 				/*


### PR DESCRIPTION
Related to #36369 this change removes the media query in the site preview to ensure that the cover block styling override applies to all screen widths. From #36369:

> Gutenberg 6.5 added a height: 100% rule to the cover image, which breaks in our Signup iframe. This updates the styles to set a static height.

#### Changes proposed in this Pull Request

* Remove media query for cover block styling override in the site preview in signup

#### Screenshot of before / after

![mobile-cover-image](https://user-images.githubusercontent.com/14988353/66023451-8ab9c000-e534-11e9-85ae-7f8693e3e409.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/start`
* Select the Business site type, and any vertical
* Resize the screen to less than 768px and particular mobile device sizes (e.g. 320px or 375px wide) and check that the preview looks like the screenshot above, and the cover block is a reasonable size with the image not blurry
* Double-check on Chrome, Firefox, Safari, IE11
* Repeat selecting the Blog site type
