### PR TITLE
Make 'v' open a new tab while 'enter' remains same

### DIFF
--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -23,10 +23,18 @@ const KEY_BINDINGS = {
 		},
 		{
 			eventName: 'open-selection',
-			keys: [ [ 'enter' ], [ 'v' ] ],
+			keys: [ [ 'enter' ] ],
 			description: {
-				keys: [ [ 'enter' ], [ 'v' ] ],
+				keys: [ [ 'enter' ] ],
 				text: translate( 'Open selection' ),
+			},
+		},
+		{
+			eventName: 'open-selection-new-tab',
+			keys: [ [ 'v' ] ],
+			description: {
+				keys: [ [ 'v' ] ],
+				text: translate( 'Open selection in a new tab' ),
 			},
 		},
 		{

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -176,7 +176,7 @@ class ReaderStream extends React.Component {
 	}
 
 	handleOpenSelectionNewTab = () => {
-		window.open( this.props.selectedPostKey.url, '_blank' );
+		window.open( this.props.selectedPostKey.url, '_blank', 'noreferrer,noopener' );
 	};
 
 	handleOpenSelection = () => {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -153,6 +153,7 @@ class ReaderStream extends React.Component {
 		KeyboardShortcuts.on( 'move-selection-down', this.selectNextItem );
 		KeyboardShortcuts.on( 'move-selection-up', this.selectPrevItem );
 		KeyboardShortcuts.on( 'open-selection', this.handleOpenSelection );
+		KeyboardShortcuts.on( 'open-selection-new-tab', this.handleOpenSelectionNewTab );
 		KeyboardShortcuts.on( 'like-selection', this.toggleLikeOnSelectedPost );
 		KeyboardShortcuts.on( 'go-to-top', this.goToTop );
 		window.addEventListener( 'popstate', this._popstate );
@@ -165,6 +166,7 @@ class ReaderStream extends React.Component {
 		KeyboardShortcuts.off( 'move-selection-down', this.selectNextItem );
 		KeyboardShortcuts.off( 'move-selection-up', this.selectPrevItem );
 		KeyboardShortcuts.off( 'open-selection', this.handleOpenSelection );
+		KeyboardShortcuts.off( 'open-selection-new-tab', this.handleOpenSelectionNewTab );
 		KeyboardShortcuts.off( 'like-selection', this.toggleLikeOnSelectedPost );
 		KeyboardShortcuts.off( 'go-to-top', this.goToTop );
 		window.removeEventListener( 'popstate', this._popstate );
@@ -172,6 +174,10 @@ class ReaderStream extends React.Component {
 			history.scrollRestoration = 'auto';
 		}
 	}
+
+	handleOpenSelectionNewTab = () => {
+		window.open( this.props.selectedPostKey.url, '_blank' );
+	};
 
 	handleOpenSelection = () => {
 		showSelectedPost( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make 'v' open a new tab while 'enter' remains same

#### Testing instructions

1. Navigate through the reader using `j` and `k` keys
2. Press `v`
Expected: It should open the post in a new tab
3. Press 'enter'
Expected: It should open the post in the same tab

Fixes #30988.
