### PR TITLE
Happiness: Enable German, Dutch and Italian locales for upwork support

### DIFF
--- a/client/state/selectors/is-eligible-for-upwork-support.ts
+++ b/client/state/selectors/is-eligible-for-upwork-support.ts
@@ -11,6 +11,11 @@ import getSitesItems from 'state/selectors/get-sites-items';
 import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
 
 const UPWORK_LOCALES = [
+	'de',
+	'de-at',
+	'de-li',
+	'de-lu',
+	'de-ch',
 	'es',
 	'es-cl',
 	'es-mx',
@@ -18,6 +23,11 @@ const UPWORK_LOCALES = [
 	'fr-ca',
 	'fr-be',
 	'fr-ch',
+	'it',
+	'it-ch',
+	'nl',
+	'nl-be',
+	'nl-nl',
 	'pt',
 	'pt-pt',
 	'pt-br',

--- a/client/state/selectors/test/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/test/is-eligible-for-upwork-support.js
@@ -93,4 +93,46 @@ describe( 'isEligibleForUpworkSupport()', () => {
 		};
 		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
 	} );
+
+	test( 'returns true for German language users without Business and E-Commerce plans', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					111: { plan: { product_slug: PLAN_FREE } },
+					222: { plan: { product_slug: PLAN_PREMIUM } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'de' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
+	} );
+
+	test( 'returns true for Italian language users without Business and E-Commerce plans', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					111: { plan: { product_slug: PLAN_FREE } },
+					222: { plan: { product_slug: PLAN_PREMIUM } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'it' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
+	} );
+
+	test( 'returns true for Dutch language users without Business and E-Commerce plans', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					111: { plan: { product_slug: PLAN_FREE } },
+					222: { plan: { product_slug: PLAN_PREMIUM } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'nl' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `de` (and variations), `it` (and variations) and `nl` (and variations) locales as eligible for upwork support.

#### Testing instructions

- Ensure that Happychat has availability (by default development Calypso connects to staging Happychat)
- Sign into Calypso as a user that has at least one paid upgrade (like a Theme, or a paid plan) but does not have any site with a Business or eCommerce plan.
- Make sure your language setting is not a German, Dutch or Italian.
- Check the inline "Contact Us" form — it should be directing you to chat support ("Chat with us" on the button)
- Now change your language setting to `de` (German).
- Re-open the inline "Contact Us" form — it should now direct you to email support even though Happychat is still available.
- Try the same thing with a user that has a Business or eCommerce plan — they should receive Chat support regardless of language setting.
- Repeat for Italian and Dutch
