### PR TITLE
Replace `createReducer[WithValidation]` across Calypso

### DIFF
--- a/client/extensions/woocommerce/state/action-list/reducer.js
+++ b/client/extensions/woocommerce/state/action-list/reducer.js
@@ -9,15 +9,21 @@ import { pick } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_ACTION_LIST_ANNOTATE,
 	WOOCOMMERCE_ACTION_LIST_CLEAR,
 } from 'woocommerce/state/action-types';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_ACTION_LIST_CLEAR ]: handleActionListClear,
-	[ WOOCOMMERCE_ACTION_LIST_ANNOTATE ]: handleActionListAnnotate,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_ACTION_LIST_CLEAR:
+			return handleActionListClear( state, action );
+		case WOOCOMMERCE_ACTION_LIST_ANNOTATE:
+			return handleActionListAnnotate( state, action );
+	}
+
+	return state;
 } );
 
 function handleActionListClear() {

--- a/client/extensions/woocommerce/state/sites/coupons/reducer.js
+++ b/client/extensions/woocommerce/state/sites/coupons/reducer.js
@@ -8,21 +8,25 @@ import { findIndex } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_COUPON_DELETED,
 	WOOCOMMERCE_COUPON_UPDATED,
 	WOOCOMMERCE_COUPONS_UPDATED,
 } from 'woocommerce/state/action-types';
 
-export default createReducer(
-	{},
-	{
-		[ WOOCOMMERCE_COUPON_DELETED ]: couponDeleted,
-		[ WOOCOMMERCE_COUPON_UPDATED ]: couponUpdated,
-		[ WOOCOMMERCE_COUPONS_UPDATED ]: pageUpdated,
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_COUPON_DELETED:
+			return couponDeleted( state, action );
+		case WOOCOMMERCE_COUPON_UPDATED:
+			return couponUpdated( state, action );
+		case WOOCOMMERCE_COUPONS_UPDATED:
+			return pageUpdated( state, action );
 	}
-);
+
+	return state;
+} );
 
 function couponDeleted( state, action ) {
 	const { couponId } = action;

--- a/client/extensions/woocommerce/state/sites/data/currencies/reducer.js
+++ b/client/extensions/woocommerce/state/sites/data/currencies/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_CURRENCIES_REQUEST,
 	WOOCOMMERCE_CURRENCIES_REQUEST_SUCCESS,
@@ -13,12 +13,16 @@ import { LOADING } from 'woocommerce/state/constants';
 
 // TODO: Handle error
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_CURRENCIES_REQUEST ]: () => {
-		return LOADING;
-	},
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_CURRENCIES_REQUEST: {
+			return LOADING;
+		}
+		case WOOCOMMERCE_CURRENCIES_REQUEST_SUCCESS: {
+			const { data } = action;
+			return data;
+		}
+	}
 
-	[ WOOCOMMERCE_CURRENCIES_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data;
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/data/locations/reducer.js
+++ b/client/extensions/woocommerce/state/sites/data/locations/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_LOCATIONS_REQUEST,
 	WOOCOMMERCE_LOCATIONS_REQUEST_SUCCESS,
@@ -13,27 +13,33 @@ import {
 import { LOADING, ERROR } from 'woocommerce/state/constants';
 import { decodeEntities } from 'lib/formatting';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_LOCATIONS_REQUEST ]: () => {
-		return LOADING;
-	},
-
-	[ WOOCOMMERCE_LOCATIONS_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data.map( continent => ( {
-			code: continent.code,
-			name: decodeEntities( continent.name ),
-			countries: continent.countries.map( country => ( {
-				code: country.code,
-				name: decodeEntities( country.name ),
-				states: country.states.map( countryState => ( {
-					code: countryState.code,
-					name: decodeEntities( countryState.name ),
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_LOCATIONS_REQUEST: {
+			return LOADING;
+		}
+		case WOOCOMMERCE_LOCATIONS_REQUEST_SUCCESS: {
+			const { data } = action;
+			return data.map( continent => ( {
+				code: continent.code,
+				name: decodeEntities( continent.name ),
+				countries: continent.countries.map( country => ( {
+					code: country.code,
+					name: decodeEntities( country.name ),
+					states: country.states.map( countryState => ( {
+						code: countryState.code,
+						name: decodeEntities( countryState.name ),
+					} ) ),
 				} ) ),
-			} ) ),
-		} ) );
-	},
+			} ) );
+		}
+		case WOOCOMMERCE_ERROR_SET: {
+			const {
+				originalAction: { type },
+			} = action;
+			return WOOCOMMERCE_LOCATIONS_REQUEST === type ? ERROR : state;
+		}
+	}
 
-	[ WOOCOMMERCE_ERROR_SET ]: ( state, { originalAction: { type } } ) => {
-		return WOOCOMMERCE_LOCATIONS_REQUEST === type ? ERROR : state;
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/meta/taxrates/reducer.js
+++ b/client/extensions/woocommerce/state/sites/meta/taxrates/reducer.js
@@ -4,22 +4,23 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
 import {
 	WOOCOMMERCE_TAXRATES_REQUEST,
 	WOOCOMMERCE_TAXRATES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-export default createReducer(
-	{},
-	{
-		[ WOOCOMMERCE_TAXRATES_REQUEST ]: () => {
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_TAXRATES_REQUEST: {
 			return LOADING;
-		},
-
-		[ WOOCOMMERCE_TAXRATES_REQUEST_SUCCESS ]: ( state, { data } ) => {
+		}
+		case WOOCOMMERCE_TAXRATES_REQUEST_SUCCESS: {
+			const { data } = action;
 			return data;
-		},
+		}
 	}
-);
+
+	return state;
+} );

--- a/client/extensions/woocommerce/state/sites/payment-methods/reducer.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
 import {
 	WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS,
@@ -14,10 +14,10 @@ import {
 
 // TODO: Handle error
 
-export default createReducer(
-	{},
-	{
-		[ WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS ]: ( state, { data } ) => {
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS: {
+			const { data } = action;
 			const methods = state || [];
 			const newMethods = methods.map( method => {
 				if ( method.id === data.id ) {
@@ -26,14 +26,15 @@ export default createReducer(
 				return method;
 			} );
 			return newMethods;
-		},
-
-		[ WOOCOMMERCE_PAYMENT_METHODS_REQUEST ]: () => {
+		}
+		case WOOCOMMERCE_PAYMENT_METHODS_REQUEST: {
 			return LOADING;
-		},
-
-		[ WOOCOMMERCE_PAYMENT_METHODS_REQUEST_SUCCESS ]: ( state, { data } ) => {
+		}
+		case WOOCOMMERCE_PAYMENT_METHODS_REQUEST_SUCCESS: {
+			const { data } = action;
 			return data;
-		},
+		}
 	}
-);
+
+	return state;
+} );

--- a/client/extensions/woocommerce/state/sites/product-variations/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-variations/reducer.js
@@ -9,15 +9,17 @@ import { compact, isEqual, isNumber } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { WOOCOMMERCE_PRODUCT_VARIATION_UPDATED } from 'woocommerce/state/action-types';
 
-export default createReducer(
-	{},
-	{
-		[ WOOCOMMERCE_PRODUCT_VARIATION_UPDATED ]: variationUpdated,
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PRODUCT_VARIATION_UPDATED:
+			return variationUpdated( state, action );
 	}
-);
+
+	return state;
+} );
 
 export function variationUpdated( state, action ) {
 	const { productId, data } = action;

--- a/client/extensions/woocommerce/state/sites/products/reducer.js
+++ b/client/extensions/woocommerce/state/sites/products/reducer.js
@@ -9,7 +9,7 @@ import { difference, forEach, get, reject } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { getSerializedProductsQuery } from './utils';
 import {
 	WOOCOMMERCE_PRODUCT_DELETE_SUCCESS,
@@ -20,16 +20,22 @@ import {
 } from 'woocommerce/state/action-types';
 import { decodeEntities } from 'lib/formatting';
 
-export default createReducer(
-	{},
-	{
-		[ WOOCOMMERCE_PRODUCT_DELETE_SUCCESS ]: productsDeleteSuccess,
-		[ WOOCOMMERCE_PRODUCT_UPDATED ]: productUpdated,
-		[ WOOCOMMERCE_PRODUCTS_REQUEST ]: productsRequest,
-		[ WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS ]: productsRequestSuccess,
-		[ WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE ]: productsRequestFailure,
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PRODUCT_DELETE_SUCCESS:
+			return productsDeleteSuccess( state, action );
+		case WOOCOMMERCE_PRODUCT_UPDATED:
+			return productUpdated( state, action );
+		case WOOCOMMERCE_PRODUCTS_REQUEST:
+			return productsRequest( state, action );
+		case WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS:
+			return productsRequestSuccess( state, action );
+		case WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE:
+			return productsRequestFailure( state, action );
 	}
-);
+
+	return state;
+} );
 
 /**
  * Merge a product into the products list

--- a/client/extensions/woocommerce/state/sites/promotions/reducer.js
+++ b/client/extensions/woocommerce/state/sites/promotions/reducer.js
@@ -12,7 +12,7 @@ import { fill, find, findIndex } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_COUPON_DELETED,
 	WOOCOMMERCE_COUPON_UPDATED,
@@ -30,13 +30,23 @@ const initialState = {
 	promotions: null,
 };
 
-export default createReducer( initialState, {
-	[ WOOCOMMERCE_COUPON_DELETED ]: couponDeleted,
-	[ WOOCOMMERCE_COUPON_UPDATED ]: couponUpdated,
-	[ WOOCOMMERCE_COUPONS_UPDATED ]: couponsUpdated,
-	[ WOOCOMMERCE_PRODUCT_UPDATED ]: productUpdated,
-	[ WOOCOMMERCE_PRODUCT_VARIATION_UPDATED ]: productVariationUpdated,
-	[ WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS ]: productsRequestSuccess,
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_COUPON_DELETED:
+			return couponDeleted( state, action );
+		case WOOCOMMERCE_COUPON_UPDATED:
+			return couponUpdated( state, action );
+		case WOOCOMMERCE_COUPONS_UPDATED:
+			return couponsUpdated( state, action );
+		case WOOCOMMERCE_PRODUCT_UPDATED:
+			return productUpdated( state, action );
+		case WOOCOMMERCE_PRODUCT_VARIATION_UPDATED:
+			return productVariationUpdated( state, action );
+		case WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS:
+			return productsRequestSuccess( state, action );
+	}
+
+	return state;
 } );
 
 function couponDeleted( state, action ) {

--- a/client/extensions/woocommerce/state/sites/review-replies/reducer.js
+++ b/client/extensions/woocommerce/state/sites/review-replies/reducer.js
@@ -9,7 +9,7 @@ import { reject, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_REVIEW_REPLIES_UPDATED,
 	WOOCOMMERCE_REVIEW_REPLY_CREATED,
@@ -17,15 +17,20 @@ import {
 	WOOCOMMERCE_REVIEW_REPLY_UPDATED,
 } from 'woocommerce/state/action-types';
 
-export default createReducer(
-	{},
-	{
-		[ WOOCOMMERCE_REVIEW_REPLIES_UPDATED ]: repliesUpdated,
-		[ WOOCOMMERCE_REVIEW_REPLY_DELETED ]: replyDeleted,
-		[ WOOCOMMERCE_REVIEW_REPLY_UPDATED ]: replyUpdated,
-		[ WOOCOMMERCE_REVIEW_REPLY_CREATED ]: replyCreated,
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_REVIEW_REPLIES_UPDATED:
+			return repliesUpdated( state, action );
+		case WOOCOMMERCE_REVIEW_REPLY_DELETED:
+			return replyDeleted( state, action );
+		case WOOCOMMERCE_REVIEW_REPLY_UPDATED:
+			return replyUpdated( state, action );
+		case WOOCOMMERCE_REVIEW_REPLY_CREATED:
+			return replyCreated( state, action );
 	}
-);
+
+	return state;
+} );
 
 export function repliesUpdated( state, action ) {
 	const { reviewId, replies, error } = action;

--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -96,18 +96,16 @@ export default withoutPersistence( ( state = null, action ) => {
 			const data = update.update;
 			return process_data( data );
 		}
-		case WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_FAILURE:
-			return ( ( state, error ) => {
-				const settings = Object.assign( {}, omit( state, 'isSaving' ) );
-				settings.error = error;
-				return settings;
-			} )( state, action );
-		case WOOCOMMERCE_EMAIL_SETTINGS_INVALID_VALUE:
-			return ( ( state, reason ) => {
-				const settings = Object.assign( {}, omit( state, [ 'save', 'isSaving' ] ) );
-				settings.invalidValue = reason;
-				return settings;
-			} )( state, action );
+		case WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_FAILURE: {
+			const settings = Object.assign( {}, omit( state, 'isSaving' ) );
+			settings.error = action;
+			return settings;
+		}
+		case WOOCOMMERCE_EMAIL_SETTINGS_INVALID_VALUE: {
+			const settings = Object.assign( {}, omit( state, [ 'save', 'isSaving' ] ) );
+			settings.invalidValue = action;
+			return settings;
+		}
 	}
 
 	return state;

--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -9,7 +9,7 @@ import { filter, omit, isEmpty, setWith, get, forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
 import { decodeEntities } from 'lib/formatting';
 import {
@@ -62,49 +62,53 @@ const process_data = data => {
 	return options;
 };
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_EMAIL_SETTINGS_REQUEST ]: () => {
-		return LOADING;
-	},
-
-	[ WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS ]: ( state, { data } ) => process_data( data ),
-
-	[ WOOCOMMERCE_EMAIL_SETTINGS_CHANGE ]: ( state, { setting } ) => {
-		if ( ! setting && ! setting.setting && ! setting.option ) {
-			return state;
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_EMAIL_SETTINGS_REQUEST: {
+			return LOADING;
 		}
+		case WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS: {
+			const { data } = action;
+			return process_data( data );
+		}
+		case WOOCOMMERCE_EMAIL_SETTINGS_CHANGE: {
+			const { setting } = action;
+			if ( ! setting && ! setting.setting && ! setting.option ) {
+				return state;
+			}
 
-		const settings = Object.assign( {}, state );
-		settings[ setting.setting ][ setting.option ].value = setting.value;
-		return settings;
-	},
+			const settings = Object.assign( {}, state );
+			settings[ setting.setting ][ setting.option ].value = setting.value;
+			return settings;
+		}
+		case WOOCOMMERCE_EMAIL_SETTINGS_SAVE_SETTINGS: {
+			const settings = Object.assign( {}, state );
+			settings.save = true;
+			return settings;
+		}
+		case WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT: {
+			const settings = Object.assign( {}, omit( state, [ 'save' ] ) );
+			settings.isSaving = true;
+			return settings;
+		}
+		case WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_SUCCESS: {
+			const { update } = action;
+			const data = update.update;
+			return process_data( data );
+		}
+		case WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_FAILURE:
+			return ( ( state, error ) => {
+				const settings = Object.assign( {}, omit( state, 'isSaving' ) );
+				settings.error = error;
+				return settings;
+			} )( state, action );
+		case WOOCOMMERCE_EMAIL_SETTINGS_INVALID_VALUE:
+			return ( ( state, reason ) => {
+				const settings = Object.assign( {}, omit( state, [ 'save', 'isSaving' ] ) );
+				settings.invalidValue = reason;
+				return settings;
+			} )( state, action );
+	}
 
-	[ WOOCOMMERCE_EMAIL_SETTINGS_SAVE_SETTINGS ]: state => {
-		const settings = Object.assign( {}, state );
-		settings.save = true;
-		return settings;
-	},
-
-	[ WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT ]: state => {
-		const settings = Object.assign( {}, omit( state, [ 'save' ] ) );
-		settings.isSaving = true;
-		return settings;
-	},
-
-	[ WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_SUCCESS ]: ( state, { update } ) => {
-		const data = update.update;
-		return process_data( data );
-	},
-
-	[ WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_FAILURE ]: ( state, error ) => {
-		const settings = Object.assign( {}, omit( state, 'isSaving' ) );
-		settings.error = error;
-		return settings;
-	},
-
-	[ WOOCOMMERCE_EMAIL_SETTINGS_INVALID_VALUE ]: ( state, reason ) => {
-		const settings = Object.assign( {}, omit( state, [ 'save', 'isSaving' ] ) );
-		settings.invalidValue = reason;
-		return settings;
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/settings/general/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { ERROR, LOADING } from 'woocommerce/state/constants';
 import { isNull } from 'lodash';
 import { updateSettings } from '../helpers';
@@ -18,53 +18,56 @@ import {
 
 // TODO: Handle error
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS ]: ( state, { data } ) => {
-		const settings = state || [];
-		const newSettings = settings.map( setting => {
-			if ( setting.id === data.id ) {
-				return data;
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS: {
+			const { data } = action;
+			const settings = state || [];
+			const newSettings = settings.map( setting => {
+				if ( setting.id === data.id ) {
+					return data;
+				}
+				return setting;
+			} );
+			return newSettings;
+		}
+		case WOOCOMMERCE_TAXES_ENABLED_UPDATE_SUCCESS: {
+			const { data } = action;
+			const settings = state || [];
+			const newSettings = settings.map( setting => {
+				if ( setting.id === data.id ) {
+					return data;
+				}
+				return setting;
+			} );
+			return newSettings;
+		}
+		case WOOCOMMERCE_SETTINGS_GENERAL_REQUEST: {
+			const {
+				meta: {
+					dataLayer: { error, data },
+				},
+			} = action;
+
+			// Don't set the loading indicator if data has previously been loaded,
+			// or if the data layer is dispatching with meta attached.
+			if ( ! data && ! error && ( isNull( state ) || ERROR === state ) ) {
+				return LOADING;
 			}
-			return setting;
-		} );
-		return newSettings;
-	},
-
-	[ WOOCOMMERCE_TAXES_ENABLED_UPDATE_SUCCESS ]: ( state, { data } ) => {
-		const settings = state || [];
-		const newSettings = settings.map( setting => {
-			if ( setting.id === data.id ) {
-				return data;
+			return state;
+		}
+		case WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE: {
+			const { data, error } = action;
+			if ( error ) {
+				return ERROR;
 			}
-			return setting;
-		} );
-		return newSettings;
-	},
-
-	[ WOOCOMMERCE_SETTINGS_GENERAL_REQUEST ]: (
-		state,
-		{
-			meta: {
-				dataLayer: { error, data },
-			},
+			return data;
 		}
-	) => {
-		// Don't set the loading indicator if data has previously been loaded,
-		// or if the data layer is dispatching with meta attached.
-		if ( ! data && ! error && ( isNull( state ) || ERROR === state ) ) {
-			return LOADING;
+		case WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS: {
+			const { data } = action;
+			return updateSettings( 'general', state || [], data );
 		}
-		return state;
-	},
+	}
 
-	[ WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE ]: ( state, { data, error } ) => {
-		if ( error ) {
-			return ERROR;
-		}
-		return data;
-	},
-
-	[ WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return updateSettings( 'general', state || [], data );
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/settings/products/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { ERROR, LOADING } from 'woocommerce/state/constants';
 import { updateSettings } from '../helpers';
 import {
@@ -24,24 +24,27 @@ const update = ( state, { data } ) => {
 	return updateSettings( 'products', state || [], data );
 };
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_SETTINGS_PRODUCTS_REQUEST ]: () => {
-		return LOADING;
-	},
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SETTINGS_PRODUCTS_REQUEST: {
+			return LOADING;
+		}
+		case WOOCOMMERCE_SETTINGS_PRODUCTS_REQUEST_SUCCESS: {
+			const { data } = action;
+			return data;
+		}
+		case WOOCOMMERCE_SETTINGS_PRODUCTS_UPDATE_REQUEST_SUCCESS:
+			return update( state, action );
+		case WOOCOMMERCE_SETTINGS_PRODUCTS_CHANGE_SETTING:
+			return update( state, action );
+		case WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS: {
+			const { data } = action;
+			return updateSettings( 'products', state || [], data );
+		}
+		case WOOCOMMERCE_SETTINGS_PRODUCTS_UPDATE_REQUEST_FAILURE: {
+			return ERROR;
+		}
+	}
 
-	[ WOOCOMMERCE_SETTINGS_PRODUCTS_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data;
-	},
-
-	[ WOOCOMMERCE_SETTINGS_PRODUCTS_UPDATE_REQUEST_SUCCESS ]: update,
-
-	[ WOOCOMMERCE_SETTINGS_PRODUCTS_CHANGE_SETTING ]: update,
-
-	[ WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return updateSettings( 'products', state || [], data );
-	},
-
-	[ WOOCOMMERCE_SETTINGS_PRODUCTS_UPDATE_REQUEST_FAILURE ]: () => {
-		return ERROR;
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/reducer.js
@@ -7,7 +7,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CLEAR_COMPLETED_NOTIFICATION,
 	WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CLEAR_ERROR,
@@ -226,17 +226,33 @@ function connectAccountOAuthConnectComplete( state = {}, action ) {
 	} );
 }
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CLEAR_COMPLETED_NOTIFICATION ]: connectAccountClearCompletedNotification,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CLEAR_ERROR ]: connectAccountClearError,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CREATE ]: connectAccountCreate,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CREATE_COMPLETE ]: connectAccountCreateComplete,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DEAUTHORIZE ]: connectAccountDeauthorize,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DEAUTHORIZE_COMPLETE ]: connectAccountDeauthorizeComplete,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DETAILS_REQUEST ]: connectAccountFetch,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DETAILS_UPDATE ]: connectAccountFetchComplete,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_INIT ]: connectAccountOAuthInit,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_INIT_COMPLETE ]: connectAccountOAuthInitComplete,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_CONNECT ]: connectAccountOAuthConnect,
-	[ WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_CONNECT_COMPLETE ]: connectAccountOAuthConnectComplete,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CLEAR_COMPLETED_NOTIFICATION:
+			return connectAccountClearCompletedNotification( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CLEAR_ERROR:
+			return connectAccountClearError( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CREATE:
+			return connectAccountCreate( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_CREATE_COMPLETE:
+			return connectAccountCreateComplete( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DEAUTHORIZE:
+			return connectAccountDeauthorize( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DEAUTHORIZE_COMPLETE:
+			return connectAccountDeauthorizeComplete( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DETAILS_REQUEST:
+			return connectAccountFetch( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_DETAILS_UPDATE:
+			return connectAccountFetchComplete( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_INIT:
+			return connectAccountOAuthInit( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_INIT_COMPLETE:
+			return connectAccountOAuthInitComplete( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_CONNECT:
+			return connectAccountOAuthConnect( state, action );
+		case WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_CONNECT_COMPLETE:
+			return connectAccountOAuthConnectComplete( state, action );
+	}
+
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/settings/tax/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/tax/reducer.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
 import {
 	WOOCOMMERCE_SETTINGS_TAX_BATCH_REQUEST,
@@ -18,39 +18,42 @@ import {
 	WOOCOMMERCE_SETTINGS_TAX_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_SETTINGS_TAX_REQUEST ]: () => {
-		return LOADING;
-	},
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SETTINGS_TAX_REQUEST: {
+			return LOADING;
+		}
+		case WOOCOMMERCE_SETTINGS_TAX_REQUEST_SUCCESS: {
+			const { data } = action;
+			return data;
+		}
+		case WOOCOMMERCE_SETTINGS_TAX_BATCH_REQUEST: {
+			return state;
+		}
+		case WOOCOMMERCE_SETTINGS_TAX_BATCH_REQUEST_SUCCESS: {
+			const { data } = action;
+			const settings = state || [];
 
-	[ WOOCOMMERCE_SETTINGS_TAX_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data;
-	},
+			// go through each existing setting
+			// if an update is present in data, replace the setting with the update
+			const newSettings = settings.map( setting => {
+				const update = find( data.update, { id: setting.id } );
+				if ( update ) {
+					return update;
+				}
+				return setting;
+			} );
 
-	[ WOOCOMMERCE_SETTINGS_TAX_BATCH_REQUEST ]: state => {
-		return state;
-	},
+			// if update adds adds a new setting, append it to settings
+			data.update.forEach( update => {
+				if ( ! find( settings, { id: update.id } ) ) {
+					newSettings.push( update );
+				}
+			} );
 
-	[ WOOCOMMERCE_SETTINGS_TAX_BATCH_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		const settings = state || [];
+			return newSettings;
+		}
+	}
 
-		// go through each existing setting
-		// if an update is present in data, replace the setting with the update
-		const newSettings = settings.map( setting => {
-			const update = find( data.update, { id: setting.id } );
-			if ( update ) {
-				return update;
-			}
-			return setting;
-		} );
-
-		// if update adds adds a new setting, append it to settings
-		data.update.forEach( update => {
-			if ( ! find( settings, { id: update.id } ) ) {
-				newSettings.push( update );
-			}
-		} );
-
-		return newSettings;
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/setup-choices/reducer.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
 import {
 	WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST_SUCCESS,
@@ -16,19 +16,20 @@ import {
 
 // TODO: Handle error
 
-export default createReducer(
-	{},
-	{
-		[ WOOCOMMERCE_SETUP_CHOICES_REQUEST ]: () => {
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SETUP_CHOICES_REQUEST: {
 			return LOADING;
-		},
-
-		[ WOOCOMMERCE_SETUP_CHOICES_REQUEST_SUCCESS ]: ( state, { data } ) => {
+		}
+		case WOOCOMMERCE_SETUP_CHOICES_REQUEST_SUCCESS: {
+			const { data } = action;
 			return data;
-		},
-
-		[ WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST_SUCCESS ]: ( state, { data } ) => {
+		}
+		case WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST_SUCCESS: {
+			const { data } = action;
 			return { ...state, ...data };
-		},
+		}
 	}
-);
+
+	return state;
+} );

--- a/client/extensions/woocommerce/state/sites/shipping-methods/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-methods/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_METHODS_REQUEST,
 	WOOCOMMERCE_SHIPPING_METHODS_REQUEST_SUCCESS,
@@ -13,12 +13,16 @@ import { LOADING } from 'woocommerce/state/constants';
 
 // TODO: Handle error
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_SHIPPING_METHODS_REQUEST ]: () => {
-		return LOADING;
-	},
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_METHODS_REQUEST: {
+			return LOADING;
+		}
+		case WOOCOMMERCE_SHIPPING_METHODS_REQUEST_SUCCESS: {
+			const { data } = action;
+			return data;
+		}
+	}
 
-	[ WOOCOMMERCE_SHIPPING_METHODS_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data;
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_DELETED,
@@ -32,147 +32,155 @@ const processZoneData = zoneData => {
 	return { ...zoneData, name: translate( 'Locations not covered by your other zones' ) };
 };
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST ]: ( state, { zoneId } ) => {
-		if ( ! isArray( state ) ) {
-			return state;
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST: {
+			const { zoneId } = action;
+			if ( ! isArray( state ) ) {
+				return state;
+			}
+			const zoneIndex = findIndex( state, { id: zoneId } );
+			if ( -1 === zoneIndex ) {
+				return state;
+			}
+
+			const zone = {
+				...state[ zoneIndex ],
+				methodIds: LOADING,
+			};
+			return [ ...state.slice( 0, zoneIndex ), zone, ...state.slice( zoneIndex + 1 ) ];
 		}
-		const zoneIndex = findIndex( state, { id: zoneId } );
-		if ( -1 === zoneIndex ) {
-			return state;
+		case WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS: {
+			const { zoneId, data } = action;
+			if ( ! isArray( state ) ) {
+				return state;
+			}
+			const zoneIndex = findIndex( state, { id: zoneId } );
+			if ( -1 === zoneIndex ) {
+				return state;
+			}
+
+			const zone = {
+				...state[ zoneIndex ],
+				methodIds: data.map( method => method.id ),
+			};
+
+			return [ ...state.slice( 0, zoneIndex ), zone, ...state.slice( zoneIndex + 1 ) ];
 		}
+		case WOOCOMMERCE_SHIPPING_ZONE_UPDATED: {
+			const {
+				data,
+				originatingAction: { zone },
+			} = action;
+			data = processZoneData( data );
+			if ( ! isArray( state ) ) {
+				return state;
+			}
 
-		const zone = {
-			...state[ zoneIndex ],
-			methodIds: LOADING,
-		};
-		return [ ...state.slice( 0, zoneIndex ), zone, ...state.slice( zoneIndex + 1 ) ];
-	},
+			if ( 'number' !== typeof zone.id ) {
+				return [
+					...state,
+					{
+						...data,
+						methodIds: [],
+					},
+				];
+			}
 
-	[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS ]: ( state, { zoneId, data } ) => {
-		if ( ! isArray( state ) ) {
-			return state;
-		}
-		const zoneIndex = findIndex( state, { id: zoneId } );
-		if ( -1 === zoneIndex ) {
-			return state;
-		}
+			const zoneIndex = findIndex( state, { id: zone.id } );
+			if ( -1 === zoneIndex ) {
+				return state;
+			}
 
-		const zone = {
-			...state[ zoneIndex ],
-			methodIds: data.map( method => method.id ),
-		};
-
-		return [ ...state.slice( 0, zoneIndex ), zone, ...state.slice( zoneIndex + 1 ) ];
-	},
-
-	[ WOOCOMMERCE_SHIPPING_ZONE_UPDATED ]: ( state, { data, originatingAction: { zone } } ) => {
-		data = processZoneData( data );
-		if ( ! isArray( state ) ) {
-			return state;
-		}
-
-		if ( 'number' !== typeof zone.id ) {
 			return [
-				...state,
+				...state.slice( 0, zoneIndex ),
 				{
 					...data,
-					methodIds: [],
+					methodIds: state[ zoneIndex ].methodIds,
 				},
+				...state.slice( zoneIndex + 1 ),
 			];
 		}
+		case WOOCOMMERCE_SHIPPING_ZONE_DELETED: {
+			const {
+				originatingAction: { zone },
+			} = action;
+			if ( ! isArray( state ) ) {
+				return state;
+			}
 
-		const zoneIndex = findIndex( state, { id: zone.id } );
-		if ( -1 === zoneIndex ) {
-			return state;
+			const zoneIndex = findIndex( state, { id: zone.id } );
+			if ( -1 === zoneIndex ) {
+				return state;
+			}
+
+			return [ ...state.slice( 0, zoneIndex ), ...state.slice( zoneIndex + 1 ) ];
 		}
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED: {
+			const {
+				data,
+				originatingAction: { zoneId },
+			} = action;
+			if ( ! isArray( state ) ) {
+				return state;
+			}
 
-		return [
-			...state.slice( 0, zoneIndex ),
-			{
-				...data,
-				methodIds: state[ zoneIndex ].methodIds,
-			},
-			...state.slice( zoneIndex + 1 ),
-		];
-	},
+			const zoneIndex = findIndex( state, { id: zoneId } );
+			if ( -1 === zoneIndex ) {
+				return state;
+			}
 
-	[ WOOCOMMERCE_SHIPPING_ZONE_DELETED ]: ( state, { originatingAction: { zone } } ) => {
-		if ( ! isArray( state ) ) {
-			return state;
+			if ( -1 !== state[ zoneIndex ].methodIds.indexOf( data.id ) ) {
+				return state;
+			}
+
+			return [
+				...state.slice( 0, zoneIndex ),
+				{
+					...state[ zoneIndex ],
+					methodIds: [ ...state[ zoneIndex ].methodIds, data.id ],
+				},
+				...state.slice( zoneIndex + 1 ),
+			];
 		}
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_DELETED: {
+			const {
+				originatingAction: { zoneId, methodId },
+			} = action;
+			if ( ! isArray( state ) ) {
+				return state;
+			}
 
-		const zoneIndex = findIndex( state, { id: zone.id } );
-		if ( -1 === zoneIndex ) {
-			return state;
+			const zoneIndex = findIndex( state, { id: zoneId } );
+			if ( -1 === zoneIndex ) {
+				return state;
+			}
+
+			const methodIndex = state[ zoneIndex ].methodIds.indexOf( methodId );
+			if ( -1 === methodIndex ) {
+				return state;
+			}
+
+			return [
+				...state.slice( 0, zoneIndex ),
+				{
+					...state[ zoneIndex ],
+					methodIds: [
+						...state[ zoneIndex ].methodIds.slice( 0, methodIndex ),
+						...state[ zoneIndex ].methodIds.slice( methodIndex + 1 ),
+					],
+				},
+				...state.slice( zoneIndex + 1 ),
+			];
 		}
-
-		return [ ...state.slice( 0, zoneIndex ), ...state.slice( zoneIndex + 1 ) ];
-	},
-
-	[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ]: (
-		state,
-		{ data, originatingAction: { zoneId } }
-	) => {
-		if ( ! isArray( state ) ) {
-			return state;
+		case WOOCOMMERCE_SHIPPING_ZONES_REQUEST: {
+			return LOADING;
 		}
-
-		const zoneIndex = findIndex( state, { id: zoneId } );
-		if ( -1 === zoneIndex ) {
-			return state;
+		case WOOCOMMERCE_SHIPPING_ZONES_REQUEST_SUCCESS: {
+			const { data } = action;
+			return data.map( processZoneData );
 		}
+	}
 
-		if ( -1 !== state[ zoneIndex ].methodIds.indexOf( data.id ) ) {
-			return state;
-		}
-
-		return [
-			...state.slice( 0, zoneIndex ),
-			{
-				...state[ zoneIndex ],
-				methodIds: [ ...state[ zoneIndex ].methodIds, data.id ],
-			},
-			...state.slice( zoneIndex + 1 ),
-		];
-	},
-
-	[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_DELETED ]: (
-		state,
-		{ originatingAction: { zoneId, methodId } }
-	) => {
-		if ( ! isArray( state ) ) {
-			return state;
-		}
-
-		const zoneIndex = findIndex( state, { id: zoneId } );
-		if ( -1 === zoneIndex ) {
-			return state;
-		}
-
-		const methodIndex = state[ zoneIndex ].methodIds.indexOf( methodId );
-		if ( -1 === methodIndex ) {
-			return state;
-		}
-
-		return [
-			...state.slice( 0, zoneIndex ),
-			{
-				...state[ zoneIndex ],
-				methodIds: [
-					...state[ zoneIndex ].methodIds.slice( 0, methodIndex ),
-					...state[ zoneIndex ].methodIds.slice( methodIndex + 1 ),
-				],
-			},
-			...state.slice( zoneIndex + 1 ),
-		];
-	},
-
-	[ WOOCOMMERCE_SHIPPING_ZONES_REQUEST ]: () => {
-		return LOADING;
-	},
-
-	[ WOOCOMMERCE_SHIPPING_ZONES_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data.map( processZoneData );
-	},
+	return state;
 } );

--- a/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
@@ -68,8 +68,8 @@ export default withoutPersistence( ( state = null, action ) => {
 			return [ ...state.slice( 0, zoneIndex ), zone, ...state.slice( zoneIndex + 1 ) ];
 		}
 		case WOOCOMMERCE_SHIPPING_ZONE_UPDATED: {
+			let { data } = action;
 			const {
-				data,
 				originatingAction: { zone },
 			} = action;
 			data = processZoneData( data );

--- a/client/extensions/woocommerce/state/sites/status/wc-api/error-reducer.js
+++ b/client/extensions/woocommerce/state/sites/status/wc-api/error-reducer.js
@@ -9,14 +9,20 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { WOOCOMMERCE_ERROR_SET, WOOCOMMERCE_ERROR_CLEAR } from 'woocommerce/state/action-types';
 
 const debug = debugFactory( 'woocommerce:errors:wc-api' );
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_ERROR_SET ]: setApiError,
-	[ WOOCOMMERCE_ERROR_CLEAR ]: clearApiError,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_ERROR_SET:
+			return setApiError( state, action );
+		case WOOCOMMERCE_ERROR_CLEAR:
+			return clearApiError( state, action );
+	}
+
+	return state;
 } );
 
 function setApiError( error, { data, originalAction, time } ) {

--- a/client/extensions/woocommerce/state/ui/payments/currency/reducer.js
+++ b/client/extensions/woocommerce/state/ui/payments/currency/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS,
 	WOOCOMMERCE_CURRENCY_CHANGE,
@@ -20,7 +20,13 @@ function currencyUpdatedAction() {
 	return null;
 }
 
-export default createReducer( initialState, {
-	[ WOOCOMMERCE_CURRENCY_CHANGE ]: changeAction,
-	[ WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS ]: currencyUpdatedAction,
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_CURRENCY_CHANGE:
+			return changeAction( state, action );
+		case WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS:
+			return currencyUpdatedAction( state, action );
+	}
+
+	return state;
 } );

--- a/client/extensions/woocommerce/state/ui/payments/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/reducer.js
@@ -9,7 +9,7 @@ import { isEmpty, isEqual, compact } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_PAYMENT_METHOD_CANCEL,
 	WOOCOMMERCE_PAYMENT_METHOD_CLOSE,
@@ -136,11 +136,21 @@ function paymentMethodUpdatedAction( state, { data } ) {
 	return state;
 }
 
-export default createReducer( initialState, {
-	[ WOOCOMMERCE_PAYMENT_METHOD_CANCEL ]: cancelAction,
-	[ WOOCOMMERCE_PAYMENT_METHOD_CLOSE ]: closeAction,
-	[ WOOCOMMERCE_PAYMENT_METHOD_EDIT_FIELD ]: editFieldAction,
-	[ WOOCOMMERCE_PAYMENT_METHOD_EDIT_ENABLED ]: changeEnabledAction,
-	[ WOOCOMMERCE_PAYMENT_METHOD_OPEN ]: openAction,
-	[ WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS ]: paymentMethodUpdatedAction,
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PAYMENT_METHOD_CANCEL:
+			return cancelAction( state, action );
+		case WOOCOMMERCE_PAYMENT_METHOD_CLOSE:
+			return closeAction( state, action );
+		case WOOCOMMERCE_PAYMENT_METHOD_EDIT_FIELD:
+			return editFieldAction( state, action );
+		case WOOCOMMERCE_PAYMENT_METHOD_EDIT_ENABLED:
+			return changeEnabledAction( state, action );
+		case WOOCOMMERCE_PAYMENT_METHOD_OPEN:
+			return openAction( state, action );
+		case WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS:
+			return paymentMethodUpdatedAction( state, action );
+	}
+
+	return state;
 } );

--- a/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
@@ -9,7 +9,7 @@ import { compact, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_PRODUCT_CATEGORY_CREATE,
 	WOOCOMMERCE_PRODUCT_CATEGORY_UPDATE,
@@ -19,10 +19,17 @@ import {
 } from 'woocommerce/state/action-types';
 import { getBucket } from '../helpers';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_PRODUCT_CATEGORY_EDIT ]: editProductCategoryAction,
-	[ WOOCOMMERCE_PRODUCT_CATEGORY_EDIT_CLEAR ]: clearEditsAction,
-	[ WOOCOMMERCE_PRODUCT_CATEGORY_UPDATED ]: productCategoryUpdatedAction,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PRODUCT_CATEGORY_EDIT:
+			return editProductCategoryAction( state, action );
+		case WOOCOMMERCE_PRODUCT_CATEGORY_EDIT_CLEAR:
+			return clearEditsAction( state, action );
+		case WOOCOMMERCE_PRODUCT_CATEGORY_UPDATED:
+			return productCategoryUpdatedAction( state, action );
+	}
+
+	return state;
 } );
 
 function productCategoryUpdatedAction( edits, action ) {

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -5,7 +5,7 @@
  */
 
 import { compact, isEqual, filter, uniqueId } from 'lodash';
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 
 /**
  * Internal dependencies
@@ -23,13 +23,23 @@ import {
 } from 'woocommerce/state/action-types';
 import { getBucket } from '../helpers';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_PRODUCT_EDIT ]: editProductAction,
-	[ WOOCOMMERCE_PRODUCT_DELETE ]: deleteProductAction,
-	[ WOOCOMMERCE_PRODUCT_EDIT_CLEAR ]: clearEditsAction,
-	[ WOOCOMMERCE_PRODUCT_UPDATED ]: productUpdatedAction,
-	[ WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT ]: editProductAttributeAction,
-	[ WOOCOMMERCE_PRODUCT_CATEGORY_UPDATED ]: productCategoryUpdatedAction,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PRODUCT_EDIT:
+			return editProductAction( state, action );
+		case WOOCOMMERCE_PRODUCT_DELETE:
+			return deleteProductAction( state, action );
+		case WOOCOMMERCE_PRODUCT_EDIT_CLEAR:
+			return clearEditsAction( state, action );
+		case WOOCOMMERCE_PRODUCT_UPDATED:
+			return productUpdatedAction( state, action );
+		case WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT:
+			return editProductAttributeAction( state, action );
+		case WOOCOMMERCE_PRODUCT_CATEGORY_UPDATED:
+			return productCategoryUpdatedAction( state, action );
+	}
+
+	return state;
 } );
 
 function productUpdatedAction( edits, action ) {

--- a/client/extensions/woocommerce/state/ui/products/list-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/list-reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { get } from 'lodash';
 
 /**
@@ -16,9 +16,15 @@ import {
 	WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_PRODUCTS_REQUEST ]: productsRequest,
-	[ WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS ]: productsRequestSuccess,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PRODUCTS_REQUEST:
+			return productsRequest( state, action );
+		case WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS:
+			return productsRequestSuccess( state, action );
+	}
+
+	return state;
 } );
 
 export function productsRequestSuccess( state = {}, action ) {

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -9,7 +9,7 @@ import { compact, find, isEqual, uniqueId } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_PRODUCT_CREATE,
 	WOOCOMMERCE_PRODUCT_EDIT,
@@ -26,13 +26,23 @@ import { editProductAttribute } from '../edits-reducer';
 import { getBucket } from 'woocommerce/state/ui/helpers';
 import generateVariations from 'woocommerce/lib/generate-variations';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_PRODUCT_EDIT ]: editProductAction,
-	[ WOOCOMMERCE_PRODUCT_UPDATED ]: productUpdatedAction,
-	[ WOOCOMMERCE_PRODUCT_VARIATION_EDIT ]: editProductVariationAction,
-	[ WOOCOMMERCE_PRODUCT_VARIATION_EDIT_CLEAR ]: clearEditsAction,
-	[ WOOCOMMERCE_PRODUCT_VARIATION_UPDATED ]: productVariationUpdatedAction,
-	[ WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT ]: editProductAttributeAction,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PRODUCT_EDIT:
+			return editProductAction( state, action );
+		case WOOCOMMERCE_PRODUCT_UPDATED:
+			return productUpdatedAction( state, action );
+		case WOOCOMMERCE_PRODUCT_VARIATION_EDIT:
+			return editProductVariationAction( state, action );
+		case WOOCOMMERCE_PRODUCT_VARIATION_EDIT_CLEAR:
+			return clearEditsAction( state, action );
+		case WOOCOMMERCE_PRODUCT_VARIATION_UPDATED:
+			return productVariationUpdatedAction( state, action );
+		case WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT:
+			return editProductAttributeAction( state, action );
+	}
+
+	return state;
 } );
 
 /**

--- a/client/extensions/woocommerce/state/ui/promotions/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/promotions/edits-reducer.js
@@ -8,16 +8,22 @@ import { uniqueId, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_PROMOTION_EDIT,
 	WOOCOMMERCE_PROMOTION_EDIT_CLEAR,
 } from 'woocommerce/state/action-types';
 import { getBucket } from '../helpers';
 
-export default createReducer( null, {
-	[ WOOCOMMERCE_PROMOTION_EDIT ]: editPromotionAction,
-	[ WOOCOMMERCE_PROMOTION_EDIT_CLEAR ]: clearPromotionEditsAction,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PROMOTION_EDIT:
+			return editPromotionAction( state, action );
+		case WOOCOMMERCE_PROMOTION_EDIT_CLEAR:
+			return clearPromotionEditsAction( state, action );
+	}
+
+	return state;
 } );
 
 function editPromotionAction( edits, action ) {

--- a/client/extensions/woocommerce/state/ui/promotions/list-reducer.js
+++ b/client/extensions/woocommerce/state/ui/promotions/list-reducer.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_PROMOTIONS_PAGE_SET,
 	WOOCOMMERCE_PROMOTIONS_SEARCH,
@@ -15,9 +15,15 @@ const initialState = {
 	searchFilter: '',
 };
 
-export default createReducer( initialState, {
-	[ WOOCOMMERCE_PROMOTIONS_PAGE_SET ]: promotionsPageSet,
-	[ WOOCOMMERCE_PROMOTIONS_SEARCH ]: promotionsSearch,
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_PROMOTIONS_PAGE_SET:
+			return promotionsPageSet( state, action );
+		case WOOCOMMERCE_PROMOTIONS_SEARCH:
+			return promotionsSearch( state, action );
+	}
+
+	return state;
 } );
 
 function promotionsPageSet( state, action ) {

--- a/client/extensions/woocommerce/state/wc-api/status/reducer.js
+++ b/client/extensions/woocommerce/state/wc-api/status/reducer.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_WC_API_SUCCESS,
 	WOOCOMMERCE_WC_API_UNAVAILABLE,
@@ -16,10 +16,17 @@ const initialState = {
 	lastErrorTime: null,
 };
 
-export default createReducer( initialState, {
-	[ WOOCOMMERCE_WC_API_SUCCESS ]: apiSuccess,
-	[ WOOCOMMERCE_WC_API_UNAVAILABLE ]: apiUnavailable,
-	[ WOOCOMMERCE_WC_API_UNKNOWN_ERROR ]: apiUnknownError,
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_WC_API_SUCCESS:
+			return apiSuccess( state, action );
+		case WOOCOMMERCE_WC_API_UNAVAILABLE:
+			return apiUnavailable( state, action );
+		case WOOCOMMERCE_WC_API_UNKNOWN_ERROR:
+			return apiUnknownError( state, action );
+	}
+
+	return state;
 } );
 
 function apiSuccess( state, action ) {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-method-schemas/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-method-schemas/reducer.js
@@ -4,21 +4,25 @@
  * Internal dependencies
  */
 
-import { createReducer, keyedReducer } from 'state/utils';
+import { keyedReducer, withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_METHOD_SCHEMA_REQUEST,
 	WOOCOMMERCE_SERVICES_SHIPPING_METHOD_SCHEMA_REQUEST_SUCCESS,
 } from 'woocommerce/woocommerce-services/state/action-types';
 import { LOADING } from 'woocommerce/state/constants';
 
-const reducer = createReducer( null, {
-	[ WOOCOMMERCE_SERVICES_SHIPPING_METHOD_SCHEMA_REQUEST ]: () => {
-		return LOADING;
-	},
+const reducer = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SERVICES_SHIPPING_METHOD_SCHEMA_REQUEST: {
+			return LOADING;
+		}
+		case WOOCOMMERCE_SERVICES_SHIPPING_METHOD_SCHEMA_REQUEST_SUCCESS: {
+			const { data } = action;
+			return data;
+		}
+	}
 
-	[ WOOCOMMERCE_SERVICES_SHIPPING_METHOD_SCHEMA_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data;
-	},
+	return state;
 } );
 
 export default keyedReducer( 'methodId', reducer );

--- a/client/extensions/wp-super-cache/state/cache/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
 	WP_SUPER_CACHE_DELETE_CACHE_FAILURE,
@@ -25,32 +25,45 @@ import {
  * @param  {Object} action Action object
  * @return {Object} Updated deleting state
  */
-const deleteStatus = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_DELETE_CACHE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				deleting: true,
-				status: 'pending',
-			},
-		} ),
-		[ WP_SUPER_CACHE_DELETE_CACHE_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				deleting: false,
-				status: 'success',
-			},
-		} ),
-		[ WP_SUPER_CACHE_DELETE_CACHE_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				deleting: false,
-				status: 'error',
-			},
-		} ),
+const deleteStatus = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_DELETE_CACHE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					deleting: true,
+					status: 'pending',
+				},
+			};
+		}
+		case WP_SUPER_CACHE_DELETE_CACHE_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					deleting: false,
+					status: 'success',
+				},
+			};
+		}
+		case WP_SUPER_CACHE_DELETE_CACHE_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					deleting: false,
+					status: 'error',
+				},
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated preloading state after an action has been dispatched.
@@ -59,20 +72,32 @@ const deleteStatus = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated preloading state
  */
-const preloading = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_PRELOAD_CACHE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ WP_SUPER_CACHE_PRELOAD_CACHE_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+const preloading = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_PRELOAD_CACHE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case WP_SUPER_CACHE_PRELOAD_CACHE_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated cache testing state after an action has been dispatched.
@@ -82,20 +107,32 @@ const preloading = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated cache testing state
  */
-const testing = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_TEST_CACHE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ WP_SUPER_CACHE_TEST_CACHE_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ WP_SUPER_CACHE_TEST_CACHE_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+const testing = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_TEST_CACHE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case WP_SUPER_CACHE_TEST_CACHE_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case WP_SUPER_CACHE_TEST_CACHE_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Tracks the cache test results for a particular site.
@@ -104,15 +141,20 @@ const testing = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated cache test results
  */
-const items = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_TEST_CACHE_SUCCESS ]: ( state, { siteId, data } ) => ( {
-			...state,
-			[ siteId ]: data,
-		} ),
+const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_TEST_CACHE_SUCCESS: {
+			const { siteId, data } = action;
+
+			return {
+				...state,
+				[ siteId ]: data,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	deleteStatus,

--- a/client/extensions/wp-super-cache/state/plugins/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_PLUGINS,
@@ -22,20 +22,32 @@ import {
  * @param  {Object} action Action object
  * @return {Object} Updated requesting state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_REQUEST_PLUGINS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ WP_SUPER_CACHE_REQUEST_PLUGINS_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ WP_SUPER_CACHE_REQUEST_PLUGINS_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_REQUEST_PLUGINS: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case WP_SUPER_CACHE_REQUEST_PLUGINS_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case WP_SUPER_CACHE_REQUEST_PLUGINS_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated plugin toggling state after an action has been dispatched.
@@ -45,29 +57,42 @@ export const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated saving state
  */
-export const toggling = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_TOGGLE_PLUGIN ]: ( state, { siteId, plugin } ) => ( {
-			...state,
-			[ siteId ]: {
-				[ plugin ]: true,
-			},
-		} ),
-		[ WP_SUPER_CACHE_TOGGLE_PLUGIN_SUCCESS ]: ( state, { siteId, plugin } ) => ( {
-			...state,
-			[ siteId ]: {
-				[ plugin ]: false,
-			},
-		} ),
-		[ WP_SUPER_CACHE_TOGGLE_PLUGIN_FAILURE ]: ( state, { siteId, plugin } ) => ( {
-			...state,
-			[ siteId ]: {
-				[ plugin ]: false,
-			},
-		} ),
+export const toggling = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_TOGGLE_PLUGIN: {
+			const { siteId, plugin } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					[ plugin ]: true,
+				},
+			};
+		}
+		case WP_SUPER_CACHE_TOGGLE_PLUGIN_SUCCESS: {
+			const { siteId, plugin } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					[ plugin ]: false,
+				},
+			};
+		}
+		case WP_SUPER_CACHE_TOGGLE_PLUGIN_FAILURE: {
+			const { siteId, plugin } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					[ plugin ]: false,
+				},
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Tracks the plugins for a particular site.
@@ -76,16 +101,20 @@ export const toggling = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated plugins
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ WP_SUPER_CACHE_RECEIVE_PLUGINS ]: ( state, { siteId, plugins } ) => ( {
-			...state,
-			[ siteId ]: plugins,
-		} ),
-	},
-	itemsSchema
-);
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_RECEIVE_PLUGINS: {
+			const { siteId, plugins } = action;
+
+			return {
+				...state,
+				[ siteId ]: plugins,
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
@@ -25,23 +25,36 @@ import {
  * @param  {Object} action Action object
  * @return {Object} Updated requesting state
  */
-const requesting = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_REQUEST_SETTINGS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: true,
-		} ),
-		[ WP_SUPER_CACHE_REQUEST_SETTINGS_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ WP_SUPER_CACHE_REQUEST_SETTINGS_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_REQUEST_SETTINGS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: true,
+			};
+		}
+		case WP_SUPER_CACHE_REQUEST_SETTINGS_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case WP_SUPER_CACHE_REQUEST_SETTINGS_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated saving state after an action has been dispatched.
@@ -51,35 +64,48 @@ const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated saving state
  */
-const saveStatus = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_SAVE_SETTINGS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				saving: true,
-				status: 'pending',
-				error: false,
-			},
-		} ),
-		[ WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				saving: false,
-				status: 'success',
-				error: false,
-			},
-		} ),
-		[ WP_SUPER_CACHE_SAVE_SETTINGS_FAILURE ]: ( state, { siteId, error } ) => ( {
-			...state,
-			[ siteId ]: {
-				saving: false,
-				status: 'error',
-				error,
-			},
-		} ),
+const saveStatus = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_SAVE_SETTINGS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					saving: true,
+					status: 'pending',
+					error: false,
+				},
+			};
+		}
+		case WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					saving: false,
+					status: 'success',
+					error: false,
+				},
+			};
+		}
+		case WP_SUPER_CACHE_SAVE_SETTINGS_FAILURE: {
+			const { siteId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					saving: false,
+					status: 'error',
+					error,
+				},
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated restoring state after an action has been dispatched.
@@ -89,23 +115,36 @@ const saveStatus = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated restoring state
  */
-export const restoring = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_RESTORE_SETTINGS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: true,
-		} ),
-		[ WP_SUPER_CACHE_RESTORE_SETTINGS_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ WP_SUPER_CACHE_RESTORE_SETTINGS_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+export const restoring = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_RESTORE_SETTINGS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: true,
+			};
+		}
+		case WP_SUPER_CACHE_RESTORE_SETTINGS_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case WP_SUPER_CACHE_RESTORE_SETTINGS_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Tracks the settings for a particular site.
@@ -114,23 +153,31 @@ export const restoring = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated settings
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ WP_SUPER_CACHE_RECEIVE_SETTINGS ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: settings,
-		} ),
-		[ WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS ]: ( state, { siteId, preloading } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				is_preloading: preloading,
-			},
-		} ),
-	},
-	itemsSchema
-);
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_RECEIVE_SETTINGS: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: settings,
+			};
+		}
+		case WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS: {
+			const { siteId, preloading } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					is_preloading: preloading,
+				},
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { statsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
@@ -26,20 +26,32 @@ import {
  * @param  {Object} action Action object
  * @return {Object} Updated generating state
  */
-export const generating = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_GENERATE_STATS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ WP_SUPER_CACHE_GENERATE_STATS_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ WP_SUPER_CACHE_GENERATE_STATS_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+export const generating = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_GENERATE_STATS: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case WP_SUPER_CACHE_GENERATE_STATS_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case WP_SUPER_CACHE_GENERATE_STATS_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated deleting state after an action has been dispatched.
@@ -49,20 +61,32 @@ export const generating = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated deleting state
  */
-const deleting = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_DELETE_FILE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ WP_SUPER_CACHE_DELETE_FILE_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ WP_SUPER_CACHE_DELETE_FILE_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+const deleting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_DELETE_FILE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case WP_SUPER_CACHE_DELETE_FILE_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case WP_SUPER_CACHE_DELETE_FILE_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Tracks the stats for a particular site.
@@ -71,14 +95,18 @@ const deleting = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated stats
  */
-const items = createReducerWithValidation(
-	{},
-	{
-		[ WP_SUPER_CACHE_GENERATE_STATS_SUCCESS ]: ( state, { siteId, stats } ) => ( {
-			...state,
-			[ siteId ]: stats,
-		} ),
-		[ WP_SUPER_CACHE_DELETE_CACHE_SUCCESS ]: ( state, { siteId, deleteExpired } ) => {
+const items = withSchemaValidation( statsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_GENERATE_STATS_SUCCESS: {
+			const { siteId, stats } = action;
+
+			return {
+				...state,
+				[ siteId ]: stats,
+			};
+		}
+		case WP_SUPER_CACHE_DELETE_CACHE_SUCCESS: {
+			const { siteId, deleteExpired } = action;
 			let emptyCache = {
 				expired: 0,
 				expired_list: {},
@@ -105,8 +133,9 @@ const items = createReducerWithValidation(
 					},
 				},
 			};
-		},
-		[ WP_SUPER_CACHE_DELETE_FILE_SUCCESS ]: ( state, { siteId, url, isSupercache, isCached } ) => {
+		}
+		case WP_SUPER_CACHE_DELETE_FILE_SUCCESS: {
+			const { siteId, url, isSupercache, isCached } = action;
 			const cacheType = isSupercache ? 'supercache' : 'wpcache';
 			const listType = isCached ? 'cached_list' : 'expired_list';
 			const countType = isCached ? 'cached' : 'expired';
@@ -125,10 +154,11 @@ const items = createReducerWithValidation(
 					},
 				},
 			};
-		},
-	},
-	statsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	deleting,

--- a/client/extensions/wp-super-cache/state/status/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_STATUS,
@@ -17,17 +17,28 @@ import {
  * @param  {Object} action Action object
  * @return {Object} Updated requesting state
  */
-const requesting = createReducer(
-	{},
-	{
-		[ WP_SUPER_CACHE_RECEIVE_STATUS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-		[ WP_SUPER_CACHE_REQUEST_STATUS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ WP_SUPER_CACHE_REQUEST_STATUS_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_RECEIVE_STATUS: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
+		case WP_SUPER_CACHE_REQUEST_STATUS: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case WP_SUPER_CACHE_REQUEST_STATUS_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Tracks the status for a particular site.
@@ -36,16 +47,17 @@ const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated status
  */
-const items = createReducerWithValidation(
-	{},
-	{
-		[ WP_SUPER_CACHE_RECEIVE_STATUS ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: action.status,
-		} ),
-	},
-	itemsSchema
-);
+const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WP_SUPER_CACHE_RECEIVE_STATUS:
+			return {
+				...state,
+				[ action.siteId ]: action.status,
+			};
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/extensions/zoninator/state/feeds/reducer.js
+++ b/client/extensions/zoninator/state/feeds/reducer.js
@@ -4,30 +4,38 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 import {
 	ZONINATOR_REQUEST_FEED,
 	ZONINATOR_REQUEST_FEED_ERROR,
 	ZONINATOR_UPDATE_FEED,
 } from '../action-types';
 
-const isRequesting = createReducer(
-	{},
-	{
-		[ ZONINATOR_REQUEST_FEED ]: () => true,
-		[ ZONINATOR_REQUEST_FEED_ERROR ]: () => false,
-		[ ZONINATOR_UPDATE_FEED ]: () => false,
+const isRequesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_REQUEST_FEED:
+			return true;
+		case ZONINATOR_REQUEST_FEED_ERROR:
+			return false;
+		case ZONINATOR_UPDATE_FEED:
+			return false;
 	}
-);
+
+	return state;
+} );
 
 export const requesting = keyedReducer( 'siteId', keyedReducer( 'zoneId', isRequesting ) );
 
-const feed = createReducer(
-	{},
-	{
-		[ ZONINATOR_UPDATE_FEED ]: ( state, { posts } ) => posts,
+const feed = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_UPDATE_FEED: {
+			const { posts } = action;
+			return posts;
+		}
 	}
-);
+
+	return state;
+} );
 
 export const items = keyedReducer( 'siteId', keyedReducer( 'zoneId', feed ) );
 

--- a/client/extensions/zoninator/state/locks/reducer.js
+++ b/client/extensions/zoninator/state/locks/reducer.js
@@ -3,28 +3,51 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 import {
 	ZONINATOR_REQUEST_LOCK_ERROR,
 	ZONINATOR_RESET_LOCK,
 	ZONINATOR_UPDATE_LOCK,
 } from '../action-types';
 
-export const blocked = createReducer( false, {
-	[ ZONINATOR_UPDATE_LOCK ]: () => false,
-	[ ZONINATOR_REQUEST_LOCK_ERROR ]: () => true,
+export const blocked = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_UPDATE_LOCK:
+			return false;
+		case ZONINATOR_REQUEST_LOCK_ERROR:
+			return true;
+	}
+
+	return state;
 } );
 
-export const created = createReducer( 0, {
-	[ ZONINATOR_RESET_LOCK ]: ( state, { time } ) => time,
+export const created = withoutPersistence( ( state = 0, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_RESET_LOCK: {
+			const { time } = action;
+			return time;
+		}
+	}
+
+	return state;
 } );
 
-export const expires = createReducer( 0, {
-	[ ZONINATOR_UPDATE_LOCK ]: ( state, action ) => action.expires,
+export const expires = withoutPersistence( ( state = 0, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_UPDATE_LOCK:
+			return action.expires;
+	}
+
+	return state;
 } );
 
-export const maxLockPeriod = createReducer( 0, {
-	[ ZONINATOR_UPDATE_LOCK ]: ( state, action ) => action.maxLockPeriod,
+export const maxLockPeriod = withoutPersistence( ( state = 0, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_UPDATE_LOCK:
+			return action.maxLockPeriod;
+	}
+
+	return state;
 } );
 
 export const items = combineReducers( {

--- a/client/extensions/zoninator/state/zones/reducer.js
+++ b/client/extensions/zoninator/state/zones/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	ZONINATOR_REQUEST_ERROR,
@@ -10,29 +10,46 @@ import {
 	ZONINATOR_UPDATE_ZONES,
 } from '../action-types';
 
-export const requesting = createReducer(
-	{},
-	{
-		[ ZONINATOR_REQUEST_ZONES ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ ZONINATOR_UPDATE_ZONES ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-		[ ZONINATOR_REQUEST_ERROR ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_REQUEST_ZONES: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case ZONINATOR_UPDATE_ZONES: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
+		case ZONINATOR_REQUEST_ERROR: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
 	}
-);
 
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ ZONINATOR_UPDATE_ZONES ]: ( state, { siteId, data } ) => ( { ...state, [ siteId ]: data } ),
-		[ ZONINATOR_UPDATE_ZONE ]: ( state, { siteId, zoneId, data } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				[ zoneId ]: data,
-			},
-		} ),
-	},
-	itemsSchema
-);
+	return state;
+} );
+
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ZONINATOR_UPDATE_ZONES: {
+			const { siteId, data } = action;
+			return { ...state, [ siteId ]: data };
+		}
+		case ZONINATOR_UPDATE_ZONE: {
+			const { siteId, zoneId, data } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ zoneId ]: data,
+				},
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	requesting,

--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import settings from './settings/reducer';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
@@ -12,10 +12,17 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 } from 'state/action-types';
 
-const isFetchingSettings = createReducer( false, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH ]: () => true,
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: () => false,
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: () => false,
+const isFetchingSettings = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH:
+			return true;
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS:
+			return false;
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED:
+			return false;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
@@ -24,31 +24,42 @@ const setTargetState = value => ( state, { target } ) => ( {
 	[ target ]: value,
 } );
 
-const isUpdating = createReducer(
-	{},
-	{
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ]: setTargetState( true ),
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: setTargetState( false ),
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: setTargetState( false ),
+const isUpdating = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE:
+			return setTargetState( true )( state, action );
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS:
+			return setTargetState( false )( state, action );
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED:
+			return setTargetState( false )( state, action );
 	}
-);
 
-const isDeleting = createReducer(
-	{},
-	{
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ]: setTargetState( true ),
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: setTargetState( false ),
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: setTargetState( false ),
-	}
-);
+	return state;
+} );
 
-const hasSentValidation = createReducer(
-	{},
-	{
-		[ ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION ]: setTargetState( true ),
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: setTargetState( true ),
+const isDeleting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_DELETE:
+			return setTargetState( true )( state, action );
+		case ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS:
+			return setTargetState( false )( state, action );
+		case ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED:
+			return setTargetState( false )( state, action );
 	}
-);
+
+	return state;
+} );
+
+const hasSentValidation = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION:
+			return setTargetState( true )( state, action );
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS:
+			return setTargetState( true )( state, action );
+	}
+
+	return state;
+} );
 
 const convertPhoneResponse = phoneResponse => {
 	if ( ! phoneResponse ) {
@@ -65,61 +76,104 @@ const convertPhoneResponse = phoneResponse => {
 	};
 };
 
-const phone = createReducer( null, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) =>
-		convertPhoneResponse( settings.phone ),
+const phone = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS: {
+			const { settings } = action;
+			return convertPhoneResponse( settings.phone );
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS: {
+			const { target, value } = action;
+			return 'phone' === target ? value : state;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS: {
+			const { target } = action;
+			return 'phone' === target ? null : state;
+		}
+	}
 
-	// There is no calling of convertPhoneResponse here, because the endpoint for updating
-	// recovery settings doesn't return the updated value in the response body. Thus,
-	// the `value` encapsulated here is actually passed down from the action creator and
-	// in the exactly the same form, hence no need of converting.
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, value } ) =>
-		'phone' === target ? value : state,
-
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
-		'phone' === target ? null : state,
+	return state;
 } );
 
-const email = createReducer( '', {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) => settings.email,
+const email = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS: {
+			const { settings } = action;
+			return settings.email;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS: {
+			const { target, value } = action;
+			return 'email' === target ? value : state;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS: {
+			const { target } = action;
+			return 'email' === target ? '' : state;
+		}
+	}
 
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, value } ) =>
-		'email' === target ? value : state,
-
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
-		'email' === target ? '' : state,
+	return state;
 } );
 
-const phoneValidated = createReducer( false, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) => settings.phone_validated,
+const phoneValidated = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS: {
+			const { settings } = action;
+			return settings.phone_validated;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS: {
+			const { target } = action;
+			return 'phone' === target ? false : state;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS: {
+			const { target } = action;
+			return 'phone' === target ? false : state;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS:
+			return true;
+	}
 
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target } ) =>
-		'phone' === target ? false : state,
-
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
-		'phone' === target ? false : state,
-
-	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS ]: () => true,
+	return state;
 } );
 
-const isValidatingPhone = createReducer( false, {
-	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE ]: () => true,
-	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS ]: () => false,
-	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED ]: () => false,
+const isValidatingPhone = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE:
+			return true;
+		case ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS:
+			return false;
+		case ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED:
+			return false;
+	}
+
+	return state;
 } );
 
-const emailValidated = createReducer( false, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) => settings.email_validated,
+const emailValidated = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS: {
+			const { settings } = action;
+			return settings.email_validated;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS: {
+			const { target } = action;
+			return 'email' === target ? false : state;
+		}
+		case ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS: {
+			const { target } = action;
+			return 'email' === target ? false : state;
+		}
+	}
 
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target } ) =>
-		'email' === target ? false : state,
-
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
-		'email' === target ? false : state,
+	return state;
 } );
 
-const isReady = createReducer( false, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: () => true,
+const isReady = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS:
+			return true;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/account/reducer.js
+++ b/client/state/account/reducer.js
@@ -3,12 +3,16 @@
  * Internal dependencies
  */
 import { ACCOUNT_CLOSE_SUCCESS } from 'state/action-types';
-import { createReducer, combineReducers } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const isClosed = createReducer( false, {
-	[ ACCOUNT_CLOSE_SUCCESS ]: () => {
-		return true;
-	},
+export const isClosed = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_CLOSE_SUCCESS: {
+			return true;
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( { isClosed } );

--- a/client/state/activity-log/activation/reducer.js
+++ b/client/state/activity-log/activation/reducer.js
@@ -14,16 +14,20 @@ import {
 	REWIND_ACTIVATE_REQUEST,
 	REWIND_ACTIVATE_SUCCESS,
 } from 'state/action-types';
-import { createReducer, keyedReducer } from 'state/utils';
+import { keyedReducer, withoutPersistence } from 'state/utils';
 
 export const activationRequesting = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ REWIND_ACTIVATE_REQUEST ]: stubTrue,
-			[ REWIND_ACTIVATE_FAILURE ]: stubFalse,
-			[ REWIND_ACTIVATE_SUCCESS ]: stubFalse,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case REWIND_ACTIVATE_REQUEST:
+				return stubTrue( state, action );
+			case REWIND_ACTIVATE_FAILURE:
+				return stubFalse( state, action );
+			case REWIND_ACTIVATE_SUCCESS:
+				return stubFalse( state, action );
 		}
-	)
+
+		return state;
+	} )
 );

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -9,7 +9,7 @@ import {
 	REWIND_RESTORE_REQUEST,
 	REWIND_RESTORE_UPDATE_PROGRESS,
 } from 'state/action-types';
-import { createReducer, keyedReducer, withSchemaValidation } from 'state/utils';
+import { keyedReducer, withSchemaValidation, withoutPersistence } from 'state/utils';
 
 const stubNull = () => null;
 
@@ -42,23 +42,37 @@ export const restoreProgress = withSchemaValidation(
 	restoreProgressSchema,
 	keyedReducer(
 		'siteId',
-		createReducer(
-			{},
-			{
-				[ REWIND_RESTORE ]: startProgress,
-				[ REWIND_RESTORE_DISMISS_PROGRESS ]: stubNull,
-				[ REWIND_RESTORE_UPDATE_PROGRESS ]: updateProgress,
-				[ REWIND_RESTORE_DISMISS ]: stubNull,
+		withoutPersistence( ( state = {}, action ) => {
+			switch ( action.type ) {
+				case REWIND_RESTORE:
+					return startProgress( state, action );
+				case REWIND_RESTORE_DISMISS_PROGRESS:
+					return stubNull( state, action );
+				case REWIND_RESTORE_UPDATE_PROGRESS:
+					return updateProgress( state, action );
+				case REWIND_RESTORE_DISMISS:
+					return stubNull( state, action );
 			}
-		)
+
+			return state;
+		} )
 	)
 );
 
 export const restoreRequest = keyedReducer(
 	'siteId',
-	createReducer( undefined, {
-		[ REWIND_RESTORE ]: () => undefined,
-		[ REWIND_RESTORE_DISMISS ]: () => undefined,
-		[ REWIND_RESTORE_REQUEST ]: ( state, { activityId } ) => activityId,
+	withoutPersistence( ( state = undefined, action ) => {
+		switch ( action.type ) {
+			case REWIND_RESTORE:
+				return undefined;
+			case REWIND_RESTORE_DISMISS:
+				return undefined;
+			case REWIND_RESTORE_REQUEST: {
+				const { activityId } = action;
+				return activityId;
+			}
+		}
+
+		return state;
 	} )
 );

--- a/client/state/application/reducer.js
+++ b/client/state/application/reducer.js
@@ -5,11 +5,17 @@
  */
 
 import { CONNECTION_LOST, CONNECTION_RESTORED } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const connectionState = createReducer( 'CHECKING', {
-	[ CONNECTION_LOST ]: () => 'OFFLINE',
-	[ CONNECTION_RESTORED ]: () => 'ONLINE',
+export const connectionState = withoutPersistence( ( state = 'CHECKING', action ) => {
+	switch ( action.type ) {
+		case CONNECTION_LOST:
+			return 'OFFLINE';
+		case CONNECTION_RESTORED:
+			return 'ONLINE';
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/atomic-transfer/reducer.js
+++ b/client/state/atomic-transfer/reducer.js
@@ -4,8 +4,8 @@
 import {
 	combineReducers,
 	keyedReducer,
-	createReducer,
-	createReducerWithValidation,
+	withSchemaValidation,
+	withoutPersistence,
 } from 'state/utils';
 import { atomicTransfer as schema } from './schema';
 import {
@@ -15,18 +15,28 @@ import {
 	ATOMIC_TRANSFER_COMPLETE,
 } from 'state/action-types';
 
-export const atomicTransfer = createReducerWithValidation(
-	{},
-	{
-		[ ATOMIC_TRANSFER_SET ]: ( state, { transfer } ) => ( { ...state, ...transfer } ),
-	},
-	schema
-);
+export const atomicTransfer = withSchemaValidation( schema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case ATOMIC_TRANSFER_SET: {
+			const { transfer } = action;
+			return { ...state, ...transfer };
+		}
+	}
 
-export const fetchingTransfer = createReducer( false, {
-	[ ATOMIC_TRANSFER_REQUEST ]: () => true,
-	[ ATOMIC_TRANSFER_REQUEST_FAILURE ]: () => false,
-	[ ATOMIC_TRANSFER_COMPLETE ]: () => false,
+	return state;
+} );
+
+export const fetchingTransfer = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case ATOMIC_TRANSFER_REQUEST:
+			return true;
+		case ATOMIC_TRANSFER_REQUEST_FAILURE:
+			return false;
+		case ATOMIC_TRANSFER_COMPLETE:
+			return false;
+	}
+
+	return state;
 } );
 
 export const atomicTransferReducers = combineReducers( {

--- a/client/state/billing-transactions/individual-transactions/reducer.js
+++ b/client/state/billing-transactions/individual-transactions/reducer.js
@@ -10,7 +10,7 @@ import {
 	BILLING_TRANSACTION_REQUEST_FAILURE,
 	BILLING_TRANSACTION_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 
 /**
  * Returns the updated requests state after an action has been dispatched.
@@ -20,10 +20,17 @@ import { combineReducers, createReducer, keyedReducer } from 'state/utils';
  * @param  {Object} action Action payload
  * @return {Boolean}        Updated state
  */
-export const requesting = createReducer( false, {
-	[ BILLING_TRANSACTION_REQUEST ]: () => true,
-	[ BILLING_TRANSACTION_REQUEST_FAILURE ]: () => false,
-	[ BILLING_TRANSACTION_REQUEST_SUCCESS ]: () => false,
+export const requesting = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case BILLING_TRANSACTION_REQUEST:
+			return true;
+		case BILLING_TRANSACTION_REQUEST_FAILURE:
+			return false;
+		case BILLING_TRANSACTION_REQUEST_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
 /**
@@ -34,10 +41,17 @@ export const requesting = createReducer( false, {
  * @param  {Object} action Action payload
  * @return {Boolean}        Updated state
  */
-export const error = createReducer( false, {
-	[ BILLING_TRANSACTION_REQUEST_FAILURE ]: () => true,
-	[ BILLING_TRANSACTION_REQUEST_SUCCESS ]: () => false,
-	[ BILLING_TRANSACTION_ERROR_CLEAR ]: () => false,
+export const error = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case BILLING_TRANSACTION_REQUEST_FAILURE:
+			return true;
+		case BILLING_TRANSACTION_REQUEST_SUCCESS:
+			return false;
+		case BILLING_TRANSACTION_ERROR_CLEAR:
+			return false;
+	}
+
+	return state;
 } );
 
 /**
@@ -48,8 +62,15 @@ export const error = createReducer( false, {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const data = createReducer( null, {
-	[ BILLING_TRANSACTION_RECEIVE ]: ( state, { receipt } ) => receipt,
+export const data = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case BILLING_TRANSACTION_RECEIVE: {
+			const { receipt } = action;
+			return receipt;
+		}
+	}
+
+	return state;
 } );
 
 export default keyedReducer(

--- a/client/state/billing-transactions/reducer.js
+++ b/client/state/billing-transactions/reducer.js
@@ -10,7 +10,7 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { billingTransactionsSchema } from './schema';
 import individualTransactions from './individual-transactions/reducer';
 
@@ -22,13 +22,16 @@ import individualTransactions from './individual-transactions/reducer';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ BILLING_TRANSACTIONS_RECEIVE ]: ( state, { past, upcoming } ) => ( { past, upcoming } ),
-	},
-	billingTransactionsSchema
-);
+export const items = withSchemaValidation( billingTransactionsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case BILLING_TRANSACTIONS_RECEIVE: {
+			const { past, upcoming } = action;
+			return { past, upcoming };
+		}
+	}
+
+	return state;
+} );
 
 /**
  * Returns the updated requests state after an action has been dispatched.
@@ -38,10 +41,17 @@ export const items = createReducerWithValidation(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const requesting = createReducer( false, {
-	[ BILLING_TRANSACTIONS_REQUEST ]: () => true,
-	[ BILLING_TRANSACTIONS_REQUEST_FAILURE ]: () => false,
-	[ BILLING_TRANSACTIONS_REQUEST_SUCCESS ]: () => false,
+export const requesting = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case BILLING_TRANSACTIONS_REQUEST:
+			return true;
+		case BILLING_TRANSACTIONS_REQUEST_FAILURE:
+			return false;
+		case BILLING_TRANSACTIONS_REQUEST_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
 /**
@@ -52,23 +62,36 @@ export const requesting = createReducer( false, {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const sendingReceiptEmail = createReducer(
-	{},
-	{
-		[ BILLING_RECEIPT_EMAIL_SEND ]: ( state, { receiptId } ) => ( {
-			...state,
-			[ receiptId ]: true,
-		} ),
-		[ BILLING_RECEIPT_EMAIL_SEND_FAILURE ]: ( state, { receiptId } ) => ( {
-			...state,
-			[ receiptId ]: false,
-		} ),
-		[ BILLING_RECEIPT_EMAIL_SEND_SUCCESS ]: ( state, { receiptId } ) => ( {
-			...state,
-			[ receiptId ]: false,
-		} ),
+export const sendingReceiptEmail = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case BILLING_RECEIPT_EMAIL_SEND: {
+			const { receiptId } = action;
+
+			return {
+				...state,
+				[ receiptId ]: true,
+			};
+		}
+		case BILLING_RECEIPT_EMAIL_SEND_FAILURE: {
+			const { receiptId } = action;
+
+			return {
+				...state,
+				[ receiptId ]: false,
+			};
+		}
+		case BILLING_RECEIPT_EMAIL_SEND_SUCCESS: {
+			const { receiptId } = action;
+
+			return {
+				...state,
+				[ receiptId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -41,7 +41,7 @@ import {
 	READER_EXPAND_COMMENTS,
 	COMMENTS_SET_ACTIVE_REPLY,
 } from 'state/action-types';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 import {
 	PLACEHOLDER_STATE,
 	NUMBER_OF_COMMENTS_PER_FETCH,
@@ -238,10 +238,9 @@ const expansionValue = type => {
 	}
 };
 
-export const expansions = createReducer(
-	{},
-	{
-		[ READER_EXPAND_COMMENTS ]: ( state, action ) => {
+export const expansions = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_EXPAND_COMMENTS: {
 			const { siteId, postId, commentIds, displayType } = action.payload;
 
 			if ( ! isValidExpansionsAction( action ) ) {
@@ -267,9 +266,11 @@ export const expansions = createReducer(
 				...state,
 				[ stateKey ]: Object.assign( {}, state[ stateKey ], newVal ),
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /***
  * Stores whether or not there are more comments, and in which directions, for a particular post.
@@ -288,10 +289,9 @@ export const expansions = createReducer(
  * @param {Object} action redux action
  * @returns {Object} new redux state
  */
-export const fetchStatus = createReducer(
-	{},
-	{
-		[ COMMENTS_RECEIVE ]: ( state, action ) => {
+export const fetchStatus = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case COMMENTS_RECEIVE: {
 			const { siteId, postId, direction, commentById } = action;
 			const stateKey = getStateKey( siteId, postId );
 
@@ -312,9 +312,11 @@ export const fetchStatus = createReducer(
 			return isEqual( state[ stateKey ], nextState )
 				? state
 				: { ...state, [ stateKey ]: nextState };
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /***
  * Stores latest comments count for post we've seen from the server
@@ -322,27 +324,28 @@ export const fetchStatus = createReducer(
  * @param {Object} action redux action
  * @returns {Object} new redux state
  */
-export const totalCommentsCount = createReducer(
-	{},
-	{
-		[ COMMENTS_COUNT_RECEIVE ]: ( state, action ) => {
+export const totalCommentsCount = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case COMMENTS_COUNT_RECEIVE: {
 			const key = getStateKey( action.siteId, action.postId );
 			return { ...state, [ key ]: action.totalCommentsCount };
-		},
-		[ COMMENTS_COUNT_INCREMENT ]: ( state, action ) => {
+		}
+		case COMMENTS_COUNT_INCREMENT: {
 			const key = getStateKey( action.siteId, action.postId );
 			return { ...state, [ key ]: state[ key ] + 1 };
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Houses errors by `siteId-commentId`
  */
-export const errors = createReducer(
-	{},
-	{
-		[ COMMENTS_RECEIVE_ERROR ]: ( state, { siteId, commentId } ) => {
+export const errors = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case COMMENTS_RECEIVE_ERROR: {
+			const { siteId, commentId } = action;
 			const key = getErrorKey( siteId, commentId );
 
 			if ( state[ key ] ) {
@@ -353,8 +356,9 @@ export const errors = createReducer(
 				...state,
 				[ key ]: { error: true },
 			};
-		},
-		[ COMMENTS_WRITE_ERROR ]: ( state, { siteId, commentId } ) => {
+		}
+		case COMMENTS_WRITE_ERROR: {
+			const { siteId, commentId } = action;
 			const key = getErrorKey( siteId, commentId );
 
 			if ( state[ key ] ) {
@@ -365,9 +369,11 @@ export const errors = createReducer(
 				...state,
 				[ key ]: { error: true },
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export const treesInitializedReducer = ( state = {}, action ) => {
 	if ( action.type === COMMENTS_TREE_SITE_ADD ) {
@@ -387,10 +393,9 @@ export const treesInitialized = keyedReducer(
  * @param {Object} action redux action
  * @returns {Object} new redux state
  */
-export const activeReplies = createReducer(
-	{},
-	{
-		[ COMMENTS_SET_ACTIVE_REPLY ]: ( state, action ) => {
+export const activeReplies = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case COMMENTS_SET_ACTIVE_REPLY: {
 			const { siteId, postId, commentId } = action.payload;
 			const stateKey = getStateKey( siteId, postId );
 
@@ -400,14 +405,16 @@ export const activeReplies = createReducer(
 			}
 
 			return { ...state, [ stateKey ]: commentId };
-		},
-		[ COMMENTS_WRITE_ERROR ]: ( state, action ) => {
+		}
+		case COMMENTS_WRITE_ERROR: {
 			const { siteId, postId, parentCommentId } = action;
 			const stateKey = getStateKey( siteId, postId );
 			return { ...state, [ stateKey ]: parentCommentId };
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 function updateCount( counts, rawStatus, value = 1 ) {
 	const status = rawStatus === 'unapproved' ? 'pending' : rawStatus;
@@ -426,10 +433,9 @@ function updateCount( counts, rawStatus, value = 1 ) {
 	};
 }
 
-export const counts = createReducer(
-	{},
-	{
-		[ COMMENT_COUNTS_UPDATE ]: ( state, action ) => {
+export const counts = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case COMMENT_COUNTS_UPDATE: {
 			const { siteId, postId, ...commentCounts } = omit( action, 'type' );
 			if ( ! siteId ) {
 				return state;
@@ -441,8 +447,8 @@ export const counts = createReducer(
 				} ),
 			};
 			return Object.assign( {}, state, siteCounts );
-		},
-		[ COMMENTS_CHANGE_STATUS ]: ( state, action ) => {
+		}
+		case COMMENTS_CHANGE_STATUS: {
 			const { siteId, postId = -1, status } = action;
 			const previousStatus = get( action, 'meta.comment.previousStatus' );
 			if ( ! siteId || ! status || ! state[ siteId ] || ! previousStatus ) {
@@ -462,8 +468,8 @@ export const counts = createReducer(
 				newPostCounts && { [ postId ]: newPostCounts }
 			);
 			return Object.assign( {}, state, { [ siteId ]: newTotalSiteCounts } );
-		},
-		[ COMMENTS_DELETE ]: ( state, action ) => {
+		}
+		case COMMENTS_DELETE: {
 			const { siteId, postId = -1, commentId } = action;
 			if ( commentId && startsWith( commentId, 'placeholder' ) ) {
 				return state;
@@ -485,8 +491,8 @@ export const counts = createReducer(
 				newPostCounts && { [ postId ]: newPostCounts }
 			);
 			return Object.assign( {}, state, { [ siteId ]: newTotalSiteCounts } );
-		},
-		[ COMMENTS_RECEIVE ]: ( state, action ) => {
+		}
+		case COMMENTS_RECEIVE: {
 			if ( get( action, 'meta.comment.context' ) !== 'add' ) {
 				return state;
 			}
@@ -507,9 +513,11 @@ export const counts = createReducer(
 				newPostCounts && { [ postId ]: newPostCounts }
 			);
 			return Object.assign( {}, state, { [ siteId ]: newTotalSiteCounts } );
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	counts,

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -102,19 +102,21 @@ export function items( state = {}, action ) {
 	const stateKey = getStateKey( siteId, postId );
 
 	switch ( type ) {
-		case COMMENTS_CHANGE_STATUS:
+		case COMMENTS_CHANGE_STATUS: {
 			const { status } = action;
 			return {
 				...state,
 				[ stateKey ]: map( state[ stateKey ], updateComment( commentId, { status } ) ),
 			};
-		case COMMENTS_EDIT:
+		}
+		case COMMENTS_EDIT: {
 			const { comment } = action;
 			return {
 				...state,
 				[ stateKey ]: map( state[ stateKey ], updateComment( commentId, comment ) ),
 			};
-		case COMMENTS_RECEIVE:
+		}
+		case COMMENTS_RECEIVE: {
 			const { skipSort } = action;
 			const comments = map( action.comments, _comment => ( {
 				..._comment,
@@ -126,6 +128,7 @@ export function items( state = {}, action ) {
 				...state,
 				[ stateKey ]: ! skipSort ? orderBy( allComments, getCommentDate, [ 'desc' ] ) : allComments,
 			};
+		}
 		case COMMENTS_DELETE:
 			return {
 				...state,
@@ -148,7 +151,7 @@ export function items( state = {}, action ) {
 				),
 			};
 		case COMMENTS_RECEIVE_ERROR:
-		case COMMENTS_WRITE_ERROR:
+		case COMMENTS_WRITE_ERROR: {
 			const { error, errorType } = action;
 			return {
 				...state,
@@ -161,6 +164,7 @@ export function items( state = {}, action ) {
 					} )
 				),
 			};
+		}
 	}
 
 	return state;
@@ -183,7 +187,7 @@ export function pendingItems( state = {}, action ) {
 	const stateKey = getStateKey( siteId, postId );
 
 	switch ( type ) {
-		case COMMENTS_UPDATES_RECEIVE:
+		case COMMENTS_UPDATES_RECEIVE: {
 			const comments = map( action.comments, _comment => ( {
 				..._comment,
 				contiguous: ! action.commentById,
@@ -194,8 +198,9 @@ export function pendingItems( state = {}, action ) {
 				...state,
 				[ stateKey ]: orderBy( allComments, getCommentDate, [ 'desc' ] ),
 			};
+		}
 
-		case COMMENTS_RECEIVE:
+		case COMMENTS_RECEIVE: {
 			const receivedCommentIds = map( action.comments, 'ID' );
 			return {
 				...state,
@@ -204,6 +209,7 @@ export function pendingItems( state = {}, action ) {
 					_comment => ! includes( receivedCommentIds, _comment.ID )
 				),
 			};
+		}
 	}
 
 	return state;

--- a/client/state/concierge/appointment-details/reducer.js
+++ b/client/state/concierge/appointment-details/reducer.js
@@ -3,15 +3,21 @@
 /**
  * Internal dependencies
  */
-import { createReducer, keyedReducer } from 'state/utils';
+import { keyedReducer, withoutPersistence } from 'state/utils';
 import {
 	CONCIERGE_APPOINTMENT_DETAILS_REQUEST,
 	CONCIERGE_APPOINTMENT_DETAILS_UPDATE,
 } from 'state/action-types';
 
-export const appointmentDetails = createReducer( null, {
-	[ CONCIERGE_APPOINTMENT_DETAILS_REQUEST ]: () => null,
-	[ CONCIERGE_APPOINTMENT_DETAILS_UPDATE ]: ( state, action ) => action.appointmentDetails,
+export const appointmentDetails = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_APPOINTMENT_DETAILS_REQUEST:
+			return null;
+		case CONCIERGE_APPOINTMENT_DETAILS_UPDATE:
+			return action.appointmentDetails;
+	}
+
+	return state;
 } );
 
 export default keyedReducer( 'appointmentId', appointmentDetails );

--- a/client/state/concierge/appointment-timespan/reducer.js
+++ b/client/state/concierge/appointment-timespan/reducer.js
@@ -3,12 +3,20 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
 
-export const appointmentTimespan = createReducer( null, {
-	[ CONCIERGE_INITIAL_REQUEST ]: () => null,
-	[ CONCIERGE_INITIAL_UPDATE ]: ( state, { initial } ) => initial.appointmentTimespan,
+export const appointmentTimespan = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_INITIAL_REQUEST:
+			return null;
+		case CONCIERGE_INITIAL_UPDATE: {
+			const { initial } = action;
+			return initial.appointmentTimespan;
+		}
+	}
+
+	return state;
 } );
 
 export default appointmentTimespan;

--- a/client/state/concierge/available-times/reducer.js
+++ b/client/state/concierge/available-times/reducer.js
@@ -3,12 +3,18 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
 
-export const availableTimes = createReducer( null, {
-	[ CONCIERGE_INITIAL_REQUEST ]: () => null,
-	[ CONCIERGE_INITIAL_UPDATE ]: ( state, action ) => action.initial.availableTimes,
+export const availableTimes = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_INITIAL_REQUEST:
+			return null;
+		case CONCIERGE_INITIAL_UPDATE:
+			return action.initial.availableTimes;
+	}
+
+	return state;
 } );
 
 export default availableTimes;

--- a/client/state/concierge/next-appointment/reducer.js
+++ b/client/state/concierge/next-appointment/reducer.js
@@ -3,12 +3,18 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
 
-export const nextAppointment = createReducer( null, {
-	[ CONCIERGE_INITIAL_REQUEST ]: () => null,
-	[ CONCIERGE_INITIAL_UPDATE ]: ( state, action ) => action.initial.nextAppointment,
+export const nextAppointment = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_INITIAL_REQUEST:
+			return null;
+		case CONCIERGE_INITIAL_UPDATE:
+			return action.initial.nextAppointment;
+	}
+
+	return state;
 } );
 
 export default nextAppointment;

--- a/client/state/concierge/schedule-id/reducer.js
+++ b/client/state/concierge/schedule-id/reducer.js
@@ -3,12 +3,20 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
 
-export const scheduleId = createReducer( null, {
-	[ CONCIERGE_INITIAL_REQUEST ]: () => null,
-	[ CONCIERGE_INITIAL_UPDATE ]: ( state, { initial } ) => initial.scheduleId,
+export const scheduleId = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_INITIAL_REQUEST:
+			return null;
+		case CONCIERGE_INITIAL_UPDATE: {
+			const { initial } = action;
+			return initial.scheduleId;
+		}
+	}
+
+	return state;
 } );
 
 export default scheduleId;

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -8,44 +8,88 @@ import moment from 'moment-timezone';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { CONCIERGE_SIGNUP_FORM_UPDATE, CONCIERGE_UPDATE_BOOKING_STATUS } from 'state/action-types';
 
-export const message = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.message,
+export const message = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.message;
+	}
+
+	return state;
 } );
 
-export const timezone = createReducer( moment.tz.guess(), {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.timezone,
+export const timezone = withoutPersistence( ( state = moment.tz.guess(), action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.timezone;
+	}
+
+	return state;
 } );
 
-export const isRebrandCitiesSite = createReducer( false, {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.isRebrandCitiesSite,
+export const isRebrandCitiesSite = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.isRebrandCitiesSite;
+	}
+
+	return state;
 } );
 
-export const firstname = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.firstname,
+export const firstname = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.firstname;
+	}
+
+	return state;
 } );
 
-export const lastname = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.lastname,
+export const lastname = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.lastname;
+	}
+
+	return state;
 } );
 
-export const phoneNumber = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.phoneNumber,
+export const phoneNumber = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.phoneNumber;
+	}
+
+	return state;
 } );
 
-export const countryCode = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.countryCode,
+export const countryCode = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.countryCode;
+	}
+
+	return state;
 } );
 
-export const phoneNumberWithoutCountryCode = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) =>
-		action.signupForm.phoneNumberWithoutCountryCode,
+export const phoneNumberWithoutCountryCode = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_SIGNUP_FORM_UPDATE:
+			return action.signupForm.phoneNumberWithoutCountryCode;
+	}
+
+	return state;
 } );
 
-export const status = createReducer( null, {
-	[ CONCIERGE_UPDATE_BOOKING_STATUS ]: ( state, action ) => action.status,
+export const status = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case CONCIERGE_UPDATE_BOOKING_STATUS:
+			return action.status;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/country-states/reducer.js
+++ b/client/state/country-states/reducer.js
@@ -7,39 +7,53 @@ import {
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Stores the complete list of states, indexed by locale key
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ COUNTRY_STATES_RECEIVE ]: ( state, action ) => ( {
-			...state,
-			[ action.countryCode ]: action.countryStates,
-		} ),
-	},
-	itemSchema
-);
+export const items = withSchemaValidation( itemSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case COUNTRY_STATES_RECEIVE:
+			return {
+				...state,
+				[ action.countryCode ]: action.countryStates,
+			};
+	}
+
+	return state;
+} );
 
 // Tracks states list fetching state
-export const isFetching = createReducer(
-	{},
-	{
-		[ COUNTRY_STATES_REQUEST ]: ( state, { countryCode } ) => ( {
-			...state,
-			[ countryCode ]: true,
-		} ),
-		[ COUNTRY_STATES_REQUEST_SUCCESS ]: ( state, { countryCode } ) => ( {
-			...state,
-			[ countryCode ]: false,
-		} ),
-		[ COUNTRY_STATES_REQUEST_FAILURE ]: ( state, { countryCode } ) => ( {
-			...state,
-			[ countryCode ]: false,
-		} ),
+export const isFetching = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case COUNTRY_STATES_REQUEST: {
+			const { countryCode } = action;
+
+			return {
+				...state,
+				[ countryCode ]: true,
+			};
+		}
+		case COUNTRY_STATES_REQUEST_SUCCESS: {
+			const { countryCode } = action;
+
+			return {
+				...state,
+				[ countryCode ]: false,
+			};
+		}
+		case COUNTRY_STATES_REQUEST_FAILURE: {
+			const { countryCode } = action;
+
+			return {
+				...state,
+				[ countryCode ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	isFetching,

--- a/client/state/current-user/email-verification/reducer.js
+++ b/client/state/current-user/email-verification/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	EMAIL_VERIFY_REQUEST,
 	EMAIL_VERIFY_REQUEST_SUCCESS,
@@ -12,18 +12,36 @@ import {
 	EMAIL_VERIFY_STATE_RESET,
 } from 'state/action-types';
 
-export const status = createReducer( null, {
-	[ EMAIL_VERIFY_REQUEST ]: () => 'requesting',
-	[ EMAIL_VERIFY_REQUEST_SUCCESS ]: () => 'sent',
-	[ EMAIL_VERIFY_REQUEST_FAILURE ]: () => 'error',
-	[ EMAIL_VERIFY_STATE_RESET ]: () => null,
+export const status = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case EMAIL_VERIFY_REQUEST:
+			return 'requesting';
+		case EMAIL_VERIFY_REQUEST_SUCCESS:
+			return 'sent';
+		case EMAIL_VERIFY_REQUEST_FAILURE:
+			return 'error';
+		case EMAIL_VERIFY_STATE_RESET:
+			return null;
+	}
+
+	return state;
 } );
 
-export const errorMessage = createReducer( '', {
-	[ EMAIL_VERIFY_REQUEST ]: () => '',
-	[ EMAIL_VERIFY_REQUEST_SUCCESS ]: () => '',
-	[ EMAIL_VERIFY_REQUEST_FAILURE ]: ( state, { message } ) => message,
-	[ EMAIL_VERIFY_STATE_RESET ]: () => '',
+export const errorMessage = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case EMAIL_VERIFY_REQUEST:
+			return '';
+		case EMAIL_VERIFY_REQUEST_SUCCESS:
+			return '';
+		case EMAIL_VERIFY_REQUEST_FAILURE: {
+			const { message } = action;
+			return message;
+		}
+		case EMAIL_VERIFY_STATE_RESET:
+			return '';
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/current-user/gravatar-status/reducer.js
+++ b/client/state/current-user/gravatar-status/reducer.js
@@ -10,24 +10,32 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const isUploading = createReducer( false, {
-	[ GRAVATAR_UPLOAD_REQUEST ]: () => true,
-	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: () => false,
-	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: () => false,
+export const isUploading = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case GRAVATAR_UPLOAD_REQUEST:
+			return true;
+		case GRAVATAR_UPLOAD_REQUEST_SUCCESS:
+			return false;
+		case GRAVATAR_UPLOAD_REQUEST_FAILURE:
+			return false;
+	}
+
+	return state;
 } );
 
-export const tempImage = createReducer(
-	{},
-	{
-		[ GRAVATAR_UPLOAD_RECEIVE ]: ( state, action ) => {
+export const tempImage = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case GRAVATAR_UPLOAD_RECEIVE: {
 			return {
 				src: action.src,
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	isUploading,

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -14,7 +14,7 @@ import {
 	PLANS_RECEIVE,
 	PRODUCTS_LIST_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, createReducerWithValidation, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
 import gravatarStatus from './gravatar-status/reducer';
 import emailVerification from './email-verification/reducer';
@@ -32,22 +32,23 @@ import emailVerification from './email-verification/reducer';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const id = createReducerWithValidation(
-	null,
-	{
-		[ CURRENT_USER_RECEIVE ]: ( state, action ) => action.user.ID,
-	},
-	idSchema
-);
+export const id = withSchemaValidation( idSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case CURRENT_USER_RECEIVE:
+			return action.user.ID;
+	}
 
-export const flags = createReducerWithValidation(
-	[],
-	{
-		[ CURRENT_USER_RECEIVE ]: ( state, action ) =>
-			get( action.user, 'meta.data.flags.active_flags', [] ),
-	},
-	flagsSchema
-);
+	return state;
+} );
+
+export const flags = withSchemaValidation( flagsSchema, ( state = [], action ) => {
+	switch ( action.type ) {
+		case CURRENT_USER_RECEIVE:
+			return get( action.user, 'meta.data.flags.active_flags', [] );
+	}
+
+	return state;
+} );
 
 /**
  * Tracks the currency code of the current user
@@ -57,25 +58,25 @@ export const flags = createReducerWithValidation(
  * @return {Object}        Updated state
  *
  */
-export const currencyCode = createReducerWithValidation(
-	null,
-	{
-		[ PRODUCTS_LIST_RECEIVE ]: ( state, action ) => {
+export const currencyCode = withSchemaValidation( currencyCodeSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case PRODUCTS_LIST_RECEIVE: {
 			return get(
 				action.productsList,
 				[ first( keys( action.productsList ) ), 'currency_code' ],
 				state
 			);
-		},
-		[ PLANS_RECEIVE ]: ( state, action ) => {
+		}
+		case PLANS_RECEIVE: {
 			return get( action.plans, [ 0, 'currency_code' ], state );
-		},
-		[ SITE_PLANS_FETCH_COMPLETED ]: ( state, action ) => {
+		}
+		case SITE_PLANS_FETCH_COMPLETED: {
 			return get( action.plans, [ 0, 'currencyCode' ], state );
-		},
-	},
-	currencyCodeSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 /**
  * Returns the updated capabilities state after an action has been dispatched.

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,
@@ -16,38 +16,43 @@ import { titleSchema, unreadCountSchema, linkSchema, metaSchema } from './schema
  */
 export const DEFAULT_META_STATE = [ { property: 'og:site_name', content: 'WordPress.com' } ];
 
-export const title = createReducerWithValidation(
-	'',
-	{
-		[ DOCUMENT_HEAD_TITLE_SET ]: ( state, action ) => action.title,
-	},
-	titleSchema
-);
+export const title = withSchemaValidation( titleSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case DOCUMENT_HEAD_TITLE_SET:
+			return action.title;
+	}
 
-export const unreadCount = createReducerWithValidation(
-	0,
-	{
-		[ DOCUMENT_HEAD_UNREAD_COUNT_SET ]: ( state, action ) => action.count,
-		[ ROUTE_SET ]: () => 0,
-	},
-	unreadCountSchema
-);
+	return state;
+} );
 
-export const meta = createReducerWithValidation(
-	DEFAULT_META_STATE,
-	{
-		[ DOCUMENT_HEAD_META_SET ]: ( state, action ) => action.meta,
-	},
-	metaSchema
-);
+export const unreadCount = withSchemaValidation( unreadCountSchema, ( state = 0, action ) => {
+	switch ( action.type ) {
+		case DOCUMENT_HEAD_UNREAD_COUNT_SET:
+			return action.count;
+		case ROUTE_SET:
+			return 0;
+	}
 
-export const link = createReducerWithValidation(
-	[],
-	{
-		[ DOCUMENT_HEAD_LINK_SET ]: ( state, action ) => action.link,
-	},
-	linkSchema
-);
+	return state;
+} );
+
+export const meta = withSchemaValidation( metaSchema, ( state = DEFAULT_META_STATE, action ) => {
+	switch ( action.type ) {
+		case DOCUMENT_HEAD_META_SET:
+			return action.meta;
+	}
+
+	return state;
+} );
+
+export const link = withSchemaValidation( linkSchema, ( state = [], action ) => {
+	switch ( action.type ) {
+		case DOCUMENT_HEAD_LINK_SET:
+			return action.link;
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	link,

--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -7,10 +7,10 @@ import { get, isArray, merge, omit, stubFalse, stubTrue } from 'lodash';
  * Internal dependencies
  */
 import {
-	createReducer,
-	createReducerWithValidation,
 	combineReducers,
 	keyedReducer,
+	withSchemaValidation,
+	withoutPersistence,
 } from 'state/utils';
 import { validationSchemas } from './validation-schemas/reducer';
 import { domainWhoisSchema } from './schema';
@@ -39,18 +39,32 @@ import { whoisType } from '../../../lib/domains/whois/constants';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const isRequestingContactDetailsCache = createReducer( false, {
-	[ DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST ]: stubTrue,
-	[ DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_SUCCESS ]: stubFalse,
-	[ DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_FAILURE ]: stubFalse,
+export const isRequestingContactDetailsCache = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST:
+			return stubTrue( state, action );
+		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_SUCCESS:
+			return stubFalse( state, action );
+		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_REQUEST_FAILURE:
+			return stubFalse( state, action );
+	}
+
+	return state;
 } );
 
 export const isRequestingWhois = keyedReducer(
 	'domain',
-	createReducer( false, {
-		[ DOMAIN_MANAGEMENT_WHOIS_REQUEST ]: stubTrue,
-		[ DOMAIN_MANAGEMENT_WHOIS_REQUEST_SUCCESS ]: stubFalse,
-		[ DOMAIN_MANAGEMENT_WHOIS_REQUEST_FAILURE ]: stubFalse,
+	withoutPersistence( ( state = false, action ) => {
+		switch ( action.type ) {
+			case DOMAIN_MANAGEMENT_WHOIS_REQUEST:
+				return stubTrue( state, action );
+			case DOMAIN_MANAGEMENT_WHOIS_REQUEST_SUCCESS:
+				return stubFalse( state, action );
+			case DOMAIN_MANAGEMENT_WHOIS_REQUEST_FAILURE:
+				return stubFalse( state, action );
+		}
+
+		return state;
 	} )
 );
 
@@ -62,23 +76,36 @@ export const isRequestingWhois = keyedReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const isSaving = createReducer(
-	{},
-	{
-		[ DOMAIN_MANAGEMENT_WHOIS_SAVE ]: ( state, { domain } ) => ( {
-			...state,
-			[ domain ]: { saving: true, status: 'pending', error: false },
-		} ),
-		[ DOMAIN_MANAGEMENT_WHOIS_SAVE_SUCCESS ]: ( state, { domain } ) => ( {
-			...state,
-			[ domain ]: { saving: false, status: 'success', error: false },
-		} ),
-		[ DOMAIN_MANAGEMENT_WHOIS_SAVE_FAILURE ]: ( state, { domain, error } ) => ( {
-			...state,
-			[ domain ]: { saving: false, status: 'error', error },
-		} ),
+export const isSaving = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case DOMAIN_MANAGEMENT_WHOIS_SAVE: {
+			const { domain } = action;
+
+			return {
+				...state,
+				[ domain ]: { saving: true, status: 'pending', error: false },
+			};
+		}
+		case DOMAIN_MANAGEMENT_WHOIS_SAVE_SUCCESS: {
+			const { domain } = action;
+
+			return {
+				...state,
+				[ domain ]: { saving: false, status: 'success', error: false },
+			};
+		}
+		case DOMAIN_MANAGEMENT_WHOIS_SAVE_FAILURE: {
+			const { domain, error } = action;
+
+			return {
+				...state,
+				[ domain ]: { saving: false, status: 'error', error },
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 function mergeDomainRegistrantContactDetails( domainState, registrantContactDetails ) {
 	return isArray( domainState )
@@ -107,29 +134,39 @@ function mergeDomainRegistrantContactDetails( domainState, registrantContactDeta
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE ]: ( state, { data } ) => ( {
-			...state,
-			_contactDetailsCache: sanitizeExtra( data ),
-		} ),
-		[ DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE ]: ( state, { data } ) => {
+export const items = withSchemaValidation( domainWhoisSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE: {
+			const { data } = action;
+
+			return {
+				...state,
+				_contactDetailsCache: sanitizeExtra( data ),
+			};
+		}
+		case DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE: {
+			const { data } = action;
 			return merge( {}, sanitizeExtra( state ), { _contactDetailsCache: sanitizeExtra( data ) } );
-		},
-		[ DOMAIN_MANAGEMENT_WHOIS_RECEIVE ]: ( state, { domain, whoisData } ) => ( {
-			...state,
-			[ domain ]: whoisData,
-		} ),
-		[ DOMAIN_MANAGEMENT_WHOIS_UPDATE ]: ( state, { domain, whoisData } ) => {
+		}
+		case DOMAIN_MANAGEMENT_WHOIS_RECEIVE: {
+			const { domain, whoisData } = action;
+
+			return {
+				...state,
+				[ domain ]: whoisData,
+			};
+		}
+		case DOMAIN_MANAGEMENT_WHOIS_UPDATE: {
+			const { domain, whoisData } = action;
 			const domainState = get( state, [ `${ domain }` ], {} );
 			return merge( {}, state, {
 				[ domain ]: mergeDomainRegistrantContactDetails( domainState, whoisData ),
 			} );
-		},
-	},
-	domainWhoisSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/domains/transfer/reducer.js
+++ b/client/state/domains/transfer/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { createReducerWithValidation, combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { domainTransferSchema } from './schema';
 import { DOMAIN_TRANSFER_UPDATE } from 'state/action-types';
 
@@ -13,16 +13,20 @@ import { DOMAIN_TRANSFER_UPDATE } from 'state/action-types';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ DOMAIN_TRANSFER_UPDATE ]: ( state, { domain, options } ) => ( {
-			...state,
-			[ domain ]: options,
-		} ),
-	},
-	domainTransferSchema
-);
+export const items = withSchemaValidation( domainTransferSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case DOMAIN_TRANSFER_UPDATE: {
+			const { domain, options } = action;
+
+			return {
+				...state,
+				[ domain ]: options,
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/email-forwarding/reducer.js
+++ b/client/state/email-forwarding/reducer.js
@@ -8,9 +8,9 @@ import { orderBy } from 'lodash';
  */
 import {
 	combineReducers,
-	createReducer,
-	createReducerWithValidation,
 	keyedReducer,
+	withSchemaValidation,
+	withoutPersistence,
 } from 'state/utils';
 import {
 	EMAIL_FORWARDING_REQUEST,
@@ -28,10 +28,17 @@ import {
 } from 'state/action-types';
 import { forwardsSchema, mxSchema, typeSchema } from './schema';
 
-export const requestingReducer = createReducer( false, {
-	[ EMAIL_FORWARDING_REQUEST ]: () => true,
-	[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: () => false,
-	[ EMAIL_FORWARDING_REQUEST_FAILURE ]: () => false,
+export const requestingReducer = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case EMAIL_FORWARDING_REQUEST:
+			return true;
+		case EMAIL_FORWARDING_REQUEST_SUCCESS:
+			return false;
+		case EMAIL_FORWARDING_REQUEST_FAILURE:
+			return false;
+	}
+
+	return state;
 } );
 
 const handleCreateRequest = ( forwards, { domainName, mailbox, destination } ) => {
@@ -87,50 +94,90 @@ const changeMailBoxTemporary = temporary => ( forwards, { mailbox } ) => {
 	} );
 };
 
-export const typeReducer = createReducerWithValidation(
-	null,
-	{
-		[ EMAIL_FORWARDING_REQUEST ]: () => null,
-		[ EMAIL_FORWARDING_REQUEST_FAILURE ]: () => null,
-		[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: ( state, { response: { type } } ) => type || null,
-	},
-	typeSchema
-);
+export const typeReducer = withSchemaValidation( typeSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case EMAIL_FORWARDING_REQUEST:
+			return null;
+		case EMAIL_FORWARDING_REQUEST_FAILURE:
+			return null;
+		case EMAIL_FORWARDING_REQUEST_SUCCESS: {
+			const {
+				response: { type },
+			} = action;
+			return type || null;
+		}
+	}
 
-export const mxServersReducer = createReducerWithValidation(
-	null,
-	{
-		[ EMAIL_FORWARDING_REQUEST ]: () => null,
-		[ EMAIL_FORWARDING_REQUEST_FAILURE ]: () => null,
-		[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: ( state, { response: { mx_servers } } ) =>
-			mx_servers || [],
-	},
-	mxSchema
-);
+	return state;
+} );
 
-export const forwardsReducer = createReducerWithValidation(
-	null,
-	{
-		[ EMAIL_FORWARDING_REQUEST ]: () => null,
-		[ EMAIL_FORWARDING_REQUEST_FAILURE ]: () => null,
-		[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: ( state, { response: { forwards } } ) => forwards || [],
-		[ EMAIL_FORWARDING_ADD_REQUEST ]: handleCreateRequest,
-		[ EMAIL_FORWARDING_ADD_REQUEST_SUCCESS ]: handleCreateRequestSuccess,
-		[ EMAIL_FORWARDING_ADD_REQUEST_FAILURE ]: handleCreateRequestFailure,
-		[ EMAIL_FORWARDING_REMOVE_REQUEST ]: changeMailBoxTemporary( true ),
-		[ EMAIL_FORWARDING_REMOVE_REQUEST_SUCCESS ]: handleRemoveRequestSuccess,
-		[ EMAIL_FORWARDING_REMOVE_REQUEST_FAILURE ]: changeMailBoxTemporary( false ),
-		[ EMAIL_FORWARDING_RESEND_VERIFICATION_REQUEST ]: changeMailBoxTemporary( true ),
-		[ EMAIL_FORWARDING_RESEND_VERIFICATION_REQUEST_SUCCESS ]: changeMailBoxTemporary( false ),
-		[ EMAIL_FORWARDING_RESEND_VERIFICATION_REQUEST_FAILURE ]: changeMailBoxTemporary( false ),
-	},
-	forwardsSchema
-);
+export const mxServersReducer = withSchemaValidation( mxSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case EMAIL_FORWARDING_REQUEST:
+			return null;
+		case EMAIL_FORWARDING_REQUEST_FAILURE:
+			return null;
+		case EMAIL_FORWARDING_REQUEST_SUCCESS: {
+			const {
+				response: { mx_servers },
+			} = action;
+			return mx_servers || [];
+		}
+	}
 
-export const requestErrorReducer = createReducer( false, {
-	[ EMAIL_FORWARDING_REQUEST ]: () => false,
-	[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: () => false,
-	[ EMAIL_FORWARDING_REQUEST_FAILURE ]: ( state, { error: { message } } ) => message || true,
+	return state;
+} );
+
+export const forwardsReducer = withSchemaValidation( forwardsSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case EMAIL_FORWARDING_REQUEST:
+			return null;
+		case EMAIL_FORWARDING_REQUEST_FAILURE:
+			return null;
+		case EMAIL_FORWARDING_REQUEST_SUCCESS: {
+			const {
+				response: { forwards },
+			} = action;
+			return forwards || [];
+		}
+		case EMAIL_FORWARDING_ADD_REQUEST:
+			return handleCreateRequest( state, action );
+		case EMAIL_FORWARDING_ADD_REQUEST_SUCCESS:
+			return handleCreateRequestSuccess( state, action );
+		case EMAIL_FORWARDING_ADD_REQUEST_FAILURE:
+			return handleCreateRequestFailure( state, action );
+		case EMAIL_FORWARDING_REMOVE_REQUEST:
+			return changeMailBoxTemporary( true )( state, action );
+		case EMAIL_FORWARDING_REMOVE_REQUEST_SUCCESS:
+			return handleRemoveRequestSuccess( state, action );
+		case EMAIL_FORWARDING_REMOVE_REQUEST_FAILURE:
+			return changeMailBoxTemporary( false )( state, action );
+		case EMAIL_FORWARDING_RESEND_VERIFICATION_REQUEST:
+			return changeMailBoxTemporary( true )( state, action );
+		case EMAIL_FORWARDING_RESEND_VERIFICATION_REQUEST_SUCCESS:
+			return changeMailBoxTemporary( false )( state, action );
+		case EMAIL_FORWARDING_RESEND_VERIFICATION_REQUEST_FAILURE:
+			return changeMailBoxTemporary( false )( state, action );
+	}
+
+	return state;
+} );
+
+export const requestErrorReducer = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case EMAIL_FORWARDING_REQUEST:
+			return false;
+		case EMAIL_FORWARDING_REQUEST_SUCCESS:
+			return false;
+		case EMAIL_FORWARDING_REQUEST_FAILURE: {
+			const {
+				error: { message },
+			} = action;
+			return message || true;
+		}
+	}
+
+	return state;
 } );
 
 export default keyedReducer(

--- a/client/state/google-my-business/reducer.js
+++ b/client/state/google-my-business/reducer.js
@@ -3,23 +3,41 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 import {
 	GOOGLE_MY_BUSINESS_STATS_FAILURE,
 	GOOGLE_MY_BUSINESS_STATS_RECEIVE,
 	GOOGLE_MY_BUSINESS_STATS_REQUEST,
 } from 'state/action-types';
 
-const stats = createReducer( null, {
-	[ GOOGLE_MY_BUSINESS_STATS_RECEIVE ]: ( state, { data } ) => data,
-	[ GOOGLE_MY_BUSINESS_STATS_REQUEST ]: () => null,
-	[ GOOGLE_MY_BUSINESS_STATS_FAILURE ]: () => null,
+const stats = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case GOOGLE_MY_BUSINESS_STATS_RECEIVE: {
+			const { data } = action;
+			return data;
+		}
+		case GOOGLE_MY_BUSINESS_STATS_REQUEST:
+			return null;
+		case GOOGLE_MY_BUSINESS_STATS_FAILURE:
+			return null;
+	}
+
+	return state;
 } );
 
-const statsError = createReducer( null, {
-	[ GOOGLE_MY_BUSINESS_STATS_RECEIVE ]: () => null,
-	[ GOOGLE_MY_BUSINESS_STATS_REQUEST ]: () => null,
-	[ GOOGLE_MY_BUSINESS_STATS_FAILURE ]: ( state, { error } ) => error,
+const statsError = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case GOOGLE_MY_BUSINESS_STATS_RECEIVE:
+			return null;
+		case GOOGLE_MY_BUSINESS_STATS_REQUEST:
+			return null;
+		case GOOGLE_MY_BUSINESS_STATS_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+	}
+
+	return state;
 } );
 
 export default keyedReducer(

--- a/client/state/gsuite-users/reducer.js
+++ b/client/state/gsuite-users/reducer.js
@@ -3,9 +3,9 @@
  */
 import {
 	combineReducers,
-	createReducerWithValidation,
-	createReducer,
 	keyedReducer,
+	withSchemaValidation,
+	withoutPersistence,
 } from 'state/utils';
 import {
 	GSUITE_USERS_REQUEST,
@@ -14,26 +14,47 @@ import {
 } from 'state/action-types';
 import { usersSchema } from './schema';
 
-export const usersReducer = createReducerWithValidation(
-	null,
-	{
-		[ GSUITE_USERS_REQUEST ]: () => null,
-		[ GSUITE_USERS_REQUEST_FAILURE ]: () => null,
-		[ GSUITE_USERS_REQUEST_SUCCESS ]: ( state, { response: { accounts } } ) => accounts,
-	},
-	usersSchema
-);
+export const usersReducer = withSchemaValidation( usersSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case GSUITE_USERS_REQUEST:
+			return null;
+		case GSUITE_USERS_REQUEST_FAILURE:
+			return null;
+		case GSUITE_USERS_REQUEST_SUCCESS: {
+			const {
+				response: { accounts },
+			} = action;
+			return accounts;
+		}
+	}
 
-export const requestErrorReducer = createReducer( false, {
-	[ GSUITE_USERS_REQUEST ]: () => false,
-	[ GSUITE_USERS_REQUEST_FAILURE ]: () => true,
-	[ GSUITE_USERS_REQUEST_SUCCESS ]: () => false,
+	return state;
 } );
 
-export const requestingReducer = createReducer( false, {
-	[ GSUITE_USERS_REQUEST ]: () => true,
-	[ GSUITE_USERS_REQUEST_FAILURE ]: () => false,
-	[ GSUITE_USERS_REQUEST_SUCCESS ]: () => false,
+export const requestErrorReducer = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case GSUITE_USERS_REQUEST:
+			return false;
+		case GSUITE_USERS_REQUEST_FAILURE:
+			return true;
+		case GSUITE_USERS_REQUEST_SUCCESS:
+			return false;
+	}
+
+	return state;
+} );
+
+export const requestingReducer = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case GSUITE_USERS_REQUEST:
+			return true;
+		case GSUITE_USERS_REQUEST_FAILURE:
+			return false;
+		case GSUITE_USERS_REQUEST_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
 export default keyedReducer(

--- a/client/state/happiness-engineers/reducer.js
+++ b/client/state/happiness-engineers/reducer.js
@@ -6,7 +6,7 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	HAPPINESS_ENGINEERS_FETCH,
@@ -23,10 +23,17 @@ import {
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const requesting = createReducer( false, {
-	[ HAPPINESS_ENGINEERS_FETCH ]: () => true,
-	[ HAPPINESS_ENGINEERS_FETCH_FAILURE ]: () => false,
-	[ HAPPINESS_ENGINEERS_FETCH_SUCCESS ]: () => false,
+export const requesting = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case HAPPINESS_ENGINEERS_FETCH:
+			return true;
+		case HAPPINESS_ENGINEERS_FETCH_FAILURE:
+			return false;
+		case HAPPINESS_ENGINEERS_FETCH_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
 /**
@@ -38,15 +45,16 @@ export const requesting = createReducer( false, {
  * @param  {Object} action Action object
  * @return {Array}         Updated state
  */
-export const items = createReducerWithValidation(
-	null,
-	{
-		[ HAPPINESS_ENGINEERS_RECEIVE ]: ( state, { happinessEngineers } ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case HAPPINESS_ENGINEERS_RECEIVE: {
+			const { happinessEngineers } = action;
 			return map( happinessEngineers, 'avatar_URL' );
-		},
-	},
-	itemsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	requesting,

--- a/client/state/happychat/user/reducer.js
+++ b/client/state/happychat/user/reducer.js
@@ -6,7 +6,7 @@ import {
 	HAPPYCHAT_ELIGIBILITY_SET,
 	PRESALE_PRECANCELLATION_CHAT_AVAILABILITY_SET,
 } from 'state/action-types';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import {
 	geoLocationSchema,
 	isEligibleSchema,
@@ -21,10 +21,9 @@ import {
  * @param {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const geoLocation = createReducerWithValidation(
-	null,
-	{
-		[ HAPPYCHAT_IO_RECEIVE_INIT ]: ( state, action ) => {
+export const geoLocation = withSchemaValidation( geoLocationSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case HAPPYCHAT_IO_RECEIVE_INIT: {
 			const {
 				user: { geoLocation: location },
 			} = action;
@@ -32,25 +31,31 @@ export const geoLocation = createReducerWithValidation(
 				return location;
 			}
 			return state;
-		},
-	},
-	geoLocationSchema
-);
+		}
+	}
 
-export const isEligible = createReducerWithValidation(
-	null,
-	{
-		[ HAPPYCHAT_ELIGIBILITY_SET ]: ( state, action ) => action.isEligible,
-	},
-	isEligibleSchema
-);
+	return state;
+} );
 
-export const isPresalesPrecancellationEligible = createReducerWithValidation(
-	null,
-	{
-		[ PRESALE_PRECANCELLATION_CHAT_AVAILABILITY_SET ]: ( state, action ) => action.availability,
-	},
-	isPresalesPrecancellationEligibleSchema
+export const isEligible = withSchemaValidation( isEligibleSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case HAPPYCHAT_ELIGIBILITY_SET:
+			return action.isEligible;
+	}
+
+	return state;
+} );
+
+export const isPresalesPrecancellationEligible = withSchemaValidation(
+	isPresalesPrecancellationEligibleSchema,
+	( state = null, action ) => {
+		switch ( action.type ) {
+			case PRESALE_PRECANCELLATION_CHAT_AVAILABILITY_SET:
+				return action.availability;
+		}
+
+		return state;
+	}
 );
 
 export default combineReducers( { geoLocation, isEligible, isPresalesPrecancellationEligible } );

--- a/client/state/help/courses/reducer.js
+++ b/client/state/help/courses/reducer.js
@@ -4,11 +4,18 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { HELP_COURSES_RECEIVE } from 'state/action-types';
 
-export const items = createReducer( null, {
-	[ HELP_COURSES_RECEIVE ]: ( state, { courses } ) => courses,
+export const items = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case HELP_COURSES_RECEIVE: {
+			const { courses } = action;
+			return courses;
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -15,9 +15,10 @@ import { STATUS_UNINITIALIZED, STATUS_INITIALIZING, STATUS_READY, STATUS_ERROR }
 
 export const questionAsked = ( state = null, action ) => {
 	switch ( action.type ) {
-		case DIRECTLY_ASK_QUESTION:
+		case DIRECTLY_ASK_QUESTION: {
 			const { questionText, name, email } = action;
 			return { questionText, name, email };
+		}
 	}
 
 	return state;

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
@@ -23,10 +23,17 @@ export const questionAsked = ( state = null, action ) => {
 	return state;
 };
 
-export const status = createReducer( STATUS_UNINITIALIZED, {
-	[ DIRECTLY_INITIALIZATION_START ]: () => STATUS_INITIALIZING,
-	[ DIRECTLY_INITIALIZATION_SUCCESS ]: () => STATUS_READY,
-	[ DIRECTLY_INITIALIZATION_ERROR ]: () => STATUS_ERROR,
+export const status = withoutPersistence( ( state = STATUS_UNINITIALIZED, action ) => {
+	switch ( action.type ) {
+		case DIRECTLY_INITIALIZATION_START:
+			return STATUS_INITIALIZING;
+		case DIRECTLY_INITIALIZATION_SUCCESS:
+			return STATUS_READY;
+		case DIRECTLY_INITIALIZATION_ERROR:
+			return STATUS_ERROR;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -5,7 +5,7 @@
  */
 import { HELP_CONTACT_FORM_SITE_SELECT, HELP_LINKS_RECEIVE } from 'state/action-types';
 import courses from './courses/reducer';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import directly from './directly/reducer';
 import ticket from './ticket/reducer';
 
@@ -16,8 +16,13 @@ import ticket from './ticket/reducer';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const selectedSiteId = createReducer( null, {
-	[ HELP_CONTACT_FORM_SITE_SELECT ]: ( state, action ) => action.siteId,
+export const selectedSiteId = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case HELP_CONTACT_FORM_SITE_SELECT:
+			return action.siteId;
+	}
+
+	return state;
 } );
 
 /**

--- a/client/state/help/ticket/reducer.js
+++ b/client/state/help/ticket/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
 	HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
@@ -12,26 +12,54 @@ import {
 	HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 } from 'state/action-types';
 
-const isRequesting = createReducer( false, {
-	[ HELP_TICKET_CONFIGURATION_REQUEST ]: () => true,
-	[ HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS ]: () => false,
-	[ HELP_TICKET_CONFIGURATION_REQUEST_FAILURE ]: () => false,
+const isRequesting = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case HELP_TICKET_CONFIGURATION_REQUEST:
+			return true;
+		case HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS:
+			return false;
+		case HELP_TICKET_CONFIGURATION_REQUEST_FAILURE:
+			return false;
+	}
+
+	return state;
 } );
 
-const isUserEligible = createReducer( false, {
-	[ HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS ]: ( state, { configuration } ) =>
-		configuration.is_user_eligible,
+const isUserEligible = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS: {
+			const { configuration } = action;
+			return configuration.is_user_eligible;
+		}
+	}
+
+	return state;
 } );
 
-const isReady = createReducer( false, {
-	[ HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS ]: () => true,
+const isReady = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS:
+			return true;
+	}
+
+	return state;
 } );
 
-const requestError = createReducer( null, {
-	[ HELP_TICKET_CONFIGURATION_REQUEST ]: () => null,
-	[ HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS ]: () => null,
-	[ HELP_TICKET_CONFIGURATION_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ HELP_TICKET_CONFIGURATION_DISMISS_ERROR ]: () => null,
+const requestError = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case HELP_TICKET_CONFIGURATION_REQUEST:
+			return null;
+		case HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS:
+			return null;
+		case HELP_TICKET_CONFIGURATION_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case HELP_TICKET_CONFIGURATION_DISMISS_ERROR:
+			return null;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/immediate-login/reducer.js
+++ b/client/state/immediate-login/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { IMMEDIATE_LOGIN_SAVE_INFO } from 'state/action-types';
 
 const initialState = {
@@ -15,12 +15,20 @@ const initialState = {
 	locale: null,
 };
 
-export default createReducer( initialState, {
-	[ IMMEDIATE_LOGIN_SAVE_INFO ]: ( state, { success, reason, email, locale } ) => ( {
-		attempt: true,
-		success: !! success,
-		reason: reason || null,
-		email: email || null,
-		locale: locale || null,
-	} ),
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case IMMEDIATE_LOGIN_SAVE_INFO: {
+			const { success, reason, email, locale } = action;
+
+			return {
+				attempt: true,
+				success: !! success,
+				reason: reason || null,
+				email: email || null,
+				locale: locale || null,
+			};
+		}
+	}
+
+	return state;
 } );

--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	IMPORTER_NUX_SITE_DETAILS_SET,
 	IMPORTS_IMPORT_CANCEL,
@@ -15,28 +15,48 @@ import { registerActionForward } from 'lib/redux-bridge';
 
 registerActionForward( IMPORTS_IMPORT_CANCEL );
 
-export const urlInputValue = createReducer( '', {
-	[ IMPORTER_NUX_URL_INPUT_SET ]: ( state, { value = '' } ) => value,
-	[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => '',
+export const urlInputValue = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case IMPORTER_NUX_URL_INPUT_SET: {
+			const { value = '' } = action;
+			return value;
+		}
+		case 'FLUX_IMPORTS_IMPORT_CANCEL':
+			return '';
+	}
+
+	return state;
 } );
 
-export const isFromSignupFlow = createReducer( false, {
-	[ IMPORTER_NUX_FROM_SIGNUP_SET ]: () => true,
-	[ IMPORTER_NUX_FROM_SIGNUP_CLEAR ]: () => false,
+export const isFromSignupFlow = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case IMPORTER_NUX_FROM_SIGNUP_SET:
+			return true;
+		case IMPORTER_NUX_FROM_SIGNUP_CLEAR:
+			return false;
+	}
+
+	return state;
 } );
 
-export const siteDetails = createReducer( null, {
-	[ IMPORTER_NUX_SITE_DETAILS_SET ]: (
-		state,
-		{ siteEngine, siteFavicon, siteTitle, siteUrl, importerTypes }
-	) => ( {
-		siteEngine,
-		siteFavicon,
-		siteTitle,
-		siteUrl,
-		importerTypes,
-	} ),
-	[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => null,
+export const siteDetails = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case IMPORTER_NUX_SITE_DETAILS_SET: {
+			const { siteEngine, siteFavicon, siteTitle, siteUrl, importerTypes } = action;
+
+			return {
+				siteEngine,
+				siteFavicon,
+				siteTitle,
+				siteUrl,
+				importerTypes,
+			};
+		}
+		case 'FLUX_IMPORTS_IMPORT_CANCEL':
+			return null;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/imports/site-importer/reducer.js
+++ b/client/state/imports/site-importer/reducer.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	SITE_IMPORTER_IMPORT_FAILURE,
 	SITE_IMPORTER_IMPORT_RESET,
@@ -27,61 +27,110 @@ const DEFAULT_ERROR_STATE = {
 const DEFAULT_IMPORT_STAGE = 'idle';
 const DEFAULT_IMPORT_DATA = {};
 
-const isLoading = createReducer( false, {
-	[ SITE_IMPORTER_IMPORT_FAILURE ]: () => false,
-	[ SITE_IMPORTER_IMPORT_START ]: () => true,
-	[ SITE_IMPORTER_IMPORT_SUCCESS ]: () => false,
-	[ SITE_IMPORTER_IMPORT_RESET ]: () => false,
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_FAILURE ]: () => false,
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_START ]: () => true,
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS ]: () => false,
+const isLoading = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case SITE_IMPORTER_IMPORT_FAILURE:
+			return false;
+		case SITE_IMPORTER_IMPORT_START:
+			return true;
+		case SITE_IMPORTER_IMPORT_SUCCESS:
+			return false;
+		case SITE_IMPORTER_IMPORT_RESET:
+			return false;
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_FAILURE:
+			return false;
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_START:
+			return true;
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
-const error = createReducer( DEFAULT_ERROR_STATE, {
-	[ SITE_IMPORTER_IMPORT_SUCCESS ]: () => DEFAULT_ERROR_STATE,
-	[ SITE_IMPORTER_IMPORT_FAILURE ]: ( state, { message } ) => ( {
-		error: true,
-		errorType: 'importError',
-		errorMessage: message,
-	} ),
-	[ SITE_IMPORTER_IMPORT_START ]: () => DEFAULT_ERROR_STATE,
+const error = withoutPersistence( ( state = DEFAULT_ERROR_STATE, action ) => {
+	switch ( action.type ) {
+		case SITE_IMPORTER_IMPORT_SUCCESS:
+			return DEFAULT_ERROR_STATE;
+		case SITE_IMPORTER_IMPORT_FAILURE: {
+			const { message } = action;
 
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS ]: () => DEFAULT_ERROR_STATE,
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_FAILURE ]: ( state, { message } ) => ( {
-		error: true,
-		errorType: 'importError',
-		errorMessage: message,
-	} ),
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_START ]: () => DEFAULT_ERROR_STATE,
-	[ SITE_IMPORTER_IMPORT_RESET ]: () => DEFAULT_ERROR_STATE,
-	[ SITE_IMPORTER_VALIDATION_ERROR_SET ]: ( state, { message } ) => ( {
-		error: true,
-		errorType: 'validationError',
-		errorMessage: message,
-	} ),
+			return {
+				error: true,
+				errorType: 'importError',
+				errorMessage: message,
+			};
+		}
+		case SITE_IMPORTER_IMPORT_START:
+			return DEFAULT_ERROR_STATE;
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS:
+			return DEFAULT_ERROR_STATE;
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_FAILURE: {
+			const { message } = action;
+
+			return {
+				error: true,
+				errorType: 'importError',
+				errorMessage: message,
+			};
+		}
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_START:
+			return DEFAULT_ERROR_STATE;
+		case SITE_IMPORTER_IMPORT_RESET:
+			return DEFAULT_ERROR_STATE;
+		case SITE_IMPORTER_VALIDATION_ERROR_SET: {
+			const { message } = action;
+
+			return {
+				error: true,
+				errorType: 'validationError',
+				errorMessage: message,
+			};
+		}
+	}
+
+	return state;
 } );
 
-const importStage = createReducer( DEFAULT_IMPORT_STAGE, {
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS ]: () => 'importable',
-	[ SITE_IMPORTER_IMPORT_RESET ]: () => DEFAULT_IMPORT_STAGE,
+const importStage = withoutPersistence( ( state = DEFAULT_IMPORT_STAGE, action ) => {
+	switch ( action.type ) {
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS:
+			return 'importable';
+		case SITE_IMPORTER_IMPORT_RESET:
+			return DEFAULT_IMPORT_STAGE;
+	}
+
+	return state;
 } );
 
-const importData = createReducer( DEFAULT_IMPORT_DATA, {
-	// TODO: How should we clean this data up / reset it?
-	// Looking at the original code, there's no other setState call that does so.
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS ]: ( state, { response } ) => ( {
-		title: response.site_title,
-		supported: response.supported_content,
-		unsupported: response.unsupported_content,
-		favicon: response.favicon,
-		engine: response.engine,
-		url: response.url,
-	} ),
+const importData = withoutPersistence( ( state = DEFAULT_IMPORT_DATA, action ) => {
+	switch ( action.type ) {
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS: {
+			const { response } = action;
+
+			return {
+				title: response.site_title,
+				supported: response.supported_content,
+				unsupported: response.unsupported_content,
+				favicon: response.favicon,
+				engine: response.engine,
+				url: response.url,
+			};
+		}
+	}
+
+	return state;
 } );
 
-const validatedSiteUrl = createReducer( '', {
-	[ SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS ]: ( state, { response } ) =>
-		get( response, 'site_url', '' ),
+const validatedSiteUrl = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case SITE_IMPORTER_IS_SITE_IMPORTABLE_SUCCESS: {
+			const { response } = action;
+			return get( response, 'site_url', '' );
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/imports/uploads/reducer.js
+++ b/client/state/imports/uploads/reducer.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	IMPORTS_UPLOAD_SET_PROGRESS,
 	IMPORTS_UPLOAD_COMPLETED,
@@ -10,24 +10,45 @@ import {
 	IMPORTS_UPLOAD_START,
 } from 'state/action-types';
 
-const inProgress = createReducer( false, {
-	[ IMPORTS_UPLOAD_COMPLETED ]: () => false,
-	[ IMPORTS_UPLOAD_FAILED ]: () => false,
-	[ IMPORTS_UPLOAD_START ]: () => true,
+const inProgress = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case IMPORTS_UPLOAD_COMPLETED:
+			return false;
+		case IMPORTS_UPLOAD_FAILED:
+			return false;
+		case IMPORTS_UPLOAD_START:
+			return true;
+	}
+
+	return state;
 } );
 
-const percentComplete = createReducer( 0, {
-	[ IMPORTS_UPLOAD_SET_PROGRESS ]: ( state, action ) =>
-		( action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) ) * 100,
-	[ IMPORTS_UPLOAD_COMPLETED ]: () => 0,
-	[ IMPORTS_UPLOAD_FAILED ]: () => 0,
-	[ IMPORTS_UPLOAD_START ]: () => 0,
+const percentComplete = withoutPersistence( ( state = 0, action ) => {
+	switch ( action.type ) {
+		case IMPORTS_UPLOAD_SET_PROGRESS:
+			return ( action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) ) * 100;
+		case IMPORTS_UPLOAD_COMPLETED:
+			return 0;
+		case IMPORTS_UPLOAD_FAILED:
+			return 0;
+		case IMPORTS_UPLOAD_START:
+			return 0;
+	}
+
+	return state;
 } );
 
-const filename = createReducer( '', {
-	[ IMPORTS_UPLOAD_COMPLETED ]: () => '',
-	[ IMPORTS_UPLOAD_FAILED ]: () => '',
-	[ IMPORTS_UPLOAD_START ]: ( state, action ) => action.filename,
+const filename = withoutPersistence( ( state = '', action ) => {
+	switch ( action.type ) {
+		case IMPORTS_UPLOAD_COMPLETED:
+			return '';
+		case IMPORTS_UPLOAD_FAILED:
+			return '';
+		case IMPORTS_UPLOAD_START:
+			return action.filename;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	INLINE_HELP_SEARCH_REQUEST,
 	INLINE_HELP_SEARCH_REQUEST_FAILURE,
@@ -23,44 +23,69 @@ import {
 	SERIALIZE,
 } from 'state/action-types';
 
-export const popover = createReducer(
-	{
-		isVisible: false,
-	},
-	{
-		[ INLINE_HELP_POPOVER_SHOW ]: state => ( { ...state, isVisible: true } ),
-		[ INLINE_HELP_POPOVER_HIDE ]: state => ( { ...state, isVisible: false } ),
+export const popover = withoutPersistence( ( state = { isVisible: false }, action ) => {
+	switch ( action.type ) {
+		case INLINE_HELP_POPOVER_SHOW:
+			return { ...state, isVisible: true };
+		case INLINE_HELP_POPOVER_HIDE:
+			return { ...state, isVisible: false };
 	}
-);
 
-export const checklistPrompt = createReducer(
-	{
+	return state;
+} );
+
+export const checklistPrompt = (
+	state = {
 		isVisible: false,
 		taskId: null,
 		step: 0,
 	},
-	{
-		[ INLINE_HELP_CHECKLIST_PROMPT_SHOW ]: state => ( { ...state, isVisible: true } ),
-		[ INLINE_HELP_CHECKLIST_PROMPT_HIDE ]: state => ( {
-			...state,
-			isVisible: false,
-			taskId: null,
-			step: 0,
-		} ),
-		[ INLINE_HELP_CHECKLIST_PROMPT_SET_TASK_ID ]: ( state, { taskId } ) => ( { ...state, taskId } ),
-		[ INLINE_HELP_CHECKLIST_PROMPT_SET_STEP ]: ( state, { step } ) => ( { ...state, step } ),
-		[ SERIALIZE ]: state => state,
+	action
+) => {
+	switch ( action.type ) {
+		case INLINE_HELP_CHECKLIST_PROMPT_SHOW:
+			return { ...state, isVisible: true };
+		case INLINE_HELP_CHECKLIST_PROMPT_HIDE:
+			return {
+				...state,
+				isVisible: false,
+				taskId: null,
+				step: 0,
+			};
+		case INLINE_HELP_CHECKLIST_PROMPT_SET_TASK_ID: {
+			const { taskId } = action;
+			return { ...state, taskId };
+		}
+		case INLINE_HELP_CHECKLIST_PROMPT_SET_STEP: {
+			const { step } = action;
+			return { ...state, step };
+		}
+		case SERIALIZE:
+			return state;
 	}
-);
 
-export const onboardingWelcomePrompt = createReducer(
-	{
-		isVisible: false,
-	},
-	{
-		[ INLINE_HELP_ONBOARDING_WELCOME_PROMPT_SHOW ]: state => ( { ...state, isVisible: true } ),
-		[ INLINE_HELP_ONBOARDING_WELCOME_PROMPT_HIDE ]: state => ( { ...state, isVisible: false } ),
-		[ INLINE_HELP_POPOVER_HIDE ]: state => ( { ...state, isVisible: false } ),
+	return state;
+};
+
+checklistPrompt.hasCustomPersistence = true;
+
+export const onboardingWelcomePrompt = withoutPersistence(
+	(
+		state = {
+			isVisible: false,
+		},
+		action
+	) => {
+		switch ( action.type ) {
+			case INLINE_HELP_ONBOARDING_WELCOME_PROMPT_SHOW:
+				return { ...state, isVisible: true };
+			case INLINE_HELP_ONBOARDING_WELCOME_PROMPT_HIDE:
+				return { ...state, isVisible: false };
+			case INLINE_HELP_POPOVER_HIDE:
+				return { ...state, isVisible: false };
+		}
+
+		return state;
 	}
 );
 
@@ -82,75 +107,92 @@ export function requesting( state = {}, action ) {
 	return state;
 }
 
-export const search = createReducer(
-	{
-		searchQuery: '',
-		items: {},
-		selectedResult: -1,
-		shouldOpenSelectedResult: false,
-	},
-	{
-		[ INLINE_HELP_SEARCH_REQUEST ]: ( state, action ) => ( {
-			...state,
-			searchQuery: action.searchQuery,
-		} ),
-		[ INLINE_HELP_SEARCH_REQUEST_SUCCESS ]: ( state, action ) => ( {
-			...state,
+export const search = withoutPersistence(
+	(
+		state = {
+			searchQuery: '',
+			items: {},
 			selectedResult: -1,
-			items: {
-				...state.items,
-				[ action.searchQuery ]: action.searchResults,
-			},
-		} ),
-		[ INLINE_HELP_SELECT_RESULT ]: ( state, action ) => ( {
-			...state,
-			selectedResult: action.resultIndex,
-		} ),
-		[ INLINE_HELP_SELECT_NEXT_RESULT ]: state => {
-			if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {
+			shouldOpenSelectedResult: false,
+		},
+		action
+	) => {
+		switch ( action.type ) {
+			case INLINE_HELP_SEARCH_REQUEST:
 				return {
 					...state,
-					selectedResult: ( state.selectedResult + 1 ) % state.items[ state.searchQuery ].length,
+					searchQuery: action.searchQuery,
 				};
-			}
-
-			return {
-				...state,
-				selectedResult: -1,
-			};
-		},
-		[ INLINE_HELP_SELECT_PREVIOUS_RESULT ]: state => {
-			if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {
-				const newResult = ( state.selectedResult - 1 ) % state.items[ state.searchQuery ].length;
+			case INLINE_HELP_SEARCH_REQUEST_SUCCESS:
 				return {
 					...state,
-					selectedResult: newResult < 0 ? state.items[ state.searchQuery ].length - 1 : newResult,
+					selectedResult: -1,
+					items: {
+						...state.items,
+						[ action.searchQuery ]: action.searchResults,
+					},
+				};
+			case INLINE_HELP_SELECT_RESULT:
+				return {
+					...state,
+					selectedResult: action.resultIndex,
+				};
+			case INLINE_HELP_SELECT_NEXT_RESULT: {
+				if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {
+					return {
+						...state,
+						selectedResult: ( state.selectedResult + 1 ) % state.items[ state.searchQuery ].length,
+					};
+				}
+
+				return {
+					...state,
+					selectedResult: -1,
 				};
 			}
+			case INLINE_HELP_SELECT_PREVIOUS_RESULT: {
+				if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {
+					const newResult = ( state.selectedResult - 1 ) % state.items[ state.searchQuery ].length;
+					return {
+						...state,
+						selectedResult: newResult < 0 ? state.items[ state.searchQuery ].length - 1 : newResult,
+					};
+				}
 
-			return {
-				...state,
-				selectedResult: -1,
-			};
-		},
+				return {
+					...state,
+					selectedResult: -1,
+				};
+			}
+		}
+
+		return state;
 	}
 );
 
 const searchResults = combineReducers( { requesting, search } );
 
-export const contactForm = createReducer(
-	{
-		isShowingQandASuggestions: false,
-	},
-	{
-		[ INLINE_HELP_CONTACT_FORM_RESET ]: state => ( {
-			...state,
+export const contactForm = withoutPersistence(
+	(
+		state = {
 			isShowingQandASuggestions: false,
-		} ),
-		[ INLINE_HELP_CONTACT_FORM_SHOW_QANDA ]: state => ( {
-			...state,
-			isShowingQandASuggestions: true,
-		} ),
+		},
+		action
+	) => {
+		switch ( action.type ) {
+			case INLINE_HELP_CONTACT_FORM_RESET:
+				return {
+					...state,
+					isShowingQandASuggestions: false,
+				};
+			case INLINE_HELP_CONTACT_FORM_SHOW_QANDA:
+				return {
+					...state,
+					isShowingQandASuggestions: true,
+				};
+		}
+
+		return state;
 	}
 );
 

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -2,24 +2,35 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { SUPPORT_ARTICLE_DIALOG_OPEN, SUPPORT_ARTICLE_DIALOG_CLOSE } from 'state/action-types';
 
-export default createReducer(
-	{
-		postId: null,
-		postUrl: null,
-		isVisible: false,
-	},
-	{
-		[ SUPPORT_ARTICLE_DIALOG_OPEN ]: ( state, { postId, postUrl = null } ) => ( {
-			postUrl,
-			postId,
-			isVisible: true,
-		} ),
-		[ SUPPORT_ARTICLE_DIALOG_CLOSE ]: state => ( {
-			...state,
+export default withoutPersistence(
+	(
+		state = {
+			postId: null,
+			postUrl: null,
 			isVisible: false,
-		} ),
+		},
+		action
+	) => {
+		switch ( action.type ) {
+			case SUPPORT_ARTICLE_DIALOG_OPEN: {
+				const { postId, postUrl = null } = action;
+
+				return {
+					postUrl,
+					postId,
+					isVisible: true,
+				};
+			}
+			case SUPPORT_ARTICLE_DIALOG_CLOSE:
+				return {
+					...state,
+					isVisible: false,
+				};
+		}
+
+		return state;
 	}
 );

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -7,7 +7,7 @@ import { includes, map, pick, zipObject } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
@@ -51,10 +51,9 @@ export function requesting( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ INVITES_REQUEST_SUCCESS ]: ( state, action ) => {
+export const items = withSchemaValidation( inviteItemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case INVITES_REQUEST_SUCCESS: {
 			// Invites are returned from the API in descending order by
 			// `invite_date`, which is what we want here.
 
@@ -84,8 +83,8 @@ export const items = createReducerWithValidation(
 				...state,
 				[ action.siteId ]: siteInvites,
 			};
-		},
-		[ INVITES_DELETE_REQUEST_SUCCESS ]: ( state, action ) => {
+		}
+		case INVITES_DELETE_REQUEST_SUCCESS: {
 			return {
 				...state,
 				[ action.siteId ]: {
@@ -93,10 +92,11 @@ export const items = createReducerWithValidation(
 					pending: deleteInvites( state[ action.siteId ].pending, action.inviteIds ),
 				},
 			};
-		},
-	},
-	inviteItemsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 /**
  * Returns an array of site invites, without the deleted invite objects.
@@ -117,23 +117,24 @@ function deleteInvites( siteInvites, invitesToDelete ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const counts = createReducer(
-	{},
-	{
-		[ INVITES_REQUEST_SUCCESS ]: ( state, action ) => {
+export const counts = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case INVITES_REQUEST_SUCCESS: {
 			return {
 				...state,
 				[ action.siteId ]: action.found,
 			};
-		},
-		[ INVITES_DELETE_REQUEST_SUCCESS ]: ( state, action ) => {
+		}
+		case INVITES_DELETE_REQUEST_SUCCESS: {
 			return {
 				...state,
 				[ action.siteId ]: state[ action.siteId ] - action.inviteIds.length,
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated site invites resend requests state after an action has been

--- a/client/state/jetpack/connection/reducer.js
+++ b/client/state/jetpack/connection/reducer.js
@@ -22,7 +22,7 @@ import {
 	JETPACK_USER_CONNECTION_DATA_REQUEST_SUCCESS,
 	JETPACK_USER_CONNECTION_DATA_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 
 /**
  * `Reducer` function which handles request/response actions
@@ -34,12 +34,16 @@ import { combineReducers, createReducer, keyedReducer } from 'state/utils';
  */
 export const items = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ JETPACK_CONNECTION_STATUS_RECEIVE ]: ( state, { status } ) => status,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case JETPACK_CONNECTION_STATUS_RECEIVE: {
+				const { status } = action;
+				return status;
+			}
 		}
-	)
+
+		return state;
+	} )
 );
 
 /**
@@ -52,14 +56,18 @@ export const items = keyedReducer(
  */
 export const requests = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ JETPACK_CONNECTION_STATUS_REQUEST ]: stubTrue,
-			[ JETPACK_CONNECTION_STATUS_REQUEST_FAILURE ]: stubFalse,
-			[ JETPACK_CONNECTION_STATUS_REQUEST_SUCCESS ]: stubFalse,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case JETPACK_CONNECTION_STATUS_REQUEST:
+				return stubTrue( state, action );
+			case JETPACK_CONNECTION_STATUS_REQUEST_FAILURE:
+				return stubFalse( state, action );
+			case JETPACK_CONNECTION_STATUS_REQUEST_SUCCESS:
+				return stubFalse( state, action );
 		}
-	)
+
+		return state;
+	} )
 );
 
 /**
@@ -72,12 +80,16 @@ export const requests = keyedReducer(
  */
 export const dataItems = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ JETPACK_USER_CONNECTION_DATA_RECEIVE ]: ( state, { data } ) => data,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case JETPACK_USER_CONNECTION_DATA_RECEIVE: {
+				const { data } = action;
+				return data;
+			}
 		}
-	)
+
+		return state;
+	} )
 );
 
 /**
@@ -90,26 +102,34 @@ export const dataItems = keyedReducer(
  */
 export const dataRequests = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ JETPACK_USER_CONNECTION_DATA_REQUEST ]: stubTrue,
-			[ JETPACK_USER_CONNECTION_DATA_REQUEST_FAILURE ]: stubFalse,
-			[ JETPACK_USER_CONNECTION_DATA_REQUEST_SUCCESS ]: stubFalse,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case JETPACK_USER_CONNECTION_DATA_REQUEST:
+				return stubTrue( state, action );
+			case JETPACK_USER_CONNECTION_DATA_REQUEST_FAILURE:
+				return stubFalse( state, action );
+			case JETPACK_USER_CONNECTION_DATA_REQUEST_SUCCESS:
+				return stubFalse( state, action );
 		}
-	)
+
+		return state;
+	} )
 );
 
 export const disconnectRequests = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ JETPACK_DISCONNECT_REQUEST ]: stubTrue,
-			[ JETPACK_DISCONNECT_REQUEST_FAILURE ]: stubFalse,
-			[ JETPACK_DISCONNECT_REQUEST_SUCCESS ]: stubFalse,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case JETPACK_DISCONNECT_REQUEST:
+				return stubTrue( state, action );
+			case JETPACK_DISCONNECT_REQUEST_FAILURE:
+				return stubFalse( state, action );
+			case JETPACK_DISCONNECT_REQUEST_SUCCESS:
+				return stubFalse( state, action );
 		}
-	)
+
+		return state;
+	} )
 );
 
 export const reducer = combineReducers( {

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -23,7 +23,7 @@ import {
 	JETPACK_SETTINGS_UPDATE,
 	JETPACK_SETTINGS_SAVE_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
 const createItemsReducer = active => {
 	return ( state, { siteId, moduleSlug } ) => {
@@ -96,16 +96,22 @@ const createSettingsItemsReducer = () => {
  * @param  {Object} action action
  * @return {Array}         Updated state
  */
-export const items = createReducer(
-	{},
-	{
-		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: createItemsReducer( true ),
-		[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createItemsReducer( false ),
-		[ JETPACK_MODULES_RECEIVE ]: createItemsListReducer(),
-		[ JETPACK_SETTINGS_UPDATE ]: createSettingsItemsReducer(),
-		[ JETPACK_SETTINGS_SAVE_SUCCESS ]: createSettingsItemsReducer(),
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case JETPACK_MODULE_ACTIVATE_SUCCESS:
+			return createItemsReducer( true )( state, action );
+		case JETPACK_MODULE_DEACTIVATE_SUCCESS:
+			return createItemsReducer( false )( state, action );
+		case JETPACK_MODULES_RECEIVE:
+			return createItemsListReducer()( state, action );
+		case JETPACK_SETTINGS_UPDATE:
+			return createSettingsItemsReducer()( state, action );
+		case JETPACK_SETTINGS_SAVE_SUCCESS:
+			return createSettingsItemsReducer()( state, action );
 	}
-);
+
+	return state;
+} );
 
 /**
  * `Reducer` function which handles request/response actions
@@ -115,20 +121,30 @@ export const items = createReducer(
  * @param {Object} action - action
  * @return {Object} updated state
  */
-export const requests = createReducer(
-	{},
-	{
-		[ JETPACK_MODULE_ACTIVATE ]: createRequestsReducer( { activating: true } ),
-		[ JETPACK_MODULE_ACTIVATE_FAILURE ]: createRequestsReducer( { activating: false } ),
-		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: createRequestsReducer( { activating: false } ),
-		[ JETPACK_MODULE_DEACTIVATE ]: createRequestsReducer( { deactivating: true } ),
-		[ JETPACK_MODULE_DEACTIVATE_FAILURE ]: createRequestsReducer( { deactivating: false } ),
-		[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createRequestsReducer( { deactivating: false } ),
-		[ JETPACK_MODULES_REQUEST ]: createModuleListRequestReducer( true ),
-		[ JETPACK_MODULES_REQUEST_FAILURE ]: createModuleListRequestReducer( false ),
-		[ JETPACK_MODULES_REQUEST_SUCCESS ]: createModuleListRequestReducer( false ),
+export const requests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case JETPACK_MODULE_ACTIVATE:
+			return createRequestsReducer( { activating: true } )( state, action );
+		case JETPACK_MODULE_ACTIVATE_FAILURE:
+			return createRequestsReducer( { activating: false } )( state, action );
+		case JETPACK_MODULE_ACTIVATE_SUCCESS:
+			return createRequestsReducer( { activating: false } )( state, action );
+		case JETPACK_MODULE_DEACTIVATE:
+			return createRequestsReducer( { deactivating: true } )( state, action );
+		case JETPACK_MODULE_DEACTIVATE_FAILURE:
+			return createRequestsReducer( { deactivating: false } )( state, action );
+		case JETPACK_MODULE_DEACTIVATE_SUCCESS:
+			return createRequestsReducer( { deactivating: false } )( state, action );
+		case JETPACK_MODULES_REQUEST:
+			return createModuleListRequestReducer( true )( state, action );
+		case JETPACK_MODULES_REQUEST_FAILURE:
+			return createModuleListRequestReducer( false )( state, action );
+		case JETPACK_MODULES_REQUEST_SUCCESS:
+			return createModuleListRequestReducer( false )( state, action );
 	}
-);
+
+	return state;
+} );
 
 export const reducer = combineReducers( {
 	items,

--- a/client/state/jetpack/onboarding/reducer.js
+++ b/client/state/jetpack/onboarding/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { createReducerWithValidation, combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import credentialsSchema from './schema';
 import {
 	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
@@ -10,14 +10,18 @@ import {
 
 const credentialsReducer = keyedReducer(
 	'siteId',
-	createReducerWithValidation(
-		{},
-		{
-			[ JETPACK_ONBOARDING_CREDENTIALS_RECEIVE ]: ( state, { credentials } ) => credentials,
-			[ JETPACK_CONNECT_AUTHORIZE_RECEIVE ]: () => undefined,
-		},
-		credentialsSchema
-	)
+	withSchemaValidation( credentialsSchema, ( state = {}, action ) => {
+		switch ( action.type ) {
+			case JETPACK_ONBOARDING_CREDENTIALS_RECEIVE: {
+				const { credentials } = action;
+				return credentials;
+			}
+			case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
+				return undefined;
+		}
+
+		return state;
+	} )
 );
 credentialsReducer.hasCustomPersistence = true;
 

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -6,7 +6,7 @@ import { mapValues, merge } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducerWithValidation, combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import { jetpackSettingsSchema } from './schema';
 import { normalizeSettings } from './utils';
 import {
@@ -19,18 +19,26 @@ import {
 
 export const settingsReducer = keyedReducer(
 	'siteId',
-	createReducerWithValidation(
-		{},
-		{
-			[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug } ) => ( {
-				...state,
-				[ moduleSlug ]: true,
-			} ),
-			[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: ( state, { moduleSlug } ) => ( {
-				...state,
-				[ moduleSlug ]: false,
-			} ),
-			[ JETPACK_MODULES_RECEIVE ]: ( state, { modules } ) => {
+	withSchemaValidation( jetpackSettingsSchema, ( state = {}, action ) => {
+		switch ( action.type ) {
+			case JETPACK_MODULE_ACTIVATE_SUCCESS: {
+				const { moduleSlug } = action;
+
+				return {
+					...state,
+					[ moduleSlug ]: true,
+				};
+			}
+			case JETPACK_MODULE_DEACTIVATE_SUCCESS: {
+				const { moduleSlug } = action;
+
+				return {
+					...state,
+					[ moduleSlug ]: false,
+				};
+			}
+			case JETPACK_MODULES_RECEIVE: {
+				const { modules } = action;
 				const modulesActivationState = mapValues( modules, module => module.active );
 				// The need for flattening module options into this moduleSettings is temporary.
 				// Once https://github.com/Automattic/jetpack/pull/6002 is released,
@@ -46,17 +54,24 @@ export const settingsReducer = keyedReducer(
 					...modulesActivationState,
 					...normalizeSettings( moduleSettings ),
 				};
-			},
-			[ JETPACK_SETTINGS_SAVE_SUCCESS ]: ( state, { settings: { post_by_email_address } } ) => {
+			}
+			case JETPACK_SETTINGS_SAVE_SUCCESS: {
+				const {
+					settings: { post_by_email_address },
+				} = action;
 				if ( post_by_email_address && post_by_email_address !== state.post_by_email_address ) {
 					return { ...state, post_by_email_address };
 				}
 				return state;
-			},
-			[ JETPACK_SETTINGS_UPDATE ]: ( state, { settings } ) => merge( {}, state, settings ),
-		},
-		jetpackSettingsSchema
-	)
+			}
+			case JETPACK_SETTINGS_UPDATE: {
+				const { settings } = action;
+				return merge( {}, state, settings );
+			}
+		}
+
+		return state;
+	} )
 );
 settingsReducer.hasCustomPersistence = true;
 

--- a/client/state/login/magic-login/reducer.js
+++ b/client/state/login/magic-login/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	CHECK_YOUR_EMAIL_PAGE,
 	INTERSTITIAL_PAGE,
@@ -27,55 +27,117 @@ import {
 	MAGIC_LOGIN_RESET_REQUEST_FORM,
 } from 'state/action-types';
 
-export const currentView = createReducer( null, {
-	[ MAGIC_LOGIN_HIDE_REQUEST_FORM ]: () => null,
-	[ MAGIC_LOGIN_RESET_REQUEST_FORM ]: () => REQUEST_FORM,
-	[ MAGIC_LOGIN_SHOW_CHECK_YOUR_EMAIL_PAGE ]: () => CHECK_YOUR_EMAIL_PAGE,
-	[ MAGIC_LOGIN_SHOW_INTERSTITIAL_PAGE ]: () => INTERSTITIAL_PAGE,
-	[ MAGIC_LOGIN_SHOW_LINK_EXPIRED ]: () => LINK_EXPIRED_PAGE,
+export const currentView = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_HIDE_REQUEST_FORM:
+			return null;
+		case MAGIC_LOGIN_RESET_REQUEST_FORM:
+			return REQUEST_FORM;
+		case MAGIC_LOGIN_SHOW_CHECK_YOUR_EMAIL_PAGE:
+			return CHECK_YOUR_EMAIL_PAGE;
+		case MAGIC_LOGIN_SHOW_INTERSTITIAL_PAGE:
+			return INTERSTITIAL_PAGE;
+		case MAGIC_LOGIN_SHOW_LINK_EXPIRED:
+			return LINK_EXPIRED_PAGE;
+	}
+
+	return state;
 } );
 
-export const isFetchingEmail = createReducer( false, {
-	[ MAGIC_LOGIN_HIDE_REQUEST_FORM ]: () => false,
-	[ MAGIC_LOGIN_HIDE_REQUEST_NOTICE ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH ]: () => true,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS ]: () => false,
+export const isFetchingEmail = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_HIDE_REQUEST_FORM:
+			return false;
+		case MAGIC_LOGIN_HIDE_REQUEST_NOTICE:
+			return false;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR:
+			return false;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH:
+			return true;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
-export const isFetchingAuth = createReducer( false, {
-	[ MAGIC_LOGIN_REQUEST_AUTH_ERROR ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_AUTH_FETCH ]: () => true,
-	[ MAGIC_LOGIN_REQUEST_AUTH_SUCCESS ]: () => false,
-	[ MAGIC_LOGIN_SHOW_INTERSTITIAL_PAGE ]: () => false,
+export const isFetchingAuth = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_REQUEST_AUTH_ERROR:
+			return false;
+		case MAGIC_LOGIN_REQUEST_AUTH_FETCH:
+			return true;
+		case MAGIC_LOGIN_REQUEST_AUTH_SUCCESS:
+			return false;
+		case MAGIC_LOGIN_SHOW_INTERSTITIAL_PAGE:
+			return false;
+	}
+
+	return state;
 } );
 
-export const requestAuthSuccess = createReducer( false, {
-	[ MAGIC_LOGIN_REQUEST_AUTH_ERROR ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_AUTH_FETCH ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_AUTH_SUCCESS ]: () => true,
+export const requestAuthSuccess = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_REQUEST_AUTH_ERROR:
+			return false;
+		case MAGIC_LOGIN_REQUEST_AUTH_FETCH:
+			return false;
+		case MAGIC_LOGIN_REQUEST_AUTH_SUCCESS:
+			return true;
+	}
+
+	return state;
 } );
 
-export const requestAuthError = createReducer( null, {
-	[ MAGIC_LOGIN_REQUEST_AUTH_ERROR ]: ( state, { error } ) => error,
-	[ MAGIC_LOGIN_REQUEST_AUTH_FETCH ]: () => null,
-	[ MAGIC_LOGIN_REQUEST_AUTH_SUCCESS ]: () => null,
+export const requestAuthError = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_REQUEST_AUTH_ERROR: {
+			const { error } = action;
+			return error;
+		}
+		case MAGIC_LOGIN_REQUEST_AUTH_FETCH:
+			return null;
+		case MAGIC_LOGIN_REQUEST_AUTH_SUCCESS:
+			return null;
+	}
+
+	return state;
 } );
 
-export const requestEmailError = createReducer( null, {
-	[ MAGIC_LOGIN_HIDE_REQUEST_NOTICE ]: () => null,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR ]: ( state, { error } ) => error,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH ]: () => null,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS ]: () => null,
-	[ MAGIC_LOGIN_RESET_REQUEST_FORM ]: () => null,
+export const requestEmailError = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_HIDE_REQUEST_NOTICE:
+			return null;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR: {
+			const { error } = action;
+			return error;
+		}
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH:
+			return null;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS:
+			return null;
+		case MAGIC_LOGIN_RESET_REQUEST_FORM:
+			return null;
+	}
+
+	return state;
 } );
 
-export const requestEmailSuccess = createReducer( false, {
-	[ MAGIC_LOGIN_HIDE_REQUEST_NOTICE ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH ]: () => false,
-	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS ]: () => true,
-	[ MAGIC_LOGIN_RESET_REQUEST_FORM ]: () => false,
+export const requestEmailSuccess = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case MAGIC_LOGIN_HIDE_REQUEST_NOTICE:
+			return false;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR:
+			return false;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH:
+			return false;
+		case MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS:
+			return true;
+		case MAGIC_LOGIN_RESET_REQUEST_FORM:
+			return false;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -9,7 +9,7 @@ import { get, isEmpty, pick, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import magicLogin from './magic-login/reducer';
 import {
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUEST,
@@ -47,108 +47,225 @@ import {
 } from 'state/action-types';
 import { login } from 'lib/paths';
 
-export const isRequesting = createReducer( false, {
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST ]: () => true,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE ]: () => false,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS ]: () => false,
-	[ LOGIN_REQUEST ]: () => true,
-	[ LOGIN_REQUEST_FAILURE ]: () => false,
-	[ LOGIN_REQUEST_SUCCESS ]: () => false,
-	[ SOCIAL_LOGIN_REQUEST ]: () => true,
-	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => false,
-	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: () => false,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST ]: () => true,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_FAILURE ]: () => false,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => false,
+export const isRequesting = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
+			return true;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE:
+			return false;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS:
+			return false;
+		case LOGIN_REQUEST:
+			return true;
+		case LOGIN_REQUEST_FAILURE:
+			return false;
+		case LOGIN_REQUEST_SUCCESS:
+			return false;
+		case SOCIAL_LOGIN_REQUEST:
+			return true;
+		case SOCIAL_LOGIN_REQUEST_FAILURE:
+			return false;
+		case SOCIAL_LOGIN_REQUEST_SUCCESS:
+			return false;
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST:
+			return true;
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST_FAILURE:
+			return false;
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
 export const redirectTo = combineReducers( {
-	original: createReducer( null, {
-		[ ROUTE_SET ]: ( state, { path, query } ) => {
-			if ( startsWith( path, '/log-in' ) ) {
-				return query.redirect_to || state;
+	original: withoutPersistence( ( state = null, action ) => {
+		switch ( action.type ) {
+			case ROUTE_SET: {
+				const { path, query } = action;
+				if ( startsWith( path, '/log-in' ) ) {
+					return query.redirect_to || state;
+				}
+
+				return state;
 			}
-
-			return state;
-		},
-	} ),
-	sanitized: createReducer( null, {
-		[ LOGIN_REQUEST ]: () => null,
-		[ LOGIN_REQUEST_FAILURE ]: () => null,
-		[ LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => get( data, 'redirect_to', null ),
-		[ SOCIAL_LOGIN_REQUEST ]: () => null,
-		[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => null,
-		[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => get( data, 'redirect_to', null ),
-		[ SOCIAL_CONNECT_ACCOUNT_REQUEST ]: () => null,
-		[ SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE ]: () => null,
-		[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: ( state, action ) =>
-			get( action, 'redirect_to', null ),
-	} ),
-} );
-
-export const isFormDisabled = createReducer( null, {
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST ]: () => true,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE ]: () => false,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS ]: () => false,
-	[ LOGIN_REQUEST ]: () => true,
-	[ LOGIN_REQUEST_FAILURE ]: () => false,
-	[ LOGIN_REQUEST_SUCCESS ]: () => true,
-	[ ROUTE_SET ]: () => false,
-	[ SOCIAL_LOGIN_REQUEST ]: () => true,
-	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => false,
-	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: () => true,
-} );
-
-export const requestError = createReducer( null, {
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST ]: () => null,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS ]: () => null,
-	[ LOGIN_REQUEST ]: () => null,
-	[ LOGIN_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ LOGIN_REQUEST_SUCCESS ]: () => null,
-	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST ]: () => null,
-	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: () => null,
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: () => null,
-	[ SOCIAL_CONNECT_ACCOUNT_REQUEST ]: () => null,
-	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => null,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST ]: () => null,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => null,
-	[ ROUTE_SET ]: () => null,
-	[ LOGIN_FORM_UPDATE ]: () => null,
-} );
-
-export const requestSuccess = createReducer( null, {
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST ]: () => null,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE ]: () => false,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS ]: () => true,
-	[ LOGIN_REQUEST ]: () => null,
-	[ LOGIN_REQUEST_FAILURE ]: () => false,
-	[ LOGIN_REQUEST_SUCCESS ]: () => true,
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: () => null,
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: () => true,
-	[ SOCIAL_CONNECT_ACCOUNT_REQUEST ]: () => null,
-	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => true,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST ]: () => null,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => true,
-} );
-
-export const requestNotice = createReducer( null, {
-	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST ]: ( state, { notice } ) => notice,
-	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE ]: () => null,
-	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS ]: ( state, { notice } ) => notice,
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: ( state, { notice } ) => notice,
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: () => null,
-	[ ROUTE_SET ]: ( state, action ) => {
-		// if we just navigated to the sms 2fa page, keep the notice (if any) from the loginUser action
-		if ( action.path === login( { isNative: true, twoFactorAuthType: 'sms' } ) ) {
-			return state;
 		}
-		return null;
-	},
+
+		return state;
+	} ),
+	sanitized: withoutPersistence( ( state = null, action ) => {
+		switch ( action.type ) {
+			case LOGIN_REQUEST:
+				return null;
+			case LOGIN_REQUEST_FAILURE:
+				return null;
+			case LOGIN_REQUEST_SUCCESS: {
+				const { data } = action;
+				return get( data, 'redirect_to', null );
+			}
+			case SOCIAL_LOGIN_REQUEST:
+				return null;
+			case SOCIAL_LOGIN_REQUEST_FAILURE:
+				return null;
+			case SOCIAL_LOGIN_REQUEST_SUCCESS: {
+				const { data } = action;
+				return get( data, 'redirect_to', null );
+			}
+			case SOCIAL_CONNECT_ACCOUNT_REQUEST:
+				return null;
+			case SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE:
+				return null;
+			case SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS:
+				return get( action, 'redirect_to', null );
+		}
+
+		return state;
+	} ),
+} );
+
+export const isFormDisabled = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
+			return true;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE:
+			return false;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS:
+			return false;
+		case LOGIN_REQUEST:
+			return true;
+		case LOGIN_REQUEST_FAILURE:
+			return false;
+		case LOGIN_REQUEST_SUCCESS:
+			return true;
+		case ROUTE_SET:
+			return false;
+		case SOCIAL_LOGIN_REQUEST:
+			return true;
+		case SOCIAL_LOGIN_REQUEST_FAILURE:
+			return false;
+		case SOCIAL_LOGIN_REQUEST_SUCCESS:
+			return true;
+	}
+
+	return state;
+} );
+
+export const requestError = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
+			return null;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS:
+			return null;
+		case LOGIN_REQUEST:
+			return null;
+		case LOGIN_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case LOGIN_REQUEST_SUCCESS:
+			return null;
+		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST:
+			return null;
+		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case SOCIAL_CREATE_ACCOUNT_REQUEST:
+			return null;
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS:
+			return null;
+		case SOCIAL_CONNECT_ACCOUNT_REQUEST:
+			return null;
+		case SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS:
+			return null;
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST:
+			return null;
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS:
+			return null;
+		case ROUTE_SET:
+			return null;
+		case LOGIN_FORM_UPDATE:
+			return null;
+	}
+
+	return state;
+} );
+
+export const requestSuccess = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
+			return null;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE:
+			return false;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS:
+			return true;
+		case LOGIN_REQUEST:
+			return null;
+		case LOGIN_REQUEST_FAILURE:
+			return false;
+		case LOGIN_REQUEST_SUCCESS:
+			return true;
+		case SOCIAL_CREATE_ACCOUNT_REQUEST:
+			return null;
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS:
+			return true;
+		case SOCIAL_CONNECT_ACCOUNT_REQUEST:
+			return null;
+		case SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS:
+			return true;
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST:
+			return null;
+		case SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS:
+			return true;
+	}
+
+	return state;
+} );
+
+export const requestNotice = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST: {
+			const { notice } = action;
+			return notice;
+		}
+		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE:
+			return null;
+		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS: {
+			const { notice } = action;
+			return notice;
+		}
+		case SOCIAL_CREATE_ACCOUNT_REQUEST: {
+			const { notice } = action;
+			return notice;
+		}
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE:
+			return null;
+		case ROUTE_SET: {
+			// if we just navigated to the sms 2fa page, keep the notice (if any) from the loginUser action
+			if ( action.path === login( { isNative: true, twoFactorAuthType: 'sms' } ) ) {
+				return state;
+			}
+			return null;
+		}
+	}
+
+	return state;
 } );
 
 const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) =>
@@ -171,97 +288,157 @@ const twoFactorProperties = [
 	'user_id',
 ];
 
-export const twoFactorAuth = createReducer( null, {
-	[ LOGIN_REQUEST ]: () => null,
-	[ LOGIN_REQUEST_FAILURE ]: () => null,
-	[ LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		if ( data ) {
-			const twoFactorData = pick( data, twoFactorProperties );
+export const twoFactorAuth = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case LOGIN_REQUEST:
+			return null;
+		case LOGIN_REQUEST_FAILURE:
+			return null;
+		case LOGIN_REQUEST_SUCCESS: {
+			const { data } = action;
+			if ( data ) {
+				const twoFactorData = pick( data, twoFactorProperties );
 
-			if ( ! isEmpty( twoFactorData ) ) {
-				return twoFactorData;
+				if ( ! isEmpty( twoFactorData ) ) {
+					return twoFactorData;
+				}
 			}
+
+			return null;
+		}
+		case SOCIAL_LOGIN_REQUEST:
+			return null;
+		case SOCIAL_LOGIN_REQUEST_FAILURE:
+			return null;
+		case SOCIAL_LOGIN_REQUEST_SUCCESS: {
+			const { data } = action;
+			if ( data ) {
+				const twoFactorData = pick( data, twoFactorProperties );
+
+				if ( ! isEmpty( twoFactorData ) ) {
+					return twoFactorData;
+				}
+			}
+
+			return null;
+		}
+		case SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS:
+			return null;
+		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE: {
+			const { twoStepNonce } = action;
+			return updateTwoStepNonce( state, { twoStepNonce, nonceType: 'sms' } );
+		}
+		case TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS: {
+			const { twoStepNonce } = action;
+			return updateTwoStepNonce( state, { twoStepNonce, nonceType: 'sms' } );
+		}
+		case TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE:
+			return updateTwoStepNonce( state, action );
+	}
+
+	return state;
+} );
+
+export const isRequestingTwoFactorAuth = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST:
+			return true;
+		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE:
+			return false;
+		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS:
+			return false;
+	}
+
+	return state;
+} );
+
+export const twoFactorAuthRequestError = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST:
+			return null;
+		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE: {
+			const { error } = action;
+			return error;
+		}
+		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS:
+			return null;
+		case ROUTE_SET:
+			return null;
+		case LOGIN_FORM_UPDATE:
+			return null;
+	}
+
+	return state;
+} );
+
+export const twoFactorAuthPushPoll = withoutPersistence(
+	( state = { inProgress: false, success: false }, action ) => {
+		switch ( action.type ) {
+			case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START:
+				return {
+					...state,
+					inProgress: true,
+					success: false,
+				};
+			case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_STOP:
+				return { ...state, inProgress: false };
+			case TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED:
+				return {
+					...state,
+					inProgress: false,
+					success: true,
+				};
 		}
 
-		return null;
-	},
-	[ SOCIAL_LOGIN_REQUEST ]: () => null,
-	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => null,
-	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		if ( data ) {
-			const twoFactorData = pick( data, twoFactorProperties );
-
-			if ( ! isEmpty( twoFactorData ) ) {
-				return twoFactorData;
-			}
-		}
-
-		return null;
-	},
-	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => null,
-	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE ]: ( state, { twoStepNonce } ) =>
-		updateTwoStepNonce( state, { twoStepNonce, nonceType: 'sms' } ),
-	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS ]: ( state, { twoStepNonce } ) =>
-		updateTwoStepNonce( state, { twoStepNonce, nonceType: 'sms' } ),
-	[ TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE ]: updateTwoStepNonce,
-} );
-
-export const isRequestingTwoFactorAuth = createReducer( false, {
-	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST ]: () => true,
-	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE ]: () => false,
-	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS ]: () => false,
-} );
-
-export const twoFactorAuthRequestError = createReducer( null, {
-	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST ]: () => null,
-	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS ]: () => null,
-	[ ROUTE_SET ]: () => null,
-	[ LOGIN_FORM_UPDATE ]: () => null,
-} );
-
-export const twoFactorAuthPushPoll = createReducer(
-	{ inProgress: false, success: false },
-	{
-		[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START ]: state => ( {
-			...state,
-			inProgress: true,
-			success: false,
-		} ),
-		[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_STOP ]: state => ( { ...state, inProgress: false } ),
-		[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED ]: state => ( {
-			...state,
-			inProgress: false,
-			success: true,
-		} ),
+		return state;
 	}
 );
 
-export const socialAccount = createReducer(
-	{ isCreating: false, createError: null },
-	{
-		[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: () => ( { isCreating: true } ),
-		[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => ( {
-			isCreating: false,
-			createError: error,
-		} ),
-		[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: ( state, { data: { username, bearerToken } } ) => ( {
-			isCreating: false,
-			username,
-			bearerToken,
-			createError: null,
-		} ),
-		[ SOCIAL_LOGIN_REQUEST_FAILURE ]: ( state, { error } ) => ( {
-			...state,
-			requestError: error,
-		} ),
-		[ CURRENT_USER_RECEIVE ]: state => ( {
-			...state,
-			bearerToken: null,
-			username: null,
-			createError: null,
-		} ),
-		[ LOGIN_REQUEST ]: state => ( { ...state, createError: null } ),
+export const socialAccount = withoutPersistence(
+	( state = { isCreating: false, createError: null }, action ) => {
+		switch ( action.type ) {
+			case SOCIAL_CREATE_ACCOUNT_REQUEST:
+				return { isCreating: true };
+			case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE: {
+				const { error } = action;
+
+				return {
+					isCreating: false,
+					createError: error,
+				};
+			}
+			case SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS: {
+				const {
+					data: { username, bearerToken },
+				} = action;
+
+				return {
+					isCreating: false,
+					username,
+					bearerToken,
+					createError: null,
+				};
+			}
+			case SOCIAL_LOGIN_REQUEST_FAILURE: {
+				const { error } = action;
+
+				return {
+					...state,
+					requestError: error,
+				};
+			}
+			case CURRENT_USER_RECEIVE:
+				return {
+					...state,
+					bearerToken: null,
+					username: null,
+					createError: null,
+				};
+			case LOGIN_REQUEST:
+				return { ...state, createError: null };
+		}
+
+		return state;
 	}
 );
 
@@ -277,23 +454,42 @@ const userExistsErrorHandler = ( state, { error, authInfo } ) => {
 	return state;
 };
 
-export const socialAccountLink = createReducer(
-	{ isLinking: false },
-	{
-		[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: userExistsErrorHandler,
-		[ SOCIAL_LOGIN_REQUEST_FAILURE ]: userExistsErrorHandler,
-		[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: () => ( { isLinking: false } ),
-		[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => ( { isLinking: false } ),
-		[ CURRENT_USER_RECEIVE ]: () => ( { isLinking: false } ),
+export const socialAccountLink = withoutPersistence( ( state = { isLinking: false }, action ) => {
+	switch ( action.type ) {
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE:
+			return userExistsErrorHandler( state, action );
+		case SOCIAL_LOGIN_REQUEST_FAILURE:
+			return userExistsErrorHandler( state, action );
+		case SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS:
+			return { isLinking: false };
+		case SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS:
+			return { isLinking: false };
+		case CURRENT_USER_RECEIVE:
+			return { isLinking: false };
 	}
-);
 
-export const authAccountType = createReducer( null, {
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST ]: () => null,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE ]: () => null,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS ]: ( state, { data: { type } } ) => type,
-	[ LOGIN_AUTH_ACCOUNT_TYPE_RESET ]: () => null,
-	[ ROUTE_SET ]: () => null,
+	return state;
+} );
+
+export const authAccountType = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
+			return null;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE:
+			return null;
+		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS: {
+			const {
+				data: { type },
+			} = action;
+			return type;
+		}
+		case LOGIN_AUTH_ACCOUNT_TYPE_RESET:
+			return null;
+		case ROUTE_SET:
+			return null;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/mailchimp/lists/reducer.js
+++ b/client/state/mailchimp/lists/reducer.js
@@ -4,14 +4,22 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { MAILCHIMP_LISTS_RECEIVE } from 'state/action-types';
 
-export const items = createReducer( [], {
-	[ MAILCHIMP_LISTS_RECEIVE ]: ( state, { siteId, lists } ) => ( {
-		...state,
-		[ siteId ]: lists,
-	} ),
+export const items = withoutPersistence( ( state = [], action ) => {
+	switch ( action.type ) {
+		case MAILCHIMP_LISTS_RECEIVE: {
+			const { siteId, lists } = action;
+
+			return {
+				...state,
+				[ siteId ]: lists,
+			};
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/mailchimp/settings/reducer.js
+++ b/client/state/mailchimp/settings/reducer.js
@@ -4,22 +4,31 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { MAILCHIMP_SETTINGS_RECEIVE, MAILCHIMP_SETTINGS_UPDATE_SUCCESS } from 'state/action-types';
 
-export const items = createReducer(
-	{},
-	{
-		[ MAILCHIMP_SETTINGS_RECEIVE ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: settings,
-		} ),
-		[ MAILCHIMP_SETTINGS_UPDATE_SUCCESS ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: settings,
-		} ),
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MAILCHIMP_SETTINGS_RECEIVE: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: settings,
+			};
+		}
+		case MAILCHIMP_SETTINGS_UPDATE_SUCCESS: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: settings,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -18,7 +18,7 @@ import {
 	MEDIA_REQUEST_SUCCESS,
 	MEDIA_REQUESTING,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import MediaQueryManager from 'lib/query-manager/media';
 
 export const queries = ( () => {
@@ -46,23 +46,26 @@ export const queries = ( () => {
 		};
 	}
 
-	return createReducer(
-		{},
-		{
-			[ MEDIA_RECEIVE ]: ( state, { siteId, media, found, query } ) => {
+	return withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case MEDIA_RECEIVE: {
+				const { siteId, media, found, query } = action;
 				return applyToManager( state, siteId, 'receive', true, media, { found, query } );
-			},
-			[ MEDIA_DELETE ]: ( state, { siteId, mediaIds } ) => {
+			}
+			case MEDIA_DELETE: {
+				const { siteId, mediaIds } = action;
 				return applyToManager( state, siteId, 'removeItems', true, mediaIds );
-			},
+			}
 		}
-	);
+
+		return state;
+	} );
 } )();
 
-export const queryRequests = createReducer(
-	{},
-	{
-		[ MEDIA_REQUESTING ]: ( state, { siteId, query } ) => {
+export const queryRequests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEDIA_REQUESTING: {
+			const { siteId, query } = action;
 			return {
 				...state,
 				[ siteId ]: {
@@ -70,21 +73,25 @@ export const queryRequests = createReducer(
 					[ MediaQueryManager.QueryKey.stringify( query ) ]: true,
 				},
 			};
-		},
-		[ MEDIA_REQUEST_SUCCESS ]: ( state, { siteId, query } ) => {
+		}
+		case MEDIA_REQUEST_SUCCESS: {
+			const { siteId, query } = action;
 			return {
 				...state,
 				[ siteId ]: omit( state[ siteId ], MediaQueryManager.QueryKey.stringify( query ) ),
 			};
-		},
-		[ MEDIA_REQUEST_FAILURE ]: ( state, { siteId, query } ) => {
+		}
+		case MEDIA_REQUEST_FAILURE: {
+			const { siteId, query } = action;
 			return {
 				...state,
 				[ siteId ]: omit( state[ siteId ], MediaQueryManager.QueryKey.stringify( query ) ),
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated site post requests state after an action has been
@@ -95,10 +102,10 @@ export const queryRequests = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const mediaItemRequests = createReducer(
-	{},
-	{
-		[ MEDIA_ITEM_REQUESTING ]: ( state, { siteId, mediaId } ) => {
+export const mediaItemRequests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEDIA_ITEM_REQUESTING: {
+			const { siteId, mediaId } = action;
 			return {
 				...state,
 				[ siteId ]: {
@@ -106,21 +113,25 @@ export const mediaItemRequests = createReducer(
 					[ mediaId ]: true,
 				},
 			};
-		},
-		[ MEDIA_ITEM_REQUEST_SUCCESS ]: ( state, { siteId, mediaId } ) => {
+		}
+		case MEDIA_ITEM_REQUEST_SUCCESS: {
+			const { siteId, mediaId } = action;
 			return {
 				...state,
 				[ siteId ]: omit( state[ siteId ], mediaId ),
 			};
-		},
-		[ MEDIA_ITEM_REQUEST_FAILURE ]: ( state, { siteId, mediaId } ) => {
+		}
+		case MEDIA_ITEM_REQUEST_FAILURE: {
+			const { siteId, mediaId } = action;
 			return {
 				...state,
 				[ siteId ]: omit( state[ siteId ], mediaId ),
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	queries,

--- a/client/state/memberships/connected-accounts/reducer.js
+++ b/client/state/memberships/connected-accounts/reducer.js
@@ -7,21 +7,29 @@ import {
 	MEMBERSHIPS_CONNECTED_ACCOUNTS_LIST,
 	MEMBERSHIPS_CONNECTED_ACCOUNTS_RECEIVE,
 } from 'state/action-types';
-import { createReducer, combineReducers } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-const accounts = createReducer(
-	{},
-	{
-		[ MEMBERSHIPS_CONNECTED_ACCOUNTS_RECEIVE ]: ( state, data ) => ( {
-			...state,
-			...data.accounts,
-		} ),
+const accounts = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_CONNECTED_ACCOUNTS_RECEIVE:
+			return ( ( state, data ) => ( {
+				...state,
+				...data.accounts,
+			} ) )( state, action );
 	}
-);
 
-const isFetching = createReducer( false, {
-	[ MEMBERSHIPS_CONNECTED_ACCOUNTS_RECEIVE ]: () => false,
-	[ MEMBERSHIPS_CONNECTED_ACCOUNTS_LIST ]: () => true,
+	return state;
+} );
+
+const isFetching = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_CONNECTED_ACCOUNTS_RECEIVE:
+			return false;
+		case MEMBERSHIPS_CONNECTED_ACCOUNTS_LIST:
+			return true;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/memberships/connected-accounts/reducer.js
+++ b/client/state/memberships/connected-accounts/reducer.js
@@ -12,10 +12,10 @@ import { combineReducers, withoutPersistence } from 'state/utils';
 const accounts = withoutPersistence( ( state = {}, action ) => {
 	switch ( action.type ) {
 		case MEMBERSHIPS_CONNECTED_ACCOUNTS_RECEIVE:
-			return ( ( state, data ) => ( {
+			return {
 				...state,
-				...data.accounts,
-			} ) )( state, action );
+				...action.accounts,
+			};
 	}
 
 	return state;

--- a/client/state/memberships/earnings/reducer.js
+++ b/client/state/memberships/earnings/reducer.js
@@ -9,10 +9,10 @@ import { combineReducers, withoutPersistence } from 'state/utils';
 const summary = withoutPersistence( ( state = {}, action ) => {
 	switch ( action.type ) {
 		case MEMBERSHIPS_EARNINGS_RECEIVE:
-			return ( ( state, data ) => ( {
+			return {
 				...state,
-				[ data.siteId ]: data.earnings,
-			} ) )( state, action );
+				[ action.siteId ]: action.earnings,
+			};
 	}
 
 	return state;

--- a/client/state/memberships/earnings/reducer.js
+++ b/client/state/memberships/earnings/reducer.js
@@ -4,17 +4,19 @@
  * Internal dependencies
  */
 import { MEMBERSHIPS_EARNINGS_RECEIVE } from 'state/action-types';
-import { createReducer, combineReducers } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-const summary = createReducer(
-	{},
-	{
-		[ MEMBERSHIPS_EARNINGS_RECEIVE ]: ( state, data ) => ( {
-			...state,
-			[ data.siteId ]: data.earnings,
-		} ),
+const summary = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_EARNINGS_RECEIVE:
+			return ( ( state, data ) => ( {
+				...state,
+				[ data.siteId ]: data.earnings,
+			} ) )( state, action );
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	summary,

--- a/client/state/memberships/product-list/reducer.js
+++ b/client/state/memberships/product-list/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import productListSchema from './schema';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import {
 	MEMBERSHIPS_PRODUCTS_RECEIVE,
 	MEMBERSHIPS_PRODUCT_RECEIVE,
@@ -38,24 +38,36 @@ function addOrEditProduct( list = [], newProduct ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ MEMBERSHIPS_PRODUCTS_RECEIVE ]: ( state, { siteId, products } ) => ( {
-			...state,
-			[ siteId ]: products,
-		} ),
-		[ MEMBERSHIPS_PRODUCT_RECEIVE ]: ( state, { siteId, product } ) => ( {
-			...state,
-			[ siteId ]: addOrEditProduct( state[ siteId ], product ),
-		} ),
-		[ MEMBERSHIPS_PRODUCT_DELETE ]: ( state, { siteId, product } ) => ( {
-			...state,
-			[ siteId ]: state[ siteId ].filter( existingProduct => existingProduct.ID !== product.ID ),
-		} ),
-	},
-	productListSchema
-);
+export const items = withSchemaValidation( productListSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_PRODUCTS_RECEIVE: {
+			const { siteId, products } = action;
+
+			return {
+				...state,
+				[ siteId ]: products,
+			};
+		}
+		case MEMBERSHIPS_PRODUCT_RECEIVE: {
+			const { siteId, product } = action;
+
+			return {
+				...state,
+				[ siteId ]: addOrEditProduct( state[ siteId ], product ),
+			};
+		}
+		case MEMBERSHIPS_PRODUCT_DELETE: {
+			const { siteId, product } = action;
+
+			return {
+				...state,
+				[ siteId ]: state[ siteId ].filter( existingProduct => existingProduct.ID !== product.ID ),
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/memberships/settings/reducer.js
+++ b/client/state/memberships/settings/reducer.js
@@ -8,18 +8,21 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { MEMBERSHIPS_SETTINGS_RECEIVE } from '../../action-types';
 
-export default createReducer(
-	{},
-	{
-		[ MEMBERSHIPS_SETTINGS_RECEIVE ]: ( state, data ) => ( {
-			...state,
-			[ data.siteId ]: {
-				connectedAccountId: get( data, 'data.connected_account_id', null ),
-				connectUrl: get( data, 'data.connect_url', null ),
-			},
-		} ),
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_SETTINGS_RECEIVE:
+			return ( ( state, data ) => ( {
+				...state,
+
+				[ data.siteId ]: {
+					connectedAccountId: get( data, 'data.connected_account_id', null ),
+					connectUrl: get( data, 'data.connect_url', null ),
+				},
+			} ) )( state, action );
 	}
-);
+
+	return state;
+} );

--- a/client/state/memberships/settings/reducer.js
+++ b/client/state/memberships/settings/reducer.js
@@ -14,14 +14,14 @@ import { MEMBERSHIPS_SETTINGS_RECEIVE } from '../../action-types';
 export default withoutPersistence( ( state = {}, action ) => {
 	switch ( action.type ) {
 		case MEMBERSHIPS_SETTINGS_RECEIVE:
-			return ( ( state, data ) => ( {
+			return {
 				...state,
 
-				[ data.siteId ]: {
-					connectedAccountId: get( data, 'data.connected_account_id', null ),
-					connectUrl: get( data, 'data.connect_url', null ),
+				[ action.siteId ]: {
+					connectedAccountId: get( action, 'data.connected_account_id', null ),
+					connectUrl: get( action, 'data.connect_url', null ),
 				},
-			} ) )( state, action );
+			};
 	}
 
 	return state;

--- a/client/state/memberships/subscribers/reducer.js
+++ b/client/state/memberships/subscribers/reducer.js
@@ -14,20 +14,20 @@ import { MEMBERSHIPS_SUBSCRIBERS_RECEIVE } from '../../action-types';
 const list = withoutPersistence( ( state = {}, action ) => {
 	switch ( action.type ) {
 		case MEMBERSHIPS_SUBSCRIBERS_RECEIVE:
-			return ( ( state, data ) => ( {
+			return {
 				...state,
 
-				[ data.siteId ]: {
-					total: get( data, 'subscribers.total', 0 ),
-					ownerships: get( data, 'subscribers.ownerships', [] ).reduce(
+				[ action.siteId ]: {
+					total: get( action, 'subscribers.total', 0 ),
+					ownerships: get( action, 'subscribers.ownerships', [] ).reduce(
 						( prev, item ) => {
 							prev[ item.id ] = item;
 							return prev;
 						},
-						{ ...get( state, [ data.siteId, 'ownerships' ], {} ) }
+						{ ...get( state, [ action.siteId, 'ownerships' ], {} ) }
 					),
 				},
-			} ) )( state, action );
+			};
 	}
 
 	return state;

--- a/client/state/memberships/subscribers/reducer.js
+++ b/client/state/memberships/subscribers/reducer.js
@@ -8,27 +8,30 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { MEMBERSHIPS_SUBSCRIBERS_RECEIVE } from '../../action-types';
 
-const list = createReducer(
-	{},
-	{
-		[ MEMBERSHIPS_SUBSCRIBERS_RECEIVE ]: ( state, data ) => ( {
-			...state,
-			[ data.siteId ]: {
-				total: get( data, 'subscribers.total', 0 ),
-				ownerships: get( data, 'subscribers.ownerships', [] ).reduce(
-					( prev, item ) => {
-						prev[ item.id ] = item;
-						return prev;
-					},
-					{ ...get( state, [ data.siteId, 'ownerships' ], {} ) }
-				),
-			},
-		} ),
+const list = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_SUBSCRIBERS_RECEIVE:
+			return ( ( state, data ) => ( {
+				...state,
+
+				[ data.siteId ]: {
+					total: get( data, 'subscribers.total', 0 ),
+					ownerships: get( data, 'subscribers.ownerships', [] ).reduce(
+						( prev, item ) => {
+							prev[ item.id ] = item;
+							return prev;
+						},
+						{ ...get( state, [ data.siteId, 'ownerships' ], {} ) }
+					),
+				},
+			} ) )( state, action );
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	list,

--- a/client/state/memberships/subscriptions/reducer.js
+++ b/client/state/memberships/subscriptions/reducer.js
@@ -10,7 +10,7 @@ import {
 	MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS,
 	MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
 /**
  * Returns the updated items state after an action has been dispatched.
@@ -20,25 +20,50 @@ import { combineReducers, createReducer } from 'state/utils';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer( [], {
-	[ MEMBERSHIPS_SUBSCRIPTIONS_RECEIVE ]: ( state, { subscriptions } ) => subscriptions,
-	[ MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS ]: ( state, { subscriptionId } ) =>
-		state.filter( sub => sub.ID !== subscriptionId ),
+export const items = withoutPersistence( ( state = [], action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_SUBSCRIPTIONS_RECEIVE: {
+			const { subscriptions } = action;
+			return subscriptions;
+		}
+		case MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS: {
+			const { subscriptionId } = action;
+			return state.filter( sub => sub.ID !== subscriptionId );
+		}
+	}
+
+	return state;
 } );
 
-export const stoppingSubscription = createReducer( [], {
-	[ MEMBERSHIPS_SUBSCRIPTION_STOP ]: ( state, { subscriptionId } ) => ( {
-		...state,
-		[ subscriptionId ]: 'start',
-	} ),
-	[ MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS ]: ( state, { subscriptionId } ) => ( {
-		...state,
-		[ subscriptionId ]: 'success',
-	} ),
-	[ MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE ]: ( state, { subscriptionId } ) => ( {
-		...state,
-		[ subscriptionId ]: 'fail',
-	} ),
+export const stoppingSubscription = withoutPersistence( ( state = [], action ) => {
+	switch ( action.type ) {
+		case MEMBERSHIPS_SUBSCRIPTION_STOP: {
+			const { subscriptionId } = action;
+
+			return {
+				...state,
+				[ subscriptionId ]: 'start',
+			};
+		}
+		case MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS: {
+			const { subscriptionId } = action;
+
+			return {
+				...state,
+				[ subscriptionId ]: 'success',
+			};
+		}
+		case MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE: {
+			const { subscriptionId } = action;
+
+			return {
+				...state,
+				[ subscriptionId ]: 'fail',
+			};
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -10,27 +10,26 @@ import { omit, reduce } from 'lodash';
  * Internal dependencies
  */
 import { NOTICE_CREATE, NOTICE_REMOVE, ROUTE_SET } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const items = createReducer(
-	{},
-	{
-		[ NOTICE_CREATE ]: ( state, action ) => {
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case NOTICE_CREATE: {
 			const { notice } = action;
 			return {
 				...state,
 				[ notice.noticeId ]: notice,
 			};
-		},
-		[ NOTICE_REMOVE ]: ( state, action ) => {
+		}
+		case NOTICE_REMOVE: {
 			const { noticeId } = action;
 			if ( ! state.hasOwnProperty( noticeId ) ) {
 				return state;
 			}
 
 			return omit( state, noticeId );
-		},
-		[ ROUTE_SET ]: state => {
+		}
+		case ROUTE_SET: {
 			return reduce(
 				state,
 				( memo, notice, noticeId ) => {
@@ -51,22 +50,25 @@ export const items = createReducer(
 				},
 				{}
 			);
-		},
+		}
 	}
-);
 
-export const lastTimeShown = createReducer(
-	{},
-	{
-		[ NOTICE_CREATE ]: ( state, action ) => {
+	return state;
+} );
+
+export const lastTimeShown = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case NOTICE_CREATE: {
 			const { notice } = action;
 			return {
 				...state,
 				[ notice.noticeId ]: Date.now(),
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/nps-survey/reducer.js
+++ b/client/state/nps-survey/reducer.js
@@ -33,7 +33,7 @@ export const isSessionEligible = withoutPersistence( ( state = false, action ) =
 export const isAvailableForConciergeSession = withoutPersistence( ( state = false, action ) => {
 	switch ( action.type ) {
 		case NPS_SURVEY_SET_CONCIERGE_SESSION_AVAILABILITY:
-			return ( ( _, action ) => action.isAvailableForConciergeSession )( state, action );
+			return action.isAvailableForConciergeSession;
 	}
 
 	return state;

--- a/client/state/nps-survey/reducer.js
+++ b/client/state/nps-survey/reducer.js
@@ -18,56 +18,95 @@ import {
 	NPS_SURVEY_SEND_FEEDBACK_REQUEST_FAILURE,
 	NPS_SURVEY_SEND_FEEDBACK_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { NOT_SUBMITTED, SUBMITTING, SUBMIT_FAILURE, SUBMITTED } from './constants';
 
-export const isSessionEligible = createReducer( false, {
-	[ NPS_SURVEY_SET_ELIGIBILITY ]: ( state, action ) => action.isSessionPicked,
+export const isSessionEligible = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_SET_ELIGIBILITY:
+			return action.isSessionPicked;
+	}
+
+	return state;
 } );
 
-export const isAvailableForConciergeSession = createReducer( false, {
-	[ NPS_SURVEY_SET_CONCIERGE_SESSION_AVAILABILITY ]: ( _, action ) =>
-		action.isAvailableForConciergeSession,
+export const isAvailableForConciergeSession = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_SET_CONCIERGE_SESSION_AVAILABILITY:
+			return ( ( _, action ) => action.isAvailableForConciergeSession )( state, action );
+	}
+
+	return state;
 } );
 
-export const wasShownThisSession = createReducer( false, {
-	[ NPS_SURVEY_MARK_SHOWN_THIS_SESSION ]: () => true,
+export const wasShownThisSession = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_MARK_SHOWN_THIS_SESSION:
+			return true;
+	}
+
+	return state;
 } );
 
-export const surveyState = createReducer( NOT_SUBMITTED, {
-	[ NPS_SURVEY_SUBMIT_REQUESTING ]: () => SUBMITTING,
-	[ NPS_SURVEY_SUBMIT_REQUEST_FAILURE ]: () => SUBMIT_FAILURE,
-	[ NPS_SURVEY_SUBMIT_REQUEST_SUCCESS ]: () => SUBMITTED,
-	[ NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUESTING ]: () => SUBMITTING,
-	[ NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_FAILURE ]: () => SUBMIT_FAILURE,
-	[ NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_SUCCESS ]: () => SUBMITTED,
-	[ NPS_SURVEY_SEND_FEEDBACK_REQUESTING ]: () => SUBMITTING,
-	[ NPS_SURVEY_SEND_FEEDBACK_REQUEST_FAILURE ]: () => SUBMIT_FAILURE,
-	[ NPS_SURVEY_SEND_FEEDBACK_REQUEST_SUCCESS ]: () => SUBMITTED,
+export const surveyState = withoutPersistence( ( state = NOT_SUBMITTED, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_SUBMIT_REQUESTING:
+			return SUBMITTING;
+		case NPS_SURVEY_SUBMIT_REQUEST_FAILURE:
+			return SUBMIT_FAILURE;
+		case NPS_SURVEY_SUBMIT_REQUEST_SUCCESS:
+			return SUBMITTED;
+		case NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUESTING:
+			return SUBMITTING;
+		case NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_FAILURE:
+			return SUBMIT_FAILURE;
+		case NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_SUCCESS:
+			return SUBMITTED;
+		case NPS_SURVEY_SEND_FEEDBACK_REQUESTING:
+			return SUBMITTING;
+		case NPS_SURVEY_SEND_FEEDBACK_REQUEST_FAILURE:
+			return SUBMIT_FAILURE;
+		case NPS_SURVEY_SEND_FEEDBACK_REQUEST_SUCCESS:
+			return SUBMITTED;
+	}
+
+	return state;
 } );
 
-export const surveyName = createReducer( null, {
-	[ NPS_SURVEY_SUBMIT_REQUESTING ]: ( state, action ) => {
-		return action.surveyName;
-	},
-	[ NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUESTING ]: ( state, action ) => {
-		return action.surveyName;
-	},
-	[ NPS_SURVEY_SEND_FEEDBACK_REQUESTING ]: ( state, action ) => {
-		return action.surveyName;
-	},
+export const surveyName = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_SUBMIT_REQUESTING: {
+			return action.surveyName;
+		}
+		case NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUESTING: {
+			return action.surveyName;
+		}
+		case NPS_SURVEY_SEND_FEEDBACK_REQUESTING: {
+			return action.surveyName;
+		}
+	}
+
+	return state;
 } );
 
-export const score = createReducer( null, {
-	[ NPS_SURVEY_SUBMIT_REQUESTING ]: ( state, action ) => {
-		return action.score;
-	},
+export const score = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_SUBMIT_REQUESTING: {
+			return action.score;
+		}
+	}
+
+	return state;
 } );
 
-export const feedback = createReducer( null, {
-	[ NPS_SURVEY_SEND_FEEDBACK_REQUESTING ]: ( state, action ) => {
-		return action.feedback;
-	},
+export const feedback = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_SEND_FEEDBACK_REQUESTING: {
+			return action.feedback;
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { OAUTH2_CLIENT_DATA_REQUEST_SUCCESS } from 'state/action-types';
 
 export const initialClientsData = {
@@ -52,10 +52,15 @@ export const initialClientsData = {
 	},
 };
 
-export default createReducer( initialClientsData, {
-	[ OAUTH2_CLIENT_DATA_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		const newData = Object.assign( {}, state[ data.id ], data );
+export default withoutPersistence( ( state = initialClientsData, action ) => {
+	switch ( action.type ) {
+		case OAUTH2_CLIENT_DATA_REQUEST_SUCCESS: {
+			const { data } = action;
+			const newData = Object.assign( {}, state[ data.id ], data );
 
-		return Object.assign( {}, state, { [ data.id ]: newData } );
-	},
+			return Object.assign( {}, state, { [ data.id ]: newData } );
+		}
+	}
+
+	return state;
 } );

--- a/client/state/order-transactions/reducer.js
+++ b/client/state/order-transactions/reducer.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 
 import {
 	ORDER_TRANSACTION_FETCH,
@@ -13,28 +13,51 @@ import {
 
 export const items = keyedReducer(
 	'orderId',
-	createReducer( null, {
-		[ ORDER_TRANSACTION_FETCH ]: () => null,
-		[ ORDER_TRANSACTION_FETCH_ERROR ]: () => null,
-		[ ORDER_TRANSACTION_SET ]: ( state, { transaction } ) => transaction,
+	withoutPersistence( ( state = null, action ) => {
+		switch ( action.type ) {
+			case ORDER_TRANSACTION_FETCH:
+				return null;
+			case ORDER_TRANSACTION_FETCH_ERROR:
+				return null;
+			case ORDER_TRANSACTION_SET: {
+				const { transaction } = action;
+				return transaction;
+			}
+		}
+
+		return state;
 	} )
 );
 
 export const isFetching = keyedReducer(
 	'orderId',
-	createReducer( false, {
-		[ ORDER_TRANSACTION_FETCH ]: () => true,
-		[ ORDER_TRANSACTION_FETCH_ERROR ]: () => false,
-		[ ORDER_TRANSACTION_SET ]: () => false,
+	withoutPersistence( ( state = false, action ) => {
+		switch ( action.type ) {
+			case ORDER_TRANSACTION_FETCH:
+				return true;
+			case ORDER_TRANSACTION_FETCH_ERROR:
+				return false;
+			case ORDER_TRANSACTION_SET:
+				return false;
+		}
+
+		return state;
 	} )
 );
 
 export const errors = keyedReducer(
 	'orderId',
-	createReducer( null, {
-		[ ORDER_TRANSACTION_FETCH ]: () => null,
-		[ ORDER_TRANSACTION_FETCH_ERROR ]: ( state, action ) => action.error,
-		[ ORDER_TRANSACTION_SET ]: () => null,
+	withoutPersistence( ( state = null, action ) => {
+		switch ( action.type ) {
+			case ORDER_TRANSACTION_FETCH:
+				return null;
+			case ORDER_TRANSACTION_FETCH_ERROR:
+				return action.error;
+			case ORDER_TRANSACTION_SET:
+				return null;
+		}
+
+		return state;
 	} )
 );
 

--- a/client/state/page-templates/reducer.js
+++ b/client/state/page-templates/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	PAGE_TEMPLATES_RECEIVE,
@@ -18,20 +18,24 @@ import {
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ PAGE_TEMPLATES_REQUEST ]: ( state, { siteId } ) => {
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PAGE_TEMPLATES_REQUEST: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: true };
-		},
-		[ PAGE_TEMPLATES_REQUEST_FAILURE ]: ( state, { siteId } ) => {
+		}
+		case PAGE_TEMPLATES_REQUEST_FAILURE: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: false };
-		},
-		[ PAGE_TEMPLATES_REQUEST_SUCCESS ]: ( state, { siteId } ) => {
+		}
+		case PAGE_TEMPLATES_REQUEST_SUCCESS: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: false };
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. Items
@@ -42,15 +46,16 @@ export const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ PAGE_TEMPLATES_RECEIVE ]: ( state, { siteId, templates } ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PAGE_TEMPLATES_RECEIVE: {
+			const { siteId, templates } = action;
 			return { ...state, [ siteId ]: templates };
-		},
-	},
-	itemsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	requesting,

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -7,7 +7,7 @@ import { omit, findIndex } from 'lodash';
  * Internal dependencies
  */
 import status from './status/reducer';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import {
 	PLUGINS_RECEIVE,
 	PLUGINS_REQUEST,
@@ -54,22 +54,29 @@ const updatePlugin = function( state, action ) {
 /*
  * Tracks all known installed plugin objects indexed by site ID.
  */
-export const plugins = createReducerWithValidation(
-	{},
-	{
-		[ PLUGINS_RECEIVE ]: ( state, action ) => {
+export const plugins = withSchemaValidation( pluginsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PLUGINS_RECEIVE: {
 			return { ...state, [ action.siteId ]: action.data };
-		},
-		[ PLUGIN_ACTIVATE_REQUEST_SUCCESS ]: updatePlugin,
-		[ PLUGIN_DEACTIVATE_REQUEST_SUCCESS ]: updatePlugin,
-		[ PLUGIN_UPDATE_REQUEST_SUCCESS ]: updatePlugin,
-		[ PLUGIN_AUTOUPDATE_ENABLE_REQUEST_SUCCESS ]: updatePlugin,
-		[ PLUGIN_AUTOUPDATE_DISABLE_REQUEST_SUCCESS ]: updatePlugin,
-		[ PLUGIN_INSTALL_REQUEST_SUCCESS ]: updatePlugin,
-		[ PLUGIN_REMOVE_REQUEST_SUCCESS ]: updatePlugin,
-	},
-	pluginsSchema
-);
+		}
+		case PLUGIN_ACTIVATE_REQUEST_SUCCESS:
+			return updatePlugin( state, action );
+		case PLUGIN_DEACTIVATE_REQUEST_SUCCESS:
+			return updatePlugin( state, action );
+		case PLUGIN_UPDATE_REQUEST_SUCCESS:
+			return updatePlugin( state, action );
+		case PLUGIN_AUTOUPDATE_ENABLE_REQUEST_SUCCESS:
+			return updatePlugin( state, action );
+		case PLUGIN_AUTOUPDATE_DISABLE_REQUEST_SUCCESS:
+			return updatePlugin( state, action );
+		case PLUGIN_INSTALL_REQUEST_SUCCESS:
+			return updatePlugin( state, action );
+		case PLUGIN_REMOVE_REQUEST_SUCCESS:
+			return updatePlugin( state, action );
+	}
+
+	return state;
+} );
 
 /*
  * Tracks the list of premium plugin objects for a single site

--- a/client/state/plugins/upload/reducer.js
+++ b/client/state/plugins/upload/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 
 import {
 	AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP,
@@ -18,57 +18,90 @@ import {
 
 export const uploadedPluginId = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ PLUGIN_UPLOAD ]: () => null,
-			[ PLUGIN_UPLOAD_COMPLETE ]: ( state, { pluginId } ) => pluginId,
-			[ PLUGIN_UPLOAD_CLEAR ]: () => null,
-			[ PLUGIN_UPLOAD_ERROR ]: () => null,
-			[ AUTOMATED_TRANSFER_STATUS_SET ]: ( state, { uploadedPluginId: pluginId } ) => pluginId,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case PLUGIN_UPLOAD:
+				return null;
+			case PLUGIN_UPLOAD_COMPLETE: {
+				const { pluginId } = action;
+				return pluginId;
+			}
+			case PLUGIN_UPLOAD_CLEAR:
+				return null;
+			case PLUGIN_UPLOAD_ERROR:
+				return null;
+			case AUTOMATED_TRANSFER_STATUS_SET: {
+				const { uploadedPluginId: pluginId } = action;
+				return pluginId;
+			}
 		}
-	)
+
+		return state;
+	} )
 );
 
 export const uploadError = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ PLUGIN_UPLOAD_ERROR ]: ( state, { error } ) => error,
-			[ PLUGIN_UPLOAD ]: () => null,
-			[ PLUGIN_UPLOAD_CLEAR ]: () => null,
-			[ PLUGIN_UPLOAD_COMPLETE ]: () => null,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case PLUGIN_UPLOAD_ERROR: {
+				const { error } = action;
+				return error;
+			}
+			case PLUGIN_UPLOAD:
+				return null;
+			case PLUGIN_UPLOAD_CLEAR:
+				return null;
+			case PLUGIN_UPLOAD_COMPLETE:
+				return null;
 		}
-	)
+
+		return state;
+	} )
 );
 
 export const progressPercent = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ PLUGIN_UPLOAD_PROGRESS ]: ( state, { progress } ) => progress,
-			[ PLUGIN_UPLOAD ]: () => 0,
-			[ PLUGIN_UPLOAD_CLEAR ]: () => 0,
-			[ PLUGIN_UPLOAD_ERROR ]: () => 0,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case PLUGIN_UPLOAD_PROGRESS: {
+				const { progress } = action;
+				return progress;
+			}
+			case PLUGIN_UPLOAD:
+				return 0;
+			case PLUGIN_UPLOAD_CLEAR:
+				return 0;
+			case PLUGIN_UPLOAD_ERROR:
+				return 0;
 		}
-	)
+
+		return state;
+	} )
 );
 
 export const inProgress = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ PLUGIN_UPLOAD ]: () => true,
-			[ PLUGIN_UPLOAD_COMPLETE ]: () => false,
-			[ PLUGIN_UPLOAD_ERROR ]: () => false,
-			[ PLUGIN_UPLOAD_CLEAR ]: () => false,
-			[ AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP ]: () => true,
-			[ AUTOMATED_TRANSFER_STATUS_SET ]: ( state, { status } ) => status !== 'complete',
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case PLUGIN_UPLOAD:
+				return true;
+			case PLUGIN_UPLOAD_COMPLETE:
+				return false;
+			case PLUGIN_UPLOAD_ERROR:
+				return false;
+			case PLUGIN_UPLOAD_CLEAR:
+				return false;
+			case AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP:
+				return true;
+			case AUTOMATED_TRANSFER_STATUS_SET: {
+				const { status } = action;
+				return status !== 'complete';
+			}
 		}
-	)
+
+		return state;
+	} )
 );
 
 export default combineReducers( {

--- a/client/state/post-formats/reducer.js
+++ b/client/state/post-formats/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { postFormatsItemsSchema } from './schema';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import {
 	POST_FORMATS_RECEIVE,
 	POST_FORMATS_REQUEST,
@@ -18,14 +18,24 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ POST_FORMATS_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ POST_FORMATS_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-		[ POST_FORMATS_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case POST_FORMATS_REQUEST: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case POST_FORMATS_REQUEST_SUCCESS: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
+		case POST_FORMATS_REQUEST_FAILURE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. The
@@ -35,15 +45,16 @@ export const requesting = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ POST_FORMATS_RECEIVE ]: ( state, { siteId, formats } ) => {
+export const items = withSchemaValidation( postFormatsItemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case POST_FORMATS_RECEIVE: {
+			const { siteId, formats } = action;
 			return { ...state, [ siteId ]: formats };
-		},
-	},
-	postFormatsItemsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	requesting,

--- a/client/state/posts/counts/reducer.js
+++ b/client/state/posts/counts/reducer.js
@@ -17,7 +17,7 @@ import {
 	POST_SAVE,
 	POSTS_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { countsSchema } from './schema';
 
 /**
@@ -133,21 +133,20 @@ export const counts = ( () => {
 		} );
 	}
 
-	return createReducerWithValidation(
-		{},
-		{
-			[ POST_COUNTS_RESET_INTERNAL_STATE ]: state => {
+	return withSchemaValidation( countsSchema, ( state = {}, action ) => {
+		switch ( action.type ) {
+			case POST_COUNTS_RESET_INTERNAL_STATE: {
 				currentUserId = undefined;
 				postStatuses = {};
 
 				return state;
-			},
-			[ CURRENT_USER_RECEIVE ]: ( state, action ) => {
+			}
+			case CURRENT_USER_RECEIVE: {
 				currentUserId = action.user.ID;
 
 				return state;
-			},
-			[ POSTS_RECEIVE ]: ( state, action ) => {
+			}
+			case POSTS_RECEIVE: {
 				action.posts.forEach( post => {
 					const postStatusKey = getPostStatusKey( post.site_ID, post.ID );
 					const postStatus = postStatuses[ postStatusKey ];
@@ -163,28 +162,29 @@ export const counts = ( () => {
 				} );
 
 				return state;
-			},
-			[ POST_SAVE ]: ( state, action ) => {
+			}
+			case POST_SAVE: {
 				const { siteId, postId, post } = action;
 				if ( ! post.status ) {
 					return state;
 				}
 
 				return transitionPostStateToStatus( state, siteId, postId, post.status );
-			},
-			[ POST_DELETE ]: ( state, action ) => {
+			}
+			case POST_DELETE: {
 				return transitionPostStateToStatus( state, action.siteId, action.postId, 'deleted' );
-			},
-			[ POST_COUNTS_RECEIVE ]: ( state, action ) => {
+			}
+			case POST_COUNTS_RECEIVE: {
 				return merge( {}, state, {
 					[ action.siteId ]: {
 						[ action.postType ]: action.counts,
 					},
 				} );
-			},
-		},
-		countsSchema
-	);
+			}
+		}
+
+		return state;
+	} );
 } )();
 
 export default combineReducers( {

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -7,7 +7,7 @@ import { dropWhile, some } from 'lodash';
  * Internal dependencies
  */
 import itemSchema from './schema';
-import { combineReducers, createReducerWithValidation, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import {
 	POST_LIKES_ADD_LIKER,
 	POST_LIKES_RECEIVE,
@@ -24,94 +24,100 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const itemReducer = createReducerWithValidation(
-	{ likes: undefined, iLike: false, found: 0, lastUpdated: undefined },
-	{
-		[ POST_LIKES_RECEIVE ]: ( state, { likes, iLike, found } ) => {
-			return {
-				likes: Array.isArray( likes )
-					? likes.map( like => {
-							return {
-								ID: like.ID,
-								avatar_URL: like.avatar_URL,
-								login: like.login,
-								name: like.name,
-								site_ID: like.site_ID,
-								site_visible: like.site_visible,
-							};
-					  } )
-					: state.likes,
-				iLike,
-				found,
-				lastUpdated: Date.now(),
-			};
-		},
-		[ POST_LIKE ]: state => {
-			if ( state.iLike ) {
-				return state;
+export const itemReducer = withSchemaValidation(
+	itemSchema,
+	( state = { likes: undefined, iLike: false, found: 0, lastUpdated: undefined }, action ) => {
+		switch ( action.type ) {
+			case POST_LIKES_RECEIVE: {
+				const { likes, iLike, found } = action;
+				return {
+					likes: Array.isArray( likes )
+						? likes.map( like => {
+								return {
+									ID: like.ID,
+									avatar_URL: like.avatar_URL,
+									login: like.login,
+									name: like.name,
+									site_ID: like.site_ID,
+									site_visible: like.site_visible,
+								};
+						  } )
+						: state.likes,
+					iLike,
+					found,
+					lastUpdated: Date.now(),
+				};
 			}
+			case POST_LIKE: {
+				if ( state.iLike ) {
+					return state;
+				}
 
-			return {
-				likes: state.likes,
-				iLike: true,
-				found: state.found + 1,
-				lastUpdated: state.lastUpdated,
-			};
-		},
-		[ POST_UNLIKE ]: state => {
-			if ( ! state.iLike ) {
-				return state;
+				return {
+					likes: state.likes,
+					iLike: true,
+					found: state.found + 1,
+					lastUpdated: state.lastUpdated,
+				};
 			}
+			case POST_UNLIKE: {
+				if ( ! state.iLike ) {
+					return state;
+				}
 
-			return {
-				likes: state.likes,
-				iLike: false,
-				found: Math.max( 0, state.found - 1 ),
-				lastUpdated: state.lastUpdated,
-			};
-		},
-		[ POST_LIKES_ADD_LIKER ]: ( state, { likeCount, liker } ) => {
-			const hasLiker = some( state.likes, like => like.ID === liker.ID );
-
-			if ( state.likeCount === likeCount && hasLiker ) {
-				// if the like count matches and we already have this liker, bail
-				return state;
+				return {
+					likes: state.likes,
+					iLike: false,
+					found: Math.max( 0, state.found - 1 ),
+					lastUpdated: state.lastUpdated,
+				};
 			}
+			case POST_LIKES_ADD_LIKER: {
+				const { likeCount, liker } = action;
+				const hasLiker = some( state.likes, like => like.ID === liker.ID );
 
-			let likes = state.likes;
-			if ( ! hasLiker ) {
-				likes = [ liker, ...( state.likes || [] ) ];
+				if ( state.likeCount === likeCount && hasLiker ) {
+					// if the like count matches and we already have this liker, bail
+					return state;
+				}
+
+				let likes = state.likes;
+				if ( ! hasLiker ) {
+					likes = [ liker, ...( state.likes || [] ) ];
+				}
+
+				return {
+					likes,
+					iLike: state.iLike,
+					found: likeCount,
+					lastUpdated: state.lastUpdated,
+				};
 			}
+			case POST_LIKES_REMOVE_LIKER: {
+				const { likeCount, liker } = action;
+				const hasLiker = some( state.likes, like => like.ID === liker.ID );
 
-			return {
-				likes,
-				iLike: state.iLike,
-				found: likeCount,
-				lastUpdated: state.lastUpdated,
-			};
-		},
-		[ POST_LIKES_REMOVE_LIKER ]: ( state, { likeCount, liker } ) => {
-			const hasLiker = some( state.likes, like => like.ID === liker.ID );
+				if ( state.likeCount === likeCount && ! hasLiker ) {
+					// if the like count matches and we don't have this liker, bail
+					return state;
+				}
 
-			if ( state.likeCount === likeCount && ! hasLiker ) {
-				// if the like count matches and we don't have this liker, bail
-				return state;
+				let likes = state.likes;
+				if ( hasLiker ) {
+					likes = dropWhile( state.likes, l => liker.ID === l.ID );
+				}
+
+				return {
+					likes,
+					iLike: state.iLike,
+					found: likeCount,
+					lastUpdated: state.lastUpdated,
+				};
 			}
+		}
 
-			let likes = state.likes;
-			if ( hasLiker ) {
-				likes = dropWhile( state.likes, l => liker.ID === l.ID );
-			}
-
-			return {
-				likes,
-				iLike: state.iLike,
-				found: likeCount,
-				lastUpdated: state.lastUpdated,
-			};
-		},
-	},
-	itemSchema
+		return state;
+	}
 );
 
 const postIdReducer = keyedReducer( 'postId', itemReducer );

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -20,7 +20,7 @@ import {
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import {
 	EDITOR_SAVE,
 	EDITOR_START,
@@ -68,10 +68,9 @@ import { getFeaturedImageId } from 'state/posts/utils';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ POSTS_RECEIVE ]: ( state, action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case POSTS_RECEIVE: {
 			return reduce(
 				action.posts,
 				( memo, post ) => {
@@ -91,8 +90,8 @@ export const items = createReducerWithValidation(
 				},
 				state
 			);
-		},
-		[ POST_DELETE_SUCCESS ]: ( state, action ) => {
+		}
+		case POST_DELETE_SUCCESS: {
 			const globalId = findKey( state, ( [ siteId, postId ] ) => {
 				return siteId === action.siteId && postId === action.postId;
 			} );
@@ -102,10 +101,11 @@ export const items = createReducerWithValidation(
 			}
 
 			return omit( state, globalId );
-		},
-	},
-	itemsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 /**
  * Returns the updated site post requests state after an action has been
@@ -191,18 +191,19 @@ export const queries = ( () => {
 		};
 	}
 
-	return createReducerWithValidation(
-		{},
-		{
-			[ POSTS_REQUEST_SUCCESS ]: ( state, { siteId, query, posts, found } ) => {
+	return withSchemaValidation( queriesSchema, ( state = {}, action ) => {
+		switch ( action.type ) {
+			case POSTS_REQUEST_SUCCESS: {
+				const { siteId, query, posts, found } = action;
 				if ( ! siteId ) {
 					// Handle site-specific queries only
 					return state;
 				}
 				const normalizedPosts = posts.map( normalizePostForState );
 				return applyToManager( state, siteId, 'receive', true, normalizedPosts, { query, found } );
-			},
-			[ POSTS_RECEIVE ]: ( state, { posts } ) => {
+			}
+			case POSTS_RECEIVE: {
+				const { posts } = action;
 				const postsBySiteId = reduce(
 					posts,
 					( memo, post ) => {
@@ -223,8 +224,9 @@ export const queries = ( () => {
 					},
 					state
 				);
-			},
-			[ POST_RESTORE ]: ( state, { siteId, postId } ) => {
+			}
+			case POST_RESTORE: {
+				const { siteId, postId } = action;
 				return applyToManager(
 					state,
 					siteId,
@@ -236,8 +238,9 @@ export const queries = ( () => {
 					},
 					{ patch: true }
 				);
-			},
-			[ POST_RESTORE_FAILURE ]: ( state, { siteId, postId } ) => {
+			}
+			case POST_RESTORE_FAILURE: {
+				const { siteId, postId } = action;
 				return applyToManager(
 					state,
 					siteId,
@@ -249,8 +252,9 @@ export const queries = ( () => {
 					},
 					{ patch: true }
 				);
-			},
-			[ POST_SAVE ]: ( state, { siteId, postId, post } ) => {
+			}
+			case POST_SAVE: {
+				const { siteId, postId, post } = action;
 				return applyToManager(
 					state,
 					siteId,
@@ -262,8 +266,9 @@ export const queries = ( () => {
 					},
 					{ patch: true }
 				);
-			},
-			[ POST_DELETE ]: ( state, { siteId, postId } ) => {
+			}
+			case POST_DELETE: {
+				const { siteId, postId } = action;
 				return applyToManager(
 					state,
 					siteId,
@@ -275,8 +280,9 @@ export const queries = ( () => {
 					},
 					{ patch: true }
 				);
-			},
-			[ POST_DELETE_FAILURE ]: ( state, { siteId, postId } ) => {
+			}
+			case POST_DELETE_FAILURE: {
+				const { siteId, postId } = action;
 				return applyToManager(
 					state,
 					siteId,
@@ -288,19 +294,21 @@ export const queries = ( () => {
 					},
 					{ patch: true }
 				);
-			},
-			[ POST_DELETE_SUCCESS ]: ( state, { siteId, postId } ) => {
+			}
+			case POST_DELETE_SUCCESS: {
+				const { siteId, postId } = action;
 				return applyToManager( state, siteId, 'removeItem', false, postId );
-			},
-			[ SERIALIZE ]: state => {
+			}
+			case SERIALIZE: {
 				return mapValues( state, ( { data, options } ) => ( { data, options } ) );
-			},
-			[ DESERIALIZE ]: state => {
+			}
+			case DESERIALIZE: {
 				return mapValues( state, ( { data, options } ) => new PostQueryManager( data, options ) );
-			},
-		},
-		queriesSchema
-	);
+			}
+		}
+
+		return state;
+	} );
 } )();
 
 /**
@@ -322,80 +330,93 @@ export const allSitesQueries = ( () => {
 		);
 	}
 
-	return createReducerWithValidation(
-		new PostQueryManager( {}, { itemKey: 'global_ID' } ),
-		{
-			[ POSTS_REQUEST_SUCCESS ]: ( state, { siteId, query, posts, found } ) => {
-				if ( siteId ) {
-					// Handle all-sites queries only.
-					return state;
+	return withSchemaValidation(
+		allSitesQueriesSchema,
+		( state = new PostQueryManager( {}, { itemKey: 'global_ID' } ), action ) => {
+			switch ( action.type ) {
+				case POSTS_REQUEST_SUCCESS: {
+					const { siteId, query, posts, found } = action;
+					if ( siteId ) {
+						// Handle all-sites queries only.
+						return state;
+					}
+					return state.receive( posts.map( normalizePostForState ), { query, found } );
 				}
-				return state.receive( posts.map( normalizePostForState ), { query, found } );
-			},
-			[ POSTS_RECEIVE ]: ( state, { posts } ) => {
-				return state.receive( posts );
-			},
-			[ POST_RESTORE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: '__RESTORE_PENDING',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_RESTORE_FAILURE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: 'trash',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_SAVE ]: ( state, { siteId, postId, post } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						...post,
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_DELETE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: '__DELETE_PENDING',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_DELETE_FAILURE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: 'trash',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_DELETE_SUCCESS ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.removeItem( globalId );
-			},
-			[ SERIALIZE ]: state => ( {
-				data: state.data,
-				options: state.options,
-			} ),
-			[ DESERIALIZE ]: state => new PostQueryManager( state.data, state.options ),
-		},
-		allSitesQueriesSchema
+				case POSTS_RECEIVE: {
+					const { posts } = action;
+					return state.receive( posts );
+				}
+				case POST_RESTORE: {
+					const { siteId, postId } = action;
+					const globalId = findItemKey( state, siteId, postId );
+					return state.receive(
+						{
+							global_ID: globalId,
+							status: '__RESTORE_PENDING',
+						},
+						{ patch: true }
+					);
+				}
+				case POST_RESTORE_FAILURE: {
+					const { siteId, postId } = action;
+					const globalId = findItemKey( state, siteId, postId );
+					return state.receive(
+						{
+							global_ID: globalId,
+							status: 'trash',
+						},
+						{ patch: true }
+					);
+				}
+				case POST_SAVE: {
+					const { siteId, postId, post } = action;
+					const globalId = findItemKey( state, siteId, postId );
+					return state.receive(
+						{
+							global_ID: globalId,
+							...post,
+						},
+						{ patch: true }
+					);
+				}
+				case POST_DELETE: {
+					const { siteId, postId } = action;
+					const globalId = findItemKey( state, siteId, postId );
+					return state.receive(
+						{
+							global_ID: globalId,
+							status: '__DELETE_PENDING',
+						},
+						{ patch: true }
+					);
+				}
+				case POST_DELETE_FAILURE: {
+					const { siteId, postId } = action;
+					const globalId = findItemKey( state, siteId, postId );
+					return state.receive(
+						{
+							global_ID: globalId,
+							status: 'trash',
+						},
+						{ patch: true }
+					);
+				}
+				case POST_DELETE_SUCCESS: {
+					const { siteId, postId } = action;
+					const globalId = findItemKey( state, siteId, postId );
+					return state.removeItem( globalId );
+				}
+				case SERIALIZE:
+					return {
+						data: state.data,
+						options: state.options,
+					};
+				case DESERIALIZE:
+					return new PostQueryManager( state.data, state.options );
+			}
+
+			return state;
+		}
 	);
 } )();
 

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -14,7 +14,7 @@ import {
 	PREFERENCES_FETCH_FAILURE,
 	PREFERENCES_SAVE_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { remoteValuesSchema } from './schema';
 
 /**
@@ -27,21 +27,24 @@ import { remoteValuesSchema } from './schema';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const localValues = createReducer(
-	{},
-	{
-		[ PREFERENCES_SET ]: ( state, { key, value } ) => {
+export const localValues = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PREFERENCES_SET: {
+			const { key, value } = action;
 			if ( state[ key ] === value ) {
 				return state;
 			}
 
 			return { ...state, [ key ]: value };
-		},
-		[ PREFERENCES_SAVE_SUCCESS ]: ( state, { key } ) => {
+		}
+		case PREFERENCES_SAVE_SUCCESS: {
+			const { key } = action;
 			return omit( state, key );
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated remote values state after an action has been dispatched.
@@ -52,22 +55,37 @@ export const localValues = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const remoteValues = createReducerWithValidation(
-	null,
-	{
-		[ PREFERENCES_RECEIVE ]: ( state, { values } ) => values,
-	},
-	remoteValuesSchema
-);
+export const remoteValues = withSchemaValidation( remoteValuesSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case PREFERENCES_RECEIVE: {
+			const { values } = action;
+			return values;
+		}
+	}
 
-export const fetching = createReducer( false, {
-	[ PREFERENCES_FETCH_SUCCESS ]: () => false,
-	[ PREFERENCES_FETCH_FAILURE ]: () => false,
-	[ PREFERENCES_FETCH ]: () => true,
+	return state;
 } );
 
-const lastFetchedTimestamp = createReducer( false, {
-	[ PREFERENCES_FETCH_SUCCESS ]: () => Date.now(),
+export const fetching = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case PREFERENCES_FETCH_SUCCESS:
+			return false;
+		case PREFERENCES_FETCH_FAILURE:
+			return false;
+		case PREFERENCES_FETCH:
+			return true;
+	}
+
+	return state;
+} );
+
+const lastFetchedTimestamp = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case PREFERENCES_FETCH_SUCCESS:
+			return Date.now();
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/products-list/reducer.js
+++ b/client/state/products-list/reducer.js
@@ -6,23 +6,31 @@ import {
 	PRODUCTS_LIST_REQUEST,
 	PRODUCTS_LIST_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { productsListSchema } from './schema';
 
 // Stores the complete list of products, indexed by the product key
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ PRODUCTS_LIST_RECEIVE ]: ( state, action ) => action.productsList,
-	},
-	productsListSchema
-);
+export const items = withSchemaValidation( productsListSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PRODUCTS_LIST_RECEIVE:
+			return action.productsList;
+	}
+
+	return state;
+} );
 
 // Tracks product list fetching state
-export const isFetching = createReducer( false, {
-	[ PRODUCTS_LIST_REQUEST ]: () => true,
-	[ PRODUCTS_LIST_RECEIVE ]: () => false,
-	[ PRODUCTS_LIST_REQUEST_FAILURE ]: () => false,
+export const isFetching = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case PRODUCTS_LIST_REQUEST:
+			return true;
+		case PRODUCTS_LIST_RECEIVE:
+			return false;
+		case PRODUCTS_LIST_REQUEST_FAILURE:
+			return false;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/profile-links/reducer.js
+++ b/client/state/profile-links/reducer.js
@@ -8,7 +8,7 @@ import { reject } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	USER_PROFILE_LINKS_ADD_DUPLICATE,
 	USER_PROFILE_LINKS_ADD_FAILURE,
@@ -20,28 +20,55 @@ import {
 	USER_PROFILE_LINKS_RESET_ERRORS,
 } from 'state/action-types';
 
-export const items = createReducer( null, {
-	[ USER_PROFILE_LINKS_RECEIVE ]: ( state, { profileLinks } ) => profileLinks,
-	[ USER_PROFILE_LINKS_DELETE_SUCCESS ]: ( state, { linkSlug } ) =>
-		reject( state, { link_slug: linkSlug } ),
+export const items = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case USER_PROFILE_LINKS_RECEIVE: {
+			const { profileLinks } = action;
+			return profileLinks;
+		}
+		case USER_PROFILE_LINKS_DELETE_SUCCESS: {
+			const { linkSlug } = action;
+			return reject( state, { link_slug: linkSlug } );
+		}
+	}
+
+	return state;
 } );
 
-export const errors = createReducer(
-	{},
-	{
-		[ USER_PROFILE_LINKS_ADD_SUCCESS ]: () => ( {} ),
-		[ USER_PROFILE_LINKS_ADD_DUPLICATE ]: ( state, { profileLinks } ) => ( {
-			duplicate: profileLinks,
-		} ),
-		[ USER_PROFILE_LINKS_ADD_MALFORMED ]: ( state, { profileLinks } ) => ( {
-			malformed: profileLinks,
-		} ),
-		[ USER_PROFILE_LINKS_ADD_FAILURE ]: ( state, { error } ) => ( { error } ),
-		[ USER_PROFILE_LINKS_DELETE_SUCCESS ]: () => ( {} ),
-		[ USER_PROFILE_LINKS_DELETE_FAILURE ]: ( state, { error } ) => ( { error } ),
-		[ USER_PROFILE_LINKS_RESET_ERRORS ]: () => ( {} ),
+export const errors = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case USER_PROFILE_LINKS_ADD_SUCCESS:
+			return {};
+		case USER_PROFILE_LINKS_ADD_DUPLICATE: {
+			const { profileLinks } = action;
+
+			return {
+				duplicate: profileLinks,
+			};
+		}
+		case USER_PROFILE_LINKS_ADD_MALFORMED: {
+			const { profileLinks } = action;
+
+			return {
+				malformed: profileLinks,
+			};
+		}
+		case USER_PROFILE_LINKS_ADD_FAILURE: {
+			const { error } = action;
+			return { error };
+		}
+		case USER_PROFILE_LINKS_DELETE_SUCCESS:
+			return {};
+		case USER_PROFILE_LINKS_DELETE_FAILURE: {
+			const { error } = action;
+			return { error };
+		}
+		case USER_PROFILE_LINKS_RESET_ERRORS:
+			return {};
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/purchases/reducer.js
+++ b/client/state/purchases/reducer.js
@@ -7,7 +7,7 @@ import { find, matches } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	PURCHASES_REMOVE,
 	PURCHASES_SITE_FETCH,
@@ -88,45 +88,52 @@ function updatePurchases( existingPurchases, action ) {
 
 const assignError = ( state, action ) => ( { ...state, error: action.error } );
 
-export default createReducer( initialState, {
-	[ PURCHASES_REMOVE ]: state => ( {
-		...state,
-		data: [],
-		hasLoadedSitePurchasesFromServer: false,
-		hasLoadedUserPurchasesFromServer: false,
-	} ),
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case PURCHASES_REMOVE:
+			return {
+				...state,
+				data: [],
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: false,
+			};
+		case PURCHASES_SITE_FETCH:
+			return { ...state, isFetchingSitePurchases: true };
+		case PURCHASES_USER_FETCH:
+			return { ...state, isFetchingUserPurchases: true };
+		case PURCHASE_REMOVE_COMPLETED:
+			return {
+				...state,
+				data: updatePurchases( state.data, action ),
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true,
+			};
+		case PURCHASES_SITE_FETCH_COMPLETED:
+			return {
+				...state,
+				data: updatePurchases( state.data, action ),
+				error: null,
+				isFetchingSitePurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+			};
+		case PURCHASES_USER_FETCH_COMPLETED:
+			return {
+				...state,
+				data: updatePurchases( state.data, action ),
+				error: null,
+				isFetchingUserPurchases: false,
+				hasLoadedUserPurchasesFromServer: true,
+			};
+		case PURCHASE_REMOVE_FAILED:
+			return assignError( state, action );
+		case PURCHASES_SITE_FETCH_FAILED:
+			return assignError( state, action );
+		case PURCHASES_USER_FETCH_FAILED:
+			return assignError( state, action );
+	}
 
-	[ PURCHASES_SITE_FETCH ]: state => ( { ...state, isFetchingSitePurchases: true } ),
-
-	[ PURCHASES_USER_FETCH ]: state => ( { ...state, isFetchingUserPurchases: true } ),
-
-	[ PURCHASE_REMOVE_COMPLETED ]: ( state, action ) => ( {
-		...state,
-		data: updatePurchases( state.data, action ),
-		error: null,
-		isFetchingSitePurchases: false,
-		isFetchingUserPurchases: false,
-		hasLoadedSitePurchasesFromServer: true,
-		hasLoadedUserPurchasesFromServer: true,
-	} ),
-
-	[ PURCHASES_SITE_FETCH_COMPLETED ]: ( state, action ) => ( {
-		...state,
-		data: updatePurchases( state.data, action ),
-		error: null,
-		isFetchingSitePurchases: false,
-		hasLoadedSitePurchasesFromServer: true,
-	} ),
-
-	[ PURCHASES_USER_FETCH_COMPLETED ]: ( state, action ) => ( {
-		...state,
-		data: updatePurchases( state.data, action ),
-		error: null,
-		isFetchingUserPurchases: false,
-		hasLoadedUserPurchasesFromServer: true,
-	} ),
-
-	[ PURCHASE_REMOVE_FAILED ]: assignError,
-	[ PURCHASES_SITE_FETCH_FAILED ]: assignError,
-	[ PURCHASES_USER_FETCH_FAILED ]: assignError,
+	return state;
 } );

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -13,17 +13,16 @@ import {
 	READER_POSTS_RECEIVE,
 } from 'state/action-types';
 import { CONVERSATION_FOLLOW_STATUS } from './follow-status';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import { key } from './utils';
 
 /**
  * Tracks all known conversation following statuses.
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ READER_CONVERSATION_FOLLOW ]: ( state, action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_CONVERSATION_FOLLOW: {
 			const newState = assign( {}, state, {
 				[ key(
 					action.payload.siteId,
@@ -31,14 +30,14 @@ export const items = createReducerWithValidation(
 				) ]: CONVERSATION_FOLLOW_STATUS.following,
 			} );
 			return newState;
-		},
-		[ READER_CONVERSATION_MUTE ]: ( state, action ) => {
+		}
+		case READER_CONVERSATION_MUTE: {
 			const newState = assign( {}, state, {
 				[ key( action.payload.siteId, action.payload.postId ) ]: CONVERSATION_FOLLOW_STATUS.muting,
 			} );
 			return newState;
-		},
-		[ READER_CONVERSATION_UPDATE_FOLLOW_STATUS ]: ( state, action ) => {
+		}
+		case READER_CONVERSATION_UPDATE_FOLLOW_STATUS: {
 			const stateKey = key( action.payload.siteId, action.payload.postId );
 
 			// If followStatus is null, remove the key from the state map entirely
@@ -51,8 +50,8 @@ export const items = createReducerWithValidation(
 			} );
 
 			return newState;
-		},
-		[ READER_POSTS_RECEIVE ]: ( state, action ) => {
+		}
+		case READER_POSTS_RECEIVE: {
 			if ( ! action.posts ) {
 				return state;
 			}
@@ -70,10 +69,11 @@ export const items = createReducerWithValidation(
 			}
 
 			return { ...state, ...newState };
-		},
-	},
-	itemsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -7,7 +7,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
 /**
@@ -29,9 +29,13 @@ import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
  */
 export const items = keyedReducer(
 	'queryKey',
-	createReducer( null, {
-		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) =>
-			uniqBy( ( state || [] ).concat( action.payload.feeds ), 'feed_URL' ),
+	withoutPersistence( ( state = null, action ) => {
+		switch ( action.type ) {
+			case READER_FEED_SEARCH_RECEIVE:
+				return uniqBy( ( state || [] ).concat( action.payload.feeds ), 'feed_URL' );
+		}
+
+		return state;
 	} )
 );
 
@@ -56,8 +60,13 @@ export const items = keyedReducer(
  */
 export const total = keyedReducer(
 	'queryKey',
-	createReducer( null, {
-		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => action.payload.total,
+	withoutPersistence( ( state = null, action ) => {
+		switch ( action.type ) {
+			case READER_FEED_SEARCH_RECEIVE:
+				return action.payload.total;
+		}
+
+		return state;
 	} )
 );
 

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -13,7 +13,7 @@ import {
 	READER_FEED_UPDATE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { itemsSchema } from './schema';
 import { safeLink } from 'lib/post-normalizer/utils';
@@ -63,16 +63,20 @@ function handleFeedUpdate( state, action ) {
 	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );
 }
 
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ SERIALIZE ]: handleSerialize,
-		[ READER_FEED_REQUEST_SUCCESS ]: handleRequestSuccess,
-		[ READER_FEED_REQUEST_FAILURE ]: handleRequestFailure,
-		[ READER_FEED_UPDATE ]: handleFeedUpdate,
-	},
-	itemsSchema
-);
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SERIALIZE:
+			return handleSerialize( state, action );
+		case READER_FEED_REQUEST_SUCCESS:
+			return handleRequestSuccess( state, action );
+		case READER_FEED_REQUEST_FAILURE:
+			return handleRequestFailure( state, action );
+		case READER_FEED_UPDATE:
+			return handleFeedUpdate( state, action );
+	}
+
+	return state;
+} );
 
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {
@@ -88,14 +92,14 @@ export function queuedRequests( state = {}, action ) {
 	return state;
 }
 
-export const lastFetched = createReducer(
-	{},
-	{
-		[ READER_FEED_REQUEST_SUCCESS ]: ( state, action ) => ( {
-			...state,
-			[ action.payload.feed_ID ]: Date.now(),
-		} ),
-		[ READER_FEED_UPDATE ]: ( state, action ) => {
+export const lastFetched = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_FEED_REQUEST_SUCCESS:
+			return {
+				...state,
+				[ action.payload.feed_ID ]: Date.now(),
+			};
+		case READER_FEED_UPDATE: {
 			const updates = reduce(
 				action.payload,
 				( memo, feed ) => {
@@ -105,9 +109,11 @@ export const lastFetched = createReducer(
 				{}
 			);
 			return assign( {}, state, updates );
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -25,7 +25,7 @@ import {
 	READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { prepareComparableUrl } from './utils';
 import { items as itemsSchema } from './schema';
 
@@ -106,31 +106,30 @@ function updateNotificationSubscription( state, { payload, type } ) {
 	};
 }
 
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ READER_RECORD_FOLLOW ]: ( state, action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_RECORD_FOLLOW: {
 			const urlKey = prepareComparableUrl( action.payload.url );
 			return {
 				...state,
 				[ urlKey ]: merge( {}, state[ urlKey ], { is_following: true } ),
 			};
-		},
-		[ READER_RECORD_UNFOLLOW ]: ( state, action ) => {
+		}
+		case READER_RECORD_UNFOLLOW: {
 			const urlKey = prepareComparableUrl( action.payload.url );
 			return {
 				...state,
 				[ urlKey ]: merge( {}, state[ urlKey ], { is_following: false } ),
 			};
-		},
-		[ READER_FOLLOW_ERROR ]: ( state, action ) => {
+		}
+		case READER_FOLLOW_ERROR: {
 			const urlKey = prepareComparableUrl( action.payload.feedUrl );
 			return {
 				...state,
 				[ urlKey ]: merge( {}, state[ urlKey ], { error: action.payload.error } ),
 			};
-		},
-		[ READER_FOLLOW ]: ( state, action ) => {
+		}
+		case READER_FOLLOW: {
 			let urlKey = prepareComparableUrl( action.payload.feedUrl );
 			const newValues = { is_following: true };
 
@@ -177,8 +176,8 @@ export const items = createReducerWithValidation(
 					newValues
 				),
 			} );
-		},
-		[ READER_UNFOLLOW ]: ( state, action ) => {
+		}
+		case READER_UNFOLLOW: {
 			const urlKey = prepareComparableUrl( action.payload.feedUrl );
 			const currentFollow = state[ urlKey ];
 			if ( ! ( currentFollow && currentFollow.is_following ) ) {
@@ -194,8 +193,8 @@ export const items = createReducerWithValidation(
 					},
 				} ),
 			};
-		},
-		[ READER_FOLLOWS_RECEIVE ]: ( state, action ) => {
+		}
+		case READER_FOLLOWS_RECEIVE: {
 			const follows = action.payload.follows;
 			const keyedNewFollows = reduce(
 				follows,
@@ -211,8 +210,8 @@ export const items = createReducerWithValidation(
 				{}
 			);
 			return merge( {}, state, keyedNewFollows );
-		},
-		[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => {
+		}
+		case READER_SITE_REQUEST_SUCCESS: {
 			const incomingSite = action.payload;
 			if ( ! incomingSite || ! incomingSite.feed_URL || ! incomingSite.is_following ) {
 				return state;
@@ -230,15 +229,22 @@ export const items = createReducerWithValidation(
 				...state,
 				[ urlKey ]: merge( {}, currentFollow, newFollow ),
 			};
-		},
-		[ READER_SUBSCRIBE_TO_NEW_POST_EMAIL ]: updateEmailSubscription,
-		[ READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION ]: updateEmailSubscription,
-		[ READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL ]: updateEmailSubscription,
-		[ READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: updateEmailSubscription,
-		[ READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: updateEmailSubscription,
-		[ READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: updateNotificationSubscription,
-		[ READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: updateNotificationSubscription,
-		[ READER_FOLLOWS_SYNC_COMPLETE ]: ( state, action ) => {
+		}
+		case READER_SUBSCRIBE_TO_NEW_POST_EMAIL:
+			return updateEmailSubscription( state, action );
+		case READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION:
+			return updateEmailSubscription( state, action );
+		case READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL:
+			return updateEmailSubscription( state, action );
+		case READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL:
+			return updateEmailSubscription( state, action );
+		case READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL:
+			return updateEmailSubscription( state, action );
+		case READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS:
+			return updateNotificationSubscription( state, action );
+		case READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS:
+			return updateNotificationSubscription( state, action );
+		case READER_FOLLOWS_SYNC_COMPLETE: {
 			const seenSubscriptions = new Set( action.payload );
 
 			// diff what we saw vs. what's in state and remove anything extra
@@ -248,22 +254,32 @@ export const items = createReducerWithValidation(
 			// we show on the manage listing. Items without an ID are either inflight follows
 			// or follows that we picked up from a feed, site, or post object.
 			return omitBy( state, follow => follow.ID && ! seenSubscriptions.has( follow.feed_URL ) );
-		},
-		[ SERIALIZE ]: state => pickBy( state, item => item.ID && item.is_following ),
-	},
-	itemsSchema
-);
+		}
+		case SERIALIZE:
+			return pickBy( state, item => item.ID && item.is_following );
+	}
 
-export const itemsCount = createReducer( 0, {
-	[ READER_FOLLOWS_RECEIVE ]: ( state, action ) => {
-		return action.payload.totalCount ? action.payload.totalCount : state;
-	},
+	return state;
 } );
 
-export const lastSyncTime = createReducer( null, {
-	[ READER_FOLLOWS_SYNC_START ]: () => {
-		return Date.now();
-	},
+export const itemsCount = withoutPersistence( ( state = 0, action ) => {
+	switch ( action.type ) {
+		case READER_FOLLOWS_RECEIVE: {
+			return action.payload.totalCount ? action.payload.totalCount : state;
+		}
+	}
+
+	return state;
+} );
+
+export const lastSyncTime = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case READER_FOLLOWS_SYNC_START: {
+			return Date.now();
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/reader/recommended-sites/reducer.js
+++ b/client/state/reader/recommended-sites/reducer.js
@@ -8,7 +8,7 @@ import { uniqBy } from 'lodash';
  * Internal dependencies
  */
 import { READER_RECOMMENDED_SITES_RECEIVE } from 'state/action-types';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 
 /**
  * Tracks mappings between randomization seeds and site recs.
@@ -20,9 +20,13 @@ import { combineReducers, createReducer, keyedReducer } from 'state/utils';
  */
 export const items = keyedReducer(
 	'seed',
-	createReducer( [], {
-		[ READER_RECOMMENDED_SITES_RECEIVE ]: ( state, action ) =>
-			uniqBy( state.concat( action.payload.sites ), 'feedId' ),
+	withoutPersistence( ( state = [], action ) => {
+		switch ( action.type ) {
+			case READER_RECOMMENDED_SITES_RECEIVE:
+				return uniqBy( state.concat( action.payload.sites ), 'feedId' );
+		}
+
+		return state;
 	} )
 );
 
@@ -36,9 +40,13 @@ export const items = keyedReducer(
  */
 export const pagingOffset = keyedReducer(
 	'seed',
-	createReducer( null, {
-		[ READER_RECOMMENDED_SITES_RECEIVE ]: ( state, action ) =>
-			Math.max( action.payload.offset, state ),
+	withoutPersistence( ( state = null, action ) => {
+		switch ( action.type ) {
+			case READER_RECOMMENDED_SITES_RECEIVE:
+				return Math.max( action.payload.offset, state );
+		}
+
+		return state;
 	} )
 );
 

--- a/client/state/reader/related-posts/reducer.js
+++ b/client/state/reader/related-posts/reducer.js
@@ -7,7 +7,7 @@ import { assign, map, partial } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	READER_RELATED_POSTS_RECEIVE,
 	READER_RELATED_POSTS_REQUEST,
@@ -16,10 +16,9 @@ import {
 } from 'state/action-types';
 import { key } from './utils';
 
-export const items = createReducer(
-	{},
-	{
-		[ READER_RELATED_POSTS_RECEIVE ]: ( state, action ) => {
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_RELATED_POSTS_RECEIVE: {
 			state = assign( {}, state, {
 				[ key( action.payload.siteId, action.payload.postId, action.payload.scope ) ]: map(
 					action.payload.posts,
@@ -27,9 +26,11 @@ export const items = createReducer(
 				),
 			} );
 			return state;
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 function setRequestFlag( val, state, action ) {
 	const { siteId, postId, scope } = action.payload;
@@ -38,14 +39,18 @@ function setRequestFlag( val, state, action ) {
 	} );
 }
 
-export const queuedRequests = createReducer(
-	{},
-	{
-		[ READER_RELATED_POSTS_REQUEST ]: partial( setRequestFlag, true ),
-		[ READER_RELATED_POSTS_REQUEST_SUCCESS ]: partial( setRequestFlag, false ),
-		[ READER_RELATED_POSTS_REQUEST_FAILURE ]: partial( setRequestFlag, false ),
+export const queuedRequests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_RELATED_POSTS_REQUEST:
+			return partial( setRequestFlag, true )( state, action );
+		case READER_RELATED_POSTS_REQUEST_SUCCESS:
+			return partial( setRequestFlag, false )( state, action );
+		case READER_RELATED_POSTS_REQUEST_FAILURE:
+			return partial( setRequestFlag, false )( state, action );
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/reader/site-blocks/reducer.js
+++ b/client/state/reader/site-blocks/reducer.js
@@ -14,21 +14,20 @@ import {
 	READER_SITE_REQUEST_SUCCESS,
 	READER_SITE_UNBLOCK,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const items = createReducer(
-	{},
-	{
-		[ READER_SITE_BLOCK ]: ( state, action ) => {
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_SITE_BLOCK: {
 			return {
 				...state,
 				[ action.payload.siteId ]: true,
 			};
-		},
-		[ READER_SITE_UNBLOCK ]: ( state, action ) => {
+		}
+		case READER_SITE_UNBLOCK: {
 			return omit( state, action.payload.siteId );
-		},
-		[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => {
+		}
+		case READER_SITE_REQUEST_SUCCESS: {
 			if ( ! action.payload.is_blocked ) {
 				if ( ! state[ action.payload.ID ] ) {
 					return state;
@@ -41,8 +40,8 @@ export const items = createReducer(
 				...state,
 				[ action.payload.ID ]: true,
 			};
-		},
-		[ READER_SITE_BLOCKS_RECEIVE ]: ( state, action ) => {
+		}
+		case READER_SITE_BLOCKS_RECEIVE: {
 			if ( ! action.payload || ! action.payload.sites ) {
 				return state;
 			}
@@ -60,34 +59,43 @@ export const items = createReducer(
 				...state,
 				...newBlocks,
 			};
-		},
+		}
 	}
-);
 
-export const currentPage = createReducer( 1, {
-	[ READER_SITE_BLOCKS_RECEIVE ]: ( state, action ) => {
-		if ( ! action.payload || ! action.payload.page ) {
-			return state;
-		}
-
-		return action.payload.page;
-	},
+	return state;
 } );
 
-export const lastPage = createReducer( null, {
-	[ READER_SITE_BLOCKS_RECEIVE ]: ( state, action ) => {
-		if ( ! action.payload || ! action.payload.page || action.payload.count > 0 ) {
-			return state;
-		}
+export const currentPage = withoutPersistence( ( state = 1, action ) => {
+	switch ( action.type ) {
+		case READER_SITE_BLOCKS_RECEIVE: {
+			if ( ! action.payload || ! action.payload.page ) {
+				return state;
+			}
 
-		return action.payload.page;
-	},
+			return action.payload.page;
+		}
+	}
+
+	return state;
 } );
 
-export const inflightPages = createReducer(
-	{},
-	{
-		[ READER_SITE_BLOCKS_REQUEST ]: ( state, action ) => {
+export const lastPage = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case READER_SITE_BLOCKS_RECEIVE: {
+			if ( ! action.payload || ! action.payload.page || action.payload.count > 0 ) {
+				return state;
+			}
+
+			return action.payload.page;
+		}
+	}
+
+	return state;
+} );
+
+export const inflightPages = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_SITE_BLOCKS_REQUEST: {
 			if ( ! action.payload || ! action.payload.page ) {
 				return state;
 			}
@@ -96,16 +104,18 @@ export const inflightPages = createReducer(
 				...state,
 				[ action.payload.page ]: true,
 			};
-		},
-		[ READER_SITE_BLOCKS_RECEIVE ]: ( state, action ) => {
+		}
+		case READER_SITE_BLOCKS_RECEIVE: {
 			if ( ! action.payload || ! action.payload.page ) {
 				return state;
 			}
 
 			return omit( state, action.payload.page );
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/reader/site-dismissals/reducer.js
+++ b/client/state/reader/site-dismissals/reducer.js
@@ -4,25 +4,26 @@
  * Internal dependencies
  */
 import { READER_DISMISS_SITE, READER_DISMISS_POST } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const items = createReducer(
-	{},
-	{
-		[ READER_DISMISS_SITE ]: ( state, action ) => {
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_DISMISS_SITE: {
 			return {
 				...state,
 				[ action.payload.siteId ]: true,
 			};
-		},
-		[ READER_DISMISS_POST ]: ( state, action ) => {
+		}
+		case READER_DISMISS_POST: {
 			return {
 				...state,
 				[ action.payload.siteId ]: true,
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/reader/tags/items/reducer.js
+++ b/client/state/reader/tags/items/reducer.js
@@ -8,7 +8,7 @@ import { keyBy, merge, mapValues } from 'lodash';
  * Internal dependencies
  */
 import { READER_TAGS_RECEIVE, READER_UNFOLLOW_TAG_RECEIVE } from 'state/action-types';
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 
 /*
  * since the api always returns the whole list of followed tags unpaginated, both read/tags*,
@@ -16,23 +16,27 @@ import { createReducer } from 'state/utils';
  *
  * the shape of a tag is { id, url, title, displayName, isFollowing }.
  */
-export const items = createReducer( null, {
-	[ READER_TAGS_RECEIVE ]: ( state, action ) => {
-		const tags = action.payload;
-		const resetFollowingData = action.meta.resetFollowingData;
+export const items = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case READER_TAGS_RECEIVE: {
+			const tags = action.payload;
+			const resetFollowingData = action.meta.resetFollowingData;
 
-		if ( ! resetFollowingData ) {
-			return merge( {}, state, keyBy( tags, 'id' ) );
+			if ( ! resetFollowingData ) {
+				return merge( {}, state, keyBy( tags, 'id' ) );
+			}
+
+			const allTagsUnfollowed = mapValues( state, tag => ( { ...tag, isFollowing: false } ) );
+
+			return merge( {}, allTagsUnfollowed, keyBy( tags, 'id' ) );
 		}
+		case READER_UNFOLLOW_TAG_RECEIVE: {
+			const removedTag = action.payload;
+			return merge( {}, state, { [ removedTag ]: { isFollowing: false } } );
+		}
+	}
 
-		const allTagsUnfollowed = mapValues( state, tag => ( { ...tag, isFollowing: false } ) );
-
-		return merge( {}, allTagsUnfollowed, keyBy( tags, 'id' ) );
-	},
-	[ READER_UNFOLLOW_TAG_RECEIVE ]: ( state, action ) => {
-		const removedTag = action.payload;
-		return merge( {}, state, { [ removedTag ]: { isFollowing: false } } );
-	},
+	return state;
 } );
 
 export default items;

--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -7,25 +7,31 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 
-export const items = createReducerWithValidation(
-	[],
-	{
-		[ READER_TEAMS_RECEIVE ]: ( state, action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
+	switch ( action.type ) {
+		case READER_TEAMS_RECEIVE: {
 			if ( action.error ) {
 				return state;
 			}
 			return get( action, [ 'payload', 'teams' ], state );
-		},
-	},
-	itemsSchema
-);
+		}
+	}
 
-export const isRequesting = createReducer( false, {
-	[ READER_TEAMS_REQUEST ]: () => true,
-	[ READER_TEAMS_RECEIVE ]: () => false,
+	return state;
+} );
+
+export const isRequesting = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case READER_TEAMS_REQUEST:
+			return true;
+		case READER_TEAMS_RECEIVE:
+			return false;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/reader/watermarks/reducer.js
+++ b/client/state/reader/watermarks/reducer.js
@@ -7,18 +7,19 @@ import { max } from 'lodash';
  * Internal dependencies
  */
 import { READER_VIEW_STREAM } from 'state/action-types';
-import { createReducerWithValidation, keyedReducer } from 'state/utils';
+import { keyedReducer, withSchemaValidation } from 'state/utils';
 import schema from './watermark-schema';
 
 export const watermarks = keyedReducer(
 	'streamKey',
-	createReducerWithValidation(
-		{},
-		{
-			[ READER_VIEW_STREAM ]: ( state, action ) => max( [ +state, +action.mark ] ),
-		},
-		schema
-	)
+	withSchemaValidation( schema, ( state = {}, action ) => {
+		switch ( action.type ) {
+			case READER_VIEW_STREAM:
+				return max( [ +state, +action.mark ] );
+		}
+
+		return state;
+	} )
 );
 
 watermarks.hasCustomPersistence = true;

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -15,41 +15,57 @@ import {
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Tracks fetching state for keyring connections
-export const isFetching = createReducer( false, {
-	[ KEYRING_CONNECTIONS_REQUEST ]: () => true,
-	[ KEYRING_CONNECTIONS_REQUEST_SUCCESS ]: () => false,
-	[ KEYRING_CONNECTIONS_REQUEST_FAILURE ]: () => false,
+export const isFetching = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case KEYRING_CONNECTIONS_REQUEST:
+			return true;
+		case KEYRING_CONNECTIONS_REQUEST_SUCCESS:
+			return false;
+		case KEYRING_CONNECTIONS_REQUEST_FAILURE:
+			return false;
+	}
+
+	return state;
 } );
 
 // Stores the list of available keyring connections
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ KEYRING_CONNECTIONS_RECEIVE ]: ( state, { connections } ) => ( {
-			...keyBy( connections, 'ID' ),
-		} ),
-		[ KEYRING_CONNECTION_DELETE ]: ( state, { connection } ) => omit( state, connection.ID ),
-		[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection } ) => {
+export const items = withSchemaValidation( itemSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case KEYRING_CONNECTIONS_RECEIVE: {
+			const { connections } = action;
+
+			return {
+				...keyBy( connections, 'ID' ),
+			};
+		}
+		case KEYRING_CONNECTION_DELETE: {
+			const { connection } = action;
+			return omit( state, connection.ID );
+		}
+		case PUBLICIZE_CONNECTION_CREATE: {
+			const { connection } = action;
 			const { keyring_connection_ID: id, site_ID: siteId } = connection;
 			const keyringConnection = state[ id ];
 			const sites = [ ...keyringConnection.sites, siteId.toString() ];
 
 			return { ...state, [ id ]: { ...keyringConnection, sites } };
-		},
-		[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection } ) => {
+		}
+		case PUBLICIZE_CONNECTION_DELETE: {
+			const { connection } = action;
 			const { keyring_connection_ID: id, site_ID: siteId } = connection;
 			const keyringConnection = state[ id ];
 			const sites = without( keyringConnection.sites, siteId.toString() );
 
 			return { ...state, [ id ]: { ...keyringConnection, sites } };
-		},
-	},
-	itemSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	isFetching,

--- a/client/state/sharing/publicize/publicize-actions/reducer.js
+++ b/client/state/sharing/publicize/publicize-actions/reducer.js
@@ -24,7 +24,7 @@ import {
 	PUBLICIZE_SHARE_ACTION_SCHEDULE_SUCCESS,
 	PUBLICIZE_SHARE_ACTION_SCHEDULE_FAILURE,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { publicizeActionsSchema } from './schema';
 
 /**
@@ -52,100 +52,152 @@ export function updateDataForPost( newValue, state, siteId, postId, actionId ) {
 	};
 }
 
-export const scheduled = createReducerWithValidation(
-	{},
-	{
-		[ PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS ]: ( state, { siteId, postId, actions } ) =>
-			updateDataForPost( actions, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_ACTION_DELETE_SUCCESS ]: ( state, { siteId, postId, actionId } ) =>
-			updateDataForPost(
+export const scheduled = withSchemaValidation( publicizeActionsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS: {
+			const { siteId, postId, actions } = action;
+			return updateDataForPost( actions, state, siteId, postId );
+		}
+		case PUBLICIZE_SHARE_ACTION_DELETE_SUCCESS: {
+			const { siteId, postId, actionId } = action;
+
+			return updateDataForPost(
 				omit( get( state, [ siteId, postId ], {} ), [ actionId ] ),
 				state,
 				siteId,
 				postId
-			),
-		[ PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS ]: ( state, { siteId, postId, item } ) =>
-			updateDataForPost( item, state, siteId, postId, item.ID ),
-		[ PUBLICIZE_SHARE_ACTION_SCHEDULE_SUCCESS ]: ( state, { siteId, postId, items } ) => {
+			);
+		}
+		case PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS: {
+			const { siteId, postId, item } = action;
+			return updateDataForPost( item, state, siteId, postId, item.ID );
+		}
+		case PUBLICIZE_SHARE_ACTION_SCHEDULE_SUCCESS: {
+			const { siteId, postId, items } = action;
 			items.forEach(
 				item => ( state = updateDataForPost( item, state, siteId, postId, item.ID ) )
 			);
 			return state;
-		},
-	},
-	publicizeActionsSchema
-);
-
-export const published = createReducerWithValidation(
-	{},
-	{
-		[ PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS ]: ( state, { siteId, postId, actions } ) =>
-			updateDataForPost( actions, state, siteId, postId ),
-	},
-	publicizeActionsSchema
-);
-
-export const fetchingSharePostActionsScheduled = createReducer(
-	{},
-	{
-		[ PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( false, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_FAILURE ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( false, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( true, state, siteId, postId ),
+		}
 	}
-);
 
-export const fetchingSharePostActionsPublished = createReducer(
-	{},
-	{
-		[ PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( false, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_FAILURE ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( false, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( true, state, siteId, postId ),
-	}
-);
+	return state;
+} );
 
-export const deletingSharePostAction = createReducer(
-	{},
-	{
-		[ PUBLICIZE_SHARE_ACTION_DELETE_SUCCESS ]: ( state, { siteId, postId, actionId } ) =>
-			updateDataForPost( false, state, siteId, postId, actionId ),
-		[ PUBLICIZE_SHARE_ACTION_DELETE_FAILURE ]: ( state, { siteId, postId, actionId } ) =>
-			updateDataForPost( false, state, siteId, postId, actionId ),
-		[ PUBLICIZE_SHARE_ACTION_DELETE ]: ( state, { siteId, postId, actionId } ) =>
-			updateDataForPost( true, state, siteId, postId, actionId ),
+export const published = withSchemaValidation( publicizeActionsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS: {
+			const { siteId, postId, actions } = action;
+			return updateDataForPost( actions, state, siteId, postId );
+		}
 	}
-);
 
-export const editingSharePostAction = createReducer(
-	{},
-	{
-		[ PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS ]: ( state, { siteId, postId, item } ) =>
-			updateDataForPost( false, state, siteId, postId, item.ID ),
-		[ PUBLICIZE_SHARE_ACTION_EDIT_FAILURE ]: ( state, { siteId, postId, actionId } ) =>
-			updateDataForPost( false, state, siteId, postId, actionId ),
-		[ PUBLICIZE_SHARE_ACTION_EDIT ]: ( state, { siteId, postId, actionId } ) =>
-			updateDataForPost( true, state, siteId, postId, actionId ),
-	}
-);
+	return state;
+} );
 
-export const schedulingSharePostActionStatus = createReducer(
-	{},
-	{
-		[ PUBLICIZE_SHARE_ACTION_SCHEDULE_SUCCESS ]: ( state, { siteId, postId, share_date } ) =>
-			updateDataForPost( { status: 'success', shareDate: share_date }, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_ACTION_SCHEDULE_FAILURE ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( { status: 'failure' }, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_ACTION_SCHEDULE ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( { status: 'requesting' }, state, siteId, postId ),
-		[ PUBLICIZE_SHARE_DISMISS ]: ( state, { siteId, postId } ) =>
-			updateDataForPost( undefined, state, siteId, postId ),
+export const fetchingSharePostActionsScheduled = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS: {
+			const { siteId, postId } = action;
+			return updateDataForPost( false, state, siteId, postId );
+		}
+		case PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_FAILURE: {
+			const { siteId, postId } = action;
+			return updateDataForPost( false, state, siteId, postId );
+		}
+		case PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST: {
+			const { siteId, postId } = action;
+			return updateDataForPost( true, state, siteId, postId );
+		}
 	}
-);
+
+	return state;
+} );
+
+export const fetchingSharePostActionsPublished = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS: {
+			const { siteId, postId } = action;
+			return updateDataForPost( false, state, siteId, postId );
+		}
+		case PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_FAILURE: {
+			const { siteId, postId } = action;
+			return updateDataForPost( false, state, siteId, postId );
+		}
+		case PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST: {
+			const { siteId, postId } = action;
+			return updateDataForPost( true, state, siteId, postId );
+		}
+	}
+
+	return state;
+} );
+
+export const deletingSharePostAction = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE_ACTION_DELETE_SUCCESS: {
+			const { siteId, postId, actionId } = action;
+			return updateDataForPost( false, state, siteId, postId, actionId );
+		}
+		case PUBLICIZE_SHARE_ACTION_DELETE_FAILURE: {
+			const { siteId, postId, actionId } = action;
+			return updateDataForPost( false, state, siteId, postId, actionId );
+		}
+		case PUBLICIZE_SHARE_ACTION_DELETE: {
+			const { siteId, postId, actionId } = action;
+			return updateDataForPost( true, state, siteId, postId, actionId );
+		}
+	}
+
+	return state;
+} );
+
+export const editingSharePostAction = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS: {
+			const { siteId, postId, item } = action;
+			return updateDataForPost( false, state, siteId, postId, item.ID );
+		}
+		case PUBLICIZE_SHARE_ACTION_EDIT_FAILURE: {
+			const { siteId, postId, actionId } = action;
+			return updateDataForPost( false, state, siteId, postId, actionId );
+		}
+		case PUBLICIZE_SHARE_ACTION_EDIT: {
+			const { siteId, postId, actionId } = action;
+			return updateDataForPost( true, state, siteId, postId, actionId );
+		}
+	}
+
+	return state;
+} );
+
+export const schedulingSharePostActionStatus = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE_ACTION_SCHEDULE_SUCCESS: {
+			const { siteId, postId, share_date } = action;
+			return updateDataForPost(
+				{ status: 'success', shareDate: share_date },
+				state,
+				siteId,
+				postId
+			);
+		}
+		case PUBLICIZE_SHARE_ACTION_SCHEDULE_FAILURE: {
+			const { siteId, postId } = action;
+			return updateDataForPost( { status: 'failure' }, state, siteId, postId );
+		}
+		case PUBLICIZE_SHARE_ACTION_SCHEDULE: {
+			const { siteId, postId } = action;
+			return updateDataForPost( { status: 'requesting' }, state, siteId, postId );
+		}
+		case PUBLICIZE_SHARE_DISMISS: {
+			const { siteId, postId } = action;
+			return updateDataForPost( undefined, state, siteId, postId );
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	scheduled,

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -22,70 +22,100 @@ import {
 	PUBLICIZE_SHARE_FAILURE,
 	PUBLICIZE_SHARE_DISMISS,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { connectionsSchema } from './schema';
 import sharePostActions from './publicize-actions/reducer';
 
-export const sharePostStatus = createReducer(
-	{},
-	{
-		[ PUBLICIZE_SHARE ]: ( state, { siteId, postId } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				[ postId ]: {
-					requesting: true,
-				},
-			},
-		} ),
-		[ PUBLICIZE_SHARE_SUCCESS ]: ( state, { siteId, postId } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				[ postId ]: {
-					requesting: false,
-					success: true,
-				},
-			},
-		} ),
-		[ PUBLICIZE_SHARE_FAILURE ]: ( state, { siteId, postId, error } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				[ postId ]: {
-					requesting: false,
-					success: false,
-					error,
-				},
-			},
-		} ),
-		[ PUBLICIZE_SHARE_DISMISS ]: ( state, { siteId, postId } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				[ postId ]: undefined,
-			},
-		} ),
-	}
-);
+export const sharePostStatus = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_SHARE: {
+			const { siteId, postId } = action;
 
-export const fetchingConnection = createReducer(
-	{},
-	{
-		[ PUBLICIZE_CONNECTION_REQUEST ]: ( state, { connectionId } ) => ( {
-			...state,
-			[ connectionId ]: true,
-		} ),
-		[ PUBLICIZE_CONNECTION_REQUEST_SUCCESS ]: ( state, { connectionId } ) => ( {
-			...state,
-			[ connectionId ]: false,
-		} ),
-		[ PUBLICIZE_CONNECTION_REQUEST_FAILURE ]: ( state, { connectionId } ) => ( {
-			...state,
-			[ connectionId ]: false,
-		} ),
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ postId ]: {
+						requesting: true,
+					},
+				},
+			};
+		}
+		case PUBLICIZE_SHARE_SUCCESS: {
+			const { siteId, postId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ postId ]: {
+						requesting: false,
+						success: true,
+					},
+				},
+			};
+		}
+		case PUBLICIZE_SHARE_FAILURE: {
+			const { siteId, postId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ postId ]: {
+						requesting: false,
+						success: false,
+						error,
+					},
+				},
+			};
+		}
+		case PUBLICIZE_SHARE_DISMISS: {
+			const { siteId, postId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ postId ]: undefined,
+				},
+			};
+		}
 	}
-);
+
+	return state;
+} );
+
+export const fetchingConnection = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_CONNECTION_REQUEST: {
+			const { connectionId } = action;
+
+			return {
+				...state,
+				[ connectionId ]: true,
+			};
+		}
+		case PUBLICIZE_CONNECTION_REQUEST_SUCCESS: {
+			const { connectionId } = action;
+
+			return {
+				...state,
+				[ connectionId ]: false,
+			};
+		}
+		case PUBLICIZE_CONNECTION_REQUEST_FAILURE: {
+			const { connectionId } = action;
+
+			return {
+				...state,
+				[ connectionId ]: false,
+			};
+		}
+	}
+
+	return state;
+} );
 
 /**
  * Track the current status for fetching connections. Maps site ID to the
@@ -93,49 +123,82 @@ export const fetchingConnection = createReducer(
  * `false` for done or failed fetching, or `undefined` if no fetch attempt
  * has been made for the site.
  */
-export const fetchingConnections = createReducer(
-	{},
-	{
-		[ PUBLICIZE_CONNECTIONS_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ PUBLICIZE_CONNECTIONS_RECEIVE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-		[ PUBLICIZE_CONNECTIONS_REQUEST_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-	}
-);
+export const fetchingConnections = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_CONNECTIONS_REQUEST: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case PUBLICIZE_CONNECTIONS_RECEIVE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
+		case PUBLICIZE_CONNECTIONS_REQUEST_FAILURE: {
+			const { siteId } = action;
 
-export const fetchedConnections = createReducer(
-	{},
-	{
-		[ PUBLICIZE_CONNECTIONS_RECEIVE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
+
+export const fetchedConnections = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_CONNECTIONS_RECEIVE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+	}
+
+	return state;
+} );
 
 // Tracks all known connection objects, indexed by connection ID.
-export const connections = createReducerWithValidation(
-	{},
-	{
-		[ PUBLICIZE_CONNECTIONS_RECEIVE ]: ( state, action ) => ( {
-			...omitBy( state, { site_ID: action.siteId } ),
-			...keyBy( action.data.connections, 'ID' ),
-		} ),
-		[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection } ) => ( {
-			...state,
-			[ connection.ID ]: connection,
-		} ),
-		[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection: { ID } } ) => omit( state, ID ),
-		[ PUBLICIZE_CONNECTION_RECEIVE ]: ( state, { connection } ) => ( {
-			...state,
-			[ connection.ID ]: connection,
-		} ),
-		[ PUBLICIZE_CONNECTION_UPDATE ]: ( state, { connection } ) => ( {
-			...state,
-			[ connection.ID ]: connection,
-		} ),
-	},
-	connectionsSchema
-);
+export const connections = withSchemaValidation( connectionsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PUBLICIZE_CONNECTIONS_RECEIVE:
+			return {
+				...omitBy( state, { site_ID: action.siteId } ),
+				...keyBy( action.data.connections, 'ID' ),
+			};
+		case PUBLICIZE_CONNECTION_CREATE: {
+			const { connection } = action;
+
+			return {
+				...state,
+				[ connection.ID ]: connection,
+			};
+		}
+		case PUBLICIZE_CONNECTION_DELETE: {
+			const {
+				connection: { ID },
+			} = action;
+			return omit( state, ID );
+		}
+		case PUBLICIZE_CONNECTION_RECEIVE: {
+			const { connection } = action;
+
+			return {
+				...state,
+				[ connection.ID ]: connection,
+			};
+		}
+		case PUBLICIZE_CONNECTION_UPDATE: {
+			const { connection } = action;
+
+			return {
+				...state,
+				[ connection.ID ]: connection,
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	fetchingConnection,

--- a/client/state/sharing/services/reducer.js
+++ b/client/state/sharing/services/reducer.js
@@ -7,23 +7,31 @@ import {
 	KEYRING_SERVICES_REQUEST_FAILURE,
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Stores the list of available keyring services
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ KEYRING_SERVICES_RECEIVE ]: ( state, action ) => action.services,
-	},
-	itemSchema
-);
+export const items = withSchemaValidation( itemSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case KEYRING_SERVICES_RECEIVE:
+			return action.services;
+	}
+
+	return state;
+} );
 
 // Tracks fetching state for keyring services
-export const isFetching = createReducer( false, {
-	[ KEYRING_SERVICES_REQUEST ]: () => true,
-	[ KEYRING_SERVICES_REQUEST_SUCCESS ]: () => false,
-	[ KEYRING_SERVICES_REQUEST_FAILURE ]: () => false,
+export const isFetching = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case KEYRING_SERVICES_REQUEST:
+			return true;
+		case KEYRING_SERVICES_REQUEST_SUCCESS:
+			return false;
+		case KEYRING_SERVICES_REQUEST_FAILURE:
+			return false;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/shortcodes/reducer.js
+++ b/client/state/shortcodes/reducer.js
@@ -7,7 +7,7 @@ import { intersection, merge, pickBy } from 'lodash';
  * Internal dependencies
  */
 import { shortcodesSchema } from './schema';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import {
 	SHORTCODE_RECEIVE,
 	SHORTCODE_REQUEST,
@@ -39,14 +39,18 @@ const createRequestingReducer = requesting => {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ SHORTCODE_REQUEST ]: createRequestingReducer( true ),
-		[ SHORTCODE_REQUEST_FAILURE ]: createRequestingReducer( false ),
-		[ SHORTCODE_REQUEST_SUCCESS ]: createRequestingReducer( false ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SHORTCODE_REQUEST:
+			return createRequestingReducer( true )( state, action );
+		case SHORTCODE_REQUEST_FAILURE:
+			return createRequestingReducer( false )( state, action );
+		case SHORTCODE_REQUEST_SUCCESS:
+			return createRequestingReducer( false )( state, action );
 	}
-);
+
+	return state;
+} );
 
 function mediaItemsReducer( state, { siteId, data } ) {
 	if ( ! state.hasOwnProperty( siteId ) ) {
@@ -86,21 +90,24 @@ function mediaItemsReducer( state, { siteId, data } ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		FLUX_RECEIVE_MEDIA_ITEM: mediaItemsReducer,
-		FLUX_RECEIVE_MEDIA_ITEMS: mediaItemsReducer,
-		[ SHORTCODE_RECEIVE ]: ( state, { siteId, shortcode, data } ) => {
+export const items = withSchemaValidation( shortcodesSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case 'FLUX_RECEIVE_MEDIA_ITEM':
+			return mediaItemsReducer( state, action );
+		case 'FLUX_RECEIVE_MEDIA_ITEMS':
+			return mediaItemsReducer( state, action );
+		case SHORTCODE_RECEIVE: {
+			const { siteId, shortcode, data } = action;
 			return merge( {}, state, {
 				[ siteId ]: {
 					[ shortcode ]: data,
 				},
 			} );
-		},
-	},
-	shortcodesSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	requesting,

--- a/client/state/signup/optional-dependencies/reducer.js
+++ b/client/state/signup/optional-dependencies/reducer.js
@@ -2,18 +2,18 @@
  * Internal dependencies
  */
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { suggestedUsernameSchema } from './schema';
 
-const suggestedUsername = createReducerWithValidation(
-	'',
-	{
-		[ SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET ]: ( state, action ) => {
+const suggestedUsername = withSchemaValidation( suggestedUsernameSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET: {
 			return action.data;
-		},
-	},
-	suggestedUsernameSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	suggestedUsername,

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -16,7 +16,7 @@ import {
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
 } from 'state/action-types';
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { schema } from './schema';
 
 const debug = debugFactory( 'calypso:state:signup:progress:reducer' );
@@ -102,15 +102,21 @@ const submitStep = ( state, { step } ) => {
 		: addStep( state, { ...step, status } );
 };
 
-export default createReducerWithValidation(
-	{},
-	{
-		[ SIGNUP_COMPLETE_RESET ]: overwriteSteps,
-		[ SIGNUP_PROGRESS_COMPLETE_STEP ]: completeStep,
-		[ SIGNUP_PROGRESS_INVALIDATE_STEP ]: invalidateStep,
-		[ SIGNUP_PROGRESS_PROCESS_STEP ]: processStep,
-		[ SIGNUP_PROGRESS_SAVE_STEP ]: saveStep,
-		[ SIGNUP_PROGRESS_SUBMIT_STEP ]: submitStep,
-	},
-	schema
-);
+export default withSchemaValidation( schema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SIGNUP_COMPLETE_RESET:
+			return overwriteSteps( state, action );
+		case SIGNUP_PROGRESS_COMPLETE_STEP:
+			return completeStep( state, action );
+		case SIGNUP_PROGRESS_INVALIDATE_STEP:
+			return invalidateStep( state, action );
+		case SIGNUP_PROGRESS_PROCESS_STEP:
+			return processStep( state, action );
+		case SIGNUP_PROGRESS_SAVE_STEP:
+			return saveStep( state, action );
+		case SIGNUP_PROGRESS_SUBMIT_STEP:
+			return submitStep( state, action );
+	}
+
+	return state;
+} );

--- a/client/state/signup/segments/reducer.js
+++ b/client/state/signup/segments/reducer.js
@@ -3,9 +3,14 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { SIGNUP_SEGMENTS_SET } from 'state/action-types';
 
-export default createReducer( null, {
-	[ SIGNUP_SEGMENTS_SET ]: ( state, action ) => action.segments,
+export default withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case SIGNUP_SEGMENTS_SET:
+			return action.segments;
+	}
+
+	return state;
 } );

--- a/client/state/signup/steps/design-type/reducer.js
+++ b/client/state/signup/steps/design-type/reducer.js
@@ -3,18 +3,18 @@
  */
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_DESIGN_TYPE_SET } from 'state/action-types';
 
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { designTypeSchema } from './schema';
 
-export default createReducerWithValidation(
-	'',
-	{
-		[ SIGNUP_STEPS_DESIGN_TYPE_SET ]: ( state, action ) => {
+export default withSchemaValidation( designTypeSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_DESIGN_TYPE_SET: {
 			return action.designType;
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+		}
+		case SIGNUP_COMPLETE_RESET: {
 			return '';
-		},
-	},
-	designTypeSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/signup/steps/site-goals/reducer.js
+++ b/client/state/signup/steps/site-goals/reducer.js
@@ -3,18 +3,18 @@
  */
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_GOALS_SET } from 'state/action-types';
 
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { siteGoalsSchema } from './schema';
 
-export default createReducerWithValidation(
-	'',
-	{
-		[ SIGNUP_STEPS_SITE_GOALS_SET ]: ( state, action ) => {
+export default withSchemaValidation( siteGoalsSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_SITE_GOALS_SET: {
 			return action.siteGoals;
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+		}
+		case SIGNUP_COMPLETE_RESET: {
 			return '';
-		},
-	},
-	siteGoalsSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/signup/steps/site-style/reducer.js
+++ b/client/state/signup/steps/site-style/reducer.js
@@ -3,18 +3,18 @@
  */
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_STYLE_SET } from 'state/action-types';
 
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { siteStyleSchema } from './schema';
 
-export default createReducerWithValidation(
-	'',
-	{
-		[ SIGNUP_STEPS_SITE_STYLE_SET ]: ( state, action ) => {
+export default withSchemaValidation( siteStyleSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_SITE_STYLE_SET: {
 			return action.siteStyle;
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+		}
+		case SIGNUP_COMPLETE_RESET: {
 			return '';
-		},
-	},
-	siteStyleSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/signup/steps/site-title/reducer.js
+++ b/client/state/signup/steps/site-title/reducer.js
@@ -3,18 +3,18 @@
  */
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_TITLE_SET } from 'state/action-types';
 
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { siteTitleSchema } from './schema';
 
-export default createReducerWithValidation(
-	'',
-	{
-		[ SIGNUP_STEPS_SITE_TITLE_SET ]: ( state, action ) => {
+export default withSchemaValidation( siteTitleSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_SITE_TITLE_SET: {
 			return action.siteTitle;
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+		}
+		case SIGNUP_COMPLETE_RESET: {
 			return '';
-		},
-	},
-	siteTitleSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/signup/steps/site-type/reducer.js
+++ b/client/state/signup/steps/site-type/reducer.js
@@ -3,18 +3,18 @@
  */
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_TYPE_SET } from 'state/action-types';
 
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { siteTypeSchema } from './schema';
 
-export default createReducerWithValidation(
-	'',
-	{
-		[ SIGNUP_STEPS_SITE_TYPE_SET ]: ( state, action ) => {
+export default withSchemaValidation( siteTypeSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_SITE_TYPE_SET: {
 			return action.siteType;
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+		}
+		case SIGNUP_COMPLETE_RESET: {
 			return '';
-		},
-	},
-	siteTypeSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -11,7 +11,7 @@ import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_STEPS_SITE_VERTICAL_SET,
 } from 'state/action-types';
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { siteVerticalSchema } from './schema';
 
 const initialState = {
@@ -26,21 +26,22 @@ const initialState = {
 // TODO:
 // This reducer can be further simplify since the verticals data can be
 // found in `signup.verticals`, so it only needs to store the site vertical name.
-export default createReducerWithValidation(
-	initialState,
-	{
-		[ SIGNUP_STEPS_SITE_VERTICAL_SET ]: ( state, siteVerticalData ) => {
-			return {
-				...state,
-				...omit( siteVerticalData, 'type' ),
-			};
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+export default withSchemaValidation( siteVerticalSchema, ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_SITE_VERTICAL_SET:
+			return ( ( state, siteVerticalData ) => {
+				return {
+					...state,
+					...omit( siteVerticalData, 'type' ),
+				};
+			} )( state, action );
+		case SIGNUP_COMPLETE_RESET: {
 			return {};
-		},
-		[ JETPACK_CONNECT_AUTHORIZE ]: () => {
+		}
+		case JETPACK_CONNECT_AUTHORIZE: {
 			return {};
-		},
-	},
-	siteVerticalSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -29,12 +29,10 @@ const initialState = {
 export default withSchemaValidation( siteVerticalSchema, ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case SIGNUP_STEPS_SITE_VERTICAL_SET:
-			return ( ( state, siteVerticalData ) => {
-				return {
-					...state,
-					...omit( siteVerticalData, 'type' ),
-				};
-			} )( state, action );
+			return {
+				...state,
+				...omit( action, 'type' ),
+			};
 		case SIGNUP_COMPLETE_RESET: {
 			return {};
 		}

--- a/client/state/signup/steps/survey/reducer.js
+++ b/client/state/signup/steps/survey/reducer.js
@@ -9,14 +9,12 @@ import { surveyStepSchema } from './schema';
 export default withSchemaValidation( surveyStepSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SIGNUP_STEPS_SURVEY_SET:
-			return ( ( state = {}, action ) => {
-				return {
-					...state,
-					vertical: action.survey.vertical,
-					otherText: action.survey.otherText,
-					siteType: action.survey.siteType,
-				};
-			} )( state, action );
+			return {
+				...state,
+				vertical: action.survey.vertical,
+				otherText: action.survey.otherText,
+				siteType: action.survey.siteType,
+			};
 		case SIGNUP_COMPLETE_RESET: {
 			return {};
 		}

--- a/client/state/signup/steps/survey/reducer.js
+++ b/client/state/signup/steps/survey/reducer.js
@@ -3,23 +3,24 @@
  */
 import { SIGNUP_STEPS_SURVEY_SET, SIGNUP_COMPLETE_RESET } from 'state/action-types';
 
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { surveyStepSchema } from './schema';
 
-export default createReducerWithValidation(
-	{},
-	{
-		[ SIGNUP_STEPS_SURVEY_SET ]: ( state = {}, action ) => {
-			return {
-				...state,
-				vertical: action.survey.vertical,
-				otherText: action.survey.otherText,
-				siteType: action.survey.siteType,
-			};
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+export default withSchemaValidation( surveyStepSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_SURVEY_SET:
+			return ( ( state = {}, action ) => {
+				return {
+					...state,
+					vertical: action.survey.vertical,
+					otherText: action.survey.otherText,
+					siteType: action.survey.siteType,
+				};
+			} )( state, action );
+		case SIGNUP_COMPLETE_RESET: {
 			return {};
-		},
-	},
-	surveyStepSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/signup/steps/user-experience/reducer.js
+++ b/client/state/signup/steps/user-experience/reducer.js
@@ -3,18 +3,18 @@
  */
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_USER_EXPERIENCE_SET } from 'state/action-types';
 
-import { createReducerWithValidation } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { userExperienceSchema } from './schema';
 
-export default createReducerWithValidation(
-	'',
-	{
-		[ SIGNUP_STEPS_USER_EXPERIENCE_SET ]: ( state, action ) => {
+export default withSchemaValidation( userExperienceSchema, ( state = '', action ) => {
+	switch ( action.type ) {
+		case SIGNUP_STEPS_USER_EXPERIENCE_SET: {
 			return action.userExperience;
-		},
-		[ SIGNUP_COMPLETE_RESET ]: () => {
+		}
+		case SIGNUP_COMPLETE_RESET: {
 			return '';
-		},
-	},
-	userExperienceSchema
-);
+		}
+	}
+
+	return state;
+} );

--- a/client/state/simple-payments/product-list/reducer.js
+++ b/client/state/simple-payments/product-list/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import productListSchema from './schema';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_RECEIVE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE,
@@ -40,28 +40,44 @@ function addOrEditProduct( list = [], newProduct ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ SIMPLE_PAYMENTS_PRODUCT_RECEIVE ]: ( state, { siteId, product } ) => ( {
-			...state,
-			[ siteId ]: addOrEditProduct( state[ siteId ], product ),
-		} ),
-		[ SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE ]: ( state, { siteId, products } ) => ( {
-			...state,
-			[ siteId ]: products,
-		} ),
-		[ SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE ]: ( state, { siteId, product } ) => ( {
-			...state,
-			[ siteId ]: addOrEditProduct( state[ siteId ], product ),
-		} ),
-		[ SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_DELETE ]: ( state, { siteId, productId } ) => ( {
-			...state,
-			[ siteId ]: state[ siteId ].filter( product => product.ID !== productId ),
-		} ),
-	},
-	productListSchema
-);
+export const items = withSchemaValidation( productListSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SIMPLE_PAYMENTS_PRODUCT_RECEIVE: {
+			const { siteId, product } = action;
+
+			return {
+				...state,
+				[ siteId ]: addOrEditProduct( state[ siteId ], product ),
+			};
+		}
+		case SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE: {
+			const { siteId, products } = action;
+
+			return {
+				...state,
+				[ siteId ]: products,
+			};
+		}
+		case SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE: {
+			const { siteId, product } = action;
+
+			return {
+				...state,
+				[ siteId ]: addOrEditProduct( state[ siteId ], product ),
+			};
+		}
+		case SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_DELETE: {
+			const { siteId, productId } = action;
+
+			return {
+				...state,
+				[ siteId ]: state[ siteId ].filter( product => product.ID !== productId ),
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/site-address-change/reducer.js
+++ b/client/state/site-address-change/reducer.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	SITE_ADDRESS_AVAILABILITY_REQUEST,
 	SITE_ADDRESS_AVAILABILITY_SUCCESS,
@@ -27,20 +27,32 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated rename request state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ SITE_ADDRESS_CHANGE_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ SITE_ADDRESS_CHANGE_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ SITE_ADDRESS_CHANGE_REQUEST_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_ADDRESS_CHANGE_REQUEST: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case SITE_ADDRESS_CHANGE_REQUEST_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case SITE_ADDRESS_CHANGE_REQUEST_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated site-rename state after an action has been dispatched.
@@ -50,76 +62,106 @@ export const requesting = createReducer(
  * @param  {Object} action 	Action object
  * @return {Object} 		Updated rename request state
  */
-export const status = createReducer(
-	{},
-	{
-		[ SITE_ADDRESS_CHANGE_REQUEST ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				status: 'pending',
-				error: false,
-			},
-		} ),
-		[ SITE_ADDRESS_CHANGE_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				status: 'success',
-				error: false,
-			},
-		} ),
-		[ SITE_ADDRESS_CHANGE_REQUEST_FAILURE ]: ( state, { siteId, error } ) => ( {
-			...state,
-			[ siteId ]: {
-				status: 'error',
-				error,
-			},
-		} ),
-	}
-);
+export const status = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_ADDRESS_CHANGE_REQUEST: {
+			const { siteId } = action;
 
-export const validation = createReducer(
-	{},
-	{
-		[ SITE_ADDRESS_AVAILABILITY_REQUEST ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				...get( state, siteId, {} ),
-				pending: true,
-				error: null,
-				isAvailable: null,
-			},
-		} ),
-		[ SITE_ADDRESS_AVAILABILITY_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				...get( state, siteId, {} ),
-				pending: false,
-				error: null,
-				isAvailable: true,
-			},
-		} ),
-		[ SITE_ADDRESS_AVAILABILITY_ERROR ]: ( state, { siteId, errorType, message } ) => ( {
-			...state,
-			[ siteId ]: {
-				...get( state, siteId, {} ),
-				isAvailable: false,
-				pending: false,
-				error: {
-					errorType,
-					message,
+			return {
+				...state,
+				[ siteId ]: {
+					status: 'pending',
+					error: false,
 				},
-			},
-		} ),
-		[ SITE_ADDRESS_AVAILABILITY_ERROR_CLEAR ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: {
-				...get( state, siteId, {} ),
-				error: null,
-				isAvailable: null,
-			},
-		} ),
+			};
+		}
+		case SITE_ADDRESS_CHANGE_REQUEST_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					status: 'success',
+					error: false,
+				},
+			};
+		}
+		case SITE_ADDRESS_CHANGE_REQUEST_FAILURE: {
+			const { siteId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					status: 'error',
+					error,
+				},
+			};
+		}
 	}
-);
+
+	return state;
+} );
+
+export const validation = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_ADDRESS_AVAILABILITY_REQUEST: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...get( state, siteId, {} ),
+					pending: true,
+					error: null,
+					isAvailable: null,
+				},
+			};
+		}
+		case SITE_ADDRESS_AVAILABILITY_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...get( state, siteId, {} ),
+					pending: false,
+					error: null,
+					isAvailable: true,
+				},
+			};
+		}
+		case SITE_ADDRESS_AVAILABILITY_ERROR: {
+			const { siteId, errorType, message } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...get( state, siteId, {} ),
+					isAvailable: false,
+					pending: false,
+					error: {
+						errorType,
+						message,
+					},
+				},
+			};
+		}
+		case SITE_ADDRESS_AVAILABILITY_ERROR_CLEAR: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...get( state, siteId, {} ),
+					error: null,
+					isAvailable: null,
+				},
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	validation,

--- a/client/state/site-roles/reducer.js
+++ b/client/state/site-roles/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { siteRolesSchema } from './schema';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import {
 	SITE_ROLES_RECEIVE,
 	SITE_ROLES_REQUEST,
@@ -19,14 +19,24 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ SITE_ROLES_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ SITE_ROLES_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-		[ SITE_ROLES_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_ROLES_REQUEST: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case SITE_ROLES_REQUEST_SUCCESS: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
+		case SITE_ROLES_REQUEST_FAILURE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. The
@@ -36,13 +46,16 @@ export const requesting = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ SITE_ROLES_RECEIVE ]: ( state, { siteId, roles } ) => ( { ...state, [ siteId ]: roles } ),
-	},
-	siteRolesSchema
-);
+export const items = withSchemaValidation( siteRolesSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_ROLES_RECEIVE: {
+			const { siteId, roles } = action;
+			return { ...state, [ siteId ]: roles };
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	requesting,

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	MEDIA_DELETE,
@@ -28,14 +28,24 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ SITE_SETTINGS_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ SITE_SETTINGS_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-		[ SITE_SETTINGS_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_SETTINGS_REQUEST: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case SITE_SETTINGS_REQUEST_SUCCESS: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
+		case SITE_SETTINGS_REQUEST_FAILURE: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: false };
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the save Request status after an action has been dispatched. The
@@ -45,23 +55,36 @@ export const requesting = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const saveRequests = createReducer(
-	{},
-	{
-		[ SITE_SETTINGS_SAVE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: { saving: true, status: 'pending', error: false },
-		} ),
-		[ SITE_SETTINGS_SAVE_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: { saving: false, status: 'success', error: false },
-		} ),
-		[ SITE_SETTINGS_SAVE_FAILURE ]: ( state, { siteId, error } ) => ( {
-			...state,
-			[ siteId ]: { saving: false, status: 'error', error },
-		} ),
+export const saveRequests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_SETTINGS_SAVE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: { saving: true, status: 'pending', error: false },
+			};
+		}
+		case SITE_SETTINGS_SAVE_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: { saving: false, status: 'success', error: false },
+			};
+		}
+		case SITE_SETTINGS_SAVE_FAILURE: {
+			const { siteId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: { saving: false, status: 'error', error },
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. The
@@ -71,21 +94,29 @@ export const saveRequests = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ SITE_SETTINGS_RECEIVE ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: settings,
-		} ),
-		[ SITE_SETTINGS_UPDATE ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				...settings,
-			},
-		} ),
-		[ MEDIA_DELETE ]: ( state, { siteId, mediaIds } ) => {
+export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_SETTINGS_RECEIVE: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: settings,
+			};
+		}
+		case SITE_SETTINGS_UPDATE: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					...settings,
+				},
+			};
+		}
+		case MEDIA_DELETE: {
+			const { siteId, mediaIds } = action;
 			const settings = state[ siteId ];
 			if ( ! settings || ! includes( mediaIds, settings.site_icon ) ) {
 				return state;
@@ -98,10 +129,11 @@ export const items = createReducerWithValidation(
 					site_icon: null,
 				},
 			};
-		},
-	},
-	itemSchemas
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/sites/blog-stickers/reducer.js
+++ b/client/state/sites/blog-stickers/reducer.js
@@ -14,18 +14,17 @@ import {
 	SITES_BLOG_STICKER_ADD,
 	SITES_BLOG_STICKER_REMOVE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const items = createReducer(
-	{},
-	{
-		[ SITES_BLOG_STICKER_LIST_RECEIVE ]: ( state, action ) => {
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITES_BLOG_STICKER_LIST_RECEIVE: {
 			return {
 				...state,
 				[ action.payload.blogId ]: action.payload.stickers,
 			};
-		},
-		[ SITES_BLOG_STICKER_ADD ]: ( state, action ) => {
+		}
+		case SITES_BLOG_STICKER_ADD: {
 			const { blogId, stickerName } = action.payload;
 
 			// If the blog already has this sticker, do nothing
@@ -37,8 +36,8 @@ export const items = createReducer(
 				...state,
 				[ blogId ]: compact( concat( stickerName, state[ blogId ] ) ),
 			};
-		},
-		[ SITES_BLOG_STICKER_REMOVE ]: ( state, action ) => {
+		}
+		case SITES_BLOG_STICKER_REMOVE: {
 			const { blogId, stickerName } = action.payload;
 
 			// If the blog doesn't have this sticker, do nothing
@@ -50,9 +49,11 @@ export const items = createReducer(
 				...state,
 				[ blogId ]: reject( state[ blogId ], sticker => sticker === stickerName ),
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/sites/connection/reducer.js
+++ b/client/state/sites/connection/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	SITE_CONNECTION_STATUS_RECEIVE,
 	SITE_CONNECTION_STATUS_REQUEST,
@@ -17,24 +17,33 @@ const createRequestingReducer = requesting => ( state, { siteId } ) => ( {
 	[ siteId ]: requesting,
 } );
 
-export const items = createReducer(
-	{},
-	{
-		[ SITE_CONNECTION_STATUS_RECEIVE ]: ( state, { siteId, status } ) => ( {
-			...state,
-			[ siteId ]: status,
-		} ),
-	}
-);
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_CONNECTION_STATUS_RECEIVE: {
+			const { siteId, status } = action;
 
-export const requesting = createReducer(
-	{},
-	{
-		[ SITE_CONNECTION_STATUS_REQUEST ]: createRequestingReducer( true ),
-		[ SITE_CONNECTION_STATUS_REQUEST_FAILURE ]: createRequestingReducer( false ),
-		[ SITE_CONNECTION_STATUS_REQUEST_SUCCESS ]: createRequestingReducer( false ),
+			return {
+				...state,
+				[ siteId ]: status,
+			};
+		}
 	}
-);
+
+	return state;
+} );
+
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_CONNECTION_STATUS_REQUEST:
+			return createRequestingReducer( true )( state, action );
+		case SITE_CONNECTION_STATUS_REQUEST_FAILURE:
+			return createRequestingReducer( false )( state, action );
+		case SITE_CONNECTION_STATUS_REQUEST_SUCCESS:
+			return createRequestingReducer( false )( state, action );
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/sites/guided-transfer/reducer.js
+++ b/client/state/sites/guided-transfer/reducer.js
@@ -10,86 +10,92 @@ import {
 	GUIDED_TRANSFER_STATUS_REQUEST_FAILURE,
 	GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { guidedTransferStatusSchema } from './schema';
 
 // Stores the status of guided transfers per site
-export const status = createReducerWithValidation(
-	{},
-	{
-		[ GUIDED_TRANSFER_STATUS_RECEIVE ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: action.guidedTransferStatus,
-		} ),
-	},
-	guidedTransferStatusSchema
-);
-
-// Tracks whether we're fetching the status of a guided transfer for a site
-export const isFetching = createReducer(
-	{},
-	{
-		[ GUIDED_TRANSFER_STATUS_REQUEST ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: true,
-		} ),
-
-		[ GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: false,
-		} ),
-
-		[ GUIDED_TRANSFER_STATUS_REQUEST_FAILURE ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: false,
-		} ),
+export const status = withSchemaValidation( guidedTransferStatusSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case GUIDED_TRANSFER_STATUS_RECEIVE:
+			return {
+				...state,
+				[ action.siteId ]: action.guidedTransferStatus,
+			};
 	}
-);
+
+	return state;
+} );
 
 // Tracks whether we're fetching the status of a guided transfer for a site
-export const error = createReducer(
-	{},
-	{
-		[ GUIDED_TRANSFER_HOST_DETAILS_SAVE ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: null,
-		} ),
+export const isFetching = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case GUIDED_TRANSFER_STATUS_REQUEST:
+			return {
+				...state,
+				[ action.siteId ]: true,
+			};
+		case GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS:
+			return {
+				...state,
+				[ action.siteId ]: false,
+			};
+		case GUIDED_TRANSFER_STATUS_REQUEST_FAILURE:
+			return {
+				...state,
+				[ action.siteId ]: false,
+			};
+	}
 
-		[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: null,
-		} ),
+	return state;
+} );
 
-		[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_FAILURE ]: ( state, action ) => {
+// Tracks whether we're fetching the status of a guided transfer for a site
+export const error = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case GUIDED_TRANSFER_HOST_DETAILS_SAVE:
+			return {
+				...state,
+				[ action.siteId ]: null,
+			};
+		case GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS:
+			return {
+				...state,
+				[ action.siteId ]: null,
+			};
+		case GUIDED_TRANSFER_HOST_DETAILS_SAVE_FAILURE: {
 			let errorCode = true;
 			if ( action.error && action.error.error ) {
 				errorCode = action.error.error;
 			}
 			return { ...state, [ action.siteId ]: errorCode };
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 // Tracks whether we're saving host details on a guided transfer for a site
-export const isSaving = createReducer(
-	{},
-	{
-		[ GUIDED_TRANSFER_HOST_DETAILS_SAVE ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: true,
-		} ),
-
-		[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: false,
-		} ),
-
-		[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_FAILURE ]: ( state, action ) => ( {
-			...state,
-			[ action.siteId ]: false,
-		} ),
+export const isSaving = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case GUIDED_TRANSFER_HOST_DETAILS_SAVE:
+			return {
+				...state,
+				[ action.siteId ]: true,
+			};
+		case GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS:
+			return {
+				...state,
+				[ action.siteId ]: false,
+			};
+		case GUIDED_TRANSFER_HOST_DETAILS_SAVE_FAILURE:
+			return {
+				...state,
+				[ action.siteId ]: false,
+			};
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	error,

--- a/client/state/sites/monitor/reducer.js
+++ b/client/state/sites/monitor/reducer.js
@@ -9,7 +9,7 @@ import { stubFalse, stubTrue } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 import {
 	SITE_MONITOR_SETTINGS_RECEIVE,
 	SITE_MONITOR_SETTINGS_REQUEST,
@@ -20,38 +20,51 @@ import {
 	SITE_MONITOR_SETTINGS_UPDATE_SUCCESS,
 } from 'state/action-types';
 
-export const items = createReducer(
-	{},
-	{
-		[ SITE_MONITOR_SETTINGS_RECEIVE ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: settings,
-		} ),
+export const items = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_MONITOR_SETTINGS_RECEIVE: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: settings,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 export const requesting = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ SITE_MONITOR_SETTINGS_REQUEST ]: stubTrue,
-			[ SITE_MONITOR_SETTINGS_REQUEST_SUCCESS ]: stubFalse,
-			[ SITE_MONITOR_SETTINGS_REQUEST_FAILURE ]: stubFalse,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case SITE_MONITOR_SETTINGS_REQUEST:
+				return stubTrue( state, action );
+			case SITE_MONITOR_SETTINGS_REQUEST_SUCCESS:
+				return stubFalse( state, action );
+			case SITE_MONITOR_SETTINGS_REQUEST_FAILURE:
+				return stubFalse( state, action );
 		}
-	)
+
+		return state;
+	} )
 );
 
 export const updating = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ SITE_MONITOR_SETTINGS_UPDATE ]: stubTrue,
-			[ SITE_MONITOR_SETTINGS_UPDATE_SUCCESS ]: stubFalse,
-			[ SITE_MONITOR_SETTINGS_UPDATE_FAILURE ]: stubFalse,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case SITE_MONITOR_SETTINGS_UPDATE:
+				return stubTrue( state, action );
+			case SITE_MONITOR_SETTINGS_UPDATE_SUCCESS:
+				return stubFalse( state, action );
+			case SITE_MONITOR_SETTINGS_UPDATE_FAILURE:
+				return stubFalse( state, action );
 		}
-	)
+
+		return state;
+	} )
 );
 
 export default combineReducers( {

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -40,10 +40,9 @@ import {
 import { sitesSchema, hasAllSitesListSchema } from './schema';
 import {
 	combineReducers,
-	createReducer,
-	createReducerWithValidation,
 	keyedReducer,
 	withSchemaValidation,
+	withoutPersistence,
 } from 'state/utils';
 
 /**
@@ -257,10 +256,17 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const requestingAll = createReducer( false, {
-	[ SITES_REQUEST ]: () => true,
-	[ SITES_REQUEST_FAILURE ]: () => false,
-	[ SITES_REQUEST_SUCCESS ]: () => false,
+export const requestingAll = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case SITES_REQUEST:
+			return true;
+		case SITES_REQUEST_FAILURE:
+			return false;
+		case SITES_REQUEST_SUCCESS:
+			return false;
+	}
+
+	return state;
 } );
 
 /**
@@ -271,20 +277,24 @@ export const requestingAll = createReducer( false, {
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ SITE_REQUEST ]: ( state, { siteId } ) => {
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_REQUEST: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: true };
-		},
-		[ SITE_REQUEST_FAILURE ]: ( state, { siteId } ) => {
+		}
+		case SITE_REQUEST_FAILURE: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: false };
-		},
-		[ SITE_REQUEST_SUCCESS ]: ( state, { siteId } ) => {
+		}
+		case SITE_REQUEST_SUCCESS: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: false };
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated deleting state after an action has been dispatched.
@@ -296,14 +306,18 @@ export const requesting = createReducer(
  */
 export const deleting = keyedReducer(
 	'siteId',
-	createReducer(
-		{},
-		{
-			[ SITE_DELETE ]: stubTrue,
-			[ SITE_DELETE_FAILURE ]: stubFalse,
-			[ SITE_DELETE_SUCCESS ]: stubFalse,
+	withoutPersistence( ( state = {}, action ) => {
+		switch ( action.type ) {
+			case SITE_DELETE:
+				return stubTrue( state, action );
+			case SITE_DELETE_FAILURE:
+				return stubFalse( state, action );
+			case SITE_DELETE_SUCCESS:
+				return stubFalse( state, action );
 		}
-	)
+
+		return state;
+	} )
 );
 
 /**
@@ -313,12 +327,16 @@ export const deleting = keyedReducer(
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const hasAllSitesList = createReducerWithValidation(
-	false,
-	{
-		[ SITES_RECEIVE ]: () => true,
-	},
-	hasAllSitesListSchema
+export const hasAllSitesList = withSchemaValidation(
+	hasAllSitesListSchema,
+	( state = false, action ) => {
+		switch ( action.type ) {
+			case SITES_RECEIVE:
+				return true;
+		}
+
+		return state;
+	}
 );
 
 export default combineReducers( {

--- a/client/state/sites/sharing-buttons/reducer.js
+++ b/client/state/sites/sharing-buttons/reducer.js
@@ -6,7 +6,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	SHARING_BUTTONS_RECEIVE,
@@ -27,20 +27,32 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ SHARING_BUTTONS_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-		[ SHARING_BUTTONS_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ SHARING_BUTTONS_REQUEST_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SHARING_BUTTONS_REQUEST: {
+			const { siteId } = action;
+			return { ...state, [ siteId ]: true };
+		}
+		case SHARING_BUTTONS_REQUEST_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case SHARING_BUTTONS_REQUEST_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the save Request status after an action has been dispatched. The
@@ -50,23 +62,36 @@ export const requesting = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const saveRequests = createReducer(
-	{},
-	{
-		[ SHARING_BUTTONS_SAVE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: { saving: true, status: 'pending' },
-		} ),
-		[ SHARING_BUTTONS_SAVE_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: { saving: false, status: 'success' },
-		} ),
-		[ SHARING_BUTTONS_SAVE_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: { saving: false, status: 'error' },
-		} ),
+export const saveRequests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SHARING_BUTTONS_SAVE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: { saving: true, status: 'pending' },
+			};
+		}
+		case SHARING_BUTTONS_SAVE_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: { saving: false, status: 'success' },
+			};
+		}
+		case SHARING_BUTTONS_SAVE_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: { saving: false, status: 'error' },
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. The
@@ -76,20 +101,28 @@ export const saveRequests = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ SHARING_BUTTONS_RECEIVE ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: settings,
-		} ),
-		[ SHARING_BUTTONS_UPDATE ]: ( state, { siteId, settings } ) => ( {
-			...state,
-			[ siteId ]: uniqBy( settings.concat( state[ siteId ] || [] ), 'ID' ),
-		} ),
-	},
-	itemSchemas
-);
+export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SHARING_BUTTONS_RECEIVE: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: settings,
+			};
+		}
+		case SHARING_BUTTONS_UPDATE: {
+			const { siteId, settings } = action;
+
+			return {
+				...state,
+				[ siteId ]: uniqBy( settings.concat( state[ siteId ] || [] ), 'ID' ),
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -7,7 +7,7 @@ import { merge, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
 import {
@@ -24,10 +24,10 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const requests = createReducer(
-	{},
-	{
-		[ SITE_STATS_REQUEST ]: ( state, { siteId, statType, query } ) => {
+export const requests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_STATS_REQUEST: {
+			const { siteId, statType, query } = action;
 			const queryKey = getSerializedStatsQuery( query );
 			return merge( {}, state, {
 				[ siteId ]: {
@@ -36,8 +36,9 @@ export const requests = createReducer(
 					},
 				},
 			} );
-		},
-		[ SITE_STATS_RECEIVE ]: ( state, { siteId, statType, query, date } ) => {
+		}
+		case SITE_STATS_RECEIVE: {
+			const { siteId, statType, query, date } = action;
 			const queryKey = getSerializedStatsQuery( query );
 			return merge( {}, state, {
 				[ siteId ]: {
@@ -46,8 +47,9 @@ export const requests = createReducer(
 					},
 				},
 			} );
-		},
-		[ SITE_STATS_REQUEST_FAILURE ]: ( state, { siteId, statType, query } ) => {
+		}
+		case SITE_STATS_REQUEST_FAILURE: {
+			const { siteId, statType, query } = action;
 			const queryKey = getSerializedStatsQuery( query );
 			return merge( {}, state, {
 				[ siteId ]: {
@@ -56,9 +58,11 @@ export const requests = createReducer(
 					},
 				},
 			} );
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. The

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -11,7 +11,7 @@ import {
 	STORED_CARDS_DELETE_COMPLETED,
 	STORED_CARDS_DELETE_FAILED,
 } from 'state/action-types';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { storedCardsSchema } from './schema';
 
 /**
@@ -22,18 +22,24 @@ import { storedCardsSchema } from './schema';
  * @param  {Object} action storeCard action
  * @return {Array}         Updated state
  */
-export const items = createReducerWithValidation(
-	[],
-	{
-		[ STORED_CARDS_ADD_COMPLETED ]: ( state, { item } ) => [ ...state, item ],
+export const items = withSchemaValidation( storedCardsSchema, ( state = [], action ) => {
+	switch ( action.type ) {
+		case STORED_CARDS_ADD_COMPLETED: {
+			const { item } = action;
+			return [ ...state, item ];
+		}
+		case STORED_CARDS_FETCH_COMPLETED: {
+			const { list } = action;
+			return list;
+		}
+		case STORED_CARDS_DELETE_COMPLETED: {
+			const { card } = action;
+			return state.filter( item => item.stored_details_id !== card.stored_details_id );
+		}
+	}
 
-		[ STORED_CARDS_FETCH_COMPLETED ]: ( state, { list } ) => list,
-
-		[ STORED_CARDS_DELETE_COMPLETED ]: ( state, { card } ) =>
-			state.filter( item => item.stored_details_id !== card.stored_details_id ),
-	},
-	storedCardsSchema
-);
+	return state;
+} );
 
 /**
  * Returns whether the list of stored cards has been loaded from the server in reaction to the specified action.

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -16,7 +16,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
@@ -53,10 +53,9 @@ export function queryRequests( state = {}, action ) {
  * The state reflects a mapping of serialized query key to an array of term IDs
  * for the query, if a query response was successfully received.
  */
-export const queries = createReducerWithValidation(
-	{},
-	{
-		[ TERMS_RECEIVE ]: ( state, action ) => {
+export const queries = withSchemaValidation( queriesSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case TERMS_RECEIVE: {
 			const { siteId, query, taxonomy, terms, found } = action;
 			const hasManager = state[ siteId ] && state[ siteId ][ taxonomy ];
 			const manager = hasManager ? state[ siteId ][ taxonomy ] : new TermQueryManager();
@@ -73,8 +72,8 @@ export const queries = createReducerWithValidation(
 					[ taxonomy ]: nextManager,
 				},
 			};
-		},
-		[ TERM_REMOVE ]: ( state, action ) => {
+		}
+		case TERM_REMOVE: {
 			const { siteId, taxonomy, termId } = action;
 			if ( ! state[ siteId ] || ! state[ siteId ][ taxonomy ] ) {
 				return state;
@@ -92,24 +91,25 @@ export const queries = createReducerWithValidation(
 					[ taxonomy ]: nextManager,
 				},
 			};
-		},
-		[ SERIALIZE ]: state => {
+		}
+		case SERIALIZE: {
 			return mapValues( state, taxonomies => {
 				return mapValues( taxonomies, ( { data, options } ) => {
 					return { data, options };
 				} );
 			} );
-		},
-		[ DESERIALIZE ]: state => {
+		}
+		case DESERIALIZE: {
 			return mapValues( state, taxonomies => {
 				return mapValues( taxonomies, ( { data, options } ) => {
 					return new TermQueryManager( data, options );
 				} );
 			} );
-		},
-	},
-	queriesSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	queries,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -7,7 +7,7 @@ import { mapValues, omit, map } from 'lodash';
  * Internal dependencies
  */
 import ThemeQueryManager from 'lib/query-manager/theme';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -52,20 +52,28 @@ import { decodeEntities } from 'lib/formatting';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const activeThemes = createReducerWithValidation(
-	{},
-	{
-		[ THEME_ACTIVATE_SUCCESS ]: ( state, { siteId, themeStylesheet } ) => ( {
-			...state,
-			[ siteId ]: getThemeIdFromStylesheet( themeStylesheet ),
-		} ),
-		[ ACTIVE_THEME_REQUEST_SUCCESS ]: ( state, { siteId, theme } ) => ( {
-			...state,
-			[ siteId ]: theme.id,
-		} ),
-	},
-	activeThemesSchema
-);
+export const activeThemes = withSchemaValidation( activeThemesSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_ACTIVATE_SUCCESS: {
+			const { siteId, themeStylesheet } = action;
+
+			return {
+				...state,
+				[ siteId ]: getThemeIdFromStylesheet( themeStylesheet ),
+			};
+		}
+		case ACTIVE_THEME_REQUEST_SUCCESS: {
+			const { siteId, theme } = action;
+
+			return {
+				...state,
+				[ siteId ]: theme.id,
+			};
+		}
+	}
+
+	return state;
+} );
 
 /**
  * Returns the updated theme activation state after an action has been
@@ -99,19 +107,28 @@ export function activationRequests( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const completedActivationRequests = createReducer(
-	{},
-	{
-		[ THEME_ACTIVATE_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: true,
-		} ),
-		[ THEME_CLEAR_ACTIVATED ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+export const completedActivationRequests = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_ACTIVATE_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: true,
+			};
+		}
+		case THEME_CLEAR_ACTIVATED: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated active theme request state after an action has been
@@ -193,22 +210,33 @@ export function themeInstalls( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const themeRequestErrors = createReducerWithValidation(
-	{},
-	{
-		[ THEME_REQUEST_FAILURE ]: ( state, { siteId, themeId, error } ) => ( {
-			...state,
-			[ siteId ]: {
-				...state[ siteId ],
-				[ themeId ]: error,
-			},
-		} ),
-		[ THEME_REQUEST_SUCCESS ]: ( state, { siteId, themeId } ) => ( {
-			...state,
-			[ siteId ]: omit( state[ siteId ], themeId ),
-		} ),
-	},
-	themeRequestErrorsSchema
+export const themeRequestErrors = withSchemaValidation(
+	themeRequestErrorsSchema,
+	( state = {}, action ) => {
+		switch ( action.type ) {
+			case THEME_REQUEST_FAILURE: {
+				const { siteId, themeId, error } = action;
+
+				return {
+					...state,
+					[ siteId ]: {
+						...state[ siteId ],
+						[ themeId ]: error,
+					},
+				};
+			}
+			case THEME_REQUEST_SUCCESS: {
+				const { siteId, themeId } = action;
+
+				return {
+					...state,
+					[ siteId ]: omit( state[ siteId ], themeId ),
+				};
+			}
+		}
+
+		return state;
+	}
 );
 
 /**
@@ -245,10 +273,10 @@ export function queryRequests( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const queryRequestErrors = createReducer(
-	{},
-	{
-		[ THEMES_REQUEST_FAILURE ]: ( state, { siteId, query, error } ) => {
+export const queryRequestErrors = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEMES_REQUEST_FAILURE: {
+			const { siteId, query, error } = action;
 			const serializedQuery = getSerializedThemesQuery( query, siteId );
 			return {
 				...state,
@@ -257,16 +285,19 @@ export const queryRequestErrors = createReducer(
 					[ serializedQuery ]: error,
 				},
 			};
-		},
-		[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query } ) => {
+		}
+		case THEMES_REQUEST_SUCCESS: {
+			const { siteId, query } = action;
 			const serializedQuery = getSerializedThemesQuery( query, siteId );
 			return {
 				...state,
 				[ siteId ]: omit( state[ siteId ], serializedQuery ),
 			};
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated theme query state after an action has been dispatched.
@@ -313,10 +344,10 @@ export const queries = ( () => {
 	// days * hours_in_day * minutes_in_hour * seconds_in_minute * miliseconds_in_second
 	const MAX_THEMES_AGE = 1 * 24 * 60 * 60 * 1000;
 
-	return createReducerWithValidation(
-		{},
-		{
-			[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query, themes, found } ) => {
+	return withSchemaValidation( queriesSchema, ( state = {}, action ) => {
+		switch ( action.type ) {
+			case THEMES_REQUEST_SUCCESS: {
+				const { siteId, query, themes, found } = action;
 				return applyToManager(
 					// Always 'patch' to avoid overwriting existing fields when receiving
 					// from a less rich endpoint such as /mine
@@ -327,16 +358,17 @@ export const queries = ( () => {
 					map( themes, fromApi ),
 					{ query, found, patch: true }
 				);
-			},
-			[ THEME_DELETE_SUCCESS ]: ( state, { siteId, themeId } ) => {
+			}
+			case THEME_DELETE_SUCCESS: {
+				const { siteId, themeId } = action;
 				return applyToManager( state, siteId, 'removeItem', false, themeId );
-			},
-			[ SERIALIZE ]: state => {
+			}
+			case SERIALIZE: {
 				const serializedState = mapValues( state, ( { data, options } ) => ( { data, options } ) );
 				serializedState._timestamp = Date.now();
 				return serializedState;
-			},
-			[ DESERIALIZE ]: state => {
+			}
+			case DESERIALIZE: {
 				if ( state._timestamp && state._timestamp + MAX_THEMES_AGE < Date.now() ) {
 					return {};
 				}
@@ -344,10 +376,11 @@ export const queries = ( () => {
 				return mapValues( noTimestampState, ( { data, options } ) => {
 					return new ThemeQueryManager( data, options );
 				} );
-			},
-		},
-		queriesSchema
-	);
+			}
+		}
+
+		return state;
+	} );
 } )();
 
 /**
@@ -358,15 +391,20 @@ export const queries = ( () => {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const lastQuery = createReducer(
-	{},
-	{
-		[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query } ) => ( {
-			...state,
-			[ siteId ]: query,
-		} ),
+export const lastQuery = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEMES_REQUEST_SUCCESS: {
+			const { siteId, query } = action;
+
+			return {
+				...state,
+				[ siteId ]: query,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated previewing theme state
@@ -376,15 +414,20 @@ export const lastQuery = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const themePreviewOptions = createReducer(
-	{},
-	{
-		[ THEME_PREVIEW_OPTIONS ]: ( state, { primary, secondary } ) => ( {
-			primary,
-			secondary,
-		} ),
+export const themePreviewOptions = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_PREVIEW_OPTIONS: {
+			const { primary, secondary } = action;
+
+			return {
+				primary,
+				secondary,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated previewing theme state
@@ -394,17 +437,27 @@ export const themePreviewOptions = createReducer(
  * @param  {Object} action Action payload
  * @return {Bool}          Updated state
  */
-export const themePreviewVisibility = createReducer( null, {
-	[ THEME_PREVIEW_STATE ]: ( state, { themeId } ) => themeId,
+export const themePreviewVisibility = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case THEME_PREVIEW_STATE: {
+			const { themeId } = action;
+			return themeId;
+		}
+	}
+
+	return state;
 } );
 
-export const themeFilters = createReducerWithValidation(
-	{},
-	{
-		[ THEME_FILTERS_ADD ]: ( state, { filters } ) => filters,
-	},
-	themeFiltersSchema
-);
+export const themeFilters = withSchemaValidation( themeFiltersSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_FILTERS_ADD: {
+			const { filters } = action;
+			return filters;
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	queries,

--- a/client/state/themes/upload-theme/reducer.js
+++ b/client/state/themes/upload-theme/reducer.js
@@ -9,7 +9,7 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import {
 	THEME_UPLOAD_START,
 	THEME_UPLOAD_SUCCESS,
@@ -23,115 +23,224 @@ import {
 	THEME_TRANSFER_STATUS_RECEIVE,
 } from 'state/action-types';
 
-export const uploadedThemeId = createReducer(
-	{},
-	{
-		[ THEME_UPLOAD_SUCCESS ]: ( state, { siteId, themeId } ) => ( {
-			...state,
-			[ siteId ]: themeId,
-		} ),
-		[ THEME_TRANSFER_STATUS_RECEIVE ]: ( state, { siteId, themeId } ) => ( {
-			...state,
-			[ siteId ]: themeId,
-		} ),
-		[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_UPLOAD_START ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => omit( state, siteId ),
-	}
-);
+export const uploadedThemeId = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_UPLOAD_SUCCESS: {
+			const { siteId, themeId } = action;
 
-export const uploadError = createReducer(
-	{},
-	{
-		[ THEME_UPLOAD_FAILURE ]: ( state, { siteId, error } ) => ( {
-			...state,
-			[ siteId ]: error,
-		} ),
-		[ THEME_TRANSFER_STATUS_FAILURE ]: ( state, { siteId, error } ) => ( {
-			...state,
-			[ siteId ]: error,
-		} ),
-		[ THEME_TRANSFER_INITIATE_FAILURE ]: ( state, { siteId, error } ) => ( {
-			...state,
-			[ siteId ]: error,
-		} ),
-		[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_UPLOAD_START ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => omit( state, siteId ),
-	}
-);
+			return {
+				...state,
+				[ siteId ]: themeId,
+			};
+		}
+		case THEME_TRANSFER_STATUS_RECEIVE: {
+			const { siteId, themeId } = action;
 
-export const progressLoaded = createReducer(
-	{},
-	{
-		[ THEME_UPLOAD_PROGRESS ]: ( state, { siteId, loaded } ) => ( {
-			...state,
-			[ siteId ]: loaded,
-		} ),
-		[ THEME_TRANSFER_INITIATE_PROGRESS ]: ( state, { siteId, loaded } ) => ( {
-			...state,
-			[ siteId ]: loaded,
-		} ),
-		[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_UPLOAD_START ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => omit( state, siteId ),
+			return {
+				...state,
+				[ siteId ]: themeId,
+			};
+		}
+		case THEME_UPLOAD_CLEAR: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_UPLOAD_START: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_TRANSFER_INITIATE_REQUEST: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
 	}
-);
 
-export const progressTotal = createReducer(
-	{},
-	{
-		[ THEME_UPLOAD_PROGRESS ]: ( state, { siteId, total } ) => ( {
-			...state,
-			[ siteId ]: total,
-		} ),
-		[ THEME_TRANSFER_INITIATE_PROGRESS ]: ( state, { siteId, total } ) => ( {
-			...state,
-			[ siteId ]: total,
-		} ),
-		[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_UPLOAD_START ]: ( state, { siteId } ) => omit( state, siteId ),
-		[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => omit( state, siteId ),
-	}
-);
+	return state;
+} );
 
-export const inProgress = createReducer(
-	{},
-	{
-		[ THEME_UPLOAD_START ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: true,
-		} ),
-		[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: true,
-		} ),
-		[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ THEME_UPLOAD_SUCCESS ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ THEME_UPLOAD_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ THEME_TRANSFER_STATUS_RECEIVE ]: ( state, { siteId, status } ) => ( {
-			...state,
-			[ siteId ]: status !== 'complete',
-		} ),
-		[ THEME_TRANSFER_INITIATE_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
-		[ THEME_TRANSFER_STATUS_FAILURE ]: ( state, { siteId } ) => ( {
-			...state,
-			[ siteId ]: false,
-		} ),
+export const uploadError = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_UPLOAD_FAILURE: {
+			const { siteId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: error,
+			};
+		}
+		case THEME_TRANSFER_STATUS_FAILURE: {
+			const { siteId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: error,
+			};
+		}
+		case THEME_TRANSFER_INITIATE_FAILURE: {
+			const { siteId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: error,
+			};
+		}
+		case THEME_UPLOAD_CLEAR: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_UPLOAD_START: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_TRANSFER_INITIATE_REQUEST: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
 	}
-);
+
+	return state;
+} );
+
+export const progressLoaded = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_UPLOAD_PROGRESS: {
+			const { siteId, loaded } = action;
+
+			return {
+				...state,
+				[ siteId ]: loaded,
+			};
+		}
+		case THEME_TRANSFER_INITIATE_PROGRESS: {
+			const { siteId, loaded } = action;
+
+			return {
+				...state,
+				[ siteId ]: loaded,
+			};
+		}
+		case THEME_UPLOAD_CLEAR: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_UPLOAD_START: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_TRANSFER_INITIATE_REQUEST: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+	}
+
+	return state;
+} );
+
+export const progressTotal = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_UPLOAD_PROGRESS: {
+			const { siteId, total } = action;
+
+			return {
+				...state,
+				[ siteId ]: total,
+			};
+		}
+		case THEME_TRANSFER_INITIATE_PROGRESS: {
+			const { siteId, total } = action;
+
+			return {
+				...state,
+				[ siteId ]: total,
+			};
+		}
+		case THEME_UPLOAD_CLEAR: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_UPLOAD_START: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+		case THEME_TRANSFER_INITIATE_REQUEST: {
+			const { siteId } = action;
+			return omit( state, siteId );
+		}
+	}
+
+	return state;
+} );
+
+export const inProgress = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case THEME_UPLOAD_START: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: true,
+			};
+		}
+		case THEME_TRANSFER_INITIATE_REQUEST: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: true,
+			};
+		}
+		case THEME_UPLOAD_CLEAR: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case THEME_UPLOAD_SUCCESS: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case THEME_UPLOAD_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case THEME_TRANSFER_STATUS_RECEIVE: {
+			const { siteId, status } = action;
+
+			return {
+				...state,
+				[ siteId ]: status !== 'complete',
+			};
+		}
+		case THEME_TRANSFER_INITIATE_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+		case THEME_TRANSFER_STATUS_FAILURE: {
+			const { siteId } = action;
+
+			return {
+				...state,
+				[ siteId ]: false,
+			};
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	uploadedThemeId,

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -1,34 +1,37 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { TIMEZONES_RECEIVE } from 'state/action-types';
 
 import { rawOffsetsSchema, labelsSchema, continentsSchema } from './schema';
 
-export const rawOffsets = createReducerWithValidation(
-	{},
-	{
-		[ TIMEZONES_RECEIVE ]: ( state, actions ) => actions.rawOffsets,
-	},
-	rawOffsetsSchema
-);
+export const rawOffsets = withSchemaValidation( rawOffsetsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case TIMEZONES_RECEIVE:
+			return ( ( state, actions ) => actions.rawOffsets )( state, action );
+	}
 
-export const labels = createReducerWithValidation(
-	{},
-	{
-		[ TIMEZONES_RECEIVE ]: ( state, actions ) => actions.labels,
-	},
-	labelsSchema
-);
+	return state;
+} );
 
-export const byContinents = createReducerWithValidation(
-	{},
-	{
-		[ TIMEZONES_RECEIVE ]: ( state, actions ) => actions.byContinents,
-	},
-	continentsSchema
-);
+export const labels = withSchemaValidation( labelsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case TIMEZONES_RECEIVE:
+			return ( ( state, actions ) => actions.labels )( state, action );
+	}
+
+	return state;
+} );
+
+export const byContinents = withSchemaValidation( continentsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case TIMEZONES_RECEIVE:
+			return ( ( state, actions ) => actions.byContinents )( state, action );
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	rawOffsets,

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -9,7 +9,7 @@ import { rawOffsetsSchema, labelsSchema, continentsSchema } from './schema';
 export const rawOffsets = withSchemaValidation( rawOffsetsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case TIMEZONES_RECEIVE:
-			return ( ( state, actions ) => actions.rawOffsets )( state, action );
+			return action.rawOffsets;
 	}
 
 	return state;
@@ -18,7 +18,7 @@ export const rawOffsets = withSchemaValidation( rawOffsetsSchema, ( state = {}, 
 export const labels = withSchemaValidation( labelsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case TIMEZONES_RECEIVE:
-			return ( ( state, actions ) => actions.labels )( state, action );
+			return action.labels;
 	}
 
 	return state;
@@ -27,7 +27,7 @@ export const labels = withSchemaValidation( labelsSchema, ( state = {}, action )
 export const byContinents = withSchemaValidation( continentsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case TIMEZONES_RECEIVE:
-			return ( ( state, actions ) => actions.byContinents )( state, action );
+			return action.byContinents;
 	}
 
 	return state;

--- a/client/state/ui/drop-zone/reducer.js
+++ b/client/state/ui/drop-zone/reducer.js
@@ -6,22 +6,31 @@
 
 import { DROPZONE_SHOW, DROPZONE_HIDE } from 'state/action-types';
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
 // TODO(biskobe) - Can be improved with `keyedReducer` instead of state spread.
-const isVisible = createReducer(
-	{},
-	{
-		[ DROPZONE_SHOW ]: ( state, { dropZoneName } ) => ( {
-			...state,
-			[ dropZoneName ]: true,
-		} ),
-		[ DROPZONE_HIDE ]: ( state, { dropZoneName } ) => ( {
-			...state,
-			[ dropZoneName ]: false,
-		} ),
+const isVisible = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case DROPZONE_SHOW: {
+			const { dropZoneName } = action;
+
+			return {
+				...state,
+				[ dropZoneName ]: true,
+			};
+		}
+		case DROPZONE_HIDE: {
+			const { dropZoneName } = action;
+
+			return {
+				...state,
+				[ dropZoneName ]: false,
+			};
+		}
 	}
-);
+
+	return state;
+} );
 
 export default combineReducers( {
 	isVisible,

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -17,7 +17,7 @@ import {
 	IMAGE_EDITOR_STATE_RESET_ALL,
 	IMAGE_EDITOR_IMAGE_HAS_LOADED,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { AspectRatios } from './constants';
 
 export const defaultTransform = {
@@ -67,11 +67,17 @@ export function hasChanges( state = false, action ) {
 	return state;
 }
 
-export const originalAspectRatio = createReducer( null, {
-	[ IMAGE_EDITOR_IMAGE_HAS_LOADED ]: ( state, { width, height } ) => {
-		return { width, height };
-	},
-	[ IMAGE_EDITOR_STATE_RESET_ALL ]: () => null,
+export const originalAspectRatio = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case IMAGE_EDITOR_IMAGE_HAS_LOADED: {
+			const { width, height } = action;
+			return { width, height };
+		}
+		case IMAGE_EDITOR_STATE_RESET_ALL:
+			return null;
+	}
+
+	return state;
 } );
 
 export function imageIsLoading( state = true, action ) {

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -94,10 +94,10 @@ export function imageIsLoading( state = true, action ) {
 
 export function fileInfo( state = defaultFileInfo, action ) {
 	switch ( action.type ) {
-		case IMAGE_EDITOR_SET_FILE_INFO:
+		case IMAGE_EDITOR_SET_FILE_INFO: {
 			const { src, fileName, mimeType, title } = action;
 			return { ...state, src, fileName, mimeType, title };
-
+		}
 		case IMAGE_EDITOR_STATE_RESET_ALL:
 			return {
 				...state,
@@ -171,7 +171,7 @@ export function aspectRatio( state = AspectRatios.FREE, action ) {
 		case IMAGE_EDITOR_SET_DEFAULT_ASPECT_RATIO:
 			return action.ratio;
 		case IMAGE_EDITOR_STATE_RESET:
-		case IMAGE_EDITOR_STATE_RESET_ALL:
+		case IMAGE_EDITOR_STATE_RESET_ALL: {
 			const { additionalData = {} } = action;
 			const { aspectRatio: payloadAspectRatio } = additionalData;
 
@@ -180,6 +180,7 @@ export function aspectRatio( state = AspectRatios.FREE, action ) {
 			}
 
 			return AspectRatios.FREE;
+		}
 	}
 
 	return state;

--- a/client/state/ui/google-my-business/reducer.js
+++ b/client/state/ui/google-my-business/reducer.js
@@ -3,11 +3,18 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
 import { GOOGLE_MY_BUSINESS_STATS_CHANGE_INTERVAL } from 'state/action-types';
 
-const statsInterval = createReducer( 'week', {
-	[ GOOGLE_MY_BUSINESS_STATS_CHANGE_INTERVAL ]: ( state, { interval } ) => interval,
+const statsInterval = withoutPersistence( ( state = 'week', action ) => {
+	switch ( action.type ) {
+		case GOOGLE_MY_BUSINESS_STATS_CHANGE_INTERVAL: {
+			const { interval } = action;
+			return interval;
+		}
+	}
+
+	return state;
 } );
 
 export default keyedReducer(

--- a/client/state/ui/media-modal/reducer.js
+++ b/client/state/ui/media-modal/reducer.js
@@ -4,11 +4,16 @@
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { MEDIA_MODAL_VIEW_SET } from 'state/action-types';
 
-export const view = createReducer( null, {
-	[ MEDIA_MODAL_VIEW_SET ]: ( state, action ) => action.view,
+export const view = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case MEDIA_MODAL_VIEW_SET:
+			return action.view;
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/ui/nps-survey-notice/reducer.js
+++ b/client/state/ui/nps-survey-notice/reducer.js
@@ -5,11 +5,17 @@
  */
 
 import { NPS_SURVEY_DIALOG_IS_SHOWING } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 
-export const isNpsSurveyDialogShowing = createReducer( false, {
-	[ NPS_SURVEY_DIALOG_IS_SHOWING ]: ( state, { isShowing } ) =>
-		isShowing !== undefined ? isShowing : state,
+export const isNpsSurveyDialogShowing = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case NPS_SURVEY_DIALOG_IS_SHOWING: {
+			const { isShowing } = action;
+			return isShowing !== undefined ? isShowing : state;
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/ui/oauth2-clients/reducer.js
+++ b/client/state/ui/oauth2-clients/reducer.js
@@ -9,21 +9,26 @@ import { startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import { ROUTE_SET } from 'state/action-types';
 
-export const currentClientId = createReducer( null, {
-	[ ROUTE_SET ]: ( state, { path, query } ) => {
-		if ( startsWith( path, '/log-in' ) ) {
-			return query.client_id ? Number( query.client_id ) : state;
-		}
+export const currentClientId = withoutPersistence( ( state = null, action ) => {
+	switch ( action.type ) {
+		case ROUTE_SET: {
+			const { path, query } = action;
+			if ( startsWith( path, '/log-in' ) ) {
+				return query.client_id ? Number( query.client_id ) : state;
+			}
 
-		if ( startsWith( path, '/start/wpcc' ) || startsWith( path, '/start/crowdsignal' ) ) {
-			return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
-		}
+			if ( startsWith( path, '/start/wpcc' ) || startsWith( path, '/start/crowdsignal' ) ) {
+				return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
+			}
 
-		return state;
-	},
+			return state;
+		}
+	}
+
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/ui/payment/reducer.js
+++ b/client/state/ui/payment/reducer.js
@@ -7,7 +7,7 @@ import { find, get, has } from 'lodash';
  * Internal dependencies
  */
 import { PAYMENT_COUNTRY_CODE_SET, PAYMENT_POSTAL_CODE_SET } from 'state/action-types';
-import { combineReducers, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { paymentCountryCodeSchema, paymentPostalCodeSchema } from './schema';
 
 /**
@@ -30,24 +30,30 @@ export const extractStoredCardMetaValue = ( action, meta_key ) =>
  * @param  {Object} action - The action object containing the new country code.
  * @return {Object} - The updated global state.
  */
-export const countryCode = createReducerWithValidation(
-	null,
-	{
-		[ PAYMENT_COUNTRY_CODE_SET ]: ( state, action ) => action.countryCode,
-		[ 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET' ]: ( state, action ) =>
-			has( action, 'rawDetails.country' ) ? get( action, 'rawDetails.country', null ) : state,
-		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) => {
-			const { payment } = action;
-			if ( has( payment, 'newCardDetails' ) ) {
-				return get( payment, 'newCardDetails.country', null );
+export const countryCode = withSchemaValidation(
+	paymentCountryCodeSchema,
+	( state = null, action ) => {
+		switch ( action.type ) {
+			case PAYMENT_COUNTRY_CODE_SET:
+				return action.countryCode;
+			case 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET':
+				return has( action, 'rawDetails.country' )
+					? get( action, 'rawDetails.country', null )
+					: state;
+			case 'FLUX_TRANSACTION_PAYMENT_SET': {
+				const { payment } = action;
+				if ( has( payment, 'newCardDetails' ) ) {
+					return get( payment, 'newCardDetails.country', null );
+				}
+				if ( has( payment, 'storedCard' ) ) {
+					return extractStoredCardMetaValue( action, 'country_code' ) || null;
+				}
+				return state;
 			}
-			if ( has( payment, 'storedCard' ) ) {
-				return extractStoredCardMetaValue( action, 'country_code' ) || null;
-			}
-			return state;
-		},
-	},
-	paymentCountryCodeSchema
+		}
+
+		return state;
+	}
 );
 
 /**
@@ -57,28 +63,32 @@ export const countryCode = createReducerWithValidation(
  * @param  {Object} action - The action object containing the new postalCode.
  * @return {Object} - The updated global state.
  */
-export const postalCode = createReducerWithValidation(
-	null,
-	{
-		[ PAYMENT_POSTAL_CODE_SET ]: ( state, action ) => action.postalCode,
-		[ 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET' ]: ( state, action ) =>
-			has( action, 'rawDetails.postal-code' )
-				? get( action, 'rawDetails.postal-code', null )
-				: state,
-		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) => {
-			const { payment } = action;
-			if ( has( payment, 'newCardDetails' ) ) {
-				return get( payment, 'newCardDetails.postal-code', null );
-			}
+export const postalCode = withSchemaValidation(
+	paymentPostalCodeSchema,
+	( state = null, action ) => {
+		switch ( action.type ) {
+			case PAYMENT_POSTAL_CODE_SET:
+				return action.postalCode;
+			case 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET':
+				return has( action, 'rawDetails.postal-code' )
+					? get( action, 'rawDetails.postal-code', null )
+					: state;
+			case 'FLUX_TRANSACTION_PAYMENT_SET': {
+				const { payment } = action;
+				if ( has( payment, 'newCardDetails' ) ) {
+					return get( payment, 'newCardDetails.postal-code', null );
+				}
 
-			if ( has( payment, 'storedCard' ) ) {
-				return extractStoredCardMetaValue( action, 'card_zip' ) || null;
-			}
+				if ( has( payment, 'storedCard' ) ) {
+					return extractStoredCardMetaValue( action, 'card_zip' ) || null;
+				}
 
-			return state;
-		},
-	},
-	paymentPostalCodeSchema
+				return state;
+			}
+		}
+
+		return state;
+	}
 );
 
 export default combineReducers( {

--- a/client/state/ui/reader/card-expansions/reducer.js
+++ b/client/state/ui/reader/card-expansions/reducer.js
@@ -4,14 +4,13 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { READER_EXPAND_CARD, READER_RESET_CARD_EXPANSIONS } from 'state/action-types';
 import { keyToString } from 'reader/post-key';
 
-export default createReducer(
-	{},
-	{
-		[ READER_EXPAND_CARD ]: ( state, action ) => {
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_EXPAND_CARD: {
 			if ( ! action.payload.postKey ) {
 				return state;
 			}
@@ -22,7 +21,10 @@ export default createReducer(
 				...state,
 				[ keyToString( postKey ) ]: true,
 			};
-		},
-		[ READER_RESET_CARD_EXPANSIONS ]: () => ( {} ),
+		}
+		case READER_RESET_CARD_EXPANSIONS:
+			return {};
 	}
-);
+
+	return state;
+} );

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -7,7 +7,7 @@ import {
 	PREVIEW_IS_SHOWING,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
 import actionLog from './action-log/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import comments from './comments/reducer';
@@ -46,8 +46,13 @@ export function selectedSiteId( state = null, action ) {
 	return state;
 }
 
-export const siteSelectionInitialized = createReducer( false, {
-	[ SELECTED_SITE_SET ]: () => true,
+export const siteSelectionInitialized = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case SELECTED_SITE_SET:
+			return true;
+	}
+
+	return state;
 } );
 
 export function hasSidebar( state = true, action ) {
@@ -66,9 +71,15 @@ export function isLoading( state = false, action ) {
 	return state;
 }
 
-export const isPreviewShowing = createReducer( false, {
-	[ PREVIEW_IS_SHOWING ]: ( state, { isShowing } ) =>
-		isShowing !== undefined ? isShowing : state,
+export const isPreviewShowing = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case PREVIEW_IS_SHOWING: {
+			const { isShowing } = action;
+			return isShowing !== undefined ? isShowing : state;
+		}
+	}
+
+	return state;
 } );
 
 /**

--- a/client/state/user-devices/reducer.js
+++ b/client/state/user-devices/reducer.js
@@ -4,12 +4,16 @@
  * Internal dependencies
  */
 
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import { USER_DEVICES_ADD } from 'state/action-types';
 
-export default createReducer(
-	{},
-	{
-		[ USER_DEVICES_ADD ]: ( state, { devices } ) => ( { ...state, ...devices } ),
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case USER_DEVICES_ADD: {
+			const { devices } = action;
+			return { ...state, ...devices };
+		}
 	}
-);
+
+	return state;
+} );

--- a/client/state/users/suggestions/reducer.js
+++ b/client/state/users/suggestions/reducer.js
@@ -7,7 +7,7 @@ import {
 	USER_SUGGESTIONS_REQUEST_FAILURE,
 	USER_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -18,20 +18,24 @@ import { itemsSchema } from './schema';
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const requesting = createReducer(
-	{},
-	{
-		[ USER_SUGGESTIONS_REQUEST ]: ( state, { siteId } ) => {
+export const requesting = withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case USER_SUGGESTIONS_REQUEST: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: true };
-		},
-		[ USER_SUGGESTIONS_REQUEST_FAILURE ]: ( state, { siteId } ) => {
+		}
+		case USER_SUGGESTIONS_REQUEST_FAILURE: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: false };
-		},
-		[ USER_SUGGESTIONS_REQUEST_SUCCESS ]: ( state, { siteId } ) => {
+		}
+		case USER_SUGGESTIONS_REQUEST_SUCCESS: {
+			const { siteId } = action;
 			return { ...state, [ siteId ]: false };
-		},
+		}
 	}
-);
+
+	return state;
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. Items
@@ -42,15 +46,16 @@ export const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const items = createReducerWithValidation(
-	{},
-	{
-		[ USER_SUGGESTIONS_RECEIVE ]: ( state, { siteId, suggestions } ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case USER_SUGGESTIONS_RECEIVE: {
+			const { siteId, suggestions } = action;
 			return { ...state, [ siteId ]: suggestions };
-		},
-	},
-	itemsSchema
-);
+		}
+	}
+
+	return state;
+} );
 
 export default combineReducers( {
 	requesting,


### PR DESCRIPTION
This PR was generated from the following codemod: Automattic/calypso-codemods#8

The code it produces appears to be sane, and there are no instances of the possible TODO introduced by the codemod to be manually handled.

I also applied some manual changes to improve generated code, where linting issues popped up.

All Calypso unit tests continue to work after this mod.

#### Changes proposed in this Pull Request

* Replace most usage of `createReducer` and `createReducerWithValidation` in the codebase, after the deprecation in #35905. 

#### Testing instructions

This touches a lot of state, so it's difficult to provide detailed testing instructions. Use as much of Calypso as you feel like, and see if anything goes wrong.

I also enabled the full suite of E2E tests to provide some measure of assurance.
