### PR TITLE
calypso-build: remove dependency on calypso-color-schemes

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,6 @@
 			"version": "file:packages/calypso-build",
 			"dev": true,
 			"requires": {
-				"@automattic/calypso-color-schemes": "file:packages/calypso-color-schemes",
 				"@babel/core": "7.6.2",
 				"@babel/plugin-proposal-class-properties": "7.5.5",
 				"@babel/plugin-syntax-dynamic-import": "7.2.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -34,7 +34,6 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
-		"@automattic/calypso-color-schemes": "file:../calypso-color-schemes",
 		"@babel/core": "7.6.2",
 		"@babel/plugin-proposal-class-properties": "7.5.5",
 		"@babel/plugin-syntax-dynamic-import": "7.2.0",

--- a/packages/calypso-build/postcss.config.js
+++ b/packages/calypso-build/postcss.config.js
@@ -1,7 +1,9 @@
-module.exports = ( { options: { preserveCssCustomProperties = true } } ) => ( {
+module.exports = ( {
+	options: { preserveCssCustomProperties = true, importCssCustomPropertiesFrom },
+} ) => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+			importFrom: importCssCustomPropertiesFrom,
 			preserve: preserveCssCustomProperties,
 		},
 		autoprefixer: {},

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -106,10 +106,7 @@ function getWebpackConfig(
 					presets,
 					workerCount,
 				} ),
-				SassConfig.loader( {
-					preserveCssCustomProperties: false,
-					prelude: '@import "~@automattic/calypso-color-schemes/src/shared/colors";',
-				} ),
+				SassConfig.loader(),
 				FileConfig.loader(),
 			],
 		},

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -16,7 +16,12 @@ const path = require( 'path' );
  *
  * @return {Object}                                   webpack loader object
  */
-module.exports.loader = ( { preserveCssCustomProperties, includePaths, prelude } ) => ( {
+module.exports.loader = ( {
+	preserveCssCustomProperties,
+	importCssCustomPropertiesFrom,
+	includePaths,
+	prelude,
+} = {} ) => ( {
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPluginWithRTL.loader,
@@ -32,6 +37,7 @@ module.exports.loader = ( { preserveCssCustomProperties, includePaths, prelude }
 				config: {
 					ctx: {
 						preserveCssCustomProperties,
+						importCssCustomPropertiesFrom,
 					},
 					path: path.join( __dirname, '..' ),
 				},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -236,6 +236,7 @@ const webpackConfig = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
+				importCssCustomPropertiesFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
 				preserveCssCustomProperties: true,
 				includePaths: [ path.join( __dirname, 'client' ) ],
 				prelude: `@import '${ path.join(


### PR DESCRIPTION
Removes the `calypso-build` dependency on `calypso-color-schemes` and lets projects that use both packages configure the needed CSS bits explicitly.

Fixes #36466. 

- removes the `calypso-color-schemes` colors prelude from the default webpack config. That was useful when the colors were defined as SCSS variables, but now when they are defined as CSS variables included in the CSS output, the prelude no longer makes sense
- removes the default `importFrom` declaration from `postcss-custom-properties` default config and replaces that with configurable `importCssCustomPropertiesFrom` option for the `SassConfig` preset.
- updates Calypso webpack config to use the new `importCssCustomPropertiesFrom` option.

Let's see how this works with other projects that use `calypso-build`.

A little reminder about what `postcss-custom-properties` does: when there is a CSS rule that uses a CSS variable:
```css
:root {
  --color: red;
}

h1 {
  color: var( --color );
}
```
it has one problem: it doesn't work in IE11 and other old browsers without CSS variable support. `postcss-custom-properties` adds a "polyfill" here. With `preserve: false`, it inlines the variable:
```css
h1 {
  color: red;
}
```
With `preserve: true`, it preserves the CSS variable and adds a fallback definition:
```css
h1 {
  color: red;
  color: var( --color );
}
```
Browser with CSS variable support uses the version with a variable (that can be overridden with a different value, depending on active CSS classes), IE11 uses the fallback.

`importFrom` option specified a module where to import the CSS variables from. When compiling modularized CSS with webpack, the CSS variable definitions are in a different compilation unit (the entrypoint) and the compiled CSS doesn't see them. They only come together after webpack bundles all the pieces together.