### PR TITLE
Adds a new signup path to make testing easier

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -339,6 +339,22 @@ export function generateFlows( {
 		};
 	}
 
+	if ( isEnabled( 'signup/global-styles' ) ) {
+		flows[ 'test-global-styles' ] = {
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getSignupDestination,
+			description: 'A copy of `onboarding` for testing Global Styles',
+			lastModified: '2019-10-02',
+		};
+	}
+
 	return flows;
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -144,6 +144,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": true,
 		"signup/full-site-editing": true,
+		"signup/global-styles": true,
 		"signup/import": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -94,6 +94,7 @@
 		"settings/theme-setup": false,
 		"sign-in-with-apple": false,
 		"signup/full-site-editing": true,
+		"signup/global-styles": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,


### PR DESCRIPTION
Related: D33655-code.

This adds a new signup path so creating sites for testing the global styles work is easier.


