### PR TITLE
Checklist: Updating the selector for Atomic sites to have the right task list

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -5,14 +5,13 @@
 import page from 'page';
 import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { get, includes, forEach } from 'lodash';
+import { get, includes } from 'lodash';
 import { isDesktop } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { getTaskList } from './wpcom-task-list';
 import { Checklist, Task } from 'components/checklist';
 import ChecklistBanner from './checklist-banner';
 import ChecklistBannerTask from './checklist-banner/task';
@@ -20,6 +19,7 @@ import ChecklistNavigation from './checklist-navigation';
 import ChecklistPrompt from './checklist-prompt';
 import ChecklistPromptTask from './checklist-prompt/task';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
+import getSiteTaskList from 'state/selectors/get-site-task-list';
 import QueryPosts from 'components/data/query-posts';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { successNotice } from 'state/notices/actions';
@@ -230,7 +230,7 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	nextInlineHelp = () => {
-		const taskList = getTaskList( this.props );
+		const taskList = this.props.taskList;
 		const firstIncomplete = taskList.getFirstIncompleteTask();
 
 		if ( firstIncomplete ) {
@@ -250,8 +250,8 @@ class WpcomChecklistComponent extends PureComponent {
 		const {
 			phase2,
 			siteId,
+			taskList,
 			taskStatuses,
-			taskUrls,
 			viewMode,
 			updateCompletion,
 			setNotification,
@@ -260,15 +260,6 @@ class WpcomChecklistComponent extends PureComponent {
 			showNotification,
 			storedTask,
 		} = this.props;
-
-		const taskList = getTaskList( this.props );
-
-		// Hide a task when we can't find the exact URL of the target page.
-		forEach( taskUrls, ( url, taskId ) => {
-			if ( ! url ) {
-				taskList.remove( taskId );
-			}
-		} );
 
 		let ChecklistComponent = Checklist;
 
@@ -1019,16 +1010,17 @@ export default connect(
 		const siteChecklist = getSiteChecklist( state, siteId );
 		const user = getCurrentUser( state );
 		const taskUrls = getChecklistTaskUrls( state, siteId );
+		const taskList = getSiteTaskList( state, siteId );
 
 		return {
 			designType: getSiteOption( state, siteId, 'design_type' ),
 			phase2: get( siteChecklist, 'phase2' ),
 			siteId,
 			siteSlug,
-			siteSegment: get( siteChecklist, 'segment' ),
 			siteVerticals: get( siteChecklist, 'verticals' ),
 			taskStatuses: get( siteChecklist, 'tasks' ),
 			taskUrls,
+			taskList,
 			userEmail: ( user && user.email ) || '',
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			isSiteUnlaunched: isUnlaunchedSite( state, siteId ),

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -1036,7 +1036,7 @@ function getPageEditorUrl( state, siteId, pageId ) {
 	return getEditorUrl( state, siteId, pageId, 'page' );
 }
 
-const getTaskUrls = createSelector(
+export const getTaskUrls = createSelector(
 	( state, siteId ) => {
 		const posts = getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY );
 		const firstPostID = get( find( posts, { type: 'post' } ), [ 0, 'ID' ] );

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -129,6 +129,12 @@ class WpcomTaskList {
 		return found;
 	}
 
+	removeTasksWithoutUrls( taskUrls ) {
+		const hasUrl = task => ! ( task.id in taskUrls ) && taskUrls[ task.id ];
+
+		this.tasks = this.tasks.filter( hasUrl );
+	}
+
 	getFirstIncompleteTask() {
 		return this.tasks.find( task => ! task.isCompleted );
 	}

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -130,7 +130,7 @@ class WpcomTaskList {
 	}
 
 	removeTasksWithoutUrls( taskUrls ) {
-		const hasUrl = task => ! ( task.id in taskUrls ) && taskUrls[ task.id ];
+		const hasUrl = task => ! ( task.id in taskUrls ) || taskUrls[ task.id ];
 
 		this.tasks = this.tasks.filter( hasUrl );
 	}

--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { find, get, some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPostsForQuery } from 'state/posts/selectors';
+import getEditorUrl from 'state/selectors/get-editor-url';
+import { getSiteOption } from 'state/sites/selectors';
+import createSelector from 'lib/create-selector';
+
+export const FIRST_TEN_SITE_POSTS_QUERY = { type: 'any', number: 10, order_by: 'ID', order: 'ASC' };
+
+function getContactPage( posts ) {
+	return get(
+		find(
+			posts,
+			post =>
+				post.type === 'page' &&
+				( some( post.metadata, { key: '_headstart_post', value: '_hs_contact_page' } ) ||
+					post.slug === 'contact' )
+		),
+		'ID',
+		null
+	);
+}
+
+function getPageEditorUrl( state, siteId, pageId ) {
+	if ( ! pageId ) {
+		return null;
+	}
+
+	return getEditorUrl( state, siteId, pageId, 'page' );
+}
+
+export default createSelector(
+	( state, siteId ) => {
+		const posts = getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY );
+		const firstPostID = get( find( posts, { type: 'post' } ), [ 0, 'ID' ] );
+		const contactPageUrl = getPageEditorUrl( state, siteId, getContactPage( posts ) );
+		const frontPageUrl = getPageEditorUrl(
+			state,
+			siteId,
+			getSiteOption( state, siteId, 'page_on_front' )
+		);
+
+		return {
+			post_published: getPageEditorUrl( state, siteId, firstPostID ),
+			contact_page_updated: contactPageUrl,
+			about_text_updated: frontPageUrl,
+			front_page_updated: frontPageUrl,
+			homepage_photo_updated: frontPageUrl,
+			business_hours_added: frontPageUrl,
+			service_list_added: frontPageUrl,
+			staff_info_added: frontPageUrl,
+			product_list_added: frontPageUrl,
+		};
+	},
+	( state, siteId ) => [ getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY ) ]
+);

--- a/client/state/selectors/get-site-task-list.js
+++ b/client/state/selectors/get-site-task-list.js
@@ -1,0 +1,31 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { getTaskList } from 'my-sites/checklist/wpcom-checklist/wpcom-task-list';
+import getSiteChecklist from './get-site-checklist';
+import getChecklistTaskUrls from './get-checklist-task-urls';
+
+/**
+ * Returns the checklist for the specified site ID
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {Object}        Site settings
+ */
+export default function getSiteTaskList( state, siteId ) {
+	const siteChecklist = getSiteChecklist( state, siteId );
+	const taskList = getTaskList( {
+		taskStatuses: get( siteChecklist, 'tasks' ),
+		phase2: get( siteChecklist, 'phase2' ),
+		siteVerticals: get( siteChecklist, 'verticals' ),
+		siteSegment: get( siteChecklist, 'siteSegment' ),
+	} );
+	const taskUrls = getChecklistTaskUrls( state, siteId );
+	taskList.removeTasksWithoutUrls( taskUrls );
+	return taskList;
+}

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -3,11 +3,10 @@
 /**
  * Internal dependencies
  */
+import getSiteTaskList from 'state/selectors/get-site-task-list';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 import { getSiteFrontPage } from 'state/sites/selectors';
-import { getTaskList } from 'my-sites/checklist/wpcom-checklist/wpcom-task-list';
-import getChecklistTaskUrls from 'state/selectors/get-checklist-task-urls';
 
 /**
  * Checks whether the tasklist has been completed.
@@ -52,14 +51,6 @@ export default function isSiteChecklistComplete( state, siteId ) {
 		return false;
 	};
 
-	const taskList = getTaskList( {
-		taskStatuses: siteChecklist.tasks,
-		phase2: siteChecklist.phase2,
-		siteVerticals: siteChecklist.verticals,
-		siteSegment: siteChecklist.siteSegment,
-	} ).getAll();
-	const taskUrls = getChecklistTaskUrls( state, siteId );
-	const hasNotUrl = task => ! ( task.id in taskUrls && ! taskUrls[ task.id ] );
-
-	return taskList.filter( hasNotUrl ).every( isTaskComplete );
+	const taskList = getSiteTaskList( state, siteId );
+	return taskList.getAll().every( isTaskComplete );
 }

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -7,7 +7,7 @@ import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 import { getSiteFrontPage } from 'state/sites/selectors';
 import { getTaskList } from 'my-sites/checklist/wpcom-checklist/wpcom-task-list';
-import { getTaskUrls } from 'my-sites/checklist/wpcom-checklist/component';
+import getChecklistTaskUrls from 'state/selectors/get-checklist-task-urls';
 
 /**
  * Checks whether the tasklist has been completed.
@@ -58,8 +58,8 @@ export default function isSiteChecklistComplete( state, siteId ) {
 		siteVerticals: siteChecklist.verticals,
 		siteSegment: siteChecklist.siteSegment,
 	} ).getAll();
-	const taskUrls = getTaskUrls( state, siteId );
-	const hasUrl = task => ! ( taskUrls.hasOwnProperty( task.id ) && ! taskUrls[ task.id ] );
+	const taskUrls = getChecklistTaskUrls( state, siteId );
+	const hasNotUrl = task => ! ( task.id in taskUrls && ! taskUrls[ task.id ] );
 
-	return taskList.filter( hasUrl ).every( isTaskComplete );
+	return taskList.filter( hasNotUrl ).every( isTaskComplete );
 }

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -6,6 +6,8 @@
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 import { getSiteFrontPage } from 'state/sites/selectors';
+import { getTaskList } from 'my-sites/checklist/wpcom-checklist/wpcom-task-list';
+import { getTaskUrls } from 'my-sites/checklist/wpcom-checklist/component';
 
 /**
  * Checks whether the tasklist has been completed.
@@ -50,5 +52,14 @@ export default function isSiteChecklistComplete( state, siteId ) {
 		return false;
 	};
 
-	return siteChecklist.tasks.every( isTaskComplete );
+	const taskList = getTaskList( {
+		taskStatuses: siteChecklist.tasks,
+		phase2: siteChecklist.phase2,
+		siteVerticals: siteChecklist.verticals,
+		siteSegment: siteChecklist.siteSegment,
+	} ).getAll();
+	const taskUrls = getTaskUrls( state, siteId );
+	const hasUrl = task => ! ( taskUrls.hasOwnProperty( task.id ) && ! taskUrls[ task.id ] );
+
+	return taskList.filter( hasUrl ).every( isTaskComplete );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The selector to check if the checklist is complete didn't work for AT sites, as the checklist tasks are overridden with ones defined in the code. AT sites do not have a `phase2` checklist. This imports and replicates the logic used in the `WpComChecklist` component, so we can correctly determine if the checklist is complete on AT sites.

#### Testing instructions

- Create a new AT site. 
- Ensure that you are assigned to the `show` variant of the `customerHomePage` A/B test using the menu in the environemnt badge.
- Complete the checklist tasks (or skip them all)
- The Customer Home page should display and not the standard checklist congratulations message.

#### N.B.

If someone completes the checklist on a simple site and then it becomes AT. then they will have a different set of tasks and the site's checklist will not be complete. They will be shown the checklist again and will need to complete additional tasks before they see the customer home. This doesn't feel like a great UX, but while the inconsistencies exist between the checklists, I think it's the best we can do!