### PR TITLE
Add an is_gutenberg-opt-out-enabled selector to fix missing Switch to Classic button

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -61,6 +61,7 @@ import { getActiveTheme } from 'state/themes/selectors';
 import { getSiteOption } from 'state/sites/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
+import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -384,7 +385,8 @@ function mapStateToProps( state, { moment } ) {
 
 	const isAllowedToUseClassic =
 		! isSiteUsingFullSiteEditing( state, siteId ) && ! isUsingGutenbergPageTemplates;
-	const showOptOut = optInEnabled && isGutenbergEditor && isAllowedToUseClassic;
+	const showOptOut =
+		isGutenbergOptOutEnabled( state, siteId ) && isGutenbergEditor && isAllowedToUseClassic;
 
 	return {
 		isOnboardingWelcomeVisible: isEligibleForChecklist && isOnboardingWelcomePromptVisible( state ),

--- a/client/state/selectors/is-gutenberg-opt-out-enabled.js
+++ b/client/state/selectors/is-gutenberg-opt-out-enabled.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getSelectedEditor from 'state/selectors/get-selected-editor';
+import isClassicEditorForced from 'state/selectors/is-classic-editor-forced';
+
+export const isGutenbergOptOutEnabled = ( state, siteId ) => {
+	return (
+		get( state, [ 'gutenbergOptIn', siteId ], true ) &&
+		getSelectedEditor( state, siteId ) === 'gutenberg-iframe' &&
+		! isClassicEditorForced( state, siteId )
+	);
+};
+
+export default isGutenbergOptOutEnabled;

--- a/client/state/selectors/is-gutenberg-opt-out-enabled.js
+++ b/client/state/selectors/is-gutenberg-opt-out-enabled.js
@@ -12,7 +12,7 @@ import isClassicEditorForced from 'state/selectors/is-classic-editor-forced';
 export const isGutenbergOptOutEnabled = ( state, siteId ) => {
 	return (
 		get( state, [ 'gutenbergOptIn', siteId ], true ) &&
-		getSelectedEditor( state, siteId ) === 'gutenberg-iframe' &&
+		getSelectedEditor( state, siteId ) !== 'classic' &&
 		! isClassicEditorForced( state, siteId )
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently the 'Switch to Classic' button is missing from the help menu. This is because there is a check in the `is-gutenberg-opt-in-enabled` selector which checks if the editor is currently 'classic' - https://github.com/Automattic/wp-calypso/blob/master/client/state/selectors/is-gutenberg-opt-in-enabled.js#L15 

The `showOptOut` prop in the popover uses the `is-gutenberg-opt-in-enabled` selector to determine if opt out should be enabled - https://github.com/Automattic/wp-calypso/blob/master/client/blocks/inline-help/popover.jsx#L387 - but since this will always return false while block editor is enabled, opt out never shows.

Rather than modifying the check, or adding an additional one,  in `is-gutenberg-opt-in-enabled` this PR adds an additional `is-gutenberg-opt-out-enabled` selector to avoid any confusion. 

I don't have any of the history behind the original prop and selector, so there may be a valid reason why `showOptOut` should use the  `is-gutenberg-opt-in-enabled` selector.

#### Testing instructions

Apply this patch and then visiting /block-editor, and click on the blue "?" help icon. You should see a switch to classic button. 

Before:
<img width="371" alt="Screen Shot 2019-10-02 at 5 45 13 PM" src="https://user-images.githubusercontent.com/1270189/66091529-00c22500-e53d-11e9-9ed1-5553b3f8dc91.png">

After:
<img width="368" alt="screen-shot-2019-07-08-at-11 34 58-am" src="https://user-images.githubusercontent.com/1270189/66091521-f869ea00-e53c-11e9-954c-e4010ad92914.png">

Fixes #36490
