### PR TITLE
Type: tree-select package

### DIFF
--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -11,7 +11,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"calypso:src": "src/index.js",
+	"calypso:src": "src/index.ts",
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
@@ -28,9 +28,14 @@
 		"dist",
 		"src"
 	],
+	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
-		"build": "transpile",
-		"prepack": "yarn run clean && yarn run build"
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"tslib": "^1.10.0"
 	}
 }

--- a/packages/tree-select/src/index.ts
+++ b/packages/tree-select/src/index.ts
@@ -12,11 +12,11 @@ const defaultGetCacheKey: GenerateCacheKey< unknown[] > = ( ...args: unknown[] )
 	args.join();
 
 const isFunction = ( fn: unknown ): fn is ( ...args: unknown[] ) => unknown => {
-	return fn && typeof fn === 'function';
+	return !! fn && typeof fn === 'function';
 };
 
 const isObject = ( o: unknown ): o is Record< string, unknown > => {
-	return o && typeof o === 'object';
+	return !! o && typeof o === 'object';
 };
 
 type WeakMapKey = object; // eslint-disable-line @typescript-eslint/ban-types
@@ -39,7 +39,7 @@ interface CachedSelector< S, A extends unknown[], R = unknown > {
  * @param selector      A standard selector for calculating cached result.
  * @param options       Options bag with additional arguments.
  *
- * @returns {Function}  Cached selector
+ * @returns Cached selector
  */
 export default function treeSelect<
 	State = unknown,

--- a/packages/tree-select/tsconfig-cjs.json
+++ b/packages/tree-select/tsconfig-cjs.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"declaration": false,
+		"declarationMap": false,
+		"declarationDir": null,
+		"outDir": "dist/cjs",
+		"composite": false,
+		"incremental": true
+	}
+}

--- a/packages/tree-select/tsconfig.json
+++ b/packages/tree-select/tsconfig.json
@@ -1,7 +1,36 @@
 {
-	"extends": "@automattic/calypso-build/tsconfig",
-	"exclude": [ "node_modules" ],
 	"compilerOptions": {
-		"allowJs": true
-	}
+		"target": "ES5",
+		"lib": [ "ES2015" ],
+		"module": "ESNEXT",
+		"allowJs": false,
+		"declaration": true,
+		"declarationMap": true,
+		"declarationDir": "dist/types",
+		"rootDir": "src",
+		"outDir": "dist/esm",
+
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+		"downlevelIteration": true,
+
+		"forceConsistentCasingInFileNames": true,
+
+		"importsNotUsedAsValues": "error",
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": [],
+
+		"noEmitHelpers": true,
+		"importHelpers": true,
+
+		"composite": true
+	},
+	"files": [ "src/index.ts" ]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -28,6 +28,7 @@
 		{ "path": "./react-i18n" },
 		{ "path": "./search" },
 		{ "path": "./shopping-cart" },
+		{ "path": "./tree-select" },
 		{ "path": "./wpcom-checkout" }
 	]
 }


### PR DESCRIPTION
- Translate `tree-select` to TypeScript.
- Will generate typings and allow them to be published/used in Calypso.

props to @beaucollins who was the original author of most of the typings.

#### Testing instructions

Confirm that clean produces a clean directory (nothing in `packages/tree-select/{dist,types}`).
Confirm that build produces expected output (CommonJS in `packages/tree-select/dist/cjs` and ECMAScript Module in corresponding `…/esm` directory.}

Compare with most recent published builds:
- `esm`: https://unpkg.com/browse/@automattic/tree-select@1.0.3/dist/esm/index.js
- `cjs`: https://unpkg.com/browse/@automattic/tree-select@1.0.3/dist/cjs/index.js

The results should be similar but not identical.

```sh
# Clean
npx lerna run clean --scope="*/tree-select"
# Build
npx lerna run prepare --scope="*/tree-select"
```