### PR TITLE
FSE: rename wp_template to wp_template_part

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -33,7 +33,7 @@ const TemplateEdit = compose(
 		const { isEditorSidebarOpened } = select( 'core/edit-post' );
 		const { templateId } = attributes;
 		const currentPostId = getCurrentPostId();
-		const template = templateId && getEntityRecord( 'postType', 'wp_template', templateId );
+		const template = templateId && getEntityRecord( 'postType', 'wp_template_part', templateId );
 		const editTemplateUrl = addQueryArgs( fullSiteEditing.editTemplateBaseUrl, {
 			post: templateId,
 			fse_parent_post: currentPostId,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -14,10 +14,10 @@ import edit from './edit';
 import './style.scss';
 import './site-logo';
 
-if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
+if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
 	registerBlockType( 'a8c/template', {
-		title: __( 'Template' ),
-		description: __( 'Display a template.' ),
+		title: __( 'Template part' ),
+		description: __( 'Display a template part.' ),
 		icon: 'layout',
 		category: 'layout',
 		attributes: {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -16,8 +16,8 @@ import './site-logo';
 
 if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
 	registerBlockType( 'a8c/template', {
-		title: __( 'Template part' ),
-		description: __( 'Display a template part.' ),
+		title: __( 'Template Part' ),
+		description: __( 'Display a Template Part.' ),
 		icon: 'layout',
 		category: 'layout',
 		attributes: {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -85,7 +85,7 @@
 }
 
 // Hide the site logo description and buttons when not editing the Template
-.block-editor-page:not( .post-type-wp_template ) {
+.block-editor-page:not( .post-type-wp_template_part ) {
 	.fse-site-logo {
 		.components-placeholder__fieldset, .components-placeholder__instructions {
 			display: none;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -23,7 +23,7 @@ class Full_Site_Editing {
 	 *
 	 * @var array
 	 */
-	private $template_post_types = [ 'wp_template' ];
+	private $template_post_types = [ 'wp_template_part' ];
 
 	/**
 	 * Current theme slug.
@@ -556,7 +556,7 @@ class Full_Site_Editing {
 	 * @return array
 	 */
 	public function remove_delete_row_action_for_template_taxonomy( $actions, $term ) {
-		if ( 'wp_template_type' === $term->taxonomy ) {
+		if ( 'wp_template_part_type' === $term->taxonomy ) {
 			unset( $actions['delete'] );
 		}
 		return $actions;
@@ -580,7 +580,7 @@ class Full_Site_Editing {
 	 * @param string  $taxonomy Taxonomy name.
 	 */
 	public function restrict_template_taxonomy_deletion( $term, $taxonomy ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed
-		if ( 'wp_template_type' === $taxonomy ) {
+		if ( 'wp_template_part_type' === $taxonomy ) {
 			wp_die( esc_html__( 'Template Types cannon be deleted.' ) );
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/remove-editor-panels/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/remove-editor-panels/index.js
@@ -24,7 +24,7 @@ const unsubscribe = subscribe( () => {
 	// removeEditorPanel action won't have the desired effect. See:
 	// https://github.com/WordPress/gutenberg/pull/17117
 	// When support is added, we should remove the CSS hack at '../style.scss'
-	if ( 'wp_template' === fullSiteEditing.editorPostType ) {
+	if ( 'wp_template_part' === fullSiteEditing.editorPostType ) {
 		removeEditorPanel( 'post-status' );
 	}
 	return unsubscribe();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -1,4 +1,4 @@
-.post-type-wp_template {
+.post-type-wp_template_part {
 	.editor-post-title,
 	.editor-post-trash {
 		display: none;
@@ -20,7 +20,7 @@
 	}
 }
 
-.post-type-page, .post-type-wp_template {
+.post-type-page, .post-type-wp_template_part {
 	@media ( min-width: 768px ) {
 		.edit-post-layout__content {
 			background: #eee;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-draft-action/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-draft-action/index.js
@@ -12,7 +12,11 @@ use( registry => {
 			const actions = { ...registry.dispatch( namespace ) };
 			const { editorPostType } = fullSiteEditing;
 
-			if ( namespace === 'core/editor' && actions.editPost && editorPostType === 'wp_template' ) {
+			if (
+				namespace === 'core/editor' &&
+				actions.editPost &&
+				editorPostType === 'wp_template_part'
+			) {
 				const originalEditPost = actions.editPost;
 
 				actions.editPost = edits => {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-trash-action/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-trash-action/index.js
@@ -12,7 +12,11 @@ use( registry => {
 			const actions = { ...registry.dispatch( namespace ) };
 			const { editorPostType } = fullSiteEditing;
 
-			if ( namespace === 'core/editor' && actions.trashPost && editorPostType === 'wp_template' ) {
+			if (
+				namespace === 'core/editor' &&
+				actions.trashPost &&
+				editorPostType === 'wp_template_part'
+			) {
 				actions.trashPost = () => {};
 			}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -17,7 +17,7 @@ domReady( () => {
 		clearInterval( editPostHeaderInception );
 
 		// When closing Template CPT (e.g. header) to navigate back to parent page.
-		if ( 'wp_template' === editorPostType && closeButtonUrl ) {
+		if ( 'wp_template_part' === editorPostType && closeButtonUrl ) {
 			const newCloseButton = document.createElement( 'a' );
 			newCloseButton.href = closeButtonUrl;
 			newCloseButton.innerHTML = closeButtonLabel;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -14,8 +14,12 @@ import { registerPlugin } from '@wordpress/plugins';
 const EditorTemplateClasses = withSelect( select => {
 	const { getEntityRecord } = select( 'core' );
 	const { getEditedPostAttribute } = select( 'core/editor' );
-	const templateClasses = map( getEditedPostAttribute( 'template_types' ), typeId => {
-		const typeName = get( getEntityRecord( 'taxonomy', 'wp_template_type', typeId ), 'name', '' );
+	const templateClasses = map( getEditedPostAttribute( 'template_part_types' ), typeId => {
+		const typeName = get(
+			getEntityRecord( 'taxonomy', 'wp_template_part_type', typeId ),
+			'name',
+			''
+		);
 		if ( endsWith( typeName, '-header' ) ) {
 			return 'site-header site-branding';
 		}
@@ -41,7 +45,7 @@ const EditorTemplateClasses = withSelect( select => {
 	return null;
 } );
 
-if ( 'wp_template' === fullSiteEditing.editorPostType ) {
+if ( 'wp_template_part' === fullSiteEditing.editorPostType ) {
 	registerPlugin( 'fse-editor-template-classes', {
 		render: EditorTemplateClasses,
 	} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-notice/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-notice/index.js
@@ -7,7 +7,7 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 domReady( () => {
-	if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
+	if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
 		return;
 	}
 	dispatch( 'core/notices' ).createNotice(

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -209,34 +209,34 @@ class WP_Template_Inserter {
 				'post_title'     => 'Header',
 				'post_content'   => $this->header_content,
 				'post_status'    => 'publish',
-				'post_type'      => 'wp_template',
+				'post_type'      => 'wp_template_part',
 				'comment_status' => 'closed',
 				'ping_status'    => 'closed',
 			]
 		);
 
-		if ( ! term_exists( "$this->theme_slug-header", 'wp_template_type' ) ) {
-			wp_insert_term( "$this->theme_slug-header", 'wp_template_type' );
+		if ( ! term_exists( "$this->theme_slug-header", 'wp_template_part_type' ) ) {
+			wp_insert_term( "$this->theme_slug-header", 'wp_template_part_type' );
 		}
 
-		wp_set_object_terms( $header_id, "$this->theme_slug-header", 'wp_template_type' );
+		wp_set_object_terms( $header_id, "$this->theme_slug-header", 'wp_template_part_type' );
 
 		$footer_id = wp_insert_post(
 			[
 				'post_title'     => 'Footer',
 				'post_content'   => $this->footer_content,
 				'post_status'    => 'publish',
-				'post_type'      => 'wp_template',
+				'post_type'      => 'wp_template_part',
 				'comment_status' => 'closed',
 				'ping_status'    => 'closed',
 			]
 		);
 
-		if ( ! term_exists( "$this->theme_slug-footer", 'wp_template_type' ) ) {
-			wp_insert_term( "$this->theme_slug-footer", 'wp_template_type' );
+		if ( ! term_exists( "$this->theme_slug-footer", 'wp_template_part_type' ) ) {
+			wp_insert_term( "$this->theme_slug-footer", 'wp_template_part_type' );
 		}
 
-		wp_set_object_terms( $footer_id, "$this->theme_slug-footer", 'wp_template_type' );
+		wp_set_object_terms( $footer_id, "$this->theme_slug-footer", 'wp_template_part_type' );
 
 		add_option( $this->fse_template_data_option, true );
 
@@ -372,30 +372,30 @@ class WP_Template_Inserter {
 	 */
 	public function register_template_post_types() {
 		register_post_type(
-			'wp_template',
+			'wp_template_part',
 			array(
 				'labels'                => array(
-					'name'                     => _x( 'Templates', 'post type general name', 'full-site-editing' ),
-					'singular_name'            => _x( 'Template', 'post type singular name', 'full-site-editing' ),
-					'menu_name'                => _x( 'Templates', 'admin menu', 'full-site-editing' ),
-					'name_admin_bar'           => _x( 'Template', 'add new on admin bar', 'full-site-editing' ),
+					'name'                     => _x( 'Template Parts', 'post type general name', 'full-site-editing' ),
+					'singular_name'            => _x( 'Template Part', 'post type singular name', 'full-site-editing' ),
+					'menu_name'                => _x( 'Template Parts', 'admin menu', 'full-site-editing' ),
+					'name_admin_bar'           => _x( 'Template Part', 'add new on admin bar', 'full-site-editing' ),
 					'add_new'                  => _x( 'Add New', 'Template', 'full-site-editing' ),
-					'add_new_item'             => __( 'Add New Template', 'full-site-editing' ),
-					'new_item'                 => __( 'New Template', 'full-site-editing' ),
-					'edit_item'                => __( 'Edit Template', 'full-site-editing' ),
-					'view_item'                => __( 'View Template', 'full-site-editing' ),
-					'all_items'                => __( 'All Templates', 'full-site-editing' ),
-					'search_items'             => __( 'Search Templates', 'full-site-editing' ),
-					'not_found'                => __( 'No templates found.', 'full-site-editing' ),
-					'not_found_in_trash'       => __( 'No templates found in Trash.', 'full-site-editing' ),
-					'filter_items_list'        => __( 'Filter templates list', 'full-site-editing' ),
-					'items_list_navigation'    => __( 'Templates list navigation', 'full-site-editing' ),
-					'items_list'               => __( 'Templates list', 'full-site-editing' ),
-					'item_published'           => __( 'Template published.', 'full-site-editing' ),
-					'item_published_privately' => __( 'Template published privately.', 'full-site-editing' ),
-					'item_reverted_to_draft'   => __( 'Template reverted to draft.', 'full-site-editing' ),
-					'item_scheduled'           => __( 'Template scheduled.', 'full-site-editing' ),
-					'item_updated'             => __( 'Template updated.', 'full-site-editing' ),
+					'add_new_item'             => __( 'Add New Template Part', 'full-site-editing' ),
+					'new_item'                 => __( 'New Template Part', 'full-site-editing' ),
+					'edit_item'                => __( 'Edit Template Part', 'full-site-editing' ),
+					'view_item'                => __( 'View Template Part', 'full-site-editing' ),
+					'all_items'                => __( 'All Template Parts', 'full-site-editing' ),
+					'search_items'             => __( 'Search Template Parts', 'full-site-editing' ),
+					'not_found'                => __( 'No template parts found.', 'full-site-editing' ),
+					'not_found_in_trash'       => __( 'No template parts found in Trash.', 'full-site-editing' ),
+					'filter_items_list'        => __( 'Filter template parts list', 'full-site-editing' ),
+					'items_list_navigation'    => __( 'Template parts list navigation', 'full-site-editing' ),
+					'items_list'               => __( 'Template parts list', 'full-site-editing' ),
+					'item_published'           => __( 'Template part published.', 'full-site-editing' ),
+					'item_published_privately' => __( 'Template part published privately.', 'full-site-editing' ),
+					'item_reverted_to_draft'   => __( 'Template part reverted to draft.', 'full-site-editing' ),
+					'item_scheduled'           => __( 'Template part scheduled.', 'full-site-editing' ),
+					'item_updated'             => __( 'Template part updated.', 'full-site-editing' ),
 				),
 				'menu_icon'             => 'dashicons-layout',
 				'public'                => false,
@@ -403,9 +403,9 @@ class WP_Template_Inserter {
 				'show_in_menu'          => false,
 				'rewrite'               => false,
 				'show_in_rest'          => true, // Otherwise previews won't be generated in full page view.
-				'rest_base'             => 'templates',
+				'rest_base'             => 'template_parts',
 				'rest_controller_class' => __NAMESPACE__ . '\REST_Templates_Controller',
-				'capability_type'       => 'template',
+				'capability_type'       => 'template_part',
 				'capabilities'          => array(
 					// You need to be able to edit posts, in order to read templates in their raw form.
 					'read'                   => 'edit_posts',
@@ -429,24 +429,24 @@ class WP_Template_Inserter {
 		);
 
 		register_taxonomy(
-			'wp_template_type',
-			'wp_template',
+			'wp_template_part_type',
+			'wp_template_part',
 			array(
 				'labels'             => array(
-					'name'              => _x( 'Template Types', 'taxonomy general name', 'full-site-editing' ),
-					'singular_name'     => _x( 'Template Type', 'taxonomy singular name', 'full-site-editing' ),
-					'menu_name'         => _x( 'Template Types', 'admin menu', 'full-site-editing' ),
-					'all_items'         => __( 'All Template Types', 'full-site-editing' ),
-					'edit_item'         => __( 'Edit Template Type', 'full-site-editing' ),
-					'view_item'         => __( 'View Template Type', 'full-site-editing' ),
-					'update_item'       => __( 'Update Template Type', 'full-site-editing' ),
-					'add_new_item'      => __( 'Add New Template Type', 'full-site-editing' ),
-					'new_item_name'     => __( 'New Template Type', 'full-site-editing' ),
-					'parent_item'       => __( 'Parent Template Type', 'full-site-editing' ),
-					'parent_item_colon' => __( 'Parent Template Type:', 'full-site-editing' ),
-					'search_items'      => __( 'Search Template Types', 'full-site-editing' ),
-					'not_found'         => __( 'No template types found.', 'full-site-editing' ),
-					'back_to_items'     => __( 'Back to template types', 'full-site-editing' ),
+					'name'              => _x( 'Template Part Types', 'taxonomy general name', 'full-site-editing' ),
+					'singular_name'     => _x( 'Template Part Type', 'taxonomy singular name', 'full-site-editing' ),
+					'menu_name'         => _x( 'Template Part Types', 'admin menu', 'full-site-editing' ),
+					'all_items'         => __( 'All Template Part Types', 'full-site-editing' ),
+					'edit_item'         => __( 'Edit Template Part Type', 'full-site-editing' ),
+					'view_item'         => __( 'View Template Part Type', 'full-site-editing' ),
+					'update_item'       => __( 'Update Template Part Type', 'full-site-editing' ),
+					'add_new_item'      => __( 'Add New Template Part Type', 'full-site-editing' ),
+					'new_item_name'     => __( 'New Template Part Type', 'full-site-editing' ),
+					'parent_item'       => __( 'Parent Template Part Type', 'full-site-editing' ),
+					'parent_item_colon' => __( 'Parent Template Part Type:', 'full-site-editing' ),
+					'search_items'      => __( 'Search Template Part Types', 'full-site-editing' ),
+					'not_found'         => __( 'No template part types found.', 'full-site-editing' ),
+					'back_to_items'     => __( 'Back to template part types', 'full-site-editing' ),
 				),
 				'public'             => false,
 				'publicly_queryable' => false,
@@ -454,7 +454,7 @@ class WP_Template_Inserter {
 				'show_in_menu'       => false,
 				'show_in_nav_menu'   => false,
 				'show_in_rest'       => true,
-				'rest_base'          => 'template_types',
+				'rest_base'          => 'template_part_types',
 				'show_tagcloud'      => false,
 				'hierarchical'       => true,
 				'rewrite'            => false,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -93,7 +93,7 @@ class WP_Template {
 			return null;
 		}
 
-		$term = get_term_by( 'name', "$this->current_theme_name-$template_type", 'wp_template_type', ARRAY_A );
+		$term = get_term_by( 'name', "$this->current_theme_name-$template_type", 'wp_template_part_type', ARRAY_A );
 
 		// Bail if current site doesn't have this term registered.
 		if ( ! isset( $term['term_id'] ) ) {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -308,7 +308,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	// ID, we want to do a server nav back to that page.
 	shouldDoServerBackNav = () => {
 		const { fseParentPageId, postType } = this.props;
-		return null != fseParentPageId && 'wp_template' === postType;
+		return null != fseParentPageId && 'wp_template_part' === postType;
 	};
 
 	loadRevision = ( {

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -141,7 +141,7 @@ class SiteMenu extends PureComponent {
 		}
 
 		// Hide Full Site Editing templates CPT. This shouldn't be editable directly.
-		if ( 'wp_template' === menuItem.name ) {
+		if ( 'wp_template_part' === menuItem.name ) {
 			return null;
 		}
 

--- a/client/state/selectors/get-editor-close-url.js
+++ b/client/state/selectors/get-editor-close-url.js
@@ -19,7 +19,7 @@ import isLastNonEditorRouteChecklist from 'state/selectors/is-last-non-editor-ro
 
 export default function getEditorCloseUrl( state, siteId, postType, fseParentPageId ) {
 	// Handle returning to parent editor for full site editing templates
-	if ( 'wp_template' === postType ) {
+	if ( 'wp_template_part' === postType ) {
 		return getGutenbergEditorUrl( state, siteId, fseParentPageId, 'page' );
 	}
 

--- a/client/state/selectors/test/get-editor-close-url.js
+++ b/client/state/selectors/test/get-editor-close-url.js
@@ -15,7 +15,7 @@ import PostQueryManager from 'lib/query-manager/post';
 
 const postType = 'post';
 const pagePostType = 'page';
-const templatePostType = 'wp_template';
+const templatePostType = 'wp_template_part';
 const siteId = 1;
 
 describe( 'getEditorCloseUrl()', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renames `wp_template` CPT registration and usages to `wp_template_part`.
Still considering whether to rename all of the other `template` term usages in the plugin, but this should be functionally enough to start with.

Fixes https://github.com/Automattic/wp-calypso/issues/36480

#### Testing instructions

1. Test on your local site.
2. Toggle Maywood theme or activate FSE plugin and make sure that `wp_template_part` CPT is populated correctly.
3. Verify that editing flows work and that pages are rendered as expected.
4. Smoke test some of the previous bugs or edge cases that you've fixed.
5. Are there any `wp_template` references that I've missed? 
6. Search for `wp_template` usages in other repositories that we've worked in (think themes, Atomic etc).
7. Apply D33537-code to your sandbox.
8. Sync these changes to your Dotcom sandbox and repeat the above steps. Note: while testing on Dotcom make sure to exclude latest SPT changes by reverting their folder to `0.7` state.
