### PR TITLE
Remove some trivial usage of `moment` in state.

### DIFF
--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -30,7 +28,6 @@ import {
 	find,
 	reject,
 } from 'lodash';
-import moment from 'moment';
 import url from 'url';
 
 /**
@@ -440,7 +437,7 @@ export function isDateEqual( localDateEdit, savedDate ) {
 		return true;
 	}
 
-	return localDateEdit && moment( localDateEdit ).isSame( savedDate );
+	return localDateEdit && new Date( localDateEdit ).getTime() === new Date( savedDate ).getTime();
 }
 
 export function isStatusEqual( localStatusEdit, savedStatus ) {
@@ -593,7 +590,7 @@ export const isBackDatedPublished = function( post, status ) {
 
 	const effectiveStatus = status || post.status;
 
-	return effectiveStatus === 'future' && moment( post.date ).isBefore( moment() );
+	return effectiveStatus === 'future' && new Date( post.date ) < Date.now();
 };
 
 // Return published status of a post. Optionally, the `status` can be overridden
@@ -663,7 +660,7 @@ export const isBackDated = function( post ) {
 		return false;
 	}
 
-	return moment( post.date ).isBefore( moment( post.modified ) );
+	return new Date( post.date ) < new Date( post.modified );
 };
 
 export const isPage = function( post ) {

--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { get } from 'lodash';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -28,7 +25,7 @@ export default function isEligibleForDotcomChecklist( state, siteId ) {
 	if (
 		! createdAt ||
 		createdAt.substr( 0, 4 ) === '0000' ||
-		moment( createdAt ).isBefore( '2018-02-01' )
+		new Date( createdAt ) < new Date( '2018-02-01' )
 	) {
 		return false;
 	}

--- a/client/state/selectors/is-user-registration-days-within-range.js
+++ b/client/state/selectors/is-user-registration-days-within-range.js
@@ -1,35 +1,28 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import moment from 'moment';
-
 /**
  * Internal dependencies
  */
 import { getCurrentUserDate } from 'state/current-user/selectors';
 
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
+
 /**
  * Returns true if the number of days the current user has been registered for falls within the specied range of values.
  *
  * @param {Object} state Global state tree
- * @param {Object} momentInTime Current moment for determination of elapsed days since registration
+ * @param {Date} refDate Date for determination of elapsed days since registration
  * @param {Number} from Lower bound on days
  * @param {Number} to Upper bound on days
  * @return {?Boolean} True if the number of days falls withing the specified range
  */
-const isUserRegistrationDaysWithinRange = ( state, momentInTime, from, to ) => {
+export default function isUserRegistrationDaysWithinRange( state, refDate, from, to ) {
 	const date = getCurrentUserDate( state );
 
 	if ( ! date ) {
 		return null;
 	}
 
-	momentInTime = momentInTime || moment();
-	const days = momentInTime.diff( date, 'days', true );
+	refDate = refDate || Date.now();
+	const days = ( refDate - new Date( date ) ) / DAY_IN_MS;
 
 	return days >= from && days <= to;
-};
-
-export default isUserRegistrationDaysWithinRange;
+}

--- a/client/state/selectors/test/is-user-registration-days-within-range.js
+++ b/client/state/selectors/test/is-user-registration-days-within-range.js
@@ -1,10 +1,3 @@
-/** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import { stub } from 'sinon';
-
 /**
  * Internal dependencies
  */
@@ -16,14 +9,12 @@ jest.mock( 'state/current-user/selectors', () => ( {
 
 describe( 'isUserRegistrationDaysWithinRange()', () => {
 	const state = 'state';
-	const registrationDate = 'registrationDate';
-	const moment = {
-		diff: stub(),
-	};
+	const registrationDate = '2019-03-15';
 
 	test( 'should return null when there is no current user date', () => {
 		getCurrentUserDate.withArgs( state ).returns( null );
-		expect( isUserRegistrationDaysWithinRange( state, moment, 5, 10 ) ).to.be.null;
+		const refDate = registrationDate;
+		expect( isUserRegistrationDaysWithinRange( state, refDate, 5, 10 ) ).toBe( null );
 	} );
 
 	describe( 'when there is a current user date', () => {
@@ -32,28 +23,28 @@ describe( 'isUserRegistrationDaysWithinRange()', () => {
 		} );
 
 		test( 'should return false when user has been registered for less than the lower bound', () => {
-			moment.diff.withArgs( registrationDate, 'days', true ).returns( 1 );
-			expect( isUserRegistrationDaysWithinRange( state, moment, 5, 10 ) ).to.be.false;
+			const refDate = new Date( '2019-03-16' );
+			expect( isUserRegistrationDaysWithinRange( state, refDate, 5, 10 ) ).toBe( false );
 		} );
 
 		test( 'should return true when user has been registered for exactly the lower bound', () => {
-			moment.diff.withArgs( registrationDate, 'days', true ).returns( 5 );
-			expect( isUserRegistrationDaysWithinRange( state, moment, 5, 10 ) ).to.be.true;
+			const refDate = new Date( '2019-03-20' );
+			expect( isUserRegistrationDaysWithinRange( state, refDate, 5, 10 ) ).toBe( true );
 		} );
 
 		test( 'should return true when user has been registered for greater than the lower bound and less than the upper bound', () => {
-			moment.diff.withArgs( registrationDate, 'days', true ).returns( 7 );
-			expect( isUserRegistrationDaysWithinRange( state, moment, 5, 10 ) ).to.be.true;
+			const refDate = new Date( '2019-03-22' );
+			expect( isUserRegistrationDaysWithinRange( state, refDate, 5, 10 ) ).toBe( true );
 		} );
 
 		test( 'should return true when user has been registered for exactly the upper bound', () => {
-			moment.diff.withArgs( registrationDate, 'days', true ).returns( 10 );
-			expect( isUserRegistrationDaysWithinRange( state, moment, 5, 10 ) ).to.be.true;
+			const refDate = new Date( '2019-03-25' );
+			expect( isUserRegistrationDaysWithinRange( state, refDate, 5, 10 ) ).toBe( true );
 		} );
 
 		test( 'should return false when user has been registered for greater than the upper bound', () => {
-			moment.diff.withArgs( registrationDate, 'days', true ).returns( 15 );
-			expect( isUserRegistrationDaysWithinRange( state, moment, 5, 10 ) ).to.be.false;
+			const refDate = new Date( '2019-03-30' );
+			expect( isUserRegistrationDaysWithinRange( state, refDate, 5, 10 ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/state/sites/selectors/can-current-user-use-checklist-menu.js
+++ b/client/state/sites/selectors/can-current-user-use-checklist-menu.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { get } from 'lodash';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -35,7 +34,7 @@ export default function canCurrentUserUseChecklistMenu( state, siteId = null ) {
 	if (
 		! createdAt ||
 		createdAt.substr( 0, 4 ) === '0000' ||
-		moment( createdAt ).isBefore( '2019-08-06' )
+		new Date( createdAt ) < new Date( '2019-08-06' )
 	) {
 		return false;
 	}

--- a/client/state/sites/selectors/is-new-site.js
+++ b/client/state/sites/selectors/is-new-site.js
@@ -1,12 +1,9 @@
 /**
- * External dependencies
- */
-import moment from 'moment';
-
-/**
  * Internal dependencies
  */
 import getSiteOption from './get-site-option';
+
+const MINUTE_IN_MS = 60 * 1000;
 
 /**
  * Returns true if the site is created less than 30 mins ago.
@@ -24,5 +21,5 @@ export default function isNewSite( state, siteId ) {
 	}
 
 	// less than 30 minutes
-	return moment().diff( createdAt, 'minutes' ) < 30;
+	return Date.now() - new Date( createdAt ) < 30 * MINUTE_IN_MS;
 }


### PR DESCRIPTION
None of these involve locales or formatting, just simple math.

An easy first step in trying to remove `moment` from state.

#### Changes proposed in this Pull Request

* Replace some usage of `moment` in state with plain JS `Date`.

#### Testing instructions

No specific instructions, other than making use of these parts of state and looking for any issues. Unit tests seem to run correctly.
