### PR TITLE
e2e- Add wait for password popover

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -203,10 +203,10 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			this.driver,
 			By.css( '.edit-post-post-visibility__toggle' )
 		);
-		await driverHelper.selectElementByText(
+		await this.driver.sleep( 1000 ); // wait for popover to be fully loaded
+		await driverHelper.setCheckbox(
 			this.driver,
-			By.css( '.editor-post-visibility__dialog-label' ),
-			'Password Protected'
+			By.css( 'input#editor-post-password-0[value="password"]' )
 		);
 		return await driverHelper.setWhenSettable(
 			this.driver,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Similar to updates made in #36433, this adds a wait and updates the selector of the page visibility popover

#### Testing instructions

* Make sure `Calypso Gutenberg Editor: Pages (mobile) Password Protected Pages` passes in CI
