### PR TITLE
SPT: Fix template insert bug

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -11,7 +11,7 @@ const PreviewTemplateTitle = ( { title, transform } ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	<div className="editor-post-title" style={ { transform } }>
 		<div className="editor-post-title__block">
-			<textarea className="editor-post-title__input" value={ title } />
+			<textarea className="editor-post-title__input" value={ title } onChange={ () => {} } />
 		</div>
 	</div>
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -121,7 +121,13 @@ class PageTemplateModal extends Component {
 		return this.props.shouldPrefetchAssets ? ensureAssets( blocks ) : Promise.resolve( blocks );
 	};
 
-	handleConfirmation = ( slug = this.state.previewedTemplate ) => this.setTemplate( slug );
+	handleConfirmation = slug => {
+		if ( typeof slug !== 'string' ) {
+			slug = this.state.previewedTemplate;
+		}
+
+		this.setTemplate( slug );
+	};
 
 	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
 


### PR DESCRIPTION
Introduced in #36454, `handleConfirmation()` would get the button click event passed as a default argument, which never allowed the default value to take effect.

In addition I added an empty `onChange` handler to silent a React error about updating template titles.

Test:
You should be able to insert templates in both small-screen and desktop view.