### PR TITLE
Navigate back to pages list rather than closing.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -140,11 +140,9 @@ class PageTemplateModal extends Component {
 
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 
-		if ( typeof window.calypsoifyGutenberg !== 'undefined' ) {
-			window.top.location = window.calypsoifyGutenberg.closeUrl;
-		} else {
-			window.top.location = 'edit.php?post_type=page';
-		}
+		// Try if we have specific URL to go back to, otherwise go to the page list.
+		const calypsoifyCloseUrl = get( window, [ 'calypsoifyGutenberg', 'closeUrl' ] );
+		window.top.location = calypsoifyCloseUrl || 'edit.php?post_type=page';
 	};
 
 	getBlocksByTemplateSlug( slug ) {
@@ -171,6 +169,7 @@ class PageTemplateModal extends Component {
 				className="page-template-modal"
 				overlayClassName="page-template-modal-screen-overlay"
 				shouldCloseOnClickOutside={ false }
+				// Using both variants here to be compatible with new Gutenberg and old (older than 6.6).
 				isDismissable={ false }
 				isDismissible={ false }
 			>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -137,8 +137,14 @@ class PageTemplateModal extends Component {
 		if ( event.target.matches( 'button.template-selector-item__label' ) ) {
 			return false;
 		}
-		this.setState( { isOpen: false } );
+
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
+
+		if ( typeof window.calypsoifyGutenberg !== 'undefined' ) {
+			window.top.location = window.calypsoifyGutenberg.closeUrl;
+		} else {
+			window.top.location = 'edit.php?post_type=page';
+		}
 	};
 
 	getBlocksByTemplateSlug( slug ) {
@@ -165,6 +171,7 @@ class PageTemplateModal extends Component {
 				className="page-template-modal"
 				overlayClassName="page-template-modal-screen-overlay"
 				shouldCloseOnClickOutside={ false }
+				isDismissable={ false }
 				isDismissible={ false }
 			>
 				<Button


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Return to wherever Calypso wants to return to when available.
* Return to pages list in all other cases.
* Adds `isDismissable` prop for back compat with Gutenberg 6.6.

#### Testing instructions

* Create a new page and click the left chevron.

Fixes #36509.
Fixes #36397.
