### PR TITLE
Rename the template part URL in the bridge server

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -643,7 +643,7 @@ const mapStateToProps = (
 			state,
 			siteId,
 			partial.placeholder,
-			'wp_template'
+			'wp_template_part'
 		),
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename another instance of wp_template

#### Testing instructions
1. Sandbox and get version 0.9 of FSE: `D33568`
2. `npm start` and load calypso. Look at a sandboxed FSE site.
3. Open a page editor and navigate to the header. The URL should contain `wp_template_part` instead of `wp_template`.

