### PR TITLE
Site Selector: Fix for hover colors on site badges

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -177,13 +177,13 @@
 	padding: 1px 10px;
 }
 
-.site__content:hover .site__badge {
+.notouch .site-selector.is-hover-enabled .site:hover .site__badge {
 	background: var( --color-sidebar-background );
 	color: var( --color-sidebar-text );
 }
 
-.current-site .site__content:hover .site__badge,
-.purchases-site .site__content:hover .site__badge {
+.current-site .site:hover .site__badge,
+.purchases-site .site:hover .site__badge {
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -76,7 +76,7 @@
 	cursor: pointer;
 
 	.site__badge {
-		color: var( --color-sidebar-menu-hover-text );
+		color: var( --color-sidebar-text );
 	}
 
 	.site__title,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure site badges have adequate contrast on hover for all color schemes.

**Before**

<img width="277" alt="Screen Shot 2019-10-03 at 7 32 23 PM" src="https://user-images.githubusercontent.com/2124984/66170984-8b298800-e614-11e9-90c8-8fe5fbbfd644.png">

**After**

<img width="272" alt="Screen Shot 2019-10-03 at 7 29 59 PM" src="https://user-images.githubusercontent.com/2124984/66170974-81078980-e614-11e9-9416-df32a0bcd83f.png">

#### Testing instructions

* Switch to this PR; navigate to Me - Account Settings and change color scheme to Contrast
* Navigate to My Sites -> Switch Site and hover over a site in the selector that is private or a domain-only/redirect site (it will have a badge underneath the site listing, as seen above)
* Hover color should have adequate contrast between background and foreground.

Fixes #36506
