### PR TITLE
Vertical suggested themes: Display suggested theme during sign…

### DIFF
--- a/client/components/signup-site-preview/component.jsx
+++ b/client/components/signup-site-preview/component.jsx
@@ -63,6 +63,7 @@ export class SignupSitePreview extends Component {
 		onPreviewClick: PropTypes.func,
 		resize: PropTypes.bool,
 		scrolling: PropTypes.bool,
+		screenshot: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -79,16 +80,17 @@ export class SignupSitePreview extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			isLoaded: false,
+			isLoaded: !! props.screenshot,
 			wrapperHeight: 800,
 		};
 	}
 
 	componentDidUpdate( prevProps ) {
 		if (
-			this.props.cssUrl !== prevProps.cssUrl ||
-			this.props.fontUrl !== prevProps.fontUrl ||
-			this.props.langSlug !== prevProps.langSlug
+			! this.props.screenshot &&
+			( this.props.cssUrl !== prevProps.cssUrl ||
+				this.props.fontUrl !== prevProps.fontUrl ||
+				this.props.langSlug !== prevProps.langSlug )
 		) {
 			this.setIsLoaded( false );
 		}
@@ -98,25 +100,32 @@ export class SignupSitePreview extends Component {
 	setWrapperHeight = wrapperHeight => this.setState( { wrapperHeight } );
 
 	render() {
-		const { isDesktop, isPhone } = this.props;
+		const { isDesktop, isPhone, screenshot } = this.props;
 		const className = classNames( this.props.className, 'signup-site-preview__wrapper', {
 			'is-desktop': isDesktop,
 			'is-phone': isPhone,
 		} );
 		const wrapperHeightStyle = {
-			height: this.state.wrapperHeight,
+			height: screenshot ? 'auto' : this.state.wrapperHeight,
 		};
 
 		return (
 			<div className={ className } style={ this.props.resize ? wrapperHeightStyle : null }>
 				<div className="signup-site-preview__iframe-wrapper">
 					{ isPhone ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
-					{ ! this.state.isLoaded && <Spinner size={ isPhone ? 20 : 40 } /> }
-					<SignupSitePreviewIframe
-						{ ...this.props }
-						setIsLoaded={ this.setIsLoaded }
-						setWrapperHeight={ this.setWrapperHeight }
-					/>
+					{ ! this.state.isLoaded && ! screenshot && <Spinner size={ isPhone ? 20 : 40 } /> }
+					{ ! screenshot && (
+						<SignupSitePreviewIframe
+							{ ...this.props }
+							setIsLoaded={ this.setIsLoaded }
+							setWrapperHeight={ this.setWrapperHeight }
+						/>
+					) }
+					{ screenshot && (
+						<div style={ isPhone ? { height: '100%', overflowY: 'scroll' } : {} }>
+							<img src={ screenshot } alt="Site preview" />
+						</div>
+					) }
 				</div>
 			</div>
 		);

--- a/client/components/signup-site-preview/component.jsx
+++ b/client/components/signup-site-preview/component.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -13,6 +10,7 @@ import { localize, translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ImagePreloader from 'components/image-preloader';
 import SignupSitePreviewIframe from 'components/signup-site-preview/iframe';
 import Spinner from 'components/spinner';
 
@@ -80,17 +78,16 @@ export class SignupSitePreview extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			isLoaded: !! props.screenshot,
+			isLoaded: false,
 			wrapperHeight: 800,
 		};
 	}
 
 	componentDidUpdate( prevProps ) {
 		if (
-			! this.props.screenshot &&
-			( this.props.cssUrl !== prevProps.cssUrl ||
-				this.props.fontUrl !== prevProps.fontUrl ||
-				this.props.langSlug !== prevProps.langSlug )
+			this.props.cssUrl !== prevProps.cssUrl ||
+			this.props.fontUrl !== prevProps.fontUrl ||
+			this.props.langSlug !== prevProps.langSlug
 		) {
 			this.setIsLoaded( false );
 		}
@@ -109,11 +106,13 @@ export class SignupSitePreview extends Component {
 			height: screenshot ? 'auto' : this.state.wrapperHeight,
 		};
 
+		const spinner = <Spinner size={ isPhone ? 20 : 40 } />;
+
 		return (
 			<div className={ className } style={ this.props.resize ? wrapperHeightStyle : null }>
 				<div className="signup-site-preview__iframe-wrapper">
 					{ isPhone ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
-					{ ! this.state.isLoaded && ! screenshot && <Spinner size={ isPhone ? 20 : 40 } /> }
+					{ ! this.state.isLoaded && ! screenshot && spinner }
 					{ ! screenshot && (
 						<SignupSitePreviewIframe
 							{ ...this.props }
@@ -123,7 +122,7 @@ export class SignupSitePreview extends Component {
 					) }
 					{ screenshot && (
 						<div style={ isPhone ? { height: '100%', overflowY: 'scroll' } : {} }>
-							<img src={ screenshot } alt="Site preview" />
+							<ImagePreloader src={ screenshot } placeholder={ spinner } alt="Site preview" />
 						</div>
 					) }
 				</div>

--- a/client/components/signup-site-preview/component.jsx
+++ b/client/components/signup-site-preview/component.jsx
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ImagePreloader from 'components/image-preloader';
 import SignupSitePreviewIframe from 'components/signup-site-preview/iframe';
+import SignupSitePreviewScreenshot from 'components/signup-site-preview/screenshot';
 import Spinner from 'components/spinner';
 import { getSiteVerticalPreviewScreenshot } from 'state/signup/steps/site-vertical/selectors';
 
@@ -108,7 +108,6 @@ export class SignupSitePreview extends Component {
 			height: usingScreenshot ? 'auto' : this.state.wrapperHeight,
 		};
 
-		const spinner = <Spinner size={ isPhone ? 20 : 40 } />;
 		const chrome = isPhone ? (
 			<MockupChromeMobile translate={ translate } />
 		) : (
@@ -120,7 +119,7 @@ export class SignupSitePreview extends Component {
 				<div className="signup-site-preview__iframe-wrapper">
 					{ chrome }
 
-					{ ! usingScreenshot && this.state.isLoading && spinner }
+					{ ! usingScreenshot && this.state.isLoading && <Spinner size={ isPhone ? 20 : 40 } /> }
 					{ ! usingScreenshot && (
 						<SignupSitePreviewIframe
 							{ ...this.props }
@@ -130,21 +129,10 @@ export class SignupSitePreview extends Component {
 					) }
 
 					{ usingScreenshot && (
-						<div style={ isPhone ? { height: '100%', overflowY: 'scroll' } : {} }>
-							<ImagePreloader
-								src={ screenshotUrl }
-								placeholder={ spinner }
-								alt={
-									isPhone
-										? translate( 'Preview of site with phone layout', {
-												comment: 'alt text of site preview',
-										  } )
-										: translate( 'Preview of site with desktop layout', {
-												comment: 'alt text of site preview',
-										  } )
-								}
-							/>
-						</div>
+						<SignupSitePreviewScreenshot
+							{ ...this.props }
+							setWrapperHeight={ this.setWrapperHeight }
+						/>
 					) }
 				</div>
 			</div>

--- a/client/components/signup-site-preview/component.jsx
+++ b/client/components/signup-site-preview/component.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ import { getSiteVerticalPreviewScreenshot } from 'state/signup/steps/site-vertic
  */
 import './style.scss';
 
-function MockupChromeMobile( { translate } ) {
+function MockupChromeMobile() {
 	return (
 		<div className="signup-site-preview__chrome-mobile">
 			<span className="signup-site-preview__chrome-label">
@@ -32,7 +32,7 @@ function MockupChromeMobile( { translate } ) {
 	);
 }
 
-function MockupChromeDesktop( { translate } ) {
+function MockupChromeDesktop() {
 	return (
 		<div className="signup-site-preview__chrome-desktop">
 			<svg width="38" height="10">
@@ -98,7 +98,7 @@ export class SignupSitePreview extends Component {
 	setWrapperHeight = wrapperHeight => this.setState( { wrapperHeight } );
 
 	render() {
-		const { isDesktop, isPhone, screenshotUrl, translate } = this.props;
+		const { isDesktop, isPhone, screenshotUrl } = this.props;
 		const className = classNames( this.props.className, 'signup-site-preview__wrapper', {
 			'is-desktop': isDesktop,
 			'is-phone': isPhone,
@@ -108,11 +108,7 @@ export class SignupSitePreview extends Component {
 			height: usingScreenshot ? 'auto' : this.state.wrapperHeight,
 		};
 
-		const chrome = isPhone ? (
-			<MockupChromeMobile translate={ translate } />
-		) : (
-			<MockupChromeDesktop translate={ translate } />
-		);
+		const chrome = isPhone ? <MockupChromeMobile /> : <MockupChromeDesktop />;
 
 		return (
 			<div className={ className } style={ this.props.resize ? wrapperHeightStyle : null }>

--- a/client/components/signup-site-preview/screenshot.tsx
+++ b/client/components/signup-site-preview/screenshot.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { noop } from 'lodash';
 import React from 'react';
 
 /**
@@ -11,29 +12,34 @@ import Spinner from 'components/spinner';
 import classNames from 'classnames';
 
 interface Props {
-	isPhone: boolean;
+	defaultViewportDevice: string;
 	setWrapperHeight: ( height: number ) => void;
 	screenshotUrl: string;
 	scrolling: boolean;
+	onPreviewClick: ( viewportSize: string ) => void;
 	translate: typeof import('i18n-calypso').translate;
 }
 
 export default function SignupSitePreviewScreenshot( {
-	isPhone,
+	defaultViewportDevice,
 	setWrapperHeight,
 	scrolling,
 	screenshotUrl,
+	onPreviewClick = noop,
 	translate,
 }: Props ) {
 	const className = classNames( {
 		'signup-site-preview__scrolling-screenshot': scrolling,
 	} );
 
+	const isPhone = defaultViewportDevice === 'phone';
+
 	return (
 		<div className={ className }>
 			<ImagePreloader
 				src={ screenshotUrl }
 				placeholder={ <Spinner size={ isPhone ? 20 : 40 } /> }
+				onClick={ () => onPreviewClick( defaultViewportDevice ) }
 				onLoad={ ( e: any ) => setWrapperHeight( e.target.height ) }
 				alt={
 					isPhone

--- a/client/components/signup-site-preview/screenshot.tsx
+++ b/client/components/signup-site-preview/screenshot.tsx
@@ -38,7 +38,9 @@ export default function SignupSitePreviewScreenshot( {
 		<div className={ className }>
 			<ImagePreloader
 				src={ screenshotUrl }
-				placeholder={ <Spinner size={ isPhone ? 20 : 40 } /> }
+				placeholder={
+					<Spinner className="signup-site-preview__screenshot-spinner" size={ isPhone ? 20 : 40 } />
+				}
 				onClick={ () => onPreviewClick( defaultViewportDevice ) }
 				onLoad={ ( e: any ) => setWrapperHeight( e.target.height ) }
 				alt={

--- a/client/components/signup-site-preview/screenshot.tsx
+++ b/client/components/signup-site-preview/screenshot.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ImagePreloader from 'components/image-preloader';
+import Spinner from 'components/spinner';
+import classNames from 'classnames';
+
+interface Props {
+	isPhone: boolean;
+	setWrapperHeight: ( height: number ) => void;
+	screenshotUrl: string;
+	scrolling: boolean;
+	translate: typeof import('i18n-calypso').translate;
+}
+
+export default function SignupSitePreviewScreenshot( {
+	isPhone,
+	setWrapperHeight,
+	scrolling,
+	screenshotUrl,
+	translate,
+}: Props ) {
+	const className = classNames( {
+		'signup-site-preview__scrolling-screenshot': scrolling,
+	} );
+
+	return (
+		<div className={ className }>
+			<ImagePreloader
+				src={ screenshotUrl }
+				placeholder={ <Spinner size={ isPhone ? 20 : 40 } /> }
+				onLoad={ ( e: any ) => setWrapperHeight( e.target.height ) }
+				alt={
+					isPhone
+						? translate( 'Preview of site with phone layout', {
+								comment: 'alt text of site preview',
+						  } )
+						: translate( 'Preview of site with desktop layout', {
+								comment: 'alt text of site preview',
+						  } )
+				}
+			/>
+		</div>
+	);
+}

--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -172,3 +172,7 @@
 	height: 100%;
 	overflow-y: scroll;
 }
+
+.signup-site-preview__screenshot-spinner {
+	margin: 40px;
+}

--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -39,7 +39,7 @@
 		transition-delay: 200ms;
 		height: 468px;
 		padding: 0 0 24px;
-		@include elevation ( 4dp );
+		@include elevation( 4dp );
 
 		@include breakpoint( '>960px' ) {
 			min-width: 280px;
@@ -51,8 +51,7 @@
 			top: 48px;
 			right: 8px;
 			z-index: 2;
-			box-shadow: 0 0 6px 0 rgba( 0, 0, 0, 0.5 ),
-			0 6px 50px 0 rgba( 0, 0, 0, 0.3 );
+			box-shadow: 0 0 6px 0 rgba( 0, 0, 0, 0.5 ), 0 6px 50px 0 rgba( 0, 0, 0, 0.3 );
 		}
 
 		// Only show one iframe at small
@@ -73,7 +72,7 @@
 
 	.is-desktop & {
 		border-radius: 4px;
-		@include elevation ( 3dp );
+		@include elevation( 3dp );
 		@include breakpoint( '<660px' ) {
 			border-radius: 12px 12px 0 0;
 		}
@@ -167,4 +166,9 @@
 		cursor: default;
 		padding: 0 6px;
 	}
+}
+
+.signup-site-preview__scrolling-screenshot {
+	height: 100%;
+	overflow-y: scroll;
 }

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -453,7 +453,7 @@ export function generateSteps( {
 
 		'site-topic': {
 			stepName: 'site-topic',
-			providesDependencies: [ 'siteTopic' ],
+			providesDependencies: [ 'siteTopic', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isSiteTopicFulfilled,
 		},
 
@@ -477,7 +477,7 @@ export function generateSteps( {
 		// These can be removed once we make the preview the default
 		'site-topic-with-preview': {
 			stepName: 'site-topic-with-preview',
-			providesDependencies: [ 'siteTopic' ],
+			providesDependencies: [ 'siteTopic', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isSiteTopicFulfilled,
 			props: {
 				showSiteMockups: true,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -454,6 +454,7 @@ export function generateSteps( {
 		'site-topic': {
 			stepName: 'site-topic',
 			providesDependencies: [ 'siteTopic', 'themeSlugWithRepo' ],
+			optionalDependencies: [ 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isSiteTopicFulfilled,
 		},
 
@@ -478,6 +479,7 @@ export function generateSteps( {
 		'site-topic-with-preview': {
 			stepName: 'site-topic-with-preview',
 			providesDependencies: [ 'siteTopic', 'themeSlugWithRepo' ],
+			optionalDependencies: [ 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isSiteTopicFulfilled,
 			props: {
 				showSiteMockups: true,

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -19,6 +19,7 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import {
 	getSiteVerticalName,
 	getSiteVerticalPreview,
+	getSiteVerticalPreviewScreenshots,
 	getSiteVerticalPreviewStyles,
 	getSiteVerticalSlug,
 } from 'state/signup/steps/site-vertical/selectors';
@@ -65,6 +66,7 @@ class SiteMockups extends Component {
 		title: PropTypes.string,
 		vertical: PropTypes.string,
 		verticalPreviewContent: PropTypes.string,
+		verticalPreviewScreenshots: PropTypes.object,
 		verticalPreviewStyles: PropTypes.string,
 	};
 
@@ -81,7 +83,10 @@ class SiteMockups extends Component {
 	shouldComponentUpdate( nextProps ) {
 		// Debouncing updates to the preview content
 		// prevents the flashing effect.
-		if ( nextProps.verticalPreviewContent !== this.props.verticalPreviewContent ) {
+		if (
+			nextProps.verticalPreviewContent !== this.props.verticalPreviewContent ||
+			nextProps.verticalPreviewScreenshots !== this.props.verticalPreviewScreenshots
+		) {
 			this.updateDebounced();
 			return false;
 		}
@@ -91,7 +96,7 @@ class SiteMockups extends Component {
 
 	updateDebounced = debounce( () => {
 		this.forceUpdate();
-		if ( this.props.verticalPreviewContent ) {
+		if ( this.props.verticalPreviewContent || this.props.verticalPreviewScreenshots ) {
 			this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_rendered', {
 				site_type: this.props.siteType,
 				vertical_slug: this.props.verticalSlug,
@@ -150,11 +155,12 @@ class SiteMockups extends Component {
 			title,
 			themeSlug,
 			verticalPreviewContent,
+			verticalPreviewScreenshots,
 			verticalPreviewStyles,
 		} = this.props;
 
 		const siteMockupClasses = classNames( 'site-mockup__wrap', {
-			'is-empty': isEmpty( verticalPreviewContent ),
+			'is-empty': isEmpty( verticalPreviewContent ) && ! verticalPreviewScreenshots,
 		} );
 		const langSlug = getLocaleSlug();
 		const language = getLanguage( langSlug );
@@ -183,9 +189,14 @@ class SiteMockups extends Component {
 						defaultViewportDevice="desktop"
 						resize={ true }
 						scrolling={ false }
+						screenshot={ verticalPreviewScreenshots && verticalPreviewScreenshots.desktopHighDpi }
 						{ ...otherProps }
 					/>
-					<SignupSitePreview defaultViewportDevice="phone" { ...otherProps } />
+					<SignupSitePreview
+						defaultViewportDevice="phone"
+						screenshot={ verticalPreviewScreenshots && verticalPreviewScreenshots.mobileHighDpi }
+						{ ...otherProps }
+					/>
 				</div>
 				{ shouldShowHelpTip && <SiteMockupHelpTipBottom siteType={ siteType } /> }
 				{ shouldFetchVerticalData && (
@@ -203,12 +214,14 @@ export default connect(
 		const themeSlug = getSiteTypePropertyValue( 'slug', siteType, 'theme' );
 		const titleFallback = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupTitleFallback' );
 		const verticalPreviewContent = getSiteVerticalPreview( state );
+		const verticalPreviewScreenshots = getSiteVerticalPreviewScreenshots( state );
 		const shouldFetchVerticalData = ! verticalPreviewContent;
 		return {
 			title: getSiteTitle( state ) || titleFallback,
 			siteStyle,
 			siteType,
 			verticalPreviewContent,
+			verticalPreviewScreenshots,
 			verticalPreviewStyles: getSiteVerticalPreviewStyles( state ),
 			siteVerticalName: getSiteVerticalName( state ),
 			verticalSlug: getSiteVerticalSlug( state ),

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -19,7 +19,7 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import {
 	getSiteVerticalName,
 	getSiteVerticalPreview,
-	getSiteVerticalPreviewScreenshots,
+	getSiteVerticalPreviewScreenshot,
 	getSiteVerticalPreviewStyles,
 	getSiteVerticalSlug,
 } from 'state/signup/steps/site-vertical/selectors';
@@ -66,7 +66,7 @@ class SiteMockups extends Component {
 		title: PropTypes.string,
 		vertical: PropTypes.string,
 		verticalPreviewContent: PropTypes.string,
-		verticalPreviewScreenshots: PropTypes.object,
+		verticalPreviewScreenshot: PropTypes.string,
 		verticalPreviewStyles: PropTypes.string,
 	};
 
@@ -85,7 +85,7 @@ class SiteMockups extends Component {
 		// prevents the flashing effect.
 		if (
 			nextProps.verticalPreviewContent !== this.props.verticalPreviewContent ||
-			nextProps.verticalPreviewScreenshots !== this.props.verticalPreviewScreenshots
+			nextProps.verticalPreviewScreenshot !== this.props.verticalPreviewScreenshot
 		) {
 			this.updateDebounced();
 			return false;
@@ -96,7 +96,7 @@ class SiteMockups extends Component {
 
 	updateDebounced = debounce( () => {
 		this.forceUpdate();
-		if ( this.props.verticalPreviewContent || this.props.verticalPreviewScreenshots ) {
+		if ( this.props.verticalPreviewContent || this.props.verticalPreviewScreenshot ) {
 			this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_rendered', {
 				site_type: this.props.siteType,
 				vertical_slug: this.props.verticalSlug,
@@ -155,12 +155,12 @@ class SiteMockups extends Component {
 			title,
 			themeSlug,
 			verticalPreviewContent,
-			verticalPreviewScreenshots,
+			verticalPreviewScreenshot,
 			verticalPreviewStyles,
 		} = this.props;
 
 		const siteMockupClasses = classNames( 'site-mockup__wrap', {
-			'is-empty': isEmpty( verticalPreviewContent ) && ! verticalPreviewScreenshots,
+			'is-empty': isEmpty( verticalPreviewContent ) && ! verticalPreviewScreenshot,
 		} );
 		const langSlug = getLocaleSlug();
 		const language = getLanguage( langSlug );
@@ -189,14 +189,9 @@ class SiteMockups extends Component {
 						defaultViewportDevice="desktop"
 						resize={ true }
 						scrolling={ false }
-						screenshot={ verticalPreviewScreenshots && verticalPreviewScreenshots.desktopHighDpi }
 						{ ...otherProps }
 					/>
-					<SignupSitePreview
-						defaultViewportDevice="phone"
-						screenshot={ verticalPreviewScreenshots && verticalPreviewScreenshots.mobileHighDpi }
-						{ ...otherProps }
-					/>
+					<SignupSitePreview defaultViewportDevice="phone" { ...otherProps } />
 				</div>
 				{ shouldShowHelpTip && <SiteMockupHelpTipBottom siteType={ siteType } /> }
 				{ shouldFetchVerticalData && (
@@ -214,14 +209,14 @@ export default connect(
 		const themeSlug = getSiteTypePropertyValue( 'slug', siteType, 'theme' );
 		const titleFallback = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupTitleFallback' );
 		const verticalPreviewContent = getSiteVerticalPreview( state );
-		const verticalPreviewScreenshots = getSiteVerticalPreviewScreenshots( state );
 		const shouldFetchVerticalData = ! verticalPreviewContent;
 		return {
 			title: getSiteTitle( state ) || titleFallback,
 			siteStyle,
 			siteType,
 			verticalPreviewContent,
-			verticalPreviewScreenshots,
+			// Used to determine whether content has changed, choose any screenshot
+			verticalPreviewScreenshot: getSiteVerticalPreviewScreenshot( state, 'desktop' ),
 			verticalPreviewStyles: getSiteVerticalPreviewStyles( state ),
 			siteVerticalName: getSiteVerticalName( state ),
 			verticalSlug: getSiteVerticalSlug( state ),

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -22,6 +22,7 @@ import {
 	getSiteVerticalIsUserInput,
 	getSiteVerticalId,
 	getSiteVerticalParentId,
+	getSiteVerticalSuggestedTheme,
 } from 'state/signup/steps/site-vertical/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
@@ -49,11 +50,19 @@ class SiteTopicForm extends Component {
 			slug: verticalData.verticalSlug,
 			id: verticalData.verticalId,
 			parentId: verticalData.parent,
+			suggestedTheme: verticalData.suggestedTheme,
 		} );
 	};
 
 	onSubmit = event => {
-		const { isUserInput, siteSlug, siteTopic, verticalId, verticalParentId } = this.props;
+		const {
+			isUserInput,
+			siteSlug,
+			siteTopic,
+			suggestedTheme,
+			verticalId,
+			verticalParentId,
+		} = this.props;
 
 		event.preventDefault();
 
@@ -69,6 +78,7 @@ class SiteTopicForm extends Component {
 			slug: siteSlug,
 			parentId: verticalParentId,
 			id: verticalId,
+			suggestedTheme,
 		} );
 	};
 
@@ -117,6 +127,7 @@ export default connect(
 			siteTopic,
 			siteType,
 			siteSlug: getSiteVerticalSlug( state ),
+			suggestedTheme: getSiteVerticalSuggestedTheme( state ),
 			isUserInput: getSiteVerticalIsUserInput( state ),
 			isButtonDisabled,
 			verticalId: getSiteVerticalId( state ),

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -39,9 +39,9 @@ class SiteTopicStep extends Component {
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
 
-	submitSiteTopic = ( { isUserInput, name, slug } ) => {
+	submitSiteTopic = ( { isUserInput, name, slug, suggestedTheme } ) => {
 		const { flowName, stepName } = this.props;
-		this.props.submitSiteVertical( { isUserInput, name, slug }, stepName );
+		this.props.submitSiteVertical( { isUserInput, name, slug }, stepName, suggestedTheme );
 		this.props.goToNextStep( flowName );
 	};
 

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -32,6 +32,7 @@ export const requestVerticals = action =>
 				limit: action.limit,
 				include_preview: true,
 				allow_synonyms: true,
+				suggest_theme: true,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -28,6 +28,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 						limit: mockAction.limit,
 						include_preview: true,
 						allow_synonyms: true,
+						suggest_theme: true,
 					},
 				},
 				mockAction

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -28,7 +28,6 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 						limit: mockAction.limit,
 						include_preview: true,
 						allow_synonyms: true,
-						suggest_theme: true,
 					},
 				},
 				mockAction

--- a/client/state/signup/steps/site-vertical/actions.js
+++ b/client/state/signup/steps/site-vertical/actions.js
@@ -27,9 +27,22 @@ export function setSiteVertical( siteVerticalData ) {
  *
  * @param {Object} siteVerticalData An object containing `isUserInput`, `name`, `preview` and `slug` vertical values.
  * @param {String} stepName The name of the step to submit. Default is `site-topic`
+ * @param {String} suggestedTheme Fulfills the theme dependency if this vertical has a suggested theme e.g. `pub/maywood`
  * @return {Function} A thunk
  */
-export const submitSiteVertical = ( siteVerticalData, stepName = 'site-topic' ) => dispatch => {
+export const submitSiteVertical = (
+	siteVerticalData,
+	stepName = 'site-topic',
+	suggestedTheme = undefined
+) => dispatch => {
 	dispatch( setSiteVertical( siteVerticalData ) );
-	dispatch( submitSignupStep( { stepName }, { siteTopic: siteVerticalData.name } ) );
+	dispatch(
+		submitSignupStep(
+			{ stepName },
+			{
+				siteTopic: siteVerticalData.name,
+				...( suggestedTheme && { themeSlugWithRepo: suggestedTheme } ),
+			}
+		)
+	);
 };

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -47,6 +47,10 @@ export function getSiteVerticalPreview( state ) {
 	return get( getSiteVerticalData( state ), 'preview', '' );
 }
 
+export function getSiteVerticalPreviewScreenshots( state ) {
+	return get( getSiteVerticalData( state ), 'previewScreenshots' );
+}
+
 export function getSiteVerticalPreviewStyles( state ) {
 	return get( getSiteVerticalData( state ), 'previewStylesUrl', '' );
 }

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -87,6 +87,10 @@ export function getSiteVerticalIsUserInput( state ) {
 	return get( state, 'signup.steps.siteVertical.isUserInput', true );
 }
 
+export function getSiteVerticalSuggestedTheme( state ) {
+	return get( state, 'signup.steps.siteVertical.suggestedTheme' );
+}
+
 // Used to fill `vertical` param to pass to to `/domains/suggestions`
 // client/signup/steps/domains/index.jsx
 export function getVerticalForDomainSuggestions( state ) {

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -47,8 +47,23 @@ export function getSiteVerticalPreview( state ) {
 	return get( getSiteVerticalData( state ), 'preview', '' );
 }
 
-export function getSiteVerticalPreviewScreenshots( state ) {
-	return get( getSiteVerticalData( state ), 'previewScreenshots' );
+export function getSiteVerticalPreviewScreenshot( state, viewportDevice ) {
+	const screenshotPropName = getScreenshotPropName( viewportDevice );
+	return get( getSiteVerticalData( state ), [ 'previewScreenshots', screenshotPropName ] );
+}
+
+function getScreenshotPropName( viewportDevice ) {
+	if ( window.devicePixelRatio === 1 ) {
+		if ( viewportDevice === 'phone' ) {
+			return 'mobileLowDpi';
+		}
+		return 'desktopLowDpi';
+	}
+
+	if ( viewportDevice === 'phone' ) {
+		return 'mobileHighDpi';
+	}
+	return 'desktopHighDpi';
 }
 
 export function getSiteVerticalPreviewStyles( state ) {

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -55,13 +55,13 @@ export function getSiteVerticalPreviewScreenshot( state, viewportDevice ) {
 function getScreenshotPropName( viewportDevice ) {
 	if ( window.devicePixelRatio === 1 ) {
 		if ( viewportDevice === 'phone' ) {
-			return 'mobileLowDpi';
+			return 'phoneLowDpi';
 		}
 		return 'desktopLowDpi';
 	}
 
 	if ( viewportDevice === 'phone' ) {
-		return 'mobileHighDpi';
+		return 'phoneHighDpi';
 	}
 	return 'desktopHighDpi';
 }


### PR DESCRIPTION
Epic: Automattic/zelda-private#108

#### Changes proposed in this Pull Request

* Add support for `suggested_theme` vertical property added in D33507-code. If a vertical has a suggested theme it will be used at site creation
* Add support for `preview_screenshots` vertical property. If a vertical has preview screenshots it will be used in the site mockup
* Opts in to both features by sending the `suggest_theme` parameter to `/verticals`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with user where `locale = en`
* In A/B test picker choose "test" group for `verticalSuggestedThemes` test
* Create a site starting from `/start`
  * Choose *Business* site type
    * Choose *Restaurants* vertical
      * You should see the Rockfield theme in the preview
      * Create the site, the new site has the Rockfield theme
    * Choose *any other vertical*
      * You see the regular DOM based preview
      * Create the site, the new site has the Maywood theme
  * Choose *Blog* site type
    * Choose *Restaurants* vertical
      * You see the regular DOM based preview
      * Create the site, the new site has the Maywood theme
* `calypso_signup_site_preview_mockup_clicked` still fires when preview is clicked
* Try it on non-retina somehow. (I'm thinking browserstack might do the trick)

Fixes Automattic/zelda-private#188
