### PR TITLE
Add passwordlessSignup A/B test (revert of revert)

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -23,7 +23,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { abtest } from 'lib/abtest';
+// import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -914,37 +914,37 @@ class SignupForm extends Component {
 
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		if (
-			this.props.flowName === 'onboarding' &&
-			'passwordless' === abtest( 'passwordlessSignup' )
-		) {
-			// const logInUrl = config.isEnabled( 'login/native-login-links' )
-			// 	? this.getLoginLink()
-			// 	: localizeUrl( config( 'login_url' ), this.props.locale );
+		// if (
+		// 	this.props.flowName === 'onboarding' &&
+		// 	'passwordless' === abtest( 'passwordlessSignup' )
+		// ) {
+		// 	const logInUrl = config.isEnabled( 'login/native-login-links' )
+		// 		? this.getLoginLink()
+		// 		: localizeUrl( config( 'login_url' ), this.props.locale );
 
-			// return (
-			// 	<div className={ classNames( 'signup-form', this.props.className ) }>
-			// 		{ this.getNotice() }
-			// 		<PasswordlessSignupForm
-			// 			stepName={ this.props.stepName }
-			// 			flowName={ this.props.flowName }
-			// 			goToNextStep={ this.props.goToNextStep }
-			// 			renderTerms={ this.termsOfServiceLink }
-			// 			logInUrl={ logInUrl }
-			// 		/>
-			// 		{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
-			// 			<SocialSignupForm
-			// 				handleResponse={ this.props.handleSocialResponse }
-			// 				socialService={ this.props.socialService }
-			// 				socialServiceResponse={ this.props.socialServiceResponse }
-			// 			/>
-			// 		) }
+		// 	return (
+		// 		<div className={ classNames( 'signup-form', this.props.className ) }>
+		// 			{ this.getNotice() }
+		// 			<PasswordlessSignupForm
+		// 				stepName={ this.props.stepName }
+		// 				flowName={ this.props.flowName }
+		// 				goToNextStep={ this.props.goToNextStep }
+		// 				renderTerms={ this.termsOfServiceLink }
+		// 				logInUrl={ logInUrl }
+		// 			/>
+		// 			{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+		// 				<SocialSignupForm
+		// 					handleResponse={ this.props.handleSocialResponse }
+		// 					socialService={ this.props.socialService }
+		// 					socialServiceResponse={ this.props.socialServiceResponse }
+		// 				/>
+		// 			) }
 
-			// 		{ this.props.footerLink || this.footerLink() }
-			// 	</div>
-			// );
-			return null;
-		}
+		// 			{ this.props.footerLink || this.footerLink() }
+		// 		</div>
+		// 	);
+		// 	return null;
+		// }
 
 		return (
 			<div className={ classNames( 'signup-form', this.props.className ) }>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -23,7 +23,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { abtest } from 'lib/abtest';
+// import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
-import PasswordlessSignupForm from 'blocks/signup-form/passwordless';
+// import PasswordlessSignupForm from 'blocks/signup-form/passwordless';
 import CrowdsignalSignupForm from './crowdsignal';
 import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -914,36 +914,36 @@ class SignupForm extends Component {
 
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		if (
-			this.props.flowName === 'onboarding' &&
-			'passwordless' === abtest( 'passwordlessSignup' )
-		) {
-			const logInUrl = config.isEnabled( 'login/native-login-links' )
-				? this.getLoginLink()
-				: localizeUrl( config( 'login_url' ), this.props.locale );
+		// if (
+		// 	this.props.flowName === 'onboarding' &&
+		// 	'passwordless' === abtest( 'passwordlessSignup' )
+		// ) {
+		// 	const logInUrl = config.isEnabled( 'login/native-login-links' )
+		// 		? this.getLoginLink()
+		// 		: localizeUrl( config( 'login_url' ), this.props.locale );
 
-			return (
-				<div className={ classNames( 'signup-form', this.props.className ) }>
-					{ this.getNotice() }
-					<PasswordlessSignupForm
-						stepName={ this.props.stepName }
-						flowName={ this.props.flowName }
-						goToNextStep={ this.props.goToNextStep }
-						renderTerms={ this.termsOfServiceLink }
-						logInUrl={ logInUrl }
-					/>
-					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
-						<SocialSignupForm
-							handleResponse={ this.props.handleSocialResponse }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
-						/>
-					) }
+		// 	return (
+		// 		<div className={ classNames( 'signup-form', this.props.className ) }>
+		// 			{ this.getNotice() }
+		// 			<PasswordlessSignupForm
+		// 				stepName={ this.props.stepName }
+		// 				flowName={ this.props.flowName }
+		// 				goToNextStep={ this.props.goToNextStep }
+		// 				renderTerms={ this.termsOfServiceLink }
+		// 				logInUrl={ logInUrl }
+		// 			/>
+		// 			{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+		// 				<SocialSignupForm
+		// 					handleResponse={ this.props.handleSocialResponse }
+		// 					socialService={ this.props.socialService }
+		// 					socialServiceResponse={ this.props.socialServiceResponse }
+		// 				/>
+		// 			) }
 
-					{ this.props.footerLink || this.footerLink() }
-				</div>
-			);
-		}
+		// 			{ this.props.footerLink || this.footerLink() }
+		// 		</div>
+		// 	);
+		// }
 
 		return (
 			<div className={ classNames( 'signup-form', this.props.className ) }>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -23,7 +23,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-// import { abtest } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
-// import PasswordlessSignupForm from 'blocks/signup-form/passwordless';
+import PasswordlessSignupForm from 'blocks/signup-form/passwordless'; // eslint-disable-line no-unused-vars
 import CrowdsignalSignupForm from './crowdsignal';
 import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -914,36 +914,37 @@ class SignupForm extends Component {
 
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		// if (
-		// 	this.props.flowName === 'onboarding' &&
-		// 	'passwordless' === abtest( 'passwordlessSignup' )
-		// ) {
-		// 	const logInUrl = config.isEnabled( 'login/native-login-links' )
-		// 		? this.getLoginLink()
-		// 		: localizeUrl( config( 'login_url' ), this.props.locale );
+		if (
+			this.props.flowName === 'onboarding' &&
+			'passwordless' === abtest( 'passwordlessSignup' )
+		) {
+			// const logInUrl = config.isEnabled( 'login/native-login-links' )
+			// 	? this.getLoginLink()
+			// 	: localizeUrl( config( 'login_url' ), this.props.locale );
 
-		// 	return (
-		// 		<div className={ classNames( 'signup-form', this.props.className ) }>
-		// 			{ this.getNotice() }
-		// 			<PasswordlessSignupForm
-		// 				stepName={ this.props.stepName }
-		// 				flowName={ this.props.flowName }
-		// 				goToNextStep={ this.props.goToNextStep }
-		// 				renderTerms={ this.termsOfServiceLink }
-		// 				logInUrl={ logInUrl }
-		// 			/>
-		// 			{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
-		// 				<SocialSignupForm
-		// 					handleResponse={ this.props.handleSocialResponse }
-		// 					socialService={ this.props.socialService }
-		// 					socialServiceResponse={ this.props.socialServiceResponse }
-		// 				/>
-		// 			) }
+			// return (
+			// 	<div className={ classNames( 'signup-form', this.props.className ) }>
+			// 		{ this.getNotice() }
+			// 		<PasswordlessSignupForm
+			// 			stepName={ this.props.stepName }
+			// 			flowName={ this.props.flowName }
+			// 			goToNextStep={ this.props.goToNextStep }
+			// 			renderTerms={ this.termsOfServiceLink }
+			// 			logInUrl={ logInUrl }
+			// 		/>
+			// 		{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+			// 			<SocialSignupForm
+			// 				handleResponse={ this.props.handleSocialResponse }
+			// 				socialService={ this.props.socialService }
+			// 				socialServiceResponse={ this.props.socialServiceResponse }
+			// 			/>
+			// 		) }
 
-		// 			{ this.props.footerLink || this.footerLink() }
-		// 		</div>
-		// 	);
-		// }
+			// 		{ this.props.footerLink || this.footerLink() }
+			// 	</div>
+			// );
+			return null;
+		}
 
 		return (
 			<div className={ classNames( 'signup-form', this.props.className ) }>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -23,7 +23,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-// import { abtest } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
-import PasswordlessSignupForm from 'blocks/signup-form/passwordless'; // eslint-disable-line no-unused-vars
+import PasswordlessSignupForm from './passwordless';
 import CrowdsignalSignupForm from './crowdsignal';
 import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -914,37 +914,36 @@ class SignupForm extends Component {
 
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		// if (
-		// 	this.props.flowName === 'onboarding' &&
-		// 	'passwordless' === abtest( 'passwordlessSignup' )
-		// ) {
-		// 	const logInUrl = config.isEnabled( 'login/native-login-links' )
-		// 		? this.getLoginLink()
-		// 		: localizeUrl( config( 'login_url' ), this.props.locale );
+		if (
+			this.props.flowName === 'onboarding' &&
+			'passwordless' === abtest( 'passwordlessSignup' )
+		) {
+			const logInUrl = config.isEnabled( 'login/native-login-links' )
+				? this.getLoginLink()
+				: localizeUrl( config( 'login_url' ), this.props.locale );
 
-		// 	return (
-		// 		<div className={ classNames( 'signup-form', this.props.className ) }>
-		// 			{ this.getNotice() }
-		// 			<PasswordlessSignupForm
-		// 				stepName={ this.props.stepName }
-		// 				flowName={ this.props.flowName }
-		// 				goToNextStep={ this.props.goToNextStep }
-		// 				renderTerms={ this.termsOfServiceLink }
-		// 				logInUrl={ logInUrl }
-		// 			/>
-		// 			{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
-		// 				<SocialSignupForm
-		// 					handleResponse={ this.props.handleSocialResponse }
-		// 					socialService={ this.props.socialService }
-		// 					socialServiceResponse={ this.props.socialServiceResponse }
-		// 				/>
-		// 			) }
+			return (
+				<div className={ classNames( 'signup-form', this.props.className ) }>
+					{ this.getNotice() }
+					<PasswordlessSignupForm
+						stepName={ this.props.stepName }
+						flowName={ this.props.flowName }
+						goToNextStep={ this.props.goToNextStep }
+						renderTerms={ this.termsOfServiceLink }
+						logInUrl={ logInUrl }
+					/>
+					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+						<SocialSignupForm
+							handleResponse={ this.props.handleSocialResponse }
+							socialService={ this.props.socialService }
+							socialServiceResponse={ this.props.socialServiceResponse }
+						/>
+					) }
 
-		// 			{ this.props.footerLink || this.footerLink() }
-		// 		</div>
-		// 	);
-		// 	return null;
-		// }
+					{ this.props.footerLink || this.footerLink() }
+				</div>
+			);
+		}
 
 		return (
 			<div className={ classNames( 'signup-form', this.props.className ) }>

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,0 +1,188 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import emailValidator from 'email-validator';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import LoggedOutForm from 'components/logged-out-form';
+import LoggedOutFormFooter from 'components/logged-out-form/footer';
+import ValidationFieldset from 'signup/validation-fieldset';
+import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+import Notice from 'components/notice';
+import { submitSignupStep } from 'state/signup/progress/actions';
+
+export class PasswordlessSignupForm extends Component {
+	static defaultProps = {
+		locale: 'en',
+	};
+
+	state = {
+		isSubmitting: false,
+		email: '',
+		errorMessages: null,
+	};
+
+	submitTracksEvent = ( isSuccessful, props ) => {
+		const tracksEventName = isSuccessful
+			? 'calypso_signup_actions_onboarding_passwordless_login_success'
+			: 'calypso_signup_actions_onboarding_passwordless_login_error';
+		this.props.recordTracksEvent( tracksEventName, {
+			...props,
+		} );
+	};
+
+	onFormSubmit = event => {
+		event.preventDefault();
+
+		if ( ! this.state.email || ! emailValidator.validate( this.state.email ) ) {
+			this.setState( {
+				errorMessages: [ this.props.translate( 'Please provide a valid email address.' ) ],
+				isSubmitting: false,
+			} );
+			this.submitTracksEvent( false, { action_message: 'Please provide a valid email address.' } );
+			return;
+		}
+
+		this.setState( {
+			isSubmitting: true,
+		} );
+
+		createUserAccountFromEmailAddress( this.createUserAccountFromEmailAddressCallback, {
+			email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+		} );
+	};
+
+	createUserAccountFromEmailAddressCallback = ( error, response ) => {
+		if ( error ) {
+			const errorMessage = this.getErrorMessage( error );
+			this.setState( {
+				errorMessages: [ errorMessage ],
+				isSubmitting: false,
+			} );
+			this.submitTracksEvent( false, { action_message: error.message } );
+			return;
+		}
+
+		this.setState( {
+			errorMessages: null,
+			isSubmitting: false,
+		} );
+
+		this.submitStep( response );
+	};
+
+	getErrorMessage( errorObj = { error: null, message: null } ) {
+		const { translate } = this.props;
+
+		switch ( errorObj.error ) {
+			case 'already_taken':
+			case 'already_active':
+				return (
+					<>
+						{ translate( 'An account with this email address already exists.' ) }
+						&nbsp;
+						{ translate( 'If this is you {{a}}log in now{{/a}}.', {
+							components: {
+								a: (
+									<a
+										href={ `${ this.props.logInUrl }&email_address=${ encodeURIComponent(
+											this.state.email
+										) }` }
+									/>
+								),
+							},
+						} ) }
+					</>
+				);
+			default:
+				return (
+					errorObj.message ||
+					translate(
+						'Sorry, something went wrong when trying to create your account. Please try again.'
+					)
+				);
+		}
+	}
+	submitStep = data => {
+		const { flowName, stepName, goToNextStep, submitCreateAccountStep } = this.props;
+		submitCreateAccountStep(
+			{
+				flowName,
+				stepName,
+				// We use this flag in the flow controller to communicate to the flow controller that we're
+				// dealing with passwordless signup, and therefore don't need to call the apiFunction
+				// normally associated with the user step.
+				isPasswordlessSignupForm: true,
+			},
+			data
+		);
+		this.submitTracksEvent( true, { action_message: 'Successful login', username: data.username } );
+		goToNextStep();
+	};
+	onInputChange = ( { target: { value } } ) =>
+		this.setState( {
+			email: value,
+			errorMessages: null,
+			isEmailAddressValid: emailValidator.validate( value ),
+		} );
+	renderNotice() {
+		return (
+			<Notice showDismiss={ false } status="is-error">
+				{ this.props.translate(
+					'Your account has already been created. You can change your email, username, and password later.'
+				) }
+			</Notice>
+		);
+	}
+	render() {
+		const { translate } = this.props;
+		const { errorMessages, isSubmitting, isEmailAddressValid } = this.state;
+		const submitButtonText = isSubmitting
+			? translate( 'Creating Your Account…' )
+			: translate( 'Create your account' );
+		return (
+			<div className="signup-form__passwordless-form-wrapper">
+				<LoggedOutForm onSubmit={ this.onFormSubmit } noValidate>
+					<ValidationFieldset errorMessages={ errorMessages }>
+						<FormLabel htmlFor="email">{ translate( 'Enter your email address' ) }</FormLabel>
+						<FormTextInput
+							autoCapitalize={ 'off' }
+							className="signup-form__passwordless-email"
+							type="email"
+							name="email"
+							onChange={ this.onInputChange }
+							disabled={ isSubmitting }
+						/>
+					</ValidationFieldset>
+					{ this.props.renderTerms() }
+					<LoggedOutFormFooter>
+						<Button
+							type="submit"
+							primary
+							busy={ isSubmitting }
+							disabled={ isSubmitting || ! isEmailAddressValid }
+						>
+							{ submitButtonText }
+						</Button>
+					</LoggedOutFormFooter>
+				</LoggedOutForm>
+			</div>
+		);
+	}
+}
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+		submitCreateAccountStep: submitSignupStep,
+	}
+)( localize( PasswordlessSignupForm ) );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux'; // eslint-disable-line no-unused-vars
-import { localize } from 'i18n-calypso'; // eslint-disable-line no-unused-vars
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import emailValidator from 'email-validator';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -16,11 +17,15 @@ import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import ValidationFieldset from 'signup/validation-fieldset';
 import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
-import { recordTracksEvent } from 'state/analytics/actions'; // eslint-disable-line no-unused-vars
+import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
-import { submitSignupStep } from 'state/signup/progress/actions'; // eslint-disable-line no-unused-vars
+import { submitSignupStep } from 'state/signup/progress/actions';
 
-export default class PasswordlessSignupForm extends Component {
+class PasswordlessSignupForm extends Component {
+	static propTypes = {
+		locale: PropTypes.string,
+	};
+
 	static defaultProps = {
 		locale: 'en',
 	};
@@ -179,10 +184,10 @@ export default class PasswordlessSignupForm extends Component {
 		);
 	}
 }
-// export default connect(
-// 	null,
-// 	{
-// 		recordTracksEvent,
-// 		submitCreateAccountStep: submitSignupStep,
-// 	}
-// )( localize( PasswordlessSignupForm ) );
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+		submitCreateAccountStep: submitSignupStep,
+	}
+)( localize( PasswordlessSignupForm ) );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -16,7 +16,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import ValidationFieldset from 'signup/validation-fieldset';
-import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
+// import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
 import { submitSignupStep } from 'state/signup/progress/actions';
@@ -61,9 +61,9 @@ class PasswordlessSignupForm extends Component {
 			isSubmitting: true,
 		} );
 
-		createUserAccountFromEmailAddress( this.createUserAccountFromEmailAddressCallback, {
-			email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
-		} );
+		// createUserAccountFromEmailAddress( this.createUserAccountFromEmailAddressCallback, {
+		// 	email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+		// } );
 	};
 
 	createUserAccountFromEmailAddressCallback = ( error, response ) => {

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux'; // eslint-disable-line no-unused-vars
+import { localize } from 'i18n-calypso'; // eslint-disable-line no-unused-vars
 import emailValidator from 'email-validator';
 
 /**
@@ -16,11 +16,11 @@ import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import ValidationFieldset from 'signup/validation-fieldset';
 import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions'; // eslint-disable-line no-unused-vars
 import Notice from 'components/notice';
-import { submitSignupStep } from 'state/signup/progress/actions';
+import { submitSignupStep } from 'state/signup/progress/actions'; // eslint-disable-line no-unused-vars
 
-export class PasswordlessSignupForm extends Component {
+export default class PasswordlessSignupForm extends Component {
 	static defaultProps = {
 		locale: 'en',
 	};
@@ -179,10 +179,10 @@ export class PasswordlessSignupForm extends Component {
 		);
 	}
 }
-export default connect(
-	null,
-	{
-		recordTracksEvent,
-		submitCreateAccountStep: submitSignupStep,
-	}
-)( localize( PasswordlessSignupForm ) );
+// export default connect(
+// 	null,
+// 	{
+// 		recordTracksEvent,
+// 		submitCreateAccountStep: submitSignupStep,
+// 	}
+// )( localize( PasswordlessSignupForm ) );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -10,13 +10,13 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import wpcom from 'lib/wp';
 import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import ValidationFieldset from 'signup/validation-fieldset';
-import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
 import { submitSignupStep } from 'state/signup/progress/actions';
@@ -61,9 +61,19 @@ class PasswordlessSignupForm extends Component {
 			isSubmitting: true,
 		} );
 
-		createUserAccountFromEmailAddress( this.createUserAccountFromEmailAddressCallback, {
-			email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
-		} );
+		wpcom
+			.undocumented()
+			.createUserAccountFromEmailAddress(
+				{ email: typeof this.state.email === 'string' ? this.state.email.trim() : '' },
+				null
+			)
+			.then( response =>
+				this.createUserAccountFromEmailAddressCallback( null, {
+					username: response.username,
+					bearer_token: response.token.access_token,
+				} )
+			)
+			.catch( err => this.createUserAccountFromEmailAddressCallback( err ) );
 	};
 
 	createUserAccountFromEmailAddressCallback = ( error, response ) => {

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -16,7 +16,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import ValidationFieldset from 'signup/validation-fieldset';
-// import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
+import { createUserAccountFromEmailAddress } from 'lib/signup/step-actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
 import { submitSignupStep } from 'state/signup/progress/actions';
@@ -61,9 +61,9 @@ class PasswordlessSignupForm extends Component {
 			isSubmitting: true,
 		} );
 
-		// createUserAccountFromEmailAddress( this.createUserAccountFromEmailAddressCallback, {
-		// 	email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
-		// } );
+		createUserAccountFromEmailAddress( this.createUserAccountFromEmailAddressCallback, {
+			email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+		} );
 	};
 
 	createUserAccountFromEmailAddressCallback = ( error, response ) => {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -58,3 +58,17 @@
 	color: var( --color-text-inverted );
 	text-decoration: underline;
 }
+
+.signup-form__passwordless-form-wrapper {
+	.signup-form__terms-of-service-link {
+		margin: 4px 0;
+	}
+
+	.logged-out-form__footer {
+		margin-top: 0;
+	}
+
+	.validation-fieldset__validation-message {
+		min-height: auto;
+	}
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -152,6 +152,7 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+<<<<<<< HEAD
 	verticalSuggestedThemes: {
 		datestamp: '20191011',
 		variations: {
@@ -160,5 +161,14 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+=======
+	passwordlessSignup: {
+		datestamp: '20190927',
+		variations: {
+			passwordless: 0,
+			default: 100,
+		},
+		defaultVariation: 'default',
+>>>>>>> Add passwordlessSignup A/B test
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -152,7 +152,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-<<<<<<< HEAD
 	verticalSuggestedThemes: {
 		datestamp: '20191011',
 		variations: {
@@ -161,14 +160,13 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-=======
+	},
 	passwordlessSignup: {
-		datestamp: '20191014',
+		datestamp: '20191013',
 		variations: {
 			passwordless: 0,
 			default: 100,
 		},
 		defaultVariation: 'default',
->>>>>>> Add passwordlessSignup A/B test
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -163,7 +163,7 @@ export default {
 		allowExistingUsers: true,
 =======
 	passwordlessSignup: {
-		datestamp: '20190927',
+		datestamp: '20191014',
 		variations: {
 			passwordless: 0,
 			default: 100,

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -33,6 +33,7 @@ import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { resetSignup, updateDependencies } from 'state/signup/actions';
 import { completeSignupStep, invalidateStep, processStep } from 'state/signup/progress/actions';
+import { abtest } from 'lib/abtest';
 
 interface Dependencies {
 	[ other: string ]: any;
@@ -289,6 +290,25 @@ export default class SignupFlowController {
 			getSignupDependencyStore( this._reduxStore.getState() ),
 			dependencies
 		);
+
+		/*
+			AB Test: passwordlessSignup
+
+			`isPasswordlessSignupForm` in this check is for the `onboarding` flow.
+
+			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
+		*/
+		if (
+			'passwordless' === abtest( 'passwordlessSignup' ) &&
+			get( step, 'isPasswordlessSignupForm' )
+		) {
+			this._processingSteps.delete( step.stepName );
+			analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {
+				step: step.stepName,
+			} );
+			this._reduxStore.dispatch( completeSignupStep( step, dependenciesFound ) );
+			return;
+		}
 
 		// deferred because a step can be processed as soon as it is submitted
 		defer( () => {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -33,7 +33,7 @@ import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { resetSignup, updateDependencies } from 'state/signup/actions';
 import { completeSignupStep, invalidateStep, processStep } from 'state/signup/progress/actions';
-import { abtest } from 'lib/abtest';
+// import { abtest } from 'lib/abtest';
 
 interface Dependencies {
 	[ other: string ]: any;
@@ -298,17 +298,18 @@ export default class SignupFlowController {
 
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		if (
-			'passwordless' === abtest( 'passwordlessSignup' ) &&
-			get( step, 'isPasswordlessSignupForm' )
-		) {
-			this._processingSteps.delete( step.stepName );
-			analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {
-				step: step.stepName,
-			} );
-			this._reduxStore.dispatch( completeSignupStep( step, dependenciesFound ) );
-			return;
-		}
+		// if (
+		// 	'passwordless' === abtest( 'passwordlessSignup' ) &&
+		// 	get( step, 'isPasswordlessSignupForm' )
+		// ) {
+		// 	console.log( 'The thing that shouldn not fire has fired' );
+		// 	this._processingSteps.delete( step.stepName );
+		// 	analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {
+		// 		step: step.stepName,
+		// 	} );
+		// 	this._reduxStore.dispatch( completeSignupStep( step, dependenciesFound ) );
+		// 	return;
+		// }
 
 		// deferred because a step can be processed as soon as it is submitted
 		defer( () => {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -33,7 +33,7 @@ import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { resetSignup, updateDependencies } from 'state/signup/actions';
 import { completeSignupStep, invalidateStep, processStep } from 'state/signup/progress/actions';
-// import { abtest } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 
 interface Dependencies {
 	[ other: string ]: any;
@@ -298,18 +298,17 @@ export default class SignupFlowController {
 
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		// if (
-		// 	'passwordless' === abtest( 'passwordlessSignup' ) &&
-		// 	get( step, 'isPasswordlessSignupForm' )
-		// ) {
-		// 	console.log( 'The thing that shouldn not fire has fired' );
-		// 	this._processingSteps.delete( step.stepName );
-		// 	analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {
-		// 		step: step.stepName,
-		// 	} );
-		// 	this._reduxStore.dispatch( completeSignupStep( step, dependenciesFound ) );
-		// 	return;
-		// }
+		if (
+			'passwordless' === abtest( 'passwordlessSignup' ) &&
+			get( step, 'isPasswordlessSignupForm' )
+		) {
+			this._processingSteps.delete( step.stepName );
+			analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {
+				step: step.stepName,
+			} );
+			this._reduxStore.dispatch( completeSignupStep( step, dependenciesFound ) );
+			return;
+		}
 
 		// deferred because a step can be processed as soon as it is submitted
 		defer( () => {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -416,7 +416,7 @@ export function createAccount(
 					nux_q_question_primary: siteVertical,
 					nux_q_question_experience: userExperience || undefined,
 					// url sent in the confirmation email
-					jetpack_redirect: get( queryArgs, 'jetpack_redirect' ),
+					jetpack_redirect: queryArgs.jetpack_redirect,
 				},
 				oauth2Signup
 					? {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -416,7 +416,7 @@ export function createAccount(
 					nux_q_question_primary: siteVertical,
 					nux_q_question_experience: userExperience || undefined,
 					// url sent in the confirmation email
-					jetpack_redirect: queryArgs.jetpack_redirect,
+					jetpack_redirect: get( queryArgs, 'jetpack_redirect' ),
 				},
 				oauth2Signup
 					? {
@@ -649,6 +649,24 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 }
 
 /**
+ * Creates a user account using an email only and logs them in immediately.
+ * It differs from `createPasswordlessUser` in that we don't require a verification step before the user can continue with onboarding.
+ * Returns the dependencies for the step.
+ *
+ * @param {function} callback API callback function
+ * @param {object}   data     An object sent via POST to WPCOM API with the following values: `email`
+ */
+export function createUserAccountFromEmailAddress( callback, { email } ) {
+	wpcom
+		.undocumented()
+		.createUserAccountFromEmailAddress( { email }, null )
+		.then( response =>
+			callback( null, { username: response.username, bearer_token: response.token.access_token } )
+		)
+		.catch( err => callback( err ) );
+}
+
+/**
  * Creates a user account and sends the user a verification code via email to confirm the account.
  * Returns the dependencies for the step.
  *
@@ -669,7 +687,7 @@ export function createPasswordlessUser( callback, { email } ) {
  * @param {function} callback Callback function
  * @param {object}   data     POST data object
  */
-export async function verifyPasswordlessUser( callback, { email, code } ) {
+export function verifyPasswordlessUser( callback, { email, code } ) {
 	wpcom
 		.undocumented()
 		.usersEmailVerification( { email, code }, null )

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1456,6 +1456,26 @@ Undocumented.prototype.usersEmailNew = function( query, fn ) {
 };
 
 /**
+ * Sign up for a new user account and login immediately
+ * Onboard a new user
+ *
+ * @param {object} query - an object with the following values: email
+ * @param {Function} fn - Function to invoke when request is complete
+ */
+Undocumented.prototype.createUserAccountFromEmailAddress = function( query, fn ) {
+	debug( '/users/email/onboard' );
+
+	// This API call is restricted to these OAuth keys
+	restrictByOauthKeys( query );
+
+	const args = {
+		path: '/users/email/onboard',
+		body: query,
+	};
+	return this.wpcom.req.post( args, fn );
+};
+
+/**
  * Verify a new passwordless user account
  *
  * @param {object} query - an object with the following values: email, code

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -102,12 +102,7 @@ const Flows = {
 	 *
 	 * The returned flow is modified according to several filters.
 	 *
-	 * `currentStepName` is the current step in the signup flow. It is used
-	 * to determine if any AB variations should be assigned after it is completed.
-	 * Example use case: To determine if a new signup step should be part of the flow or not.
-	 *
 	 * @param {String} flowName The name of the flow to return
-	 * @param {String} currentStepName The current step. See description above
 	 * @returns {Object} A flow object
 	 */
 	getFlow( flowName ) {


### PR DESCRIPTION
This is a revert of a revert, restoring changes from (#34768) that were reverted in (#36429) due to issue (#36428). This change fixes the issue where signups were broken on calypso.live (and production) when a user begins at `/jetpack/new` (for example, a logged in user who clicks `My Sites > Add new site`. The issue appears to be caused by importing from `/lib/signup/step-actions` too early in the signup process. In this change, that import is removed, and instead we're importing `wpcom` directly from `lib/wp`. More discussion below on the [problem](https://github.com/Automattic/wp-calypso/pull/36519#issuecomment-539359076), and the [solution](https://github.com/Automattic/wp-calypso/pull/36519#issuecomment-539853081).

## Changes proposed in this Pull Request

From the original PR #34768

We want to test the hypothesis that simplifying our account step for new users to only show an email address (and not require a password or username) will increase the number of people completing signup.

We will know this is true if we see an increase in the number of sites being created, and (hopefully) revenue increase.

The simplified passwordless signup form looks like:

![passwordless-signup](https://user-images.githubusercontent.com/14988353/66459627-26ad7380-eac1-11e9-8556-cc03d5afab50.png)

## Testing instructions

These instructions are copied from the original PR #34768 —

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

ℹ️ For internal testing purposes, we'll launch this PR with the control set to 100% for a few days. ~Let's see if it survives :)~ (it didn't survive the first time, let's see if it survives a second time!)

Engage `passwordless` variation for the `passwordlessSignup` AB test.

or set the local storage value:

`localStorage.setItem( 'ABTests', '{"passwordlessSignup_20190927":"passwordless"}' );`

![image](https://user-images.githubusercontent.com/14988353/66458418-763e7000-eabe-11e9-955e-a134806da610.png)

### Test case for ensuring the regression is fixed

Note this needs to be tested on calypso.live as it uses the production configuration. The regression only appeared in production-like environments, and not in the local development environment / `developer.json` config.

* Go to: https://calypso.live/?branch=add/passwordless-signup-ab-test-round-two and then go to `/jetpack/new`
* Click to create a new site
* Create a new user account in the default signup form
* Select the Business site type
* Enter 'Tech blog' as the site topic
* Enter any name for the site title
* Select a free sub-domain on the domains step
* Select the Free plan

### Test cases for the original PR

1. **Signup with a new email address and create a site:**
  a. You should be able to create an account and a site as per normal.
  b. You should be able to create an account, pay for a plan and domain as usual
  c. You should receive an activation email that explains about your generated username and (lack of) password^
  d. There should be an account activation task in the checklist
2. **Attempt signup with an exisiting account** - You be notified that you have an existing account and be prompted to log in. If the account is passwordless, you'll be sent a Magic Link.
3. **Attempt to sign in/sign up and create a site with a Google account** - You should be able to continue as per normal.
4. **On a flow other than onboarding** - Even with the AB variant set to passwordless you should never see the passwordless form
5. **Creating an account via Jetpack is unaffected** - Create a new site via https://jurassic.ninja/ — once it's created, click to setup Jetpack. On the login screen for Jetpack, update the URL to use `calypso.localhost:3000` and select to create an account. This will take you to the `/jetpack/connect/authorize` URL, which should show the default login form (email, username, password) even if you have the AB variant set to `passwordless`.

### Relevant tracking events

`calypso_signup_actions_onboarding_passwordless_login_success` and `calypso_signup_actions_onboarding_passwordless_login_error` - fired when the user submits the passwordless version of the user step. Important Parameters:

```
action_message: "Successful login" | "An account with this email address already exists."
username: {The generated username (if successful)}
```

^ Activation email

![image](https://user-images.githubusercontent.com/14988353/66458728-31670900-eabf-11e9-8529-2a5fb9ba483f.png)
