### PR TITLE
Importer Track events: fix tracking of import file upload and start of import from a URL.

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -221,19 +221,23 @@ export function startImporting( importerStatus ) {
 	wpcom.updateImporter( siteId, importOrder( importerStatus ) );
 }
 
+export const setUploadStartState = ( importerId, filenameOrUrl ) => {
+	const startUploadAction = {
+		type: IMPORTS_UPLOAD_START,
+		filename: filenameOrUrl,
+		importerId,
+	};
+	Dispatcher.handleViewAction( startUploadAction );
+	reduxDispatch( startUploadAction );
+};
+
 export const startUpload = ( importerStatus, file ) => {
 	const {
 		importerId,
 		site: { ID: siteId },
 	} = importerStatus;
 
-	const startUploadAction = {
-		type: IMPORTS_UPLOAD_START,
-		filename: file.name,
-		importerId,
-	};
-	Dispatcher.handleViewAction( startUploadAction );
-	reduxDispatch( startUploadAction );
+	setUploadStartState( importerId, file.name );
 
 	wpcom
 		.uploadExportFile( siteId, {

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -105,7 +105,7 @@ class SectionImport extends Component {
 	trackImporterStateChange = memoizeLast( ( importerState, importerId ) => {
 		const stateToEventNameMap = {
 			[ appStates.READY_FOR_UPLOAD ]: 'calypso_importer_view',
-			[ appStates.UPLOAD_PROCESSING ]: 'calypso_importer_upload_start',
+			[ appStates.UPLOADING ]: 'calypso_importer_upload_start',
 			[ appStates.UPLOAD_SUCCESS ]: 'calypso_importer_upload_success',
 			[ appStates.UPLOAD_FAILURE ]: 'calypso_importer_upload_fail',
 			[ appStates.MAP_AUTHORS ]: 'calypso_importer_map_authors_view',

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -34,7 +34,7 @@ import ImporterActionButtonContainer from 'my-sites/importer/importer-action-but
 import ErrorPane from '../error-pane';
 import SiteImporterSitePreview from './site-importer-site-preview';
 import { appStates } from 'state/imports/constants';
-import { cancelImport } from 'lib/importer/actions';
+import { cancelImport, setUploadStartState } from 'lib/importer/actions';
 
 /**
  * Style dependencies
@@ -183,6 +183,10 @@ class SiteImporterInputPane extends React.Component {
 	};
 
 	importSite = () => {
+		// To track an "upload start"
+		const { importerId } = this.props.importerStatus;
+		setUploadStartState( importerId, this.props.validatedSiteUrl );
+
 		this.props.importSite( {
 			engine: this.props.importData.engine,
 			importerStatus: this.props.importerStatus,


### PR DESCRIPTION
In the Tracks Trends for `calypso_importer_upload_start` and related Tracks events, `calypso_importer_upload_start` is lower than `calypso_importer_upload_success` and `calypso_importer_upload_fail`. 

#### Changes proposed in this Pull Request

* The `calypso_importer_upload_start` track event is currently mapped to the `UPLOAD_PROCESSING` state. This corresponds to the "processing" status returned by the import API. But the importer only sets that status if the import file is a zip, and even then the status is liable to change to "importing" before the API returns it to Calypso.
* This PR changes the mapping to `UPLOADING`. This state is set as soon as the user initiates the upload of the import file.
* The API also returns upload success and failure statuses when an attempted import from a URL has caused an import to start or fail, even though there hasn't been any upload start event. To correct this, the PR sets the upload status when someone initiates an import, passing the action the URL instead of a filename.

#### Testing instructions

* Apply the PR and run Calypso locally, or test on `calypso.live`.
* Open your browser's dev tools and enable the debugging of Tracks events:
```
localStorage.setItem( 'debug', 'calypso:analytics:tracks' )
``` 
* Go to the Import page, choose a file importer like WordPress, and upload an import file.
* Check the console tab. You should see the Tracks event `calypso_importer_upload_start`. When the upload has finished you should see the Tracks event `calypso_importer_upload_success`.
* Cancel the import and go to a URL importer like Wix, and enter the URL of a site to import. The importer will process the URL and show you the site preview. Click the "Yes! Start import" button.
* Check the console tab. You should see the Tracks event `calypso_importer_upload_start` event. Later you should see the Tracks event `calypso_importer_upload_success`.

Partially fixes samus-290
