### PR TITLE
SPT: fix non a11y compliant back button

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
-import { Button, Modal, Spinner, Dashicon } from '@wordpress/components';
+import { Button, Modal, Spinner, IconButton } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
@@ -167,12 +167,12 @@ class PageTemplateModal extends Component {
 				shouldCloseOnClickOutside={ false }
 				isDismissible={ false }
 			>
-				<Button
+				<IconButton
 					className="page-template-modal__close-button components-icon-button"
 					onClick={ this.closeModal }
-				>
-					<Dashicon icon="arrow-left-alt2" />
-				</Button>
+					icon="arrow-left-alt2"
+					label={ __( 'Go back' ) }
+				/>
 
 				<div className="page-template-modal__inner">
 					{ isLoading ? (


### PR DESCRIPTION
Currently, the newly implemented back button relies on visuals only (ie: an icon) to convey meaning. This is not accessible to non-sighted users.

This PR updates the implementation to utilise the `IconButton` component and provides a suitable descriptive text label to ensure the button is perceivable for non-sighted users.

#### Testing instructions

* Open the Page selector
* Hover/focus the "back" button.
* See the descriptive tooltip appear.
* Check tooltip is defined as `aria-label` in DOM.
* Check tooltip is translatable.
