### PR TITLE
SPT: updates interaction states to be more perceivable

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -184,14 +184,28 @@ body.is-fullscreen-mode {
 		&:hover,
 		&:focus,
 		&.is-selected {
-			@media screen and ( min-width: 660px ) {
-				border-color: #2562b7;
-				box-shadow: 0 0 0 1px #2562b7;
-				outline: 1px solid transparent;
-				outline-offset: -1px;
-				color: inherit;
+			outline: 1px solid transparent;
+			outline-offset: -1px;
+			color: inherit;
+		}
+		
+		&:hover,
+		&:focus {
+			border-color: #555d66;
+			box-shadow: 0 0 0 1px #555d66;
+		}
+
+		&.is-selected {
+			border-color: #2562b7;
+			box-shadow: 0 0 0 1px #2562b7;
+
+			&:hover,
+			&:focus {
+				box-shadow: 0 0 0 1px #555d66, 0 0 0 2px #fff, 0 0 0 3px #2562b7;
 			}
 		}
+
+		
 	}
 
 	.template-selector-item__preview-wrap {


### PR DESCRIPTION
Currently, when interacting with a template preview it isn't possible to visually perceive all the states.

For example, if a preview element is selected it is not possible to perceive when that same element becomes focused.

This PR attempts to rectify this by mirroring some of the interaction states that already exist within Gutenberg. Please see https://github.com/Automattic/wp-calypso/issues/35884.

#### Screenshots
<img width="710" alt="Screen Shot 2019-10-04 at 10 35 12" src="https://user-images.githubusercontent.com/444434/66197609-a9ce6400-e692-11e9-933f-d818a775ade3.png">

#### Testing instructions

* Create new Page and see Template Selector
* "Blank" should already be selected - it should be perceivable.
* Using your keyboard, `TAB` until the "Blank" option receives `focus`. This should be perceivable.
* Using mouse or keyboard try hovering on other previews and mixing and matching changing the selection. It should be possible to perceive all the possible permutations of state changes.

Fixes https://github.com/Automattic/wp-calypso/issues/35884
