### PR TITLE
Classic Editor: don't render interactive UI inside EditorDrawerLabel

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -163,9 +163,8 @@ class EditorDrawer extends Component {
 						'An excerpt is a short summary you can add to your posts. ' +
 							"Some themes show excerpts alongside post titles on your site's homepage and archive pages."
 					) }
-				>
-					<EditorExcerpt />
-				</EditorDrawerLabel>
+				/>
+				<EditorExcerpt />
 			</AccordionSection>
 		);
 	}

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -45,8 +45,7 @@ class EditorMoreOptionsCopyPost extends Component {
 
 	isPost = () => 'post' === this.props.type;
 
-	openDialog = event => {
-		event.preventDefault();
+	openDialog = () => {
 		this.setState( {
 			showDialog: true,
 		} );
@@ -100,14 +99,13 @@ class EditorMoreOptionsCopyPost extends Component {
 							? translate( "Pick a post and we'll copy the title, content, tags and categories." )
 							: translate( "Pick a page and we'll copy the title and content." )
 					}
-				>
-					<Button borderless compact onClick={ this.openDialog }>
-						<Gridicon icon="clipboard" />
-						{ this.isPost()
-							? translate( 'Select a post to copy' )
-							: translate( 'Select a page to copy' ) }
-					</Button>
-				</EditorDrawerLabel>
+				/>
+				<Button borderless compact onClick={ this.openDialog }>
+					<Gridicon icon="clipboard" />
+					{ this.isPost()
+						? translate( 'Select a post to copy' )
+						: translate( 'Select a page to copy' ) }
+				</Button>
 				<Dialog
 					isVisible={ showDialog }
 					buttons={ buttons }

--- a/client/post-editor/editor-more-options/slug.jsx
+++ b/client/post-editor/editor-more-options/slug.jsx
@@ -48,12 +48,8 @@ class EditorMoreOptionsSlug extends PureComponent {
 
 		return (
 			<AccordionSection className="editor-more-options__slug">
-				<EditorDrawerLabel labelText={ translate( 'Slug' ) } helpText={ this.getPopoverLabel() }>
-					<Slug
-						instanceName={ postType + '-sidebar' }
-						className="editor-more-options__slug-field"
-					/>
-				</EditorDrawerLabel>
+				<EditorDrawerLabel labelText={ translate( 'Slug' ) } helpText={ this.getPopoverLabel() } />
+				<Slug instanceName={ postType + '-sidebar' } className="editor-more-options__slug-field" />
 			</AccordionSection>
 		);
 	}

--- a/client/post-editor/editor-page-templates/index.jsx
+++ b/client/post-editor/editor-page-templates/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { find, size, map } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -85,32 +85,31 @@ class EditorPageTemplates extends Component {
 
 		const templates = this.getTemplates();
 		return (
-			<div>
+			<Fragment>
 				{ siteId && <QueryPageTemplates siteId={ siteId } /> }
 				{ size( templates ) > 1 && (
 					<AccordionSection>
-						<EditorDrawerLabel labelText={ translate( 'Page Template' ) }>
-							<EditorThemeHelp className="editor-page-templates__help-link" />
-							<SelectDropdown selectedText={ this.getSelectedTemplateText() }>
-								{ map( templates, ( { file, label } ) => (
-									/* eslint-disable react/jsx-no-bind */
-									// jsx-no-bind disabled because while it's possible
-									// to extract this out into a separate component
-									// with its own click handler, that would severely
-									// harm the readability of this component.
-									<SelectDropdown.Item
-										key={ file }
-										selected={ file === template }
-										onClick={ () => this.selectTemplate( file ) }
-									>
-										{ label }
-									</SelectDropdown.Item>
-								) ) }
-							</SelectDropdown>
-						</EditorDrawerLabel>
+						<EditorDrawerLabel labelText={ translate( 'Page Template' ) } />
+						<EditorThemeHelp className="editor-page-templates__help-link" />
+						<SelectDropdown selectedText={ this.getSelectedTemplateText() }>
+							{ map( templates, ( { file, label } ) => (
+								/* eslint-disable react/jsx-no-bind */
+								// jsx-no-bind disabled because while it's possible
+								// to extract this out into a separate component
+								// with its own click handler, that would severely
+								// harm the readability of this component.
+								<SelectDropdown.Item
+									key={ file }
+									selected={ file === template }
+									onClick={ () => this.selectTemplate( file ) }
+								>
+									{ label }
+								</SelectDropdown.Item>
+							) ) }
+						</SelectDropdown>
 					</AccordionSection>
 				) }
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -70,16 +70,15 @@ class EditorSeoAccordion extends Component {
 								'The post content is used by default.'
 						) }
 						labelText={ translate( 'Meta Description' ) }
-					>
-						<CountedTextarea
-							maxLength="300"
-							acceptableLength={ 159 }
-							placeholder={ translate( 'Write a description…' ) }
-							aria-label={ translate( 'Write a description…' ) }
-							value={ metaDescription }
-							onChange={ this.onMetaChange }
-						/>
-					</EditorDrawerLabel>
+					/>
+					<CountedTextarea
+						maxLength="300"
+						acceptableLength={ 159 }
+						placeholder={ translate( 'Write a description…' ) }
+						aria-label={ translate( 'Write a description…' ) }
+						value={ metaDescription }
+						onChange={ this.onMetaChange }
+					/>
 					{ isJetpack && (
 						<div>
 							<Button className="editor-seo-accordion__preview-button" onClick={ this.showPreview }>

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -128,18 +128,11 @@ class PublicizeMessage extends Component {
 						labelText={ translate( 'Customize the message', {
 							context: 'Post editor sharing message heading',
 						} ) }
-					>
-						<TrackInputChanges onNewValue={ this.recordStats }>
-							{ this.renderTextarea() }
-						</TrackInputChanges>
-					</EditorDrawerLabel>
+					/>
 				) }
-
-				{ ! displayMessageHeading && (
-					<TrackInputChanges onNewValue={ this.recordStats }>
-						{ this.renderTextarea() }
-					</TrackInputChanges>
-				) }
+				<TrackInputChanges onNewValue={ this.recordStats }>
+					{ this.renderTextarea() }
+				</TrackInputChanges>
 			</div>
 		);
 	}


### PR DESCRIPTION
When clicking anywhere inside the `label` HTML element, Safari will deliver the click event to the first `button` element inside it. That breaks many UI flows, like editing SEO Description, Post Excerpt, Post Slug etc.

Other browsers than Safari don't deliver that event if the click happens inside an interactive element like `button`, `input` or `textarea`. But Safari does. That means that if `label` has two `button` children, a click on the second one will also invoke click handler of the first one :-|

This patch reorganizes UI that uses `EditorDrawerLabel` to avoid markup like this:
```
<label>
  <button onClick={ openPopover }>More Info</button>
  <textarea>post excerpt</textarea>
</label>
```
and instead use markup like this:
```
<label>
  <button onClick={ openPopover }>More Info</button>
</label>
<textarea>post excerpt</textarea>
```

Fixes #36455.

**How to test:**
Open a post/page in classic editor in Safari and verify that the following works:
- editing post excerpt
- editing post slug
- editing post SEO description
- editing post publicize message
- selecting a post to copy (in the code, note how we used to need `preventDefault` to make it work!)
- selecting a page template (only available when multiple page templates are defined)
