### PR TITLE
Update Full Site Editing plugins codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -122,7 +122,11 @@
 /docs/coding-guidelines/typescript* @Automattic/type-review
 
 # FSE (Full Site Editing)
-/apps/full-site-editing @Automattic/serenity @Automattic/cylon @Automattic/ajax
+/apps/full-site-editing/* @Automattic/serenity @Automattic/cylon @Automattic/ajax
+/apps/full-site-editing/full-site-editing-plugin/* @Automattic/serenity @Automattic/cylon @Automattic/ajax
+/apps/full-site-editing/full-site-editing-plugin/full-site-editing @Automattic/serenity @Automattic/cylon
+/apps/full-site-editing/full-site-editing-plugin/posts-list-block @Automattic/ajax
+/apps/full-site-editing/full-site-editing-plugin/starter-page-templates @Automattic/ajax
 
 # WPcom Block Editor
 /apps/wpcom-block-editor @Automattic/serenity @Automattic/cylon @Automattic/ajax


### PR DESCRIPTION
I personally feel that half of my GitHub notifications are about tasks unrelated to my day-to-day work.
This is because all three Edit Focus teams are set up as code owners of the entire Full Site Editing plugin, while in fact they each only manage some part of it.

This PR makes sure that only the relevant teams are pinged:
- Full Site Editing (the wrapping plugin's root folders): Serenity, Cylon, and Ajax
- Full Site Editing (the actual plugin): Serenity and Cylon
- Posts List Block: Ajax
- Starter Page Templates: Ajax

Please feel free to discuss if you feel this change doesn't make sense, or if I've incorrectly assigned a team to a folder.