### PR TITLE
WIP: Add masterbar back to checkout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -141,7 +141,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				<MasterbarLoggedIn
 					section={ this.props.sectionGroup }
-					compact={ this.props.sectionName === 'checkout' }
+					isCheckout={ this.props.sectionName === 'checkout' }
 				/>
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
 				<LayoutLoader />
@@ -189,8 +189,7 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const isJetpack = isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
-	const noMasterbarForCheckout = startsWith( currentRoute, '/checkout' );
-	const noMasterbarForRoute = isJetpackLogin || noMasterbarForCheckout;
+	const noMasterbarForRoute = isJetpackLogin;
 	const noMasterbarForSection = 'signup' === sectionName || 'jetpack-connect' === sectionName;
 	const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 	const isJetpackWooCommerceFlow =

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -31,6 +31,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import { getStatsPathForTab } from 'lib/route';
 import { domainManagementList } from 'my-sites/domains/paths';
+import WordPressWordmark from 'components/wordpress-wordmark';
 
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
@@ -40,7 +41,7 @@ class MasterbarLoggedIn extends React.Component {
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string,
 		hasMoreThanOneSite: PropTypes.bool,
-		compact: PropTypes.bool,
+		isCheckout: PropTypes.bool,
 	};
 
 	clickMySites = () => {
@@ -113,10 +114,19 @@ class MasterbarLoggedIn extends React.Component {
 	}
 
 	render() {
-		const { domainOnlySite, translate, compact } = this.props;
+		const { domainOnlySite, translate, isCheckout } = this.props;
 
-		if ( compact === true ) {
-			return <Masterbar>{ this.renderMySites() }</Masterbar>;
+		if ( isCheckout === true ) {
+			return (
+				<Masterbar>
+					<div className="masterbar__secure-checkout">
+						<WordPressWordmark className="masterbar__wpcom-wordmark" />
+						<span className="masterbar__secure-checkout-text">
+							{ translate( 'Secure checkout' ) }
+						</span>
+					</div>
+				</Masterbar>
+			);
 		}
 
 		return (

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -517,3 +517,19 @@ $autobar-height: 20px;
 	opacity: 0;
 	pointer-events: none;
 }
+
+.masterbar__secure-checkout {
+	display: flex;
+	align-items: center;
+	padding-left: 10px;
+
+	.masterbar__wpcom-wordmark {
+		margin-right: 5px;
+	}
+
+	.masterbar__secure-checkout-text {
+		font-weight: 300;
+		color: var( --color-primary-5 );
+		transform: translateY( 1px );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the masterbar, with WordPress.com branding, back to checkout to build more trust with people buying our products. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/66205648-eb9fe000-e67b-11e9-8ed5-fca26f2a5364.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/66205633-e347a500-e67b-11e9-8d5b-85d147f1b311.png)


#### Testing instructions
- Add a plan and domain to your cart and visit checkout. 
- Upgrade to higher plan.

Additional considerations: 
- Change your Calypso colour schemes to make sure it still looks good. 
- Check the screens before and after checkout to make sure the checkout masterbar doesn't appear where it shouldn't.
