### PR TITLE
Show the connection tab unless there is no site id

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -136,7 +136,7 @@ export default connect( state => {
 
 	return {
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
-		showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
+		showConnections: !! siteId,
 		showTraffic: canManageOptions && !! siteId,
 		isVip: isVipSite( state, siteId ),
 		siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Since Jetpack sites can now have connections even if publicize is turned off, we should always show the "Connections" tab for every site

#### Testing instructions

* Open http://calypso.localhost:3000/marketing/
* Select a Simple site
* Confirm that you see the "Connections" tab
* Select a Jetpack site
* Confirm that you see the "Connections" tab

