### PR TITLE
Disable Sign in with Apple for Safari on iOS 13 and Mac OS Catalina while we implement the redirect flow

### DIFF
--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -42,8 +42,25 @@ class AppleLoginButton extends Component {
 		requestExternalAccess( connectUrl, this.props.responseHandler );
 	};
 
+	shouldBeDisabledOnThisPlatform() {
+		const userAgent = typeof window !== 'undefined' ? window.navigator.userAgent : '';
+		// redirect flow will fix this
+		if ( config.isEnabled( 'sign-in-with-apple/redirect' ) ) {
+			return false;
+		}
+		// exception for Chrome user agent which contains "Safari"
+		if ( userAgent.includes( 'Chrome' ) ) {
+			return false;
+		}
+		// Disabled on Safari for iOS 13 and macOS Catalina, as those do not support the popup flow at the moment
+		return (
+			userAgent.includes( 'Safari' ) &&
+			( userAgent.includes( 'Mac OS X 10_15' ) || userAgent.includes( 'iPhone OS 13' ) )
+		);
+	}
+
 	render() {
-		if ( ! config.isEnabled( 'sign-in-with-apple' ) ) {
+		if ( ! config.isEnabled( 'sign-in-with-apple' ) || this.shouldBeDisabledOnThisPlatform() ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While https://github.com/Automattic/wp-calypso/pull/36444 is being tested we might want to disable Sign In with Apple for incompatible browsers. Namely:
- Safari for iOS 13
- Safari for macOS Catalina
On both platform, Safari bypasses the OAuth2 flow and instead shows a native UI, which seems to currently fail with our popup based implementation.

The major problem with this issue is that user who have tried authenticating on those platform have either seen an error screen or worse, they were able to complete the oauth flow but we did not receive the email address associated with the account and were thus unable to create an account. In those cases, we cannot have the user try again as Apple now considers that the user is connected with us, the only way to fix it is for the user to go to https://appleid.apple.com/account/manage and remove their connection with WordPress.


#### Testing instructions

* Check on Safari on iOS 13 and macOS Catalina that the "Continue with Apple" button is hidden.
You can use the calypso.live env for this.
