### PR TITLE
Starter Page Templates: Tile interaction styling

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -12,9 +12,12 @@
 }
 
 $template-selector-border-color: #e2e4e7;
+$template-selector-border-color-selected: #555d66;
+$template-selector-border-color-active: #00a0d2;
+$template-selector-border-color-hover: #c9c9ca;
 $template-selector-empty-background: #fff;
-$template-selector-modal-offset-right: 32px;
 $template-selector-modal-offset-bottom: 25px;
+$template-selector-modal-offset-right: 32px;
 $template-selector-blank-template-mobile-height: 70px;
 $template-large-preview-title-height: 117px;
 
@@ -181,31 +184,27 @@ body.is-fullscreen-mode {
 			background-color: #fff;
 		}
 
-		$selection-color: #555d66;
-		$active-color: #00a0d2;
-		$hover-color: #c9c9ca;
-
 		&:focus {
-			box-shadow: 0 0 0 1px #fff, 0 0 0 3px $active-color;
+			box-shadow: 0 0 0 1px #fff, 0 0 0 3px $template-selector-border-color-active;
 		
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
 		}
 	
 		&:hover {
-			border: solid 2px $hover-color;
+			border: solid 2px $template-selector-border-color-hover;
 		}
 	
 		&.is-selected {
-			border: solid 2px $selection-color;
+			border: solid 2px $template-selector-border-color-selected;
 		
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
 			outline-offset: -2px;
 	
 			&:focus {
-				box-shadow: 0 0 0 1px #fff, 0 0 0 3px $active-color;
-				border: solid 2px $selection-color;
+				box-shadow: 0 0 0 1px #fff, 0 0 0 3px $template-selector-border-color-active;
+				border: solid 2px $template-selector-border-color-selected;
 			
 				// Windows High Contrast mode will show this outline, but not the box-shadow.
 				outline: 4px solid transparent;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -11,7 +11,7 @@
 	word-wrap: normal !important;
 }
 
-$template-selector-border-color: #a1aab2;
+$template-selector-border-color: #e2e4e7;
 $template-selector-empty-background: #fff;
 $template-selector-modal-offset-right: 32px;
 $template-selector-modal-offset-bottom: 25px;
@@ -162,8 +162,7 @@ body.is-fullscreen-mode {
 		width: 100%;
 		font-size: 14px;
 		text-align: center;
-		//border: 0;//1px solid $template-selector-border-color;
-		border: solid 2px transparent;
+		border: solid 2px $template-selector-border-color;
 		border-radius: 6px;
 		cursor: pointer;
 		appearance: none;
@@ -184,7 +183,7 @@ body.is-fullscreen-mode {
 
 		$selection-color: #555d66;
 		$active-color: #00a0d2;
-		$hover-color: #f3f4f5;
+		$hover-color: #c9c9ca;
 
 		&:focus {
 			box-shadow: 0 0 0 1px #fff, 0 0 0 3px $active-color;
@@ -194,11 +193,7 @@ body.is-fullscreen-mode {
 		}
 	
 		&:hover {
-			background: $hover-color;
-
-			.template-selector-item__template-title {
-				background: $hover-color;
-			}
+			border: solid 2px $hover-color;
 		}
 	
 		&.is-selected {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -162,7 +162,8 @@ body.is-fullscreen-mode {
 		width: 100%;
 		font-size: 14px;
 		text-align: center;
-		border: 1px solid $template-selector-border-color;
+		//border: 0;//1px solid $template-selector-border-color;
+		border: solid 2px transparent;
 		border-radius: 6px;
 		cursor: pointer;
 		appearance: none;
@@ -181,27 +182,39 @@ body.is-fullscreen-mode {
 			background-color: #fff;
 		}
 
-		&:hover,
-		&:focus,
-		&.is-selected {
-			outline: 1px solid transparent;
-			outline-offset: -1px;
-			color: inherit;
-		}
-		
-		&:hover,
+		$selection-color: #555d66;
+		$active-color: #00a0d2;
+		$hover-color: #f3f4f5;
+
 		&:focus {
-			border-color: #555d66;
-			box-shadow: 0 0 0 1px #555d66;
+			box-shadow: 0 0 0 1px #fff, 0 0 0 3px $active-color;
+		
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
 		}
+	
+		&:hover {
+			background: $hover-color;
 
+			.template-selector-item__template-title {
+				background: $hover-color;
+			}
+		}
+	
 		&.is-selected {
-			border-color: #2562b7;
-			box-shadow: 0 0 0 1px #2562b7;
-
-			&:hover,
+			border: solid 2px $selection-color;
+		
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
+			outline-offset: -2px;
+	
 			&:focus {
-				box-shadow: 0 0 0 1px #555d66, 0 0 0 2px #fff, 0 0 0 3px #2562b7;
+				box-shadow: 0 0 0 1px #fff, 0 0 0 3px $active-color;
+				border: solid 2px $selection-color;
+			
+				// Windows High Contrast mode will show this outline, but not the box-shadow.
+				outline: 4px solid transparent;
+				outline-offset: -4px;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* get as close to Gutenberg styles as humanly possible

#### Testing instructions

* open dialog, try interacting with template tiles - focus, hover, active, selected states… all should resemble the style picker in Gutenberg (as seen in Quote block for example)

Fixes #35884
