### PR TITLE
Checkout: Disable phone number field test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -145,8 +145,8 @@ export default {
 	checkoutCollectPhoneNumber: {
 		datestamp: '20191003',
 		variations: {
-			show: 50,
-			hide: 50,
+			show: 0,
+			hide: 100,
 		},
 		defaultVariation: 'hide',
 		allowExistingUsers: true,


### PR DESCRIPTION
It looks like the checkout phone number field test added in #35750 is
causing some issues in Safari. This disables the test until we can track
that down.
