### PR TITLE
Fix: Post checkout flow broken

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -50,6 +50,15 @@ class CheckoutContainer extends React.Component {
 		}
 	}
 
+	shouldComponentUpdate( nextProps ) {
+		if ( this.props.isComingFromSignup !== nextProps.isComingFromSignup ) {
+			this.setState( { shouldDisplaySiteCreatedNotice: nextProps.isComingFromSignup } );
+			return false;
+		}
+
+		return true;
+	}
+
 	renderCheckoutHeader() {
 		return this.state.headerText && <FormattedHeader headerText={ this.state.headerText } />;
 	}
@@ -71,6 +80,7 @@ class CheckoutContainer extends React.Component {
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;
+
 		return (
 			<>
 				{ this.renderCheckoutHeader() }

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -56,7 +56,6 @@ class CheckoutContainer extends React.Component {
 	shouldDisplaySiteCreatedNotice() {
 		return (
 			this.props.isComingFromSignup &&
-			this.props.selectedSite &&
 			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) )
 		);
 	}

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -35,13 +35,10 @@ function isSiteCreatedDateNew( createdAt, creationWindowInMinutes = 5 ) {
 class CheckoutContainer extends React.Component {
 	state = {
 		headerText: '',
-		shouldDisplaySiteCreatedNotice:
-			this.props.isComingFromSignup &&
-			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) ),
 	};
 
 	componentDidMount() {
-		if ( this.state.shouldDisplaySiteCreatedNotice ) {
+		if ( this.shouldDisplaySiteCreatedNotice() ) {
 			this.setHeaderText(
 				this.props.translate(
 					'Your WordPress.com site is ready! Finish your purchase to get the most out of it.'
@@ -50,20 +47,19 @@ class CheckoutContainer extends React.Component {
 		}
 	}
 
-	shouldComponentUpdate( nextProps ) {
-		if ( this.props.isComingFromSignup !== nextProps.isComingFromSignup ) {
-			this.setState( { shouldDisplaySiteCreatedNotice: nextProps.isComingFromSignup } );
-			return false;
-		}
-
-		return true;
-	}
-
 	renderCheckoutHeader() {
 		return this.state.headerText && <FormattedHeader headerText={ this.state.headerText } />;
 	}
 
 	setHeaderText = headerText => this.setState( { headerText } );
+
+	shouldDisplaySiteCreatedNotice() {
+		return (
+			this.props.isComingFromSignup &&
+			this.props.selectedSite &&
+			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) )
+		);
+	}
 
 	render() {
 		const {
@@ -84,7 +80,7 @@ class CheckoutContainer extends React.Component {
 		return (
 			<>
 				{ this.renderCheckoutHeader() }
-				{ this.state.shouldDisplaySiteCreatedNotice && (
+				{ this.shouldDisplaySiteCreatedNotice() && (
 					<TransactionData>
 						<SignupSiteCreatedNotice selectedSite={ this.props.selectedSite } />
 					</TransactionData>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -160,6 +160,7 @@ export function upsellNudge( context, next ) {
 			shouldShowCart={ false }
 			clearTransaction={ true }
 			purchaseId={ Number( receiptId ) }
+			isComingFromSignup={ !! context.query.signup }
 		>
 			<UpsellNudge
 				siteSlugParam={ site }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -160,7 +160,6 @@ export function upsellNudge( context, next ) {
 			shouldShowCart={ false }
 			clearTransaction={ true }
 			purchaseId={ Number( receiptId ) }
-			isComingFromSignup={ !! context.query.signup }
 		>
 			<UpsellNudge
 				siteSlugParam={ site }

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -647,7 +647,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe.skip( 'Sign up for a site on a personal paid plan coming in via /create as personal flow in GBP currency @parallel', function() {
+	describe( 'Sign up for a site on a personal paid plan coming in via /create as personal flow in GBP currency @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When going through the signup flow, post checkout gives a JS error:

<img width="767" alt="Screenshot 2019-10-04 at 2 43 21 PM" src="https://user-images.githubusercontent.com/1269602/66217061-36554280-e6e4-11e9-93b5-4d47bb5718eb.png">

This leads to:
1. Post checkout upsell nudges not being shown
2. Post checkout redirect to /plans instead of customer home page.

* This bug is related to the changes made in https://github.com/Automattic/wp-calypso/pull/35757
* The bug occurs because the state variable `this.state.shouldDisplaySiteCreatedNotice` in [this line](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/checkout-container.jsx#L77) does not get reset when the upsell offer nudge reloads the `<CheckoutContainer>` component [here](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/controller.jsx#L159), retaining its `true` value when in fact it should be `false`. As a result, `<SignupSiteCreatedNotice>` component is mounted [here](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/checkout-container.jsx#L79) with a null `this.props.selectedSite` value.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow and add a Personal plan to cart
* Complete checkout and verify that the Quick Start session upsell is shown
* Clicking Yes(and completing payment) or No on the upsell nudge should take you to the checklist
* Repeat with a Business plan in cart. Verify that post checkout no upsell nudge is shown and that you're taken to checklist.

Fixes https://github.com/Automattic/wp-calypso/issues/36290