### PR TITLE
Fix redirect when logging in.

### DIFF
--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -11,6 +11,7 @@ import debugFactory from 'debug';
  */
 import config from 'config';
 import { setCurrentUser } from 'state/current-user/actions';
+import setRouteAction from 'state/ui/actions/set-route';
 
 const debug = debugFactory( 'calypso' );
 
@@ -91,7 +92,16 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 	}
 };
 
+const setRouteMiddleware = reduxStore => {
+	page( '*', ( context, next ) => {
+		reduxStore.dispatch( setRouteAction( context.pathname, context.query ) );
+
+		next();
+	} );
+};
+
 export function setupMiddlewares( currentUser, reduxStore ) {
 	setupContextMiddleware( reduxStore );
+	setRouteMiddleware( reduxStore );
 	renderDevHelpers( reduxStore );
 }

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -3,7 +3,6 @@
  */
 import {
 	SELECTED_SITE_SET,
-	ROUTE_SET,
 	PREVIEW_IS_SHOWING,
 	NOTIFICATIONS_PANEL_TOGGLE,
 	NAVIGATE,
@@ -15,8 +14,9 @@ import 'state/data-layer/wpcom/sites/jitm';
 /**
  * Re-exports
  */
-export { setSection } from './section/actions';
-export { showMasterbar, hideMasterbar } from './masterbar-visibility/actions';
+export { default as setRoute } from './set-route';
+export { setSection } from '../section/actions';
+export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
 
 /**
  * Returns an action object to be used in signalling that a site has been set
@@ -42,21 +42,6 @@ export function setAllSitesSelected() {
 	return {
 		type: SELECTED_SITE_SET,
 		siteId: null,
-	};
-}
-
-/**
- * Returns an action object signalling that the current route is to be changed
- *
- * @param  {String} path    Route path
- * @param  {Object} [query] Query arguments
- * @return {Object}         Action object
- */
-export function setRoute( path, query = {} ) {
-	return {
-		type: ROUTE_SET,
-		path,
-		query,
 	};
 }
 

--- a/client/state/ui/actions/set-route.js
+++ b/client/state/ui/actions/set-route.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { ROUTE_SET } from 'state/action-types';
+
+/**
+ * Returns an action object signalling that the current route is to be changed
+ *
+ * @param  {String} path    Route path
+ * @param  {Object} [query] Query arguments
+ * @return {Object}         Action object
+ */
+export default function setRoute( path, query = {} ) {
+	return {
+		type: ROUTE_SET,
+		path,
+		query,
+	};
+}


### PR DESCRIPTION
The `redirect_to` URL parameter was being ignored during login, due to a bug introduced by #33642, where an important setup action was no longer being dispatched.

This PR fixes that, while moving the action to its separate file, in order to keep bundle sizes small.

#### Changes proposed in this Pull Request

* Dispatch `ROUTE_SET` action through a middleware for the login entrypoint
* Move `setRoute` action to its own file, while keeping everything else in an index file

#### Testing instructions

Follow the steps in #36518 and ensure that the login page redirects you to the expected location at the end.

Fixes #36518.