### PR TITLE
FormPhoneMediaInput: Prevent unnecessary re-renders

### DIFF
--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,24 +14,31 @@ import PhoneInput from 'components/phone-input';
 import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 
-export default function FormPhoneMediaInput( props ) {
-	const {
-		additionalClasses,
-		label,
-		countryCode,
-		className,
-		disabled,
-		errorMessage,
-		isError = 'false',
-		children,
-	} = props;
-
+export default function FormPhoneMediaInput( {
+	additionalClasses,
+	label,
+	value,
+	countryCode,
+	className,
+	disabled,
+	errorMessage,
+	isError = 'false',
+	onChange,
+	countriesList,
+	setComponentReference,
+	enableStickyCountry,
+	children,
+} ) {
 	return (
 		<div className={ classnames( additionalClasses, 'phone' ) }>
 			<div>
 				<FormLabel htmlFor={ name }>{ label }</FormLabel>
 				<PhoneInput
-					{ ...omit( props, [ 'className', 'countryCode', 'children' ] ) }
+					onChange={ onChange }
+					value={ value }
+					countriesList={ countriesList }
+					setComponentReference={ setComponentReference }
+					enableStickyCountry={ enableStickyCountry }
 					countryCode={ countryCode.toUpperCase() }
 					className={ className }
 					isError={ isError }

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -108,6 +108,12 @@ class PhoneInput extends React.PureComponent {
 	}
 
 	componentWillUpdate( nextProps ) {
+		if (
+			nextProps.value === this.props.value &&
+			nextProps.countryCode === this.props.countryCode
+		) {
+			return;
+		}
 		const currentFormat = this.props.value;
 		const currentCursorPoint = this.numberInput.selectionStart;
 		const nextFormat = nextProps.value;

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { find, identity, noop } from 'lodash';
+import { find, identity } from 'lodash';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -30,13 +30,17 @@ import './style.scss';
 class PhoneInput extends React.PureComponent {
 	static propTypes = {
 		onChange: PropTypes.func.isRequired,
+		className: PropTypes.string,
+		isError: PropTypes.bool,
+		disabled: PropTypes.bool,
 		value: PropTypes.string.isRequired,
 		countryCode: PropTypes.string.isRequired,
 		countriesList: PropTypes.array.isRequired,
+		setComponentReference: PropTypes.func,
+		enableStickyCountry: PropTypes.bool,
 	};
 
 	static defaultProps = {
-		setComponentReference: noop,
 		enableStickyCountry: true,
 	};
 
@@ -82,11 +86,11 @@ class PhoneInput extends React.PureComponent {
 		if ( value !== this.props.value || countryCode !== this.props.countryCode ) {
 			this.props.onChange( { value, countryCode } );
 		}
-		this.props.setComponentReference( this );
+		this.props.setComponentReference && this.props.setComponentReference( this );
 	}
 
 	componentWillUnmount() {
-		this.props.setComponentReference( undefined );
+		this.props.setComponentReference && this.props.setComponentReference( undefined );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -104,9 +108,9 @@ class PhoneInput extends React.PureComponent {
 	}
 
 	componentWillUpdate( nextProps ) {
-		const currentFormat = this.props.value,
-			currentCursorPoint = this.numberInput.selectionStart,
-			nextFormat = nextProps.value;
+		const currentFormat = this.props.value;
+		const currentCursorPoint = this.numberInput.selectionStart;
+		const nextFormat = nextProps.value;
 
 		let newCursorPoint = currentCursorPoint;
 		/*


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `FormPhoneMediaInput` component acts as a wrapper to `PhoneInput` to
include some modified props and extra markup. It does this by passing
along all of its props directly to `PhoneInput` except the ones it
wanted to change.

The `PhoneInput` component, however, is a `PureComponent`. If it is
passed modified props, it will re-render when it shouldn't, causing
strange behavior like stealing focus.

This change clarifies the props required by `PhoneInput` (the PropTypes
were out-of-date) and modifies `FormPhoneMediaInput` to pass along only
these props.

It also prevents cases where `PhoneInput` may steal input focus when first
displayed.

#### Testing instructions

It's very important to try this with Safari on Mac OS, which is where this bug manifests.

- Using the "bug" icon menu in the development environment, add yourself to the `checkoutCollectPhoneNumber` abtest.
- Add a plan to your cart and visit checkout.
- If necessary, click to add a new credit cart.
- Type a name into the cardholder name field. Be sure there is no problem doing so.
- Fill out the rest of the form, including the phone number field. Be sure there is no problem doing so.