### PR TITLE
SPT: Update breakpoints for grid and preview

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -137,8 +137,12 @@ class PageTemplateModal extends Component {
 		if ( event.target.matches( 'button.template-selector-item__label' ) ) {
 			return false;
 		}
-		this.setState( { isOpen: false } );
+
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
+
+		// Try if we have specific URL to go back to, otherwise go to the page list.
+		const calypsoifyCloseUrl = get( window, [ 'calypsoifyGutenberg', 'closeUrl' ] );
+		window.top.location = calypsoifyCloseUrl || 'edit.php?post_type=page';
 	};
 
 	getBlocksByTemplateSlug( slug ) {
@@ -165,6 +169,8 @@ class PageTemplateModal extends Component {
 				className="page-template-modal"
 				overlayClassName="page-template-modal-screen-overlay"
 				shouldCloseOnClickOutside={ false }
+				// Using both variants here to be compatible with new Gutenberg and old (older than 6.6).
+				isDismissable={ false }
 				isDismissible={ false }
 			>
 				<IconButton

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -142,15 +142,6 @@ body.is-fullscreen-mode {
 			); // allow grid to take over number of cols on large screens
 			// stylelint-enable unit-whitelist
 		}
-
-		@media screen and ( min-width: 1200px ) {
-			// stylelint-disable unit-whitelist
-			grid-template-columns: repeat(
-				auto-fit,
-				minmax( 150px, 1fr )
-			); // allow grid to take over number of cols on large screens
-			// stylelint-enable unit-whitelist
-		}
 	}
 
 	.template-selector-control__option {
@@ -286,7 +277,11 @@ body.is-fullscreen-mode {
 
 .page-template-modal__form {
 	@media screen and ( min-width: 660px ) {
-		max-width: 50%;
+		max-width: 20%;
+	}
+
+	@media screen and ( min-width: 783px ) {
+		max-width: 30%;
 	}
 }
 
@@ -332,7 +327,7 @@ body.is-fullscreen-mode {
 	top: 111px;
 	bottom: 24px;
 	right: 24px;
-	width: calc( 50% - 50px );
+	width: calc( 80% - 50px );
 	background: $template-selector-empty-background;
 	border-radius: 2px;
 	overflow-x: hidden;
@@ -370,11 +365,11 @@ body.is-fullscreen-mode {
 
 body:not( .is-fullscreen-mode ) .template-selector-preview {
 	@media screen and ( min-width: 783px ) {
-		width: calc( 50% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
+		width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
 	}
 
 	@media screen and ( min-width: 961px ) {
-		width: calc( 50% - #{$wp-org-sidebar-full } );
+		width: calc( 70% - #{$wp-org-sidebar-full } );
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -120,6 +120,13 @@ body.is-fullscreen-mode {
 	@media screen and ( min-width: 1200px ) {
 		max-width: 100%;
 	}
+
+	@media screen and ( min-width: 1441px ) {
+		max-width: 1440px;
+		display: flex;
+		align-content: flex-start;
+		justify-content: space-between;
+	}
 }
 
 .page-template-modal__list {
@@ -283,6 +290,10 @@ body.is-fullscreen-mode {
 	@media screen and ( min-width: 783px ) {
 		max-width: 30%;
 	}
+
+	@media screen and ( min-width: 1441px ) {
+		width: 30%;
+	}
 }
 
 .page-template-modal__form-title {
@@ -321,6 +332,16 @@ body.is-fullscreen-mode {
 .template-selector-preview {
 	@media screen and ( max-width: 659px ) {
 		display: none;
+	}
+
+	@media screen and ( min-width: 783px ) {
+		width: calc( 70% - 50px );
+	}
+
+	@media screen and ( min-width: 1441px ) {
+		position: unset;
+		width: calc( 70% - 84px );
+		height: calc( 100vh - 130px );
 	}
 
 	position: fixed;
@@ -371,6 +392,10 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	@media screen and ( min-width: 961px ) {
 		width: calc( 70% - #{$wp-org-sidebar-full } );
 	}
+
+	@media screen and ( min-width: 1441px ) {
+		width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
+	}
 }
 
 .template-selector-preview__placeholder {
@@ -380,6 +405,13 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	transform: translateX( -50% );
 	width: 80%;
 	text-align: center;
+
+	@media screen and ( min-width: 1441px ) {
+		left: auto;
+		right: 0;
+		transform: none;
+		width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
+	}
 }
 
 // Preview adjustments.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update breakpoints on site page template selection screen.
* Fixing some layout issues where the thumbnails got really small, and keeping the focus on a larger preview.

#### Before/After

**800px**

Before | After
------------ | -------------
![Screen Shot 2019-10-04 at 15 35 54](https://user-images.githubusercontent.com/448298/66234842-b36cc180-e6bc-11e9-99ed-db279f0f29f1.png) | ![Screen Shot 2019-10-04 at 15 39 12](https://user-images.githubusercontent.com/448298/66235021-22e2b100-e6bd-11e9-97d8-af641658d5e9.png)

**1168px**

Before | After
------------ | -------------
![Screen Shot 2019-10-04 at 15 36 31](https://user-images.githubusercontent.com/448298/66234863-c2ec0a80-e6bc-11e9-9897-4bc555326c49.png) | ![Screen Shot 2019-10-04 at 15 38 38](https://user-images.githubusercontent.com/448298/66235060-37bf4480-e6bd-11e9-9b41-72d3dbfe697e.png)


**Extra large**

Before | After
------------ | -------------
![Screenshot_2019-10-04 Add New Page ‹ wp-dev — WordPress(4)](https://user-images.githubusercontent.com/448298/66234904-ddbe7f00-e6bc-11e9-9169-7383dbd12f21.jpg) | ![Screenshot_2019-10-04 Add New Page ‹ wp-dev — WordPress(3)](https://user-images.githubusercontent.com/448298/66234676-49541c80-e6bc-11e9-8f15-a0cc04c8e472.jpg)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Copy the `/apps/full-site-editing/full-site-editing-plugin` folder into the `wp-content` directory of your local WordPress install.
* Run your local WP environment, making sure Gutenberg plugin and the Maywood theme are activated.
* Create a new page to view the template picker.
* Test at various viewport sizes to make sure nothing breaks or looks wonky.
* Test in Gutenberg's full-screen mode too.

Fixes #36396 
