### PR TITLE
Add concierge refund policy to the checkout page

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-terms.jsx
+++ b/client/my-sites/checkout/checkout/checkout-terms.jsx
@@ -11,6 +11,7 @@ import TermsOfService from './terms-of-service';
 import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationHsts from './domain-registration-hsts';
+import ConciergeRefundPolicy from './concierge-refund-policy';
 import { localize } from 'i18n-calypso';
 
 class CheckoutTerms extends React.Component {
@@ -30,6 +31,7 @@ class CheckoutTerms extends React.Component {
 				<DomainRegistrationAgreement cart={ cart } />
 				<DomainRegistrationHsts cart={ cart } />
 				<DomainRegistrationRefundPolicy cart={ cart } />
+				<ConciergeRefundPolicy cart={ cart } />
 			</Fragment>
 		);
 	}

--- a/client/my-sites/checkout/checkout/concierge-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/concierge-refund-policy.jsx
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import { REFUNDS } from 'lib/url/support';
+import Gridicon from 'components/gridicon';
+import { hasConciergeSession } from 'lib/cart-values/cart-items';
+
+class ConciergeRefundPolicy extends React.Component {
+	static displayName = 'RegistrationRefundPolicy';
+
+	recordRefundsSupportClick = () => {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Refund Support Link' );
+	};
+
+	renderPolicy = () => {
+		const message = this.props.translate(
+			'You understand that {{refundsSupportPage}}Quick Start Session refunds{{/refundsSupportPage}} are limited to 30 days from the date of purchase.',
+			{
+				components: {
+					refundsSupportPage: (
+						<a
+							href={ REFUNDS }
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ this.recordRefundsSupportClick }
+						/>
+					),
+				},
+			}
+		);
+
+		return message;
+	};
+
+	render() {
+		if ( ! hasConciergeSession( this.props.cart ) ) {
+			return null;
+		}
+
+		return (
+			<div className="checkout__concierge-refund-policy">
+				<Gridicon icon="info-outline" size={ 18 } />
+				<p>{ this.renderPolicy() }</p>
+			</div>
+		);
+	}
+}
+
+export default localize( ConciergeRefundPolicy );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -239,6 +239,7 @@
 
 	.checkout__terms,
 	.checkout__domain-refund-policy,
+	.checkout__concierge-refund-policy,
 	.checkout__domain-registration-agreement-link,
 	.checkout__domain-registration-hsts {
 		color: var( --color-text-subtle );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the concierge session refund policy to the checkout page

<img width="1039" alt="Screenshot 2019-10-04 at 11 53 00 PM" src="https://user-images.githubusercontent.com/1269602/66230676-4c71fb80-e702-11e9-84c4-042edae6425d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /checkout/offer-quickstart-session and click the Yes button.
* In the Checkout page, verify that the concierge refund policy is mentioned.
