### PR TITLE
Updated New Password text message to make it more meaningful

### DIFF
--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -140,7 +140,7 @@ const AccountPassword = createReactClass( {
 		const failure = head( this.props.accountPasswordData.getValidationFailures() );
 
 		if ( this.props.accountPasswordData.passwordValidationSuccess() ) {
-			return <FormInputValidation text={ translate( 'Your password can be saved.' ) } />;
+			return <FormInputValidation text={ translate( 'Strong Password.' ) } />;
 		} else if ( ! isEmpty( failure ) ) {
 			return <FormInputValidation isError text={ failure.explanation } />;
 		}

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -140,7 +140,7 @@ const AccountPassword = createReactClass( {
 		const failure = head( this.props.accountPasswordData.getValidationFailures() );
 
 		if ( this.props.accountPasswordData.passwordValidationSuccess() ) {
-			return <FormInputValidation text={ translate( 'Strong Password.' ) } />;
+			return <FormInputValidation text={ translate( 'Your password is strong enough to be saved.' ) } />;
 		} else if ( ! isEmpty( failure ) ) {
 			return <FormInputValidation isError text={ failure.explanation } />;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the text displayed (Your password can be saved) when adding new password under: https://wpcalypso.wordpress.com/me/security to `Strong Password`.

![image](https://user-images.githubusercontent.com/16509219/66267750-98cc5100-e852-11e9-87f3-2ea799ba4036.png)


#### Testing instructions

- Go to your WordPress.com account -> Security : For example: https://wpcalypso.wordpress.com/me/security

- Type in new Password that meets all the criteria for a strong password. The message should say `Strong Password`.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



Fixes # https://github.com/Automattic/wp-calypso/issues/36414
