### PR TITLE
Fix: Plans grid: payment options spacing

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -103,7 +103,8 @@ $plan-features-sidebar-width: 272px;
 
 	@include breakpoint( '<1040px' ) {
 		border-spacing: 0;
-		margin: 0 15px;
+		margin-left: 15px;
+		margin-right: 15px;
 		width: calc( 100% - 30px );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces css margin shorthand (`margin`) by individual margin props (`margin-left`, `margin-right`) to prevent overrides from another css rule set

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Screenshot before fix (from the issue reported)

![](https://user-images.githubusercontent.com/87168/63323424-6ca25280-c32e-11e9-91ba-3f038416de5a.png)

* Screenshot after fix

![Pay-options-spacing-fix](https://user-images.githubusercontent.com/11641900/66286762-7ee14b80-e8f0-11e9-880c-fff216019e29.png)


Fixes #35597
