### PR TITLE
FormPhoneMediaInput: pass the name prop to PhoneInput, fix isError, remove ref setter

### DIFF
--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import classnames from 'classnames';
 
@@ -17,15 +14,15 @@ import FormInputValidation from 'components/forms/form-input-validation';
 export default function FormPhoneMediaInput( {
 	additionalClasses,
 	label,
+	name,
 	value,
 	countryCode,
 	className,
 	disabled,
 	errorMessage,
-	isError = 'false',
+	isError,
 	onChange,
 	countriesList,
-	setComponentReference,
 	enableStickyCountry,
 	children,
 } ) {
@@ -34,10 +31,10 @@ export default function FormPhoneMediaInput( {
 			<div>
 				<FormLabel htmlFor={ name }>{ label }</FormLabel>
 				<PhoneInput
+					name={ name }
 					onChange={ onChange }
 					value={ value }
 					countriesList={ countriesList }
-					setComponentReference={ setComponentReference }
 					enableStickyCountry={ enableStickyCountry }
 					countryCode={ countryCode.toUpperCase() }
 					className={ className }

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -33,10 +33,10 @@ class PhoneInput extends React.PureComponent {
 		className: PropTypes.string,
 		isError: PropTypes.bool,
 		disabled: PropTypes.bool,
+		name: PropTypes.string,
 		value: PropTypes.string.isRequired,
 		countryCode: PropTypes.string.isRequired,
 		countriesList: PropTypes.array.isRequired,
-		setComponentReference: PropTypes.func,
 		enableStickyCountry: PropTypes.bool,
 	};
 
@@ -86,11 +86,6 @@ class PhoneInput extends React.PureComponent {
 		if ( value !== this.props.value || countryCode !== this.props.countryCode ) {
 			this.props.onChange( { value, countryCode } );
 		}
-		this.props.setComponentReference && this.props.setComponentReference( this );
-	}
-
-	componentWillUnmount() {
-		this.props.setComponentReference && this.props.setComponentReference( undefined );
 	}
 
 	componentWillReceiveProps( nextProps ) {


### PR DESCRIPTION
Several component fixes as a follow-up to #36541:
- pass also the `name` prop to the `PhoneInput` so that the `<label for>` and `<input name>` are connected together with that attribute.
- remove the stringy `'false'` default value of the `isError` prop. That value is truthy, causing confusion when the `isError` prop is not specified. Let it default to `undefined`.
- remove the `setComponentReference` prop. It's not used anywhere, and if anyone needs to get the ref to `PhoneInput` in the future, let them implement that as a standard React ref with `React.forwardRef` etc.
