### PR TITLE
Connection: Change the name of the connections tab

### DIFF
--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -136,7 +136,7 @@ class SharingButtons extends Component {
 			<form
 				onSubmit={ this.saveChanges }
 				id="sharing-buttons"
-				className="sharing-settings sharing-buttons"
+				className="buttons__sharing-settings buttons__sharing-buttons"
 			>
 				<PageViewTracker
 					path="/marketing/sharing-buttons/:site"

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -25,7 +25,7 @@ const SharingConnections = ( { translate } ) => (
 		<QueryKeyringServices />
 		<QueryPublicizeConnections selectedSite />
 		<SharingServicesGroup type="publicize" title={ translate( 'Publicize Your Posts' ) } />
-		<SharingServicesGroup type="other" title={ translate( 'Other Connections' ) } />
+		<SharingServicesGroup type="other" title={ translate( 'Connections' ) } />
 	</div>
 );
 

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -19,13 +19,13 @@ import QueryPublicizeConnections from 'components/data/query-publicize-connectio
 import SharingServicesGroup from './services-group';
 
 const SharingConnections = ( { translate } ) => (
-	<div className="sharing-settings sharing-connections">
+	<div className="connections__sharing-settings connections__sharing-connections">
 		<PageViewTracker path="/marketing/connections/:site" title="Marketing > Connections" />
 		<QueryKeyringConnections />
 		<QueryKeyringServices />
 		<QueryPublicizeConnections selectedSite />
 		<SharingServicesGroup type="publicize" title={ translate( 'Publicize Your Posts' ) } />
-		<SharingServicesGroup type="other" title={ translate( 'Connections' ) } />
+		<SharingServicesGroup type="other" title={ translate( 'Manage Connections' ) } />
 	</div>
 );
 

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -77,7 +77,8 @@
 	}
 }
 
-.sharing-settings {
+.buttons__sharing-settings,
+.connections__sharing-settings {
 	// labels, checkboxes, radio
 
 	label label {
@@ -104,7 +105,7 @@
 	}
 }
 
-.sharing-settings.sharing-connections {
+.connections__sharing-settings.connections__sharing-connections {
 	@include breakpoint( '<480px' ) {
 		padding: 16px 0;
 	}
@@ -459,7 +460,7 @@
 
 // Sharing Buttons Section
 
-.sharing-settings.sharing-buttons {
+.buttons__sharing-settings.buttons__sharing-buttons {
 	.sharing-button-styles {
 		box-shadow: 0 -2px 0 var( --color-neutral-0 ) inset;
 		padding-bottom: 0.5em;
@@ -1108,7 +1109,7 @@
 	max-width: 300px;
 }
 
-.sharing-connections__mailchimp-gutenberg_explanation {
+.connections__sharing-connections__mailchimp-gutenberg_explanation {
 	margin-top: 1.5em;
 }
 


### PR DESCRIPTION
This tab should have a more generic name so that even if publicize isn't enabled the name makes sense. Suggested by @creativecoder in #36453 

This solution is simpler than adding logic to determine if publicize was enabled, and I don't think that adds sufficient value to warrant the additional complexity.

#### Testing instructions

* Go to /marketing/connections and confirm that the tab now reads "connections" not "other connections".
