### PR TITLE
Remove `moment` dependency from `lib/abtest`.

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -7,7 +5,6 @@ import debugFactory from 'debug';
 import { every, get, includes, isArray, keys, reduce, some } from 'lodash';
 import store from 'store';
 import i18n from 'i18n-calypso';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -70,13 +67,22 @@ export const getAllTests = () => keys( activeTests ).map( ABTest );
 const isUserSignedIn = () => user && user.get() !== false;
 
 const parseDateStamp = datestamp => {
-	const date = moment( datestamp, 'YYYYMMDD' );
+	const format = 'YYYYMMDD';
 
-	if ( ! date.isValid() ) {
-		throw new Error( 'The date ' + datestamp + ' should be in the YYYYMMDD format' );
+	if ( datestamp.length === format.length ) {
+		const year = datestamp.substr( 0, 4 );
+		const month = datestamp.substr( 4, 2 );
+		const day = datestamp.substr( 6, 2 );
+		const toParse = `${ year }-${ month }-${ day }`;
+
+		const date = Date.parse( toParse );
+
+		if ( ! isNaN( date ) ) {
+			return date;
+		}
 	}
 
-	return date;
+	throw new Error( `The date ${ datestamp } should be in the ${ format } format` );
 };
 
 const languageSlugs = getLanguageSlugs();
@@ -274,7 +280,7 @@ ABTest.prototype.isEligibleForAbTest = function() {
 };
 
 ABTest.prototype.hasTestStartedYet = function() {
-	return moment().isAfter( this.startDate );
+	return new Date() > new Date( this.startDate );
 };
 
 ABTest.prototype.hasBeenInPreviousSeriesTest = function() {
@@ -294,7 +300,7 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function() {
 };
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function() {
-	return user && user.get() && moment( user.get().date ).isBefore( this.startDate );
+	return user && user.get() && new Date( user.get().date ) < new Date( this.startDate );
 };
 
 ABTest.prototype.getSavedVariation = function() {


### PR DESCRIPTION
The usage is relatively straightforward, so we replace with native features.

May be worth revisiting to simplify the timestamp parsing if we ever replace `moment` with a smaller library.

This PR is working towards the goal of removing the `moment` dependency from the login entry point.

#### Changes proposed in this Pull Request

* Replace usage of `moment` in `lib/abtest` with native Date features.

#### Testing instructions

* Ensure that AB tests continue triggering on the right dates.

Unit tests for the library continue working correctly with no changes.
