### PR TITLE
Language Picker: move the Modal element out of the clickable picker button

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -103,14 +103,6 @@ export class LanguagePicker extends PureComponent {
 		}
 	};
 
-	handleKeyPress = event => {
-		if ( event.key === 'Enter' || event.key === ' ' ) {
-			event.preventDefault();
-			this.props.onClick( event );
-			this.toggleOpen();
-		}
-	};
-
 	handleClose = () => this.setState( { open: false } );
 
 	renderPlaceholder() {
@@ -156,30 +148,25 @@ export class LanguagePicker extends PureComponent {
 		const { langCode, langSubcode } = getLanguageCodeLabels( language.langSlug );
 
 		return (
-			<div
-				tabIndex="0"
-				role="button"
-				className="language-picker"
-				onKeyPress={ this.handleKeyPress }
-				onClick={ this.handleClick }
-				disabled={ disabled }
-			>
-				<div className="language-picker__icon">
-					<div className="language-picker__icon-inner">
-						{ langCode }
-						{ langSubcode && <br /> }
-						{ langSubcode }
-					</div>
-				</div>
-				<div className="language-picker__name">
-					<div className="language-picker__name-inner">
-						<div className="language-picker__name-label">{ langName }</div>
-						<div className="language-picker__name-change">{ translate( 'Change' ) }</div>
-					</div>
-				</div>
-				{ this.renderModal( language.langSlug ) }
+			<Fragment>
 				<QueryLanguageNames />
-			</div>
+				<button className="language-picker" onClick={ this.handleClick } disabled={ disabled }>
+					<div className="language-picker__icon">
+						<div className="language-picker__icon-inner">
+							{ langCode }
+							{ langSubcode && <br /> }
+							{ langSubcode }
+						</div>
+					</div>
+					<div className="language-picker__name">
+						<div className="language-picker__name-inner">
+							<div className="language-picker__name-label">{ langName }</div>
+							<div className="language-picker__name-change">{ translate( 'Change' ) }</div>
+						</div>
+					</div>
+				</button>
+				{ this.renderModal( language.langSlug ) }
+			</Fragment>
 		);
 	}
 }

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -10,6 +10,8 @@
 	align-items: stretch;
 	cursor: pointer;
 	transition: border-color 150ms ease-in-out;
+	text-align: left;
+	line-height: inherit;
 
 	@include breakpoint( '<660px' ) {
 		width: 100%;


### PR DESCRIPTION
If we used a React Portal to render the Language Picker modal, Click events inside the modal would bubble up to the button element, even though the button is not the modal's DOM parent. But it's its React tree parent and React bubbles the events synthetically for portal. Therefore, any click inside the modal triggers the `toggleOpen` click handler on the button.

This patch rearranges the Language Picker button markkup to move the modal element outside the `button` element. Also replaces `div` with more accessible and semantic `button` tag.

Preparation for the `RootChild` modernization in #32899, where React Portals will be used.

**How to test:**
Go to `/me/account` and verify that you can click on the "Interface Language" button (both mouse and keyboard) and the modal opens.