### PR TITLE
[Signup] Pass vertical name to the API

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -137,6 +137,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	const designType = getDesignType( state ).trim();
 	const siteTitle = getSiteTitle( state ).trim();
 	const siteVerticalId = getSiteVerticalId( state );
+	const siteVerticalName = getSiteVerticalName( state );
 	const siteGoals = getSiteGoals( state ).trim();
 	const siteType = getSiteType( state ).trim();
 	const siteStyle = getSiteStyle( state ).trim();
@@ -154,6 +155,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			site_style: siteStyle || undefined,
 			site_segment: siteSegment || undefined,
 			site_vertical: siteVerticalId || undefined,
+			site_vertical_name: siteVerticalName || undefined,
 			site_information: {
 				title: siteTitle,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

To address https://github.com/Automattic/zelda-private/issues/149 we need to pass Vertical name to the API as it is instead of relying on Vertical ID. This PR adds support for that, which in turn makes it possible to populate new sites with the vertical name.

#### Testing instructions

Follow the instructions in D33651-code

Fixes https://github.com/Automattic/zelda-private/issues/149
