### PR TITLE
Login: fix OAuth login UI by adding oauth2Clients to login reducer

### DIFF
--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -16,12 +16,14 @@ import login from 'state/login/reducer';
 import language from 'state/ui/language/reducer';
 import route from 'state/ui/route/reducer';
 import masterbarVisibility from 'state/ui/masterbar-visibility/reducer';
+import oauth2ClientsUI from 'state/ui/oauth2-clients/reducer';
 import section from 'state/ui/section/reducer';
 import notices from 'state/notices/reducer';
 import i18n from 'state/i18n/reducer';
 import users from 'state/users/reducer';
 import currentUser from 'state/current-user/reducer';
 import preferences from 'state/preferences/reducer';
+import oauth2Clients from 'state/oauth2-clients/reducer';
 
 // Create Redux store
 const reducer = combineReducers( {
@@ -34,10 +36,12 @@ const reducer = combineReducers( {
 	users,
 	currentUser,
 	preferences,
+	oauth2Clients,
 	ui: combineReducers( {
 		language,
 		route,
 		masterbarVisibility,
+		oauth2Clients: oauth2ClientsUI,
 		section,
 	} ),
 } );


### PR DESCRIPTION
The Login entrypoint's reducer misses two `oauth2Clients` stores: the `ui` one watches the `ROUTE_SET` actions and permanently stores the OAuth `client_id` in Redux. The other one stores info about OAuth clients fetched from a REST endpoint, mapping `client_id` to attributes like `title`.

Adding the stores fixes a regression where login with `client_id` query parameter stopped showing a customized UI. That's because the `getCurrentOAuth2Client` selector always returns `null` when the state is not there.

**How to test:**
Go to akismet.com or woocommerce.com when logged out and try to login. Before this fix, you'll see a plain WP.com login dialog:

<img width="415" alt="Screenshot 2019-10-07 at 14 40 31" src="https://user-images.githubusercontent.com/664258/66313589-e9a37e80-e912-11e9-8fd2-74003d9b8487.png">

After this patch, you'll see a customized login UI:

<img width="424" alt="Screenshot 2019-10-07 at 14 41 09" src="https://user-images.githubusercontent.com/664258/66313642-faec8b00-e912-11e9-9369-4c533e328621.png">

Some OAuth clients just customize the header, others, like Woo or CrowdSignal, completely restyle the login UI.
