### PR TITLE
Depend on some sites selectors directly.

### DIFF
--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External Dependencies
  */
@@ -15,7 +13,7 @@ import { clearJITM, insertJITM } from 'state/jitm/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { isJetpackSite } from 'state/sites/selectors';
+import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
 import { SECTION_SET, SELECTED_SITE_SET, JITM_DISMISS } from 'state/action-types';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';

--- a/client/state/document-head/selectors.js
+++ b/client/state/document-head/selectors.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { compact } from 'lodash';
 
 /**
@@ -12,7 +9,7 @@ import { compact } from 'lodash';
 import createSelector from 'lib/create-selector';
 import { decodeEntities } from 'lib/formatting';
 import { getSelectedSiteId, isSiteSection } from 'state/ui/selectors';
-import { getSiteTitle } from 'state/sites/selectors';
+import getSiteTitle from 'state/sites/selectors/get-site-title';
 
 const UNREAD_COUNT_CAP = 40;
 

--- a/client/state/ui/selectors/get-selected-site-slug.js
+++ b/client/state/ui/selectors/get-selected-site-slug.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getSiteSlug } from 'state/sites/selectors';
+import getSiteSlug from 'state/sites/selectors/get-site-slug';
 import getSelectedSiteId from './get-selected-site-id';
 
 /**

--- a/client/state/ui/selectors/get-selected-site.js
+++ b/client/state/ui/selectors/get-selected-site.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getSite } from 'state/sites/selectors';
+import getSite from 'state/sites/selectors/get-site';
 import getSelectedSiteId from './get-selected-site-id';
 
 /**


### PR DESCRIPTION
The tree-shaking algorithm isn't perfect, so some libraries are still being included, when they should have been tree-shaken. Depending on the actual selectors directly explicitly indicates we don't need anything else, removing work from the tree-shaking algorithm and the ability for
it to fail.

#### Changes proposed in this Pull Request

* Replace some `sites/selectors` named imports with direct imports from the individual modules.

#### Testing instructions

No specific testing instructions; this is a simple mechanical change.
