### PR TITLE
Remove `moment` dependency from 2fa.

### DIFF
--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
@@ -5,11 +5,6 @@ import React from 'react';
 import { colors as PALETTE } from '@automattic/color-studio';
 
 /**
- * Internal dependencies
- */
-import { useLocalizedMoment } from 'components/localized-moment';
-
-/**
  * Style dependencies
  */
 import './push-notification-illustration.scss';
@@ -72,8 +67,13 @@ function NotificationSvg() {
 }
 
 export default function PushNotificationIllustration() {
-	const moment = useLocalizedMoment();
-	const currentTime = moment().format( 'h:mm' );
+	const now = new Date();
+	const hours = now.getHours() || 12;
+	const minutes = now.getMinutes();
+
+	const currentTime = `${ hours > 12 ? hours - 12 : hours }:${
+		minutes < 10 ? '0' + minutes : minutes
+	}`;
 
 	// Inlining two stacked SVGs because they’re a part of an animated image.
 	// By not loading them externally, we’re making sure the animation will

--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
@@ -67,14 +67,6 @@ function NotificationSvg() {
 }
 
 export default function PushNotificationIllustration() {
-	const now = new Date();
-	const hours = now.getHours() || 12;
-	const minutes = now.getMinutes();
-
-	const currentTime = `${ hours > 12 ? hours - 12 : hours }:${
-		minutes < 10 ? '0' + minutes : minutes
-	}`;
-
 	// Inlining two stacked SVGs because they’re a part of an animated image.
 	// By not loading them externally, we’re making sure the animation will
 	// get fired right away with all of its elements in place.
@@ -82,7 +74,7 @@ export default function PushNotificationIllustration() {
 	return (
 		<div className="two-factor-authentication__illustration" aria-hidden="true">
 			<DeviceSvg />
-			<div className="two-factor-authentication__illustration-screen">{ currentTime }</div>
+			<div className="two-factor-authentication__illustration-screen">10:07</div>
 			<div className="two-factor-authentication__illustration-notification-container">
 				<NotificationSvg />
 			</div>


### PR DESCRIPTION
Replace current time in illustration with a hardcoded string.

#### Changes proposed in this Pull Request

* Replace current time in illustration with a hardcoded string.

#### Testing instructions

I'm not entirely sure how to test this in-place. However, we're just replacing some string formatting with a hardcoded string.