### PR TITLE
Hosting Panel: Add menu item to sidebar

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -493,6 +493,30 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	trackHostingClick = () => {
+		this.trackMenuItemClick( 'hosting' );
+		this.onNavigate();
+	};
+
+	hosting() {
+		const { translate, path, site, isAtomicSite, siteSuffix } = this.props;
+
+		if ( ! site || ! isAtomicSite ) {
+			return null;
+		}
+
+		return (
+			<SidebarItem
+				label={ translate( 'Hosting' ) }
+				selected={ itemLinkMatches( '/hosting', path ) }
+				link={ `/hosting${ siteSuffix }` }
+				onNavigate={ this.trackHostingClick }
+				preloadSectionName="hosting"
+				expandSection={ this.expandManageSection }
+			/>
+		);
+	}
+
 	trackPeopleClick = () => {
 		this.trackMenuItemClick( 'people' );
 		this.onNavigate();
@@ -720,6 +744,7 @@ export class MySitesSidebar extends Component {
 						materialIcon="settings"
 					>
 						<ul>
+							{ this.hosting() }
 							{ this.upgrades() }
 							{ this.users() }
 							{ this.siteSettings() }


### PR DESCRIPTION
### Summary

Adds a menu item to the sidebar for the new Hosting section.

<hr>

### Screenshots

<img width="541" alt="Screen Shot 2019-10-07 at 12 06 19 PM" src="https://user-images.githubusercontent.com/8892849/66328693-1e0b4080-e8fb-11e9-8531-921bd66b3a79.png">

<hr>

### Testing

* Spin up a local Calypso environment.
* Select an Atomic site.
    * Ensure that 'Hosting' link shows up under the collapsible 'Manage' section in the sidebar.
    * Click on the 'Hosting' menu item, ensure that it navigates to the Hosting panel (`/hosting/{site}`).
    * Ensure that the Hosting menu item is highlighted when you are on the Hosting panel.
* Select a non-Atomic site in Calypso.
    * Ensure that the 'Hosting' section does not show up in the sidebar.

