### PR TITLE
Action Panel Component: Fix Alignment

### DIFF
--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -21,12 +21,9 @@
 	line-height: 20px;
 	color: var( --color-text-subtle );
 	overflow: hidden;
-	display: flex;
-	flex-direction: column;
 
 	p {
 		margin-bottom: 20px;
-		flex-grow: 1;
 	}
 }
 

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -22,6 +22,10 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
+		
+		p {
+			flex-grow: 1;
+		}
 	}
 
 	&.is-primary {

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -19,6 +19,8 @@
 	}
 
 	.action-panel__body {
+		display: flex;
+		flex-direction: column;
 		flex-grow: 1;
 	}
 
@@ -28,16 +30,13 @@
 				max-width: 310px;
 			}
 		}
-		
+
 		.action-panel__body {
-			display: flex;
-			flex-direction: column;
-			justify-content:center;
+			justify-content: center;
 			p {
 				flex-grow: 0;
 			}
 		}
-
 
 		background-color: var( --color-primary-0 );
 	}
@@ -48,4 +47,3 @@
 		}
 	}
 }
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#34896 introduced a defect with this change [here](https://github.com/Automattic/wp-calypso/commit/790599f82e85caec3583c2f6da0da7ff5a3a7098).

It's a necessary few lines of code, because otherwise on the promotional card component (currently only used in the Earn section), the buttons can float too high.

<img width="512" alt="Screenshot 2019-10-07 at 17 03 41" src="https://user-images.githubusercontent.com/43215253/66328499-a6eaa200-e924-11e9-9e0a-4fae20656723.png">

But it's not specific enough currently, so it's causing #36532. This PR increases the specificity so both issues are resolved.

<img width="887" alt="Screenshot 2019-10-07 at 17 10 14" src="https://user-images.githubusercontent.com/43215253/66328852-5a539680-e925-11e9-9c46-623ea04b894b.png">

<img width="799" alt="Screenshot 2019-10-07 at 17 12 08" src="https://user-images.githubusercontent.com/43215253/66329023-a4d51300-e925-11e9-8c14-d0850f4c6942.png">

#### Testing instructions

Visit the cases in #36532 and test them. You can find them at `/settings/delete-site/site` and `/settings/theme-setup/site`. But also ensure that the buttons on the Earn page don't float up like the image above.

Fixes #36532
