### PR TITLE
Remove autofocus from checkout

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -254,7 +254,7 @@ export class CreditCardFormFields extends React.Component {
 		eventFormName: 'Credit card input',
 		onFieldChange: noop,
 		getErrorMessage: noop,
-		autoFocus: true,
+		autoFocus: false,
 		isNewTransaction: false,
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When you load checkout on a small screen, the autofocus takes you right there and the appearance looks broken:

![image](https://user-images.githubusercontent.com/6981253/66332272-58c4a700-e902-11e9-8b0c-b14492e1b27c.png)

In this PR, I removed the autofocus so that the checkout screen loads at the top every time:

![image](https://user-images.githubusercontent.com/6981253/66332296-6843f000-e902-11e9-86f0-ecc6b9762179.png)

Thanks @ianstewart for reporting.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Reduce your browser's height and visit checkout
* The cardholder's name should not be auto-focused.

cc @sirbrillig 
