### PR TITLE
Jetpack Cloud: PoC v1

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -18,7 +18,8 @@ import store from 'store';
  * Internal dependencies
  */
 import config from 'config';
-import { JetpackDashboardReduxWrappedLayout, ReduxWrappedLayout } from 'controller';
+import { ReduxWrappedLayout } from 'controller';
+import { JetpackDashboardReduxWrappedLayout } from 'jetpack-dashboard/controller';
 import notices from 'notices';
 import { getToken } from 'lib/oauth-token';
 import emailVerification from 'components/email-verification';

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -34,6 +34,7 @@ import { setReduxStore as setReduxBridgeReduxStore } from 'lib/redux-bridge';
 import { init as pushNotificationsInit } from 'state/push-notifications/actions';
 import { setSupportSessionReduxStore } from 'lib/user/support-user-interop';
 import analytics from 'lib/analytics';
+import { isJetpackDashboard } from 'lib/jetpack-dashboard';
 import superProps from 'lib/analytics/super-props';
 import { getSiteFragment, normalize } from 'lib/route';
 import { isLegacyRoute } from 'lib/route/legacy-routes';
@@ -436,11 +437,4 @@ function renderLayout( reduxStore ) {
 	ReactDom.render( layoutElement, document.getElementById( 'wpcom' ) );
 
 	debug( 'Main layout rendered.' );
-}
-
-function isJetpackDashboard() {
-	return !! (
-		process.env.JETPACK_DASHBOARD ||
-		( typeof window !== 'undefined' && 'dashboard.jetpack.com' === window.location.host )
-	);
 }

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -9,7 +9,6 @@ import page from 'page';
  * Internal Dependencies
  */
 import config from 'config';
-import JetpackDashboardLayout from 'layout/jetpack-dashboard';
 import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
 import { MomentProvider } from 'components/localized-moment/context';
@@ -43,17 +42,7 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } )
 	);
 };
 
-export const JetpackDashboardReduxWrappedLayout = ( { store, primary, secondary } ) => (
-	<ReduxProvider store={ store }>
-		<JetpackDashboardLayout primary={ primary } secondary={ secondary } />
-	</ReduxProvider>
-);
-
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
-
-export const makeJetpackDashboardLayout = makeLayoutMiddleware(
-	JetpackDashboardReduxWrappedLayout
-);
 
 /**
  * Isomorphic routing helper, client side

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -9,6 +9,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import config from 'config';
+import JetpackDashboardLayout from 'layout/jetpack-dashboard';
 import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
 import { MomentProvider } from 'components/localized-moment/context';
@@ -42,7 +43,17 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } )
 	);
 };
 
+export const JetpackDashboardReduxWrappedLayout = ( { store, primary, secondary } ) => (
+	<ReduxProvider store={ store }>
+		<JetpackDashboardLayout primary={ primary } secondary={ secondary } />
+	</ReduxProvider>
+);
+
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
+
+export const makeJetpackDashboardLayout = makeLayoutMiddleware(
+	JetpackDashboardReduxWrappedLayout
+);
 
 /**
  * Isomorphic routing helper, client side

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -19,8 +19,10 @@ import EnvironmentBadge, {
 	PreferencesHelper,
 } from 'components/environment-badge';
 import { chunkCssLinks } from './utils';
+import JetpackLogo from 'components/jetpack-logo';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from '../../server/sanitize';
+import { isJetpackDashboard } from 'lib/jetpack-dashboard';
 
 class Document extends React.Component {
 	render() {
@@ -132,9 +134,13 @@ class Document extends React.Component {
 									'is-wccom-oauth-flow': isWCComConnect,
 								} ) }
 							>
-								<div className="masterbar" />
+								{ ! isJetpackDashboard() && <div className="masterbar" /> }
 								<div className="layout__content">
-									<WordPressLogo size={ 72 } className="wpcom-site__logo" />
+									{ isJetpackDashboard() ? (
+										<JetpackLogo size={ 48 } className="jetpack-logo__loading" full />
+									) : (
+										<WordPressLogo size={ 72 } className="wpcom-site__logo" />
+									) }
 									{ hasSecondary && (
 										<Fragment>
 											<div className="layout__secondary" />

--- a/client/jetpack-dashboard-sections.js
+++ b/client/jetpack-dashboard-sections.js
@@ -3,6 +3,7 @@ const sections = [
 		name: 'jetpack-dashboard',
 		paths: [ '/' ],
 		module: 'jetpack-dashboard',
+		group: 'jetpack-dashboard',
 		secondary: false,
 		enableLoggedOut: true,
 	},

--- a/client/jetpack-dashboard-sections.js
+++ b/client/jetpack-dashboard-sections.js
@@ -1,0 +1,11 @@
+const sections = [
+	{
+		name: 'jetpack-dashboard',
+		paths: [ '/' ],
+		module: 'jetpack-dashboard',
+		secondary: false,
+		enableLoggedOut: true,
+	},
+];
+
+module.exports = sections;

--- a/client/jetpack-dashboard-sections.js
+++ b/client/jetpack-dashboard-sections.js
@@ -1,7 +1,7 @@
 const sections = [
 	{
 		name: 'jetpack-dashboard',
-		paths: [ '/' ],
+		paths: [ '/', '/security' ],
 		module: 'jetpack-dashboard',
 		group: 'jetpack-dashboard',
 		secondary: false,

--- a/client/jetpack-dashboard/controller.js
+++ b/client/jetpack-dashboard/controller.js
@@ -21,6 +21,25 @@ export function setupSidebar( context, next ) {
 
 export function jetpackDashboard( context, next ) {
 	context.primary = <div>Jetpack.com Dashboard</div>;
+	next();
+}
 
+export function security( context, next ) {
+	context.primary = <div>Security</div>;
+	next();
+}
+
+export function backups( context, next ) {
+	context.primary = <div>Backups</div>;
+	next();
+}
+
+export function scan( context, next ) {
+	context.primary = <div>Malware Scan</div>;
+	next();
+}
+
+export function antiSpam( context, next ) {
+	context.primary = <div>Anti-spam</div>;
 	next();
 }

--- a/client/jetpack-dashboard/controller.js
+++ b/client/jetpack-dashboard/controller.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import { preload } from 'sections-helper';
+
+export function preloadJetpackDashboard( context, next ) {
+	preload( 'jetpack-dashboard' );
+	next();
+}
+
+export function jetpackDashboard( context, next ) {
+	context.primary = <div>Hello world</div>;
+
+	next();
+}

--- a/client/jetpack-dashboard/controller.js
+++ b/client/jetpack-dashboard/controller.js
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import JetpackDashboardSecurity from './security';
 import JetpackDashboardSidebar from './sidebar';
 import { preload } from 'sections-helper';
 
@@ -20,12 +21,13 @@ export function setupSidebar( context, next ) {
 }
 
 export function jetpackDashboard( context, next ) {
-	context.primary = <div>Jetpack.com Dashboard</div>;
+	context.primary = <div>Hi, this is the Jetpack.com Dashboard!</div>;
 	next();
 }
 
 export function security( context, next ) {
-	context.primary = <div>Security</div>;
+	const siteId = context.params.siteId || 0;
+	context.primary = <JetpackDashboardSecurity siteId={ siteId } />;
 	next();
 }
 

--- a/client/jetpack-dashboard/controller.js
+++ b/client/jetpack-dashboard/controller.js
@@ -2,18 +2,49 @@
  * External dependencies
  */
 import React from 'react';
+import ReactDom from 'react-dom';
+import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
+import JetpackDashboardLayout from 'layout/jetpack-dashboard';
 import JetpackDashboardSecurity from './security';
 import JetpackDashboardSidebar from './sidebar';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { isEnabled } from 'config';
 import {
 	JETPACK_DASHBOARD_PRIMARY_DOMAIN,
 	JETPACK_DASHBOARD_SECONDARY_DOMAIN,
 } from 'lib/jetpack-dashboard';
 import { preload } from 'sections-helper';
+
+export const JetpackDashboardReduxWrappedLayout = ( { store, primary, secondary } ) => (
+	<ReduxProvider store={ store }>
+		<JetpackDashboardLayout primary={ primary } secondary={ secondary } />
+	</ReduxProvider>
+);
+
+export const makeLayout = ( context, next ) => {
+	const { store, primary, secondary } = context;
+
+	// On server, only render LoggedOutLayout when logged-out.
+	if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
+		context.layout = (
+			<JetpackDashboardLayout
+				store={ store }
+				primary={ primary }
+				secondary={ secondary }
+				redirectUri={ context.originalUrl }
+			/>
+		);
+	}
+	next();
+};
+
+export const clientRender = context => {
+	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+};
 
 export function preloadJetpackDashboard( context, next ) {
 	preload( 'jetpack-dashboard' );

--- a/client/jetpack-dashboard/controller.js
+++ b/client/jetpack-dashboard/controller.js
@@ -31,7 +31,7 @@ export const makeLayout = ( context, next ) => {
 	// On server, only render LoggedOutLayout when logged-out.
 	if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
 		context.layout = (
-			<JetpackDashboardLayout
+			<JetpackDashboardReduxWrappedLayout
 				store={ store }
 				primary={ primary }
 				secondary={ secondary }

--- a/client/jetpack-dashboard/controller.js
+++ b/client/jetpack-dashboard/controller.js
@@ -8,10 +8,32 @@ import React from 'react';
  */
 import JetpackDashboardSecurity from './security';
 import JetpackDashboardSidebar from './sidebar';
+import { isEnabled } from 'config';
+import {
+	JETPACK_DASHBOARD_PRIMARY_DOMAIN,
+	JETPACK_DASHBOARD_SECONDARY_DOMAIN,
+} from 'lib/jetpack-dashboard';
 import { preload } from 'sections-helper';
 
 export function preloadJetpackDashboard( context, next ) {
 	preload( 'jetpack-dashboard' );
+	next();
+}
+
+export function handleRedirects( context, next ) {
+	if ( ! isEnabled( 'jetpack-dashboard' ) ) {
+		window.location = 'https://wordpress.com';
+		return;
+	}
+
+	if ( window.location.host === JETPACK_DASHBOARD_SECONDARY_DOMAIN ) {
+		window.location = window.location.href.replace(
+			JETPACK_DASHBOARD_SECONDARY_DOMAIN,
+			JETPACK_DASHBOARD_PRIMARY_DOMAIN
+		);
+		return;
+	}
+
 	next();
 }
 

--- a/client/jetpack-dashboard/controller.js
+++ b/client/jetpack-dashboard/controller.js
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import JetpackDashboardSidebar from './sidebar';
 import { preload } from 'sections-helper';
 
 export function preloadJetpackDashboard( context, next ) {
@@ -13,8 +14,13 @@ export function preloadJetpackDashboard( context, next ) {
 	next();
 }
 
+export function setupSidebar( context, next ) {
+	context.secondary = <JetpackDashboardSidebar />;
+	next();
+}
+
 export function jetpackDashboard( context, next ) {
-	context.primary = <div>Hello world</div>;
+	context.primary = <div>Jetpack.com Dashboard</div>;
 
 	next();
 }

--- a/client/jetpack-dashboard/index.js
+++ b/client/jetpack-dashboard/index.js
@@ -10,6 +10,7 @@ import { makeJetpackDashboardLayout, render as clientRender } from 'controller';
 import {
 	antiSpam,
 	backups,
+	handleRedirects,
 	jetpackDashboard,
 	preloadJetpackDashboard,
 	scan,
@@ -20,6 +21,7 @@ import {
 export default function() {
 	page(
 		'/security/backups',
+		handleRedirects,
 		preloadJetpackDashboard,
 		setupSidebar,
 		backups,
@@ -28,6 +30,7 @@ export default function() {
 	);
 	page(
 		'/security/scan',
+		handleRedirects,
 		preloadJetpackDashboard,
 		setupSidebar,
 		scan,
@@ -36,6 +39,7 @@ export default function() {
 	);
 	page(
 		'/security/anti-spam',
+		handleRedirects,
 		preloadJetpackDashboard,
 		setupSidebar,
 		antiSpam,
@@ -44,6 +48,7 @@ export default function() {
 	);
 	page(
 		'/security/:siteId?',
+		handleRedirects,
 		preloadJetpackDashboard,
 		setupSidebar,
 		security,
@@ -52,6 +57,7 @@ export default function() {
 	);
 	page(
 		'/',
+		handleRedirects,
 		preloadJetpackDashboard,
 		setupSidebar,
 		jetpackDashboard,

--- a/client/jetpack-dashboard/index.js
+++ b/client/jetpack-dashboard/index.js
@@ -7,9 +7,49 @@ import page from 'page';
  * Internal dependencies
  */
 import { makeJetpackDashboardLayout, render as clientRender } from 'controller';
-import { jetpackDashboard, preloadJetpackDashboard, setupSidebar } from './controller';
+import {
+	antiSpam,
+	backups,
+	jetpackDashboard,
+	preloadJetpackDashboard,
+	scan,
+	security,
+	setupSidebar,
+} from './controller';
 
 export default function() {
+	page(
+		'/security/backups',
+		preloadJetpackDashboard,
+		setupSidebar,
+		backups,
+		makeJetpackDashboardLayout,
+		clientRender
+	);
+	page(
+		'/security/scan',
+		preloadJetpackDashboard,
+		setupSidebar,
+		scan,
+		makeJetpackDashboardLayout,
+		clientRender
+	);
+	page(
+		'/security/anti-spam',
+		preloadJetpackDashboard,
+		setupSidebar,
+		antiSpam,
+		makeJetpackDashboardLayout,
+		clientRender
+	);
+	page(
+		'/security',
+		preloadJetpackDashboard,
+		setupSidebar,
+		security,
+		makeJetpackDashboardLayout,
+		clientRender
+	);
 	page(
 		'/',
 		preloadJetpackDashboard,

--- a/client/jetpack-dashboard/index.js
+++ b/client/jetpack-dashboard/index.js
@@ -6,12 +6,13 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { makeJetpackDashboardLayout, render as clientRender } from 'controller';
 import {
 	antiSpam,
 	backups,
+	clientRender,
 	handleRedirects,
 	jetpackDashboard,
+	makeLayout,
 	preloadJetpackDashboard,
 	scan,
 	security,
@@ -25,7 +26,7 @@ export default function() {
 		preloadJetpackDashboard,
 		setupSidebar,
 		backups,
-		makeJetpackDashboardLayout,
+		makeLayout,
 		clientRender
 	);
 	page(
@@ -34,7 +35,7 @@ export default function() {
 		preloadJetpackDashboard,
 		setupSidebar,
 		scan,
-		makeJetpackDashboardLayout,
+		makeLayout,
 		clientRender
 	);
 	page(
@@ -43,7 +44,7 @@ export default function() {
 		preloadJetpackDashboard,
 		setupSidebar,
 		antiSpam,
-		makeJetpackDashboardLayout,
+		makeLayout,
 		clientRender
 	);
 	page(
@@ -52,7 +53,7 @@ export default function() {
 		preloadJetpackDashboard,
 		setupSidebar,
 		security,
-		makeJetpackDashboardLayout,
+		makeLayout,
 		clientRender
 	);
 	page(
@@ -61,7 +62,7 @@ export default function() {
 		preloadJetpackDashboard,
 		setupSidebar,
 		jetpackDashboard,
-		makeJetpackDashboardLayout,
+		makeLayout,
 		clientRender
 	);
 }

--- a/client/jetpack-dashboard/index.js
+++ b/client/jetpack-dashboard/index.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { makeJetpackDashboardLayout, render as clientRender } from 'controller';
+import { jetpackDashboard, preloadJetpackDashboard } from './controller';
+
+export default function() {
+	page( '/', preloadJetpackDashboard, jetpackDashboard, makeJetpackDashboardLayout, clientRender );
+}

--- a/client/jetpack-dashboard/index.js
+++ b/client/jetpack-dashboard/index.js
@@ -7,8 +7,15 @@ import page from 'page';
  * Internal dependencies
  */
 import { makeJetpackDashboardLayout, render as clientRender } from 'controller';
-import { jetpackDashboard, preloadJetpackDashboard } from './controller';
+import { jetpackDashboard, preloadJetpackDashboard, setupSidebar } from './controller';
 
 export default function() {
-	page( '/', preloadJetpackDashboard, jetpackDashboard, makeJetpackDashboardLayout, clientRender );
+	page(
+		'/',
+		preloadJetpackDashboard,
+		setupSidebar,
+		jetpackDashboard,
+		makeJetpackDashboardLayout,
+		clientRender
+	);
 }

--- a/client/jetpack-dashboard/index.js
+++ b/client/jetpack-dashboard/index.js
@@ -43,7 +43,7 @@ export default function() {
 		clientRender
 	);
 	page(
-		'/security',
+		'/security/:siteId?',
 		preloadJetpackDashboard,
 		setupSidebar,
 		security,

--- a/client/jetpack-dashboard/security.jsx
+++ b/client/jetpack-dashboard/security.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import QuerySites from 'components/data/query-sites';
+import { requestActivityLogs } from 'state/data-getters';
+import { getSite } from 'state/sites/selectors';
+
+class JetpackDashboardSecurity extends React.PureComponent {
+	render() {
+		const { logs, moment, site, siteId } = this.props;
+
+		if ( ! siteId ) {
+			return (
+				<Fragment>
+					<p>Site not selected. Append `/12345` to the URL, where `12345` is your site ID.</p>
+				</Fragment>
+			);
+		}
+
+		if ( siteId && ! site ) {
+			return (
+				<Fragment>
+					<QuerySites siteId={ siteId } />
+					<p>Loading...</p>
+				</Fragment>
+			);
+		}
+
+		return (
+			<Fragment>
+				<h3>Backups events for site { site.title }</h3>
+				{ logs && (
+					<ul>
+						{ logs.map( ( { activityDate, activityId, activityTitle } ) => (
+							<li key={ 'activity-' + activityId }>
+								{ activityTitle } on { moment( activityDate ).format( 'MMMM Do YYYY' ) } at{' '}
+								{ moment( activityDate ).format( 'h:mm:ss a' ) }
+							</li>
+						) ) }
+					</ul>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default connect( ( state, { siteId } ) => {
+	const logs =
+		siteId &&
+		requestActivityLogs( siteId, {
+			group: 'rewind',
+		} );
+
+	return {
+		siteId,
+		site: siteId && getSite( state, siteId ),
+		logs: ( siteId && logs.data ) || [],
+	};
+} )( localize( JetpackDashboardSecurity ) );

--- a/client/jetpack-dashboard/security.jsx
+++ b/client/jetpack-dashboard/security.jsx
@@ -19,7 +19,10 @@ class JetpackDashboardSecurity extends React.PureComponent {
 		if ( ! siteId ) {
 			return (
 				<Fragment>
-					<p>Site not selected. Append `/12345` to the URL, where `12345` is your site ID.</p>
+					<p>
+						Site not selected. Append <code>/12345</code> to the URL, where <code>12345</code> is
+						your site ID.
+					</p>
 				</Fragment>
 			);
 		}

--- a/client/jetpack-dashboard/sidebar.jsx
+++ b/client/jetpack-dashboard/sidebar.jsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { memoize } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Sidebar from 'layout/sidebar';
+import SidebarItem from 'layout/sidebar/item';
+import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+
+class JetpackDashboardSidebar extends React.PureComponent {
+	isItemSelected( itemPath, isStrict = true ) {
+		const { path } = this.props;
+
+		if ( isStrict ) {
+			return path === itemPath;
+		}
+
+		return path.indexOf( itemPath ) === 0;
+	}
+
+	toggleSection = memoize( id => () => this.props.toggleSection( id ) );
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<Sidebar>
+				<SidebarItem
+					label={ translate( 'Jetpack.com Dashboard' ) }
+					link="/"
+					selected={ this.isItemSelected( '/' ) }
+					icon="plans"
+				/>
+				<ExpandableSidebarMenu expanded title={ translate( 'Security' ) } icon="lock">
+					<SidebarItem
+						label={ translate( 'Dashboard' ) }
+						link="/security"
+						selected={ this.isItemSelected( '/security' ) }
+					/>
+					<SidebarItem
+						label={ translate( 'Backups' ) }
+						link="/security/backups"
+						selected={ this.isItemSelected( '/security/backups' ) }
+					/>
+					<SidebarItem
+						label={ translate( 'Malware scan' ) }
+						link="/security/scan"
+						selected={ this.isItemSelected( '/security/scan' ) }
+					/>
+					<SidebarItem
+						label={ translate( 'Anti-spam' ) }
+						link="/security/anti-spam"
+						selected={ this.isItemSelected( '/security/anti-spam' ) }
+					/>
+				</ExpandableSidebarMenu>
+				<ExpandableSidebarMenu
+					expanded={ false }
+					title={ translate( 'Performance' ) }
+					icon="time"
+				/>
+				<ExpandableSidebarMenu expanded={ false } title={ translate( 'Marketing' ) } icon="money" />
+			</Sidebar>
+		);
+	}
+}
+
+export default localize( JetpackDashboardSidebar );

--- a/client/jetpack-dashboard/sidebar.jsx
+++ b/client/jetpack-dashboard/sidebar.jsx
@@ -42,7 +42,7 @@ class JetpackDashboardSidebar extends React.PureComponent {
 					<SidebarItem
 						label={ translate( 'Dashboard' ) }
 						link="/security"
-						selected={ this.isItemSelected( '/security' ) }
+						selected={ this.isItemSelected( '/security', false ) }
 					/>
 					<SidebarItem
 						label={ translate( 'Backups' ) }

--- a/client/jetpack-dashboard/sidebar.jsx
+++ b/client/jetpack-dashboard/sidebar.jsx
@@ -42,7 +42,7 @@ class JetpackDashboardSidebar extends React.PureComponent {
 					<SidebarItem
 						label={ translate( 'Dashboard' ) }
 						link="/security"
-						selected={ this.isItemSelected( '/security', false ) }
+						selected={ this.isItemSelected( '/security' ) }
 					/>
 					<SidebarItem
 						label={ translate( 'Backups' ) }

--- a/client/jetpack-dashboard/sidebar.jsx
+++ b/client/jetpack-dashboard/sidebar.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { memoize } from 'lodash';
 
@@ -11,6 +12,7 @@ import { memoize } from 'lodash';
 import Sidebar from 'layout/sidebar';
 import SidebarItem from 'layout/sidebar/item';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 class JetpackDashboardSidebar extends React.PureComponent {
 	isItemSelected( itemPath, isStrict = true ) {
@@ -69,4 +71,6 @@ class JetpackDashboardSidebar extends React.PureComponent {
 	}
 }
 
-export default localize( JetpackDashboardSidebar );
+export default connect( state => ( {
+	path: getCurrentRoute( state ),
+} ) )( localize( JetpackDashboardSidebar ) );

--- a/client/layout/jetpack-dashboard.jsx
+++ b/client/layout/jetpack-dashboard.jsx
@@ -11,6 +11,7 @@ import classnames from 'classnames';
  */
 import AsyncLoad from 'components/async-load';
 import GlobalNotices from 'components/global-notices';
+import JetpackDashboardMasterbar from 'layout/masterbar/jetpack-dashboard';
 import notices from 'notices';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
@@ -34,6 +35,8 @@ class JetpackDashboardLayout extends Component {
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
+
+				<JetpackDashboardMasterbar />
 
 				<div id="content" className="layout__content">
 					<GlobalNotices id="notices" notices={ notices.list } />

--- a/client/layout/jetpack-dashboard.jsx
+++ b/client/layout/jetpack-dashboard.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import AsyncLoad from 'components/async-load';
+import GlobalNotices from 'components/global-notices';
+import notices from 'notices';
+import { getSelectedSiteId, getSectionGroup, getSectionName } from 'state/ui/selectors';
+import DocumentHead from 'components/data/document-head';
+import BodySectionCssClass from './body-section-css-class';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class JetpackDashboardLayout extends Component {
+	static propTypes = {
+		primary: PropTypes.element,
+		secondary: PropTypes.element,
+		// connected props
+		sectionGroup: PropTypes.string,
+		sectionName: PropTypes.string,
+	};
+
+	render() {
+		const sectionClass = classnames( 'layout', `is-section-${ this.props.sectionName }` );
+
+		return (
+			<div className={ sectionClass }>
+				<BodySectionCssClass group={ this.props.sectionGroup } section={ this.props.sectionName } />
+				<DocumentHead />
+
+				<div id="content" className="layout__content">
+					<GlobalNotices id="notices" notices={ notices.list } />
+					<div id="secondary" className="layout__secondary" role="navigation">
+						{ this.props.secondary }
+					</div>
+					<div id="primary" className="layout__primary">
+						{ this.props.primary }
+					</div>
+				</div>
+				{ 'development' === process.env.NODE_ENV && (
+					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
+				) }
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const sectionGroup = getSectionGroup( state );
+	const sectionName = getSectionName( state );
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		sectionGroup,
+		sectionName,
+		siteId,
+	};
+} )( JetpackDashboardLayout );

--- a/client/layout/jetpack-dashboard.jsx
+++ b/client/layout/jetpack-dashboard.jsx
@@ -14,7 +14,6 @@ import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
 import { getSelectedSiteId, getSectionGroup, getSectionName } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
-import BodySectionCssClass from './body-section-css-class';
 
 /**
  * Style dependencies
@@ -35,7 +34,6 @@ class JetpackDashboardLayout extends Component {
 
 		return (
 			<div className={ sectionClass }>
-				<BodySectionCssClass group={ this.props.sectionGroup } section={ this.props.sectionName } />
 				<DocumentHead />
 
 				<div id="content" className="layout__content">

--- a/client/layout/jetpack-dashboard.jsx
+++ b/client/layout/jetpack-dashboard.jsx
@@ -15,6 +15,11 @@ import notices from 'notices';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
 
+/**
+ * Style dependencies
+ */
+import './jetpack-dashboard.scss';
+
 class JetpackDashboardLayout extends Component {
 	static propTypes = {
 		primary: PropTypes.element,

--- a/client/layout/jetpack-dashboard.jsx
+++ b/client/layout/jetpack-dashboard.jsx
@@ -15,11 +15,6 @@ import notices from 'notices';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 class JetpackDashboardLayout extends Component {
 	static propTypes = {
 		primary: PropTypes.element,

--- a/client/layout/jetpack-dashboard.jsx
+++ b/client/layout/jetpack-dashboard.jsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 import AsyncLoad from 'components/async-load';
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
-import { getSelectedSiteId, getSectionGroup, getSectionName } from 'state/ui/selectors';
+import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
 
 /**
@@ -25,7 +25,6 @@ class JetpackDashboardLayout extends Component {
 		primary: PropTypes.element,
 		secondary: PropTypes.element,
 		// connected props
-		sectionGroup: PropTypes.string,
 		sectionName: PropTypes.string,
 	};
 
@@ -54,12 +53,10 @@ class JetpackDashboardLayout extends Component {
 }
 
 export default connect( state => {
-	const sectionGroup = getSectionGroup( state );
 	const sectionName = getSectionName( state );
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		sectionGroup,
 		sectionName,
 		siteId,
 	};

--- a/client/layout/jetpack-dashboard.scss
+++ b/client/layout/jetpack-dashboard.scss
@@ -1,0 +1,6 @@
+.jetpack-logo__loading {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+}

--- a/client/layout/masterbar/jetpack-dashboard.jsx
+++ b/client/layout/masterbar/jetpack-dashboard.jsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Item from './item';
+import JetpackLogo from 'components/jetpack-logo';
+import Masterbar from './masterbar';
+
+const JetpackDashboardMasterbar = () => (
+	<Masterbar>
+		<Item className="masterbar__item-logo">
+			<JetpackLogo className="masterbar__jetpack-logo" full />
+		</Item>
+	</Masterbar>
+);
+
+export default JetpackDashboardMasterbar;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -23,6 +23,11 @@ $autobar-height: 20px;
 		background: var( --studio-orange );
 		border-bottom: 1px solid var( --studio-orange-60 );
 	}
+
+	.is-section-jetpack-dashboard & {
+		background: var( --studio-gray-10 );
+		border-bottom-color: var( --studio-gray-20 );
+	}
 }
 
 .pride .masterbar {
@@ -145,6 +150,10 @@ $autobar-height: 20px;
 		width: 150px;
 		height: 25px;
 		margin: 0 5px;
+	}
+
+	.masterbar__jetpack-logo {
+		margin: 17px 0 0 65px;
 	}
 
 	@include breakpoint( '<480px' ) {

--- a/client/lib/jetpack-dashboard/index.js
+++ b/client/lib/jetpack-dashboard/index.js
@@ -1,0 +1,6 @@
+export function isJetpackDashboard() {
+	return !! (
+		process.env.JETPACK_DASHBOARD ||
+		( typeof window !== 'undefined' && 'dashboard.jetpack.com' === window.location.host )
+	);
+}

--- a/client/lib/jetpack-dashboard/index.js
+++ b/client/lib/jetpack-dashboard/index.js
@@ -1,4 +1,10 @@
-const jetpackDashboardDomains = [ 'cloud.jetpack.com', 'my.jetpack.com' ];
+export const JETPACK_DASHBOARD_PRIMARY_DOMAIN = 'cloud.jetpack.com';
+export const JETPACK_DASHBOARD_SECONDARY_DOMAIN = 'my.jetpack.com';
+
+const jetpackDashboardDomains = [
+	JETPACK_DASHBOARD_PRIMARY_DOMAIN,
+	JETPACK_DASHBOARD_SECONDARY_DOMAIN,
+];
 
 export function isJetpackDashboard() {
 	return !! (

--- a/client/lib/jetpack-dashboard/index.js
+++ b/client/lib/jetpack-dashboard/index.js
@@ -1,6 +1,9 @@
+const jetpackDashboardDomains = [ 'cloud.jetpack.com', 'my.jetpack.com' ];
+
 export function isJetpackDashboard() {
 	return !! (
 		process.env.JETPACK_DASHBOARD ||
-		( typeof window !== 'undefined' && 'dashboard.jetpack.com' === window.location.host )
+		( typeof window !== 'undefined' &&
+			jetpackDashboardDomains.indexOf( window.location.host ) >= 0 )
 	);
 }

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -16,9 +16,8 @@ import * as controller from './controller/index.web';
 import { pathToRegExp } from './utils';
 import { receiveSections, load } from './sections-helper';
 import { addReducerToStore } from 'state/add-reducer';
-
 import sections from './sections';
-receiveSections( sections );
+import jetpackDashboardSections from './jetpack-dashboard-sections';
 
 function activateSection( sectionDefinition, context ) {
 	context.store.dispatch( setSection( sectionDefinition ) );
@@ -106,7 +105,19 @@ function createPageDefinition( path, sectionDefinition ) {
 }
 
 export const setupRoutes = () => {
+	receiveSections( sections );
+
 	for ( const section of sections ) {
+		for ( const path of section.paths ) {
+			createPageDefinition( path, section );
+		}
+	}
+};
+
+export const setupJetpackDashboardRoutes = () => {
+	receiveSections( jetpackDashboardSections );
+
+	for ( const section of jetpackDashboardSections ) {
 		for ( const path of section.paths ) {
 			createPageDefinition( path, section );
 		}

--- a/client/state/document-head/selectors.js
+++ b/client/state/document-head/selectors.js
@@ -13,6 +13,7 @@ import createSelector from 'lib/create-selector';
 import { decodeEntities } from 'lib/formatting';
 import { getSelectedSiteId, isSiteSection } from 'state/ui/selectors';
 import { getSiteTitle } from 'state/sites/selectors';
+import { isJetpackDashboard } from 'lib/jetpack-dashboard';
 
 const UNREAD_COUNT_CAP = 40;
 
@@ -79,7 +80,12 @@ export const getDocumentHeadFormattedTitle = createSelector(
 			title = decodeEntities( title ) + ' — ';
 		}
 
-		return title + 'WordPress.com';
+		let titleBase = 'WordPress.com';
+		if ( isJetpackDashboard() ) {
+			titleBase = 'Jetpack.com Dashboard';
+		}
+
+		return title + titleBase;
 	},
 	state => [ state.documentHead, state.ui.section, state.ui.selectedSiteId ]
 );

--- a/client/state/document-head/test/selectors.js
+++ b/client/state/document-head/test/selectors.js
@@ -87,6 +87,35 @@ describe( 'selectors', () => {
 				expect( formattedTitle ).to.equal( 'WordPress.com' );
 			} );
 
+			test( 'should return only "Jetpack.com Dashboard" if no title is set on the Jetpack Dashboard', () => {
+				process.env.JETPACK_DASHBOARD = 1;
+				const formattedTitle = getDocumentHeadFormattedTitle( {
+					documentHead: {},
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								name: 'WordPress.com Example Blog',
+								URL: 'http://yourgroovydomain.com',
+							},
+						},
+					},
+					ui: {
+						selectedSiteId: 2916284,
+						section: {
+							name: 'reader',
+							paths: [ '/', '/read' ],
+							module: 'reader',
+							group: 'reader',
+							secondary: true,
+						},
+					},
+				} );
+				delete process.env.JETPACK_DASHBOARD;
+
+				expect( formattedTitle ).to.equal( 'Jetpack.com Dashboard' );
+			} );
+
 			test( 'should return formatted title made up of section but not site name', () => {
 				const formattedTitle = getDocumentHeadFormattedTitle( {
 					documentHead: {

--- a/config/development.json
+++ b/config/development.json
@@ -63,6 +63,7 @@
 		"hosting": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
+		"jetpack-dashboard": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,6 +40,7 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": false,
+		"jetpack-dashboard": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -222,6 +222,15 @@ function getAcceptedLanguagesFromHeader( header ) {
 		.filter( lang => lang );
 }
 
+function getFaviconUrl() {
+	if ( isJetpackDashboard() ) {
+		// TODO: Use an actual favicon
+		return 'https://jetpackme.files.wordpress.com/2018/04/cropped-jetpack-favicon-2018.png?w=240';
+	}
+
+	return config( 'favicon_url' );
+}
+
 /*
  * Look at the request headers and determine if the request is logged in or logged out or if
  * it's a support session. Set `req.context.isLoggedIn` and `req.context.isSupportSession` flags
@@ -298,7 +307,7 @@ function getDefaultContext( request ) {
 		lang,
 		entrypoint: getFilesForEntrypoint( target, 'entry-main' ),
 		manifest: getAssets( target ).manifests.manifest,
-		faviconURL: config( 'favicon_url' ),
+		faviconURL: getFaviconUrl(),
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		preferencesHelper: !! config.isEnabled( 'dev/preferences-helper' ),
@@ -566,7 +575,7 @@ function setUpRoute( req, res, next ) {
 
 function render404( req, res ) {
 	const ctx = {
-		faviconURL: config( 'favicon_url' ),
+		faviconURL: getFaviconUrl(),
 		isRTL: config( 'rtl' ),
 		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), 'entry-main' ),
 	};
@@ -584,7 +593,7 @@ function renderServerError( err, req, res, next ) {
 	}
 
 	const ctx = {
-		faviconURL: config( 'favicon_url' ),
+		faviconURL: getFaviconUrl(),
 		isRTL: config( 'rtl' ),
 		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), 'entry-main' ),
 	};

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -32,7 +32,9 @@ import config from 'config';
 import sanitize from 'sanitize';
 import utils from 'bundler/utils';
 import { pathToRegExp } from '../../client/utils';
+import jetpackDashboardSections from '../../client/jetpack-dashboard-sections';
 import sections from '../../client/sections';
+import { isJetpackDashboard } from '../../client/lib/jetpack-dashboard';
 import loginRouter, { LOGIN_SECTION_DEFINITION } from '../../client/login';
 import { serverRouter, getNormalizedPath } from 'isomorphic-routing';
 import { serverRender, renderJsx, attachBuildTimestamp, attachHead, attachI18n } from 'render';
@@ -785,7 +787,9 @@ module.exports = function() {
 		}
 	}
 
-	sections
+	const appSections = isJetpackDashboard() ? jetpackDashboardSections : sections;
+
+	appSections
 		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
 		.forEach( section => {
 			section.paths.forEach( sectionPath => handleSectionPath( section, sectionPath ) );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -284,6 +284,7 @@ const webpackConfig = {
 	plugins: _.compact( [
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+			'process.env.JETPACK_DASHBOARD': JSON.stringify( process.env.JETPACK_DASHBOARD ),
 			'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
 				!! process.env.FORCE_REDUCED_MOTION || false
 			),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -244,6 +244,13 @@ const webpackConfig = {
 				},
 			},
 			{
+				include: path.join( __dirname, 'client/jetpack-dashboard-sections.js' ),
+				loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
+				options: {
+					include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
+				},
+			},
+			{
 				test: /\.html$/,
 				loader: 'html-loader',
 			},

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -133,6 +133,7 @@ const webpackConfig = {
 			BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),
 			COMMIT_SHA: JSON.stringify( commitSha ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+			'process.env.JETPACK_DASHBOARD': JSON.stringify( process.env.JETPACK_DASHBOARD ),
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]analytics$/, 'lodash/noop' ), // Depends on BOM


### PR DESCRIPTION
**DO NOT MERGE - this is an experiment.**

#### Changes proposed in this Pull Request

This experimental PR creates a new section in Calypso, called Jetpack Dashboard, which isn't registered by default. We update all of Calypso to contain a "is Jetpack Dashboard" state. In that state, Calypso loads that new section only, and doesn't load any of the original ones. To load Calypso in the "Jetpack Dashboard" state, either of these has to be fulfilled:

* `JETPACK_DASHBOARD` environment variable to be `1`.
* Domain this is running on to be `dashboard.jetpack.com`.

The purpose of this is to allow for a new Jetpack Dashboard to be built and developed, which will work independently and have its own set of features, but will live in Calypso and will use the same staging and production environments. The only notable difference is that in staging/production it will use a different domain, `dashboard.jetpack.com`. The original Calypso should stay untouched.

#### Preview

Dashboard/landing screen
![](https://cldup.com/cGwofuM0k6.png)

Backups loaded:
![](https://cldup.com/gFFG8D3iu4.png)

Loading screen:
![](https://cldup.com/F8jBLgZh13.png)

#### Testing instructions

* Checkout this branch.
* Run `JETPACK_DASHBOARD=1 npm start`
* Load http://calypso.localhost:3000/
* Verify it looks okay.
* Click through the pages and verify you can navigate.
* Go to http://calypso.localhost:3000/security/12345 where `12345` is the ID of a Jetpack site with backups enabled and working.
* Verify you can see the latest backup operations.
* Run `npm start`.
* Verify original Calypso still works normally.
