### PR TITLE
Build: Add script to test react module equality

### DIFF
--- a/bin/check-same-react-root-wp-element.js
+++ b/bin/check-same-react-root-wp-element.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const m = require( 'module' );
+
+// Create an instance of `require` with its root in the `@wordpress/element` module.
+const requireFromWpElement = m.createRequireFromPath( require.resolve( '@wordpress/element' ) );
+
+// We should get the same module requiring from the root or from @wordpress/element
+if ( require( 'react' ) === requireFromWpElement( 'react' ) ) {
+	process.exit( 0 );
+} else {
+	const reactRootVersion = require( 'react/package.json' ).version;
+	const reactWpElementVersion = requireFromWpElement( 'react/package.json' ).version;
+	throw new Error(
+		`Encountered different versions of React between the root and @wordpress/element: ${ reactRootVersion } (root) vs. ${ reactWpElementVersion }`
+	);
+}


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/36494 showed issues with duplicated React packages between `@wordpress/*` packages and the project root.

Try to ensure the modules are in sync.

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
