### PR TITLE
Use jest .each tables for upwork tests

### DIFF
--- a/client/state/selectors/is-eligible-for-upwork-support.ts
+++ b/client/state/selectors/is-eligible-for-upwork-support.ts
@@ -10,7 +10,7 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 import getSitesItems from 'state/selectors/get-sites-items';
 import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
 
-const UPWORK_LOCALES = [
+export const UPWORK_LOCALES = [
 	'de',
 	'de-at',
 	'de-li',

--- a/client/state/selectors/is-eligible-for-upwork-support.ts
+++ b/client/state/selectors/is-eligible-for-upwork-support.ts
@@ -25,12 +25,16 @@ export const UPWORK_LOCALES = [
 	'fr-ch',
 	'it',
 	'it-ch',
+	'ja',
 	'nl',
 	'nl-be',
 	'nl-nl',
 	'pt',
 	'pt-pt',
 	'pt-br',
+	'sv',
+	'sv-fi',
+	'sv-se',
 ];
 
 /**

--- a/client/state/selectors/test/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/test/is-eligible-for-upwork-support.js
@@ -12,47 +12,7 @@ import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_FREE, PLAN_PREMIUM } from 'lib/plan
 import isEligibleForUpworkSupport from 'state/selectors/is-eligible-for-upwork-support';
 
 describe( 'isEligibleForUpworkSupport()', () => {
-	test( 'returns true for Spanish language users without Business and E-Commerce plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					111: { plan: { product_slug: PLAN_FREE } },
-					222: { plan: { product_slug: PLAN_PREMIUM } },
-				},
-			},
-			users: { items: { 1: { localeSlug: 'es' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
-	} );
-
-	test( 'returns false for Spanish language users with Business plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					333: { plan: { product_slug: PLAN_BUSINESS } },
-				},
-			},
-			users: { items: { 1: { localeSlug: 'es' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.false;
-	} );
-
-	test( 'returns false for Spanish language users with E-Commerce plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					444: { plan: { product_slug: PLAN_ECOMMERCE } },
-				},
-			},
-			users: { items: { 1: { localeSlug: 'es' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.false;
-	} );
-
-	test( 'returns false for non-Spanish language users false if all sites have a free plan', () => {
+	test( 'returns false for `en` users and all sites have a free plan', () => {
 		const state = {
 			currentUser: { id: 1 },
 			sites: {
@@ -66,73 +26,46 @@ describe( 'isEligibleForUpworkSupport()', () => {
 		expect( isEligibleForUpworkSupport( state ) ).to.be.false;
 	} );
 
-	test( 'returns true for French language users without Business and E-Commerce plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					111: { plan: { product_slug: PLAN_FREE } },
-					222: { plan: { product_slug: PLAN_PREMIUM } },
-				},
-			},
-			users: { items: { 1: { localeSlug: 'fr' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
-	} );
+	/**
+	 * These locales are expected to be eligible for upwork
+	 * when no Business or E-Commerce plan is present.
+	 */
+	const upworkLocales = [ 'es', 'fr', 'pt', 'de', 'it', 'nl' ];
 
-	test( 'returns true for Portugese language users without Business and E-Commerce plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					111: { plan: { product_slug: PLAN_FREE } },
-					222: { plan: { product_slug: PLAN_PREMIUM } },
-				},
-			},
-			users: { items: { 1: { localeSlug: 'pt' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
-	} );
+	/**
+	 * If any plan listed below in user's account then not eligible
+	 * for upwork support.
+	 */
+	const nonUpworkPlans = [ PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
-	test( 'returns true for German language users without Business and E-Commerce plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					111: { plan: { product_slug: PLAN_FREE } },
-					222: { plan: { product_slug: PLAN_PREMIUM } },
+	describe.each( upworkLocales )( 'when locale %s', localeSlug => {
+		test( 'returns true for users without Business and E-Commerce plans', () => {
+			const state = {
+				currentUser: { id: 1 },
+				sites: {
+					items: {
+						111: { plan: { product_slug: PLAN_FREE } },
+						222: { plan: { product_slug: PLAN_PREMIUM } },
+					},
 				},
-			},
-			users: { items: { 1: { localeSlug: 'de' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
-	} );
+				users: { items: { 1: { localeSlug } } },
+			};
+			expect( isEligibleForUpworkSupport( state ) ).to.be.true;
+		} );
 
-	test( 'returns true for Italian language users without Business and E-Commerce plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					111: { plan: { product_slug: PLAN_FREE } },
-					222: { plan: { product_slug: PLAN_PREMIUM } },
-				},
-			},
-			users: { items: { 1: { localeSlug: 'it' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
-	} );
-
-	test( 'returns true for Dutch language users without Business and E-Commerce plans', () => {
-		const state = {
-			currentUser: { id: 1 },
-			sites: {
-				items: {
-					111: { plan: { product_slug: PLAN_FREE } },
-					222: { plan: { product_slug: PLAN_PREMIUM } },
-				},
-			},
-			users: { items: { 1: { localeSlug: 'nl' } } },
-		};
-		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
+		describe.each( nonUpworkPlans )( 'with plan %s', product_slug => {
+			test( 'returns false', () => {
+				const state = {
+					currentUser: { id: 1 },
+					sites: {
+						items: {
+							333: { plan: { product_slug } },
+						},
+					},
+					users: { items: { 1: { localeSlug } } },
+				};
+				expect( isEligibleForUpworkSupport( state ) ).to.be.false;
+			} );
+		} );
 	} );
 } );

--- a/client/state/selectors/test/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/test/is-eligible-for-upwork-support.js
@@ -9,7 +9,9 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_FREE, PLAN_PREMIUM } from 'lib/plans/constants';
-import isEligibleForUpworkSupport from 'state/selectors/is-eligible-for-upwork-support';
+import isEligibleForUpworkSupport, {
+	UPWORK_LOCALES,
+} from 'state/selectors/is-eligible-for-upwork-support';
 
 describe( 'isEligibleForUpworkSupport()', () => {
 	test( 'returns false for `en` users and all sites have a free plan', () => {
@@ -27,18 +29,12 @@ describe( 'isEligibleForUpworkSupport()', () => {
 	} );
 
 	/**
-	 * These locales are expected to be eligible for upwork
-	 * when no Business or E-Commerce plan is present.
-	 */
-	const upworkLocales = [ 'es', 'fr', 'pt', 'de', 'it', 'nl' ];
-
-	/**
 	 * If any plan listed below in user's account then not eligible
 	 * for upwork support.
 	 */
 	const nonUpworkPlans = [ PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
-	describe.each( upworkLocales )( 'when locale %s', localeSlug => {
+	describe.each( UPWORK_LOCALES )( 'when locale %s', localeSlug => {
 		test( 'returns true for users without Business and E-Commerce plans', () => {
 			const state = {
 				currentUser: { id: 1 },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Unit tests use Jest `describe.each` and `test.each`.
* Adds `ja`, `sv`, `sv-fi` and `sv-se` to Upwork supported locales.

#### Testing instructions

* Unit tests should be logically equivalent
* Unit tests should pass

