### PR TITLE
Fix _close typo in Dialogue component

### DIFF
--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -91,11 +91,11 @@ class Dialog extends Component {
 		this.close( button.action );
 	}
 
-	close( action ) {
+	close = action => {
 		if ( this.props.onClose ) {
 			this.props.onClose( action );
 		}
-	}
+	};
 
 	render() {
 		const {
@@ -121,7 +121,7 @@ class Dialog extends Component {
 			<RootChild>
 				<Modal
 					isOpen={ this.props.isVisible }
-					onRequestClose={ this._close }
+					onRequestClose={ this.close }
 					closeTimeoutMS={ this.props.leaveTimeout }
 					contentLabel={ this.props.label }
 					overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't


### PR DESCRIPTION
Previously, the onRequestClose prop referenced `this._close`, which does not exist on the class. 
Additionally, I changed close to an arrow function to make sure it
binds the this context to the class.

#### Changes proposed in this Pull Request

* Change onRequestClose to reference `this.close`
* Change close to an arrow function to make sure it binds to the component and can access props.

#### Testing instructions
1. In calypso.localhost, go to a site's theme page. Activate a different theme:
<img width="1352" alt="Screen Shot 2019-10-07 at 10 03 34 PM" src="https://user-images.githubusercontent.com/6265975/66368771-6f90eb00-e94e-11e9-9c7d-5f2204746121.png">

2. Click in the background and make sure the Dialogue closes.
<img width="1367" alt="Screen Shot 2019-10-07 at 10 03 42 PM" src="https://user-images.githubusercontent.com/6265975/66368788-820b2480-e94e-11e9-9163-633a01b2e36a.png">

3. Try again, but this time hit the "escape" button on your keyboard, and the dialogue should close in this case as well.

Previously, neither steps 2 nor 3 would work - the dialogue remained annoying which is super frustrating. **This was a bug for all places where we use Dialogues.**

Fixes #35892
