### PR TITLE
QuickLanguageSwitcher: rerender UI with new locale slug after switching language

### DIFF
--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -2,58 +2,47 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment, useReducer } from 'react';
 import { connect } from 'react-redux';
-import { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import MasterbarItem from './item';
 import LanguagePickerModal from 'components/language-picker/modal';
-import switchLocale from 'lib/i18n-utils/switch-locale';
 import { languages } from 'languages';
 import { setLocale } from 'state/ui/language/actions';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 
-class QuickLanguageSwitcher extends React.Component {
-	state = {
-		isShowingModal: false,
-	};
+function QuickLanguageSwitcher( props ) {
+	const [ isShowingModal, toggleLanguagesModal ] = useReducer( toggled => ! toggled, false );
+	const onSelected = languageSlug => props.setLocale( languageSlug );
 
-	toggleLanguagesModal = () => this.setState( { isShowingModal: ! this.state.isShowingModal } );
-
-	onClick = event => {
-		this.toggleLanguagesModal();
-		event.preventDefault();
-	};
-
-	onSelected = languageSlug => {
-		switchLocale( languageSlug );
-		this.props.setLocale( languageSlug );
-	};
-
-	render() {
-		const selectedLanguageSlug = getLocaleSlug();
-
-		return (
-			<div className="masterbar__item masterbar__quick-language-switcher">
-				<MasterbarItem icon="globe" onClick={ this.onClick }>
-					{ selectedLanguageSlug }
-				</MasterbarItem>
-
+	return (
+		<Fragment>
+			<MasterbarItem
+				icon="globe"
+				className="masterbar__quick-language-switcher"
+				onClick={ toggleLanguagesModal }
+			>
+				{ props.selectedLanguageSlug }
+			</MasterbarItem>
+			{ isShowingModal && (
 				<LanguagePickerModal
-					isVisible={ this.state.isShowingModal }
+					isVisible
 					languages={ languages }
-					selected={ selectedLanguageSlug }
-					onSelected={ this.onSelected }
-					onClose={ this.toggleLanguagesModal }
+					selected={ props.selectedLanguageSlug }
+					onSelected={ onSelected }
+					onClose={ toggleLanguagesModal }
 				/>
-			</div>
-		);
-	}
+			) }
+		</Fragment>
+	);
 }
 
 export default connect(
-	null,
+	state => ( {
+		selectedLanguageSlug: getCurrentLocaleSlug( state ),
+	} ),
 	{ setLocale }
 )( QuickLanguageSwitcher );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -492,7 +492,7 @@ $autobar-height: 20px;
 	}
 }
 
-.masterbar__quick-language-switcher a {
+a.masterbar__quick-language-switcher {
 	cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes a bug where the Quick Language Switcher would still show the old locale slug even after the language has been switched to another. The reason is that the React component gets the current locale slug from `i18n.getLocaleSlug`, but doesn't subscribe to `i18n` updates. The component is never rerendered after change.

Fixed by fetching the locale slug from Redux instead.

There are several other drive-by changes that amount to quite a rewrite of this small component:
- don't call `switchLocale` -- dispatching the `setLocale` Redux action will do that automatically.
- rearrange the HTML markup to avoid two nested `masterbar__item` elements. We need just one `MasterbarItem`.
- rewrite the component to use hooks

**How to test:**
1. Open Calypso with `?flags=quick-language-switcher` query arg.
2. Test the language switcher in masterbar and verify that the language slug updates
3. (Verify that without this patch, the slug indeed doesn't update)
