### PR TITLE
Remove memoization from locale selectors

### DIFF
--- a/client/state/selectors/get-current-locale-slug.js
+++ b/client/state/selectors/get-current-locale-slug.js
@@ -1,24 +1,13 @@
 /**
- * Eternal dependencies
- *
- * @format
+ * External dependencies
  */
-
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import createSelector from 'lib/create-selector';
 
 /**
  * Gets the current ui locale slug
  * @param {Object} state - global redux state
  * @return {String} current state value
  */
-const getCurrentLocaleSlug = createSelector(
-	state => get( state, 'ui.language.localeSlug', null ),
-	state => state.ui.language
-);
-
-export default getCurrentLocaleSlug;
+export default function getCurrentLocaleSlug( state ) {
+	return get( state, 'ui.language.localeSlug', null );
+}

--- a/client/state/selectors/get-current-locale-variant.js
+++ b/client/state/selectors/get-current-locale-variant.js
@@ -1,23 +1,13 @@
 /**
  * External dependencies
- *
- * @format
  */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import createSelector from 'lib/create-selector';
 
 /**
  * Gets the current ui locale variant
  * @param {Object} state - global redux state
  * @return {String?} current state value
  */
-const getCurrentLocaleVariant = createSelector(
-	state => get( state, 'ui.language.localeVariant', null ),
-	state => state.ui.language
-);
-
-export default getCurrentLocaleVariant;
+export default function getCurrentLocaleVariant( state ) {
+	return get( state, 'ui.language.localeVariant', null );
+}


### PR DESCRIPTION
Simplify the `getCurrentLocale*` selectors by removing the `createSelector` memoization.
The result of the selectors is a string and there is no calculation involved. The
optimization only adds overhead.
