### PR TITLE
Full Site Editing: Update Site Description block attributes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -19,7 +19,7 @@ import {
 	RichText,
 	withColors,
 	withFontSizes,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -157,9 +157,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, { blockIndex, rootClientId } ) => ( {
 		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
-		insertDefaultBlock: () => {
-			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 );
-			dispatch( 'core/block-editor' ).selectNextBlock( rootClientId );
-		},
+		insertDefaultBlock: () =>
+			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
 	} ) ),
 ] )( SiteDescriptionEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -16,6 +16,7 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 	PlainText,
+	RichText,
 	withColors,
 	withFontSizes,
 } from '@wordpress/editor';
@@ -111,7 +112,30 @@ function SiteDescriptionEdit( {
 					/>
 				</PanelColorSettings>
 			</InspectorControls>
-			<PlainText
+			{ false && (
+				<PlainText
+					aria-label={ __( 'Site Description' ) }
+					className={ classNames( 'site-description', className, {
+						'has-text-color': textColor.color,
+						'has-background': backgroundColor.color,
+						[ `has-text-align-${ textAlign }` ]: textAlign,
+						[ backgroundColor.class ]: backgroundColor.class,
+						[ textColor.class ]: textColor.class,
+						[ fontSize.class ]: fontSize.class,
+					} ) }
+					onChange={ value => handleChange( value ) }
+					onKeyDown={ onKeyDown }
+					placeholder={ __( 'Add a Site Description' ) }
+					style={ {
+						backgroundColor: backgroundColor.color,
+						color: textColor.color,
+						fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+					} }
+					value={ option }
+				/>
+			) }
+			<RichText
+				allowedFormats={ [] }
 				aria-label={ __( 'Site Description' ) }
 				className={ classNames( 'site-description', className, {
 					'has-text-color': textColor.color,
@@ -121,14 +145,15 @@ function SiteDescriptionEdit( {
 					[ textColor.class ]: textColor.class,
 					[ fontSize.class ]: fontSize.class,
 				} ) }
+				identifier="content"
 				onChange={ value => handleChange( value ) }
-				onKeyDown={ onKeyDown }
 				placeholder={ __( 'Add a Site Description' ) }
 				style={ {
 					backgroundColor: backgroundColor.color,
 					color: textColor.color,
 					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 				} }
+				tagName="p"
 				value={ option }
 			/>
 		</Fragment>
@@ -156,7 +181,9 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, { blockIndex, rootClientId } ) => ( {
 		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
-		insertDefaultBlock: () =>
-			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
+		insertDefaultBlock: () => {
+			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 );
+			dispatch( 'core/block-editor' ).selectNextBlock( rootClientId );
+		},
 	} ) ),
 ] )( SiteDescriptionEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -1,3 +1,5 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -6,12 +8,23 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { PlainText } from '@wordpress/editor';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	ContrastChecker,
+	FontSizePicker,
+	InspectorControls,
+	PanelColorSettings,
+	PlainText,
+	withColors,
+	withFontSizes,
+} from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -19,14 +32,23 @@ import { ENTER } from '@wordpress/keycodes';
 import useSiteOptions from '../useSiteOptions';
 
 function SiteDescriptionEdit( {
+	attributes,
+	backgroundColor,
 	className,
 	createErrorNotice,
-	shouldUpdateSiteOption,
+	fontSize,
+	insertDefaultBlock,
+	isLocked,
 	isSelected,
 	setAttributes,
-	isLocked,
-	insertDefaultBlock,
+	setBackgroundColor,
+	setFontSize,
+	setTextColor,
+	shouldUpdateSiteOption,
+	textColor,
 } ) {
+	const { textAlign } = attributes;
+
 	const inititalDescription = __( 'Site description loading…' );
 
 	const { siteOptions, handleChange } = useSiteOptions(
@@ -52,19 +74,70 @@ function SiteDescriptionEdit( {
 
 	return (
 		<Fragment>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ nextAlign => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
+					<FontSizePicker onChange={ setFontSize } value={ fontSize.size } />
+				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color Settings' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: backgroundColor.color,
+							onChange: setBackgroundColor,
+							label: __( 'Background Color' ),
+						},
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color' ),
+						},
+					] }
+				>
+					<ContrastChecker
+						{ ...{
+							textColor: textColor.color,
+							backgroundColor: backgroundColor.color,
+						} }
+						fontSize={ fontSize.size }
+					/>
+				</PanelColorSettings>
+			</InspectorControls>
 			<PlainText
-				className={ classNames( 'site-description', className ) }
-				value={ option }
+				aria-label={ __( 'Site Description' ) }
+				className={ classNames( 'site-description', className, {
+					'has-text-color': textColor.color,
+					'has-background': backgroundColor.color,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
+					[ backgroundColor.class ]: backgroundColor.class,
+					[ textColor.class ]: textColor.class,
+					[ fontSize.class ]: fontSize.class,
+				} ) }
 				onChange={ value => handleChange( value ) }
 				onKeyDown={ onKeyDown }
 				placeholder={ __( 'Add a Site Description' ) }
-				aria-label={ __( 'Site Description' ) }
+				style={ {
+					backgroundColor: backgroundColor.color,
+					color: textColor.color,
+					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+				} }
+				value={ option }
 			/>
 		</Fragment>
 	);
 }
 
 export default compose( [
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+	withFontSizes( 'fontSize' ),
 	withSelect( ( select, { clientId } ) => {
 		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
 			'core/editor'

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -16,7 +16,6 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 	PlainText,
-	RichText,
 	withColors,
 	withFontSizes,
 } from '@wordpress/block-editor';
@@ -112,30 +111,7 @@ function SiteDescriptionEdit( {
 					/>
 				</PanelColorSettings>
 			</InspectorControls>
-			{ false && (
-				<PlainText
-					aria-label={ __( 'Site Description' ) }
-					className={ classNames( 'site-description', className, {
-						'has-text-color': textColor.color,
-						'has-background': backgroundColor.color,
-						[ `has-text-align-${ textAlign }` ]: textAlign,
-						[ backgroundColor.class ]: backgroundColor.class,
-						[ textColor.class ]: textColor.class,
-						[ fontSize.class ]: fontSize.class,
-					} ) }
-					onChange={ value => handleChange( value ) }
-					onKeyDown={ onKeyDown }
-					placeholder={ __( 'Add a Site Description' ) }
-					style={ {
-						backgroundColor: backgroundColor.color,
-						color: textColor.color,
-						fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
-					} }
-					value={ option }
-				/>
-			) }
-			<RichText
-				allowedFormats={ [] }
+			<PlainText
 				aria-label={ __( 'Site Description' ) }
 				className={ classNames( 'site-description', className, {
 					'has-text-color': textColor.color,
@@ -145,15 +121,15 @@ function SiteDescriptionEdit( {
 					[ textColor.class ]: textColor.class,
 					[ fontSize.class ]: fontSize.class,
 				} ) }
-				identifier="content"
 				onChange={ value => handleChange( value ) }
+				onKeyDown={ onKeyDown }
 				placeholder={ __( 'Add a Site Description' ) }
 				style={ {
 					backgroundColor: backgroundColor.color,
 					color: textColor.color,
 					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+					padding: backgroundColor.color ? '16px' : undefined,
 				} }
-				tagName="p"
 				value={ option }
 			/>
 		</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,7 +16,7 @@ import {
 	FontSizePicker,
 	InspectorControls,
 	PanelColorSettings,
-	PlainText,
+	RichText,
 	withColors,
 	withFontSizes,
 } from '@wordpress/block-editor';
@@ -23,7 +24,6 @@ import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ENTER } from '@wordpress/keycodes';
 import { PanelBody } from '@wordpress/components';
 
 /**
@@ -38,7 +38,6 @@ function SiteDescriptionEdit( {
 	createErrorNotice,
 	fontSize,
 	insertDefaultBlock,
-	isLocked,
 	isSelected,
 	setAttributes,
 	setBackgroundColor,
@@ -61,16 +60,6 @@ function SiteDescriptionEdit( {
 	);
 
 	const { option } = siteOptions;
-
-	const onKeyDown = event => {
-		if ( event.keyCode !== ENTER ) {
-			return;
-		}
-		event.preventDefault();
-		if ( ! isLocked ) {
-			insertDefaultBlock();
-		}
-	};
 
 	return (
 		<Fragment>
@@ -111,7 +100,8 @@ function SiteDescriptionEdit( {
 					/>
 				</PanelColorSettings>
 			</InspectorControls>
-			<PlainText
+			<RichText
+				allowedFormats={ [] }
 				aria-label={ __( 'Site Description' ) }
 				className={ classNames( 'site-description', className, {
 					'has-text-color': textColor.color,
@@ -121,15 +111,17 @@ function SiteDescriptionEdit( {
 					[ textColor.class ]: textColor.class,
 					[ fontSize.class ]: fontSize.class,
 				} ) }
+				identifier="content"
 				onChange={ value => handleChange( value ) }
-				onKeyDown={ onKeyDown }
+				onReplace={ insertDefaultBlock }
+				onSplit={ noop }
 				placeholder={ __( 'Add a Site Description' ) }
 				style={ {
 					backgroundColor: backgroundColor.color,
 					color: textColor.color,
 					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
-					padding: backgroundColor.color ? '16px' : undefined,
 				} }
+				tagName="p"
 				value={ option }
 			/>
 		</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -50,6 +50,7 @@ registerBlockType( 'a8c/site-description', {
 		},
 		fontSize: {
 			type: 'string',
+			default: 'small',
 		},
 		customFontSize: {
 			type: 'number',

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -32,6 +32,28 @@ registerBlockType( 'a8c/site-description', {
 			type: 'string',
 			default: 'wide',
 		},
+		textAlign: {
+			type: 'string',
+			default: 'center',
+		},
+		textColor: {
+			type: 'string',
+		},
+		customTextColor: {
+			type: 'string',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		customBackgroundColor: {
+			type: 'string',
+		},
+		fontSize: {
+			type: 'string',
+		},
+		customFontSize: {
+			type: 'number',
+		},
 	},
 	edit,
 	save: () => null,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -29,6 +29,10 @@ function render_site_description_block( $attributes ) {
 	}
 	$class .= $align;
 
+	if ( isset( $attributes['textAlign'] ) ) {
+		$class .= ' has-text-align-' . $attributes['textAlign'];
+	}
+
 	if ( isset( $attributes['textColor'] ) ) {
 		$class .= ' has-text-color';
 		$class .= ' has-' . $attributes['textColor'] . '-color';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -31,6 +31,8 @@ function render_site_description_block( $attributes ) {
 
 	if ( isset( $attributes['textAlign'] ) ) {
 		$class .= ' has-text-align-' . $attributes['textAlign'];
+	} else {
+		$class .= ' has-text-align-center';
 	}
 
 	if ( isset( $attributes['textColor'] ) ) {
@@ -53,6 +55,8 @@ function render_site_description_block( $attributes ) {
 		$class .= ' has-' . $attributes['fontSize'] . '-font-size';
 	} elseif ( isset( $attributes['customFontSize'] ) ) {
 		$styles .= ' font-size: ' . $attributes['customFontSize'] . 'px;';
+	} else {
+		$class .= ' has-small-font-size';
 	}
 
 	?>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -16,6 +16,8 @@ namespace A8C\FSE;
 function render_site_description_block( $attributes ) {
 	ob_start();
 
+	$styles = '';
+
 	$class = 'site-description wp-block-a8c-site-description';
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
@@ -27,8 +29,30 @@ function render_site_description_block( $attributes ) {
 	}
 	$class .= $align;
 
+	if ( isset( $attributes['textColor'] ) ) {
+		$class .= ' has-text-color';
+		$class .= ' has-' . $attributes['textColor'] . '-color';
+	} elseif ( isset( $attributes['customTextColor'] ) ) {
+		$class  .= ' has-text-color';
+		$styles .= ' color: ' . $attributes['customTextColor'] . ';';
+	}
+
+	if ( isset( $attributes['backgroundColor'] ) ) {
+		$class .= ' has-background';
+		$class .= ' has-' . $attributes['backgroundColor'] . '-background-color';
+	} elseif ( isset( $attributes['customBackgroundColor'] ) ) {
+		$class  .= ' has-background';
+		$styles .= ' background-color: ' . $attributes['customBackgroundColor'] . ';';
+	}
+
+	if ( isset( $attributes['fontSize'] ) ) {
+		$class .= ' has-' . $attributes['fontSize'] . '-font-size';
+	} elseif ( isset( $attributes['customFontSize'] ) ) {
+		$styles .= ' font-size: ' . $attributes['customFontSize'] . 'px;';
+	}
+
 	?>
-	<p class="<?php echo esc_attr( $class ); ?>">
+	<p class="<?php echo esc_attr( $class ); ?>" style="<?php echo esc_attr( $styles ); ?>">
 		<?php bloginfo( 'description' ); ?>
 	</p>
 	<?php

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -38,6 +38,13 @@
 	.block-editor-block-list__block-edit::before {
 		display: none;
 	}
+
+	@media ( min-width: 600px ) {
+		.block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] {
+			margin-left: 14px;
+			margin-right: 14px;
+		}
+	}
 }
 
 .template-block__overlay {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `PlainText` with `RichText` in the Full Site Editing's Site Description block.
* Add visual styling attributes:
  - Text alignment (separate from block alignment)
  - Font size (predefined list and custom)
  - Text color (palette and custom)
  - Background color (palette and custom)

This change, along with #36675 and Automattic/themes#1500, removes the hardcoded styling of the Site Title and Description blocks, allowing the user to customize them in the Block Editor, in roughly the same way as the Heading and Paragraph block respectively.


| Editor | Front End |
| - | - |
| <img width="1330" alt="Screenshot 2019-10-08 at 15 13 43" src="https://user-images.githubusercontent.com/2070010/66404780-0312fc00-e9e1-11e9-86f9-dc047cddfc3d.png"> | <img width="1317" alt="Screenshot 2019-10-08 at 15 13 58" src="https://user-images.githubusercontent.com/2070010/66404789-073f1980-e9e1-11e9-96c4-199ff19336e3.png"> |

(Please disregard the Site Title font size difference, it's not related to this PR.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change on an FSE site.
* Edit a template and make sure the Site Description block has all the options listed above.
* If you also want to visually see all the changes, also apply https://github.com/Automattic/themes/pull/1500.
Otherwise, just check that the rendered block has all the expected classes and styles.

Fixes #36604