### PR TITLE
Transpile `filesize` module.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,6 +111,7 @@ const nodeModulesToTranspile = [
 	'd3-scale/',
 	'debug/',
 	'@github/webauthn-json/',
+	'filesize/'
 ];
 /**
  * Check to see if we should transpile certain files in node_modules


### PR DESCRIPTION
The `filesize` module now ships with ES6, so we need to transpile it in order to avoid ES6 making its way into the fallback build.

This issue was introduced in #36439.

#### Changes proposed in this Pull Request

* Add `filesize` to list of `npm` modules to transpile

#### Testing instructions

Follow the steps in #36589 using the live branch, and ensure that the errors are resolved.

Fixes #36589.
