### PR TITLE
[WIP/Draft] Add gutenboarding sidebar

### DIFF
--- a/client/gutenboarding/components/settings-button/index.js
+++ b/client/gutenboarding/components/settings-button/index.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { IconButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+/* eslint-disable no-restricted-syntax */
+import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';
+/* eslint-enable no-restricted-syntax */
+
+export default function SettingsButton( { onClick, isToggled } ) {
+	return (
+		<IconButton
+			icon="admin-generic"
+			label={ 'Site Block Settings' }
+			onClick={ onClick }
+			isToggled={ isToggled }
+			aria-expanded={ isToggled }
+			shortcut={ shortcuts.toggleSidebar }
+		/>
+	);
+}

--- a/client/gutenboarding/components/settings-sidebar/index.js
+++ b/client/gutenboarding/components/settings-sidebar/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { BlockInspector } from '@wordpress/block-editor';
+import { Panel, PanelBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Sidebar from '../sidebar';
+
+import './style.scss';
+/* eslint-disable no-restricted-syntax */
+import '@wordpress/edit-post/build-style/style.css';
+/* eslint-enable no-restricted-syntax */
+
+export default function SettingsSidebar( { isActive } ) {
+	return (
+		<Sidebar
+			label={ 'SiteBlock Settings' }
+			className={ 'gutenboarding__settings-sidebar' }
+			isActive={ isActive }
+		>
+			<Panel>
+				<PanelBody className="edit-post-settings-sidebar__panel-block">
+					<BlockInspector />
+				</PanelBody>
+			</Panel>
+		</Sidebar>
+	);
+}

--- a/client/gutenboarding/components/settings-sidebar/style.scss
+++ b/client/gutenboarding/components/settings-sidebar/style.scss
@@ -1,0 +1,5 @@
+/*
+ * Relevant styles:
+ * @wordpress/edit-post/src/components/sidebar/settings-sidebar/style.scss
+ * .edit-post-settings-sidebar__panel-block
+ */

--- a/client/gutenboarding/components/sidebar/index.js
+++ b/client/gutenboarding/components/sidebar/index.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill, Animate } from '@wordpress/components';
+import { compose, ifCondition } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+
+// import './style.scss';
+/* eslint-disable no-restricted-syntax */
+import '@wordpress/edit-post/build-style/style.css';
+/* eslint-enable no-restricted-syntax */
+
+const { Fill, Slot } = createSlotFill( 'Sidebar' );
+
+function Sidebar( { children, label, className } ) {
+	return (
+		<div
+			className={ classnames( 'edit-post-sidebar', className ) }
+			role="region"
+			aria-label={ label }
+			tabIndex="-1"
+		>
+			{ children }
+		</div>
+	);
+}
+
+function AnimatedSidebarFill( props ) {
+	return (
+		<Fill>
+			<Animate type="slide-in" options={ { origin: 'left' } }>
+				{ () => <Sidebar { ...props } /> }
+			</Animate>
+		</Fill>
+	);
+}
+
+const WrappedSidebar = compose(
+	withSelect( ( select, { isActive } ) => ( { isActive } ) ),
+	ifCondition( ( { isActive } ) => isActive )
+)( AnimatedSidebarFill );
+
+WrappedSidebar.Slot = Slot;
+
+export default WrappedSidebar;

--- a/client/gutenboarding/components/sidebar/style.scss
+++ b/client/gutenboarding/components/sidebar/style.scss
@@ -1,0 +1,5 @@
+/*
+ * Relevant styles:
+ * @wordpress/edit-post/src/components/sidebar/style.scss
+ * .edit-post-sidebar
+ */

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -19,6 +19,9 @@ import '@wordpress/format-library';
  * Internal dependencies
  */
 import './style.scss';
+import Sidebar from './components/sidebar';
+import SettingsSidebar from './components/settings-sidebar';
+import SettingsButton from './components/settings-button';
 
 /* eslint-disable no-restricted-syntax */
 import '@wordpress/components/build-style/style.css';
@@ -31,6 +34,11 @@ import '@wordpress/format-library/build-style/style.css';
 
 export function Gutenboard() {
 	const [ blocks, updateBlocks ] = useState( [] );
+	const [ isSettingsSidebarActive, updateIsSettingsSidebarActive ] = useState( true );
+
+	function handleToggleSettingsSidebar() {
+		updateIsSettingsSidebarActive( ! isSettingsSidebarActive );
+	}
 
 	return (
 		<>
@@ -47,6 +55,15 @@ export function Gutenboard() {
 						>
 							<div className="editor-styles-wrapper">
 								<BlockEditorKeyboardShortcuts />
+
+								<SettingsButton
+									onClick={ handleToggleSettingsSidebar }
+									isToggled={ isSettingsSidebarActive }
+								/>
+
+								<SettingsSidebar isActive={ isSettingsSidebarActive } />
+								<Sidebar.Slot />
+
 								<WritingFlow>
 									<ObserveTyping>
 										<BlockList />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Pulls in the sidebar and a button to show/hide. Sticks closely to the existing sidebar functionality in Gutenberg's post editor. Sidebar content are the selected block's inspector.

Not intended for merging before found useful.

![2019-10-08 16 42 07](https://user-images.githubusercontent.com/1705499/66400955-11feac00-e9eb-11e9-81e5-e050ca55a698.gif)

CC @Automattic/luna 