### PR TITLE
Add build-time ES5 validation to fallback build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
 		"prebuild-server": "mkdirp build",
 		"build-server": "cross-env-shell BROWSERSLIST_ENV=server NODE_PATH=$NODE_PATH:server:client:. webpack --display errors-only --config webpack.config.node.js",
 		"build-client": "npm run build-client-evergreen",
-		"build-client-fallback": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
+		"build-client-fallback": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only && npm run validate-fallback-es5",
 		"build-client-evergreen": "cross-env-shell BROWSERSLIST_ENV=evergreen NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
 		"build-client-both": "concurrently -c cyan -n \"fallback ,evergreen\" \"npm run build-client-fallback\" \"npm run build-client-evergreen\"",
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-both",
@@ -280,6 +280,7 @@
 		"test-server:watch": "npm run -s test-server -- --watch",
 		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
 		"update-deps": "npx rimraf npm-shrinkwrap.json && npm run -s distclean && npm i && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
+		"validate-fallback-es5": "npx eslint --env=es5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",
 		"whybundled": "whybundled stats.json"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,7 +111,13 @@ const nodeModulesToTranspile = [
 	'd3-scale/',
 	'debug/',
 	'@github/webauthn-json/',
-	'filesize/'
+	'filesize/',
+	'acorn-jsx/',
+	'prismjs/',
+	'regenerate-unicode-properties/',
+	'regexpu-core/',
+	'unicode-match-property-ecmascript/',
+	'unicode-match-property-value-ecmascript/',
 ];
 /**
  * Check to see if we should transpile certain files in node_modules


### PR DESCRIPTION
ES6+ code sometimes finds its way into the fallback build, which should only include ES5, when one of our dependencies decides to ship their package with newer syntax.

This PR adds a new build-time check that ensures no non-ES5 syntax is present in the generated fallback build, breaking the build if that's the case. This will help us catch these issues as soon as they happen, rather than when an IE11 user reports them.

This PR also fixes all existing instances of this problem.

Thanks to @simison for suggesting the command line check! 👍 

#### Changes proposed in this Pull Request

* Add `validate-fallback-es5` `npm` script to `fallback` build process
* Add all existing instances of non-ES5 libraries to `nodeModulesToTranspile `

#### Testing instructions

Ensure the build doesn't fail. For extra points, ensure that devdocs works correctly in IE11 now (or at least it doesn't complain about invalid syntax).