### PR TITLE
Track global styles redux actions

### DIFF
--- a/apps/wpcom-block-editor/src/common/tracking.js
+++ b/apps/wpcom-block-editor/src/common/tracking.js
@@ -73,6 +73,12 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
 	} );
 };
 
+/**
+ * Track update and publish action for Global Styles plugin.
+ *
+ * @param {string} eventName Name of the track event.
+ * @return {function}
+ */
 const trackGlobalStyles = eventName => options => {
 	tracksRecordEvent( eventName, {
 		...options,
@@ -88,7 +94,7 @@ const trackGlobalStyles = eventName => options => {
  */
 const REDUX_TRACKING = {
 	'a8c/global-styles': {
-		resetOptions: trackGlobalStyles( 'wpcom_global_styles_reset' ),
+		resetLocalChanges: 'wpcom_global_styles_reset',
 		updateOptions: trackGlobalStyles( 'wpcom_global_styles_update' ),
 		publishOptions: trackGlobalStyles( 'wpcom_global_styles_publish' ),
 	},

--- a/apps/wpcom-block-editor/src/common/tracking.js
+++ b/apps/wpcom-block-editor/src/common/tracking.js
@@ -73,6 +73,12 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
 	} );
 };
 
+const trackGlobalStyles = eventName => options => {
+	tracksRecordEvent( eventName, {
+		...options,
+	} );
+};
+
 /**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
@@ -81,6 +87,11 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
  * @type {object}
  */
 const REDUX_TRACKING = {
+	'a8c/global-styles': {
+		resetOptions: trackGlobalStyles( 'wpcom_global_styles_reset' ),
+		updateOptions: trackGlobalStyles( 'wpcom_global_styles_update' ),
+		publishOptions: trackGlobalStyles( 'wpcom_global_styles_publish' ),
+	},
 	'core/editor': {
 		undo: 'wpcom_block_editor_undo_performed',
 		redo: 'wpcom_block_editor_redo_performed',

--- a/apps/wpcom-block-editor/src/common/tracking.js
+++ b/apps/wpcom-block-editor/src/common/tracking.js
@@ -93,7 +93,7 @@ const trackGlobalStyles = eventName => options => {
  * @type {object}
  */
 const REDUX_TRACKING = {
-	'a8c/global-styles': {
+	'jetpack/global-styles': {
 		resetLocalChanges: 'wpcom_global_styles_reset',
 		updateOptions: trackGlobalStyles( 'wpcom_global_styles_update' ),
 		publishOptions: trackGlobalStyles( 'wpcom_global_styles_publish' ),


### PR DESCRIPTION
Related: D33718-code.

This PR adds the necessary code to track the three existing actions for the Global Styles plugin.

