### PR TITLE
Apps: Add clean scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,5 @@ cover.html
 cached-requests.json
 
 # Monorepo output
-/apps/**/dist/
+/apps/*/dist/
 /packages/*/dist/

--- a/apps/full-site-editing/.gitignore
+++ b/apps/full-site-editing/.gitignore
@@ -1,0 +1,1 @@
+/full-site-editing-plugin/*/dist/

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -25,11 +25,14 @@
 		"starter-page-templates": "calypso-build --source='starter-page-templates'",
 		"dev:starter-page-templates": "npm run starter-page-templates",
 		"build:starter-page-templates": "NODE_ENV=production npm run starter-page-templates",
-		"dev": "rimraf dist && npm-run-all --parallel dev:*",
-		"build": "rimraf dist && npm-run-all --parallel build:*",
+		"dev": "npm-run-all --parallel dev:*",
+		"build": "npm-run-all --parallel build:*",
 		"test:unit": "wp-scripts test-unit-js --config='jest.config.js'",
 		"test:unit:help": "wp-scripts test-unit-js --config='jest.config.js' --help",
-		"test:unit:watch": "wp-scripts test-unit-js --config='jest.config.js' --watch"
+		"test:unit:watch": "wp-scripts test-unit-js --config='jest.config.js' --watch",
+		"clean": "npx rimraf dist",
+		"prebuild": "npm run clean",
+		"predev": "npm run clean"
 	},
 	"dependencies": {
 		"classnames": "2.2.6"

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -30,7 +30,7 @@
 		"test:unit": "wp-scripts test-unit-js --config='jest.config.js'",
 		"test:unit:help": "wp-scripts test-unit-js --config='jest.config.js' --help",
 		"test:unit:watch": "wp-scripts test-unit-js --config='jest.config.js' --watch",
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist full-site-editing-plugin/*/dist",
 		"prebuild": "npm run clean",
 		"predev": "npm run clean"
 	},

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -19,7 +19,9 @@
 		"bundle": "calypso-build --env.WP",
 		"build:dev": "npm run bundle --",
 		"build:prod": "NODE_ENV=production npm run bundle --",
-		"build": "npm-run-all --parallel \"build:* -- {@}\" --"
+		"build": "npm-run-all --parallel \"build:* -- {@}\" --",
+		"clean": "npx rimraf dist",
+		"prebuild": "npm run clean"
 	},
 	"dependencies": {
 		"debug": "3.2.6"


### PR DESCRIPTION
Adds `clean` scripts following conventions from other packages and apps in the monorepo.

#### Changes proposed in this Pull Request

* All the apps now have clean scripts and follow a convention.

#### Testing instructions

* `npx lerna run clean` should result in apps being cleaned up
* Clean scripts should run before relevant scripts, like build and dev.
* Artifacts produced by relevant CircleCI jobs should be unchanged.

Noticed in #36583
