### PR TITLE
Domains: Remove smaller Notice component on single domain screen

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/header/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/header/index.jsx
@@ -10,7 +10,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import DomainPrimaryFlag from 'my-sites/domains/domain-management/components/domain/primary-flag';
-import DomainTransferFlag from 'my-sites/domains/domain-management/components/domain/transfer-flag';
 import PrimaryDomainButton from './primary-domain-button';
 import SectionHeader from 'components/section-header';
 
@@ -35,7 +34,6 @@ class Header extends React.Component {
 		return (
 			<SectionHeader label={ domain.name }>
 				<DomainPrimaryFlag domain={ domain } />
-				<DomainTransferFlag domain={ domain } />
 
 				{ renderButton && (
 					<PrimaryDomainButton domain={ domain } selectedSite={ this.props.selectedSite } />

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -61,6 +61,22 @@ class Transfer extends React.PureComponent {
 				);
 			}
 		} else {
+			transferNotice = (
+				<Notice status={ 'is-error' } showDismiss={ false }>
+					{ translate( 'The transfer has failed. {{a}}Learn more{{/a}}.', {
+						components: {
+							a: (
+								<a
+									href="https://en.support.wordpress.com/move-domain/incoming-domain-transfer/#checking-your-transfer-status-and-failed-transfers"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					} ) }
+				</Notice>
+			);
+
 			cancelNavItem = (
 				<VerticalNav>
 					<VerticalNavItem path={ cancelPurchaseLink( selectedSite.slug, domain.subscriptionId ) }>

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -60,7 +60,7 @@ class Transfer extends React.PureComponent {
 					</Notice>
 				);
 			}
-		} else {
+		} else if ( domain.transferStatus === transferStatus.CANCELLED ) {
 			transferNotice = (
 				<Notice status={ 'is-error' } showDismiss={ false }>
 					{ translate( 'The transfer has failed. {{a}}Learn more{{/a}}.', {
@@ -77,6 +77,14 @@ class Transfer extends React.PureComponent {
 				</Notice>
 			);
 
+			cancelNavItem = (
+				<VerticalNav>
+					<VerticalNavItem path={ cancelPurchaseLink( selectedSite.slug, domain.subscriptionId ) }>
+						{ translate( 'Cancel Transfer' ) }
+					</VerticalNavItem>
+				</VerticalNav>
+			);
+		} else {
 			cancelNavItem = (
 				<VerticalNav>
 					<VerticalNavItem path={ cancelPurchaseLink( selectedSite.slug, domain.subscriptionId ) }>

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -36,7 +36,7 @@ class Transfer extends React.PureComponent {
 		let cancelNavItem;
 		if ( domain.transferStatus === transferStatus.PENDING_REGISTRY ) {
 			transferNotice = (
-				<Notice status={ 'is-info' } showDismiss={ false }>
+				<Notice status={ 'is-warning' } showDismiss={ false }>
 					{ translate(
 						'This transfer has been started and is waiting for authorization from your current provider. ' +
 							'If you need to cancel the transfer, please contact them for assistance.'
@@ -46,7 +46,7 @@ class Transfer extends React.PureComponent {
 
 			if ( domain.transferEndDate ) {
 				transferNotice = (
-					<Notice status={ 'is-info' } showDismiss={ false }>
+					<Notice status={ 'is-warning' } showDismiss={ false }>
 						{ translate(
 							'This transfer has been started and is waiting for authorization from your current provider. ' +
 								'It should complete by %(transferFinishDate)s. ' +


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Other, similar notices (including a compact one on the same page) use the `is-warning` Notice component style.
* Remove the smaller "Transfer in progress" flag since we've combined it into the main notice at the top of the screen.

**Before**

<img width="752" alt="Screen Shot 2019-10-11 at 10 56 21 AM" src="https://user-images.githubusercontent.com/2124984/66661972-edd2e300-ec15-11e9-9aa2-4117a14a393c.png">

**After**

<img width="763" alt="Screen Shot 2019-10-11 at 10 56 07 AM" src="https://user-images.githubusercontent.com/2124984/66661955-e7446b80-ec15-11e9-9822-614c49cb2cc5.png">


#### Testing instructions

* Switch to this PR
* Navigate to Manage -> Domains and transfer a domain to WordPress.com. (I don't know of a better way to test this, unfortunately.)
* While the transfer is in progress, click on the domain name you've transferred.
* The notice at the top of the screen should be yellow instead of pink, and you should no longer see the "Transfer in progress" flag next to the domain name.

Fixes #36479
