### PR TITLE
Importer: Reduce Link Width Area

### DIFF
--- a/client/my-sites/importer/section-import.scss
+++ b/client/my-sites/importer/section-import.scss
@@ -12,8 +12,7 @@
 		color: var( --color-neutral-dark );
 
 		a {
-			display: block;
-			width: 100%;
+			display: inline-block;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This reduces the area of the link width in the Importer.

#### Testing instructions

Visit the Importer and verify the link width has been reduced, so you now actually need to click the link itself to be redirected.

**Before:**

<img width="590" alt="Screenshot 2019-10-08 at 20 53 14" src="https://user-images.githubusercontent.com/43215253/66428306-b7c31280-ea0d-11e9-97e9-c4f9e162976d.png">

**After:**

<img width="547" alt="Screenshot 2019-10-08 at 20 53 05" src="https://user-images.githubusercontent.com/43215253/66428320-bc87c680-ea0d-11e9-9a22-0eeafd311e2f.png">

Fixes #36613
