### PR TITLE
Domains: Improve wording in the nudge message

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -161,7 +161,7 @@ export class SiteNotice extends React.Component {
 				} );
 			}
 		} else {
-			noticeText = translate( 'Get a domain starting at %(minDomainPrice)s', {
+			noticeText = translate( 'Add another domain from %(minDomainPrice)s', {
 				args: {
 					minDomainPrice: formatCurrency( priceAndSaleInfo.minRegularPrice, currencyCode ),
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improve wording on the nudge to avoid confusion

Before:

<img width="271" alt="before" src="https://user-images.githubusercontent.com/13062352/66458150-51241000-ea72-11e9-8f90-06cffa3eb926.png">

After:

<img width="273" alt="after" src="https://user-images.githubusercontent.com/13062352/66458156-55502d80-ea72-11e9-98b2-e654ab88d31f.png">


See also: #36208, p99Zz8-K5-p2