### PR TITLE
Checkout: Fix validation of state when changing country in contact form 

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -177,8 +177,14 @@ export class ContactDetailsFormFields extends Component {
 
 	getMainFieldValues() {
 		const mainFieldValues = formState.getAllFieldValues( this.state.form );
-		const { countryCode, hasCountryStates, needsFax } = this.props;
+		const { needsFax } = this.props;
+		const { countryCode } = mainFieldValues;
 		let state = mainFieldValues.state;
+
+		const hasCountryStates =
+			countryCode === this.props.countryCode
+				? this.props.hasCountryStates
+				: ! isEmpty( getCountryStates( this.state, countryCode ) );
 
 		// domains registered according to ancient validation rules may have state set even though not required
 		if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes validation of the State field when changing from a country that doesn't require a state, to another that requires a state.

See p2MSmN-7sR-p2

#### Testing instructions

To reproduce the issue:

* Change your country to Spain in the contact info for one of your domains and save
* Then set the country to Belgium
* Select a state from the dropdown
* Click somewhere outside the form or in another field to trigger validation check

You should get a validation error like in the screenshot below:

<img width="706" alt="Screenshot 2019-10-09 at 9 59 56 AM" src="https://user-images.githubusercontent.com/13062352/66462528-91d45700-ea7b-11e9-8568-d8673c0bb771.png">

The issue above should not occur with this change. 
