### PR TITLE
Plans Single Products: Add base UI elements triggered by a feature flag

### DIFF
--- a/client/my-sites/plans-features-main/header.jsx
+++ b/client/my-sites/plans-features-main/header.jsx
@@ -1,0 +1,25 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PlansFeaturesMainHeader = ( { heading, subhead } ) => (
+	<div className="plans-features-main__header">
+		<h2 className="plans-features-main__heading">{ heading }</h2>
+		{ subhead && <p className="plans-features-main__subhead">{ subhead }</p> }
+	</div>
+);
+
+PlansFeaturesMainHeader.propTypes = {
+	heading: PropTypes.string.isRequired,
+	subhead: PropTypes.string,
+};
+
+PlansFeaturesMainHeader.defaultProps = {
+	heading: '',
+	subhead: null,
+};
+
+export default PlansFeaturesMainHeader;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -383,8 +383,13 @@ export class PlansFeaturesMain extends Component {
 
 	renderSingleProducts() {
 		const { displayJetpackPlans, translate } = this.props;
-
 		if ( ! displayJetpackPlans ) {
+			return null;
+		}
+
+		const displayBackup = isEnabled( 'plans/jetpack-backup' );
+		const displayScan = isEnabled( 'plans/jetpack-scan' );
+		if ( ! displayBackup && ! displayScan ) {
 			return null;
 		}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import classNames from 'classnames';
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
  */
 import warn from 'lib/warn';
 import PlanFeatures from 'my-sites/plan-features';
+import PlansSingleProducts from 'my-sites/plans-single-products';
 import {
 	TYPE_FREE,
 	TYPE_BLOGGER,
@@ -28,6 +29,7 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
+import Header from './header';
 import JetpackFAQ from './jetpack-faq';
 import WpcomFAQ from './wpcom-faq';
 import CartData from 'components/data/cart';
@@ -379,6 +381,26 @@ export class PlansFeaturesMain extends Component {
 		return false;
 	}
 
+	renderSingleProducts() {
+		const { displayJetpackPlans, translate } = this.props;
+
+		if ( ! displayJetpackPlans ) {
+			return null;
+		}
+
+		return (
+			<Fragment>
+				<Header
+					heading={ translate( 'Single Products' ) }
+					subhead={ translate(
+						'Get these proven security tools make sure your site stays online and hack-free.'
+					) }
+				/>
+				<PlansSingleProducts className="plans-features-main__single-products" />
+			</Fragment>
+		);
+	}
+
 	render() {
 		const { displayJetpackPlans, isInSignup, siteId, plansWithScroll } = this.props;
 		let faqs = null;
@@ -396,6 +418,7 @@ export class PlansFeaturesMain extends Component {
 				<QueryPlans />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
+				{ this.renderSingleProducts() }
 				{ this.getPlanFeatures() }
 				<CartData>
 					<PaymentMethods />

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -41,3 +41,39 @@
 		margin-left: 0.5em;
 	}
 }
+
+// Header sub-component
+.plans-features-main__header {
+	margin: 0 0 16px;
+	padding: 0 16px;
+
+	@include breakpoint( '>480px' ) {
+		margin-bottom: 28px;
+		padding: 0 24px;
+	}
+
+	@include breakpoint( '>660px' ) {
+		padding: 0;
+	}
+}
+
+.plans-features-main__heading {
+	margin: 0 0 12px;
+	font-size: 17px;
+	line-height: 1;
+	font-weight: 700;
+	color: var( --color-text );
+
+	@include breakpoint( '>480px' ) {
+		font-size: 24px;
+		font-weight: 400;
+	}
+
+}
+
+.plans-features-main__subhead {
+	margin: 0;
+	font-size: 14px;
+	line-height: 1.35;
+	color: var( --color-text-subtle );
+}

--- a/client/my-sites/plans-single-products/index.jsx
+++ b/client/my-sites/plans-single-products/index.jsx
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { isEnabled } from 'config';
 import Product from './product';
 
 /**
@@ -16,8 +16,8 @@ import Product from './product';
 import './style.scss';
 
 const PlansSingleProducts = ( { translate } ) => {
-	const displayBackup = config.isEnabled( 'plans/jetpack-backup' );
-	const displayScan = config.isEnabled( 'plans/jetpack-scan' );
+	const displayBackup = isEnabled( 'plans/jetpack-backup' );
+	const displayScan = isEnabled( 'plans/jetpack-scan' );
 
 	if ( ! displayBackup && ! displayScan ) {
 		return null;

--- a/client/my-sites/plans-single-products/index.jsx
+++ b/client/my-sites/plans-single-products/index.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import Product from './product';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PlansSingleProducts = ( { translate } ) => {
+	const displayBackup = config.isEnabled( 'plans/jetpack-backup' );
+	const displayScan = config.isEnabled( 'plans/jetpack-scan' );
+
+	if ( ! displayBackup && ! displayScan ) {
+		return null;
+	}
+
+	return (
+		<div className="plans-single-products">
+			{ displayScan && <Product heading={ translate( 'Jetpack Scan' ) } /> }
+			{ displayBackup && <Product heading={ translate( 'Jetpack Backup' ) } /> }
+		</div>
+	);
+};
+
+export default localize( PlansSingleProducts );

--- a/client/my-sites/plans-single-products/product.jsx
+++ b/client/my-sites/plans-single-products/product.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+class PlansSingleProduct extends Component {
+	static propTypes = {
+		heading: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { heading } = this.props;
+
+		return (
+			<div className="plans-single-products__card">
+				<h3 className="plans-single-products__heading">{ heading }</h3>
+			</div>
+		);
+	}
+}
+
+export default localize( PlansSingleProduct );

--- a/client/my-sites/plans-single-products/style.scss
+++ b/client/my-sites/plans-single-products/style.scss
@@ -1,0 +1,38 @@
+.plans-single-products,
+.plans-single-products__card {
+	display: block;
+	position: relative;
+	box-sizing: border-box;
+}
+
+.plans-single-products {
+	margin: 0 auto 28px;
+
+	// On larger screens we want the container to be one big card.
+	@include breakpoint( '>660px' ) {
+		background: var( --color-surface );
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+	}
+}
+
+.plans-single-products__card {
+	margin: 0 auto 12px;
+	padding: 24px 16px;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+
+	// On mobile we want each product to be an individual card.
+	@include breakpoint( '>660px' ) {
+		margin-bottom: 0;
+		padding: 24px;
+		background: transparent;
+		box-shadow: none;
+	}
+}
+
+.plans-single-products__heading {
+	font-size: 22px;
+	line-height: 1;
+	font-weight: 400;
+	color: var( --color-primary-50 );
+}

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -95,6 +95,8 @@
 		"oauth": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/jetpack-backup": false,
+		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -68,6 +68,8 @@
 		"me/trophies": false,
 		"oauth": true,
 		"persist-redux": true,
+		"plans/jetpack-backup": false,
+		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/development.json
+++ b/config/development.json
@@ -115,6 +115,8 @@
 		"oauth": false,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/jetpack-backup": true,
+		"plans/jetpack-scan": true,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -77,6 +77,8 @@
 		"network-connection": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/jetpack-backup": false,
+		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/production.json
+++ b/config/production.json
@@ -83,6 +83,8 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/jetpack-backup": false,
+		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -85,6 +85,8 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/jetpack-backup": false,
+		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -72,6 +72,8 @@
 		"network-connection": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/jetpack-backup": false,
+		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/image-editor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -96,6 +96,8 @@
 		"nps-survey/dev-trigger": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/jetpack-backup": true,
+		"plans/jetpack-scan": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `plans/jetpack-backup` and `plans/jetpack/scan` feature flags.
* Add a reusable `Header` sub-component to the `PlansFeaturesMain` component. It is meant to be used to add the Plans Grid header as well.
* Add `PlansSingleProducts` component along with a `Product` sub-component and base responsive styling.
* Render the `Header` followed by the `PlansSingleProducts` component in the `PlansFeaturesMain`.

**Mobile:**

![Screenshot 2019-10-09 at 14 35 15](https://user-images.githubusercontent.com/478735/66481875-1afe8480-eaa2-11e9-9c51-5884c6eccb47.png)

**Desktop:**

![Screenshot 2019-10-09 at 14 35 29](https://user-images.githubusercontent.com/478735/66482063-6dd83c00-eaa2-11e9-908a-7d0fe34b9dfa.png)

#### Testing instructions

* Checkout the `add/single-product-ui` branch on your local dev environment.
* Run `npm start`.
* Go to "Plans" page for a given site.
* Confirm both "Jetpack Scan" and "Jetpack Backup" product cards are displayed (just headings for now).
* Play around with `plans/jetpack-backup` and `plans/jetpack/scan` feature flags to see if only one product is displayed or the whole section is absent in case both flags are `false`.

**Master thread:** p1HpG7-7nT-p2

Fixes no known issue.
