### PR TITLE
Remove `wpcom-xhr-request` from client bundle.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -353,6 +353,15 @@ if ( isCalypsoClient ) {
 	webpackConfig.plugins.push( new ExtensiveLodashReplacementPlugin() );
 }
 
+// Don't bundle `wpcom-xhr-request` for the browser.
+// Even though it's requested, we don't need it on the browser, because we're using
+// `wpcom-proxy-request` instead. Keep it for desktop and server, though.
+if ( isCalypsoClient && ! isDesktop ) {
+	webpackConfig.plugins.push(
+		new webpack.NormalModuleReplacementPlugin( /^wpcom-xhr-request$/, 'lodash-es/noop' )
+	);
+}
+
 // List of polyfills that we skip including in the evergreen bundle.
 // CoreJS polyfills are automatically dropped using the browserslist definitions; no need to include them here.
 const polyfillsSkippedInEvergreen = [


### PR DESCRIPTION
Even though it's being imported both by Calypso and its dependencies, it isn't really needed in client code, since we use `wpcom-proxy-request` instead.

This alias allows us to remove the dependency (and its transitive dependencies) without modifying the libraries.

This PR helps us finally get rid of `superagent` in our client-side code! 🎉 

#### Changes proposed in this Pull Request

* Remove `wpcom-xhr-request` from client bundles (not desktop), by aliasing it to a no-op.

#### Testing instructions

* Open the live branch and use Calypso normally. Ensure that API calls continue working correctly. Any errors would likely result in most of the application not working.
