### PR TITLE
Restore current time to 2FA illustration.

### DIFF
--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
@@ -70,11 +70,18 @@ export default function PushNotificationIllustration() {
 	// Inlining two stacked SVGs because they’re a part of an animated image.
 	// By not loading them externally, we’re making sure the animation will
 	// get fired right away with all of its elements in place.
+	const now = new Date();
+	const hours = now.getHours() || 12;
+	const minutes = now.getMinutes();
+
+	const currentTime = `${ hours > 12 ? hours - 12 : hours }:${
+		minutes < 10 ? '0' + minutes : minutes
+	}`;
 
 	return (
 		<div className="two-factor-authentication__illustration" aria-hidden="true">
 			<DeviceSvg />
-			<div className="two-factor-authentication__illustration-screen">10:07</div>
+			<div className="two-factor-authentication__illustration-screen">{ currentTime }</div>
 			<div className="two-factor-authentication__illustration-notification-container">
 				<NotificationSvg />
 			</div>

--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
@@ -71,17 +71,12 @@ export default function PushNotificationIllustration() {
 	// By not loading them externally, we’re making sure the animation will
 	// get fired right away with all of its elements in place.
 	const now = new Date();
-	const hours = now.getHours() || 12;
-	const minutes = now.getMinutes();
-
-	const currentTime = `${ hours > 12 ? hours - 12 : hours }:${
-		minutes < 10 ? '0' + minutes : minutes
-	}`;
+	const time = `${ now.getHours() % 12 || 12 }:${ String( now.getMinutes() ).padStart( 2, '0' ) }`;
 
 	return (
 		<div className="two-factor-authentication__illustration" aria-hidden="true">
 			<DeviceSvg />
-			<div className="two-factor-authentication__illustration-screen">{ currentTime }</div>
+			<div className="two-factor-authentication__illustration-screen">{ time }</div>
 			<div className="two-factor-authentication__illustration-notification-container">
 				<NotificationSvg />
 			</div>


### PR DESCRIPTION
This was removed in #36568, but design felt this was an important detail that would be appreciated by like-minded folks, and remove user confusion vs a hardcoded time.

Note that this PR restores the feature as it was, albeit with an implementation that doesn't use `moment` any more. As before, it always presents the time in `h:mm` format, regardless of whether that's the preferred locale format or not. I could add support for localisation (where available) if you feel that's important.

#### Changes proposed in this Pull Request

* Use current system time in 2FA push notification illustration

#### Testing instructions

See #36568 for the steps, as listed by @blowery 
