### PR TITLE
Add flag to make SIWA redirect live on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -103,6 +103,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
+		"sign-in-with-apple/redirect": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the flag to make the Sign in With Apple redirect flow live in production

#### Testing instructions

* This was tested in: https://github.com/Automattic/wp-calypso/pull/36444