### PR TITLE
Marketing: update document head title to match proper page title

### DIFF
--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import MarketingTools from './tools';
 import notices from 'notices';
-import Sharing from './main';
+import Marketing from './main';
 import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
 import Traffic from './traffic/';
@@ -36,7 +36,7 @@ export const redirectSharingButtons = context => {
 export const layout = ( context, next ) => {
 	const { contentComponent, path } = context;
 
-	context.primary = createElement( Sharing, { contentComponent, path } );
+	context.primary = createElement( Marketing, { contentComponent, path } );
 
 	next();
 };

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -32,7 +32,7 @@ import { FEATURE_NO_ADS } from 'lib/plans/constants';
  */
 import './style.scss';
 
-export const Sharing = ( {
+export const Marketing = ( {
 	contentComponent,
 	path,
 	showButtons,
@@ -86,8 +86,8 @@ export const Sharing = ( {
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<Main wideLayout className="sharing">
-			<DocumentHead title={ translate( 'Sharing' ) } />
+		<Main wideLayout className="marketing">
+			<DocumentHead title={ translate( 'Marketing' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			<SidebarNavigation />
 			{ filters.length > 0 && (
@@ -114,7 +114,7 @@ export const Sharing = ( {
 	);
 };
 
-Sharing.propTypes = {
+Marketing.propTypes = {
 	canManageOptions: PropTypes.bool,
 	isVipSite: PropTypes.bool,
 	contentComponent: PropTypes.node,
@@ -142,4 +142,4 @@ export default connect( state => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};
-} )( localize( Sharing ) );
+} )( localize( Marketing ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the document head on the `Marketing` page to the proper title because `Sharing` doesn't make sense for the main marketing tab.

Before | After
------------ | -------------
<img width="469" alt="Screen Shot 2019-10-09 at 2 15 00 PM" src="https://user-images.githubusercontent.com/448298/66508777-c22dec80-ea9f-11e9-88e2-9f771b810b1a.png"> | <img width="519" alt="Screen Shot 2019-10-09 at 2 13 11 PM" src="https://user-images.githubusercontent.com/448298/66508773-be9a6580-ea9f-11e9-852c-7e336af0f5e9.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Visit http://calypso.localhost:3000/marketing/tools/{site} or click the `Tools > Marketing` menu item
* Confirm the page loads and the title says `Marketing` in the browser window
