### PR TITLE
PopoverMenu: change proptype of popoverComponent to PropTypes.elementType

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -21,7 +21,7 @@ class PopoverMenu extends Component {
 		onClose: PropTypes.func.isRequired,
 		position: PropTypes.string,
 		className: PropTypes.string,
-		popoverComponent: PropTypes.func,
+		popoverComponent: PropTypes.elementType,
 		popoverTitle: PropTypes.string, // used by ReaderPopover
 		customPosition: PropTypes.object,
 	};


### PR DESCRIPTION
React components are usually functions (type of a class is function, too), but the thing returned from `forwardRef` is an object. Since `Popover` started using the `withRtl` HOC, `PropTypes.func` no longer works and issues a warning.

**How to test:**
Verify that Calypso stops reporting a console warning after opening Reader:
<img width="857" alt="Screenshot 2019-10-10 at 08 53 16" src="https://user-images.githubusercontent.com/664258/66545769-bdb71180-eb3b-11e9-8d43-c12fc0ccae4a.png">
