### PR TITLE
Review usage of CheckoutData and CartData providers in Plans

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -11,7 +11,6 @@ import { get, isEmpty, some, dropRight } from 'lodash';
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
-import CheckoutData from 'components/data/checkout';
 import config from 'config';
 import InstallInstructions from './install-instructions';
 import JetpackAuthorize from './authorize';
@@ -282,18 +281,16 @@ export function plansSelection( context, next ) {
 	analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
 	context.primary = (
-		<CheckoutData>
-			<Plans
-				basePlansPath={
-					context.query.redirect
-						? addQueryArgs( { redirect: context.query.redirect }, JPC_PATH_PLANS )
-						: JPC_PATH_PLANS
-				}
-				context={ context }
-				interval={ context.params.interval }
-				queryRedirect={ context.query.redirect }
-			/>
-		</CheckoutData>
+		<Plans
+			basePlansPath={
+				context.query.redirect
+					? addQueryArgs( { redirect: context.query.redirect }, JPC_PATH_PLANS )
+					: JPC_PATH_PLANS
+			}
+			context={ context }
+			interval={ context.params.interval }
+			queryRedirect={ context.query.redirect }
+		/>
 	);
 	next();
 }

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -6,7 +6,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { reject } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -30,39 +29,55 @@ import TrackComponentView from 'lib/analytics/track-component-view';
  */
 import './style.scss';
 
-// eslint-disable-next-line react/prefer-es6-class
-const PopoverCart = createReactClass( {
-	displayName: 'PopoverCart',
-
-	propTypes: {
+class PopoverCart extends React.Component {
+	static propTypes = {
 		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		onToggle: PropTypes.func.isRequired,
 		closeSectionNavMobilePanel: PropTypes.func,
 		visible: PropTypes.bool.isRequired,
 		pinned: PropTypes.bool.isRequired,
-	},
+	};
 
-	toggleButton: React.createRef(),
-	hasUnmounted: false,
+	toggleButtonRef = React.createRef();
+	hasUnmounted = false;
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		this.hasUnmounted = true;
-	},
+	}
 
-	itemCount: function() {
+	itemCount() {
 		if ( ! this.props.cart.hasLoadedFromServer ) {
 			return;
 		}
 
 		return reject( this.props.cart.products, isCredits ).length;
-	},
+	}
 
-	render: function() {
+	onToggle = () => {
+		this.props.closeSectionNavMobilePanel();
+		this.props.onToggle();
+	};
+
+	onClose = () => {
+		// Since this callback can fire after the user navigates off the page, we
+		// we need to check if it's mounted to prevent errors.
+		if ( this.hasUnmounted ) {
+			return;
+		}
+
+		// if the cart became pinned, ignore close event from Popover
+		if ( this.props.pinned ) {
+			return;
+		}
+
+		this.onToggle();
+	};
+
+	render() {
 		const { cart, selectedSite } = this.props;
 		let countBadge;
-		const classes = classNames( {
-			'popover-cart': true,
+		const classes = classNames( 'popover-cart', {
 			pinned: this.props.pinned,
 		} );
 
@@ -81,7 +96,7 @@ const PopoverCart = createReactClass( {
 				<div className={ classes }>
 					<button
 						className="cart-toggle-button"
-						ref={ this.toggleButton }
+						ref={ this.toggleButtonRef }
 						onClick={ this.onToggle }
 					>
 						<div className="popover-cart__label">{ this.props.translate( 'Cart' ) }</div>
@@ -90,12 +105,12 @@ const PopoverCart = createReactClass( {
 					</button>
 				</div>
 
-				{ this.cartContent() }
+				{ this.renderCartContent() }
 			</div>
 		);
-	},
+	}
 
-	cartContent: function() {
+	renderCartContent() {
 		if ( ! this.props.pinned ) {
 			return (
 				<Popover
@@ -103,9 +118,9 @@ const PopoverCart = createReactClass( {
 					isVisible={ this.props.visible }
 					position="bottom left"
 					onClose={ this.onClose }
-					context={ this.toggleButton.current }
+					context={ this.toggleButtonRef.current }
 				>
-					{ this.cartBody() }
+					{ this.renderCartBody() }
 					<TrackComponentView
 						eventName="calypso_popover_cart_content_impression"
 						eventProperties={ { style: 'popover' } }
@@ -113,11 +128,12 @@ const PopoverCart = createReactClass( {
 				</Popover>
 			);
 		}
+
 		if ( this.props.visible ) {
 			return (
 				<div className="popover-cart__mobile-cart">
 					<div className="top-arrow" />
-					{ this.cartBody() }
+					{ this.renderCartBody() }
 					<TrackComponentView
 						eventName="calypso_popover_cart_content_impression"
 						eventProperties={ { style: 'mobile-cart' } }
@@ -125,14 +141,9 @@ const PopoverCart = createReactClass( {
 				</div>
 			);
 		}
-	},
+	}
 
-	onToggle: function( event ) {
-		this.props.closeSectionNavMobilePanel();
-		this.props.onToggle( event );
-	},
-
-	cartBody: function() {
+	renderCartBody() {
 		if ( ! this.props.cart.hasLoadedFromServer ) {
 			return <CartBodyLoadingPlaceholder />;
 		}
@@ -143,31 +154,11 @@ const PopoverCart = createReactClass( {
 
 		return (
 			<div>
-				<CartBody
-					collapse={ true }
-					cart={ this.props.cart }
-					selectedSite={ this.props.selectedSite }
-				/>
-
+				<CartBody collapse cart={ this.props.cart } selectedSite={ this.props.selectedSite } />
 				<CartButtons selectedSite={ this.props.selectedSite } />
 			</div>
 		);
-	},
-
-	onClose: function() {
-		// Since this callback can fire after the user navigates off the page, we
-		// we need to check if it's mounted to prevent errors.
-		if ( this.hasUnmounted ) {
-			return;
-		}
-
-		// if the cart became pinned, ignore close event from Popover
-		if ( this.props.pinned ) {
-			return;
-		}
-
-		this.onToggle();
-	},
-} );
+	}
+}
 
 export default localize( PopoverCart );

--- a/client/my-sites/current-site/pending-payment-notice.jsx
+++ b/client/my-sites/current-site/pending-payment-notice.jsx
@@ -22,7 +22,7 @@ export const PendingPaymentNotice = ( { translate, cart = {} } ) => {
 			icon="info-outline"
 			isCompact
 			status="is-warning"
-			text={ translate( 'Processing your payment...', {
+			text={ translate( 'Processing your payment…', {
 				comment: 'Notice to user that a payment is pending',
 			} ) }
 		>

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -8,13 +8,13 @@ import { get } from 'lodash';
 /**
  * Internal Dependencies
  */
-import CheckoutData from 'components/data/checkout';
+import CartData from 'components/data/cart';
 import Plans from './plans';
 import { isValidFeatureKey } from 'lib/plans/features-list';
 
 export function plans( context, next ) {
 	context.primary = (
-		<CheckoutData>
+		<CartData>
 			<Plans
 				context={ context }
 				intervalType={ context.params.intervalType }
@@ -24,7 +24,7 @@ export function plans( context, next ) {
 				withDiscount={ context.query.discount }
 				discountEndDate={ context.query.ts }
 			/>
-		</CheckoutData>
+		</CartData>
 	);
 	next();
 }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -8,23 +8,20 @@ import { get } from 'lodash';
 /**
  * Internal Dependencies
  */
-import CartData from 'components/data/cart';
 import Plans from './plans';
 import { isValidFeatureKey } from 'lib/plans/features-list';
 
 export function plans( context, next ) {
 	context.primary = (
-		<CartData>
-			<Plans
-				context={ context }
-				intervalType={ context.params.intervalType }
-				customerType={ context.query.customerType }
-				selectedFeature={ context.query.feature }
-				selectedPlan={ context.query.plan }
-				withDiscount={ context.query.discount }
-				discountEndDate={ context.query.ts }
-			/>
-		</CartData>
+		<Plans
+			context={ context }
+			intervalType={ context.params.intervalType }
+			customerType={ context.query.customerType }
+			selectedFeature={ context.query.feature }
+			selectedPlan={ context.query.plan }
+			withDiscount={ context.query.discount }
+			discountEndDate={ context.query.ts }
+		/>
 	);
 	next();
 }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -27,10 +27,10 @@ import isSiteAutomatedTransferSelector from 'state/selectors/is-site-automated-t
 import { isJetpackSite } from 'state/sites/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
+import CartData from 'components/data/cart';
 
 class Plans extends React.Component {
 	static propTypes = {
-		cart: PropTypes.object.isRequired,
 		context: PropTypes.object.isRequired,
 		displayJetpackPlans: PropTypes.bool,
 		intervalType: PropTypes.string,
@@ -109,7 +109,9 @@ class Plans extends React.Component {
 					) }
 					{ canAccessPlans && (
 						<div id="plans" className="plans plans__has-sidebar">
-							<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
+							<CartData>
+								<PlansNavigation path={ this.props.context.path } />
+							</CartData>
 							<PlansFeaturesMain
 								displayJetpackPlans={ displayJetpackPlans }
 								hideFreePlan={ true }

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -110,11 +110,7 @@ class PlansNavigation extends React.Component {
 		);
 	}
 
-	toggleCartVisibility = event => {
-		if ( event ) {
-			event.preventDefault();
-		}
-
+	toggleCartVisibility = () => {
 		this.setState( { cartVisible: ! this.state.cartVisible } );
 	};
 


### PR DESCRIPTION
This patch simplifies the usage of the `CheckoutData` and `CartData` Flux providers in Plans code.

`CheckoutData` connects to the `Cart` and `Transaction` stores and passes `cart` and `transaction` props to the children. The only place, however, where we really use the `transaction` is `Checkout`. At all other places, we can replace `CheckoutData` with just `CartData`, as we only need the cart there. That's the case with `Plans`, both WP.com and Jetpack Connect variants.

Going further, the only reason why `Plans` need `CartData` is to display the `PopoverCart` component in `PlansNavigation`:

<img width="342" alt="Screenshot 2019-10-09 at 15 57 36" src="https://user-images.githubusercontent.com/664258/66549656-0d014000-eb44-11e9-8b81-5e9eb8587588.png">

That means that we can remove the provider altogether in Jetpack Connect Plans, which don't show the `PlansNavigation` and `PopoverCart` at all.

And we can also push the `CartData` component down in the WP.com `Plans` component, to wrap around only `PlansNavigation`.

**How to test:**
Best reviewed commit by commit, I tried to make them small and focused.

Test that the plans in Jetpack Connect and in WP.com still work as expected, especially the `PopoverCart` (see the screenshot above).