### PR TITLE
Domains: Fix nudge dismiss button issue in smaller displays

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -40,8 +40,11 @@ import QueryProductsList from 'components/data/query-products-list';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getUnformattedDomainPrice, getUnformattedDomainSalePrice } from 'lib/domains';
 import formatCurrency from '@automattic/format-currency/src';
-import { getDomainType } from 'lib/domains/utils';
 import { type as domainTypes } from 'lib/domains/constants';
+import { getPreference } from 'state/preferences/selectors';
+import { savePreference } from 'state/preferences/actions';
+
+const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
 
 export class SiteNotice extends React.Component {
 	static propTypes = {
@@ -105,14 +108,14 @@ export class SiteNotice extends React.Component {
 	}
 
 	domainUpsellNudge() {
-		if ( ! this.props.isPlanOwner ) {
+		if ( ! this.props.isPlanOwner || this.props.domainUpsellNudgeDismissedDate ) {
 			return null;
 		}
 
-		const nonWPCOMDomains = reject( this.props.domains, domain => {
-			const domainType = getDomainType( domain );
-			return domainType === domainTypes.WPCOM || domainType === domainTypes.ATOMIC_STAGING;
-		} );
+		const nonWPCOMDomains = reject(
+			this.props.domains,
+			domain => domain.type === domainTypes.WPCOM || domain.type === domainTypes.ATOMIC_STAGING
+		);
 
 		if ( nonWPCOMDomains.length < 1 || nonWPCOMDomains.length > 2 ) {
 			return null;
@@ -169,13 +172,25 @@ export class SiteNotice extends React.Component {
 		}
 
 		return (
-			<SidebarBanner
-				ctaName="domain-upsell-nudge"
-				ctaText={ translate( 'Go' ) }
-				href={ '/domains/add/' + site.slug }
+			<Notice
+				isCompact
+				status="is-success"
 				icon="info-outline"
+				onDismissClick={ this.props.clickDomainUpsellDismiss }
+				showDismiss={ true }
 				text={ noticeText }
-			/>
+			>
+				<NoticeAction
+					onClick={ this.props.clickDomainUpsellGo }
+					href={ `/domains/add/${ site.slug }` }
+				>
+					{ translate( 'Go' ) }
+					<TrackComponentView
+						eventName={ 'calypso_upgrade_nudge_impression' }
+						eventProperties={ { cta_name: 'domain-upsell-nudge' } }
+					/>
+				</NoticeAction>
+			</Notice>
 		);
 	}
 
@@ -312,6 +327,7 @@ export default connect(
 			domains: getDomainsBySiteId( state, siteId ),
 			isPlanOwner: isCurrentUserCurrentPlanOwner( state, siteId ),
 			currencyCode: getCurrentUserCurrencyCode( state ),
+			domainUpsellNudgeDismissedDate: getPreference( state, DOMAIN_UPSELL_NUDGE_DISMISS_KEY ),
 		};
 	},
 	dispatch => {
@@ -322,6 +338,20 @@ export default connect(
 						cta_name: 'current_site_domain_notice',
 					} )
 				),
+			clickDomainUpsellGo: () =>
+				dispatch(
+					recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
+						cta_name: 'domain-upsell-nudge',
+					} )
+				),
+			clickDomainUpsellDismiss: () => {
+				dispatch( savePreference( DOMAIN_UPSELL_NUDGE_DISMISS_KEY, new Date().toISOString() ) );
+				dispatch(
+					recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
+						cta_name: 'domain-upsell-nudge-dismiss',
+					} )
+				);
+			},
 			clickFreeToPaidPlanNotice: () =>
 				dispatch(
 					recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -186,7 +186,7 @@ export class SiteNotice extends React.Component {
 				>
 					{ translate( 'Go' ) }
 					<TrackComponentView
-						eventName={ 'calypso_upgrade_nudge_impression' }
+						eventName="calypso_upgrade_nudge_impression"
 						eventProperties={ { cta_name: 'domain-upsell-nudge' } }
 					/>
 				</NoticeAction>

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -178,13 +178,12 @@ export class SiteNotice extends React.Component {
 				icon="info-outline"
 				onDismissClick={ this.props.clickDomainUpsellDismiss }
 				showDismiss={ true }
-				text={ noticeText }
 			>
 				<NoticeAction
 					onClick={ this.props.clickDomainUpsellGo }
 					href={ `/domains/add/${ site.slug }` }
 				>
-					{ translate( 'Go' ) }
+					{ noticeText }
 					<TrackComponentView
 						eventName="calypso_upgrade_nudge_impression"
 						eventProperties={ { cta_name: 'domain-upsell-nudge' } }

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -178,12 +178,13 @@ export class SiteNotice extends React.Component {
 				icon="info-outline"
 				onDismissClick={ this.props.clickDomainUpsellDismiss }
 				showDismiss={ true }
+				text={ noticeText }
 			>
 				<NoticeAction
 					onClick={ this.props.clickDomainUpsellGo }
 					href={ `/domains/add/${ site.slug }` }
 				>
-					{ noticeText }
+					{ translate( 'Go' ) }
 					<TrackComponentView
 						eventName="calypso_upgrade_nudge_impression"
 						eventProperties={ { cta_name: 'domain-upsell-nudge' } }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restore the Go button due to issue in smaller displays

The nudge should look like this:

<img width="272" alt="Screenshot 2019-10-09 at 7 40 54 PM" src="https://user-images.githubusercontent.com/13062352/66506209-303cd880-eacd-11e9-84aa-99e2f10c9cd2.png">

See also: #36633, #36208, #36623, p99Zz8-K5-p2
