### PR TITLE
Types: Use react-redux@5 types

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2994,27 +2994,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/hoist-non-react-statics": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-			"integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*",
-				"hoist-non-react-statics": "^3.3.0"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-					"dev": true,
-					"requires": {
-						"react-is": "^16.7.0"
-					}
-				}
-			}
-		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -3091,14 +3070,27 @@
 			}
 		},
 		"@types/react-redux": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.0.6.tgz",
-			"integrity": "sha512-Nlofk/xq8oVWpylvrFayezNb/HONsYJfjlSmTmZ7xoMDe+Muf6c1qHMVRZ7C5S2W1+iVcY21ggZwlUgLv+66hQ==",
+			"version": "5.0.21",
+			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-5.0.21.tgz",
+			"integrity": "sha512-ewkOW4GjnyXq5L++T31utI8yRmwj8iCIahZohYi1Ef7Xkrw0V/q92ao7x20rm38FKgImDaCCsaRGWfCJmF/Ukg==",
 			"dev": true,
 			"requires": {
-				"@types/hoist-non-react-statics": "^3.3.0",
 				"@types/react": "*",
-				"redux": "^4.0.0"
+				"redux": "^3.6.0"
+			},
+			"dependencies": {
+				"redux": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+					"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.2.1",
+						"lodash-es": "^4.2.1",
+						"loose-envify": "^1.1.0",
+						"symbol-observable": "^1.0.3"
+					}
+				}
 			}
 		},
 		"@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
 		"@types/lodash": "4.14.123",
 		"@types/page": "1.8.0",
 		"@types/react": "16.8.16",
-		"@types/react-redux": "7.0.6",
+		"@types/react-redux": "5.0.21",
 		"@types/webpack-env": "1.14.0",
 		"@typescript-eslint/eslint-plugin": "1.10.2",
 		"@typescript-eslint/parser": "1.10.2",


### PR DESCRIPTION
We currently use react-redux@7 types. Use react-redux@5 types, matching our react-redux version.

This fixes an additional issue we see with `hoist-non-react-statics` (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33690)