### PR TITLE
[WIP] Plans Single Products: Add remaining UI elements and styles

### DIFF
--- a/client/my-sites/plans-features-main/header.jsx
+++ b/client/my-sites/plans-features-main/header.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/my-sites/plans-single-products/index.jsx
+++ b/client/my-sites/plans-single-products/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,13 +15,10 @@ import Product from './product';
  */
 import './style.scss';
 
-const PlansSingleProducts = ( { translate } ) => {
+const PlansSingleProducts = () => {
+	const translate = useTranslate();
 	const displayBackup = isEnabled( 'plans/jetpack-backup' );
 	const displayScan = isEnabled( 'plans/jetpack-scan' );
-
-	if ( ! displayBackup && ! displayScan ) {
-		return null;
-	}
 
 	return (
 		<div className="plans-single-products">
@@ -31,4 +28,4 @@ const PlansSingleProducts = ( { translate } ) => {
 	);
 };
 
-export default localize( PlansSingleProducts );
+export default PlansSingleProducts;

--- a/client/my-sites/plans-single-products/index.jsx
+++ b/client/my-sites/plans-single-products/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,14 +15,13 @@ import Product from './product';
 import './style.scss';
 
 const PlansSingleProducts = () => {
-	const translate = useTranslate();
 	const displayBackup = isEnabled( 'plans/jetpack-backup' );
 	const displayScan = isEnabled( 'plans/jetpack-scan' );
 
 	return (
 		<div className="plans-single-products">
-			{ displayScan && <Product heading={ translate( 'Jetpack Scan' ) } /> }
-			{ displayBackup && <Product heading={ translate( 'Jetpack Backup' ) } /> }
+			{ displayScan && <Product productSlug="jetpack-scan" /> }
+			{ displayBackup && <Product productSlug="jetpack-backup" /> }
 		</div>
 	);
 };

--- a/client/my-sites/plans-single-products/product.jsx
+++ b/client/my-sites/plans-single-products/product.jsx
@@ -3,22 +3,115 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PlanPrice from 'my-sites/plan-price';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 
 class PlansSingleProduct extends Component {
 	static propTypes = {
-		heading: PropTypes.string.isRequired,
+		billingTimeFrame: PropTypes.string,
+		currencyCode: PropTypes.string,
+		discountedPrice: PropTypes.number,
+		fullPrice: PropTypes.number,
+		isPlaceholder: PropTypes.bool,
+		moreInfoLabel: PropTypes.string,
+		productDescription: PropTypes.string,
+		title: PropTypes.string,
 	};
 
+	static defaultProps = {
+		isPlaceholder: false,
+	};
+
+	renderPriceGroup() {
+		const { currencyCode, discountedPrice, fullPrice, isPlaceholder } = this.props;
+
+		const priceGroupClasses = classNames( 'plans-single-products__price-group', {
+			'is-placeholder': isPlaceholder,
+		} );
+
+		return (
+			<div className={ priceGroupClasses }>
+				<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original />
+				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
+			</div>
+		);
+	}
+
+	renderBillingTimeFrame() {
+		const { billingTimeFrame, isPlaceholder } = this.props;
+
+		const timeFrameClasses = classNames( 'plans-single-products__billing-timeframe', {
+			'is-placeholder': isPlaceholder,
+		} );
+
+		return <p className={ timeFrameClasses }>{ billingTimeFrame }</p>;
+	}
+
+	renderProductDescription() {
+		const { moreInfoLabel, isPlaceholder, productDescription } = this.props;
+
+		const productDescriptionClasses = classNames( 'plans-single-products__product-description', {
+			'is-placeholder': isPlaceholder,
+		} );
+
+		const moreInfo = moreInfoLabel ? <a href="/">{ moreInfoLabel }</a> : null;
+
+		return (
+			<p className={ productDescriptionClasses }>
+				{ productDescription } { moreInfo }
+			</p>
+		);
+	}
+
 	render() {
-		const { heading } = this.props;
+		const { title } = this.props;
 
 		return (
 			<div className="plans-single-products__card">
-				<h3 className="plans-single-products__heading">{ heading }</h3>
+				<div className="plans-single-products__card-header">
+					<h3 className="plans-single-products__product-name">{ title }</h3>
+					{ this.renderPriceGroup() }
+					{ this.renderBillingTimeFrame() }
+				</div>
+				<div className="plans-single-products__card-content">
+					{ this.renderProductDescription() }
+				</div>
 			</div>
 		);
 	}
 }
 
-export default localize( PlansSingleProduct );
+export default connect( ( state, { productSlug } ) => {
+	const productProperties = {
+		'jetpack-scan': {
+			discountedPrice: 10,
+			fullPrice: 16,
+			moreInfoLabel: 'More info',
+			productDescription:
+				'Automatic scanning and one-click fixes keep your site one step ahead of security threats.',
+			title: 'Jetpack Scan',
+		},
+		'jetpack-backup': {
+			discountedPrice: 16,
+			fullPrice: 25,
+			moreInfoLabel: 'Which one do I need?',
+			productDescription:
+				'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.',
+			title: 'Jetpack Backup',
+		},
+	};
+
+	return {
+		billingTimeFrame: 'per year',
+		currencyCode: getCurrentUserCurrencyCode( state ),
+		isPlaceholder: false,
+		...productProperties[ productSlug ],
+	};
+} )( localize( PlansSingleProduct ) );

--- a/client/my-sites/plans-single-products/style.scss
+++ b/client/my-sites/plans-single-products/style.scss
@@ -17,22 +17,87 @@
 
 .plans-single-products__card {
 	margin: 0 auto 12px;
-	padding: 24px 16px;
 	background: var( --color-surface );
 	box-shadow: 0 0 0 1px var( --color-border-subtle );
 
 	// On mobile we want each product to be an individual card.
 	@include breakpoint( '>660px' ) {
 		margin-bottom: 0;
-		padding: 24px;
 		background: transparent;
 		box-shadow: none;
 	}
 }
 
-.plans-single-products__heading {
+.plans-single-products__card-header,
+.plans-single-products__card-content {
+	padding: 22px 16px;
+
+	@include breakpoint( '>660px' ) {
+		padding: 24px;
+	}
+}
+
+// Product header
+.plans-single-products__card-header {
+	border-bottom: solid 2px var( --color-jetpack-plan-free );
+}
+
+.plans-single-products__product-name {
 	font-size: 22px;
 	line-height: 1;
 	font-weight: 400;
 	color: var( --color-primary-50 );
+}
+
+// Prices
+.plans-single-products__price-group {
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	max-width: calc( 100% - 20px );
+
+	@include breakpoint( '<960px' ) {
+		max-width: calc( 100% - 10px );
+	}
+
+	&.is-placeholder {
+		@include placeholder( --color-neutral-10 );
+		width: 145px;
+		height: 25px;
+		margin-top: 6px;
+		margin-bottom: 5px;
+	}
+
+	&.is-placeholder .plan-price {
+		display: none;
+	}
+}
+
+// Billing timeframe
+.plans-single-products__billing-timeframe {
+	font-size: 12px;
+	font-style: italic;
+	font-weight: 400;
+	color: var( --color-text-subtle );
+	line-height: 1;
+	margin: 0;
+
+	&.is-placeholder {
+		@include placeholder( --color-neutral-10 );
+		width: 140px;
+		height: 12px;
+	}
+}
+
+// Product description
+.plans-single-products__product-description {
+	font-size: 14px;
+	line-height: 20px;
+	color: var( --color-text-subtle );
+	margin: 0;
+
+	a {
+		display: inline-block;
+		color: var( --color-link-light );
+	}
 }


### PR DESCRIPTION
**It's a draft - do not merge**

#### Changes proposed in this Pull Request

* Add single product UI elements (mobile, non-responsive for now).

![Screenshot 2019-10-10 at 12 07 55](https://user-images.githubusercontent.com/478735/66559958-a6d1e880-eb56-11e9-90fd-fde7ac8679bf.png)

#### Testing instructions

* Checkout the `add/single-product-ui` branch on your local dev environment.
* Run `npm start`.
* Go to "Plans" page for a given site.
* Confirm both "Jetpack Scan" and "Jetpack Backup" product cards are displayed.

**Master thread:** p1HpG7-7nT-p2

Fixes no known issue.
