### PR TITLE
Domains: Fix domain upsell dismiss button positioning

### DIFF
--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -102,5 +102,6 @@
 
 	.notice__action {
 		margin-left: auto;
+		white-space: normal;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to fix the domain upsell nudge so that the dismiss button does not get pushed out of display.

Before:

<img width="270" alt="Screenshot 2019-10-10 at 9 46 54 AM" src="https://user-images.githubusercontent.com/13062352/66549233-21910880-eb43-11e9-8737-cf47ce8d3922.png">

After:

<img width="269" alt="Screenshot 2019-10-10 at 12 06 40 PM" src="https://user-images.githubusercontent.com/13062352/66559859-6e320f00-eb56-11e9-9316-232b2c3c6d15.png">

This change may impact a couple of other notices though. Another way to approach this would be to add a prop to `NoticeAction` (e.g. `lineBreak`), which we would then use to explicitly choose when line breaks are allowed.

See also: #36633, #36208, #36623, p99Zz8-K5-p2

#### Testing instructions

Test this out and make sure that the clickable action will not push the dismiss button out of the view.
