### PR TITLE
Add/price plan supports range

### DIFF
--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -31,9 +31,9 @@ export default class extends React.Component {
 | Prop         | Type   | Description                                               |
 | ----         | -------| -----------                                               |
 | rawPrice     | number | Price of the plan                                         |
+| rawPriceRange| Array  | The Min and Max Price of the plan                         |
 | original     | bool   | Is the price discounted and this is the original one?     |
 | discounted   | bool   | Is the price discounted and this is the discounted one?   |
 | isOnSale     | bool   | Is the product this price is for on sale?                 |
 | currencyCode | string | Currency of the price                                     |
 | className    | string | If you need to add additional classes                     |
-

--- a/client/my-sites/plan-price/docs/example.jsx
+++ b/client/my-sites/plan-price/docs/example.jsx
@@ -16,11 +16,21 @@ function PlanPriceExample() {
 		<div>
 			<h3>Plan with standard price</h3>
 			<PlanPrice rawPrice={ 99 } />
+			<PlanPrice rawPriceRange={ [ 99, 140 ] } />
 
 			<h3>Plan with discounted price</h3>
 			<span style={ { display: 'flex' } }>
 				<PlanPrice rawPrice={ 8.25 } original />
 				<PlanPrice rawPrice={ 2.25 } discounted />
+				<PlanPrice rawPriceRange={ [ 8.25, 20.23 ] } original />
+				<PlanPrice rawPriceRange={ [ 2.25, 3.5 ] } discounted />
+			</span>
+			<h3>Plan with discounted price with tax</h3>
+			<span style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original taxText="10" />
+				<PlanPrice rawPrice={ 2.25 } discounted taxText="10" />
+				<PlanPrice rawPriceRange={ [ 8.25, 20.23 ] } original taxText="10" />
+				<PlanPrice rawPriceRange={ [ 2.25, 3.5 ] } discounted taxText="10" />
 			</span>
 		</div>
 	);

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { getCurrencyObject } from '@automattic/format-currency';
@@ -25,6 +25,7 @@ export class PlanPrice extends Component {
 		const {
 			currencyCode,
 			rawPrice,
+			rawPriceRange,
 			original,
 			discounted,
 			className,
@@ -33,24 +34,72 @@ export class PlanPrice extends Component {
 			taxText,
 			translate,
 		} = this.props;
-		if ( ! currencyCode || ( rawPrice !== 0 && ! rawPrice ) ) {
+
+		let priceRange = false;
+		if ( rawPrice && rawPrice !== 0 ) {
+			priceRange = [
+				{
+					price: getCurrencyObject( rawPrice, currencyCode ),
+					raw: rawPrice,
+				},
+			];
+		}
+
+		if (
+			rawPriceRange &&
+			rawPriceRange[ 0 ] &&
+			rawPriceRange[ 1 ] &&
+			rawPriceRange[ 0 ] + rawPriceRange[ 1 ] !== 0
+		) {
+			priceRange = [
+				{
+					price: getCurrencyObject( rawPriceRange[ 0 ], currencyCode ),
+					raw: rawPriceRange[ 0 ],
+				},
+				{
+					price: getCurrencyObject( rawPriceRange[ 1 ], currencyCode ),
+					raw: rawPriceRange[ 1 ],
+				},
+			];
+		}
+
+		if ( ! currencyCode || ! priceRange ) {
 			return null;
 		}
-		const price = getCurrencyObject( rawPrice, currencyCode );
+
 		const classes = classNames( 'plan-price', className, {
 			'is-original': original,
 			'is-discounted': discounted,
 		} );
 
+		const renderPrice = priceObj => {
+			return [
+				priceObj.price.integer,
+				priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction,
+			];
+		};
+
 		if ( isInSignup ) {
 			return (
 				<span className={ classes }>
-					{ price.symbol }
-					{ price.integer }
-					{ rawPrice - price.integer > 0 && price.fraction }
+					{ priceRange[ 0 ].price.symbol }
+					{ renderPrice( priceRange[ 0 ] ) }
+					{ priceRange[ 1 ] && ' - ' }
+					{ priceRange[ 1 ] && renderPrice( priceRange[ 1 ] ) }
 				</span>
 			);
 		}
+
+		const renderPriceHtml = priceObj => {
+			return (
+				<Fragment>
+					<span className="plan-price__integer">{ priceObj.price.integer }</span>
+					<sup className="plan-price__fraction">
+						{ priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction }
+					</sup>
+				</Fragment>
+			);
+		};
 
 		const saleBadgeText = translate( 'Sale', {
 			comment: 'Shown next to a domain that has a special discounted sale price',
@@ -58,11 +107,10 @@ export class PlanPrice extends Component {
 
 		return (
 			<h4 className={ classes }>
-				<sup className="plan-price__currency-symbol">{ price.symbol }</sup>
-				<span className="plan-price__integer">{ price.integer }</span>
-				<sup className="plan-price__fraction">
-					{ rawPrice - price.integer > 0 && price.fraction }
-				</sup>
+				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
+				{ renderPriceHtml( priceRange[ 0 ] ) }
+				{ priceRange[ 1 ] && ' - ' }
+				{ priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] ) }
 				{ taxText && (
 					<sup className="plan-price__tax-amount">
 						{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
@@ -78,6 +126,7 @@ export default localize( PlanPrice );
 
 PlanPrice.propTypes = {
 	rawPrice: PropTypes.number,
+	rawPriceRange: PropTypes.array,
 	original: PropTypes.bool,
 	discounted: PropTypes.bool,
 	currencyCode: PropTypes.string,

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -49,7 +49,8 @@ export class PlanPrice extends Component {
 			rawPriceRange &&
 			rawPriceRange[ 0 ] &&
 			rawPriceRange[ 1 ] &&
-			rawPriceRange[ 0 ] + rawPriceRange[ 1 ] !== 0
+			rawPriceRange[ 0 ] !== 0 &&
+			rawPriceRange[ 1 ] !== 0
 		) {
 			priceRange = [
 				{


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Currently the PricePlan component doesn't support a range of prices. This PR fixed this. 
* The ability to display a range is needed for the new Jetpack product plans.

Before:
<img width="688" alt="Screen Shot 2019-10-10 at 2 14 43 PM" src="https://user-images.githubusercontent.com/115071/66567840-5e232b00-eb68-11e9-884a-399fbdd47237.png">

After:
<img width="681" alt="Screen Shot 2019-10-10 at 1 42 29 PM" src="https://user-images.githubusercontent.com/115071/66567853-62e7df00-eb68-11e9-8306-57d21ad64aec.png">

#### Testing instructions
Go to the plans pages does everything still look like before?
Go the devdoc. Does the PricePlan component look like you would expect it to work.
