### PR TITLE
G Suite: Prevent users from adding G Suite to mapped domains without WordPress.com nameservers

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -163,13 +163,13 @@ function isMappedDomain( domain ) {
 }
 
 /**
- * Checks if the supplied `domain` is a mapped domain and has WP.com name servers.
+ * Checks if the supplied domain is a mapped domain and has WordPress.com name servers.
  *
- * @param {Object} domain domain object
- * @returns {boolean} true if condition is met.
+ * @param {Object} domain - domain object
+ * @returns {Boolean} - true if the domain is mapped and has WordPress.com name servers, false otherwise
  */
 function isMappedDomainWithWpcomNameservers( domain ) {
-	return isMappedDomain( domain ) && get( domain, 'hasWpcomNameservers', false ) === true;
+	return isMappedDomain( domain ) && get( domain, 'hasWpcomNameservers', false );
 }
 
 function getSelectedDomain( { domains, selectedDomainName, isTransfer } ) {

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -162,6 +162,16 @@ function isMappedDomain( domain ) {
 	return domain.type === domainTypes.MAPPED;
 }
 
+/**
+ * Checks if the supplied `domain` is a mapped domain and has WP.com name servers.
+ *
+ * @param {Object} domain domain object
+ * @returns {boolean} true if condition is met.
+ */
+function isMappedDomainWithWpcomNameservers( domain ) {
+	return isMappedDomain( domain ) && get( domain, 'hasWpcomNameservers', false ) === true;
+}
+
 function getSelectedDomain( { domains, selectedDomainName, isTransfer } ) {
 	return find( domains, domain => {
 		if ( domain.name !== selectedDomainName ) {
@@ -374,7 +384,7 @@ export {
 	getUnformattedDomainSalePrice,
 	hasMappedDomain,
 	isHstsRequired,
-	isMappedDomain,
+	isMappedDomainWithWpcomNameservers,
 	isRegisteredDomain,
 	isSubdomain,
 	resendInboundTransferEmail,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -384,6 +384,7 @@ export {
 	getUnformattedDomainSalePrice,
 	hasMappedDomain,
 	isHstsRequired,
+	isMappedDomain,
 	isMappedDomainWithWpcomNameservers,
 	isRegisteredDomain,
 	isSubdomain,

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -109,9 +109,11 @@ function getGSuiteSupportedDomains( domains ) {
 
 		const isHostedOnWpcom =
 			isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuiteWithUs( domain ) );
-		const isMappedWithWpcomNameservers = isMappedDomainWithWpcomNameservers( domain );
 
-		return ( isHostedOnWpcom || isMappedWithWpcomNameservers ) && canDomainAddGSuite( domain.name );
+		return (
+			( isHostedOnWpcom || isMappedDomainWithWpcomNameservers( domain ) ) &&
+			canDomainAddGSuite( domain.name )
+		);
 	} );
 }
 

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -96,10 +96,10 @@ function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 }
 
 /**
- * Filters a list of domains by the domains that eligible for G Suite
+ * Filters a list of domains by the domains that eligible for G Suite.
  *
  * @param {Array} domains - list of domain objects
- * @returns {Array} - Array of G Suite supported domans
+ * @returns {Array} - the list of domains that are eligible for G Suite
  */
 function getGSuiteSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
@@ -107,13 +107,13 @@ function getGSuiteSupportedDomains( domains ) {
 			return false;
 		}
 
-		const isHostedOnWpcom =
-			isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuiteWithUs( domain ) );
+		const isHostedOnWpcom = isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuiteWithUs( domain ) );
 
-		return (
-			( isHostedOnWpcom || isMappedDomainWithWpcomNameservers( domain ) ) &&
-			canDomainAddGSuite( domain.name )
-		);
+		if ( ! isHostedOnWpcom && ! isMappedDomainWithWpcomNameservers( domain ) ) {
+			return false;
+		}
+
+		return canDomainAddGSuite( domain.name );
 	} );
 }
 

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -7,7 +7,7 @@ import { get, includes, some, endsWith, find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isMappedDomain, isRegisteredDomain } from 'lib/domains';
+import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import userFactory from 'lib/user';
 
 /**
@@ -109,9 +109,9 @@ function getGSuiteSupportedDomains( domains ) {
 
 		const isHostedOnWpcom =
 			isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuiteWithUs( domain ) );
-		const isMapped = isMappedDomain( domain );
+		const isMappedWithWpcomNameservers = isMappedDomainWithWpcomNameservers( domain );
 
-		return ( isHostedOnWpcom || isMapped ) && canDomainAddGSuite( domain.name );
+		return ( isHostedOnWpcom || isMappedWithWpcomNameservers ) && canDomainAddGSuite( domain.name );
 	} );
 }
 

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -77,12 +77,22 @@ describe( 'index', () => {
 			expect( getGSuiteSupportedDomains( [ registered ] ) ).toEqual( [ registered ] );
 		} );
 
-		test( 'returns domain object if domain is valid and type of mapped', () => {
+		test( 'returns empty array if domain is valid and type of mapped without our nameservers', () => {
 			const mapped = { name: 'foo.blog', type: 'MAPPED', googleAppsSubscription: {} };
+			expect( getGSuiteSupportedDomains( [ mapped ] ) ).toEqual( [] );
+		} );
+
+		test( 'returns domain object if domain is valid and type of mapped with our nameservers', () => {
+			const mapped = {
+				name: 'foo.blog',
+				type: 'MAPPED',
+				googleAppsSubscription: {},
+				hasWpcomNameservers: true,
+			};
 			expect( getGSuiteSupportedDomains( [ mapped ] ) ).toEqual( [ mapped ] );
 		} );
 
-		test( 'returns domain object if domain is valid and type of site redirected', () => {
+		test( 'returns empty array if domain is valid and type of site redirected', () => {
 			const siteRedirect = { name: 'foo.blog', type: 'SITE_REDIRECT', googleAppsSubscription: {} };
 			expect( getGSuiteSupportedDomains( [ siteRedirect ] ) ).toEqual( [] );
 		} );
@@ -113,10 +123,23 @@ describe( 'index', () => {
 			).toEqual( false );
 		} );
 
-		test( 'returns true if passed an array with valid domains', () => {
+		test( 'returns false if passed an array with valid domains and no nameservers', () => {
 			expect(
 				hasGSuiteSupportedDomain( [
 					{ name: 'foo.blog', type: 'MAPPED', googleAppsSubscription: {} },
+				] )
+			).toEqual( false );
+		} );
+
+		test( 'returns true if passed an array with valid domains and our nameservers', () => {
+			expect(
+				hasGSuiteSupportedDomain( [
+					{
+						name: 'foo.blog',
+						type: 'MAPPED',
+						googleAppsSubscription: {},
+						hasWpcomNameservers: true,
+					},
 				] )
 			).toEqual( true );
 		} );

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -142,7 +142,7 @@ class EmailManagement extends React.Component {
 					line: translate(
 						'Only domains using WordPress.com name servers are eligible for G Suite.'
 					),
-					action: translate( 'How To Change Name Servers' ),
+					action: translate( 'How to change your name servers' ),
 					actionURL:
 						'https://en.support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers',
 					actionTarget: '_blank',

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -35,7 +35,7 @@ import PlansNavigation from 'my-sites/plans/navigation';
 import EmptyContent from 'components/empty-content';
 import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
 import { emailManagement, emailManagementForwarding } from 'my-sites/email/paths';
-import { getSelectedDomain } from 'lib/domains';
+import { getSelectedDomain, isMappedDomain } from 'lib/domains';
 import DocumentHead from 'components/data/document-head';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -137,6 +137,17 @@ class EmailManagement extends React.Component {
 				secondaryAction: translate( 'Add Email Forwarding' ),
 				secondaryActionURL: emailManagementForwarding( selectedSiteSlug, selectedDomainName ),
 			};
+			if ( isMappedDomain( selectedDomain ) ) {
+				Object.assign( emptyContentProps, {
+					line: translate(
+						'Only domains using WordPress.com name servers are eligible for G Suite.'
+					),
+					action: translate( 'How To Change Name Servers' ),
+					actionURL:
+						'https://en.support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers',
+					actionTarget: '_blank',
+				} );
+			}
 		} else {
 			emptyContentProps = {
 				title: translate( 'Enable powerful email features.' ),
@@ -147,11 +158,12 @@ class EmailManagement extends React.Component {
 				),
 			};
 		}
-		Object.assign( emptyContentProps, {
-			illustration: customDomainImage,
-			action: translate( 'Add a Custom Domain' ),
-			actionURL: '/domains/add/' + selectedSiteSlug,
-		} );
+		emptyContentProps.action ||
+			Object.assign( emptyContentProps, {
+				illustration: customDomainImage,
+				action: translate( 'Add a Custom Domain' ),
+				actionURL: '/domains/add/' + selectedSiteSlug,
+			} );
 
 		return <EmptyContent { ...emptyContentProps } />;
 	}

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -62,6 +62,7 @@ class EmailManagement extends React.Component {
 
 	render() {
 		const { selectedSiteId } = this.props;
+
 		return (
 			<Main className="email-management" wideLayout>
 				{ selectedSiteId && <QueryGSuiteUsers siteId={ selectedSiteId } /> }
@@ -76,6 +77,7 @@ class EmailManagement extends React.Component {
 
 	headerOrPlansNavigation() {
 		const { cart, selectedSiteSlug, selectedDomainName, translate } = this.props;
+
 		if ( selectedDomainName ) {
 			return (
 				<Header onClick={ this.goToEditOrList } selectedDomainName={ selectedDomainName }>
@@ -83,6 +85,7 @@ class EmailManagement extends React.Component {
 				</Header>
 			);
 		}
+
 		return (
 			<PlansNavigation
 				cart={ cart }
@@ -119,6 +122,7 @@ class EmailManagement extends React.Component {
 
 	emptyContent() {
 		const { selectedSiteSlug, translate } = this.props;
+
 		const defaultEmptyContentProps = {
 			illustration: customDomainImage,
 			action: translate( 'Add a Custom Domain' ),
@@ -135,17 +139,6 @@ class EmailManagement extends React.Component {
 
 		const selectedDomain = getSelectedDomain( this.props );
 
-		if ( isGSuiteRestricted() && ! selectedDomainName ) {
-			return {
-				title: translate( 'Enable powerful email features.' ),
-				line: translate(
-					'To set up email forwarding, and other email ' +
-						'services for your site, upgrade your site’s web address ' +
-						'to a professional custom domain.'
-				),
-			};
-		}
-
 		if ( selectedDomain && hasGSuiteWithAnotherProvider( selectedDomain ) ) {
 			return {
 				title: translate( 'G Suite is not supported on this domain' ),
@@ -161,7 +154,7 @@ class EmailManagement extends React.Component {
 		};
 
 		if (
-			selectedDomainName &&
+			selectedDomain &&
 			isMappedDomain( selectedDomain ) &&
 			! isMappedDomainWithWpcomNameservers( selectedDomain )
 		) {
@@ -198,6 +191,7 @@ class EmailManagement extends React.Component {
 
 	googleAppsUsersCard() {
 		const { domains, gsuiteUsers, selectedDomainName } = this.props;
+
 		return (
 			<GSuiteUsersCard
 				domains={ domains }
@@ -211,6 +205,7 @@ class EmailManagement extends React.Component {
 		const { domains, selectedDomainName } = this.props;
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
 		const gsuiteDomainName = getEligibleGSuiteDomain( selectedDomainName, domains );
+
 		return (
 			<Fragment>
 				<GSuitePurchaseCta domainName={ gsuiteDomainName } />
@@ -221,6 +216,7 @@ class EmailManagement extends React.Component {
 
 	addEmailForwardingCard( domain ) {
 		const { selectedSiteSlug, translate } = this.props;
+
 		return (
 			<VerticalNav>
 				<VerticalNavItem path={ emailManagementForwarding( selectedSiteSlug, domain ) }>
@@ -232,6 +228,7 @@ class EmailManagement extends React.Component {
 
 	goToEditOrList = () => {
 		const { selectedDomainName, selectedSiteSlug } = this.props;
+
 		if ( selectedDomainName ) {
 			page( domainManagementEdit( selectedSiteSlug, selectedDomainName ) );
 		} else {

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -93,42 +93,47 @@ class EmailManagement extends React.Component {
 
 	content() {
 		const { domains, gsuiteUsers, isRequestingDomains, selectedDomainName } = this.props;
-		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
+
 		if ( isRequestingDomains || ! gsuiteUsers ) {
 			return <Placeholder />;
 		}
+
 		const domainList = selectedDomainName ? [ getSelectedDomain( this.props ) ] : domains;
 
 		if ( domainList.some( hasGSuiteWithUs ) ) {
 			return this.googleAppsUsersCard();
 		}
+
 		if ( hasGSuiteSupportedDomain( domainList ) ) {
 			return this.addGSuiteCta();
 		}
+
+		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
+
 		if ( emailForwardingDomain && isGSuiteRestricted() && selectedDomainName ) {
 			return this.addEmailForwardingCard( emailForwardingDomain );
 		}
-		return this.getEmptyContent();
+
+		return this.emptyContent();
 	}
 
-	getEmptyContent() {
+	emptyContent() {
 		const { selectedSiteSlug, translate } = this.props;
 		const defaultEmptyContentProps = {
 			illustration: customDomainImage,
 			action: translate( 'Add a Custom Domain' ),
 			actionURL: '/domains/add/' + selectedSiteSlug,
 		};
-		const emptyContentProps = { ...defaultEmptyContentProps, ...this.emptyContentProps() };
+
+		const emptyContentProps = { ...defaultEmptyContentProps, ...this.getEmptyContentProps() };
+
 		return <EmptyContent { ...emptyContentProps } />;
 	}
 
-	emptyContentProps() {
+	getEmptyContentProps() {
 		const { selectedDomainName, selectedSiteSlug, translate } = this.props;
+
 		const selectedDomain = getSelectedDomain( this.props );
-		const emailForwardingAction = {
-			secondaryAction: translate( 'Add Email Forwarding' ),
-			secondaryActionURL: emailManagementForwarding( selectedSiteSlug, selectedDomainName ),
-		};
 
 		if ( isGSuiteRestricted() && ! selectedDomainName ) {
 			return {
@@ -150,6 +155,11 @@ class EmailManagement extends React.Component {
 			};
 		}
 
+		const emailForwardingAction = {
+			secondaryAction: translate( 'Add Email Forwarding' ),
+			secondaryActionURL: emailManagementForwarding( selectedSiteSlug, selectedDomainName ),
+		};
+
 		if (
 			selectedDomainName &&
 			isMappedDomain( selectedDomain ) &&
@@ -162,8 +172,7 @@ class EmailManagement extends React.Component {
 					{ args: { domain: selectedDomainName } }
 				),
 				action: translate( 'How to change your name servers' ),
-				actionURL:
-					'https://support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers',
+				actionURL: 'https://support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers',
 				actionTarget: '_blank',
 				...emailForwardingAction,
 			};

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -139,8 +139,10 @@ class EmailManagement extends React.Component {
 			};
 			if ( isMappedDomain( selectedDomain ) ) {
 				Object.assign( emptyContentProps, {
+					title: translate( 'G Suite is not supported on this domain yet.' ),
 					line: translate(
-						'Only domains using WordPress.com name servers are eligible for G Suite.'
+						'To enable G Suite on %(domain)s, please have its name servers changed to that of WordPress.com.',
+						{ args: { domain: selectedDomainName } }
 					),
 					action: translate( 'How to change your name servers' ),
 					actionURL:

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -139,7 +139,7 @@ class EmailManagement extends React.Component {
 			};
 			if ( isMappedDomain( selectedDomain ) ) {
 				Object.assign( emptyContentProps, {
-					title: translate( 'G Suite is not supported on this domain yet.' ),
+					title: translate( 'G Suite is not supported on this domain' ),
 					line: translate(
 						'To enable G Suite on %(domain)s, please have its name servers changed to that of WordPress.com.',
 						{ args: { domain: selectedDomainName } }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Introduces:
- `isMappedDomainWithWpcomNameservers` which is an update to `isMappedDomain` that filters for mapped domains that are configured with WPcom nameservers

#### Testing instructions

_This PR **works** in collaboration with D33844-code._

- Attempt to replicate issue #36211 
- Confirm that you cannot purchase G Suite when domain is mapped and has not been configured with WordPress.com nameservers.
- You should see screen instead:

<img width="786" alt="Screenshot 2019-10-24 at 5 07 10 AM" src="https://user-images.githubusercontent.com/277661/67452766-329a4900-f61c-11e9-92ef-47b64dbc22b7.png">

