### PR TITLE
Take two: Premium plan bump test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,7 +135,7 @@ export default {
 		localeTargets: 'any',
 	},
 	showPlanUpsellConcierge: {
-		datestamp: '20191010',
+		datestamp: '20191029',
 		variations: {
 			variantShowPlanBump: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -134,4 +134,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	showPlanUpsellConcierge: {
+		datestamp: '20191010',
+		variations: {
+			variantShowPlanBump: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -88,7 +88,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import getPreviousPath from 'state/selectors/get-previous-path.js';
 import config from 'config';
-// import { abtest } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/utils';
 import { isExternal } from 'lib/url';
@@ -882,9 +882,7 @@ export class Checkout extends React.Component {
 			analyticsPath = '/checkout/no-site';
 		}
 
-		if ( 'variantShowPlanBump' !== getABTestVariation( 'showPlanUpsellConcierge' ) ) {
-			abtest( 'showPlanUpsellConcierge' );
-		}
+		abtest( 'showPlanUpsellConcierge' );
 
 		if ( this.props.children ) {
 			this.props.setHeaderText( '' );

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -882,10 +882,6 @@ export class Checkout extends React.Component {
 			analyticsPath = '/checkout/no-site';
 		}
 
-		if ( hasPersonalPlan( this.props.cart ) ) {
-			abtest( 'showPlanUpsellConcierge' );
-		}
-
 		if ( this.props.children ) {
 			this.props.setHeaderText( '' );
 			return React.Children.map( this.props.children, child => {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -429,6 +429,18 @@ export class Checkout extends React.Component {
 		return;
 	}
 
+	maybeShowPlanBumpOfferConcierge( receiptId ) {
+		const { cart, selectedSiteSlug } = this.props;
+
+		if ( hasPersonalPlan( cart ) ) {
+			if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellConcierge' ) ) {
+				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
+			}
+		}
+
+		return;
+	}
+
 	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
 		const { cart, selectedSiteSlug, previousRoute } = this.props;
 
@@ -443,6 +455,11 @@ export class Checkout extends React.Component {
 			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
 			! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-plan-upgrade` )
 		) {
+			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId );
+			if ( upgradePath ) {
+				return upgradePath;
+			}
+
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
 
@@ -863,6 +880,10 @@ export class Checkout extends React.Component {
 			analyticsProps = { site: selectedSiteSlug };
 		} else {
 			analyticsPath = '/checkout/no-site';
+		}
+
+		if ( 'variantShowPlanBump' !== getABTestVariation( 'showPlanUpsellConcierge' ) ) {
+			abtest( 'showPlanUpsellConcierge' );
 		}
 
 		if ( this.props.children ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -882,7 +882,9 @@ export class Checkout extends React.Component {
 			analyticsPath = '/checkout/no-site';
 		}
 
-		abtest( 'showPlanUpsellConcierge' );
+		if ( hasPersonalPlan( this.props.cart ) ) {
+			abtest( 'showPlanUpsellConcierge' );
+		}
 
 		if ( this.props.children ) {
 			this.props.setHeaderText( '' );

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -42,7 +42,7 @@ export class ConciergeQuickstartSession extends PureComponent {
 				<PageViewTracker
 					path={ pageViewTrackerPath }
 					title={ title }
-					properties={ { isLoggedIn: isLoggedIn } }
+					properties={ { is_logged_in: isLoggedIn } }
 				/>
 				<DocumentHead title={ title } />
 				{ receiptId ? (

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -22,17 +22,27 @@ import './style.scss';
 
 export class ConciergeQuickstartSession extends PureComponent {
 	render() {
-		const { receiptId, translate } = this.props;
+		const { receiptId, translate, siteSlug, isLoggedIn } = this.props;
 
 		const title = translate( 'Checkout ‹ Quick Start Session', {
 			comment: '"Checkout" is the part of the site where a user is preparing to make a purchase.',
 		} );
 
+		let pageViewTrackerPath;
+		if ( receiptId ) {
+			pageViewTrackerPath = '/checkout/offer-quickstart-session/:receipt_id/:site';
+		} else if ( siteSlug ) {
+			pageViewTrackerPath = '/checkout/offer-quickstart-session/:site';
+		} else {
+			pageViewTrackerPath = '/checkout/offer-quickstart-session';
+		}
+
 		return (
 			<>
 				<PageViewTracker
-					path="/checkout/:site/offer-quickstart-session/:receipt_id"
+					path={ pageViewTrackerPath }
 					title={ title }
+					properties={ { isLoggedIn: isLoggedIn } }
 				/>
 				<DocumentHead title={ title } />
 				{ receiptId ? (

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -194,7 +194,7 @@ export class ConciergeQuickstartSession extends PureComponent {
 									{
 										components: { del: <del />, em: <em /> },
 										args: {
-											oldPrice: formatCurrency( fullCost, currencyCode ),
+											oldPrice: formatCurrency( fullCost, currencyCode, { stripZeros: true } ),
 											price: productDisplayCost,
 										},
 									}
@@ -208,7 +208,7 @@ export class ConciergeQuickstartSession extends PureComponent {
 										{
 											components: { b: <b />, em: <em /> },
 											args: {
-												oldPrice: formatCurrency( fullCost, currencyCode ),
+												oldPrice: formatCurrency( fullCost, currencyCode, { stripZeros: true } ),
 											},
 										}
 								  )

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
@@ -163,7 +163,7 @@ export class ConciergeSupportSession extends PureComponent {
 								'Reserve a 45-minute "Quick Start" appointment, and save %(saveAmount)s if you sign up today.',
 								{
 									args: {
-										saveAmount: formatCurrency( savings, currencyCode ),
+										saveAmount: formatCurrency( savings, currencyCode, { stripZeros: true } ),
 									},
 								}
 							) }
@@ -176,7 +176,7 @@ export class ConciergeSupportSession extends PureComponent {
 									{
 										components: { del: <del /> },
 										args: {
-											oldPrice: formatCurrency( fullCost, currencyCode ),
+											oldPrice: formatCurrency( fullCost, currencyCode, { stripZeros: true } ),
 											price: productDisplayCost,
 										},
 									}

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/index.jsx
@@ -28,9 +28,13 @@ export class ConciergeSupportSession extends PureComponent {
 			comment: '"Checkout" is the part of the site where a user is preparing to make a purchase.',
 		} );
 
+		const pageViewTrackerPath = receiptId
+			? '/checkout/offer-support-session/:receipt_id/:site'
+			: '/checkout/offer-support-session/:site';
+
 		return (
 			<>
-				<PageViewTracker path="/checkout/:site/offer-support-session/:receipt_id" title={ title } />
+				<PageViewTracker path={ pageViewTrackerPath } title={ title } />
 				<DocumentHead title={ title } />
 				{ receiptId ? (
 					<CompactCard className="concierge-support-session__card-header">

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -119,6 +119,7 @@ export class UpsellNudge extends React.Component {
 			isLoggedIn,
 			upsellType,
 			translate,
+			siteSlug,
 		} = this.props;
 
 		switch ( upsellType ) {
@@ -131,6 +132,7 @@ export class UpsellNudge extends React.Component {
 						isLoggedIn={ isLoggedIn }
 						receiptId={ receiptId }
 						translate={ translate }
+						siteSlug={ siteSlug }
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
 					/>
@@ -145,6 +147,7 @@ export class UpsellNudge extends React.Component {
 						isLoggedIn={ isLoggedIn }
 						receiptId={ receiptId }
 						translate={ translate }
+						siteSlug={ siteSlug }
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
 					/>

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -35,7 +35,10 @@ export class PlanUpgradeUpsell extends PureComponent {
 
 		return (
 			<>
-				<PageViewTracker path="/checkout/:site/plan-upgrade-nudge/:receipt_id" title={ title } />
+				<PageViewTracker
+					path="/checkout/:site/offer-plan-upgrade/:upgrade_item/:receipt_id"
+					title={ title }
+				/>
 				<DocumentHead title={ title } />
 				{ receiptId ? (
 					<CompactCard className="plan-upgrade-upsell__card-header">{ this.header() }</CompactCard>

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -154,7 +154,9 @@ export class PlanUpgradeUpsell extends PureComponent {
 								'But if you upgrade to a Premium plan with this special offer, you can enjoy the full collection of premium themes for just an additional %(discountPrice)s!',
 								{
 									args: {
-										discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode ),
+										discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
+											stripZeros: true,
+										} ),
 									},
 								}
 							) }
@@ -220,8 +222,10 @@ export class PlanUpgradeUpsell extends PureComponent {
 										components: { del: <del /> },
 										args: {
 											bundleValue: formatCurrency( bundleValue, currencyCode, { precision: 0 } ),
-											fullPrice: formatCurrency( planRawPrice, currencyCode ),
-											discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode ),
+											fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
+											discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
+												stripZeros: true,
+											} ),
 										},
 									}
 								) }

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -66,8 +66,8 @@ export class PlanUpgradeUpsell extends PureComponent {
 	body() {
 		const { translate, planRawPrice, planDiscountedRawPrice, currencyCode } = this.props;
 		const bundleValue = planRawPrice * 77;
-		const premiumThemePriceLow = planDiscountedRawPrice * 1.37;
-		const premiumThemePriceHigh = planDiscountedRawPrice * 2.75;
+		const premiumThemePriceLow = planRawPrice * 0.73;
+		const premiumThemePriceHigh = planRawPrice * 1.045;
 		return (
 			<>
 				<h2 className="plan-upgrade-upsell__header">
@@ -120,7 +120,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								"That's exactly why we've partnered with some of the world's greatest designers to offer nearly 200 high-end designs that you can use to make your site look incredible."
+								"That's exactly why we've partnered with some of the world's greatest designers to offer over 250 high-end designs that you can use to make your site look incredible."
 							) }
 						</p>
 						<p>
@@ -135,7 +135,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								'Normally, each of these WordPress themes {{b}}costs between %(premiumThemePriceLow)s and %(premiumThemePriceHigh)s or more{{/b}}.',
+								'Typically, this type of high-end WordPress theme {{b}}costs an average of %(premiumThemePriceLow)s, with some going as high as %(premiumThemePriceHigh)s and more{{/b}}.',
 								{
 									args: {
 										premiumThemePriceLow: formatCurrency( premiumThemePriceLow, currencyCode, {
@@ -151,7 +151,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								'But if you upgrade to a Premium plan with this special offer, you can enjoy the full collection of premium themes for just an additional %(discountPrice)s!',
+								'But if you upgrade to a Premium plan with this special offer, you will get our full collection of over 250 premium themes for just an additional %(discountPrice)s!',
 								{
 									args: {
 										discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
@@ -217,7 +217,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 						<p>
 							<b>
 								{ translate(
-									'Upgrade to the Premium plan and access nearly 200 premium themes for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more.',
+									'Upgrade to the Premium plan and access over 250 premium themes for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more.',
 									{
 										components: { del: <del /> },
 										args: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bring back the plan bump test, originally implemented in https://github.com/Automattic/wp-calypso/pull/35134 and then turned off in https://github.com/Automattic/wp-calypso/pull/36292 due to discrepancies in the test results.

* The plan bump test shows an upsell nudge to upgrade to the Premium plan after a user has completed purchase of a Personal plan.

* The plan upgrade offer looks like this:

<img src="https://user-images.githubusercontent.com/1269602/61631074-02eb4600-aca7-11e9-9bd4-4ffac7fe3b1c.png" >

* We retired the previous test due to discrepancies in the AB test results, as described in pa1C6h-z7-p2.

* We are hoping that running only one test at a time, ~along with early bucketing(i.e invoking the `abtest_start` event much before the redirect by firing it when the user sees the checkout form [as implemented here](https://github.com/Automattic/wp-calypso/pull/36655/files#diff-199e3967ae413c2ff48db966abbf8386R879)) might help resolve the issue.~ 

* There are a couple of other minor fixes gone in:
    - The PageViewTracker paths in all the offer pages had old values which were wrong, so updated them with the most current URL paths.
    - Strip zeros from the offer pages for better readability.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1** _(Testing behaviour of `showPlanUpsellConcierge` A/B test)_

* Signup for a new account from http://calypso.localhost:3000/start.
* Add a Personal plan to cart and complete the purchase
* Verify the following:
    - That you are shown the premium upgrade upsell if on the `variantShowPlanBump` variation of `showPlanUpsellConcierge` test.
    - That you are shown the concierge upsell if on the `control` variation of `showPlanUpsellConcierge` test.

If on the plan upsell nudge, verify the following:
- Clicking the `No thanks ...` button should take you to the checklist page.
- Clicking the `Yes, I'd love to try ....` button should take you to the checkout page with the Premium plan added to cart and **credits applied**. Verify that after you complete the purchase, you are **not shown the concierge upsell** but instead taken to the checklist page.

If on the concierge upsell nudge, verify the following:
- Clicking Skip on the nudge should take you to checklist.
- Clicking Accept on the nudge, and completing the concierge session purchase should take you checklist. _**No more upsell nudges should be shown**_.

**Scenario 2** (Test that the offer is shown when upgrading from a lower tier plan to Personal)
* Login to a site having a Free or Blogger plan, go to /plans page and upgrade to Personal
* After purchase completes, verify the following:
    - That you are shown the premium upgrade upsell if on the `variantShowPlanBump` variation of `showPlanUpsellConcierge` test.
    - That you are shown the concierge upsell if on the `control` variation of `showPlanUpsellConcierge` test.
In both cases above, complete the upsell purchase and verify that you are not show any more upsell nudges.

**Scenario 3** 
* Verify status quo i.e current behaviour is maintained for non-Personal plan purchases.
* Add a Premium plan to cart and complete signup. Verify that only the concierge upsell nudge is shown. In browser console, type `localStorage.ABTests;` and verify that it does not list the `showPlanUpsellConcierge` test. 

