### PR TITLE
Move dialog in EditGravatar.

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -190,7 +190,6 @@ export class EditGravatar extends Component {
 					{ this.state.showEmailVerificationNotice && (
 						<VerifyEmailDialog onClose={ this.closeVerifyEmailDialog } />
 					) }
-					{ this.renderImageEditor() }
 					<FilePicker accept="image/*" onPick={ this.onReceiveFile }>
 						<div
 							data-tip-target="edit-gravatar"
@@ -215,6 +214,7 @@ export class EditGravatar extends Component {
 						</div>
 					</FilePicker>
 				</div>
+				{ this.renderImageEditor() }
 				<div>
 					<p className="edit-gravatar__explanation">
 						{ translate( 'Your profile photo is public.' ) }


### PR DESCRIPTION
The image editor dialog in `EditGravatar` was being placed inside of an unrelated part of the render tree, that dealt with unverified emails.
Not only did this not make a lot of sense, it could lead to issues when #32899 gets merged, due to the parent element having a click handler.

This change moves the dialog to a more sensible part of the render tree.

#### Changes proposed in this Pull Request

* Move image editor dialog in `EditGravatar`.

#### Testing instructions

* Go to `/me`
* Click "Click to edit photo"
* Upload an image
* Ensure that the image editor dialog is shown and works correctly.
