### PR TITLE
Fix missing login events, pull in analytics middleware and reducer

### DIFF
--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -10,6 +10,8 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import config from 'config';
+import analytics from 'lib/analytics';
+import superProps from 'lib/analytics/super-props';
 import { setCurrentUser } from 'state/current-user/actions';
 import setRouteAction from 'state/ui/actions/set-route';
 
@@ -100,8 +102,21 @@ const setRouteMiddleware = reduxStore => {
 	} );
 };
 
+const setAnalyticsMiddleware = ( currentUser, reduxStore ) => {
+	analytics.setDispatch( reduxStore.dispatch );
+
+	if ( currentUser.get() ) {
+		// When logged in the analytics module requires user and superProps objects
+		// Inject these here
+		analytics.initialize( currentUser, superProps );
+	} else {
+		analytics.setSuperProps( superProps );
+	}
+};
+
 export function setupMiddlewares( currentUser, reduxStore ) {
 	setupContextMiddleware( reduxStore );
 	setRouteMiddleware( reduxStore );
+	setAnalyticsMiddleware( currentUser, reduxStore );
 	renderDevHelpers( reduxStore );
 }

--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -8,8 +8,10 @@ import thunkMiddleware from 'redux-thunk';
  * Internal dependencies
  */
 import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
+import analyticsMiddleware from 'state/analytics/middleware';
 import { reducer as httpData, enhancer as httpDataEnhancer } from 'state/data-layer/http-data';
 import { combineReducers } from 'state/utils';
+import analytics from 'state/analytics/reducer';
 import application from 'state/application/reducer';
 import documentHead from 'state/document-head/reducer';
 import login from 'state/login/reducer';
@@ -27,6 +29,7 @@ import oauth2Clients from 'state/oauth2-clients/reducer';
 
 // Create Redux store
 const reducer = combineReducers( {
+	analytics,
 	application,
 	documentHead,
 	httpData,
@@ -51,5 +54,8 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 export default () =>
 	createStore(
 		reducer,
-		composeEnhancers( httpDataEnhancer, applyMiddleware( thunkMiddleware, wpcomApiMiddleware ) )
+		composeEnhancers(
+			httpDataEnhancer,
+			applyMiddleware( thunkMiddleware, wpcomApiMiddleware, analyticsMiddleware )
+		)
 	);


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Fixes bug from #33642 which caused us to stop sending tracking events from the separated login entry point.

#### Testing instructions

* Enable debug logging for analytics with `localStorage.debug = 'calypso:analytics:*'` in the console
* Load http://calypso.localhost:3000/log-in
* Verify that tracks events are being logged to the console

Follow on from #33642

cc @sgomes @jsnajdr 
