### PR TITLE
Full Site Editing: Update the Navigation Menu fallback page ordering

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -63,7 +63,7 @@ function get_fallback_navigation_menu() {
 			'container'   => 'ul',
 			'echo'        => false,
 			'menu_class'  => 'main-menu footer-menu',
-			'sort_column' => 'post_date',
+			'sort_column' => 'menu_order, post_date',
 		]
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the sorting of the Full Site Editing's Navigation Menu fallback from `post_date` to `menu_order, post_date`, to order it by the page's order attribute if set, or by date otherwise.

The FSE Navigation Menu block has various display mode.
If a Primary menu is defined, it uses that. Otherwise it falls back to a simple list of all published pages.
This fallback currently only sorts by date, but we should honour the page's order attribute if the user has set it.

#### Testing instructions

* Apply this PR on an FSE site.
* If needed, open the Menu page (`/wp-admin/nav-menus.php`) and remove any menu from the Primary location.
* Open the Pages List (`/wp-admin/edit.php?post_type=page`) and set the order of one or more pages. A good way to test this would be to pick a page that normally appears at the beginning of the Navigation Menu block, and set its order to a very large number so that it would end up last.

<img width="815" alt="Screenshot 2019-10-10 at 19 10 06" src="https://user-images.githubusercontent.com/2070010/66594760-a9056880-eb91-11e9-844b-9821af606c3f.png">

* Open the front end and make sure the pages in the Navigation Menu are ordered as expected.

Fixes #35547
