### PR TITLE
Remove domain suggestion provider A/B Test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,15 +98,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	domainSuggestionsEn: {
-		datestamp: '20191003',
-		variations: {
-			control: 50,
-			test: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	verticalSuggestedThemes: {
 		datestamp: '20191011',
 		variations: {

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,17 +1,5 @@
 /** @format */
-/**
- * Internal dependencies
- */
-import { abtest, isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
-	if ( isUsingGivenLocales( [ 'en' ] ) ) {
-		if ( abtest( 'domainSuggestionsEn' ) === 'test' ) {
-			return 'variation2_front';
-		}
-
-		return 'variation_front';
-	}
-
 	return 'variation2_front';
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ending abtest added in #36445 and defaulting to new provider.

#### Testing instructions

* Visit http://calypso.localhost:3000/domains/add
* Make sure the /suggestions endpoint has the `variation2_front` vendor
