### PR TITLE
Logo Tool: Updates url to use wp.me short link

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -272,7 +272,7 @@ class Home extends Component {
 								iconSrc="/calypso/images/customer-home/images.svg"
 							/>
 							<ActionBox
-								href="https://logojoy.grsm.io/looka"
+								href="https://wp.me/logo-maker"
 								onClick={ () => trackAction( 'my_site', 'design_logo' ) }
 								label={ translate( 'Design a logo' ) }
 								iconSrc="/calypso/images/customer-home/logo.svg"

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -48,8 +48,8 @@ import StatsBanners from 'my-sites/stats/stats-banners';
  */
 import './style.scss';
 
-const ActionBox = ( { href, onClick, iconSrc, label } ) => {
-	const buttonAction = { href, onClick };
+const ActionBox = ( { href, onClick, target, iconSrc, label } ) => {
+	const buttonAction = { href, onClick, target };
 	return (
 		<div className="customer-home__box-action">
 			<Button { ...buttonAction }>
@@ -274,6 +274,7 @@ class Home extends Component {
 							<ActionBox
 								href="https://wp.me/logo-maker"
 								onClick={ () => trackAction( 'my_site', 'design_logo' ) }
+								target="_blank"
 								label={ translate( 'Design a logo' ) }
 								iconSrc="/calypso/images/customer-home/logo.svg"
 							/>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -77,7 +77,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					<Button
 						compact
 						onClick={ handleCreateALogoClick }
-						href="http://logojoy.grsm.io/looka"
+						href="https://wp.me/logo-maker"
 						target="_blank"
 					>
 						{ translate( 'Create A Logo' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Updates the logo tool link to use the wp.me short link (https://wp.me/logo-maker) so that it's easier to update across Calpyso and wpcom
- Opens the logo maker in a new window tab from Customer Home

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Marketing tools**

* Visit `/marketing/tools/{site}` and click on "Create a logo"

**Customer Home**

- Create a new site (or with a recently created site), add your user to the `show` group of the `customerHomePage` a/b test.
- Visit `/home/{site}` and complete the checklist, if needed
- Click on "Design a logo"

In both cases, the link should open `https://wp.me/logo-maker`, which then redirects to `https://looka.com/wordpress-looka/`
