### PR TITLE
FSE: Sideload images on template insertion

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -44,6 +44,7 @@ function load_full_site_editing() {
 	require_once __DIR__ . '/full-site-editing/templates/class-rest-templates-controller.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
+	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/serialize-block-fallback.php';
 
 	Full_Site_Editing::get_instance();
@@ -178,6 +179,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_starter_page_templates' );
  */
 function populate_wp_template_data() {
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
+	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 
 	$fse = Full_Site_Editing::get_instance();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Full site editing file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class WP_Template_Inserter
+ */
+class Template_Image_Inserter {
+	/**
+	 * Upload any images passed in params into the media library.
+	 * At the same time, check if created post content contains the URL so we can
+	 * replace the URL with the user's blog's uploaded image URL.
+	 *
+	 * @param array $urls  URLs of images from the annotation files.
+	 * @param array $posts An array of posts to update with new images.
+	 */
+	public function copy_images_and_update_posts( $urls = [], $posts = [] ) {
+		if ( empty( $urls ) || empty( $created_posts ) ) {
+			return;
+		}
+
+		$images = upload_images( $urls );
+		foreach ( $posts as $post ) {
+			update_post_images( $post, $images );
+		}
+	}
+
+	/**
+	 * Upload an array of images to the media library.
+	 *
+	 * @param array $image_urls Images URLs to upload.
+	 * @return array Each entry contains the old and new URL of the image.
+	 */
+	public function upload_images( $image_urls ) {
+		return array_reduce(
+			$image_urls,
+			function( $total, $url ) {
+				$local_url = $this->upload_image( $url );
+				if ( $local_url ) {
+					$total[] = [
+						'old_url' => $url,
+						'new_url' => $local_url,
+					];
+				} else {
+					do_action(
+						'a8c_fse_log',
+						'image_sideload_failure',
+						[
+							'context'   => 'Template_Image_Inserter->upload_images',
+							'error'     => 'Issue uploading the image',
+							'image_url' => $url,
+						]
+					);
+				}
+				return $total;
+			},
+			[]
+		);
+	}
+
+	/**
+	 * Upload an image URL.
+	 *
+	 * @param string $image_url The URL to download then upload.
+	 * @return string|WP_Error  The local URL of the uploaded image.
+	 */
+	public function upload_image( $image_url ) {
+		if ( ! function_exists( 'media_handle_sideload' ) ) {
+			require_once ABSPATH . '/wp-admin/includes/file.php';
+			require_once ABSPATH . '/wp-admin/includes/media.php';
+			require_once ABSPATH . '/wp-admin/includes/image.php';
+		}
+
+		$file_name = basename( wp_parse_url( $image_url, PHP_URL_PATH ) );
+		$tmp       = download_url( $image_url );
+
+		$desc       = 'Placeholder Image';
+		$file_array = array(
+			'name'     => $file_name,
+			'tmp_name' => $tmp,
+		);
+
+		if ( is_wp_error( $tmp ) ) {
+			return;
+		}
+
+		$id = media_handle_sideload( $file_array, 0, $desc );
+
+		if ( is_wp_error( $id ) ) {
+			return;
+		}
+
+		return wp_get_attachment_url( $id );
+	}
+
+	/**
+	 * Upload an image URL.
+	 *
+	 * @param array $post   The post which should be updated with the new URLs.
+	 * @param array $images An array of old/new image URLs to replace.
+	 */
+	public function update_post_images( $post, $images ) {
+		$content = $post->post_content;
+		foreach ( $images as $image ) {
+			$content = str_replace( $image['old_url'], $image['new_url'], $content );
+		}
+
+		$res = wp_update_post(
+			[
+				'ID'           => $post->ID,
+				'post_content' => $content,
+			]
+		);
+
+		if ( ! $res ) {
+			do_action(
+				'a8c_fse_log',
+				'update_post_with_new_image',
+				[
+					'context' => 'Template_Image_Inserter->update_post_images',
+					'error'   => 'Issue updating the post with the new image URLs.',
+				]
+			);
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
@@ -12,50 +12,75 @@ namespace A8C\FSE;
  */
 class Template_Image_Inserter {
 	/**
-	 * Upload any images passed in params into the media library.
-	 * At the same time, check if created post content contains the URL so we can
-	 * replace the URL with the user's blog's uploaded image URL.
+	 * Uploads specific images to the media libraray
 	 *
-	 * @param array $urls  URLs of images from the annotation files.
-	 * @param array $posts An array of posts to update with new images.
+	 * It then checks if any of the passed image URLs are also in the post content
+	 * of any of the passed post IDs. If so, then the post content is updated to
+	 * use the new local URL instead of the passed URL.
+	 *
+	 * @param array $img_urls URLs of images which should be uploaded.
+	 * @param array $post_ids An array of posts IDs which should be updated with newly uploaded image URLs.
 	 */
-	public function copy_images_and_update_posts( $urls = [], $posts = [] ) {
-		if ( empty( $urls ) || empty( $created_posts ) ) {
+	public function copy_images_and_update_posts( $img_urls = [], $post_ids = [] ) {
+		do_action(
+			'a8c_fse_log',
+			'template_image_sideload_begin',
+			[
+				'context'    => 'Template_Image_Inserter->copy_images_and_update_posts',
+				'image_urls' => $img_urls,
+			]
+		);
+
+		if ( empty( $img_urls ) || empty( $post_ids ) ) {
 			return;
 		}
 
-		$images = upload_images( $urls );
-		foreach ( $posts as $post ) {
-			update_post_images( $post, $images );
+		$images = $this->upload_images( $img_urls );
+		foreach ( $post_ids as $id ) {
+			$this->update_post_images( $id, $images );
 		}
 	}
 
 	/**
 	 * Upload an array of images to the media library.
 	 *
-	 * @param array $image_urls Images URLs to upload.
-	 * @return array Each entry contains the old and new URL of the image.
+	 * If an file fails to upload, the error is logged to the FSE error handler.
+	 *
+	 * @param  array $image_urls Images URLs to upload.
+	 * @return array Each entry contains the old and new URL of an image if successfully uploaded.
 	 */
 	public function upload_images( $image_urls ) {
 		return array_reduce(
 			$image_urls,
 			function( $accumulator, $url ) {
+				// 1. Attempt to sideload the image and get the local URL.
 				$local_url = $this->upload_image( $url );
-				if ( $local_url ) {
-					$accumulator[] = [
-						'old_url' => $url,
-						'new_url' => $local_url,
-					];
-				} else {
+
+				// 2. Check if anything went wrong during upload.
+				$error_msg = null;
+				if ( is_wp_error( $local_url ) ) {
+					$error_msg = $local_url->get_error_message();
+				} elseif ( ! is_string( $local_url ) ) {
+					$error_msg = 'Issue uploading the image.';
+				}
+
+				// 3. If there was an error, report it.
+				if ( is_string( $error_msg ) ) {
 					do_action(
 						'a8c_fse_log',
 						'image_sideload_failure',
 						[
-							'context'   => 'Template_Image_Inserter->upload_images',
-							'error'     => 'Issue uploading the image',
-							'image_url' => $url,
+							'context'          => 'Template_Image_Inserter->upload_images',
+							'error'            => $error_msg,
+							'remote_image_url' => $url,
 						]
 					);
+				} else {
+					// 4. Otherwise, save the url.
+					$accumulator[] = [
+						'old_url' => $url,
+						'new_url' => $local_url,
+					];
 				}
 				return $accumulator;
 			},
@@ -64,10 +89,10 @@ class Template_Image_Inserter {
 	}
 
 	/**
-	 * Upload an image URL.
+	 * Sideload a remote image URL and return the local attachment URL.
 	 *
-	 * @param string $image_url The URL to download then upload.
-	 * @return string|WP_Error  The local URL of the uploaded image.
+	 * @param  string $image_url The URL to sideload to the local site.
+	 * @return string The local URL of the newly uploaded image.
 	 */
 	public function upload_image( $image_url ) {
 		if ( ! function_exists( 'media_handle_sideload' ) ) {
@@ -76,23 +101,24 @@ class Template_Image_Inserter {
 			require_once ABSPATH . '/wp-admin/includes/image.php';
 		}
 
-		$file_name = basename( wp_parse_url( $image_url, PHP_URL_PATH ) );
-		$tmp       = download_url( $image_url );
-
-		$desc       = 'Placeholder Image';
-		$file_array = array(
-			'name'     => $file_name,
-			'tmp_name' => $tmp,
-		);
-
-		if ( is_wp_error( $tmp ) ) {
-			return;
+		// 1. Download the image.
+		$local_file = download_url( $image_url );
+		if ( is_wp_error( $local_file ) ) {
+			return $local_file;
 		}
 
-		$id = media_handle_sideload( $file_array, 0, $desc );
+		// 2. Create a file object.
+		$file_name  = basename( wp_parse_url( $image_url, PHP_URL_PATH ) );
+		$desc       = 'Template Part Image';
+		$file_array = array(
+			'name'     => $file_name,
+			'tmp_name' => $local_file,
+		);
 
+		// 3. Sideload and return the local URL.
+		$id = media_handle_sideload( $file_array, 0, $desc );
 		if ( is_wp_error( $id ) ) {
-			return;
+			return $id;
 		}
 
 		return wp_get_attachment_url( $id );
@@ -101,18 +127,31 @@ class Template_Image_Inserter {
 	/**
 	 * Upload an image URL.
 	 *
-	 * @param array $post   The post which should be updated with the new URLs.
-	 * @param array $images An array of old/new image URLs to replace.
+	 * @param  array $post_id The post ID which should be updated with the new URLs.
+	 * @param  array $images  An array of old/new image URLs to replace.
 	 */
-	public function update_post_images( $post, $images ) {
-		$content = $post->post_content;
+	public function update_post_images( $post_id, $images ) {
+		$content = get_post_field( 'post_content', $post_id );
+		if ( empty( $content ) ) {
+			do_action(
+				'a8c_fse_log',
+				'update_post_with_new_images_get_post_failure',
+				[
+					'context' => 'Template_Image_Inserter->update_post_images',
+					'error'   => 'Could not retrieve post content.',
+					'post_id' => $post_id,
+				]
+			);
+			return;
+		}
+
+		// Replace the matching images in the content and update the post.
 		foreach ( $images as $image ) {
 			$content = str_replace( $image['old_url'], $image['new_url'], $content );
 		}
-
 		$res = wp_update_post(
 			[
-				'ID'           => $post->ID,
+				'ID'           => $post_id,
 				'post_content' => $content,
 			]
 		);
@@ -120,10 +159,11 @@ class Template_Image_Inserter {
 		if ( ! $res ) {
 			do_action(
 				'a8c_fse_log',
-				'update_post_with_new_image',
+				'update_post_with_new_images_update_postfailure',
 				[
-					'context' => 'Template_Image_Inserter->update_post_images',
-					'error'   => 'Issue updating the post with the new image URLs.',
+					'context'    => 'Template_Image_Inserter->update_post_images',
+					'error'      => 'Issue updating the post with the new image URLs.',
+					'image_urls' => $images,
 				]
 			);
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
@@ -159,7 +159,7 @@ class Template_Image_Inserter {
 		if ( ! $res ) {
 			do_action(
 				'a8c_fse_log',
-				'update_post_with_new_images_update_postfailure',
+				'update_post_with_new_images_update_post_failure',
 				[
 					'context'    => 'Template_Image_Inserter->update_post_images',
 					'error'      => 'Issue updating the post with the new image URLs.',

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
@@ -8,7 +8,7 @@
 namespace A8C\FSE;
 
 /**
- * Class WP_Template_Inserter
+ * Class Template_Image_Inserter
  */
 class Template_Image_Inserter {
 	/**
@@ -39,10 +39,10 @@ class Template_Image_Inserter {
 	public function upload_images( $image_urls ) {
 		return array_reduce(
 			$image_urls,
-			function( $total, $url ) {
+			function( $accumulator, $url ) {
 				$local_url = $this->upload_image( $url );
 				if ( $local_url ) {
-					$total[] = [
+					$accumulator[] = [
 						'old_url' => $url,
 						'new_url' => $local_url,
 					];
@@ -57,7 +57,7 @@ class Template_Image_Inserter {
 						]
 					);
 				}
-				return $total;
+				return $accumulator;
 			},
 			[]
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-template-image-inserter.php
@@ -110,13 +110,16 @@ class Template_Image_Inserter {
 		// 2. Create a file object.
 		$file_name  = basename( wp_parse_url( $image_url, PHP_URL_PATH ) );
 		$desc       = 'Template Part Image';
-		$file_array = array(
+		$file_array = [
 			'name'     => $file_name,
 			'tmp_name' => $local_file,
-		);
+		];
 
-		// 3. Sideload and return the local URL.
+		// 3. Sideload, remove tmp file, and return the local URL.
 		$id = media_handle_sideload( $file_array, 0, $desc );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@unlink( $local_file );
+
 		if ( is_wp_error( $id ) ) {
 			return $id;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -256,6 +256,8 @@ class WP_Template_Inserter {
 		// parts can work with the remote URLs even if this fails.
 		$image_urls = $this->image_urls;
 		if ( ! empty( $image_urls ) ) {
+			$image_inserter = new Template_Image_Inserter();
+			$image_inserter->copy_images_and_update_posts( $image_urls, [ $header_id, $footer_id ] );
 			do_action( 'a8c_fse_upload_template_part_images', $image_urls, [ $header_id, $footer_id ] );
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -258,7 +258,6 @@ class WP_Template_Inserter {
 		if ( ! empty( $image_urls ) ) {
 			$image_inserter = new Template_Image_Inserter();
 			$image_inserter->copy_images_and_update_posts( $image_urls, [ $header_id, $footer_id ] );
-			do_action( 'a8c_fse_upload_template_part_images', $image_urls, [ $header_id, $footer_id ] );
 		}
 
 		do_action(

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -256,8 +256,14 @@ class WP_Template_Inserter {
 		// parts can work with the remote URLs even if this fails.
 		$image_urls = $this->image_urls;
 		if ( ! empty( $image_urls ) ) {
-			$image_inserter = new Template_Image_Inserter();
-			$image_inserter->copy_images_and_update_posts( $image_urls, [ $header_id, $footer_id ] );
+			// Uploading images locally does not work in the WordPress.com environment,
+			// so we use an action to handle it with Headstart there.
+			if ( has_action( 'a8c_fse_upload_template_part_images' ) ) {
+				do_action( 'a8c_fse_upload_template_part_images', $image_urls, [ $header_id, $footer_id ] );
+			} else {
+				$image_inserter = new Template_Image_Inserter();
+				$image_inserter->copy_images_and_update_posts( $image_urls, [ $header_id, $footer_id ] );
+			}
 		}
 
 		do_action(


### PR DESCRIPTION
This approach has been updated since D33903-code. In that approach, we used an action to call existing image uploading code which lives on dotcom. The advantage of this approach is that it works on local sites, which means it should work on Atomic as well. The other approach would only work for Simple sites.

### Changes proposed in this Pull Request
1. Create a class for inserting images and updating post content if images match.
2. Use that class to handle image insertion from the template part API.

### Testing instructions (Local Sites)
1. Pull this code to your local WordPress environment.
2. Deactivate the Full Site Editing plugin. 
3. Edit this function to `return false;`
4. Activate the FSE plugin.
5. Go to http://localhost:8889/wp-admin/edit.php?post_type=wp_template_part (whatever localhost port you're running on, anyways.)
6. Open the most recently created header template part. Inspect the logo image block and make sure the Maywood logo URL points to localhost.

<img width="759" alt="Screen Shot 2019-10-14 at 5 29 39 PM" src="https://user-images.githubusercontent.com/6265975/66791252-37d2f780-eea8-11e9-995a-df131d93f663.png">

7. Open the media library and make sure the Maywood logo shows up there.


### Testing instructions (Simple Sites)

1. Build this FSE PR and sync it to the 0.12 version folder on your sandbox. Also apply D33903-code to your sandbox.
2. Sandbox the site URL you're about to create on Horizon in advance.
3. Create a new user at horizon.wordpress.com/start/test-fse
4. Choose business and go through the steps.
5. Edit the header and make sure image src points to the local site (see above screenshot)
6. Verify that the Maywood logo shows up in the media library.

Fixes #35911 