### PR TITLE
Checklist: Update the check for the site having a Store

### DIFF
--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -18,7 +18,7 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
  */
 export default function isEligibleForDotcomChecklist( state, siteId ) {
 	const siteOptions = getSiteOptions( state, siteId );
-	const designType = get( siteOptions, 'design_type' );
+	const isWpComStore = get( siteOptions, 'is_wpcom_store' );
 	const createdAt = get( siteOptions, 'created_at', '' );
 
 	// Checklist should not show up if the site is created before the feature was launched.
@@ -34,5 +34,5 @@ export default function isEligibleForDotcomChecklist( state, siteId ) {
 		return false;
 	}
 
-	return 'store' !== designType;
+	return ! isWpComStore;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The selector which checks for eligibility for the checklist, was
checking if the site had a store by using the `design_type` option. This
was found to be unreliable and was sometimes `null` on sites with a
store.

This change updates the check to use the `is_wpcom_store` option which
is derived from a check to see if Woocommerce is installed on an Atomic
site.

#### Testing instructions

- Create an Atomic site (or use one created since 6th August 2019), and add a store to it.
- Check the site options and if the `design_type` isn't `null` update it so that it is.
- You should see either the Checklist or My Home option in the sidebar.
- Using this branch, that option should be removed.
