### PR TITLE
Full Site Editing: Update Site Title block attributes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -1,17 +1,29 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
 import classNames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PlainText } from '@wordpress/editor';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	FontSizePicker,
+	InspectorControls,
+	PanelColorSettings,
+	RichText,
+	withColors,
+	withFontSizes,
+} from '@wordpress/block-editor';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
-import { ENTER } from '@wordpress/keycodes';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -19,15 +31,22 @@ import { ENTER } from '@wordpress/keycodes';
 import useSiteOptions from '../useSiteOptions';
 
 function SiteTitleEdit( {
+	attributes,
 	className,
 	createErrorNotice,
-	shouldUpdateSiteOption,
+	fontSize,
+	insertDefaultBlock,
 	isSelected,
 	setAttributes,
-	isLocked,
-	insertDefaultBlock,
+	setFontSize,
+	setTextColor,
+	shouldUpdateSiteOption,
+	textColor,
 } ) {
+	const { textAlign } = attributes;
+
 	const inititalTitle = __( 'Site title loading…' );
+
 	const { siteOptions, handleChange } = useSiteOptions(
 		'title',
 		inititalTitle,
@@ -39,31 +58,60 @@ function SiteTitleEdit( {
 
 	const { option } = siteOptions;
 
-	const onKeyDown = event => {
-		if ( event.keyCode !== ENTER ) {
-			return;
-		}
-		event.preventDefault();
-		if ( ! isLocked ) {
-			insertDefaultBlock();
-		}
-	};
-
 	return (
 		<Fragment>
-			<PlainText
-				className={ classNames( 'site-title', className ) }
-				value={ option }
-				onChange={ value => handleChange( value ) }
-				onKeyDown={ onKeyDown }
-				placeholder={ __( 'Add a Site Title' ) }
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ nextAlign => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
+					<FontSizePicker onChange={ setFontSize } value={ fontSize.size } />
+				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color Settings' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color' ),
+						},
+					] }
+				/>
+			</InspectorControls>
+			<RichText
+				allowedFormats={ [] }
 				aria-label={ __( 'Site Title' ) }
+				className={ classNames( 'site-title', className, {
+					'has-text-color': textColor.color,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
+					[ textColor.class ]: textColor.class,
+					[ fontSize.class ]: fontSize.class,
+				} ) }
+				identifier="content"
+				onChange={ value => handleChange( value ) }
+				onReplace={ insertDefaultBlock }
+				onSplit={ noop }
+				placeholder={ __( 'Add a Site Title' ) }
+				style={ {
+					color: textColor.color,
+					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+				} }
+				tagName="h1"
+				value={ option }
 			/>
 		</Fragment>
 	);
 }
 
 export default compose( [
+	withColors( { textColor: 'color' } ),
+	withFontSizes( 'fontSize' ),
 	withSelect( ( select, { clientId } ) => {
 		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
 			'core/editor'

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.js
@@ -27,6 +27,23 @@ registerBlockType( 'a8c/site-title', {
 			type: 'string',
 			default: 'wide',
 		},
+		textAlign: {
+			type: 'string',
+			default: 'center',
+		},
+		textColor: {
+			type: 'string',
+		},
+		customTextColor: {
+			type: 'string',
+		},
+		fontSize: {
+			type: 'string',
+			default: 'normal',
+		},
+		customFontSize: {
+			type: 'number',
+		},
 	},
 	edit,
 	save: () => null,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.php
@@ -16,6 +16,8 @@ namespace A8C\FSE;
 function render_site_title_block( $attributes ) {
 	ob_start();
 
+	$styles = '';
+
 	$class = 'site-title wp-block-a8c-site-title';
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
@@ -27,8 +29,30 @@ function render_site_title_block( $attributes ) {
 	}
 	$class .= $align;
 
+	if ( isset( $attributes['textAlign'] ) ) {
+		$class .= ' has-text-align-' . $attributes['textAlign'];
+	} else {
+		$class .= ' has-text-align-center';
+	}
+
+	if ( isset( $attributes['textColor'] ) ) {
+		$class .= ' has-text-color';
+		$class .= ' has-' . $attributes['textColor'] . '-color';
+	} elseif ( isset( $attributes['customTextColor'] ) ) {
+		$class  .= ' has-text-color';
+		$styles .= ' color: ' . $attributes['customTextColor'] . ';';
+	}
+
+	if ( isset( $attributes['fontSize'] ) ) {
+		$class .= ' has-' . $attributes['fontSize'] . '-font-size';
+	} elseif ( isset( $attributes['customFontSize'] ) ) {
+		$styles .= ' font-size: ' . $attributes['customFontSize'] . 'px;';
+	} else {
+		$class .= ' has-normal-font-size';
+	}
+
 	?>
-	<h1 class="<?php echo esc_attr( $class ); ?>">
+	<h1 class="<?php echo esc_attr( $class ); ?>" style="<?php echo esc_attr( $styles ); ?>">
 		<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
 	</h1>
 	<!-- a8c:site-title -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `PlainText` with `RichText` in the Full Site Editing's Site Title block.
* Add visual styling attributes:
  - Text alignment (separate from block alignment)
  - Font size (predefined list and custom)
  - Text color (palette and custom)

This change, along with https://github.com/Automattic/wp-calypso/pull/36588 and https://github.com/Automattic/themes/pull/1500, removes the hardcoded styling of the Site Title and Description blocks, allowing the user to customize them in the Block Editor, in roughly the same way as the Heading and Paragraph block respectively.

#### Notes

While for the Site Description block I've replicated all text and color attributes of the Paragraph block, in this case I had to adapt it a bit.

Heading doesn't have the background color attribute and I've chosen to not add it to the Site Title block as well.
I don't have any strong opinions about it, but I'm sure that if Core chose to not have it on the Heading they had some good reasons, and I'd avoid creating a possible inconsistency between our and their Site Title block.

Heading has a tag selector (`h1` to `h6`) which doesn't make sense for the Site Title.
I've replaced it with a simple font size selector (which on the other hand doesn't make sense for the Heading block).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change on an FSE site.
* Edit a template and make sure the Site Title block has all the options listed above.
* If you also want to visually see all the changes, also apply https://github.com/Automattic/themes/pull/1500.
Otherwise, just check that the rendered block has all the expected classes and styles.

Fixes #36603