### PR TITLE
Reader: Tidy up visual alignment of headings

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -54,7 +54,7 @@
 	font-size: 17px;
 	font-weight: 700;
 	line-height: 1.4;
-	margin-top:-4px;
+	margin-top: -4px;
 	padding-left: 1px;
 	position: relative;
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -54,6 +54,7 @@
 	font-size: 17px;
 	font-weight: 700;
 	line-height: 1.4;
+	margin-top:-4px;
 	padding-left: 1px;
 	position: relative;
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -417,6 +417,7 @@
 
 .reader-post-card__title {
 	line-height: 1.4;
+	margin-top: -4px;
 	overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
Whilst the headings of posts in the reader are _technically_ aligned they don't look right visually when situated next to thumbnails. This PR changes the headings to be aligned visually to match images (when appropriate)

Fixes #33292.

#### Changes proposed in this Pull Request

* Adjust the top-margin of H1 titles in the reader to visually align with thunbnails

#### Testing instructions

Load the reader and check the alignment of different posts (depending on the number of thumbnails displayed.

Before:
<img width="802" alt="Screen Shot 2019-10-11 at 10 24 05 pm" src="https://user-images.githubusercontent.com/1842363/66647995-1be80f80-ec76-11e9-98ce-349ca01e2ca7.png">

After:
<img width="791" alt="Screen Shot 2019-10-11 at 10 24 41 pm" src="https://user-images.githubusercontent.com/1842363/66648037-391cde00-ec76-11e9-95e8-f66057bb0d88.png">


