### PR TITLE
FSE: Add transformation for Posts List block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */
@@ -6,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { Placeholder, RangeControl, PanelBody } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
+/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -69,7 +69,8 @@ registerBlockType( metadata.name, {
 				type: 'block',
 				blocks: [ 'newspack-blocks/homepage-articles' ],
 				transform: ( { postsPerPage } ) => {
-					// Configure the Newspack block to look the closest this one.
+					// Configure the Newspack block to look as close as possible
+					// to the output of this one.
 					return createBlock( 'newspack-blocks/homepage-articles', {
 						postsToShow: postsPerPage,
 						showAvatar: false,

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { Placeholder, RangeControl, PanelBody } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
@@ -61,4 +61,21 @@ registerBlockType( metadata.name, {
 		</Fragment>
 	),
 	save: () => null,
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'newspack-blocks/homepage-articles' ],
+				transform: ( { postsPerPage } ) => {
+					// Configure the Newspack block to look the closest this one.
+					return createBlock( 'newspack-blocks/homepage-articles', {
+						postsToShow: postsPerPage,
+						showAvatar: false,
+						displayPostDate: true,
+						displayPostContent: true,
+					} );
+				},
+			},
+		],
+	},
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Posts list block is slowly going away, this adds a way to transform it into the more powerful Newspack Homepage Articles block.
* It moves over the single configurable option — number of posts — and configures the rest of attributes to show the same stuff as posts list (date, author, excerpt)

#### Testing instructions

- Install Newspack Blocks on your site, following the readme https://github.com/automattic/newspack-blocks
  - if you don't want to setup the whole dev env right away, you can generate the plugin zip in the repo and install it on your site that way
- Insert "Blog Posts Listing" into the editor and configure the number of posts
- Preview the resulting page to see how posts show up
- Back in the editor, confirm you can see the transformation into NHA and use it
- Preview page again and confirm it still shows the same data (date, author, excerpt, in a list layout, with the amount of posts you've configured by the slider)

#### Screenshots

As tested with twenty nineteen…

| 📷 | Before | After |
| - | - | -
| Editor | <img width="733" alt="Screenshot 2019-10-11 at 14 41 27" src="https://user-images.githubusercontent.com/156676/66652144-3c43aa00-ec35-11e9-881f-d08ba8669632.png"> | <img width="755" alt="Screenshot 2019-10-11 at 14 41 21" src="https://user-images.githubusercontent.com/156676/66652156-45347b80-ec35-11e9-9c31-599f1c48292e.png">
| Frontend | <img width="757" alt="Screenshot 2019-10-11 at 14 39 56" src="https://user-images.githubusercontent.com/156676/66652166-4f567a00-ec35-11e9-9828-2cde918acb7a.png"> | <img width="814" alt="Screenshot 2019-10-11 at 14 40 05" src="https://user-images.githubusercontent.com/156676/66652180-57161e80-ec35-11e9-96b0-e47c78c8d4dc.png">


Transformation UI…

<img width="758" alt="Screenshot 2019-10-11 at 14 45 14" src="https://user-images.githubusercontent.com/156676/66652328-c55ae100-ec35-11e9-8019-9e59d360d591.png">
