### PR TITLE
Add WooCommerce Onboarding login/signup track events

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -186,21 +186,14 @@ export class LoginForm extends Component {
 
 	loginUser() {
 		const { password, usernameOrEmail } = this.state;
-		const { onSuccess, redirectTo, domain, isJetpackWooCommerceFlow } = this.props;
+		const { onSuccess, redirectTo, domain } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
-
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
-			this.props.recordTracksEvent( 'wcadmin_storeprofiler_login_jetpack_account', {
-				login_method: 'email',
-			} );
-		}
 
 		this.props
 			.loginUser( usernameOrEmail, password, redirectTo, domain )
 			.then( () => {
 				this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
-
 				onSuccess( redirectTo );
 			} )
 			.catch( error => {
@@ -271,11 +264,26 @@ export class LoginForm extends Component {
 	}
 
 	onWooCommerceSocialSuccess = ( ...args ) => {
-		this.props.recordTracksEvent( 'wcadmin_storeprofiler_login_jetpack_account', {
-			login_method: 'google',
-		} );
+		this.recordWooCommerceLoginTracks( 'social' );
 		this.props.onSuccess( args );
 	};
+
+	recordWooCommerceLoginTracks( method ) {
+		const { isJetpackWooCommerceFlow, oauth2Client, wccomFrom } = this.props;
+		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
+			this.props.recordTracksEvent( 'wcadmin_storeprofiler_login_jetpack_account', {
+				login_method: method,
+			} );
+		} else if (
+			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+			isWooOAuth2Client( oauth2Client ) &&
+			'cart' === wccomFrom
+		) {
+			this.props.recordTracksEvent( 'wcadmin_storeprofiler_payment_login', {
+				login_method: method,
+			} );
+		}
+	}
 
 	handleWooCommerceSubmit = event => {
 		event.preventDefault();
@@ -284,6 +292,7 @@ export class LoginForm extends Component {
 			this.props.getAuthAccountType( this.state.usernameOrEmail );
 			return;
 		}
+		this.recordWooCommerceLoginTracks( 'email' );
 		this.loginUser();
 	};
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -596,24 +596,38 @@ class SignupForm extends Component {
 		);
 	}
 
+	recordWooCommerceSignupTracks( method ) {
+		const { isJetpackWooCommerceFlow, oauth2Client, wccomFrom } = this.props;
+		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
+			analytics.tracks.recordEvent( 'wcadmin_storeprofiler_create_jetpack_account', {
+				signup_method: method,
+			} );
+		} else if (
+			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+			isWooOAuth2Client( oauth2Client ) &&
+			'cart' === wccomFrom
+		) {
+			analytics.tracks.recordEvent( 'wcadmin_storeprofiler_payment_create_account', {
+				signup_method: method,
+			} );
+		}
+	}
+
 	handleWooCommerceSocialConnect = ( ...args ) => {
-		analytics.tracks.recordEvent( 'wcadmin_storeprofiler_create_jetpack_account', {
-			signup_method: 'google',
-		} );
+		this.recordWooCommerceSignupTracks( 'social' );
 		this.props.handleSocialResponse( args );
 	};
 
 	handleWooCommerceSubmit = event => {
 		event.preventDefault();
 		document.activeElement.blur();
+		this.recordWooCommerceSignupTracks( 'email' );
+
 		this.formStateController.handleSubmit( hasErrors => {
 			if ( hasErrors ) {
 				this.setState( { submitting: false } );
 				return;
 			}
-			analytics.tracks.recordEvent( 'wcadmin_storeprofiler_create_jetpack_account', {
-				signup_method: 'email',
-			} );
 		} );
 		this.handleSubmit( event );
 	};

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -71,6 +71,8 @@ const EVENT_NAME_EXCEPTIONS = [
 	'wcadmin_storeprofiler_create_jetpack_account',
 	'wcadmin_storeprofiler_connect_store',
 	'wcadmin_storeprofiler_login_jetpack_account',
+	'wcadmin_storeprofiler_payment_login',
+	'wcadmin_storeprofiler_payment_create_account',
 ];
 
 // Load tracking scripts


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-admin/issues/2993.

This PR adds the remaining WooCommerce Onboarding events outlined in p1560449057014200-slack-wc-onboarding. These are fired on special versions of the login/signup screens that are displayed during the Jetpack connection process and the WooCommerce.com connection process.

<img width="1104" alt="Screen Shot 2019-10-11 at 10 53 24 AM" src="https://user-images.githubusercontent.com/689165/66661674-62595200-ec15-11e9-99cb-6403e6977e94.png">

#### Testing instructions

* Paste `localStorage.setItem('debug', 'calypso:analytics:*');` in your developer console to see tracks debug.

We are going to work on a test build of the onboarding code that will make testing things easier, but in the meantime the best way to load the routes is the following:

* `npm start` this branch
* Install WooCommerce
* Install WooCommerce Admin from GitHub (https://github.com/woocommerce/woocommerce-admin) and `npm run dev`.
* `define( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT', 'development' );` in your wp-config.php.
* `define( 'WP_DEBUG', true );` in your wp-config.php.

To test the events that occur during the WooCommerce.com cart / connection flow:

* Go to `/wp-admin/edit.php?post_type=shop_order` and click the Help Tab.
* Under Setup Wizard you should see `Quickly access the WooCommerce.com connection flow in Calypso.`. Click the connect button here.
* Change `wccom-from` in the query string to `wccom-from=cart`. You should see `Cart, Payment, Installation` in the header as pictured above.
* Verify login / signup events occur.

To test the events that occur during the Jetpack connection flow:

* Go to `/wp-admin/edit.php?post_type=shop_order` and click the Help Tab.
* Under Setup Wizard you should see `Quickly access the Jetpack connection flow in Calypso.`. Click the connect button here.
* Verify login / signup events occur.