### PR TITLE
Full Site Editing: Update Navigation Menu block attributes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -1,24 +1,85 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /* eslint-disable import/no-extraneous-dependencies */
-/**
- * External dependencies
- */
-
 /**
  * WordPress dependencies
  */
 import ServerSideRender from '@wordpress/server-side-render';
 import { Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	ContrastChecker,
+	FontSizePicker,
+	InspectorControls,
+	PanelColorSettings,
+	withColors,
+	withFontSizes,
+} from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 
-const NavigationMenuEdit = () => {
+const NavigationMenuEdit = ( {
+	attributes,
+	backgroundColor,
+	fontSize,
+	setAttributes,
+	setBackgroundColor,
+	setFontSize,
+	setTextColor,
+	textColor,
+} ) => {
+	const { textAlign } = attributes;
+
 	return (
 		<Fragment>
-			<ServerSideRender block="a8c/navigation-menu" />
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ nextAlign => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
+					<FontSizePicker onChange={ setFontSize } value={ fontSize.size } />
+				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color Settings' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: backgroundColor.color,
+							onChange: setBackgroundColor,
+							label: __( 'Background Color' ),
+						},
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color' ),
+						},
+					] }
+				>
+					<ContrastChecker
+						{ ...{
+							textColor: textColor.color,
+							backgroundColor: backgroundColor.color,
+						} }
+						fontSize={ fontSize.size }
+					/>
+				</PanelColorSettings>
+			</InspectorControls>
+			<ServerSideRender block="a8c/navigation-menu" attributes={ attributes } />
 		</Fragment>
 	);
 };
 
-export default NavigationMenuEdit;
+export default compose( [
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+	withFontSizes( 'fontSize' ),
+] )( NavigationMenuEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
@@ -28,12 +28,6 @@ registerBlockType( 'a8c/navigation-menu', {
 		html: false,
 		reusable: false,
 	},
-	attributes: {
-		align: {
-			type: 'string',
-			default: 'wide',
-		},
-	},
 	edit,
 	save: () => null,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -14,6 +14,49 @@ namespace A8C\FSE;
  * @return string
  */
 function render_navigation_menu_block( $attributes ) {
+	$styles = '';
+
+	$class = 'menu-primary-container';
+	if ( isset( $attributes['className'] ) ) {
+		$class .= ' ' . $attributes['className'];
+	}
+
+	$align = ' alignwide';
+	if ( isset( $attributes['align'] ) ) {
+		$align = empty( $attributes['align'] ) ? '' : ' align' . $attributes['align'];
+	}
+	$class .= $align;
+
+	if ( isset( $attributes['textAlign'] ) ) {
+		$class .= ' has-text-align-' . $attributes['textAlign'];
+	} else {
+		$class .= ' has-text-align-center';
+	}
+
+	if ( isset( $attributes['textColor'] ) ) {
+		$class .= ' has-text-color';
+		$class .= ' has-' . $attributes['textColor'] . '-color';
+	} elseif ( isset( $attributes['customTextColor'] ) ) {
+		$class  .= ' has-text-color';
+		$styles .= ' color: ' . $attributes['customTextColor'] . ';';
+	}
+
+	if ( isset( $attributes['backgroundColor'] ) ) {
+		$class .= ' has-background';
+		$class .= ' has-' . $attributes['backgroundColor'] . '-background-color';
+	} elseif ( isset( $attributes['customBackgroundColor'] ) ) {
+		$class  .= ' has-background';
+		$styles .= ' background-color: ' . $attributes['customBackgroundColor'] . ';';
+	}
+
+	if ( isset( $attributes['fontSize'] ) ) {
+		$class .= ' has-' . $attributes['fontSize'] . '-font-size';
+	} elseif ( isset( $attributes['customFontSize'] ) ) {
+		$styles .= ' font-size: ' . $attributes['customFontSize'] . 'px;';
+	} else {
+		$class .= ' has-small-font-size';
+	}
+
 	$menu = wp_nav_menu(
 		[
 			'echo'           => false,
@@ -21,13 +64,9 @@ function render_navigation_menu_block( $attributes ) {
 			'items_wrap'     => '<ul id="%1$s" class="%2$s" aria-label="submenu">%3$s</ul>',
 			'menu_class'     => 'main-menu footer-menu',
 			'theme_location' => 'menu-1',
+			'container'      => '',
 		]
 	);
-
-	$align = ' alignwide';
-	if ( isset( $attributes['align'] ) ) {
-		$align = empty( $attributes['align'] ) ? '' : ' align' . $attributes['align'];
-	}
 
 	ob_start();
 	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -41,7 +80,9 @@ function render_navigation_menu_block( $attributes ) {
 			<span class="hide-visually expanded-text"><?php esc_html_e( 'expanded', 'full-site-editing' ); ?></span>
 			<span class="hide-visually collapsed-text"><?php esc_html_e( 'collapsed', 'full-site-editing' ); ?></span>
 		</label>
-		<?php echo $menu ? $menu : get_fallback_navigation_menu(); ?>
+		<div class="<?php echo esc_attr( $class ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+			<?php echo $menu ? $menu : get_fallback_navigation_menu(); ?>
+		</div>
 	</nav>
 	<!-- #site-navigation -->
 	<?php
@@ -75,7 +116,5 @@ function get_fallback_navigation_menu() {
 	$original_classes    = [ 'children', 'page_item_has_sub-menu' ];
 	$replacement_classes = [ 'sub-menu', 'menu-item-has-children' ];
 
-	return '<div class="menu-primary-container">'
-		. str_replace( $original_classes, $replacement_classes, $menu )
-		. '</div>';
+	return str_replace( $original_classes, $replacement_classes, $menu );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -197,9 +197,36 @@ class Full_Site_Editing {
 			'a8c/navigation-menu',
 			array(
 				'attributes'      => [
-					'className' => [
-						'default' => '',
+					'className'             => [
 						'type'    => 'string',
+						'default' => '',
+					],
+					'align'                 => [
+						'type'    => 'string',
+						'default' => 'wide',
+					],
+					'textAlign'             => [
+						'type'    => 'string',
+						'default' => 'center',
+					],
+					'textColor'             => [
+						'type' => 'string',
+					],
+					'customTextColor'       => [
+						'type' => 'string',
+					],
+					'backgroundColor'       => [
+						'type' => 'string',
+					],
+					'customBackgroundColor' => [
+						'type' => 'string',
+					],
+					'fontSize'              => [
+						'type'    => 'string',
+						'default' => 'normal',
+					],
+					'customFontSize'        => [
+						'type' => 'number',
 					],
 				],
 				'render_callback' => __NAMESPACE__ . '\render_navigation_menu_block',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add visual styling attributes to the Full Site Editing's Navigation Menu block:
  - Text alignment (separate from block alignment)
  - Font size (predefined list and custom)
  - Text color (palette and custom)
  - Background color (palette and custom)

This change, along with #36588, #36675, and Automattic/themes#1500, removes the hardcoded styling of the Site Title and Description blocks, allowing the user to customize them in the Block Editor, in roughly the same way as the Heading and Paragraph block respectively.


| Editor | Front End |
| - | - |
| <img width="1348" alt="Screenshot 2019-10-11 at 16 26 09" src="https://user-images.githubusercontent.com/2070010/66664331-3b664480-ec44-11e9-9c8f-55da83f1642c.png"> | <img width="1053" alt="Screenshot 2019-10-11 at 16 26 47" src="https://user-images.githubusercontent.com/2070010/66664340-415c2580-ec44-11e9-8b05-9548ceeb4461.png"> |

(Please disregard any other FSE blocks visual inconsistencies: it's because the theme PR is only one for all three blocks.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change on an FSE site.
* Edit a template and make sure the Navigation Menu block has all the options listed above.
* If you also want to visually see all the changes, also apply https://github.com/Automattic/themes/pull/1500.
Otherwise, just check that the rendered block has all the expected classes and styles.

Fixes #36605