### PR TITLE
Add interactive UI elements to the single product component

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -383,13 +383,9 @@ export class PlansFeaturesMain extends Component {
 
 	renderSingleProducts() {
 		const { displayJetpackPlans, translate } = this.props;
-		if ( ! displayJetpackPlans ) {
-			return null;
-		}
-
 		const displayBackup = isEnabled( 'plans/jetpack-backup' );
-		const displayScan = isEnabled( 'plans/jetpack-scan' );
-		if ( ! displayBackup && ! displayScan ) {
+
+		if ( ! displayJetpackPlans || ! displayBackup ) {
 			return null;
 		}
 

--- a/client/my-sites/plans-single-products/index.jsx
+++ b/client/my-sites/plans-single-products/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -10,46 +10,64 @@ import { connect } from 'react-redux';
 import { isEnabled } from 'config';
 import Product from './product';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import Button from 'components/button';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const PlansSingleProducts = props => {
-	const {
-		billingTimeFrame,
-		currencyCode,
-		isPlaceholder,
-		onProductSelect,
-		productProperties,
-	} = props;
-	const displayBackup = isEnabled( 'plans/jetpack-backup' );
-	const displayScan = isEnabled( 'plans/jetpack-scan' );
+class PlansSingleProducts extends Component {
+	renderJetpackBackup() {
+		const {
+			billingTimeFrame,
+			currencyCode,
+			isPlaceholder,
+			onProductChange,
+			productProperties,
+			selectedProduct,
+		} = this.props;
 
-	return (
-		<div className="plans-single-products">
-			{ displayScan && (
-				<Product
-					billingTimeFrame={ billingTimeFrame }
-					currencyCode={ currencyCode }
-					isPlaceholder={ isPlaceholder }
-					onSelect={ onProductSelect }
-					{ ...productProperties.jetpackScan }
-				/>
-			) }
-			{ displayBackup && (
-				<Product
-					billingTimeFrame={ billingTimeFrame }
-					currencyCode={ currencyCode }
-					isPlaceholder={ isPlaceholder }
-					onSelect={ onProductSelect }
-					{ ...productProperties.jetpackBackup }
-				/>
-			) }
-		</div>
-	);
-};
+		if ( ! isEnabled( 'plans/jetpack-backup' ) ) {
+			return null;
+		}
+
+		return (
+			<Product
+				billingTimeFrame={ billingTimeFrame }
+				currencyCode={ currencyCode }
+				isPlaceholder={ isPlaceholder }
+				onChange={ onProductChange }
+				selectedProduct={ selectedProduct }
+				{ ...productProperties.jetpackBackup }
+			/>
+		);
+	}
+
+	renderUpgradeButton() {
+		const { onUpgrade, selectedProduct } = this.props;
+
+		return (
+			<div className="plans-single-products__actions">
+				<Button className="plans-single-products__actions-button" onClick={ onUpgrade } primary>
+					{ selectedProduct === 'jetpack_backup_realtime'
+						? // @todo: Add i18n once the copy in the designs is final.
+						  'Upgrade to Real-Time Backups'
+						: 'Upgrade to Daily Backups' }
+				</Button>
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div className="plans-single-products">
+				{ this.renderJetpackBackup() }
+				{ this.renderUpgradeButton() }
+			</div>
+		);
+	}
+}
 
 export default connect(
 	state => {
@@ -58,15 +76,6 @@ export default connect(
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			isPlaceholder: false,
 			productProperties: {
-				jetpackScan: {
-					discountedPrice: 10,
-					fullPrice: 16,
-					moreInfoLabel: 'More info',
-					productDescription:
-						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.',
-					slug: 'jetpack-scan',
-					title: 'Jetpack Scan',
-				},
 				jetpackBackup: {
 					discountedPrice: 16,
 					fullPrice: 25,
@@ -92,11 +101,15 @@ export default connect(
 					title: 'Jetpack Backup',
 				},
 			},
+			selectedProduct: 'jetpack_backup_realtime',
 		};
 	},
 	() => {
 		return {
-			onProductSelect: () => {
+			onProductChange: () => {
+				return null;
+			},
+			onUpgrade: () => {
 				return null;
 			},
 		};

--- a/client/my-sites/plans-single-products/product-option.jsx
+++ b/client/my-sites/plans-single-products/product-option.jsx
@@ -3,12 +3,13 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import PlanPrice from 'my-sites/plan-price';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import ProductPriceGroup from './product-price-group';
 
 class PlansSingleProductOption extends Component {
 	static propTypes = {
@@ -16,42 +17,17 @@ class PlansSingleProductOption extends Component {
 		currencyCode: PropTypes.string,
 		discountedPrice: PropTypes.number,
 		fullPrice: PropTypes.number,
+		isChecked: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
-		onSelect: PropTypes.func,
+		onChange: PropTypes.func,
 		slug: PropTypes.string,
 		title: PropTypes.string,
 	};
 
 	static defaultProps = {
+		isChecked: false,
 		isPlaceholder: false,
 	};
-
-	renderPriceGroup() {
-		const { currencyCode, discountedPrice, fullPrice, isPlaceholder } = this.props;
-
-		const priceGroupClasses = classNames( 'plans-single-products__option-price-group', {
-			'is-placeholder': isPlaceholder,
-		} );
-
-		return (
-			<div className={ priceGroupClasses }>
-				<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original />
-				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
-			</div>
-		);
-	}
-
-	renderBillingTimeFrame() {
-		const { billingTimeFrame, discountedPrice, isPlaceholder } = this.props;
-		const isDiscounted = !! discountedPrice;
-
-		const timeFrameClasses = classNames( 'plans-single-products__option-billing-timeframe', {
-			'is-discounted': isDiscounted,
-			'is-placeholder': isPlaceholder,
-		} );
-
-		return <p className={ timeFrameClasses }>{ billingTimeFrame }</p>;
-	}
 
 	handleSelect() {
 		const { onSelect, slug } = this.props;
@@ -59,14 +35,31 @@ class PlansSingleProductOption extends Component {
 	}
 
 	render() {
-		const { title } = this.props;
+		const {
+			billingTimeFrame,
+			currencyCode,
+			discountedPrice,
+			fullPrice,
+			isChecked,
+			isPlaceholder,
+			onChange,
+			title,
+		} = this.props;
 
 		return (
-			<div className="plans-single-products__option">
-				<div className="plans-single-products__option-name">{ title }</div>
-				{ this.renderPriceGroup() }
-				{ this.renderBillingTimeFrame() }
-			</div>
+			<FormLabel className="plans-single-products__option">
+				<FormRadio checked={ isChecked } onChange={ onChange } />
+				<div className="plans-single-products__option-description">
+					<div className="plans-single-products__option-name">{ title }</div>
+					<ProductPriceGroup
+						billingTimeFrame={ billingTimeFrame }
+						currencyCode={ currencyCode }
+						discountedPrice={ discountedPrice }
+						fullPrice={ fullPrice }
+						isPlaceholder={ isPlaceholder }
+					/>
+				</div>
+			</FormLabel>
 		);
 	}
 }

--- a/client/my-sites/plans-single-products/product-price-group.jsx
+++ b/client/my-sites/plans-single-products/product-price-group.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PlanPrice from 'my-sites/plan-price';
+
+const PlansSingleProductPriceGroup = props => {
+	const { billingTimeFrame, currencyCode, discountedPrice, fullPrice, isPlaceholder } = props;
+	const isDiscounted = !! discountedPrice;
+	const priceGroupClasses = classNames( 'plans-single-products__price-group', {
+		'is-discounted': isDiscounted,
+		'is-placeholder': isPlaceholder,
+	} );
+
+	if ( ! isDiscounted ) {
+		return (
+			<div className={ priceGroupClasses }>
+				<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } />
+				<span className="plans-single-products__billing-timeframe">{ billingTimeFrame }</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className={ priceGroupClasses }>
+			<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original />
+			<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
+			<span className="plans-single-products__billing-timeframe">{ billingTimeFrame }</span>
+		</div>
+	);
+};
+
+PlansSingleProductPriceGroup.propTypes = {
+	billingTimeFrame: PropTypes.string,
+	currencyCode: PropTypes.string,
+	discountedPrice: PropTypes.number,
+	fullPrice: PropTypes.number,
+	isPlaceholder: PropTypes.bool,
+};
+
+export default PlansSingleProductPriceGroup;

--- a/client/my-sites/plans-single-products/product.jsx
+++ b/client/my-sites/plans-single-products/product.jsx
@@ -8,8 +8,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import PlanPrice from 'my-sites/plan-price';
 import ProductOption from './product-option';
+import ProductPriceGroup from './product-price-group';
 
 class PlansSingleProduct extends Component {
 	static propTypes = {
@@ -19,10 +19,11 @@ class PlansSingleProduct extends Component {
 		fullPrice: PropTypes.number,
 		isPlaceholder: PropTypes.bool,
 		moreInfoLabel: PropTypes.string,
-		onSelect: PropTypes.func,
+		onChange: PropTypes.func,
 		options: PropTypes.array,
 		optionsHeading: PropTypes.string,
 		productDescription: PropTypes.string,
+		selectedProduct: PropTypes.string,
 		slug: PropTypes.string,
 		title: PropTypes.string,
 	};
@@ -30,33 +31,6 @@ class PlansSingleProduct extends Component {
 	static defaultProps = {
 		isPlaceholder: false,
 	};
-
-	renderPriceGroup() {
-		const { currencyCode, discountedPrice, fullPrice, isPlaceholder } = this.props;
-		const isDiscounted = !! discountedPrice;
-
-		const priceGroupClasses = classNames( 'plans-single-products__price-group', {
-			'is-discounted': isDiscounted,
-			'is-placeholder': isPlaceholder,
-		} );
-
-		return (
-			<div className={ priceGroupClasses }>
-				<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original />
-				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
-			</div>
-		);
-	}
-
-	renderBillingTimeFrame() {
-		const { billingTimeFrame, isPlaceholder } = this.props;
-
-		const timeFrameClasses = classNames( 'plans-single-products__billing-timeframe', {
-			'is-placeholder': isPlaceholder,
-		} );
-
-		return <p className={ timeFrameClasses }>{ billingTimeFrame }</p>;
-	}
 
 	renderProductDescription() {
 		const { moreInfoLabel, isPlaceholder, productDescription } = this.props;
@@ -75,7 +49,15 @@ class PlansSingleProduct extends Component {
 	}
 
 	renderOptions() {
-		const { billingTimeFrame, currencyCode, onSelect, options, optionsHeading } = this.props;
+		const {
+			billingTimeFrame,
+			currencyCode,
+			isPlaceholder,
+			onChange,
+			options,
+			optionsHeading,
+			selectedProduct,
+		} = this.props;
 
 		if ( ! options ) {
 			return null;
@@ -91,7 +73,9 @@ class PlansSingleProduct extends Component {
 						key={ option.slug }
 						billingTimeFrame={ billingTimeFrame }
 						currencyCode={ currencyCode }
-						onSelect={ onSelect }
+						isChecked={ selectedProduct === option.slug }
+						isPlaceholder={ isPlaceholder }
+						onChange={ onChange }
 						{ ...option }
 					/>
 				) ) }
@@ -100,14 +84,26 @@ class PlansSingleProduct extends Component {
 	}
 
 	render() {
-		const { title } = this.props;
+		const {
+			billingTimeFrame,
+			currencyCode,
+			discountedPrice,
+			fullPrice,
+			isPlaceholder,
+			title,
+		} = this.props;
 
 		return (
 			<div className="plans-single-products__card">
 				<div className="plans-single-products__card-header">
 					<h3 className="plans-single-products__product-name">{ title }</h3>
-					{ this.renderPriceGroup() }
-					{ this.renderBillingTimeFrame() }
+					<ProductPriceGroup
+						billingTimeFrame={ billingTimeFrame }
+						currencyCode={ currencyCode }
+						discountedPrice={ discountedPrice }
+						fullPrice={ fullPrice }
+						isPlaceholder={ isPlaceholder }
+					/>
 				</div>
 				<div className="plans-single-products__card-content">
 					{ this.renderProductDescription() }

--- a/client/my-sites/plans-single-products/style.scss
+++ b/client/my-sites/plans-single-products/style.scss
@@ -7,10 +7,10 @@
 
 .plans-single-products {
 	margin: 0 auto 28px;
-	max-width: 660px;
 
 	// On larger screens we want the container to be one big card.
 	@include breakpoint( '>660px' ) {
+		max-width: 520px;
 		background: var( --color-surface );
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
 	}
@@ -62,56 +62,6 @@
 	}
 }
 
-// Prices
-.plans-single-products__price-group {
-	display: flex;
-	flex-flow: row wrap;
-	align-items: center;
-	max-width: calc( 100% - 20px );
-
-	@include breakpoint( '<960px' ) {
-		max-width: calc( 100% - 10px );
-	}
-
-	.plan-price {
-		@include breakpoint( '>660px' ) {
-			font-size: 17px;
-		}
-	}
-
-	&.is-placeholder {
-		@include placeholder( --color-neutral-10 );
-		width: 145px;
-		height: 25px;
-		margin-top: 6px;
-		margin-bottom: 5px;
-	}
-
-	&.is-placeholder .plan-price {
-		display: none;
-	}
-
-	&.is-discounted .plans-single-products__billing-timeframe {
-		color: var( --color-success );
-	}
-}
-
-// Billing timeframe
-.plans-single-products__billing-timeframe {
-	font-size: 12px;
-	font-style: italic;
-	font-weight: 400;
-	color: var( --color-text-subtle );
-	line-height: 1;
-	margin: 0;
-
-	&.is-placeholder {
-		@include placeholder( --color-neutral-10 );
-		width: 140px;
-		height: 12px;
-	}
-}
-
 // Product description
 .plans-single-products__product-description {
 	font-size: 14px;
@@ -128,6 +78,13 @@
 // Plan options
 .plans-single-products__options {
 	padding: 10px 0 0;
+
+	@include breakpoint( '>960px' ) {
+		display: flex;
+		flex-flow: row wrap;
+		justify-content: space-around; // IE11 fallback.
+		justify-content: space-evenly;
+	}
 }
 
 .plans-single-products__options-heading {
@@ -136,40 +93,143 @@
 	font-size: 14px;
 	color: var( --color-text-subtle );
 	border-bottom: 1px solid var( --color-border-subtle );
+
+	@include breakpoint( '>960px' ) {
+		flex: 0 0 100%;
+		margin-bottom: 12px;
+	}
 }
 
 // Plan option
 .plans-single-products__option,
-.plans-single-products__option-price-group {
+.plans-single-products__option-description {
 	display: flex;
-	flex-flow: row nowrap;
 	align-items: center;
 }
 
 .plans-single-products__option {
+	margin: 0;
 	padding: 16px 0;
+
+	@include breakpoint( '>960px' ) {
+		flex: 0 0 40%;
+		align-items: flex-start;
+	}
+}
+
+.plans-single-products__option-description {
+	margin-left: 8px;
+	flex-grow: 1;
+	flex-wrap: wrap;
 }
 
 .plans-single-products__option-name {
 	flex-grow: 1;
 	font-size: 16px;
 	font-weight: 700;
-}
 
-.plans-single-products__option-price-group {
-	.plan-price {
-		font-size: 16px;
-		line-height: 19px;
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 2px;
+		flex: 0 0 100%;
+		font-size: 14px;
+		line-height: 20px;
 	}
 }
 
-.plans-single-products__option-billing-timeframe {
-	margin: auto 0 0;
-	font-size: 12px;
-	font-style: italic;
-	line-height: 19px;
+// Price group
+.plans-single-products__price-group {
+	display: flex;
+	flex-flow: row wrap;
+	align-items: baseline;
 
-	&.is-discounted {
+	&.is-placeholder .plan-price {
+		display: none;
+	}
+}
+
+.plans-single-products__billing-timeframe {
+	font-style: italic;
+	font-weight: 400;
+	color: var( --color-text-subtle );
+	line-height: 1;
+
+	.is-placeholder & {
+		@include placeholder( --color-neutral-10 );
+		width: 140px;
+		height: 12px;
+	}
+}
+
+// @todo: Refactor these nested selectors once the components are extracted from the .plans-single-products
+.plans-single-products__card-header {
+	.plans-single-products__price-group {
+		.plan-price {
+			@include breakpoint( '>660px' ) {
+				margin-right: 4px;
+				font-size: 16px;
+			}
+		}
+
+		.plan-price + .plan-price {
+			@include breakpoint( '>660px' ) {
+				margin-left: 4px;
+			}
+		}
+
+		&.is-placeholder {
+			margin-top: 6px;
+			margin-bottom: 5px;
+		}
+	}
+
+	.plans-single-products__billing-timeframe {
+		font-size: 12px;
+	}
+
+	.is-discounted .plans-single-products__billing-timeframe {
+		@include breakpoint( '>660px' ) {
+			color: var( --color-success );
+		}
+	}
+}
+
+// @todo: Refactor these nested selectors once the components are extracted from the .plans-single-products
+.plans-single-products__card-content {
+	.plans-single-products__price-group {
+		.plan-price {
+			margin-right: 4px;
+			font-size: 16px;
+			line-height: 16px;
+		}
+
+		.plan-price + .plan-price {
+			margin-left: 4px;
+		}
+	}
+
+	.plans-single-products__billing-timeframe {
+		font-size: 12px;
+	}
+
+	.is-discounted .plans-single-products__billing-timeframe {
 		color: var( --color-success );
+	}
+}
+
+// Actions
+.plans-single-products__actions {
+	padding: 16px;
+	display: flex;
+	justify-content: center;
+
+	@include breakpoint( '>660px' ) {
+		padding: 16px 24px;
+	}
+}
+
+.plans-single-products__actions-button {
+	width: 100%;
+	@include breakpoint( '>480px' ) {
+		max-width: 290px;
 	}
 }


### PR DESCRIPTION
**Please note that this is a third and last PR that covers only the UI part of the Single Products Plans project.**

No form control or button is yet functional. Also, the data is hardcoded and is meant to be replaced by a proper Calypso *block*.

As a next step the `PlansSingleProduct` should be refactored so that presentational Calypso *components* are extracted and docs/examples are added.

#### Changes proposed in this Pull Request

* Add radio buttons to the product options.
* Add submit (upgrade) button.
* Extract `PriceGroup` to a separate, reusable component.
* Improve responsiveness of the component.
* Fix various CSS issues.

![Screenshot 2019-10-11 at 17 55 47](https://user-images.githubusercontent.com/478735/66666373-bfbec480-ec50-11e9-8422-8235ed45982d.png)

![Screenshot 2019-10-11 at 17 55 11](https://user-images.githubusercontent.com/478735/66666378-c2b9b500-ec50-11e9-94e1-689dbccb4b83.png)

#### Testing instructions

* Checkout the `add/single-product-forms` branch on your local dev environment.
* Run `npm start`.
* Go to "Plans" page for a given site.
* Confirm that "Jetpack Backup" product card is displayed.

**Master thread:** p1HpG7-7nT-p2

Fixes no known issue.
