### PR TITLE
Sidebar: add clarity to menu hierarchy

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -172,7 +172,17 @@
 	}
 
 	.sidebar__menu-link {
-		padding-left: 55px;
+		padding-left: 75px;
+
+		&::before {
+			background-color: var( --color-neutral-10 );
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 58px;
+			height: 100%;
+			width: 1px;
+		}
 	}
 
 	&.is-toggle-open {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add indentation and a thin vertical line to the category subnavigation. By visually differentiating the category headings from their children, we improve the hierarchy of the menu and add clarity.

Before | After
------------ | -------------
<img width="257" alt="Screen Shot 2019-10-11 at 12 28 42 PM" src="https://user-images.githubusercontent.com/448298/66668559-858afe00-ec23-11e9-8975-0a688ab839c8.png"> | <img width="257" alt="Screen Shot 2019-10-11 at 12 29 11 PM" src="https://user-images.githubusercontent.com/448298/66668554-815ee080-ec23-11e9-9b7d-99bced1a7f0f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or visit the calypso.live link at https://calypso.live/?branch=update/sidebar-children-link-hierarchy
* View the sidebar navigation on any `My Sites` screen
* Expand the menu categories and confirm the changes as in the screenshot above
* Make sure there's no weirdness with the rest of the menu
* Test on mobile viewport to make sure it still looks ok

Fixes #35937
