### PR TITLE
FSE: Hide Posts List block from the inserter

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -29,6 +29,7 @@ registerBlockType( metadata.name, {
 		html: false,
 		multiple: false,
 		reusable: false,
+		inserter: false,
 	},
 	attributes: metadata.attributes,
 	edit: ( { attributes, setAttributes, isSelected } ) => (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide Posts List block from the inserter

#### Testing instructions

* Make sure it's hidden from the inserter but the functionality of already inserted blocks has not been affected. 

Easy way to test the functionality (if you don't have the block somewhere already inserted before hiding it) is to switch Gutenberg from Visual into the Code mode and insert the block markup there (paste `<!-- wp:a8c/posts-list /-->`) and after switching back to the visual mode, you should see the block working. 

If you preview such page, the block should also keep working on the frontend and show you some posts.
