### PR TITLE
Masterbar: Fix Draft Number Background on Hover

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -402,6 +402,8 @@ $autobar-height: 20px;
 	transition: all 0.2s ease-out;
 
 	&:hover {
+		background-color: var( --color-neutral-0 );
+		
 		.count {
 			border-color: var( --color-primary );
 			color: var( --color-primary );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I think #35645 might have caused a defect where the hover styles of the draft number on the masterbar can be overriden.

<img width="298" alt="Screenshot 2019-10-11 at 19 04 07" src="https://user-images.githubusercontent.com/43215253/66674285-75424580-ec5a-11e9-8419-ee64c7f05965.png">


#### Testing instructions

- Create a draft post on a site
- Visit the Stats (or any page) of that site 
- Click the number or the masterbar or hover over it

<img width="168" alt="Screenshot 2019-10-11 at 19 11 02" src="https://user-images.githubusercontent.com/43215253/66674483-e3870800-ec5a-11e9-9f04-5e0bcd679f33.png">

- Verify the background colour overrides the button background colour

<img width="284" alt="Screenshot 2019-10-11 at 19 04 25" src="https://user-images.githubusercontent.com/43215253/66674500-f26dba80-ec5a-11e9-98a4-564614aadcbf.png">

cc @zandyring, @diegohaz, @jsnajdr 

Fixes #36685
