### PR TITLE
FSE: Use @wordpress/block-editor instead of @wordpress/editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/edit.js
@@ -10,7 +10,7 @@ import classNames from 'classnames';
  */
 import { compose, withState } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { InnerBlocks, PostTitle } from '@wordpress/editor';
+import { InnerBlocks, PostTitle } from '@wordpress/block-editor';
 import { Component, Fragment } from '@wordpress/element';
 
 class PostContentEdit extends Component {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/edit.js
@@ -10,7 +10,8 @@ import classNames from 'classnames';
  */
 import { compose, withState } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { InnerBlocks, PostTitle } from '@wordpress/block-editor';
+import { PostTitle } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { Component, Fragment } from '@wordpress/element';
 
 class PostContentEdit extends Component {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/save.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/save.js
@@ -1,6 +1,6 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 export default () => <InnerBlocks.Content />;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -11,7 +11,7 @@ import { get, noop } from 'lodash';
  * WordPress dependencies
  */
 import { parse, createBlock } from '@wordpress/blocks';
-import { BlockEdit } from '@wordpress/editor';
+import { BlockEdit } from '@wordpress/block-editor';
 import { Button, Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/post-content-block-appender.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/post-content-block-appender.js
@@ -7,7 +7,8 @@ import { withSelect } from '@wordpress/data';
 
 const PostContentBlockAppender = compose(
 	withSelect( select => {
-		const { getBlocks, getEditorSettings } = select( 'core/editor' );
+		const { getEditorSettings } = select( 'core/editor' );
+		const { getBlocks } = select( 'core/block-editor' );
 		const { getEditorMode } = select( 'core/edit-post' );
 
 		const postContentBlock = getBlocks().find( block => block.name === 'a8c/post-content' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/post-content-block-appender.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/post-content-block-appender.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Inserter } from '@wordpress/editor';
+import { Inserter } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
@@ -17,7 +17,7 @@ const unsubscribe = subscribe( () => {
 	if ( 'page' !== fullSiteEditing.editorPostType ) {
 		return unsubscribe();
 	}
-	if ( select( 'core/editor' ).isValidTemplate() === false ) {
-		dispatch( 'core/editor' ).setTemplateValidity( true );
+	if ( select( 'core/block-editor' ).isValidTemplate() === false ) {
+		dispatch( 'core/block-editor' ).setTemplateValidity( true );
 	}
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -6,7 +6,7 @@ import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { Placeholder, RangeControl, PanelBody } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 /* eslint-enable import/no-extraneous-dependencies */
 
 /**


### PR DESCRIPTION
Note: the Site Title and Site Description pieces of this are handled in
other PRs.

Only changes code in the FSE plugin.

#### Testing instructions
1. Pull this code to your local testing environment and build FSE.
2. Verify that FSE flows like adding blocks to the header/footer still work as expected. Also check creating and publishing pages.

Work towards #35823
