### PR TITLE
Disable conciergeUpsellDial test

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -93,7 +93,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import getPreviousPath from 'state/selectors/get-previous-path.js';
 import config from 'config';
-import { abtest } from 'lib/abtest';
+// import { abtest } from 'lib/abtest';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/utils';
 import { isExternal } from 'lib/url';
@@ -443,9 +443,12 @@ export class Checkout extends React.Component {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
 
-			if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
-				return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ selectedSiteSlug }`;
-			}
+			// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
+			// being offered and so sold, to be inline with HE availability.
+			// To dial back, uncomment the condition below and modify the test config.
+			// if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
+			return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ selectedSiteSlug }`;
+			// }
 		}
 
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Even though this test is currently set to 100/0, it's still preventing the concierge upsell page from being shown to users who we don't necessarily want restricted from the offer.
ie. anyone who ends up not qualifying for the ab test, mainly non-en users. Also anyone who previously might have been put into the `noOffer` group when we were using the dial test.

We don't currently want to restrict this offer in any of those ways.

Commenting out for now, we should only use this test when we need it at less than 100%.

#### Testing instructions

* Buy a Personal or Premium plan (without a domain).

* Make sure you're shown the concierge upsell offer

* Make sure you were **not** assigned to either group of the `conciergeUpsellDial` test.

<img width="505" alt="Screen Shot 2019-10-11 at 2 10 20 PM" src="https://user-images.githubusercontent.com/690843/66685766-43b58400-ec32-11e9-9638-8af9b470eb3a.png">
