### PR TITLE
People: Distinguish Between Followers & Email Followers

### DIFF
--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -37,3 +37,5 @@ This is the base component and acts as a wrapper for a section's (a list of card
 #### Props
 - `className` - *optional* (string|object) Classes to be added to the rendered component.
 - `label` - *optional* (string) The text to be displayed in the header.
+- `popoverText` - *optional* (string) If entered, a support popover will appear to the right with this text.
+

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 
@@ -12,6 +9,7 @@ import classNames from 'classnames';
  */
 import CompactCard from 'components/card/compact';
 import Count from 'components/count';
+import SupportInfo from 'components/support-info';
 
 /**
  * Style dependencies
@@ -21,6 +19,7 @@ import './style.scss';
 export default class SectionHeader extends PureComponent {
 	static defaultProps = {
 		label: '',
+		popoverText: '',
 		href: null,
 		isPlaceholder: false,
 	};
@@ -32,7 +31,7 @@ export default class SectionHeader extends PureComponent {
 			'is-empty': isEmpty,
 			'is-placeholder': this.props.isPlaceholder,
 		} );
-		const { id } = this.props;
+		const { id, popoverText } = this.props;
 		const otherProps = { id };
 
 		return (
@@ -40,6 +39,7 @@ export default class SectionHeader extends PureComponent {
 				<div className="section-header__label">
 					<span className="section-header__label-text">{ this.props.label }</span>
 					{ hasCount && <Count count={ this.props.count } /> }
+					{ popoverText && ! this.props.isPlaceholder && <SupportInfo text={ popoverText } /> }
 				</div>
 				<div className="section-header__actions">{ this.props.children }</div>
 			</CompactCard>

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -39,7 +39,9 @@ export default class SectionHeader extends PureComponent {
 				<div className="section-header__label">
 					<span className="section-header__label-text">{ this.props.label }</span>
 					{ hasCount && <Count count={ this.props.count } /> }
-					{ popoverText && ! this.props.isPlaceholder && <SupportInfo text={ popoverText } /> }
+					{ popoverText && ! this.props.isPlaceholder && (
+						<SupportInfo position="right" text={ popoverText } />
+					) }
 				</div>
 				<div className="section-header__actions">{ this.props.children }</div>
 			</CompactCard>

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -28,8 +28,14 @@
 		margin: 4px 0;
 	}
 
-	.count {
+	.count,
+	.support-info {
 		margin-left: 8px;
+	}
+	
+	.support-info {
+		position: relative;
+		top: 3px;
 	}
 }
 

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -8,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get } from 'lodash';
+import { get, startsWith } from 'lodash';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -16,8 +14,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import SectionHeader from 'components/section-header';
+import InfoPopover from 'components/info-popover';
 import Button from 'components/button';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 /**
@@ -51,6 +51,20 @@ class PeopleListSectionHeader extends Component {
 		return '/people/new/' + siteSlug;
 	}
 
+	getPopoverText() {
+		const { currentRoute, translate } = this.props;
+
+		if ( startsWith( currentRoute, '/people/followers' ) ) {
+			return translate( 'A list of people currently following your site' );
+		}
+
+		if ( startsWith( currentRoute, '/people/email-followers' ) ) {
+			return translate( 'A list of people who are subscribed to your blog via email only' );
+		}
+
+		return null;
+	}
+
 	render() {
 		const { label, count, children, translate } = this.props;
 		const siteLink = this.getAddLink();
@@ -62,6 +76,7 @@ class PeopleListSectionHeader extends Component {
 				count={ count }
 				label={ label }
 				isPlaceholder={ this.props.isPlaceholder }
+				popoverText={ this.getPopoverText() }
 			>
 				{ children }
 				{ siteLink && (
@@ -81,6 +96,7 @@ const mapStateToProps = state => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
+		currentRoute: getCurrentRoute( state ),
 	};
 };
 

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import SectionHeader from 'components/section-header';
-import InfoPopover from 'components/info-popover';
 import Button from 'components/button';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getCurrentRoute from 'state/selectors/get-current-route';

--- a/client/my-sites/people/people-section-nav/README.md
+++ b/client/my-sites/people/people-section-nav/README.md
@@ -1,4 +1,4 @@
 PeopleSectionNav
 ================
 
-Renders the SectionNav for the People section which will include tabs for Team, Followers, Email Followers, and Viewers for private wpcom sites. This component will also render a search component for the current selected tab. Team and Email Followers can be searched, while Followers and Viewers cannot.
+Renders the SectionNav for the People section which will include tabs for Team, Followers, Email Followers, and Viewers for private wpcom sites. This component will also render a search component for the current selected tab. Team and Email Followers can be searched, while Followers and Viewers cannot. A popover will also appear for the text under "Email Followers" and "Followers" to distinguish between the two, but not for the other tabs.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a `popoverText ` prop to the Section Header component, so that a popover can be added next to the text
* Uses this to distinguish between Followers and Email Followers in People

#### Testing instructions

Visit `/people/followers/` and click the popover.

<img width="657" alt="Screenshot 2019-10-13 at 13 39 29" src="https://user-images.githubusercontent.com/43215253/66715791-5c06d980-edbf-11e9-8d9b-076a330b2104.png">

Visit `/people/email-followers/` and click the popover.

<img width="794" alt="Screenshot 2019-10-13 at 13 39 49" src="https://user-images.githubusercontent.com/43215253/66715794-66c16e80-edbf-11e9-9872-21426cdf2b7e.png">

Verify that the popover doesn't appear anywhere else due to this PR (such as the other tabs in the People section).

cc @zdenys, @scruffian, @samouri 

Fixes #36700
