### PR TITLE
Remove the false string from startup if not fraction is set

### DIFF
--- a/client/my-sites/plan-price/docs/example.jsx
+++ b/client/my-sites/plan-price/docs/example.jsx
@@ -15,31 +15,31 @@ function PlanPriceExample() {
 	return (
 		<div>
 			<h3>Plan with standard price</h3>
-			<PlanPrice rawPrice={ 99 } />
+			<PlanPrice rawPrice={ 99.8 } />
 			<PlanPrice rawPriceRange={ [ 99, 140 ] } />
 			<br />
 			<h3>Plan with discounted price</h3>
 			<span style={ { display: 'flex' } }>
 				<PlanPrice rawPrice={ 8.25 } original />
-				<PlanPrice rawPrice={ 2.25 } discounted />
+				<PlanPrice rawPrice={ 2 } discounted />
 				<PlanPrice rawPriceRange={ [ 8.25, 20.23 ] } original />
-				<PlanPrice rawPriceRange={ [ 2.25, 3.5 ] } discounted />
+				<PlanPrice rawPriceRange={ [ 2.25, 3 ] } discounted />
 			</span>
 			<br />
 			<h3>Plan with discounted price and tax</h3>
 			<span style={ { display: 'flex' } }>
 				<PlanPrice rawPrice={ 8.25 } original taxText="10%" />
-				<PlanPrice rawPrice={ 2.25 } discounted taxText="10%" />
+				<PlanPrice rawPrice={ 2 } discounted taxText="10%" />
 				<PlanPrice rawPriceRange={ [ 8.25, 20.23 ] } original taxText="10%" />
-				<PlanPrice rawPriceRange={ [ 2.25, 3.5 ] } discounted taxText="10%" />
+				<PlanPrice rawPriceRange={ [ 2.25, 3 ] } discounted taxText="10%" />
 			</span>
 			<br />
 			<h3>Simple View (isInSignup) - Plan with discounted price and tax </h3>
 			<span style={ { display: 'flex' } }>
 				<PlanPrice rawPrice={ 8.25 } original taxText="10%" isInSignup={ true } />
-				<PlanPrice rawPrice={ 2.25 } discounted taxText="10%" isInSignup={ true } />
+				<PlanPrice rawPrice={ 2 } discounted taxText="10%" isInSignup={ true } />
 				<PlanPrice rawPriceRange={ [ 8.25, 20.23 ] } original taxText="10%" isInSignup={ true } />
-				<PlanPrice rawPriceRange={ [ 2.25, 3.5 ] } discounted taxText="10%" isInSignup={ true } />
+				<PlanPrice rawPriceRange={ [ 2.25, 3 ] } discounted taxText="10%" isInSignup={ true } />
 			</span>
 		</div>
 	);

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -75,7 +75,10 @@ export class PlanPrice extends Component {
 
 		const renderPrice = priceObj => {
 			const fraction = priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction;
-			return `${ priceObj.price.integer }${ fraction }`;
+			if ( fraction ) {
+				return `${ priceObj.price.integer }${ fraction }`;
+			}
+			return priceObj.price.integer;
 		};
 
 		if ( isInSignup ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `false` from the Connection plans page. 
Fixes https://github.com/Automattic/wp-calypso/issues/36706

See 
<img width="907" alt="Screen Shot 2019-10-14 at 8 59 32 AM" src="https://user-images.githubusercontent.com/115071/66734034-f3246d80-ee61-11e9-842b-22aa9f30efc1.png">


#### Testing instructions
Go to the connections plans page for a particular jetpack site. 
* http://calypso.localhost:3000/jetpack/connect/plans/example.com
* Notice that the plans page looks as expected. 
* Got to dev docs example and notice that the it looks as expected. 
* http://calypso.localhost:3000/devdocs/blocks/plan-price
