### PR TITLE
Add magic link path to login function in paths/login

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -21,6 +21,7 @@ export function login( {
 	oauth2ClientId,
 	wccomFrom,
 	site,
+	useMagicLink,
 } = {} ) {
 	let url = config( 'login_url' );
 
@@ -37,6 +38,8 @@ export function login( {
 			url += '/social-connect';
 		} else if ( isJetpack ) {
 			url += '/jetpack';
+		} else if ( useMagicLink ) {
+			url += '/link';
 		}
 	}
 

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -1,36 +1,36 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { login } from '../';
-import config from 'config';
-import { useSandbox } from 'test/helpers/use-sinon';
+
+jest.mock( 'config', () => ( {
+	__esModule: true,
+	default: jest.fn( key => {
+		if ( 'login_url' === key ) {
+			return 'https://wordpress.com/wp-login.php';
+		}
+	} ),
+	isEnabled: jest.fn( key => {
+		if ( 'login/wp-login' === key ) {
+			return true;
+		}
+	} ),
+} ) );
 
 describe( 'index', () => {
 	describe( '#login()', () => {
-		useSandbox( sandbox => {
-			sandbox
-				.stub( config, 'isEnabled' )
-				.withArgs( 'login/wp-login' )
-				.returns( true );
-		} );
-
 		test( 'should return the legacy login url', () => {
 			const url = login();
 
-			expect( url ).to.equal( 'https://wordpress.com/wp-login.php' );
+			expect( url ).toEqual( 'https://wordpress.com/wp-login.php' );
 		} );
 
 		test( 'should return the legacy login url with encoded redirect url param', () => {
 			const url = login( { redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
 
-			expect( url ).to.equal(
+			expect( url ).toEqual(
 				'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
 			);
 		} );
@@ -38,13 +38,13 @@ describe( 'index', () => {
 		test( 'should return the login url', () => {
 			const url = login( { isNative: true } );
 
-			expect( url ).to.equal( '/log-in' );
+			expect( url ).toEqual( '/log-in' );
 		} );
 
 		test( 'should return the login url when the two factor auth page is supplied', () => {
 			const url = login( { isNative: true, twoFactorAuthType: 'code' } );
 
-			expect( url ).to.equal( '/log-in/code' );
+			expect( url ).toEqual( '/log-in/code' );
 		} );
 
 		test( 'should return the login url with encoded redirect url param', () => {
@@ -53,7 +53,7 @@ describe( 'index', () => {
 				redirectTo: 'https://wordpress.com/?search=test&foo=bar',
 			} );
 
-			expect( url ).to.equal(
+			expect( url ).toEqual(
 				'/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
 			);
 		} );
@@ -61,31 +61,31 @@ describe( 'index', () => {
 		test( 'should return the login url with encoded email_address param', () => {
 			const url = login( { isNative: true, emailAddress: 'foo@bar.com' } );
 
-			expect( url ).to.equal( '/log-in?email_address=foo%40bar.com' );
+			expect( url ).toEqual( '/log-in?email_address=foo%40bar.com' );
 		} );
 
 		test( 'should return the login url with encoded OAuth2 client ID param', () => {
 			const url = login( { isNative: true, oauth2ClientId: 12345 } );
 
-			expect( url ).to.equal( '/log-in?client_id=12345' );
+			expect( url ).toEqual( '/log-in?client_id=12345' );
 		} );
 
 		test( 'should return the login url for Jetpack specific login', () => {
 			const url = login( { isNative: true, isJetpack: true } );
 
-			expect( url ).to.equal( '/log-in/jetpack' );
+			expect( url ).toEqual( '/log-in/jetpack' );
 		} );
 
 		test( 'should return the login url with WooCommerce from handler', () => {
 			const url = login( { isNative: true, isJetpack: true, isWoo: true } );
 
-			expect( url ).to.equal( '/log-in/jetpack?from=woocommerce-setup-wizard' );
+			expect( url ).toEqual( '/log-in/jetpack?from=woocommerce-setup-wizard' );
 		} );
 
 		test( 'should return the login url with WooCommerce.com handler', () => {
 			const url = login( { isNative: true, oauth2ClientId: 12345, wccomFrom: 'testing' } );
 
-			expect( url ).to.equal( '/log-in?client_id=12345&wccom-from=testing' );
+			expect( url ).toEqual( '/log-in?client_id=12345&wccom-from=testing' );
 		} );
 	} );
 } );

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -87,5 +87,23 @@ describe( 'index', () => {
 
 			expect( url ).toEqual( '/log-in?client_id=12345&wccom-from=testing' );
 		} );
+
+		test( 'should return the login url for requesting a magic login link', () => {
+			const url = login( { isNative: true, useMagicLink: true } );
+
+			expect( url ).toEqual( '/log-in/link' );
+		} );
+
+		test( 'should return the login url for requesting a magic login link with encoded email_address param', () => {
+			const url = login( { isNative: true, useMagicLink: true, emailAddress: 'foo@bar.com' } );
+
+			expect( url ).toEqual( '/log-in/link?email_address=foo%40bar.com' );
+		} );
+
+		test( 'should return the login url for Jetpack, ignoring useMagicLink parameter', () => {
+			const url = login( { isNative: true, isJetpack: true, useMagicLink: true } );
+
+			expect( url ).toEqual( '/log-in/jetpack' );
+		} );
 	} );
 } );


### PR DESCRIPTION
This adds an additional attribute `useMagicLink` to object in the `login` function, to tell the function to return a URL to the magic login link URL instead of the normal `/log-in` url. This attribute takes the least precedence, so if it's present as well as `isJetpack` etc, the others will take precedence over this new attribute.

While we have the existing `twoFactorAuthType` attribute, for the case of passwordless signup where we're using the magic link, it isn't really _two_ factor, so in this case, I thought it might be cleaner to have a separate attribute specifically for the magic link.

#### Changes proposed in this Pull Request

* Add `useMagicLink` attribute to the object parameter for the login path function
* Remove `chai` and `sinon` from tests for the `login` function in `lib/paths/login`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure no regressions:

* Go to `calypso.localhost:3000/start` and click on the log in link at the bottom of the user step. It should direct to `http://calypso.localhost:3000/log-in?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fstart%2Fsite-type` and after logging in, should take you to the site type step.
* Create a Jetpack site using https://jurassic.ninja and after it's created, click to set up Jetpack. 

Related to #36519 — it would be useful to be able to generate login links directly to the magic login page.
