### PR TITLE
Customer Home: Use localized app badges with attribution links

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -366,7 +366,7 @@ class Home extends Component {
 								storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
 								storeName={ 'android' }
 								titleText={ translate( 'Download the WordPress Android mobile app.' ) }
-								altText={ translate( 'Google Play' ) }
+								altText={ translate( 'Google Play Store download badge' ) }
 							>
 								<img src="/calypso/images/customer-home/google-play.png" alt="" />
 							</AppsBadge>
@@ -374,7 +374,7 @@ class Home extends Component {
 								storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
 								storeName={ 'ios' }
 								titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
-								altText={ translate( 'Apple App Store' ) }
+								altText={ translate( 'Apple App Store download badge' ) }
 							>
 								<img src="/calypso/images/customer-home/apple-store.png" alt="" />
 							</AppsBadge>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -13,6 +13,7 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
+import AppsBadge from 'blocks/get-apps/apps-badge';
 import Banner from 'components/banner';
 import Button from 'components/button';
 import Card from 'components/card';
@@ -361,20 +362,22 @@ class Home extends Component {
 							{ translate( 'Make updates on the go' ) }
 						</h6>
 						<div className="customer-home__card-button-pair customer-home__card-mobile">
-							<Button
-								href="https://play.google.com/store/apps/details?id=org.wordpress.android"
-								aria-label={ translate( 'Google Play' ) }
-								onClick={ () => trackAction( 'mobile', 'google_play' ) }
+							<AppsBadge
+								storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
+								storeName={ 'android' }
+								titleText={ translate( 'Download the WordPress Android mobile app.' ) }
+								altText={ translate( 'Google Play' ) }
 							>
 								<img src="/calypso/images/customer-home/google-play.png" alt="" />
-							</Button>
-							<Button
-								href="https://apps.apple.com/us/app/wordpress/id335703880"
-								aria-label={ translate( 'App Store' ) }
-								onClick={ () => trackAction( 'mobile', 'app_store' ) }
+							</AppsBadge>
+							<AppsBadge
+								storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
+								storeName={ 'ios' }
+								titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
+								altText={ translate( 'Apple App Store' ) }
 							>
 								<img src="/calypso/images/customer-home/apple-store.png" alt="" />
-							</Button>
+							</AppsBadge>
 						</div>
 					</Card>
 				</div>

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -105,12 +105,6 @@
 	}
 }
 
-.customer-home__card-mobile .button {
-	background: #000;
-	border: none; /* it was cheaper to remove it here than setting borderless and then remove the border on hover*/
-	
-	img {
-		height: 25px;
-    	vertical-align: middle;
-	}
+.customer-home__card-mobile {
+    justify-content: space-around;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the mobile apps card in the Customer Home:

* Adds attribution links to the app badges for mobile growth tracking.
* Uses the `AppsBadge` dependency (from the Get Apps block, but without pulling in all the other pieces of that block) to get localized apps badges. This ensures that the app badge matches the interface language, although it does change the style of the badges on this page.

The first change (attribution links) is a high priority, but if there are concerns about either change I'd be happy to discuss them further.

Before (English and Spanish):
![Screenshot 2019-10-14 12 57 37](https://user-images.githubusercontent.com/8658164/66749952-14e21c80-ee83-11e9-81cc-60dadf4839db.png)
![Screenshot 2019-10-14 12 58 28](https://user-images.githubusercontent.com/8658164/66749957-16134980-ee83-11e9-8513-5b26195d7b4a.png)


After (English and Spanish):
![Screenshot 2019-10-14 13 01 03](https://user-images.githubusercontent.com/8658164/66749961-17dd0d00-ee83-11e9-9ad9-b4f150ed03cd.png)
![Screenshot 2019-10-14 13 00 23](https://user-images.githubusercontent.com/8658164/66749963-190e3a00-ee83-11e9-8436-ea065d9e40ba.png)


#### Testing instructions

* Visit your customer home at `/home/SITE_ADDRESS` and confirm the app badge links include a campaign source (`calypso-customer-home`).
* Click the app badges and confirm you are directed to the correct app store page.
* After clicking the app badges, confirm the AppsBadge tracks events are fired (`calypso_app_download_android_click ` and `calypso_app_download_ios_click`).
* Go to your [account settings](https://wordpress.com/me/account) and change your interface language to a non-English language. Return to the customer home and confirm the app badges now match your selected interface language (e.g. Spanish) or use an English fallback for unsupported languages.
