### PR TITLE
Domains: Replace smaller transfer warning with larger one inline

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -87,7 +87,7 @@ export class List extends React.Component {
 			return (
 				<DomainWarnings
 					domains={ this.props.domains }
-					position="domain-list"
+					position="domain-list-item"
 					selectedSite={ this.props.selectedSite }
 					ruleWhiteList={ [
 						'newDomainsWithPrimary',
@@ -96,7 +96,6 @@ export class List extends React.Component {
 						'pendingGSuiteTosAcceptanceDomains',
 						'unverifiedDomainsCannotManage',
 						'wrongNSMappedDomains',
-						'transferStatus',
 						'newTransfersWrongNS',
 						'pendingConsent',
 					] }
@@ -442,6 +441,7 @@ export class List extends React.Component {
 					} ) }
 					onSelect={ this.handleUpdatePrimaryDomain }
 					onClick={ this.goToEditDomainRoot }
+					selectedSite={ this.props.selectedSite }
 				/>
 			);
 		} );

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import CompactCard from 'components/card/compact';
 import DomainPrimaryFlag from 'my-sites/domains/domain-management/components/domain/primary-flag';
-import DomainTransferFlag from 'my-sites/domains/domain-management/components/domain/transfer-flag';
+import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import Notice from 'components/notice';
 import { type as domainTypes, gdprConsentStatus } from 'lib/domains/constants';
 import Spinner from 'components/spinner';
@@ -59,8 +59,14 @@ class ListItem extends React.PureComponent {
 						this.showDomainExpirationWarning( this.props.domain ) }
 					{ this.showGdprConsentPending( this.props.domain ) }
 					<DomainPrimaryFlag domain={ this.props.domain } />
-					<DomainTransferFlag domain={ this.props.domain } />
 				</span>
+				<DomainWarnings
+					compact
+					domain={ this.props.domain }
+					position="domain-list-item"
+					selectedSite={ this.props.selectedSite }
+					ruleWhiteList={ [ 'transferStatus' ] }
+				/>
 				{ this.busyMessage() }
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -20,9 +20,8 @@
 
 	.domain__primary-flag {
 		vertical-align: middle;
-		margin-left: 8px;
-		background: var( --sidebar-menu-hover-background );
-		color: var( --sidebar-menu-hover-color );
+		background: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-menu-hover-text );
 		border-radius: 12px;
 		display: inline-block;
 		padding: 2px 10px;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -61,6 +61,14 @@
 	.notice {
 		margin: 0 0 0 8px;
 	}
+
+	& > *:last-child {
+		margin-left: 8px;
+	}
+
+	& > *:first-child {
+		margin-left: 0;
+	}
 }
 
 .domain-management-list-item__type {
@@ -109,4 +117,10 @@ input[type='radio'].domain-management-list-item__radio {
 		margin-top: -11px;
 		margin-right: 15px;
 	}
+}
+
+.domain-management-list-item .domain-warnings__notice {
+	margin-bottom: 0;
+	margin-top: 8px;
+	max-width: 90%;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove smaller Transfer in progress warning in favor of moving the larger, more complete warning directly into the domains list for better context.
* Also fixes small CSS bug with Primary Domain flag styles.

**Before**

<img width="1078" src="https://user-images.githubusercontent.com/2124984/66088280-8ac3bb00-e548-11e9-8e5f-9708f3e31072.png">

**After**

<img width="1078" alt="Screen Shot 2019-10-22 at 4 54 16 PM" src="https://user-images.githubusercontent.com/2124984/67332119-a76e6580-f4ec-11e9-9af3-1c2b2d7b126a.png">

#### Testing instructions

* Transfer your domain to a WP.com simple site, or temporarily modify the `client/state/sites/domains/assembler.js` file on your local install; change the following lines starting on line 71:
```
type: domain.domain == 'your-domain.com' ? 'TRANSFER' : getDomainType( domain ),
transferStatus: domain.domain == 'your-domain.com' ? transferStatus.PENDING_REGISTRY : getTransferStatus( domain ),
```
where `your-domain.com` is the name of a domain on the simple site you're working with.
* Check the domain listings screen. You should see a transfer notice in the domain list for `your-domain.com`.

Fixes #36481