### PR TITLE
Build: Add react-spring to transpilation list

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,13 +107,14 @@ const nodeModulesToTranspile = [
 	// general form is <package-name>/.
 	// The trailing slash makes sure we're not matching these as prefixes
 	// In some cases we do want prefix style matching (lodash. for lodash.assign)
+	'@github/webauthn-json/',
+	'acorn-jsx/',
 	'd3-array/',
 	'd3-scale/',
 	'debug/',
-	'@github/webauthn-json/',
 	'filesize/',
-	'acorn-jsx/',
 	'prismjs/',
+	'react-spring/',
 	'regenerate-unicode-properties/',
 	'regexpu-core/',
 	'unicode-match-property-ecmascript/',


### PR DESCRIPTION
In #36494 (changes included there), `react-spring` was found to ship es>5 code in its exposed `module`.

Add it to the transpilation list.

#### Testing instructions

* When this library is included (like in #36494) fallback build no longer errors.