### PR TITLE
Move Add and Install Plugins Buttons under header

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -6,6 +6,7 @@ import page from 'page';
 import { connect } from 'react-redux';
 import { capitalize, find, flow, isEmpty, some } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -41,7 +42,7 @@ import {
 	isRequestingSites,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import HeaderButton from 'components/header-button';
+import Button from 'components/button';
 import { isEnabled } from 'config';
 
 /**
@@ -421,13 +422,15 @@ export class PluginsMain extends Component {
 		const browserUrl = '/plugins' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
 
 		return (
-			<HeaderButton
-				icon="plus"
-				label={ translate( 'Add Plugin' ) }
-				aria-label={ translate( 'Browse all plugins', { context: 'button label' } ) }
+			<Button
+				className="plugins__button"
+				compact
 				href={ browserUrl }
 				onClick={ this.handleAddPluginButtonClick }
-			/>
+			>
+				<Gridicon icon="plus" />
+				<span className="plugins__button-text">{ translate( 'Add Plugin' ) }</span>
+			</Button>
 		);
 	}
 
@@ -445,13 +448,15 @@ export class PluginsMain extends Component {
 		const uploadUrl = '/plugins/upload' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
 
 		return (
-			<HeaderButton
-				icon="cloud-upload"
-				label={ translate( 'Upload Plugin' ) }
-				aria-label={ translate( 'Upload Plugin' ) }
+			<Button
+				className="plugins__button"
+				compact
 				href={ uploadUrl }
 				onClick={ this.handleUploadPluginButtonClick }
-			/>
+			>
+				<Gridicon icon="cloud-upload" />
+				<span className="plugins__button-text">{ translate( 'Install Plugin' ) }</span>
+			</Button>
 		);
 	}
 
@@ -502,20 +507,22 @@ export class PluginsMain extends Component {
 				{ this.renderDocumentHead() }
 				{ this.renderPageViewTracking() }
 				<SidebarNavigation />
-				<div className="plugins__header">
-					<SectionNav selectedText={ this.getSelectedText() }>
-						<NavTabs>{ navItems }</NavTabs>
-						<Search
-							pinned
-							fitsContainer
-							onSearch={ this.props.doSearch }
-							initialValue={ this.props.search }
-							ref="url-search"
-							analyticsGroup="Plugins"
-							placeholder={ this.getSearchPlaceholder() }
-						/>
-					</SectionNav>
-					<div className="plugins__header-buttons">
+				<div className="plugins__main">
+					<div className="plugins__main-header">
+						<SectionNav selectedText={ this.getSelectedText() }>
+							<NavTabs>{ navItems }</NavTabs>
+							<Search
+								pinned
+								fitsContainer
+								onSearch={ this.props.doSearch }
+								initialValue={ this.props.search }
+								ref={ `url-search` }
+								analyticsGroup="Plugins"
+								placeholder={ this.getSearchPlaceholder() }
+							/>
+						</SectionNav>
+					</div>
+					<div className="plugins__main-buttons">
 						{ this.renderAddPluginButton() }
 						{ this.renderUploadPluginButton() }
 					</div>

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -11,15 +11,9 @@
 }
 
 .plugins-browser__main-header .section-nav {
-	border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
-	border-width: 0 0 1px;
 	box-shadow: none;
 	flex: auto;
 	margin: 0;
-
-	@include breakpoint( '>480px' ) {
-		border-width: 0 1px 0 0;
-	}
 }
 
 .plugins-browser__main-buttons {
@@ -38,7 +32,7 @@
 		}
 
 		&:last-child {
-			@include breakpoint( '<480px' ) {
+			@include breakpoint( '<660px' ) {
 				margin-right: 15px;
 			}
 		}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -8,7 +8,6 @@
 
 .plugins__header {
 	background: var( --color-surface );
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
 	flex-direction: column;
 	display: flex;
 	margin-bottom: 9px;
@@ -35,23 +34,44 @@
 	margin-bottom: 1px;
 }
 
-.plugins__header-buttons {
+.plugins__main-buttons {
 	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 9px;
+	width: 100%;
 
-	.header-button {
-		flex: auto;
-		flex-basis: 0;
+	@include breakpoint( '>480px' ) {
+		margin-bottom: 17px;
+	}
 
+
+	.plugins__button {
 		&:not( :last-child ) {
-			border-right: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
+			margin-right: 10px;
+		}
+
+		&:last-child {
+			@include breakpoint( '<480px' ) {
+				margin-right: 15px;
+			}
 		}
 
 		.gridicon {
-			margin-top: 4px;
+			margin-right: 0;
+			@include breakpoint( '>480px' ) {
+				margin-right: 4px;
+			}
 		}
 
 		@include breakpoint( '>480px' ) {
 			flex: none;
+		}
+
+		.plugins__button-text {
+			display: none;
+			@include breakpoint( '>480px' ) {
+				display: inline-block;
+			}
 		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -6,7 +6,7 @@
 	white-space: nowrap;
 }
 
-.plugins__header {
+.plugins__main-header {
 	background: var( --color-surface );
 	flex-direction: column;
 	display: flex;
@@ -18,15 +18,14 @@
 	}
 }
 
-.plugins__header .section-nav {
+.plugins__main-header .section-nav {
 	border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
-	border-width: 0 0 1px;
 	box-shadow: none;
 	flex: auto;
 	margin: 0;
 
-	@include breakpoint( '>480px' ) {
-		border-width: 0 1px 0 0;
+	@include breakpoint( '<660px' ) {
+		border-width: 1px 0;
 	}
 }
 
@@ -51,7 +50,7 @@
 		}
 
 		&:last-child {
-			@include breakpoint( '<480px' ) {
+			@include breakpoint( '<660px' ) {
 				margin-right: 15px;
 			}
 		}


### PR DESCRIPTION
This PR moves the Add plugin and Install plugin buttons outside of the
main header area to be consistent with changed made to buttons in plugin
browser view.

Before: 
![BEFORE](https://user-images.githubusercontent.com/17905991/66766481-312e8b00-ee7c-11e9-9aab-5a239b1e415d.png)

After:
![AFTER](https://user-images.githubusercontent.com/17905991/66766491-355aa880-ee7c-11e9-85d2-e72921eb1e81.png)

See this PR for more details: https://github.com/Automattic/wp-calypso/pull/36141#issuecomment-535293039

#### Testing instructions

1. Select **My Sites**
2. Choose a Jetpack connected site 
3. Go to the Plugins menu
4. Select the Manage Plugins buttons
5. Be sure to check various screen widths!