### PR TITLE
Add a Woo Connect flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -190,6 +190,13 @@ export function generateFlows( {
 			description: 'A very simple signup flow',
 			lastModified: '2019-05-09',
 		},
+
+		'woo-connect': {
+			steps: [ 'passwordless-woo' ],
+			destination: '/',
+			description: 'A woo connection flow',
+			lastModified: '2019-10-14',
+		},
 	};
 
 	if ( isEnabled( 'rewind/clone-site' ) ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -58,6 +58,7 @@ const stepNameToModuleName = {
 	'domains-with-preview': 'domains',
 	'site-title-with-preview': 'site-title',
 	passwordless: 'passwordless',
+	'passwordless-woo': 'passwordless',
 };
 
 export async function getStepComponent( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -524,6 +524,17 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'email', 'username' ],
 			unstorableDependencies: [ 'bearer_token' ],
 		},
+
+		'passwordless-woo': {
+			stepName: 'passwordless-woo',
+			props: {
+				headerText: i18n.translate( 'Connect your store' ),
+				subHeaderText: i18n.translate( 'Enter your email address to connect to WooPayments' ),
+			},
+			providesToken: true,
+			providesDependencies: [ 'bearer_token', 'email', 'username' ],
+			unstorableDependencies: [ 'bearer_token' ],
+		},
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This just adds a variant of the passwordless signup flow for Woo Connect purposes
* The problem is how we direct the user. The URL they need to go to has to be dynamic, but we can't trust parameters passed in the query string...

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

