### PR TITLE
FIX: Align of Importer-> WordPress

### DIFF
--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -7,7 +7,6 @@
 	align-items: center;
 
 	.author-selector__author-toggle {
-		width: 45%;
 		padding-top: 4px;
 		margin-right: -7px;
 		float: right;

--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -1,5 +1,6 @@
 .importer__author-mapping {
-	height: 58px;
+	padding: 8px 0 16px;
+	height: auto;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
@@ -18,7 +19,7 @@
 }
 
 .importer__source-author {
-	padding-top: 7px;
+	padding-top: 0;
 	display: inline-block;
 	color: var( --color-neutral-70 );
 	text-align: left;

--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -12,6 +12,10 @@
 		float: right;
 	}
 
+	& > span {
+		width: 45%;
+	}
+
 	div.user {
 		display: inline;
 	}

--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -1,5 +1,9 @@
 .importer__author-mapping {
 	height: 58px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
 
 	.author-selector__author-toggle {
 		width: 45%;
@@ -14,9 +18,7 @@
 }
 
 .importer__source-author {
-	width: 45%;
 	padding-top: 7px;
-	float: left;
 	display: inline-block;
 	color: var( --color-neutral-70 );
 	text-align: left;

--- a/client/my-sites/importer/author-mapping-pane.scss
+++ b/client/my-sites/importer/author-mapping-pane.scss
@@ -1,6 +1,6 @@
 .importer__mapping-header {
 	border-bottom: 1px solid var( --color-neutral-light );
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 	padding-bottom: 8px;
 
 	font-size: 11px;

--- a/client/my-sites/importer/author-mapping-pane.scss
+++ b/client/my-sites/importer/author-mapping-pane.scss
@@ -1,6 +1,6 @@
 .importer__mapping-header {
 	border-bottom: 1px solid var( --color-neutral-light );
-	margin-bottom: 8px;
+	margin-bottom: 0;
 	padding-bottom: 8px;
 
 	font-size: 11px;


### PR DESCRIPTION
This a fix for issue #36735
#### Changes proposed in this Pull Request

* Fix the align of original site and site title info section.
Previously: 
![screencapture-wordpress-import-sunnyssr-wordpress-com-2019-10-15-01_15_11](https://user-images.githubusercontent.com/41870839/66778493-763cd680-eee9-11e9-9c17-922b334e46f1.png)
Now:
![screencapture-wordpress-import-sunnyssr-wordpress-com-2019-10-15-01_16_20](https://user-images.githubusercontent.com/41870839/66778509-7dfc7b00-eee9-11e9-9920-a34611e95840.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
