### PR TITLE
Fix wpcomstaging domain management

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -159,7 +159,7 @@ function isHstsRequired( productSlug, productsList ) {
 }
 
 function isMappedDomain( domain ) {
-	return domain.type === domainTypes.MAPPED;
+	return domain.type === domainTypes.MAPPED || domain.type === domainTypes.ATOMIC_STAGING;
 }
 
 function getSelectedDomain( { domains, selectedDomainName, isTransfer } ) {

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -54,6 +54,7 @@ class Edit extends React.Component {
 	getDetailsForType = type => {
 		switch ( type ) {
 			case domainTypes.MAPPED:
+			case domainTypes.ATOMIC_STAGING:
 				return MappedDomain;
 
 			case domainTypes.REGISTERED:

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -170,6 +170,7 @@ class ListItem extends React.PureComponent {
 
 		switch ( domain.type ) {
 			case domainTypes.MAPPED:
+			case domainTypes.ATOMIC_STAGING:
 				return translate( 'Mapped Domain' );
 
 			case domainTypes.REGISTERED:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes some bugs that were introduced in PR #36208 due to a new domain type on the client. This is achieved (for now) by reinstating the old behaviour for these domains.

#### Testing instructions

* Ensure that you can edit the domain details for a `*.wpcomstaging.com` domain attached to an Atomic site (via Manage > Domains and then clicking on the entry for [your.wpcomstaging.com])
* Ensure that the domain shows text for "Mapped Domain" on the domains listing page

We also need to check places where `isMappedDomain()` is called:
* When adding G Suite functionality (I think?) -- this should have no impact due to `wpcomstaging.com` being blacklisted already
* When showing the DNS edit screen -- this should have no effect on the items displayed at the bottom of the screen for other mail providers -- for now, they should appear. (This reinstates old behaviour.)

Fixes #36727 
