### PR TITLE
Store: Remove simple createReducer usage

### DIFF
--- a/client/extensions/woocommerce/state/sites/shipping-classes/reducers.js
+++ b/client/extensions/woocommerce/state/sites/shipping-classes/reducers.js
@@ -1,23 +1,18 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_CLASSES_REQUEST,
 	WOOCOMMERCE_SHIPPING_CLASSES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 import { LOADING } from 'woocommerce/state/constants';
 
-const reducers = {};
-
-reducers[ WOOCOMMERCE_SHIPPING_CLASSES_REQUEST ] = () => {
-	return LOADING;
-};
-
-reducers[ WOOCOMMERCE_SHIPPING_CLASSES_REQUEST_SUCCESS ] = ( state, { data } ) => {
-	return data;
-};
-
-export default createReducer( {}, reducers );
+export default function( state = {}, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_CLASSES_REQUEST:
+			return LOADING;
+		case WOOCOMMERCE_SHIPPING_CLASSES_REQUEST_SUCCESS:
+			return action.data;
+	}
+	return state;
+}

--- a/client/extensions/woocommerce/state/sites/shipping-classes/reducers.js
+++ b/client/extensions/woocommerce/state/sites/shipping-classes/reducers.js
@@ -1,13 +1,14 @@
 /**
  * Internal dependencies
  */
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_CLASSES_REQUEST,
 	WOOCOMMERCE_SHIPPING_CLASSES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 import { LOADING } from 'woocommerce/state/constants';
 
-export default function( state = {}, action ) {
+export default withoutPersistence( function( state = {}, action ) {
 	switch ( action.type ) {
 		case WOOCOMMERCE_SHIPPING_CLASSES_REQUEST:
 			return LOADING;
@@ -15,4 +16,4 @@ export default function( state = {}, action ) {
 			return action.data;
 	}
 	return state;
-}
+} );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/flat-rate/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/flat-rate/reducer.js
@@ -1,10 +1,6 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST,
@@ -15,20 +11,20 @@ const initialState = {
 	cost: 5,
 };
 
-const reducer = {};
+export default function( state = initialState, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE:
+			return {
+				...state,
+				tax_status: action.isTaxable ? 'taxable' : 'none',
+			};
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE ] = ( state, { isTaxable } ) => {
-	return {
-		...state,
-		tax_status: isTaxable ? 'taxable' : 'none',
-	};
-};
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST:
+			return {
+				...state,
+				cost: action.cost,
+			};
+	}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST ] = ( state, { cost } ) => {
-	return {
-		...state,
-		cost,
-	};
-};
-
-export default createReducer( initialState, reducer );
+	return state;
+}

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/flat-rate/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/flat-rate/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST,
@@ -11,7 +12,7 @@ const initialState = {
 	cost: 5,
 };
 
-export default function( state = initialState, action ) {
+export default withoutPersistence( function( state = initialState, action ) {
 	switch ( action.type ) {
 		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE:
 			return {
@@ -27,4 +28,4 @@ export default function( state = initialState, action ) {
 	}
 
 	return state;
-}
+} );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/free-shipping/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/free-shipping/reducer.js
@@ -1,10 +1,6 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_CONDITION,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_MIN_COST,
@@ -15,20 +11,19 @@ const initialState = {
 	min_amount: 0,
 };
 
-const reducer = {};
+export default function( state = initialState, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_CONDITION:
+			return {
+				...state,
+				requires: action.condition,
+			};
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_CONDITION ] = ( state, { condition } ) => {
-	return {
-		...state,
-		requires: condition,
-	};
-};
-
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_MIN_COST ] = ( state, { cost } ) => {
-	return {
-		...state,
-		min_amount: cost,
-	};
-};
-
-export default createReducer( initialState, reducer );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_MIN_COST:
+			return {
+				...state,
+				min_amount: action.cost,
+			};
+	}
+	return state;
+}

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/free-shipping/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/free-shipping/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_CONDITION,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_MIN_COST,
@@ -11,7 +12,7 @@ const initialState = {
 	min_amount: 0,
 };
 
-export default function( state = initialState, action ) {
+export default withoutPersistence( function( state = initialState, action ) {
 	switch ( action.type ) {
 		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_CONDITION:
 			return {
@@ -26,4 +27,4 @@ export default function( state = initialState, action ) {
 			};
 	}
 	return state;
-}
+} );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/local-pickup/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/local-pickup/reducer.js
@@ -1,10 +1,6 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST,
@@ -15,20 +11,19 @@ const initialState = {
 	cost: 0,
 };
 
-const reducer = {};
+export default function( state = initialState, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE:
+			return {
+				...state,
+				tax_status: action.isTaxable ? 'taxable' : 'none',
+			};
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE ] = ( state, { isTaxable } ) => {
-	return {
-		...state,
-		tax_status: isTaxable ? 'taxable' : 'none',
-	};
-};
-
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST ] = ( state, { cost } ) => {
-	return {
-		...state,
-		cost,
-	};
-};
-
-export default createReducer( initialState, reducer );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST:
+			return {
+				...state,
+				cost: action.cost,
+			};
+	}
+	return state;
+}

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/local-pickup/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/local-pickup/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_COST,
@@ -11,7 +12,7 @@ const initialState = {
 	cost: 0,
 };
 
-export default function( state = initialState, action ) {
+export default withoutPersistence( function( state = initialState, action ) {
 	switch ( action.type ) {
 		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_SET_TAXABLE:
 			return {
@@ -26,4 +27,4 @@ export default function( state = initialState, action ) {
 			};
 	}
 	return state;
-}
+} );


### PR DESCRIPTION
Remove simple usages of `createReducer`. These cases could not be handled by the codemod.

Necessary to remove `createReducer` completely in https://github.com/Automattic/wp-calypso/pull/36678

I consider these cases simple enough to handle in bulk. More complicated cases can be handled one by one.

This should be _functionally equivalent_ and result in _no behavioral changes_ to the application.

#### Testing instructions

I'm unfamiliar with this part of the code base and unable to provide instructions for manual testing.