### PR TITLE
Domains: Fix wpcomstaging domain management page

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -1,7 +1,6 @@
 /** @format */
 
 export const type = {
-	ATOMIC_STAGING: 'ATOMIC_STAGING',
 	MAPPED: 'MAPPED',
 	REGISTERED: 'REGISTERED',
 	SITE_REDIRECT: 'SITE_REDIRECT',

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -27,10 +27,6 @@ export function getDomainType( domainFromApi ) {
 		return domainTypes.REGISTERED;
 	}
 
-	if ( get( domainFromApi, 'domain', '' ).endsWith( '.wpcomstaging.com' ) ) {
-		return domainTypes.ATOMIC_STAGING;
-	}
-
 	return domainTypes.MAPPED;
 }
 

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -40,7 +40,6 @@ import QueryProductsList from 'components/data/query-products-list';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getUnformattedDomainPrice, getUnformattedDomainSalePrice } from 'lib/domains';
 import formatCurrency from '@automattic/format-currency/src';
-import { type as domainTypes } from 'lib/domains/constants';
 import { getPreference } from 'state/preferences/selectors';
 import { savePreference } from 'state/preferences/actions';
 
@@ -114,7 +113,7 @@ export class SiteNotice extends React.Component {
 
 		const nonWPCOMDomains = reject(
 			this.props.domains,
-			domain => domain.type === domainTypes.WPCOM || domain.type === domainTypes.ATOMIC_STAGING
+			domain => domain.isWPCOMDomain || domain.name.endsWith( '.wpcomstaging.com' )
 		);
 
 		if ( nonWPCOMDomains.length < 1 || nonWPCOMDomains.length > 2 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes bug introduced in #36208 by removing `ATOMIC_STAGING` from domain types

#### Testing instructions

* Make sure that when you go to `Manage > Domains` for an Atomic site, you can see the type "Mapped Domain" for the domain ending in `.wpcomstaging.com`
* Verify that when clicking on the `.wpcomstaging.com` domain, the page actually loads and isn't stuck in a "loading" screen
* Verify that the domain upsell nudge works as expected (see #36208)

Fixes #36727
