### PR TITLE
Store: Remove createReducer from shipping-zone-methods

### DIFF
--- a/client/extensions/woocommerce/state/sites/shipping-zone-methods/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-methods/reducer.js
@@ -1,9 +1,6 @@
 /**
  * Externals dependencies
- *
- * @format
  */
-
 import { mapValues } from 'lodash';
 
 /**
@@ -14,11 +11,9 @@ import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 import { WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS } from 'woocommerce/woocommerce-services/state/action-types';
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 
-const reducers = {};
-
-reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS ] = ( state, { data } ) => {
+function handleRequestSuccess( state, { data } ) {
 	const newState = { ...state };
 	data.forEach( method => {
 		newState[ method.id ] = {
@@ -33,9 +28,9 @@ reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS ] = ( state, { data 
 	} );
 
 	return newState;
-};
+}
 
-reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ] = ( state, { data, originatingAction } ) => {
+function handleMethodUpdated( state, { data, originatingAction } ) {
 	if ( ! data.id ) {
 		// WCS endpoints don't return the data on success, get that info from the originatingAction
 		return {
@@ -48,13 +43,10 @@ reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ] = ( state, { data, originat
 			},
 		};
 	}
-	return reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS ]( state, { data: [ data ] } );
-};
+	return handleRequestSuccess( state, { data: [ data ] } );
+}
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS ] = (
-	state,
-	{ instanceId, data }
-) => {
+function handleSettingsRequestSuccess( state, { instanceId, data } ) {
 	return {
 		...state,
 		[ instanceId ]: {
@@ -62,6 +54,16 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS ] =
 			...data.formData,
 		},
 	};
-};
+}
 
-export default createReducer( {}, reducers );
+export default withoutPersistence( ( state = {}, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS:
+			return handleRequestSuccess( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED:
+			return handleMethodUpdated( state, action );
+		case WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS:
+			return handleSettingsRequestSuccess( state, action );
+	}
+	return state;
+} );

--- a/client/extensions/woocommerce/state/sites/shipping-zone-methods/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-methods/reducer.js
@@ -1,6 +1,9 @@
 /**
  * Externals dependencies
+ *
+ * @format
  */
+
 import { mapValues } from 'lodash';
 
 /**
@@ -11,11 +14,14 @@ import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 import { WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS } from 'woocommerce/woocommerce-services/state/action-types';
+import { createReducer } from 'state/utils';
 
-function addMethodsToState( state, methods ) {
-	const nextState = { ...state };
-	methods.forEach( method => {
-		nextState[ method.id ] = {
+const reducers = {};
+
+reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS ] = ( state, { data } ) => {
+	const newState = { ...state };
+	data.forEach( method => {
+		newState[ method.id ] = {
 			id: method.id,
 			order: method.order,
 			enabled: method.enabled,
@@ -25,37 +31,37 @@ function addMethodsToState( state, methods ) {
 			...mapValues( method.settings, 'value' ),
 		};
 	} );
-	return nextState;
-}
 
-export default function( state = {}, action ) {
-	switch ( action.type ) {
-		case WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS:
-			return addMethodsToState( state, action.data );
+	return newState;
+};
 
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED:
-			if ( ! action.data.id ) {
-				// WCS endpoints don't return the data on success, get that info from the originatingAction
-				return {
-					...state,
-					[ action.originatingAction.methodId ]: {
-						...state[ action.originatingAction.methodId ], // Preserve the previous method data
-						id: action.originatingAction.methodId,
-						methodType: action.originatingAction.methodType,
-						...action.originatingAction.method,
-					},
-				};
-			}
-			return addMethodsToState( state, [ action.data ] );
-
-		case WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS:
-			return {
-				...state,
-				[ action.instanceId ]: {
-					...state[ action.instanceId ],
-					...action.data.formData,
-				},
-			};
+reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ] = ( state, { data, originatingAction } ) => {
+	if ( ! data.id ) {
+		// WCS endpoints don't return the data on success, get that info from the originatingAction
+		return {
+			...state,
+			[ originatingAction.methodId ]: {
+				...state[ originatingAction.methodId ], // Preserve the previous method data
+				id: originatingAction.methodId,
+				methodType: originatingAction.methodType,
+				...originatingAction.method,
+			},
+		};
 	}
-	return state;
-}
+	return reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST_SUCCESS ]( state, { data: [ data ] } );
+};
+
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS ] = (
+	state,
+	{ instanceId, data }
+) => {
+	return {
+		...state,
+		[ instanceId ]: {
+			...state[ instanceId ],
+			...data.formData,
+		},
+	};
+};
+
+export default createReducer( {}, reducers );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `createReducer` from a single reducer as part of #36678

#### Testing instructions

I'm unfamiliar with the store and unable to provide manual testing instructions.