### PR TITLE
Store: Remove createReducer from ui shipping-zone-methods

### DIFF
--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { find, findIndex, isEmpty, isEqual, isNil, omit, reject } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_OPEN,
@@ -47,8 +44,6 @@ export const initialState = {
 	currentlyEditingChangedType: false,
 };
 
-const reducer = {};
-
 /**
  * Gets the temporal ID object that the next created method should have.
  * @param {Object} state Current edit state
@@ -60,7 +55,7 @@ const nextCreateId = state => {
 	};
 };
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD ] = ( state, action ) => {
+function handleZoneMethodAdd( state, action ) {
 	const { methodType, title } = action;
 	const id = nextCreateId( state );
 	let method = { id, methodType };
@@ -78,9 +73,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD ] = ( state, action ) => {
 		currentlyEditingChangedType: false,
 		currentlyEditingChanges: method,
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_OPEN ] = ( state, action ) => {
+function handleZoneMethodOpen( state, action ) {
 	return {
 		...state,
 		currentlyEditingId: action.methodId,
@@ -88,18 +83,18 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_OPEN ] = ( state, action ) => {
 		currentlyEditingChangedType: false,
 		currentlyEditingNew: false,
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CANCEL ] = state => {
+function handleZoneMethodCancel( state ) {
 	return {
 		...state,
 		currentlyEditingId: null,
 		currentlyEditingChangedType: false,
 		currentlyEditingNew: false,
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE ] = state => {
+function handleZoneMethodClose( state ) {
 	const {
 		currentlyEditingId,
 		currentlyEditingChanges,
@@ -141,9 +136,7 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE ] = state => {
 			originalId = method._originalId;
 		}
 
-		state = reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_REMOVE ]( state, {
-			methodId: currentlyEditingId,
-		} );
+		state = handleZoneMethodRemove( state, { methodId: currentlyEditingId } );
 		return {
 			...state,
 			currentlyEditingId: null,
@@ -189,9 +182,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE ] = state => {
 		currentlyEditingNew: false,
 		[ bucket ]: newBucket,
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_REMOVE ] = ( state, { methodId } ) => {
+function handleZoneMethodRemove( state, { methodId } ) {
 	const newState = {
 		...state,
 		currentlyEditingId: null,
@@ -204,9 +197,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_REMOVE ] = ( state, { methodId } ) => 
 	newState[ bucket ] = reject( state[ bucket ], { id: methodId } );
 
 	return newState;
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CHANGE_TYPE ] = ( state, action ) => {
+function handleZoneMethodChangeType( state, action ) {
 	const { methodType, title } = action;
 	if ( ! builtInShippingMethods[ methodType ] ) {
 		return state;
@@ -225,9 +218,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CHANGE_TYPE ] = ( state, action ) => {
 		currentlyEditingChangedType: true,
 		currentlyEditingChanges,
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_EDIT_TITLE ] = ( state, { title } ) => {
+function handleZoneMethodEditTitle( state, { title } ) {
 	return {
 		...state,
 		currentlyEditingChanges: {
@@ -235,9 +228,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_EDIT_TITLE ] = ( state, { title } ) =>
 			title,
 		},
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_OPENED_ENABLED ] = ( state, { enabled } ) => {
+function handleZoneMethodToggleOpenedEnabled( state, { enabled } ) {
 	return {
 		...state,
 		currentlyEditingChanges: {
@@ -245,9 +238,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_OPENED_ENABLED ] = ( state, { e
 			enabled,
 		},
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_ENABLED ] = ( state, { methodId, enabled } ) => {
+function handleZoneMethodToggleEnabled( state, { methodId, enabled } ) {
 	const bucket = getBucket( { id: methodId } );
 	const index = findIndex( state[ bucket ], { id: methodId } );
 
@@ -277,12 +270,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_ENABLED ] = ( state, { methodId
 			...state[ bucket ].slice( index + 1 ),
 		],
 	};
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ] = (
-	state,
-	{ data, originatingAction: { methodId, method } }
-) => {
+function handleZoneMethodUpdated( state, { data, originatingAction: { methodId, method } } ) {
 	const bucket = getBucket( { id: methodId } );
 	const newState = {
 		...state,
@@ -317,12 +307,9 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ] = (
 		}
 	}
 	return newState;
-};
+}
 
-reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_DELETED ] = (
-	state,
-	{ originatingAction: { methodId } }
-) => {
+function handleZoneMethodDeleted( state, { originatingAction: { methodId } } ) {
 	return {
 		...state,
 		creates: reject( state.creates, { id: methodId } ),
@@ -330,13 +317,32 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_DELETED ] = (
 		deletes: reject( state.deletes, { id: methodId } ),
 		currentlyEditingId: null,
 	};
-};
+}
 
-const mainReducer = createReducer( initialState, reducer );
-
-export default ( state, action ) => {
-	if ( reducer[ action.type ] ) {
-		return mainReducer( state, action );
+export default withoutPersistence( ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD:
+			return handleZoneMethodAdd( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_OPEN:
+			return handleZoneMethodOpen( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_CANCEL:
+			return handleZoneMethodCancel( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE:
+			return handleZoneMethodClose( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_REMOVE:
+			return handleZoneMethodRemove( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_CHANGE_TYPE:
+			return handleZoneMethodChangeType( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_EDIT_TITLE:
+			return handleZoneMethodEditTitle( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_OPENED_ENABLED:
+			return handleZoneMethodToggleOpenedEnabled( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_ENABLED:
+			return handleZoneMethodToggleEnabled( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED:
+			return handleZoneMethodUpdated( state, action );
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_DELETED:
+			return handleZoneMethodDeleted( state, action );
 	}
 
 	const { methodId, methodType } = action;
@@ -355,4 +361,4 @@ export default ( state, action ) => {
 	}
 
 	return state;
-};
+} );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
@@ -1,11 +1,15 @@
+/** @format */
+
 /**
  * External dependencies
  */
+
 import { find, findIndex, isEmpty, isEqual, isNil, omit, reject } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_OPEN,
@@ -43,6 +47,8 @@ export const initialState = {
 	currentlyEditingChangedType: false,
 };
 
+const reducer = {};
+
 /**
  * Gets the temporal ID object that the next created method should have.
  * @param {Object} state Current edit state
@@ -54,283 +60,138 @@ const nextCreateId = state => {
 	};
 };
 
-export default function mainReducer( state = initialState, action ) {
-	switch ( action.type ) {
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD: {
-			const { methodType, title } = action;
-			const id = nextCreateId( state );
-			let method = { id, methodType };
-			if ( builtInShippingMethods[ methodType ] ) {
-				method = {
-					...method,
-					title,
-					...builtInShippingMethods[ methodType ]( undefined, action ),
-				};
-			}
-			return {
-				...state,
-				currentlyEditingId: id,
-				currentlyEditingNew: true,
-				currentlyEditingChangedType: false,
-				currentlyEditingChanges: method,
-			};
-		}
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_OPEN:
-			return {
-				...state,
-				currentlyEditingId: action.methodId,
-				currentlyEditingChanges: {},
-				currentlyEditingChangedType: false,
-				currentlyEditingNew: false,
-			};
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_CANCEL:
-			return {
-				...state,
-				currentlyEditingId: null,
-				currentlyEditingChangedType: false,
-				currentlyEditingNew: false,
-			};
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE: {
-			const {
-				currentlyEditingId,
-				currentlyEditingChanges,
-				currentlyEditingNew,
-				currentlyEditingChangedType,
-			} = state;
-
-			if ( null === currentlyEditingId ) {
-				return state;
-			}
-			if ( isEmpty( currentlyEditingChanges ) ) {
-				// Nothing to save, no need to go through the rest of the algorithm
-				return {
-					...state,
-					currentlyEditingChangedType: false,
-					currentlyEditingNew: false,
-					currentlyEditingId: null,
-				};
-			}
-
-			const bucket = getBucket( { id: currentlyEditingId } );
-
-			if ( currentlyEditingNew ) {
-				return {
-					...state,
-					creates: [ ...state.creates, currentlyEditingChanges ],
-					currentlyEditingId: null,
-					currentlyEditingNew: false,
-					currentlyEditingChangedType: false,
-					currentlyEditingChanges: {},
-				};
-			}
-
-			//if method type has been changed, then remove the old one and a new method in its place
-			if ( currentlyEditingChangedType ) {
-				const method = find( state[ bucket ], { id: currentlyEditingId } );
-				let originalId = currentlyEditingId;
-				if ( method && ! isNil( method._originalId ) ) {
-					originalId = method._originalId;
-				}
-
-				state = removeShippingMethod( state, currentlyEditingId );
-
-				return {
-					...state,
-					currentlyEditingId: null,
-					currentlyEditingChangedType: false,
-					currentlyEditingNew: false,
-					creates: [
-						...state.creates,
-						{
-							...currentlyEditingChanges,
-							// If the "Enabled" toggle hasn't been modified in the current changes, use the value from the old method
-							enabled: isNil( currentlyEditingChanges.enabled )
-								? method && method.enabled
-								: currentlyEditingChanges.enabled,
-							id: nextCreateId( state ),
-							_originalId: originalId,
-						},
-					],
-				};
-			}
-
-			let found = false;
-			const newBucket = state[ bucket ].map( method => {
-				if ( isEqual( currentlyEditingId, method.id ) ) {
-					found = true;
-					// If edits for the method were already in the expected bucket, just update them
-					return {
-						...method,
-						...currentlyEditingChanges,
-					};
-				}
-				return method;
-			} );
-
-			if ( ! found ) {
-				// If edits for the zone were *not* in the bucket yet, add them
-				newBucket.push( { id: currentlyEditingId, ...currentlyEditingChanges } );
-			}
-
-			return {
-				...state,
-				currentlyEditingId: null,
-				currentlyEditingChangedType: false,
-				currentlyEditingNew: false,
-				[ bucket ]: newBucket,
-			};
-		}
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_REMOVE:
-			return removeShippingMethod( state, action.methodId );
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_CHANGE_TYPE: {
-			const { methodType, title } = action;
-			if ( ! builtInShippingMethods[ methodType ] ) {
-				return state;
-			}
-
-			const currentlyEditingChanges = {
-				...builtInShippingMethods[ methodType ]( undefined, action ),
-				id: state.currentlyEditingId,
-				title,
-				methodType,
-				enabled: state.currentlyEditingChanges && state.currentlyEditingChanges.enabled,
-			};
-
-			return {
-				...state,
-				currentlyEditingChangedType: true,
-				currentlyEditingChanges,
-			};
-		}
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_EDIT_TITLE:
-			return {
-				...state,
-				currentlyEditingChanges: {
-					...state.currentlyEditingChanges,
-					title: action.title,
-				},
-			};
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_OPENED_ENABLED:
-			return {
-				...state,
-				currentlyEditingChanges: {
-					...state.currentlyEditingChanges,
-					enabled: action.enabled,
-				},
-			};
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_ENABLED: {
-			const { methodId, enabled } = action;
-			const bucket = getBucket( { id: methodId } );
-			const index = findIndex( state[ bucket ], { id: methodId } );
-
-			if ( -1 === index ) {
-				return {
-					...state,
-					[ bucket ]: [
-						...state[ bucket ],
-						{
-							id: methodId,
-							enabled,
-						},
-					],
-				};
-			}
-
-			const methodState = {
-				...state[ bucket ][ index ],
-				enabled,
-			};
-
-			return {
-				...state,
-				[ bucket ]: [
-					...state[ bucket ].slice( 0, index ),
-					methodState,
-					...state[ bucket ].slice( index + 1 ),
-				],
-			};
-		}
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED: {
-			const {
-				data,
-				originatingAction: { methodId, method },
-			} = action;
-			const bucket = getBucket( { id: methodId } );
-			const newState = {
-				...state,
-				currentlyEditingId: null,
-			};
-
-			if ( 'creates' === bucket ) {
-				const createEdit = find( state.creates, { id: methodId } );
-				if ( createEdit ) {
-					newState.updates = [
-						...state.updates,
-						{
-							...createEdit,
-							id: data.id,
-						},
-					];
-				}
-				newState.creates = reject( state[ bucket ], { id: methodId } );
-			} else {
-				// WCS does partial updates, so only remove the method from the "updates" bucket if it all its fields were updated
-				const edit = find( state.updates, { id: methodId } );
-				const newEditFields = omit( edit, Object.keys( method ) );
-				if ( isEmpty( omit( newEditFields, [ 'id', 'methodType' ] ) ) ) {
-					newState.updates = reject( state.updates, { id: methodId } );
-				} else {
-					const index = findIndex( state.updates, { id: methodId } );
-					newState.updates = [
-						...state[ bucket ].slice( 0, index ),
-						newEditFields,
-						...state[ bucket ].slice( index + 1 ),
-					];
-				}
-			}
-			return newState;
-		}
-
-		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_DELETED:
-			return {
-				...state,
-				creates: reject( state.creates, { id: action.originatingAction.methodId } ),
-				updates: reject( state.updates, { id: action.originatingAction.methodId } ),
-				deletes: reject( state.deletes, { id: action.originatingAction.methodId } ),
-				currentlyEditingId: null,
-			};
-
-		default: {
-			const { methodId, methodType } = action;
-			// If the action has something to do with a built-in shipping method, fire its reducer
-			if ( methodId && methodType && builtInShippingMethods[ methodType ] ) {
-				// Only give the shipping method reducer data about the shipping method itself, not the whole tree
-				const methodState = state.currentlyEditingChanges;
-				const newMethodState = builtInShippingMethods[ methodType ]( methodState, action );
-
-				if ( newMethodState !== methodState ) {
-					return {
-						...state,
-						currentlyEditingChanges: newMethodState,
-					};
-				}
-			}
-
-			return state;
-		}
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD ] = ( state, action ) => {
+	const { methodType, title } = action;
+	const id = nextCreateId( state );
+	let method = { id, methodType };
+	if ( builtInShippingMethods[ methodType ] ) {
+		method = {
+			...method,
+			title,
+			...builtInShippingMethods[ methodType ]( undefined, action ),
+		};
 	}
-}
+	return {
+		...state,
+		currentlyEditingId: id,
+		currentlyEditingNew: true,
+		currentlyEditingChangedType: false,
+		currentlyEditingChanges: method,
+	};
+};
 
-function removeShippingMethod( state, methodId ) {
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_OPEN ] = ( state, action ) => {
+	return {
+		...state,
+		currentlyEditingId: action.methodId,
+		currentlyEditingChanges: {},
+		currentlyEditingChangedType: false,
+		currentlyEditingNew: false,
+	};
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CANCEL ] = state => {
+	return {
+		...state,
+		currentlyEditingId: null,
+		currentlyEditingChangedType: false,
+		currentlyEditingNew: false,
+	};
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE ] = state => {
+	const {
+		currentlyEditingId,
+		currentlyEditingChanges,
+		currentlyEditingNew,
+		currentlyEditingChangedType,
+	} = state;
+
+	if ( null === currentlyEditingId ) {
+		return state;
+	}
+	if ( isEmpty( currentlyEditingChanges ) ) {
+		// Nothing to save, no need to go through the rest of the algorithm
+		return {
+			...state,
+			currentlyEditingChangedType: false,
+			currentlyEditingNew: false,
+			currentlyEditingId: null,
+		};
+	}
+
+	const bucket = getBucket( { id: currentlyEditingId } );
+
+	if ( currentlyEditingNew ) {
+		return {
+			...state,
+			creates: [ ...state.creates, currentlyEditingChanges ],
+			currentlyEditingId: null,
+			currentlyEditingNew: false,
+			currentlyEditingChangedType: false,
+			currentlyEditingChanges: {},
+		};
+	}
+
+	//if method type has been changed, then remove the old one and a new method in its place
+	if ( currentlyEditingChangedType ) {
+		const method = find( state[ bucket ], { id: currentlyEditingId } );
+		let originalId = currentlyEditingId;
+		if ( method && ! isNil( method._originalId ) ) {
+			originalId = method._originalId;
+		}
+
+		state = reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_REMOVE ]( state, {
+			methodId: currentlyEditingId,
+		} );
+		return {
+			...state,
+			currentlyEditingId: null,
+			currentlyEditingChangedType: false,
+			currentlyEditingNew: false,
+			creates: [
+				...state.creates,
+				{
+					...currentlyEditingChanges,
+					// If the "Enabled" toggle hasn't been modified in the current changes, use the value from the old method
+					enabled: isNil( currentlyEditingChanges.enabled )
+						? method && method.enabled
+						: currentlyEditingChanges.enabled,
+					id: nextCreateId( state ),
+					_originalId: originalId,
+				},
+			],
+		};
+	}
+
+	let found = false;
+	const newBucket = state[ bucket ].map( method => {
+		if ( isEqual( currentlyEditingId, method.id ) ) {
+			found = true;
+			// If edits for the method were already in the expected bucket, just update them
+			return {
+				...method,
+				...currentlyEditingChanges,
+			};
+		}
+		return method;
+	} );
+
+	if ( ! found ) {
+		// If edits for the zone were *not* in the bucket yet, add them
+		newBucket.push( { id: currentlyEditingId, ...currentlyEditingChanges } );
+	}
+
+	return {
+		...state,
+		currentlyEditingId: null,
+		currentlyEditingChangedType: false,
+		currentlyEditingNew: false,
+		[ bucket ]: newBucket,
+	};
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_REMOVE ] = ( state, { methodId } ) => {
 	const newState = {
 		...state,
 		currentlyEditingId: null,
@@ -343,4 +204,155 @@ function removeShippingMethod( state, methodId ) {
 	newState[ bucket ] = reject( state[ bucket ], { id: methodId } );
 
 	return newState;
-}
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CHANGE_TYPE ] = ( state, action ) => {
+	const { methodType, title } = action;
+	if ( ! builtInShippingMethods[ methodType ] ) {
+		return state;
+	}
+
+	const currentlyEditingChanges = {
+		...builtInShippingMethods[ methodType ]( undefined, action ),
+		id: state.currentlyEditingId,
+		title,
+		methodType,
+		enabled: state.currentlyEditingChanges && state.currentlyEditingChanges.enabled,
+	};
+
+	return {
+		...state,
+		currentlyEditingChangedType: true,
+		currentlyEditingChanges,
+	};
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_EDIT_TITLE ] = ( state, { title } ) => {
+	return {
+		...state,
+		currentlyEditingChanges: {
+			...state.currentlyEditingChanges,
+			title,
+		},
+	};
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_OPENED_ENABLED ] = ( state, { enabled } ) => {
+	return {
+		...state,
+		currentlyEditingChanges: {
+			...state.currentlyEditingChanges,
+			enabled,
+		},
+	};
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_ENABLED ] = ( state, { methodId, enabled } ) => {
+	const bucket = getBucket( { id: methodId } );
+	const index = findIndex( state[ bucket ], { id: methodId } );
+
+	if ( -1 === index ) {
+		return {
+			...state,
+			[ bucket ]: [
+				...state[ bucket ],
+				{
+					id: methodId,
+					enabled,
+				},
+			],
+		};
+	}
+
+	const methodState = {
+		...state[ bucket ][ index ],
+		enabled,
+	};
+
+	return {
+		...state,
+		[ bucket ]: [
+			...state[ bucket ].slice( 0, index ),
+			methodState,
+			...state[ bucket ].slice( index + 1 ),
+		],
+	};
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ] = (
+	state,
+	{ data, originatingAction: { methodId, method } }
+) => {
+	const bucket = getBucket( { id: methodId } );
+	const newState = {
+		...state,
+		currentlyEditingId: null,
+	};
+
+	if ( 'creates' === bucket ) {
+		const createEdit = find( state.creates, { id: methodId } );
+		if ( createEdit ) {
+			newState.updates = [
+				...state.updates,
+				{
+					...createEdit,
+					id: data.id,
+				},
+			];
+		}
+		newState.creates = reject( state[ bucket ], { id: methodId } );
+	} else {
+		// WCS does partial updates, so only remove the method from the "updates" bucket if it all its fields were updated
+		const edit = find( state.updates, { id: methodId } );
+		const newEditFields = omit( edit, Object.keys( method ) );
+		if ( isEmpty( omit( newEditFields, [ 'id', 'methodType' ] ) ) ) {
+			newState.updates = reject( state.updates, { id: methodId } );
+		} else {
+			const index = findIndex( state.updates, { id: methodId } );
+			newState.updates = [
+				...state[ bucket ].slice( 0, index ),
+				newEditFields,
+				...state[ bucket ].slice( index + 1 ),
+			];
+		}
+	}
+	return newState;
+};
+
+reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_DELETED ] = (
+	state,
+	{ originatingAction: { methodId } }
+) => {
+	return {
+		...state,
+		creates: reject( state.creates, { id: methodId } ),
+		updates: reject( state.updates, { id: methodId } ),
+		deletes: reject( state.deletes, { id: methodId } ),
+		currentlyEditingId: null,
+	};
+};
+
+const mainReducer = createReducer( initialState, reducer );
+
+export default ( state, action ) => {
+	if ( reducer[ action.type ] ) {
+		return mainReducer( state, action );
+	}
+
+	const { methodId, methodType } = action;
+	// If the action has something to do with a built-in shipping method, fire its reducer
+	if ( methodId && methodType && builtInShippingMethods[ methodType ] ) {
+		// Only give the shipping method reducer data about the shipping method itself, not the whole tree
+		const methodState = state.currentlyEditingChanges;
+		const newMethodState = builtInShippingMethods[ methodType ]( methodState, action );
+
+		if ( newMethodState !== methodState ) {
+			return {
+				...state,
+				currentlyEditingChanges: newMethodState,
+			};
+		}
+	}
+
+	return state;
+};

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/test/reducer.js
@@ -1,10 +1,3 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */
@@ -31,23 +24,23 @@ describe( 'reducer', () => {
 				initialState,
 				addMethodToShippingZone( siteId, 'flat_rate', 'Flat rate' )
 			);
-			expect( newState.currentlyEditingId ).to.deep.equal( { index: 0 } );
-			expect( newState.currentlyEditingNew ).to.equal( true );
-			expect( newState.creates.length ).to.equal( 0 );
-			expect( newState.currentlyEditingChanges.id ).to.deep.equal( { index: 0 } );
-			expect( newState.currentlyEditingChanges.methodType ).to.equal( 'flat_rate' );
-			expect( newState.currentlyEditingChanges.title ).to.equal( 'Flat rate' );
+			expect( newState.currentlyEditingId ).toEqual( { index: 0 } );
+			expect( newState.currentlyEditingNew ).toBe( true );
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.currentlyEditingChanges.id ).toEqual( { index: 0 } );
+			expect( newState.currentlyEditingChanges.methodType ).toBe( 'flat_rate' );
+			expect( newState.currentlyEditingChanges.title ).toBe( 'Flat rate' );
 			// Check that the method was initialized:
-			expect( newState.currentlyEditingChanges.cost ).to.be.a( 'number' );
+			expect( typeof newState.currentlyEditingChanges.cost ).toBe( 'number' );
 		} );
 	} );
 
 	describe( 'removeMethodFromShippingZone', () => {
 		test( 'should add the method ID to the "deletes" list if it is a server-side ID', () => {
 			const newState = reducer( initialState, removeMethodFromShippingZone( siteId, 1 ) );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.updates ).to.be.empty;
-			expect( newState.deletes ).to.deep.equal( [ { id: 1 } ] );
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toEqual( [ { id: 1 } ] );
 		} );
 
 		test( 'should delete any previous "updates" the method had', () => {
@@ -57,9 +50,9 @@ describe( 'reducer', () => {
 				deletes: [],
 			};
 			const newState = reducer( state, removeMethodFromShippingZone( siteId, 1 ) );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.updates ).to.be.empty;
-			expect( newState.deletes ).to.deep.equal( [ { id: 1 } ] );
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toEqual( [ { id: 1 } ] );
 		} );
 
 		test( 'should remove the method from the "creates" list if it had a provisional ID', () => {
@@ -69,9 +62,9 @@ describe( 'reducer', () => {
 				deletes: [],
 			};
 			const newState = reducer( state, removeMethodFromShippingZone( siteId, { index: 0 } ) );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.updates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -91,10 +84,10 @@ describe( 'reducer', () => {
 				state,
 				changeShippingZoneMethodType( siteId, 'flat_rate', 'Flat rate' )
 			);
-			expect( newState.currentlyEditingChanges.methodType ).to.equal( 'flat_rate' );
-			expect( newState.currentlyEditingChanges.title ).to.equal( 'Flat rate' );
-			expect( newState.currentlyEditingChangedType ).to.equal( true );
-			expect( newState.currentlyEditingNew ).to.equal( false );
+			expect( newState.currentlyEditingChanges.methodType ).toBe( 'flat_rate' );
+			expect( newState.currentlyEditingChanges.title ).toBe( 'Flat rate' );
+			expect( newState.currentlyEditingChangedType ).toBe( true );
+			expect( newState.currentlyEditingNew ).toBe( false );
 		} );
 
 		test( 'should change the type of a newly added method and keep it marked as new', () => {
@@ -112,10 +105,10 @@ describe( 'reducer', () => {
 				state,
 				changeShippingZoneMethodType( siteId, 'flat_rate', 'Flat rate' )
 			);
-			expect( newState.currentlyEditingChanges.methodType ).to.equal( 'flat_rate' );
-			expect( newState.currentlyEditingChanges.title ).to.equal( 'Flat rate' );
-			expect( newState.currentlyEditingChangedType ).to.equal( true );
-			expect( newState.currentlyEditingNew ).to.equal( true );
+			expect( newState.currentlyEditingChanges.methodType ).toBe( 'flat_rate' );
+			expect( newState.currentlyEditingChanges.title ).toBe( 'Flat rate' );
+			expect( newState.currentlyEditingChangedType ).toBe( true );
+			expect( newState.currentlyEditingNew ).toBe( true );
 		} );
 	} );
 
@@ -130,7 +123,7 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, changeShippingZoneMethodTitle( siteId, 'New Title' ) );
-			expect( newState.currentlyEditingChanges ).to.deep.equal( { title: 'New Title' } );
+			expect( newState.currentlyEditingChanges ).toEqual( { title: 'New Title' } );
 		} );
 	} );
 
@@ -145,7 +138,7 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, setShippingCost( siteId, 1, 42 ) );
-			expect( newState.currentlyEditingChanges.cost ).to.equal( 42 );
+			expect( newState.currentlyEditingChanges.cost ).toBe( 42 );
 		} );
 	} );
 
@@ -160,10 +153,10 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, openShippingZoneMethod( siteId, 1 ) );
-			expect( newState.currentlyEditingId ).to.equal( 1 );
-			expect( newState.currentlyEditingNew ).to.equal( false );
-			expect( newState.currentlyEditingChangedType ).to.equal( false );
-			expect( newState.currentlyEditingChanges ).to.deep.equal( {} );
+			expect( newState.currentlyEditingId ).toBe( 1 );
+			expect( newState.currentlyEditingNew ).toBe( false );
+			expect( newState.currentlyEditingChangedType ).toBe( false );
+			expect( newState.currentlyEditingChanges ).toEqual( {} );
 		} );
 	} );
 
@@ -177,7 +170,7 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, cancelShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
+			expect( newState.currentlyEditingId ).toBeNull();
 		} );
 
 		test( 'should discard the changes', () => {
@@ -190,8 +183,8 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, cancelShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.updates[ 0 ].title ).to.equal( 'Old Title' );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.updates[ 0 ].title ).toBe( 'Old Title' );
 		} );
 	} );
 
@@ -211,7 +204,7 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
+			expect( newState.currentlyEditingId ).toBeNull();
 		} );
 
 		test( 'method creation - should add the new method to creates and remove the isNew flag', () => {
@@ -225,64 +218,56 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.currentlyEditingNew ).to.equal( false );
-			expect( newState.creates.length ).to.equal( 1 );
-			expect( newState.creates[ 0 ].id ).to.deep.equal( { index: 0 } );
-			expect( newState.creates[ 0 ].title ).to.equal( 'abc' );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.currentlyEditingNew ).toBe( false );
+			expect( newState.creates.length ).toBe( 1 );
+			expect( newState.creates[ 0 ].id ).toEqual( { index: 0 } );
+			expect( newState.creates[ 0 ].title ).toBe( 'abc' );
 		} );
 
-		test(
-			'method type changed - should add the old method to "deletes" and add the new one to "creates" ' +
-				'if it had a server-side ID',
-			() => {
-				const state = {
-					creates: [],
-					updates: [ { id: 7, methodType: 'free_shipping', title: 'MyMethod' } ],
-					deletes: [],
-					currentlyEditingId: 7,
-					currentlyEditingChanges: { id: 7, methodType: 'flat_rate', cost: 12 },
-					currentlyEditingChangedType: true,
-				};
+		test( 'method type changed - should add the old method to "deletes" and add the new one to "creates" if it had a server-side ID', () => {
+			const state = {
+				creates: [],
+				updates: [ { id: 7, methodType: 'free_shipping', title: 'MyMethod' } ],
+				deletes: [],
+				currentlyEditingId: 7,
+				currentlyEditingChanges: { id: 7, methodType: 'flat_rate', cost: 12 },
+				currentlyEditingChangedType: true,
+			};
 
-				const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-				expect( newState.currentlyEditingId ).to.equal( null );
-				expect( newState.updates ).to.be.empty;
-				expect( newState.deletes ).to.deep.equal( [ { id: 7 } ] );
-				expect( newState.creates.length ).to.equal( 1 );
-				expect( newState.creates[ 0 ].id ).to.deep.equal( { index: 0 } );
-				expect( newState.creates[ 0 ].methodType ).to.equal( 'flat_rate' );
-				expect( newState.creates[ 0 ]._originalId ).to.equal( 7 );
-				// Check that the method was initialized:
-				expect( newState.creates[ 0 ].cost ).to.be.a( 'number' );
-			}
-		);
+			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toEqual( [ { id: 7 } ] );
+			expect( newState.creates.length ).toBe( 1 );
+			expect( newState.creates[ 0 ].id ).toEqual( { index: 0 } );
+			expect( newState.creates[ 0 ].methodType ).toBe( 'flat_rate' );
+			expect( newState.creates[ 0 ]._originalId ).toBe( 7 );
+			// Check that the method was initialized:
+			expect( typeof newState.creates[ 0 ].cost ).toBe( 'number' );
+		} );
 
-		test(
-			'method type changed - should remove the old method from "creates" and replace it with the new one ' +
-				'if it had a provisional ID',
-			() => {
-				const state = {
-					creates: [ { id: { index: 0 }, methodType: 'free_shipping', title: 'MyMethod' } ],
-					updates: [],
-					deletes: [],
-					currentlyEditingId: { index: 0 },
-					currentlyEditingChanges: { id: { index: 0 }, methodType: 'flat_rate', cost: 12 },
-					currentlyEditingChangedType: true,
-				};
+		test( 'method type changed - should remove the old method from "creates" and replace it with the new one if it had a provisional ID', () => {
+			const state = {
+				creates: [ { id: { index: 0 }, methodType: 'free_shipping', title: 'MyMethod' } ],
+				updates: [],
+				deletes: [],
+				currentlyEditingId: { index: 0 },
+				currentlyEditingChanges: { id: { index: 0 }, methodType: 'flat_rate', cost: 12 },
+				currentlyEditingChangedType: true,
+			};
 
-				const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-				expect( newState.currentlyEditingId ).to.equal( null );
-				expect( newState.updates ).to.be.empty;
-				expect( newState.deletes ).to.be.empty;
-				expect( newState.creates.length ).to.equal( 1 );
-				expect( newState.creates[ 0 ].id ).to.deep.equal( { index: 0 } );
-				expect( newState.creates[ 0 ].methodType ).to.equal( 'flat_rate' );
-				expect( newState.creates[ 0 ]._originalId ).to.deep.equal( { index: 0 } );
-				// Check that the method was initialized:
-				expect( newState.creates[ 0 ].cost ).to.be.a( 'number' );
-			}
-		);
+			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.creates.length ).toBe( 1 );
+			expect( newState.creates[ 0 ].id ).toEqual( { index: 0 } );
+			expect( newState.creates[ 0 ].methodType ).toBe( 'flat_rate' );
+			expect( newState.creates[ 0 ]._originalId ).toEqual( { index: 0 } );
+			// Check that the method was initialized:
+			expect( typeof newState.creates[ 0 ].cost ).toBe( 'number' );
+		} );
 
 		test( 'method type changed - should preserve the _originalId field if the method had already changed type before', () => {
 			const state = {
@@ -294,13 +279,13 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.updates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.creates.length ).to.equal( 1 );
-			expect( newState.creates[ 0 ].id ).to.deep.equal( { index: 0 } );
-			expect( newState.creates[ 0 ].methodType ).to.equal( 'flat_rate' );
-			expect( newState.creates[ 0 ]._originalId ).to.deep.equal( 7 );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.creates.length ).toBe( 1 );
+			expect( newState.creates[ 0 ].id ).toEqual( { index: 0 } );
+			expect( newState.creates[ 0 ].methodType ).toBe( 'flat_rate' );
+			expect( newState.creates[ 0 ]._originalId ).toBe( 7 );
 		} );
 
 		test( 'title change - should change the entry on "updates" if the method has a server-side ID', () => {
@@ -313,10 +298,10 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.updates ).to.deep.equal( [ { id: 1, title: 'New Title' } ] );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.updates ).toEqual( [ { id: 1, title: 'New Title' } ] );
 		} );
 
 		test(
@@ -332,10 +317,10 @@ describe( 'reducer', () => {
 				};
 
 				const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-				expect( newState.currentlyEditingId ).to.equal( null );
-				expect( newState.creates ).to.be.empty;
-				expect( newState.deletes ).to.be.empty;
-				expect( newState.updates ).to.deep.equal( [ { id: 1, title: 'New Title' } ] );
+				expect( newState.currentlyEditingId ).toBeNull();
+				expect( newState.creates ).toHaveLength( 0 );
+				expect( newState.deletes ).toHaveLength( 0 );
+				expect( newState.updates ).toEqual( [ { id: 1, title: 'New Title' } ] );
 			}
 		);
 
@@ -349,10 +334,10 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.updates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.creates ).to.deep.equal( [ { id: { index: 0 }, title: 'New Title' } ] );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.creates ).toEqual( [ { id: { index: 0 }, title: 'New Title' } ] );
 		} );
 
 		test( 'property change - should change the entry on "updates" if the method has a server-side ID', () => {
@@ -365,10 +350,10 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.updates ).to.deep.equal( [ { id: 1, cost: 42 } ] );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.updates ).toEqual( [ { id: 1, cost: 42 } ] );
 		} );
 
 		test( 'property change - should add an entry on "updates" if the method has a server-side ID and it has not been edited', () => {
@@ -381,11 +366,11 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.updates.length ).to.equal( 1 );
-			expect( newState.updates[ 0 ] ).to.deep.include( { id: 1, cost: 42 } );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.updates.length ).toBe( 1 );
+			expect( newState.updates[ 0 ] ).toMatchObject( { id: 1, cost: 42 } );
 		} );
 
 		test( 'property change - should change the entry in "creates" if the method has a provisional ID', () => {
@@ -398,10 +383,10 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, closeShippingZoneMethod( siteId ) );
-			expect( newState.currentlyEditingId ).to.equal( null );
-			expect( newState.updates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.creates ).to.deep.equal( [ { id: { index: 0 }, cost: 42 } ] );
+			expect( newState.currentlyEditingId ).toBeNull();
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.creates ).toEqual( [ { id: { index: 0 }, cost: 42 } ] );
 		} );
 	} );
 
@@ -416,7 +401,7 @@ describe( 'reducer', () => {
 			};
 
 			const newState = reducer( state, toggleOpenedShippingZoneMethodEnabled( siteId, true ) );
-			expect( newState.currentlyEditingChanges.enabled ).to.equal( true );
+			expect( newState.currentlyEditingChanges.enabled ).toBe( true );
 		} );
 	} );
 
@@ -428,9 +413,9 @@ describe( 'reducer', () => {
 				deletes: [],
 			};
 			const newState = reducer( state, toggleShippingZoneMethodEnabled( siteId, 1, false ) );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.updates ).to.deep.equal( [ { id: 1, enabled: false } ] );
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.updates ).toEqual( [ { id: 1, enabled: false } ] );
 		} );
 
 		test( 'should add an entry on "updates" if the method has a server-side ID and it has not been edited', () => {
@@ -440,9 +425,9 @@ describe( 'reducer', () => {
 				deletes: [],
 			};
 			const newState = reducer( state, toggleShippingZoneMethodEnabled( siteId, 1, true ) );
-			expect( newState.creates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.updates ).to.deep.equal( [ { id: 1, enabled: true } ] );
+			expect( newState.creates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.updates ).toEqual( [ { id: 1, enabled: true } ] );
 		} );
 
 		test( 'should change the entry in "creates" if the method has a provisional ID', () => {
@@ -455,9 +440,9 @@ describe( 'reducer', () => {
 				state,
 				toggleShippingZoneMethodEnabled( siteId, { index: 0 }, true )
 			);
-			expect( newState.updates ).to.be.empty;
-			expect( newState.deletes ).to.be.empty;
-			expect( newState.creates ).to.deep.equal( [ { id: { index: 0 }, enabled: true } ] );
+			expect( newState.updates ).toHaveLength( 0 );
+			expect( newState.deletes ).toHaveLength( 0 );
+			expect( newState.creates ).toEqual( [ { id: { index: 0 }, enabled: true } ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `createReducer` from a single reducer as part of #36678

#### Testing instructions

I'm unfamiliar with the store and unable to provide manual testing instructions.