### PR TITLE
Notices: Fix line height on button links in notices

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -123,6 +123,7 @@
 		button.is-link {
 			text-decoration: underline;
 			color: var( --color-text-inverted );
+			line-height: inherit;
 
 			&:hover {
 				color: var( --color-text-inverted );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We set a fixed line-height on button links, and this carries over to notices. In some cases, the line height on the notice copy differs from the button link, and you get something like this:

<img width="720" alt="Screen Shot 2019-10-14 at 5 28 47 PM" src="https://user-images.githubusercontent.com/2124984/66784820-87fe8980-eea9-11e9-8821-46f77f72e7a8.png">

This PR resets the line height for button links within notices to match, so the above now looks like this:

<img width="464" alt="Screen Shot 2019-10-14 at 5 36 26 PM" src="https://user-images.githubusercontent.com/2124984/66784844-9482e200-eea9-11e9-9cff-99bd6213349f.png">


#### Testing instructions

* Switch to this PR, navigate to Tools -> Import -> GoDaddy
* Put in a URL to a site you know cannot be imported from GoDaddy (I used calobeedoodles.com)
* You'll get the above error. The line height for the two links at the end of the error should be vertically aligned with the "or" between them.
* Check for other cases where links appear within notices; does the line height look correct?

Fixes #36731