### PR TITLE
Use wp/v2 tags and category delete to delete the right term

### DIFF
--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -120,7 +120,7 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 }
 
 /**
- * Avoids an additional request to wp/v2 /taxonomies. The rest_base of a taxonomy slug may not match its slug
+ * Queries wp/v2 /taxonomies for a custom taxonomies rest_base. The rest_base of a taxonomy slug may not match its slug
  * For example tags have a taxonomy slug of post_tag, but are modifiable at /wp/v2/tags/
  *
  * @param   {Number} siteId   Site ID
@@ -220,18 +220,20 @@ export function deleteTerm( siteId, taxonomy, termId ) {
 		return new Promise( ( resolve, reject ) => {
 			// Taxonomy Slugs are not unique! Use wp/v2 for deletion to avoid deleting the wrong term!
 			// https://github.com/Automattic/wp-calypso/issues/36620
-			getTaxonomyRestBase( siteId, taxonomy ).then( taxonomyRestBase => {
-				wpcom.req
-					.get( {
-						path: `/sites/${ siteId }/${ taxonomyRestBase }/${ termId }?force=true`,
-						method: 'DELETE',
-						apiNamespace: 'wp/v2',
-					} )
-					.then( () => {
-						removeTermFromState( { dispatch, getState, siteId, taxonomy, termId } );
-						resolve();
-					}, reject );
-			} );
+			getTaxonomyRestBase( siteId, taxonomy )
+				.then( taxonomyRestBase => {
+					wpcom.req
+						.get( {
+							path: `/sites/${ siteId }/${ taxonomyRestBase }/${ termId }?force=true`,
+							method: 'DELETE',
+							apiNamespace: 'wp/v2',
+						} )
+						.then( () => {
+							removeTermFromState( { dispatch, getState, siteId, taxonomy, termId } );
+							resolve();
+						}, reject );
+				} )
+				.catch( reject );
 		} );
 	};
 }

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -409,11 +409,9 @@ describe( 'actions', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( `/rest/v1.1/sites/${ siteId }/taxonomies/${ taxonomyName }/terms/slug:ribs/delete` )
+				.delete( `/wp/v2/sites/2916284/jetpack-testimonials/10?force=true` )
 				.reply( 200, { status: 'ok' } )
-				.post(
-					`/rest/v1.1/sites/${ siteId }/taxonomies/${ categoryTaxonomyName }/terms/slug:ribs/delete`
-				)
+				.delete( `/wp/v2/sites/2916284/categories/10?force=true` )
 				.reply( 200, { status: 'ok' } );
 		} );
 

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -47,7 +47,7 @@ const testTerms = [
 	},
 ];
 const siteId = 2916284;
-const taxonomyName = 'jetpack-testimonials';
+const taxonomyName = 'jetpack-portfolio-tag';
 const categoryTaxonomyName = 'category';
 
 describe( 'actions', () => {
@@ -409,9 +409,11 @@ describe( 'actions', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.delete( `/wp/v2/sites/2916284/jetpack-testimonials/10?force=true` )
+				.get( `/wp/v2/sites/${ siteId }/taxonomies/${ taxonomyName }/` )
+				.reply( 200, { rest_base: taxonomyName } )
+				.delete( `/wp/v2/sites/${ siteId }/${ taxonomyName }/10?force=true` )
 				.reply( 200, { status: 'ok' } )
-				.delete( `/wp/v2/sites/2916284/categories/10?force=true` )
+				.delete( `/wp/v2/sites/${ siteId }/categories/10?force=true` )
 				.reply( 200, { status: 'ok' } );
 		} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/36620 

Slugs for taxonomies aren't guaranteed to be unique. This means that wpcom v1.x APIs that rely on this behavior may in fact delete or update the wrong term. For example a tag of `test` and `test'` will share a slug of `test` but have a different `id` and `name` field.

This PR only updates the delete method to use the wp/v2 taxonomies endpoint https://developer.wordpress.org/rest-api/reference/taxonomies/#definition-2

Overall I'd recommend a full refactor of this section to use `wp/v2` APIs, but I'd like a smaller fix here to address the terrible behavior noted in the parent issue. I've added https://github.com/Automattic/wp-calypso/issues/36877 to track the larger refactor.

<img width="1075" alt="66780737-7657ba80-ee86-11e9-856f-e571a25540dc" src="https://user-images.githubusercontent.com/1270189/66786419-19afcc00-ee95-11e9-8427-d83de1d25035.png">

### Testing Instructions
- It may be more stable to visit `wp-admin/edit-tags.php?taxonomy=post_tag` and add/edit tags there.
- Create Posts with both `test'` and other posts with `test`
- Visit http://calypso.localhost:3000/settings/taxonomies/post_tag/siteId (Manage > Settings > Tags)
- Delete a tag `test'`
- Verify that `test'` was deleted only, not `test` and that tag references are removed from posts.
- Repeat for Categories (Manage > Settings > Categories)
- Manually visit a custom taxonomy by visiting `http://calypso.localhost:3000/settings/taxonomies/${ taxonomy }/${ siteId }` (The UI may be a bit funky)
- Verify that deleting still works as expected.

### Notes
- The Calypso Classic editor allows creating tags of `test'` but will save with a tag of `test`
- The Block Editor will properly add and tag `test'`
- There's some odd behavior with adding a single tag in the Block-Editor which should be resolved in a separate PR