### PR TITLE
Customer Home: Force a new component as the selected site changes

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -12,15 +12,16 @@ import page from 'page';
  */
 import { abtest } from 'lib/abtest';
 import CustomerHome from './main';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 
 export default function( context, next ) {
+	const siteId = getSelectedSiteId( context.store.getState() );
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome checklistMode={ get( context, 'query.d' ) } />;
+	context.primary = <CustomerHome checklistMode={ get( context, 'query.d' ) } key={ siteId } />;
 
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Because we need to use component state in order to determine if the checklist has just been completed, and therefore whether we should display the congratulations message, this state needs to be reset when a new site is selected. [The preferred way to do that](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) is to set a key on the component with the state, which forces React to render a new component as that key changes.

#### Testing instructions

* Ensure you are part of the customer home a/b test by setting the `customerHomePage` test to `show` in the environment menu
* Setup two sites, one with the checklist complete and one without the checklist complete.
* Load `/home` for the site without the checklist complete. 
* Switch site to the site with the checklist complete and you should see the congratulations message
* Navigate back to the other site and the message will remain - displayed above the checklist.

This in not desired behaviour! Using this branch, run the same test and the message should not be displayed.

Additionally you can complete the checklist on a site (be sure to launch your site before completing all the other tasks, and that you return to the checklist in a development environment as it's easy to end up on wordpress.com). As you complete the last task in the checklist, you should be shown Customer Home with the congratulations message. Selecting the other site will cause the message to disappear.

Fixes #
