### PR TITLE
Prevent flash of hosting content by returning on success before running redirect

### DIFF
--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -19,15 +19,15 @@ export function redirectIfNotAtomic( context, next ) {
 	const state = store.getState();
 	const isAtomic = isSiteAutomatedTransfer( state, getSelectedSiteId( state ) );
 
-	if ( ! config.isEnabled( 'hosting' ) || ! isAtomic ) {
-		page.redirect( '/' );
+	if ( config.isEnabled( 'hosting' ) && isAtomic ) {
+		next();
+		return;
 	}
 
-	next();
+	page.redirect( '/' );
 }
 
 export function layout( context, next ) {
 	context.primary = React.createElement( Hosting );
-
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the order in which the permissions failure is handled in hosting controller

#### Testing instructions

* Apply this patch to your local calypso dev environment
* Go direct to http://calypso.localhost:3000/hosting/{simple-site-domain}
* Make sure these is no flash of the hosting page content before you are redirected
* Go to http://calypso.localhost:3000/hosting/{atomic-site-domain}
* Make sure hosting panel loads correctly

Fixes #36756
