### PR TITLE
Gutenboarding: Add top-down Gutenboarding experiment

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,12 @@ const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
 const config = {
 	presets: [ [ '@automattic/calypso-build/babel/default', { modules } ] ],
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
+	overrides: [
+		{
+			test: [ './client/gutenboarding', './client/gutenboarding-topdown' ],
+			presets: [ require.resolve( '@automattic/calypso-build/babel/wordpress-element' ) ],
+		},
+	],
 	env: {
 		build_pot: {
 			plugins: [

--- a/client/gutenboarding-topdown/.eslintrc.js
+++ b/client/gutenboarding-topdown/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+	extends: [ '../../.eslintrc.js' ],
+	rules: {
+		'react/react-in-jsx-scope': 0,
+	},
+};

--- a/client/gutenboarding-topdown/controller.tsx
+++ b/client/gutenboarding-topdown/controller.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import config from 'config';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Editor from './editor';
+import { hideMasterbar as hideMasterbarAction } from 'state/ui/actions';
+
+export const redirectIfNotEnabled: PageJS.Callback = ( context, next ) => {
+	if ( ! config.isEnabled( 'gutenboarding' ) ) {
+		page.redirect( '/' );
+		return;
+	}
+	next();
+};
+
+export const hideMasterbar: PageJS.Callback = ( context, next ) => {
+	context.store.dispatch( hideMasterbarAction() );
+	next();
+};
+
+export const main: PageJS.Callback = ( context, next ) => {
+	context.primary = <Editor />;
+	next();
+};

--- a/client/gutenboarding-topdown/editor.js
+++ b/client/gutenboarding-topdown/editor.js
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import memize from 'memize';
+import { size, map, without } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withSelect, withDispatch } from '@wordpress/data';
+import { EditorProvider, ErrorBoundary, PostLockedModal } from '@wordpress/editor';
+import { StrictMode, Component } from '@wordpress/element';
+import { KeyboardShortcuts, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import preventEventDiscovery from '@wordpress/edit-post/build-module/prevent-event-discovery';
+import Layout from '@wordpress/edit-post/build-module/components/layout';
+import EditorInitialization from '@wordpress/edit-post/build-module/components/editor-initialization';
+import EditPostSettings from '@wordpress/edit-post/build-module/components/edit-post-settings';
+
+class Editor extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.getEditorSettings = memize( this.getEditorSettings, {
+			maxSize: 1,
+		} );
+	}
+
+	getEditorSettings(
+		settings,
+		hasFixedToolbar,
+		showInserterHelpPanel,
+		focusMode,
+		hiddenBlockTypes,
+		blockTypes,
+		preferredStyleVariations,
+		__experimentalLocalAutosaveInterval,
+		updatePreferredStyleVariations
+	) {
+		settings = {
+			...settings,
+			__experimentalPreferredStyleVariations: {
+				value: preferredStyleVariations,
+				onChange: updatePreferredStyleVariations,
+			},
+			hasFixedToolbar,
+			focusMode,
+			showInserterHelpPanel,
+			__experimentalLocalAutosaveInterval,
+		};
+
+		// Omit hidden block types if exists and non-empty.
+		if ( size( hiddenBlockTypes ) > 0 ) {
+			// Defer to passed setting for `allowedBlockTypes` if provided as
+			// anything other than `true` (where `true` is equivalent to allow
+			// all block types).
+			const defaultAllowedBlockTypes =
+				true === settings.allowedBlockTypes
+					? map( blockTypes, 'name' )
+					: settings.allowedBlockTypes || [];
+
+			settings.allowedBlockTypes = without( defaultAllowedBlockTypes, ...hiddenBlockTypes );
+		}
+
+		return settings;
+	}
+
+	render() {
+		const {
+			settings,
+			hasFixedToolbar,
+			focusMode,
+			post,
+			postId,
+			initialEdits,
+			onError,
+			hiddenBlockTypes,
+			blockTypes,
+			preferredStyleVariations,
+			__experimentalLocalAutosaveInterval,
+			showInserterHelpPanel,
+			updatePreferredStyleVariations,
+			...props
+		} = this.props;
+
+		if ( ! post ) {
+			return null;
+		}
+
+		const editorSettings = this.getEditorSettings(
+			settings,
+			hasFixedToolbar,
+			showInserterHelpPanel,
+			focusMode,
+			hiddenBlockTypes,
+			blockTypes,
+			preferredStyleVariations,
+			__experimentalLocalAutosaveInterval,
+			updatePreferredStyleVariations
+		);
+
+		return (
+			<StrictMode>
+				<EditPostSettings.Provider value={ settings }>
+					<SlotFillProvider>
+						<DropZoneProvider>
+							<EditorProvider
+								settings={ editorSettings }
+								post={ post }
+								initialEdits={ initialEdits }
+								useSubRegistry={ false }
+								{ ...props }
+							>
+								<ErrorBoundary onError={ onError }>
+									<EditorInitialization postId={ postId } />
+									<Layout />
+									<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
+								</ErrorBoundary>
+								<PostLockedModal />
+							</EditorProvider>
+						</DropZoneProvider>
+					</SlotFillProvider>
+				</EditPostSettings.Provider>
+			</StrictMode>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( ( select, { postId, postType } ) => {
+		const { isFeatureActive, getPreference } = select( 'core/edit-post' );
+		const { getEntityRecord } = select( 'core' );
+		const { getBlockTypes } = select( 'core/blocks' );
+
+		return {
+			showInserterHelpPanel: isFeatureActive( 'showInserterHelpPanel' ),
+			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			focusMode: isFeatureActive( 'focusMode' ),
+			post: getEntityRecord( 'postType', postType, postId ),
+			preferredStyleVariations: getPreference( 'preferredStyleVariations' ),
+			hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
+			blockTypes: getBlockTypes(),
+			__experimentalLocalAutosaveInterval: getPreference( 'localAutosaveInterval' ),
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { updatePreferredStyleVariations } = dispatch( 'core/edit-post' );
+		return {
+			updatePreferredStyleVariations,
+		};
+	} ),
+] )( Editor );

--- a/client/gutenboarding-topdown/editor.js
+++ b/client/gutenboarding-topdown/editor.js
@@ -21,6 +21,9 @@ import Layout from '@wordpress/edit-post/build-module/components/layout';
 import EditorInitialization from '@wordpress/edit-post/build-module/components/editor-initialization';
 import EditPostSettings from '@wordpress/edit-post/build-module/components/edit-post-settings';
 
+// We need a core/edit-post store
+import '@wordpress/edit-post/build-module/store';
+
 class Editor extends Component {
 	constructor() {
 		super( ...arguments );

--- a/client/gutenboarding-topdown/index.ts
+++ b/client/gutenboarding-topdown/index.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { hideMasterbar, main, redirectIfNotEnabled } from './controller';
+import { makeLayout, render as clientRender } from 'controller';
+
+export default function() {
+	page(
+		'/gutenboarding-topdown',
+		redirectIfNotEnabled,
+		hideMasterbar,
+		main,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -470,6 +470,14 @@ const sections = [
 		group: 'sites',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'gutenboarding-topdown',
+		paths: [ '/gutenboarding-topdown' ],
+		module: 'gutenboarding-topdown',
+		secondary: false,
+		group: 'sites',
+		enableLoggedOut: true,
+	},
 ];
 
 for ( const extension of require( './extensions' ) ) {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
 		"lru": "3.1.0",
 		"lunr": "2.3.7",
 		"marked": "0.7.0",
+		"memize": "1.0.5",
 		"mkdirp": "0.5.1",
 		"moment": "2.24.0",
 		"moment-timezone": "0.5.26",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Top-down approach to get Gutenberg working in Calypso.

Currently failing with 

```
ERROR in ./client/gutenboarding-topdown/editor.js
Module not found: Error: Can't resolve '@wordpress/edit-post/build-module/components/edit-post-settings' in '~/src/wp-calypso/client/gutenboarding-topdown'
```

-- probably because that file is missing from our the currently used `@wordpress/` packages? See #36583.

#### Testing instructions

TBD
