### PR TITLE
FSE: fix default menu ordering of pages

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -323,6 +323,7 @@ class WP_Template_Inserter {
 					'post_content' => $template_content_by_slug['about'],
 					'post_status'  => 'publish',
 					'post_type'    => 'page',
+					'menu_order'   => 1,
 				]
 			);
 		}
@@ -334,6 +335,7 @@ class WP_Template_Inserter {
 					'post_content' => $template_content_by_slug['contact'],
 					'post_status'  => 'publish',
 					'post_type'    => 'page',
+					'menu_order'   => 1,
 				]
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes our default pages have the same menu order as Home page that's created by Headstart on Dotcom. This will allow them to fall back to `post_date` sorting properly.

Fixes https://github.com/Automattic/wp-calypso/issues/36773

#### Testing instructions

1. Recreate default pages locally (on a fresh FSE site) and verify that page order is set to 1.
2. Sync these changes to Dotcom.
3. Sandbox your test site in advance.
4. Go through Horizon test FSE flow.
5. Make sure that Home is the first item in the navigation menu by default.