### PR TITLE
Remove i18n-calypso moment from line-chart.

### DIFF
--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -1,11 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
-import { moment } from 'i18n-calypso';
 import { range, random } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -15,7 +13,7 @@ import LineChart from 'components/line-chart';
 
 const NUM_DATA_SERIES = 3;
 
-class LineChartExample extends Component {
+export default class LineChartExample extends Component {
 	static displayName = 'LineChart';
 
 	static createData( dataMin, dataMax, seriesLength ) {
@@ -95,9 +93,9 @@ class LineChartExample extends Component {
 	render() {
 		return (
 			<div>
-				<a className="docs__design-toggle button" onClick={ this.toggleDataControls }>
+				<button className="docs__design-toggle button" onClick={ this.toggleDataControls }>
 					{ this.state.showDataControls ? 'Hide Data Controls' : 'Show Data Controls' }
-				</a>
+				</button>
 
 				<Card>
 					<LineChart
@@ -109,29 +107,35 @@ class LineChartExample extends Component {
 
 				{ this.state.showDataControls && (
 					<div>
-						<label>Data Min</label>
-						<input
-							type="number"
-							value={ this.state.dataMin }
-							min="0"
-							onChange={ this.changeDataMin }
-						/>
+						<label>
+							Data Min
+							<input
+								type="number"
+								value={ this.state.dataMin }
+								min="0"
+								onChange={ this.changeDataMin }
+							/>
+						</label>
 
-						<label>Data Max</label>
-						<input
-							type="number"
-							value={ this.state.dataMax }
-							min="0"
-							onChange={ this.changeDataMax }
-						/>
+						<label>
+							Data Max
+							<input
+								type="number"
+								value={ this.state.dataMax }
+								min="0"
+								onChange={ this.changeDataMax }
+							/>
+						</label>
 
-						<label>Series Length</label>
-						<input
-							type="number"
-							value={ this.state.seriesLength }
-							min="3"
-							onChange={ this.changeSeriesLength }
-						/>
+						<label>
+							Series Length
+							<input
+								type="number"
+								value={ this.state.seriesLength }
+								min="3"
+								onChange={ this.changeSeriesLength }
+							/>
+						</label>
 
 						<div>
 							<label>
@@ -149,5 +153,3 @@ class LineChartExample extends Component {
 		);
 	}
 }
-
-export default LineChartExample;

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -11,13 +9,13 @@ import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale
 import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
 import { concat, first, last, mean, throttle, uniq } from 'lodash';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import D3Base from 'components/d3-base';
 import Tooltip from 'components/tooltip';
+import { withLocalizedMoment } from 'components/localized-moment';
 import LineChartLegend from './legend';
 
 /**
@@ -35,27 +33,6 @@ const X_AXIS_TICKS_SPACE = 70;
 const Y_AXIS_TICKS = 6;
 const Y_AXIS_TICKS_SPACE = 30;
 const APPROXIMATELY_A_MONTH_IN_MS = 31 * 24 * 60 * 60 * 1000;
-
-const dateFormatFunction = displayMonthTicksOnly => ( date, index, tickRefs ) => {
-	const everyOtherTickOnly = ! displayMonthTicksOnly && tickRefs.length > X_AXIS_TICKS_MAX;
-	// this can only be figured out here, becuase D3 will decide how many ticks there should be
-	const isFirstMonthTick =
-		index ===
-		Math.round(
-			mean(
-				tickRefs
-					.map( ( tickRef, tickRefIndex ) =>
-						tickRef.__data__.getMonth() === date.getMonth() ? tickRefIndex : null
-					)
-					.filter( e => e !== null )
-			)
-		);
-	return ( ! everyOtherTickOnly && ! displayMonthTicksOnly ) ||
-		( everyOtherTickOnly && index % 2 === 0 ) ||
-		( displayMonthTicksOnly && isFirstMonthTick )
-		? moment( date ).format( displayMonthTicksOnly ? 'MMM' : 'MMM D' )
-		: '';
-};
 
 const dateToAbsoluteMonth = date => date.getYear() * 12 + date.getMonth();
 // number of different colors this component can display
@@ -107,6 +84,27 @@ class LineChart extends Component {
 		return null;
 	}
 
+	dateFormatFunction = displayMonthTicksOnly => ( date, index, tickRefs ) => {
+		const everyOtherTickOnly = ! displayMonthTicksOnly && tickRefs.length > X_AXIS_TICKS_MAX;
+		// this can only be figured out here, because D3 will decide how many ticks there should be
+		const isFirstMonthTick =
+			index ===
+			Math.round(
+				mean(
+					tickRefs
+						.map( ( tickRef, tickRefIndex ) =>
+							tickRef.__data__.getMonth() === date.getMonth() ? tickRefIndex : null
+						)
+						.filter( e => e !== null )
+				)
+			);
+		return ( ! everyOtherTickOnly && ! displayMonthTicksOnly ) ||
+			( everyOtherTickOnly && index % 2 === 0 ) ||
+			( displayMonthTicksOnly && isFirstMonthTick )
+			? this.props.moment( date ).format( displayMonthTicksOnly ? 'MMM' : 'MMM D' )
+			: '';
+	};
+
 	drawAxes = ( svg, params ) => {
 		this.drawXAxis( svg, params );
 		this.drawYAxis( svg, params );
@@ -118,7 +116,7 @@ class LineChart extends Component {
 
 		const axis = d3AxisBottom( xScale );
 		axis.ticks( xTicks );
-		axis.tickFormat( dateFormatFunction( displayMonthOnly ) );
+		axis.tickFormat( this.dateFormatFunction( displayMonthOnly ) );
 		axis.tickSizeOuter( 0 );
 
 		svg
@@ -535,4 +533,4 @@ class LineChart extends Component {
 	}
 }
 
-export default LineChart;
+export default withLocalizedMoment( LineChart );


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

#### Changes proposed in this Pull Request

* Remove all usage of `i18n-calypso`'s `moment` export from `line-chart`.
* Fix a few linting issues in the `line-chart` example.

#### Testing instructions

* Open `/devdocs/design/line-chart`
* Ensure that the line chart continues working correctly.
