### PR TITLE
Full Site Editing: Stop using theme classes for template parts (experiment)

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -16,9 +16,11 @@ namespace A8C\FSE;
 function render_navigation_menu_block( $attributes ) {
 	$styles = '';
 
-	$class = 'menu-primary-container';
+	$container_class = 'menu-primary-container';
+	$toggle_class    = 'button';
 	if ( isset( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
+		$container_class .= ' ' . $attributes['className'];
+		$toggle_class    .= ' ' . $attributes['className'];
 	}
 
 	$align = ' alignwide';
@@ -57,6 +59,9 @@ function render_navigation_menu_block( $attributes ) {
 		$class .= ' has-small-font-size';
 	}
 
+	$container_class .= $class;
+	$toggle_class    .= $class;
+
 	$menu = wp_nav_menu(
 		[
 			'echo'           => false,
@@ -73,14 +78,14 @@ function render_navigation_menu_block( $attributes ) {
 	?>
 	<nav class="main-navigation wp-block-a8c-navigation-menu<?php echo esc_attr( $align ); ?>">
 		<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
-		<label for="toggle" id="toggle-menu" class="button">
+		<label for="toggle" id="toggle-menu" class="<?php echo esc_attr( $toggle_class ); ?>" style="<?php echo esc_attr( $styles ); ?>">
 			<?php esc_html_e( 'Menu', 'full-site-editing' ); ?>
 			<span class="dropdown-icon open">+</span>
 			<span class="dropdown-icon close">&times;</span>
 			<span class="hide-visually expanded-text"><?php esc_html_e( 'expanded', 'full-site-editing' ); ?></span>
 			<span class="hide-visually collapsed-text"><?php esc_html_e( 'collapsed', 'full-site-editing' ); ?></span>
 		</label>
-		<div class="<?php echo esc_attr( $class ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+		<div class="<?php echo esc_attr( $container_class ); ?>" style="<?php echo esc_attr( $styles ); ?>">
 			<?php echo $menu ? $menu : get_fallback_navigation_menu(); ?>
 		</div>
 	</nav>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -27,7 +27,7 @@ function render_navigation_menu_block( $attributes ) {
 	if ( isset( $attributes['align'] ) ) {
 		$align = empty( $attributes['align'] ) ? '' : ' align' . $attributes['align'];
 	}
-	$class .= $align;
+	$class = $align;
 
 	if ( isset( $attributes['textAlign'] ) ) {
 		$class .= ' has-text-align-' . $attributes['textAlign'];

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* global fullSiteEditing */
 /**
  * External dependencies
@@ -21,10 +22,10 @@ const EditorTemplateClasses = withSelect( select => {
 			''
 		);
 		if ( endsWith( typeName, '-header' ) ) {
-			return 'site-header site-branding';
+			return 'fse-header';
 		}
 		if ( endsWith( typeName, '-footer' ) ) {
-			return 'site-footer';
+			return 'fse-footer';
 		}
 	} );
 	return { templateClasses };
@@ -39,7 +40,7 @@ const EditorTemplateClasses = withSelect( select => {
 		}
 		clearInterval( blockListInception );
 
-		blockList.className = classNames( 'a8c-template-editor', ...templateClasses );
+		blockList.className = classNames( 'a8c-template-editor fse-template', ...templateClasses );
 	} );
 
 	return null;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -40,7 +40,7 @@ const EditorTemplateClasses = withSelect( select => {
 		}
 		clearInterval( blockListInception );
 
-		blockList.className = classNames( 'a8c-template-editor fse-template', ...templateClasses );
+		blockList.className = classNames( 'a8c-template-editor fse-template-part', ...templateClasses );
 	} );
 
 	return null;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -161,9 +161,9 @@ class WP_Template {
 			return null;
 		}
 
-		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"label\":\"" . __( 'Header', 'full-site-editing' ) . '","className":"site-header site-branding"} /-->' .
+		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"label\":\"" . __( 'Header', 'full-site-editing' ) . '","className":"fse-template-part fse-header"} /-->' .
 				'<!-- wp:a8c/post-content /-->' .
-				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"label\":\"" . __( 'Footer', 'full-site-editing' ) . '","className":"site-footer"} /-->';
+				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"label\":\"" . __( 'Footer', 'full-site-editing' ) . '","className":"fse-template-part fse-footer"} /-->';
 	}
 
 	/**


### PR DESCRIPTION
After adding the style attributes to all FSE blocks, I've realized that we are giving the user enough freedom that reusing the default theme classes makes things unnecessarily harder.

Once removing the theme classes, we can also remove a lot of now superfluous overrides.

For example, before the blocks attributes, we inherited the site title, menu, etc. style from the theme.
To make the transition between pre-FSE and FSE as painless as possible, we simply added, say the `.site-header` class to the FSE Header Template Part.
On one hand this was helpful in keeping all consistent with the theme.
On the other, though, this was applying a lot of styles directly conflicting with the new blocks attributes.
Why do we need to force a site title font size when we let the user choose it freely?

The first step for this is to remove the theme classes from the FSE Template Parts.
I've replaced `.site-header` etc. with the corresponding `.fse-header` etc. This allows us to fine tune the theme if we need it.
Also, all template parts gained a new `.fse-template` class, which should be useful to replace and simplify all those `.site-header, .site-footer { ... }` that ended up cluttering the FSE theme styles.

The Gutenberg styles will keep relying on the `.entry-content` class, which remains unchanged, applied to all FSE Template Parts.

Theme-side it's mostly a matter of removing a lot of lines of code.
What remains is just a handful of minor overrides (mostly on the Navigation Menu, which is inevitably complicated to handle), and some minor adjustments.

#### Gotcha

This will unavoidably change how existing FSE sites look, even if just slightly.

#### Testing Instructions

- Apply this and https://github.com/Automattic/themes/pull/1517
- Smoke test all the things! 😄 

Fixes https://github.com/Automattic/wp-calypso/issues/36606 (amongst others)