### PR TITLE
Remove i18n-calypso moment from tests.

### DIFF
--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -1,5 +1,4 @@
 /**
- * @format
  * @jest-environment jsdom
  */
 
@@ -9,7 +8,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import MockDate from 'mockdate';
-import { moment, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
@@ -1,9 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
 import { expect } from 'chai';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/store-stats/test/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/test/utils.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { assert, expect } from 'chai';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -4,7 +4,7 @@
 import debugFactory from 'debug';
 import { every, get, includes, isArray, keys, reduce, some } from 'lodash';
 import store from 'store';
-import i18n from 'i18n-calypso';
+import { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -207,7 +207,7 @@ export const isUsingGivenLocales = ( localeTargets, experimentId = null ) => {
 	const clientLanguage = client.language || client.userLanguage || 'en';
 	const clientLanguagesPrimary =
 		client.languages && client.languages.length ? client.languages[ 0 ] : 'en';
-	const localeFromSession = i18n.getLocaleSlug() || 'en';
+	const localeFromSession = getLocaleSlug() || 'en';
 	const localeMatcher = new RegExp( '^(' + localeTargets.join( '|' ) + ')', 'i' );
 	const userLocale = user.get().localeSlug || 'en';
 

--- a/client/my-sites/site-settings/date-time-format/test/index.js
+++ b/client/my-sites/site-settings/date-time-format/test/index.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import chai from 'chai';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -1,11 +1,11 @@
-/** @format */
 /**
  * External dependencies
  */
 import { expect as chaiExpect } from 'chai';
 import { shallow } from 'enzyme';
-import { translate, moment } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import React from 'react';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/state/billing-transactions/test/util.js
+++ b/client/state/billing-transactions/test/util.js
@@ -1,10 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,7 +21,7 @@ describe( 'util', () => {
 
 			expect( updatedTransaction ).to.eql( {
 				id: 123456,
-				date: moment( transaction.date ).toDate(),
+				date: new Date( transaction.date ),
 			} );
 		} );
 	} );

--- a/client/state/selectors/test/get-billing-transactions-by-type.js
+++ b/client/state/selectors/test/get-billing-transactions-by-type.js
@@ -1,10 +1,3 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { moment } from 'i18n-calypso';
-
 /**
  * Internal dependencies
  */
@@ -38,7 +31,7 @@ describe( 'getBillingTransactionsByType()', () => {
 			{
 				id: '12345678',
 				amount: '$1.23',
-				date: moment( '2016-12-12T11:22:33+0000' ).toDate(),
+				date: new Date( '2016-12-12T11:22:33+0000' ),
 			},
 		] );
 	} );
@@ -49,7 +42,7 @@ describe( 'getBillingTransactionsByType()', () => {
 			{
 				id: '87654321',
 				amount: '$4.56',
-				date: moment( '2016-10-12T11:22:33+0000' ).toDate(),
+				date: new Date( '2016-10-12T11:22:33+0000' ),
 			},
 		] );
 	} );

--- a/client/state/selectors/test/get-billing-transactions.js
+++ b/client/state/selectors/test/get-billing-transactions.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { expect } from 'chai';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -39,14 +36,14 @@ describe( 'getBillingTransactions()', () => {
 				{
 					id: '12345678',
 					amount: '$1.23',
-					date: moment( '2016-12-12T11:22:33+0000' ).toDate(),
+					date: new Date( '2016-12-12T11:22:33+0000' ),
 				},
 			],
 			upcoming: [
 				{
 					id: '87654321',
 					amount: '$4.56',
-					date: moment( '2016-13-12T11:22:33+0000' ).toDate(),
+					date: new Date( '2016-13-12T11:22:33+0000' ),
 				},
 			],
 		} );

--- a/client/state/selectors/test/get-filtered-billing-transactions.js
+++ b/client/state/selectors/test/get-filtered-billing-transactions.js
@@ -1,8 +1,6 @@
-/** @format */
 /**
  * External dependencies
  */
-import { moment } from 'i18n-calypso';
 import { cloneDeep, slice } from 'lodash';
 import deepFreeze from 'deep-freeze';
 
@@ -184,7 +182,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ).map(
 					transaction => ( {
 						...transaction,
-						date: moment( transaction.date ).toDate(),
+						date: new Date( transaction.date ),
 					} )
 				),
 			} );
@@ -225,7 +223,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ).map(
 					transaction => ( {
 						...transaction,
-						date: moment( transaction.date ).toDate(),
+						date: new Date( transaction.date ),
 					} )
 				),
 			} );
@@ -254,7 +252,7 @@ describe( 'getBillingTransactionAppFilterValues()', () => {
 				transactions: slice( state.billingTransactions.items.past, 0, PAGE_SIZE ).map(
 					transaction => ( {
 						...transaction,
-						date: moment( transaction.date ).toDate(),
+						date: new Date( transaction.date ),
 					} )
 				),
 			} );

--- a/client/state/selectors/test/get-past-billing-transaction.js
+++ b/client/state/selectors/test/get-past-billing-transaction.js
@@ -1,9 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
 import { clone } from 'lodash';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -36,7 +34,7 @@ describe( 'getPastBillingTransaction()', () => {
 		const output = getPastBillingTransaction( state, '12345678' );
 		expect( output ).toEqual( {
 			...state.billingTransactions.items.past[ 0 ],
-			date: moment( '2016-12-12T11:22:33+0000' ).toDate(),
+			date: new Date( '2016-12-12T11:22:33+0000' ),
 		} );
 	} );
 

--- a/client/state/selectors/test/get-past-billing-transactions.js
+++ b/client/state/selectors/test/get-past-billing-transactions.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { expect } from 'chai';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -34,7 +31,7 @@ describe( 'getPastBillingTransactions()', () => {
 			},
 		};
 		const expected = state.billingTransactions.items.past.map( transaction => {
-			transaction.date = moment( transaction.date ).toDate();
+			transaction.date = new Date( transaction.date );
 			return transaction;
 		} );
 		const output = getPastBillingTransactions( state );

--- a/client/state/selectors/test/get-upcoming-billing-transactions.js
+++ b/client/state/selectors/test/get-upcoming-billing-transactions.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { expect } from 'chai';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -34,7 +31,7 @@ describe( 'getUpcomingBillingTransactions()', () => {
 			},
 		};
 		const expected = state.billingTransactions.items.upcoming.map( transaction => {
-			transaction.date = moment( transaction.date ).toDate();
+			transaction.date = new Date( transaction.date );
 			return transaction;
 		} );
 		const output = getUpcomingBillingTransactions( state );

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { expect } from 'chai';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1,9 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/state/ui/guided-tours/test/contexts.js
+++ b/client/state/ui/guided-tours/test/contexts.js
@@ -1,5 +1,4 @@
 /**
- * @format
  * @jest-environment jsdom
  */
 
@@ -7,7 +6,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

It modifies a number of files, but the changes are trivial.

#### Changes proposed in this Pull Request

* Replace trivial usage of moment with native `Date` across several tests
* Replace usage of `i18n-calypso`'s `moment` export with vanilla `moment` across several tests
* Use named export instead of default export for `i18n-calypso` in one test

#### Testing instructions

* This one's easy. Ensure the updated tests don't fail!