### PR TITLE
Marketing Survey: Remove unused import survey step

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -557,10 +557,6 @@ class CancelPurchaseForm extends React.Component {
 				);
 			}
 
-			if ( surveyStep === steps.IMPORT_SURVEY_STEP ) {
-				return <div>Import survey here</div>;
-			}
-
 			if ( surveyStep === steps.BUSINESS_AT_STEP ) {
 				return <BusinessATStep />;
 			}


### PR DESCRIPTION
#36272 inadvertently included unused code from an earlier plan for the import survey -- which included a constant that was removed in later development, but still referenced from the stubbed code.

#### Changes proposed in this Pull Request

* Removes unused import survey stub

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the warning described in #36768 is no longer present in this PR:
```
WARNING in ./client/components/marketing-survey/cancel-purchase-form/index.jsx 510:25-49
"export 'IMPORT_SURVEY_STEP' (imported as 'steps') was not found in './steps'
```

Fixes #36768
