### PR TITLE
User: fetch only on app boot

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -42,9 +42,5 @@ const boot = currentUser => {
 
 window.AppBoot = () => {
 	const user = userFactory();
-	if ( user.initialized ) {
-		boot( user );
-	} else {
-		user.once( 'change', () => boot( user ) );
-	}
+	user.initialize().then( () => boot( user ) );
 };

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -11,7 +11,6 @@ import { find, isEmpty } from 'lodash';
  */
 import Translatable from './translatable';
 import { languages } from 'languages';
-import User from 'lib/user';
 import userSettings from 'lib/user-settings';
 import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 
@@ -24,7 +23,6 @@ import './style.scss';
  * Local variables
  */
 const debug = debugModule( 'calypso:community-translator' );
-const user = new User();
 
 class CommunityTranslator extends Component {
 	languageJson = null;
@@ -43,13 +41,11 @@ class CommunityTranslator extends Component {
 		// the callback is overwritten by the translator on load/unload, so we're returning it within an anonymous function.
 		i18n.registerComponentUpdateHook( () => {} );
 		i18n.on( 'change', this.refresh );
-		user.on( 'change', this.refresh );
 		userSettings.on( 'change', this.refresh );
 	}
 
 	componentWillUnmount() {
 		i18n.off( 'change', this.refresh );
-		user.removeListener( 'change', this.refresh );
 		userSettings.removeListener( 'change', this.refresh );
 	}
 

--- a/client/components/redirect-when-logged-in/README.md
+++ b/client/components/redirect-when-logged-in/README.md
@@ -5,7 +5,7 @@ This is a helper component to redirect once it has been detected that the user i
 ## How It Works
 
 On mount, it consults the global state tree. If a user is detected, it kicks off the redirect.
-If a user is not detected, it subscribes to the `storage` event and listens for changes to the `wpcom_user` key.
+If a user is not detected, it subscribes to the `storage` event and listens for changes to the `wpcom_user_id` key.
 
 ## Usage
 ```javascript

--- a/client/components/redirect-when-logged-in/index.jsx
+++ b/client/components/redirect-when-logged-in/index.jsx
@@ -51,15 +51,10 @@ class RedirectWhenLoggedIn extends React.Component {
 	}
 
 	storageEventHandler = e => {
-		if ( e.key !== 'wpcom_user' ) {
-			return;
+		if ( e.key === 'wpcom_user_id' && e.newValue != null ) {
+			debug( 'detected change of wpcom_user_id, redirecting' );
+			this.doTheRedirect();
 		}
-		try {
-			const newUser = JSON.parse( e.newValue );
-			if ( this.isUserLoggedIn( newUser ) ) {
-				this.doTheRedirect();
-			}
-		} catch {}
 	};
 
 	componentDidMount() {

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -49,9 +49,5 @@ const boot = currentUser => {
 
 window.AppBoot = () => {
 	const user = userFactory();
-	if ( user.initialized ) {
-		boot( user );
-	} else {
-		user.once( 'change', () => boot( user ) );
-	}
+	user.initialize().then( () => boot( user ) );
 };

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -338,6 +338,5 @@ export function trackTranslatorStatus( isTranslatorEnabled ) {
 
 // re-initialize when new locale data is loaded
 i18n.on( 'change', communityTranslatorJumpstart.init.bind( communityTranslatorJumpstart ) );
-user.on( 'change', communityTranslatorJumpstart.init.bind( communityTranslatorJumpstart ) );
 
 export default communityTranslatorJumpstart;

--- a/client/lib/user/test/utils.js
+++ b/client/lib/user/test/utils.js
@@ -1,76 +1,54 @@
 /**
- * @format
- * @jest-environment jsdom
- */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import sinon from 'sinon';
-
-/**
  * Internal dependencies
  */
 import UserUtils from '../utils';
-import configMock from 'config';
+import config from 'config';
+import User from 'lib/user';
+
+const user = User();
 
 jest.mock( 'config', () => {
-	const { stub } = require( 'sinon' );
-
-	const mock = stub();
-	mock.isEnabled = stub();
+	const mock = jest.fn();
+	mock.isEnabled = jest.fn();
 
 	return mock;
 } );
 
-jest.mock( 'lib/wp', () => ( {
-	me: () => ( {
-		get: async () => ( {} ),
-	} ),
-} ) );
+const configMock = values => key => values[ key ];
 
 describe( 'UserUtils', () => {
-	let user;
-
-	beforeAll( () => {
-		user = require( 'lib/user' )();
-	} );
-
-	beforeEach( () => {
-		configMock.returns( '/url-with-|subdomain|' );
-	} );
-
 	describe( 'without logout url', () => {
 		beforeAll( () => {
-			configMock.isEnabled.withArgs( 'always_use_logout_url' ).returns( false );
+			config.isEnabled.mockImplementation( configMock( { always_use_logout_url: false } ) );
 		} );
 
 		test( 'uses userData.logout_URL when available', () => {
-			sinon.stub( user, 'get' ).returns( { logout_URL: '/userdata' } );
-			expect( UserUtils.getLogoutUrl() ).to.equal( '/userdata' );
-			user.get.restore();
+			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata' } );
+			expect( UserUtils.getLogoutUrl() ).toBe( '/userdata' );
 		} );
 	} );
 
 	describe( 'with logout url', () => {
 		beforeAll( () => {
-			configMock.isEnabled.withArgs( 'always_use_logout_url' ).returns( true );
+			config.isEnabled.mockImplementation( configMock( { always_use_logout_url: true } ) );
 		} );
 
 		test( 'works when |subdomain| is not present', () => {
-			configMock.returns( '/url-without-domain' );
-			expect( UserUtils.getLogoutUrl() ).to.equal( '/url-without-domain' );
+			config.mockImplementation( configMock( { logout_url: 'wp.com/without-domain' } ) );
+			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata', localeSlug: 'es' } );
+			expect( UserUtils.getLogoutUrl() ).toBe( 'wp.com/without-domain' );
 		} );
 
-		test( 'replaces |subdomain| when present and have domain', () => {
-			sinon.stub( user, 'get' ).returns( { localeSlug: 'es' } );
-			expect( UserUtils.getLogoutUrl() ).to.equal( '/url-with-es.' );
-			user.get.restore();
+		test( 'replaces |subdomain| when present and have non-default locale', () => {
+			config.mockImplementation( configMock( { logout_url: '|subdomain|wp.com/with-domain' } ) );
+			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata', localeSlug: 'es' } );
+			expect( UserUtils.getLogoutUrl() ).toBe( 'es.wp.com/with-domain' );
 		} );
 
-		test( 'replaces |subdomain| when present but no domain', () => {
-			expect( UserUtils.getLogoutUrl() ).to.equal( '/url-with-' );
+		test( 'replaces |subdomain| when present but no locale', () => {
+			config.mockImplementation( configMock( { logout_url: '|subdomain|wp.com/with-domain' } ) );
+			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata' } );
+			expect( UserUtils.getLogoutUrl() ).toBe( 'wp.com/with-domain' );
 		} );
 	} );
 } );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -207,10 +207,6 @@ User.prototype.handleFetchSuccess = function( userData ) {
 		}
 	}
 	this.data = userData;
-	if ( this.settings ) {
-		debug( 'Retaining fetched settings data in new user data' );
-		this.data.settings = this.settings;
-	}
 	this.initialized = true;
 	this.emit( 'change' );
 };
@@ -252,7 +248,6 @@ User.prototype.clear = async function() {
 	 * to discard any user reference that the application may hold
 	 */
 	this.data = [];
-	delete this.settings;
 	store.clearAll();
 	if ( config.isEnabled( 'persist-redux' ) ) {
 		await clearStorage();

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -95,7 +95,7 @@ User.prototype.initialize = async function() {
 User.prototype.clearStoreIfChanged = function( userId ) {
 	const storedUserId = store.get( 'wpcom_user_id' );
 
-	if ( storedUserId !== null && storedUserId !== userId ) {
+	if ( storedUserId != null && storedUserId !== userId ) {
 		debug( 'Clearing localStorage because user changed' );
 		store.clearAll();
 	}

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -115,8 +115,9 @@ User.prototype.get = function() {
  * and stores it in local cache.
  *
  * @uses `wpcom`
+ * @returns {Promise<void>} Promise that resolves (with no value) when fetching is finished
  */
-User.prototype.fetch = async function() {
+User.prototype.fetch = function() {
 	if ( this.fetching ) {
 		// if already fetching, return the in-flight promise
 		return this.fetching;


### PR DESCRIPTION
This patch removes automatic call to `user.fetch()` every time the `user.get()` getter is called and the user data are not available (i.e., not logged in or not initialized yet).

Instead, we call `user.fetch()` only when calling `user.initialize()` at Calypso boot and at a few places that call it explicitly to reload the updated user object.

This change should make problems like these in #36519 much more tractable -- no more uncontrolled user fetching at random places, especially in Signup.

I also removed code that stores the user object to local storage key `wpcom_user` and tries to load it from there on boot. That code is quite useless and only causes trouble: I experienced several times a weird Calypso state where the user is logged out (i.e., doesn't have session cookies), but valid user is loaded from `wpcom_user`, making Calypso think it's logged in.

The only supported ways how to get the user info is server-side bootstrap and the `/me` endpoint.

Now we only store `wpcom_user_id` in local storage and the only purpose is to clear local storage when a different user logs in.


**How to test:**
Test that the support sessions continue to work -- need help from @brandonpayton 🙂 

Test that Signup continues to work, especially the logged-out -> logged-in transitions. Something for @andrewserong and @Automattic/zelda 

Another place where I had to work hard is accepting invites by user who doesn't have an account yet and is signing up at the same time. e2e tests were failing and it took me several hours to figure out that I need to change `!==` to `!=` in 27f94b2 🙂 