### PR TITLE
Remove i18n-calypso moment from cart and checkout.

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -1,12 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import url from 'url';
 import { extend, get, isArray, invert } from 'lodash';
 import update, { extend as extendImmutabilityHelper } from 'immutability-helper';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import config from 'config';
 
 /**
@@ -234,7 +232,7 @@ export function getNewMessages( previousCartValue, nextCartValue ) {
 
 	const previousDate = previousCartValue.client_metadata.last_server_response_date;
 	const nextDate = nextCartValue.client_metadata.last_server_response_date;
-	const hasNewServerData = i18n.moment( nextDate ).isAfter( previousDate );
+	const hasNewServerData = new Date( nextDate ) > new Date( previousDate );
 
 	return hasNewServerData ? nextCartMessages : [];
 }
@@ -344,7 +342,7 @@ export function paymentMethodName( method ) {
 	const paymentMethodsNames = {
 		alipay: 'Alipay',
 		bancontact: 'Bancontact',
-		'credit-card': i18n.translate( 'Credit or debit card' ),
+		'credit-card': translate( 'Credit or debit card' ),
 		eps: 'EPS',
 		giropay: 'Giropay',
 		ideal: 'iDEAL',
@@ -359,7 +357,7 @@ export function paymentMethodName( method ) {
 		// user), so it's fine to just hardcode this to "Apple Pay" in the
 		// meantime.
 		'web-payment': 'Apple Pay',
-		wechat: i18n.translate( 'WeChat Pay', {
+		wechat: translate( 'WeChat Pay', {
 			comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
 		} ),
 		sofort: 'Sofort',

--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { assign, flowRight, get } from 'lodash';
-import i18n from 'i18n-calypso';
 import Dispatcher from 'dispatcher';
 import { TRANSACTION_STEP_SET } from 'lib/upgrades/action-types';
 import debugFactory from 'debug';
@@ -34,7 +31,7 @@ function preprocessCartFromServer( cart ) {
 // NOTE: This object has underscored keys to match the rest of the attributes
 //   in the `CartValue object`.
 function createClientMetadata() {
-	return { last_server_response_date: i18n.moment().toISOString() };
+	return { last_server_response_date: new Date().toISOString() };
 }
 
 // FIXME: Temporary fix to cast string product IDs to numbers. There is a bug

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import { connect } from 'react-redux';
 import { flatten, filter, find, get, isEmpty, isEqual, reduce, startsWith } from 'lodash';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -97,6 +96,7 @@ import { abtest } from 'lib/abtest';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/utils';
 import { isExternal } from 'lib/url';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -647,8 +647,10 @@ export class Checkout extends React.Component {
 						{
 							args: {
 								productName: renewalItem.product_name,
-								duration: i18n.moment.duration( { days: renewalItem.bill_period } ).humanize(),
-								date: i18n.moment( product.expiry ).format( 'LL' ),
+								duration: this.props.moment
+									.duration( { days: renewalItem.bill_period } )
+									.humanize(),
+								date: this.props.moment( product.expiry ).format( 'LL' ),
 								email: product.user_email,
 							},
 						}
@@ -924,4 +926,4 @@ export default connect(
 		requestSite,
 		loadTrackingTool,
 	}
-)( localize( Checkout ) );
+)( localize( withLocalizedMoment( Checkout ) ) );

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -1,12 +1,11 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -40,7 +39,7 @@ RecentRenewalListItem.propTypes = {
 };
 
 function getRecentRenewalProductsMatchingIds( products, ids ) {
-	const oldestMoment = i18n.moment().subtract( 30, 'days' );
+	const oldestMoment = moment().subtract( 30, 'days' );
 	return products.filter( product => {
 		return (
 			ids.includes( product.productId ) &&


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

This PR focuses on cart and checkout.

**Note**: If I added you and you feel you're not the right person to review these changes, I apologise for that; please feel free to ignore or remove yourself. I just went with the default GitHub suggestions since I had no idea who to add 🤷‍♂ 

#### Changes proposed in this Pull Request

* Replace trivial `moment` usage with native `Date`
* Replace non-localized usage of `i18n-calypso` `moment` with vanilla `moment`
* Replace localized usage of `i18n-calypso` `moment` with `withLocalizedMoment`

#### Testing instructions

The changes are simple, so there shouldn't be much need for testing beyond ensuring checkout/cart functionality continues to work correctly, particularly where it comes to date-related functionality.
