### PR TITLE
Jetpack: Connect: Add specificity to fix width of cobranded logo

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -41,7 +41,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 }
 
-.jetpack-connect__main {
+.jetpack-connect__main.main {
 	max-width: 400px;
 
 	.formatted-header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes #36725 by adding specificity to `.jetpack-connect_main` selector so that the declaration for width is respected.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before checking out patch, follow testing instructions in to load cobranded logo on Jetpack connection page
* Verify that cobranded logo is very large
* Check out patch
* Reload connection page
* Verify that cobranded logo fits the expected width

Fixes #36725

#### After screenshot

<img width="477" alt="Screen Shot 2019-10-15 at 10 51 44 AM" src="https://user-images.githubusercontent.com/1126811/66847957-dc514a00-ef39-11e9-844d-1200550aee7d.png">

#### Before screenshot

<img width="867" alt="Screen Shot 2019-10-15 at 10 51 55 AM" src="https://user-images.githubusercontent.com/1126811/66848076-0acf2500-ef3a-11e9-8f40-4c323def735e.png">

