### PR TITLE
Importers: Left-align text unless it's a progress indicator

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -320,7 +320,9 @@ class ImportingPane extends React.PureComponent {
 							<br />
 						</div>
 					) ) }
-				{ blockingMessage && <div>{ blockingMessage }</div> }
+				{ blockingMessage && (
+					<div className="importer__import-progress-message">{ blockingMessage }</div>
+				) }
 				<div>
 					<p className="importer__status-message">{ statusMessage }</p>
 				</div>

--- a/client/my-sites/importer/importing-pane.scss
+++ b/client/my-sites/importer/importing-pane.scss
@@ -1,5 +1,9 @@
 .importer__import-progress {
 	&.progress-bar {
+		display: block;
+		margin-bottom: 5px;
+		margin-left: auto;
+		margin-right: auto;
 		width: 80%;
 	}
 
@@ -12,6 +16,11 @@
 	}
 }
 
+.importer__import-progress-message {
+	text-align: center;
+	color: var( --color-text-subtle );
+}
+
 .importer__start {
 	float: none !important;
 }
@@ -22,11 +31,6 @@
 	transform: translateX( -50% );
 }
 
-.importer__importing-pane {
-	text-align: center;
-}
-
 .importer__status-message {
-	font-style: italic;
-	color: var( --color-neutral-light );
+	text-align: center;
 }

--- a/client/my-sites/importer/importing-pane.scss
+++ b/client/my-sites/importer/importing-pane.scss
@@ -32,5 +32,6 @@
 }
 
 .importer__status-message {
+	color: var( --color-text-subtle );
 	text-align: center;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Left aligns any importer text that is not part of the progress indicator, since paragraphs of centered text are harder to read.
* Also minor updates to the color and style of the success message after import.

**Before**

<img width="743" alt="Screen Shot 2019-10-15 at 1 11 11 PM" src="https://user-images.githubusercontent.com/2124984/66853475-5a6b1c00-ef4d-11e9-943b-6bbd54adcc22.png">

<img width="735" alt="Screen Shot 2019-10-15 at 1 11 28 PM" src="https://user-images.githubusercontent.com/2124984/66853476-5a6b1c00-ef4d-11e9-84e4-7f57d9585486.png">

<img width="740" alt="Screen Shot 2019-10-15 at 1 11 36 PM" src="https://user-images.githubusercontent.com/2124984/66853477-5a6b1c00-ef4d-11e9-812d-35afd2c96db7.png">

<img width="739" alt="Screen Shot 2019-10-15 at 1 10 55 PM" src="https://user-images.githubusercontent.com/2124984/66853474-5a6b1c00-ef4d-11e9-86b9-126740e0e747.png">

**After**

<img width="744" alt="Screen Shot 2019-10-15 at 1 12 49 PM" src="https://user-images.githubusercontent.com/2124984/66853543-88e8f700-ef4d-11e9-8c0e-758919f4c9c3.png">

<img width="736" alt="Screen Shot 2019-10-15 at 12 50 52 PM" src="https://user-images.githubusercontent.com/2124984/66853294-edf01d00-ef4c-11e9-8590-d835e1f9c8a8.png">

<img width="736" alt="Screen Shot 2019-10-15 at 1 15 16 PM" src="https://user-images.githubusercontent.com/2124984/66853710-e9783400-ef4d-11e9-87e4-fd22974c5078.png">

<img width="745" alt="Screen Shot 2019-10-15 at 1 16 01 PM" src="https://user-images.githubusercontent.com/2124984/66853730-f432c900-ef4d-11e9-9360-e10306c07481.png">


#### Testing instructions

* Switch to this PR
* Go to Tools -> Import
* Check each of the primary importers; can you successfully import content? Does the alignment look OK? 
* Check each of the importers on mobile web, too.

Fixes #33891
