### PR TITLE
Remove i18n-calypso moment from marketing-survey.

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -93,7 +93,7 @@ class CancelAutoRenewalForm extends Component {
 		submitSurvey(
 			'calypso-cancel-auto-renewal',
 			selectedSite.ID,
-			enrichedSurveyData( surveyData, null, selectedSite, purchase )
+			enrichedSurveyData( surveyData, selectedSite, purchase )
 		);
 
 		this.props.onClose();

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -1,12 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -22,6 +20,10 @@ import { submitSurvey } from 'lib/upgrades/actions';
 import { isDomainRegistration, isPlan } from 'lib/products-values';
 import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import PrecancellationChatButton from 'components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
+
+/**
+ * Style dependencies
+ */
 import './style.scss';
 
 class CancelAutoRenewalForm extends Component {
@@ -91,7 +93,7 @@ class CancelAutoRenewalForm extends Component {
 		submitSurvey(
 			'calypso-cancel-auto-renewal',
 			selectedSite.ID,
-			enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
+			enrichedSurveyData( surveyData, null, selectedSite, purchase )
 		);
 
 		this.props.onClose();

--- a/client/components/marketing-survey/cancel-purchase-form/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/enriched-survey-data.js
@@ -4,16 +4,11 @@
 import { get } from 'lodash';
 import moment from 'moment';
 
-export default function enrichedSurveyData( surveyData, timestamp, site, purchase ) {
+export default function enrichedSurveyData( surveyData, site, purchase, timestamp = moment() ) {
 	const purchaseStartDate = get( purchase, 'subscribedDate', null );
 	const siteStartDate = get( site, 'options.created_at', null );
 	const purchaseId = get( purchase, 'id', null );
 	const productSlug = get( purchase, 'productSlug', null );
-
-	// Use current time if no timestamp is provided.
-	if ( timestamp === undefined || timestamp === null ) {
-		timestamp = moment();
-	}
 
 	return {
 		purchase: productSlug,

--- a/client/components/marketing-survey/cancel-purchase-form/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/enriched-survey-data.js
@@ -1,28 +1,29 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+import moment from 'moment';
 
-export default function enrichedSurveyData( surveyData, moment, site, purchase ) {
+export default function enrichedSurveyData( surveyData, timestamp, site, purchase ) {
 	const purchaseStartDate = get( purchase, 'subscribedDate', null );
 	const siteStartDate = get( site, 'options.created_at', null );
 	const purchaseId = get( purchase, 'id', null );
 	const productSlug = get( purchase, 'productSlug', null );
 
-	return Object.assign(
-		{
-			purchase: productSlug,
-			purchaseId,
-		},
-		purchaseStartDate && {
-			daysSincePurchase: moment.diff( purchaseStartDate, 'days', true ),
-		},
-		siteStartDate && {
-			daysSinceSiteCreation: moment.diff( siteStartDate, 'days', true ),
-		},
-		surveyData
-	);
+	// Use current time if no timestamp is provided.
+	if ( timestamp === undefined || timestamp === null ) {
+		timestamp = moment();
+	}
+
+	return {
+		purchase: productSlug,
+		purchaseId,
+		...( purchaseStartDate && {
+			daysSincePurchase: timestamp.diff( purchaseStartDate, 'days', true ),
+		} ),
+		...( siteStartDate && {
+			daysSinceSiteCreation: timestamp.diff( siteStartDate, 'days', true ),
+		} ),
+		...surveyData,
+	};
 }

--- a/client/components/marketing-survey/cancel-purchase-form/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/enriched-survey-data.js
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import { get } from 'lodash';
-import moment from 'moment';
 
-export default function enrichedSurveyData( surveyData, site, purchase, timestamp = moment() ) {
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
+
+export default function enrichedSurveyData( surveyData, site, purchase, timestamp = new Date() ) {
 	const purchaseStartDate = get( purchase, 'subscribedDate', null );
 	const siteStartDate = get( site, 'options.created_at', null );
 	const purchaseId = get( purchase, 'id', null );
@@ -14,10 +15,10 @@ export default function enrichedSurveyData( surveyData, site, purchase, timestam
 		purchase: productSlug,
 		purchaseId,
 		...( purchaseStartDate && {
-			daysSincePurchase: timestamp.diff( purchaseStartDate, 'days', true ),
+			daysSincePurchase: ( new Date( timestamp ) - new Date( purchaseStartDate ) ) / DAY_IN_MS,
 		} ),
 		...( siteStartDate && {
-			daysSinceSiteCreation: timestamp.diff( siteStartDate, 'days', true ),
+			daysSinceSiteCreation: ( new Date( timestamp ) - new Date( siteStartDate ) ) / DAY_IN_MS,
 		} ),
 		...surveyData,
 	};

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -248,7 +248,7 @@ class CancelPurchaseForm extends React.Component {
 			submitSurvey(
 				'calypso-remove-purchase',
 				selectedSite.ID,
-				enrichedSurveyData( surveyData, null, selectedSite, purchase )
+				enrichedSurveyData( surveyData, selectedSite, purchase )
 			).then( () => {
 				this.setState( {
 					isSubmitting: false,

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1,14 +1,11 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { shuffle } from 'lodash';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -251,7 +248,7 @@ class CancelPurchaseForm extends React.Component {
 			submitSurvey(
 				'calypso-remove-purchase',
 				selectedSite.ID,
-				enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
+				enrichedSurveyData( surveyData, null, selectedSite, purchase )
 			).then( () => {
 				this.setState( {
 					isSubmitting: false,

--- a/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
@@ -12,15 +12,7 @@ jest.mock( 'lib/analytics', () => ( {} ) );
 
 describe( 'enrichedSurveyData', () => {
 	test( 'should duplicate survey data if no site or purchase are provided', () => {
-		expect( enrichedSurveyData( { key: 'value' }, moment() ) ).toEqual( {
-			key: 'value',
-			purchase: null,
-			purchaseId: null,
-		} );
-	} );
-
-	test( 'should duplicate survey data if no site, purchase, or timestamp are provided', () => {
-		expect( enrichedSurveyData( { key: 'value' }, null ) ).toEqual( {
+		expect( enrichedSurveyData( { key: 'value' } ) ).toEqual( {
 			key: 'value',
 			purchase: null,
 			purchaseId: null,
@@ -30,7 +22,7 @@ describe( 'enrichedSurveyData', () => {
 	test( 'should add purchase id and slug to survey data if purchase is provided', () => {
 		const site = null;
 		const purchase = { id: 'purchase id', productSlug: 'product slug' };
-		expect( enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase ).toEqual(
+		expect( enrichedSurveyData( { key: 'value' }, site, purchase ).purchase ).toEqual(
 			'product slug'
 		);
 	} );
@@ -39,7 +31,7 @@ describe( 'enrichedSurveyData', () => {
 		const site = null;
 		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
 		expect(
-			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase )
+			enrichedSurveyData( {}, site, purchase, moment( '2017-01-19T03:00:00+00:00' ) )
 				.daysSincePurchase
 		).toEqual( 10 );
 	} );
@@ -50,7 +42,7 @@ describe( 'enrichedSurveyData', () => {
 		};
 		const purchase = null;
 		expect(
-			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase )
+			enrichedSurveyData( {}, site, purchase, moment( '2017-01-19T03:00:00+00:00' ) )
 				.daysSinceSiteCreation
 		).toEqual( 10 );
 	} );

--- a/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import moment from 'moment';
 
 /**
@@ -13,7 +12,15 @@ jest.mock( 'lib/analytics', () => ( {} ) );
 
 describe( 'enrichedSurveyData', () => {
 	test( 'should duplicate survey data if no site or purchase are provided', () => {
-		expect( enrichedSurveyData( { key: 'value' }, moment() ) ).to.deep.equal( {
+		expect( enrichedSurveyData( { key: 'value' }, moment() ) ).toEqual( {
+			key: 'value',
+			purchase: null,
+			purchaseId: null,
+		} );
+	} );
+
+	test( 'should duplicate survey data if no site, purchase, or timestamp are provided', () => {
+		expect( enrichedSurveyData( { key: 'value' }, null ) ).toEqual( {
 			key: 'value',
 			purchase: null,
 			purchaseId: null,
@@ -23,7 +30,7 @@ describe( 'enrichedSurveyData', () => {
 	test( 'should add purchase id and slug to survey data if purchase is provided', () => {
 		const site = null;
 		const purchase = { id: 'purchase id', productSlug: 'product slug' };
-		expect( enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase ).to.equal(
+		expect( enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase ).toEqual(
 			'product slug'
 		);
 	} );
@@ -34,7 +41,7 @@ describe( 'enrichedSurveyData', () => {
 		expect(
 			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase )
 				.daysSincePurchase
-		).to.equal( 10 );
+		).toEqual( 10 );
 	} );
 
 	test( 'should add daysSinceSiteCreation to survey data when site.options.created_at is provided', () => {
@@ -45,6 +52,6 @@ describe( 'enrichedSurveyData', () => {
 		expect(
 			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase )
 				.daysSinceSiteCreation
-		).to.equal( 10 );
+		).toEqual( 10 );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import moment from 'moment';
-
-/**
  * Internal dependencies
  */
 import enrichedSurveyData from '../enriched-survey-data';
@@ -31,8 +26,7 @@ describe( 'enrichedSurveyData', () => {
 		const site = null;
 		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
 		expect(
-			enrichedSurveyData( {}, site, purchase, moment( '2017-01-19T03:00:00+00:00' ) )
-				.daysSincePurchase
+			enrichedSurveyData( {}, site, purchase, '2017-01-19T03:00:00+00:00' ).daysSincePurchase
 		).toEqual( 10 );
 	} );
 
@@ -42,8 +36,7 @@ describe( 'enrichedSurveyData', () => {
 		};
 		const purchase = null;
 		expect(
-			enrichedSurveyData( {}, site, purchase, moment( '2017-01-19T03:00:00+00:00' ) )
-				.daysSinceSiteCreation
+			enrichedSurveyData( {}, site, purchase, '2017-01-19T03:00:00+00:00' ).daysSinceSiteCreation
 		).toEqual( 10 );
 	} );
 } );

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -104,7 +104,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 			},
 			type: 'remove',
 		};
-		survey.addResponses( enrichedSurveyData( surveyData, null, site, purchase ) );
+		survey.addResponses( enrichedSurveyData( surveyData, site, purchase ) );
 
 		const response = await survey.submit();
 		if ( ! response.success ) {

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -106,7 +104,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 			},
 			type: 'remove',
 		};
-		survey.addResponses( enrichedSurveyData( surveyData, moment(), site, purchase ) );
+		survey.addResponses( enrichedSurveyData( surveyData, null, site, purchase ) );
 
 		const response = await survey.submit();
 		if ( ! response.success ) {

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -58,7 +58,7 @@ class ConfirmDisconnection extends PureComponent {
 		submitSurvey(
 			'calypso-disconnect-jetpack-july2019',
 			siteId,
-			enrichedSurveyData( surveyData, null, site, purchase )
+			enrichedSurveyData( surveyData, site, purchase )
 		);
 	};
 

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -26,7 +26,6 @@ class ConfirmDisconnection extends PureComponent {
 		reason: PropTypes.string,
 		text: PropTypes.oneOfType( [ PropTypes.string, PropTypes.arrayOf( PropTypes.string ) ] ),
 		// Provided by HOCs
-		moment: PropTypes.func,
 		purchase: PropTypes.object,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
@@ -44,7 +43,7 @@ class ConfirmDisconnection extends PureComponent {
 	];
 
 	submitSurvey = () => {
-		const { moment, purchase, reason, site, siteId, text } = this.props;
+		const { purchase, reason, site, siteId, text } = this.props;
 
 		const surveyData = {
 			'why-cancel': {
@@ -59,7 +58,7 @@ class ConfirmDisconnection extends PureComponent {
 		submitSurvey(
 			'calypso-disconnect-jetpack-july2019',
 			siteId,
-			enrichedSurveyData( surveyData, moment(), site, purchase )
+			enrichedSurveyData( surveyData, null, site, purchase )
 		);
 	};
 


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

In `marketing-survey`, the export was only needed in `enrichedSurveyData`, which doesn't need localization. It probably doesn't need `moment` either, but I'm leaving that for future explorations.

Everywhere else, the `moment` export was only being used to feed data to `enrichedSurveyData`, and always using the current timestamp. This was therefore moved inside `enrichedSurveyData`, while preserving the option of providing it from outside.

**Note**: If I added you and you feel you're not the right person to review these changes, I apologise for that; please feel free to ignore or remove yourself. I just went with the default GitHub suggestions since I had no idea who to add 🤷‍♂

#### Changes proposed in this Pull Request

* Have `enrichedSurveyData` allow for an optional timestamp, and use current time in case it's not provided
* Rewrite `enrichedSurveyData` consumers to not depend on `moment` directly
* Modernize `enrichedSurveyData` and its test code somewhat.

#### Testing instructions

The unit tests work correctly, so this gives me some degree of confidence that the functionality is correct. Otherwise, please ensure that the marketing survey functionality continues to work correctly, particularly where days since purchase and days since site creation are concerned.
