### PR TITLE
Add sleep to give executescripts time to complete

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -283,9 +283,10 @@ export async function ensureNotLoggedIn( driver ) {
 		await driver.executeScript( 'window.document.cookie = "sensitive_pixel_option=no;";' );
 	}
 
-	return await driver.executeScript(
+	await driver.executeScript(
 		'window.document.cookie = "sensitive_pixel_option=no;domain=.wordpress.com";'
 	);
+	return driver.sleep( 500 );
 }
 
 export async function dismissAllAlerts( driver ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On some runs, the `ensurenotloggedin` function wasn't finishing before the next steps were starting to run. I made sure everything was awaited, but I suspect this is an issue with Chrome or Chromedriver. Adding this short wait seems to be enough make tests pass.

#### Testing instructions

* Ensure `[WPCOM] Sign Up  (mobile, en) Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link` test passes in CircleCI
