### PR TITLE
Importers: update button capitalization to sentence case

### DIFF
--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -61,7 +61,7 @@ class AuthorMappingPane extends React.PureComponent {
 				'We found one author on your %(sourceType)s site. ' +
 					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
 					'all imported content will be assigned to you. ' +
-					'Click Start Import to proceed.',
+					'Click Start import to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
@@ -77,7 +77,7 @@ class AuthorMappingPane extends React.PureComponent {
 				'We found multiple authors on your %(sourceType)s site. ' +
 					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
 					'all imported content will be assigned to you. ' +
-					'Click Start Import to proceed.',
+					'Click Start import to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
@@ -92,7 +92,7 @@ class AuthorMappingPane extends React.PureComponent {
 			return this.props.translate(
 				'We found multiple authors on {{b}}%(destinationSiteTitle)s{{/b}}. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click Start Import.',
+					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click Start import.',
 				{
 					args: {
 						sourceType: 'WordPress',
@@ -107,7 +107,7 @@ class AuthorMappingPane extends React.PureComponent {
 			return this.props.translate(
 				'We found multiple authors on your %(sourceType)s site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click Start Import.',
+					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click Start import.',
 				{
 					args: {
 						sourceType: 'WordPress',
@@ -172,7 +172,7 @@ class AuthorMappingPane extends React.PureComponent {
 				<ImporterActionButtonContainer>
 					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
 					<ImporterActionButton primary disabled={ ! canStartImport } onClick={ onStartImport }>
-						{ this.props.translate( 'Start Import' ) }
+						{ this.props.translate( 'Start import' ) }
 					</ImporterActionButton>
 				</ImporterActionButtonContainer>
 			</div>

--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -75,7 +75,7 @@ export class DoneButton extends React.PureComponent {
 
 		return (
 			<ImporterActionButton primary onClick={ this.handleClick }>
-				{ translate( 'View Site' ) }
+				{ translate( 'View site' ) }
 			</ImporterActionButton>
 		);
 	}

--- a/client/my-sites/importer/importer-header/start-button.jsx
+++ b/client/my-sites/importer/importer-header/start-button.jsx
@@ -55,7 +55,7 @@ class StartButton extends React.PureComponent {
 				isPrimary={ false }
 				onClick={ this.handleClick }
 			>
-				{ translate( 'Start Import', { context: 'verb' } ) }
+				{ translate( 'Start import', { context: 'verb' } ) }
 			</Button>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the button capitalization on the import flow to sentence case as per the [`Button` guidelines](https://github.com/Automattic/wp-calypso/tree/83cefb18976d90ddee3ca9518c7cb375b0ff1a14/packages/calypso-ui/src/button#general-guidelines).

**Before**
<img width="788" alt="Screen Shot 2019-10-15 at 2 16 47 PM" src="https://user-images.githubusercontent.com/448298/66858030-817a1b80-ef56-11e9-91c4-71232100b91f.png">
<img width="787" alt="Screen Shot 2019-10-15 at 2 17 09 PM" src="https://user-images.githubusercontent.com/448298/66858038-85a63900-ef56-11e9-8bad-de2934476c77.png">
<img width="819" alt="Screen Shot 2019-10-15 at 2 11 12 PM" src="https://user-images.githubusercontent.com/448298/66858045-88a12980-ef56-11e9-9a31-5dffd333ef94.png">

**After**
<img width="847" alt="Screen Shot 2019-10-15 at 2 09 41 PM" src="https://user-images.githubusercontent.com/448298/66858070-9191fb00-ef56-11e9-9506-c5a83cbcacdf.png">
<img width="786" alt="Screen Shot 2019-10-15 at 2 09 28 PM" src="https://user-images.githubusercontent.com/448298/66858077-95258200-ef56-11e9-8767-6245e1abf1b4.png">
<img width="789" alt="Screen Shot 2019-10-15 at 2 11 27 PM" src="https://user-images.githubusercontent.com/448298/66858093-9a82cc80-ef56-11e9-8adc-409a48a92100.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Visit https://calypso.localhost:3000/import/{site} or click `Import` in the sidebar
* Confirm the buttons are sentence case
* Click to import WordPress and upload a file
* Continue the process of importing taking note of the capitalization on the buttons
* Go through a Wix or GoDaddy import flow, taking note of button capitalization

Fixes #36734
