### PR TITLE
wp-checkout: Add prop types to internal components

### DIFF
--- a/packages/wp-checkout/src/components/checkout-payment-methods.js
+++ b/packages/wp-checkout/src/components/checkout-payment-methods.js
@@ -70,3 +70,9 @@ function PaymentMethod( { id, button, form, checked, onClick } ) {
 	);
 	/* eslint-enable jsx-a11y/label-has-associated-control */
 }
+
+PaymentMethod.propTypes = {
+	id: PropTypes.string.isRequired,
+	onClick: PropTypes.func.isRequired,
+	checked: PropTypes.bool.isRequired,
+};

--- a/packages/wp-checkout/src/components/checkout.js
+++ b/packages/wp-checkout/src/components/checkout.js
@@ -130,3 +130,12 @@ function PaymentMethodsStep( {
 		</React.Fragment>
 	);
 }
+
+PaymentMethodsStep.propTypes = {
+	setStepNumber: PropTypes.func.isRequired,
+	isActive: PropTypes.bool.isRequired,
+	isComplete: PropTypes.bool.isRequired,
+	availablePaymentMethods: PropTypes.arrayOf( PropTypes.string ),
+	setPaymentMethod: PropTypes.func.isRequired,
+	paymentMethod: PropTypes.string.isRequired,
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add proptypes declarations for PaymentMethod and PaymentMethodsStep
