### PR TITLE
Enable the new WooCommerce Onboarding in wpcalypso for easier testing.

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,7 +56,7 @@
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/site-questions": false,
-		"jetpack/connect/woocommerce": false,
+		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"login/magic-login": true,
@@ -163,7 +163,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
-		"woocommerce/onboarding-oauth": false,
+		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
We are moving towards testing the WooCommerce Onboarding experience with others inside Automattic, including none developers. This PR enables the new onboarding Jetpack and WooCommerce helper flows on `wpcalypso`, so that the flow can be ran end to end from WooCommerce Admin, without needing to run Calypso or WooCommerce Admin locally.

See https://github.com/Automattic/wp-calypso/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+author%3Ajustinshreve+merged%3A%3E2019-05-01 for previous PRs. If you wish to test the flows, you can follow the directions via https://github.com/Automattic/wp-calypso/pull/36432.