### PR TITLE
Jetpack: Enable JITM for dotcom sites

### DIFF
--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -13,9 +13,7 @@ import { clearJITM, insertJITM } from 'state/jitm/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
 import { SECTION_SET, SELECTED_SITE_SET, JITM_DISMISS } from 'state/action-types';
-
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 /**
@@ -59,8 +57,8 @@ const unescapeDecimalEntities = str => {
  */
 const transformApiRequest = ( { data: jitms } ) =>
 	jitms.map( jitm => ( {
-		message: unescapeDecimalEntities( jitm.content.message ),
-		description: unescapeDecimalEntities( jitm.content.description ),
+		message: unescapeDecimalEntities( jitm.content.message || '' ),
+		description: unescapeDecimalEntities( jitm.content.description || '' ),
 		featureClass: jitm.feature_class,
 		callToAction: unescapeDecimalEntities( jitm.CTA.message ),
 		id: jitm.id,
@@ -75,11 +73,6 @@ export const fetchJITM = action => ( dispatch, getState ) => {
 	}
 
 	const currentSite = process.lastSite;
-
-	if ( ! isJetpackSite( getState(), currentSite ) ) {
-		return;
-	}
-
 	const currentRoute = getCurrentRoute( getState() );
 	const isIgnoredRoute = some( routesToIgnore, route => startsWith( currentRoute, route ) );
 	if ( isIgnoredRoute ) {

--- a/client/state/data-layer/wpcom/sites/jitm/schema.json
+++ b/client/state/data-layer/wpcom/sites/jitm/schema.json
@@ -7,12 +7,15 @@
 					"CTA": {
 						"properties": {
 							"hook": {
-								"type": "string"
+								"type": [ "string", "null" ]
 							},
 							"message": {
 								"type": "string"
 							},
 							"primary": {
+								"type": "boolean"
+							},
+							"newWindow": {
 								"type": "boolean"
 							}
 						},
@@ -26,17 +29,30 @@
 							"description": {
 								"type": "string"
 							},
-							"emblem": {
-								"type": "null"
-							},
 							"icon": {
-								"type": "string"
+								"type": [ "string", "null" ]
 							},
 							"message": {
 								"type": "string"
+							},
+							"list": {
+								"items": {
+									"properties": {
+										"item": {
+											"type": "string"
+										},
+										"url": {
+											"type": [ "string", "null" ]
+										}
+									}
+								},
+								"type": "array"
 							}
 						},
 						"type": "object"
+					},
+					"expires": {
+						"type": "integer"
 					},
 					"feature_class": {
 						"type": "string"

--- a/client/state/data-layer/wpcom/sites/jitm/test/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/test/index.js
@@ -24,6 +24,11 @@ const createDispatcher = ( dispatch, getState ) => action => {
 
 describe( 'jitms', () => {
 	describe( 'fetchJITM', () => {
+		beforeEach( () => {
+			// To remove the side effect, the section name should be initialized before every test.
+			handleRouteChange( { section: { name: '' } } );
+		} );
+
 		test( 'should not dispatch', () => {
 			const dispatch = jest.fn();
 			const getState = () => ( {} );
@@ -89,7 +94,7 @@ describe( 'jitms', () => {
 			);
 		} );
 
-		test( 'should be not set a jitm if not a jetpack site', () => {
+		test( 'should set a jitm for dotcom sites as well', () => {
 			const dispatch = jest.fn();
 			const state = {
 				sites: {
@@ -111,8 +116,23 @@ describe( 'jitms', () => {
 			};
 
 			const dispatcher = createDispatcher( dispatch, getState );
+
 			dispatcher( handleRouteChange( action_transition ) );
-			expect( dispatch ).not.toHaveBeenCalled();
+			expect( dispatch ).toHaveBeenCalledWith(
+				http(
+					{
+						apiNamespace: 'rest',
+						method: 'GET',
+						path: '/v1.1/jetpack-blogs/100/rest-api/',
+						query: {
+							path: '/jetpack/v4/jitm',
+							query: JSON.stringify( { message_path: 'calypso:test:admin_notices' } ),
+							http_envelope: 1,
+						},
+					},
+					{ ...action_transition, messagePath: 'test' }
+				)
+			);
 		} );
 
 		test( 'should not dispatch for ignored routes', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable JITM for dotcom sites.
* Fix the related JSON schema.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply D34075-code to your sandboxed `public-api.wordpress.com`
2. Move to the stats page of your _dotcom_ site where you're an admin.
3. You should be able to see the welcome banner as follows:
   ![image](https://user-images.githubusercontent.com/212034/66878109-66111e00-eff3-11e9-8715-d0ebfb45af9c.png)
   * If you dismiss the banner by clicking on the `X` icon, the banner never show up within a minute due to the settings.
   * "Click here" CTA will take you to Jetpack plans page regardless of whether the site is Jetpack or not.
4. Try 1-2 again for a Jetpack/atomic site. Any banners should not show up this time.

See also #23565
