### PR TITLE
Revert prefillDomainStepValue A/B test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -201,11 +201,7 @@ class RegisterDomainStep extends React.Component {
 				this.state.subdomainSearchResults = props.initialState.subdomainSearchResults;
 			}
 
-			if (
-				this.state.searchResults ||
-				this.state.subdomainSearchResults ||
-				! props.initialState.isInitialQueryActive
-			) {
+			if ( this.state.searchResults || this.state.subdomainSearchResults ) {
 				this.state.lastQuery = props.initialState.lastQuery;
 			} else {
 				this.state.railcarId = this.getNewRailcarId();
@@ -247,7 +243,6 @@ class RegisterDomainStep extends React.Component {
 			unavailableDomains: [],
 			trademarkClaimsNoticeInfo: null,
 			selectedSuggestion: null,
-			isInitialQueryActive: !! this.props.suggestion,
 		};
 	}
 
@@ -489,7 +484,7 @@ class RegisterDomainStep extends React.Component {
 	};
 
 	acceptTrademarkClaim = () => {
-		this.props.onAddDomain( this.state.selectedSuggestion, this.state.isInitialQueryActive );
+		this.props.onAddDomain( this.state.selectedSuggestion );
 	};
 
 	renderTrademarkClaimsNotice() {
@@ -677,11 +672,9 @@ class RegisterDomainStep extends React.Component {
 
 		const cleanedQuery = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 		const loadingResults = Boolean( cleanedQuery );
-		const isInitialQueryActive = searchQuery === this.props.suggestion;
 
 		this.setState(
 			{
-				isInitialQueryActive,
 				availabilityError: null,
 				availabilityErrorData: null,
 				exactMatchDomain: null,
@@ -1137,11 +1130,11 @@ class RegisterDomainStep extends React.Component {
 							selectedSuggestion: suggestion,
 						} );
 					} else {
-						this.props.onAddDomain( suggestion, this.state.isInitialQueryActive );
+						this.props.onAddDomain( suggestion );
 					}
 				} );
 		} else {
-			this.props.onAddDomain( suggestion, this.state.isInitialQueryActive );
+			this.props.onAddDomain( suggestion );
 		}
 	};
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -201,7 +201,11 @@ class RegisterDomainStep extends React.Component {
 				this.state.subdomainSearchResults = props.initialState.subdomainSearchResults;
 			}
 
-			if ( this.state.searchResults || this.state.subdomainSearchResults ) {
+			if (
+				this.state.searchResults ||
+				this.state.subdomainSearchResults ||
+				! props.initialState.isInitialQueryActive
+			) {
 				this.state.lastQuery = props.initialState.lastQuery;
 			} else {
 				this.state.railcarId = this.getNewRailcarId();
@@ -243,6 +247,7 @@ class RegisterDomainStep extends React.Component {
 			unavailableDomains: [],
 			trademarkClaimsNoticeInfo: null,
 			selectedSuggestion: null,
+			isInitialQueryActive: !! this.props.suggestion,
 		};
 	}
 
@@ -672,9 +677,11 @@ class RegisterDomainStep extends React.Component {
 
 		const cleanedQuery = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 		const loadingResults = Boolean( cleanedQuery );
+		const isInitialQueryActive = searchQuery === this.props.suggestion;
 
 		this.setState(
 			{
+				isInitialQueryActive,
 				availabilityError: null,
 				availabilityErrorData: null,
 				exactMatchDomain: null,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,15 +115,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	prefillDomainStepValue: {
-		datestamp: '20190929',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	domainSuggestionsEn: {
 		datestamp: '20191003',
 		variations: {


### PR DESCRIPTION
This reverts the A/B test where the site title was re-used in the domain step search.

#### Changes proposed in this Pull Request

* Revert `prefillDomainStepValue` A/B test (#35615)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Test ordinary sign up

1. Go to `http://calypso.localhost:3000/start`
2. Sign in and go to create a site selecting one of Blog, Business, or Professional site types, enter a site title, and when you reach the domain step, the search field should be empty.
3. On the domain step, try searching for a couple of different domains
4. Click back, and update the site title
5. Click forward and the domain field should be unaffected by what you entered as a site title
6. Select a domain and complete signup until you reach the checkout page, and double check that the domain you selected is in your cart

(This last step is just to double-check that we haven't accidentally broken the cart process for the domain selection).

##### Test using a query parameter to set a domain name for the domain search

* Follow the above steps, but enter a domain name via URL, e.g. starting from `http://calypso.localhost:3000/start?new=mytestdomain.com`
* When you reach the domain step, the search should be pre-filled with your domain name

Reverts #35615 
