### PR TITLE
Fix type errors in flow-controller.ts

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -227,7 +227,7 @@ export default class SignupFlowController {
 	_getFlowProvidesDependencies() {
 		return flatMap( this._flow.steps, stepName =>
 			get( steps, [ stepName, 'providesDependencies' ], [] )
-		).concat( this._flow.providesDependenciesInQuery );
+		).concat( this._flow.providesDependenciesInQuery || [] );
 	}
 
 	_process() {
@@ -349,7 +349,7 @@ export default class SignupFlowController {
 
 	_getStoredDependencies() {
 		const requiredDependencies = flatMap( this._flow.steps, stepName =>
-			get( steps, [ stepName, 'providesDependencies' ], [] )
+			get( steps[ stepName ], 'providesDependencies', [] )
 		);
 
 		return reduce(

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -225,8 +225,9 @@ export default class SignupFlowController {
 	 * @return {array} a list of dependency names
 	 */
 	_getFlowProvidesDependencies() {
-		return flatMap( this._flow.steps, stepName =>
-			get( steps, [ stepName, 'providesDependencies' ], [] )
+		return flatMap(
+			this._flow.steps,
+			stepName => ( steps && steps[ stepName ] && steps[ stepName ].providesDependencies ) || []
 		).concat( this._flow.providesDependenciesInQuery || [] );
 	}
 
@@ -348,8 +349,9 @@ export default class SignupFlowController {
 	}
 
 	_getStoredDependencies() {
-		const requiredDependencies = flatMap( this._flow.steps, stepName =>
-			get( steps[ stepName ], 'providesDependencies', [] )
+		const requiredDependencies = flatMap(
+			this._flow.steps,
+			stepName => ( steps && steps[ stepName ] && steps[ stepName ].providesDependencies ) || []
 		);
 
 		return reduce(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

> PR split from the larger #36517

A couple of type errors snuck in, probably due to @types/lodash being updated at some stage.

Error in `_getFlowProvidesDependencies`:
`_.concat` doesn't accept `undefined` as an argument, so default to `[]` to have the same effect.

Error in `_getStoredDependencies`:
Using `_.get` is always a bit tricky in TS. Using the array path overload erases the type information, so it had no way to figure out that `requiredDependencies` was going to be a `string[]`.
This change should have the same effect (if there's not step with that name the statement will still default to `[]`).

#### Testing instructions

- No type errors should appear in your editor
- `npm --silent run typecheck | grep flow-controller` prints no output
