### PR TITLE
Vertical suggested themes: Add `optionalDependencies` that might not be submitted by a step

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -56,6 +56,7 @@ interface Step {
 	dependencies?: string[];
 	providedDependencies?: string[];
 	providesDependencies?: string[];
+	optionalDependencies?: string[];
 	providesToken?: boolean;
 	stepName: string;
 }
@@ -199,7 +200,13 @@ export default class SignupFlowController {
 				return;
 			}
 
-			const dependenciesNotProvided = difference( step.providesDependencies, storedDependencies );
+			const optionalDependencies = step.optionalDependencies || [];
+
+			const dependenciesNotProvided = difference(
+				step.providesDependencies,
+				optionalDependencies,
+				storedDependencies
+			);
 
 			if ( dependenciesNotProvided.length > 0 ) {
 				throw new Error(

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -523,7 +523,13 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 	}
 
 	const stepProvidesDependencies = steps[ stepName ].providesDependencies;
-	const dependenciesNotProvided = difference( stepProvidesDependencies, fulfilledDependencies );
+	const stepOptionalDependencies = steps[ stepName ].optionalDependencies;
+
+	const dependenciesNotProvided = difference(
+		stepProvidesDependencies,
+		stepOptionalDependencies,
+		fulfilledDependencies
+	);
 	return isEmpty( dependenciesNotProvided );
 }
 

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -240,4 +240,76 @@ describe( 'flow-controller', () => {
 			store.dispatch( submitSignupStep( { stepName: 'stepRequiringSiteSlug' } ) );
 		} );
 	} );
+
+	describe( 'controlling a flow with optional dependencies', () => {
+		test( 'should run `onComplete` once all steps are submitted, including optional dependency', done => {
+			const store = createSignupStore();
+			signupFlowController = new SignupFlowController( {
+				flowName: 'flowWithSiteTopicWithOptionalTheme',
+				onComplete: () => done(),
+				reduxStore: store,
+			} );
+
+			store.dispatch( submitSignupStep( { stepName: 'stepA' } ) );
+			store.dispatch( submitSignupStep( { stepName: 'stepB' } ) );
+			store.dispatch(
+				submitSignupStep(
+					{
+						stepName: 'site-topic-with-optional-theme',
+					},
+					{
+						siteTopic: 'foo',
+						themeSlugWithRepo: 'bar',
+					}
+				)
+			);
+		} );
+
+		test( 'should run `onComplete` once all steps are submitted, excluding optional dependency', done => {
+			const store = createSignupStore();
+			signupFlowController = new SignupFlowController( {
+				flowName: 'flowWithSiteTopicWithOptionalTheme',
+				onComplete: () => done(),
+				reduxStore: store,
+			} );
+
+			store.dispatch( submitSignupStep( { stepName: 'stepA' } ) );
+			store.dispatch( submitSignupStep( { stepName: 'stepB' } ) );
+			store.dispatch(
+				submitSignupStep(
+					{
+						stepName: 'site-topic-with-optional-theme',
+					},
+					{
+						siteTopic: 'foo',
+					}
+				)
+			);
+		} );
+
+		test( "should throw if step doesn't provide required dependency", () => {
+			const store = createSignupStore();
+			signupFlowController = new SignupFlowController( {
+				flowName: 'flowWithSiteTopicWithOptionalTheme',
+				onComplete: () => {},
+				reduxStore: store,
+			} );
+
+			store.dispatch( submitSignupStep( { stepName: 'stepA' } ) );
+			store.dispatch( submitSignupStep( { stepName: 'stepB' } ) );
+
+			expect( () =>
+				store.dispatch(
+					submitSignupStep(
+						{
+							stepName: 'site-topic-with-optional-theme',
+						},
+						{
+							themeSlugWithRepo: 'foo',
+						}
+					)
+				)
+			).toThrow( /the dependencies .* were not provided/i );
+		} );
+	} );
 } );

--- a/client/lib/signup/test/mocks/signup/config/flows-pure.js
+++ b/client/lib/signup/test/mocks/signup/config/flows-pure.js
@@ -41,5 +41,13 @@ const flows = {
 	flowWithSiteTopicAndSurvey: {
 		steps: [ 'stepA', 'stepB', 'site-topic', 'survey' ],
 	},
+
+	flowWithSiteTopicWithOptionalTheme: {
+		steps: [ 'stepA', 'stepB', 'site-topic-with-optional-theme' ],
+	},
+
+	flowWithSiteTopicWithOptionalSurveyQuestion: {
+		steps: [ 'stepA', 'stepB', 'site-topic-with-optional-survey-question' ],
+	},
 };
 export default flows;

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -96,6 +96,18 @@ export default {
 		stepName: 'site-topic-and-title',
 		providesDependencies: [ 'siteTopic', 'siteTitle' ],
 	},
+
+	'site-topic-with-optional-theme': {
+		stepName: 'site-topic-with-optional-theme',
+		providesDependencies: [ 'siteTopic', 'themeSlugWithRepo' ],
+		optionalDependencies: [ 'themeSlugWithRepo' ],
+	},
+
+	'site-topic-with-optional-survey-question': {
+		stepName: 'site-topic-with-optional-survey-question',
+		providesDependencies: [ 'siteTopic', 'surveyQuestion' ],
+		optionalDependencies: [ 'surveyQuestion' ],
+	},
 };
 
 export const isDomainStepSkippable = jest.fn( () => false );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -485,4 +485,30 @@ describe( 'isSiteTopicFulfilled()', () => {
 		expect( setSurvey ).not.toHaveBeenCalled();
 		expect( submitSiteVertical ).not.toHaveBeenCalled();
 	} );
+
+	test( 'should remove a step with optional dependency not met', () => {
+		const flowName = 'flowWithSiteTopicWithOptionalTheme';
+		const stepName = 'site-topic-with-optional-theme';
+		const initialContext = { query: { vertical: 'verticalSlug' } };
+		const nextProps = { initialContext, flowName, submitSignupStep, submitSiteVertical, setSurvey };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isSiteTopicFulfilled( stepName, undefined, nextProps );
+
+		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-topic-with-optional-theme' );
+	} );
+
+	test( 'should remove a step with optional dependency met', () => {
+		const flowName = 'flowWithSiteTopicWithOptionalSurveyQuestion';
+		const stepName = 'site-topic-with-optional-survey-question';
+		const initialContext = { query: { vertical: 'verticalSlug' } };
+		const nextProps = { initialContext, flowName, submitSignupStep, submitSiteVertical, setSurvey };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isSiteTopicFulfilled( stepName, undefined, nextProps );
+
+		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-topic-with-optional-survey-question' );
+	} );
 } );

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -33,11 +33,12 @@ Once you've added the flow to `flows-pure.js`, it'll be available for users at `
 
 Anyone can create steps that flow designers can use in their flows.
 
-You can add a new step to Modular Signup from `/client/signup/config/steps-pure.js`. A step is defined by three properties:
+You can add a new step to Modular Signup from `/client/signup/config/steps-pure.js`. A step is defined by a number of properties:
 
 - `stepName` is the identifier used to reference a step in `/client/signup/config/flows-pure.js`.
 - (optional) `dependencies`, which specify which properties this step needs from other steps in the flow in order to be processed.
-- (optional) `providesDependencies` is an array that lets the signup framework know what dependencies the step is expected to provide. If the step does not provide all of these, or if it provides more than it says, an error will be thrown.
+- (optional) `providesDependencies` is an array that lets the signup framework know what dependencies the step is expected to provide. If the step does not provide all of these, or if it provides more than it says, an error will be thrown (unless `optionalDependencies` is used, see below).
+- (optional) `optionalDependencies` is an array that lists which of the items in `providesDependencies` are optional. If one of these values is missing when a step is submitted there'll be no error.
 - (optional) `delayApiRequestUntilComplete` is a boolean that, when true, causes the step's `apiRequestFunction` to be called only after the user has submitted every step in the signup flow. This is useful for steps that the user should be able to go back and change at any point in signup.
 
 You will also need to define which React component implements your step in `/client/signup/config/step-components.js`. Make sure to require the component as an internal dependency in `step-components.js`.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

> Split from the larger #36517

Currently if a step submits a dependency without listing it in `steps-pure.js` there'll be an assertion (see `client/lib/signup/asserts.js`).

After this change steps can list some of their dependencies as optional. A step will be permitted to provide this dependency when submitting, but it also won't prevent the flow from progressing if it's missing.

Following the lead of `unstorableDependencies`; a step definition should list its optionals in both `providesDependencies` and `optionalDependencies`.

#### Rationale

I'm planning on making a change (in #36517) so the site-topic step can sometimes provide a theme, sometimes not.

#### Testing instructions

`npm run test-client -- client/signup`

Will rebase #36517 so it's a child of this PR. It will be manually testable there.

