### PR TITLE
Vertical suggested themes: Send `use_demo_content` option if part of AB test group

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -15,7 +15,7 @@ import { parse as parseURL } from 'url';
 import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
-import { getSavedVariations } from 'lib/abtest';
+import { abtest, getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import {
 	updatePrivacyForDomain,
@@ -143,6 +143,12 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	const siteStyle = getSiteStyle( state ).trim();
 	const siteSegment = getSiteTypePropertyValue( 'slug', siteType, 'id' );
 
+	// flowName isn't always passed in
+	const flowToCheck = flowName || lastKnownFlow;
+
+	const verticalSuggestedThemeTest =
+		flowToCheck === 'onboarding' && abtest( 'verticalSuggestedThemes' ) === 'test';
+
 	const newSiteParams = {
 		blog_title: siteTitle,
 		options: {
@@ -156,6 +162,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			site_segment: siteSegment || undefined,
 			site_vertical: siteVerticalId || undefined,
 			site_vertical_name: siteVerticalName || undefined,
+			use_demo_content: verticalSuggestedThemeTest,
 			site_information: {
 				title: siteTitle,
 			},
@@ -163,9 +170,6 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		public: getNewSitePublicSetting( state ),
 		validate: false,
 	};
-
-	// flowName isn't always passed in
-	const flowToCheck = flowName || lastKnownFlow;
 
 	if ( ! siteUrl && isDomainStepSkippable( flowToCheck ) ) {
 		newSiteParams.blog_name =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In D33972-code the API will headstart the new site with demosite content if it think's it's appropriate. Adding this flag opts into that behaviour.

* Send `use_demo_content` option to site creation API if user is in AB test group.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D33972-code
  * Create a new site where type=business and topic=Restaurants
    * ~*Note that the preview doesn't look like the Rockfield theme, that's #36517*~ merged
    * ~The new site will have the Maywood theme (that change is also in #36517)~ merged
    * The new site will be populated with the same content as https://rockfielddemo.wordpress.com/
    * Apply the Rockfield theme on the new site for easier comparison
  * Create a new site with other options
    * The new site will be populated with the regular content it would get on production