### PR TITLE
LanguagePicker: set button type to 'button' to prevent submitting a form

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -150,7 +150,12 @@ export class LanguagePicker extends PureComponent {
 		return (
 			<Fragment>
 				<QueryLanguageNames />
-				<button className="language-picker" onClick={ this.handleClick } disabled={ disabled }>
+				<button
+					type="button"
+					className="language-picker"
+					onClick={ this.handleClick }
+					disabled={ disabled }
+				>
 					<div className="language-picker__icon">
 						<div className="language-picker__icon-inner">
 							{ langCode }


### PR DESCRIPTION
When changing site language, the `LanguagePicker` button is rendered inside a `form` element, and because the default type of a button is `submit`, clicking on it submits the form, causing a full page reload. Fixed by explicitly setting `type="button"`.

**How to test:**
1. Go to Site Settings for your site
2. Try to change the site language
3. Verify that the page no longer reloads after clicking the button. The modal should open and stay.
