### PR TITLE
Devdocs: Add width to product selector example

### DIFF
--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -57,7 +57,9 @@ class ProductSelectorExample extends Component {
 					</SegmentedControl.Item>
 				</SegmentedControl>
 
-				<ProductSelector products={ products } intervalType={ this.state.interval } />
+				<div style={ { maxWidth: 520, margin: '0 auto' } }>
+					<ProductSelector products={ products } intervalType={ this.state.interval } />
+				</div>
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Devdocs: Add width to product selector example

#### Preview

Before:
![](https://cldup.com/FSNiibHSVN.png)

After:
![](https://cldup.com/1i0g4KARu0.png)

#### Testing instructions

* Checkout this branch and build Calypso `npm start`
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector
* Verify the block is contained in a reasonable width now.
