### PR TITLE
Show SMS option when an account is using the SMS for 2fa

### DIFF
--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -268,7 +268,11 @@ const ReauthRequired = createReactClass( {
 				<TwoFactorActions
 					twoFactorAuthType={ twoFactorAuthType }
 					onChange={ this.handleAuthSwitch }
-					isSmsSupported={ method === 'sms' || method === 'authenticator' }
+					isSmsSupported={
+						method === 'sms' ||
+						( method === 'authenticator' &&
+							this.props.twoStepAuthorization.data.two_step_sms_last_four.length )
+					}
 					isAuthenticatorSupported={ method !== 'sms' }
 					isSmsAllowed={ shouldEnableSmsButton }
 					isSecurityKeySupported={ isSecurityKeySupported }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -250,6 +250,9 @@ const ReauthRequired = createReactClass( {
 		const shouldEnableSmsButton =
 			this.state.smsRequestsAllowed || ( method === 'sms' && twoFactorAuthType === 'webauthn' );
 
+		const hasSmsRecoveryNumber = !! this.props.twoStepAuthorization.data.two_step_sms_last_four
+			?.length;
+
 		return (
 			<Dialog
 				autoFocus={ false }
@@ -269,9 +272,7 @@ const ReauthRequired = createReactClass( {
 					twoFactorAuthType={ twoFactorAuthType }
 					onChange={ this.handleAuthSwitch }
 					isSmsSupported={
-						method === 'sms' ||
-						( method === 'authenticator' &&
-							this.props.twoStepAuthorization.data.two_step_sms_last_four.length )
+						method === 'sms' || ( method === 'authenticator' && hasSmsRecoveryNumber )
 					}
 					isAuthenticatorSupported={ method !== 'sms' }
 					isSmsAllowed={ shouldEnableSmsButton }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -250,7 +250,7 @@ const ReauthRequired = createReactClass( {
 		const shouldEnableSmsButton =
 			this.state.smsRequestsAllowed || ( method === 'sms' && twoFactorAuthType === 'webauthn' );
 
-		const hasSmsRecoveryNumber = !! this.props.twoStepAuthorization.data.two_step_sms_last_four
+		const hasSmsRecoveryNumber = !! this.props?.twoStepAuthorization?.data?.two_step_sms_last_four
 			?.length;
 
 		return (

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -192,7 +192,7 @@ class Security2faCodePrompt extends React.Component {
 
 	render() {
 		const method = twoStepAuthorization.isTwoStepSMSEnabled() ? 'sms' : 'app';
-		const hasSmsRecoveryNumber = !! twoStepAuthorization.data.two_step_sms_last_four?.length;
+		const hasSmsRecoveryNumber = !! twoStepAuthorization?.data?.two_step_sms_last_four?.length;
 
 		return (
 			<form className="security-2fa-code-prompt" onSubmit={ this.onSubmit }>

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -192,6 +192,7 @@ class Security2faCodePrompt extends React.Component {
 
 	render() {
 		const method = twoStepAuthorization.isTwoStepSMSEnabled() ? 'sms' : 'app';
+		const hasSmsRecoveryNumber = !! twoStepAuthorization.data.two_step_sms_last_four?.length;
 
 		return (
 			<form className="security-2fa-code-prompt" onSubmit={ this.onSubmit }>
@@ -201,9 +202,9 @@ class Security2faCodePrompt extends React.Component {
 					</FormLabel>
 
 					<FormVerificationCodeInput
-						autoFocus
 						className="security-2fa-code-prompt__verification-code"
 						disabled={ this.state.submittingForm }
+						id="verification-code"
 						method={ method }
 						name="verificationCode"
 						onFocus={ function () {
@@ -215,7 +216,7 @@ class Security2faCodePrompt extends React.Component {
 					{ this.state.codeRequestPerformed ? (
 						<FormSettingExplanation>
 							{ this.props.translate(
-								'A code has been sent to your device via SMS.  ' +
+								'A code has been sent to your device via SMS. ' +
 									'You may request another code after one minute.'
 							) }
 						</FormSettingExplanation>
@@ -233,7 +234,7 @@ class Security2faCodePrompt extends React.Component {
 						{ this.getSubmitButtonLabel() }
 					</FormButton>
 
-					{ twoStepAuthorization.isTwoStepSMSEnabled() && this.props.showSMSButton ? (
+					{ hasSmsRecoveryNumber && this.props.showSMSButton ? (
 						<FormButton
 							className="security-2fa-code-prompt__send-code"
 							disabled={ ! this.state.codeRequestsAllowed }

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -233,7 +233,7 @@ class Security2faCodePrompt extends React.Component {
 						{ this.getSubmitButtonLabel() }
 					</FormButton>
 
-					{ this.props.showSMSButton ? (
+					{ twoStepAuthorization.isTwoStepSMSEnabled() && this.props.showSMSButton ? (
 						<FormButton
 							className="security-2fa-code-prompt__send-code"
 							disabled={ ! this.state.codeRequestsAllowed }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This hides the Send Code by SMS buttons on the 2fa prompt as well as when one wants to disable 2fa for a given account.
<img width="426" alt="Screen Shot 2020-08-12 at 1 35 42 PM" src="https://user-images.githubusercontent.com/1689238/90266668-54222680-de22-11ea-8dd7-2d734d9cda0d.png">

<img width="735" alt="Screen Shot 2020-08-14 at 11 34 02 AM" src="https://user-images.githubusercontent.com/1689238/90266618-42d91a00-de22-11ea-9c7b-dbd70aef7855.png">

- Only show the sms button on the 2fa prompt (re-auth) and 2fa disable prompt when sms recovery phone number has been added
- Fix linter issues: remove extra space in translated text and remove `autoFocus` because it's an accessibility / usability issue to skip the warning text above the verification field. Also add id for the verification field to associate it with its label.

#### Testing instructions

- Log in to WP.com with an account with 2fa enabled via app, and with sms disabled (an a8c account for example).
- Navigate to http://calypso.localhost:3000/
- Remove the `twostep_auth` cookie from the `wordpress.com/public-api.wordpress.com` domain and refresh.
- Navigate to http://calypso.localhost:3000/me
- [ ] The 2fa re-auth prompt does NOT contain the "Send code via text message" button at the bottom
- Re-enter the verification code and go to two-step settings (me/security/two-step) and click "Disable two-step authentication"
- [ ] The 2fa disable prompt does NOT contain the "Send code via SMS" button at the bottom
- Repeat the above steps with an account that has 2fa enabled via app and an SMS recovery number added.
- [ ] The 2fa re-auth prompt does contain the "Send code via text message" button at the bottom
- [ ] The 2fa disable prompt does contain the "Send code via SMS" button at the bottom

Fixes #36809
