### PR TITLE
Remove default export from i18n-calypso.

### DIFF
--- a/apps/notifications/src/panel/templates/filters.js
+++ b/apps/notifications/src/panel/templates/filters.js
@@ -1,4 +1,7 @@
-import i18n from 'i18n-calypso';
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
 
 import { store } from '../state';
 
@@ -9,13 +12,13 @@ export const Filters = {
 		return {
 			name: 'all',
 			index: 0,
-			label: i18n.translate( 'All', {
+			label: translate( 'All', {
 				comment: "Notifications filter: all of a users' notifications",
 			} ),
-			emptyMessage: i18n.translate( 'No notifications yet.', {
+			emptyMessage: translate( 'No notifications yet.', {
 				comment: 'Notifications all filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( 'Get active! Comment on posts from blogs you follow.', {
+			emptyLinkMessage: translate( 'Get active! Comment on posts from blogs you follow.', {
 				comment: 'Notifications all filter: no notifications',
 			} ),
 			emptyLink: 'https://wordpress.com/read/',
@@ -27,13 +30,13 @@ export const Filters = {
 		return {
 			name: 'unread',
 			index: 1,
-			label: i18n.translate( 'Unread', {
+			label: translate( 'Unread', {
 				comment: 'Notifications filter: unread notifications',
 			} ),
-			emptyMessage: i18n.translate( "You're all caught up!", {
+			emptyMessage: translate( "You're all caught up!", {
 				comment: 'Notifications unread filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( 'Reignite the conversation: write a new post.', {
+			emptyLinkMessage: translate( 'Reignite the conversation: write a new post.', {
 				comment: 'Notifications unread filter: no notifications',
 			} ),
 			emptyLink: 'https://wordpress.com/post/',
@@ -45,13 +48,13 @@ export const Filters = {
 		return {
 			name: 'comments',
 			index: 2,
-			label: i18n.translate( 'Comments', {
+			label: translate( 'Comments', {
 				comment: 'Notifications filter: comment notifications',
 			} ),
-			emptyMessage: i18n.translate( 'No new comments yet!', {
+			emptyMessage: translate( 'No new comments yet!', {
 				comment: 'Notifications comments filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate(
+			emptyLinkMessage: translate(
 				'Join a conversation: search for blogs that share your interests in the Reader.',
 				{
 					comment: 'Notifications comments filter: no notifications',
@@ -66,13 +69,13 @@ export const Filters = {
 		return {
 			name: 'follows',
 			index: 3,
-			label: i18n.translate( 'Follows', {
+			label: translate( 'Follows', {
 				comment: 'Notifications filter: notifications about users following your blogs',
 			} ),
-			emptyMessage: i18n.translate( 'No new followers to report yet.', {
+			emptyMessage: translate( 'No new followers to report yet.', {
 				comment: 'Notifications follows filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( "Get noticed: comment on posts you've read.", {
+			emptyLinkMessage: translate( "Get noticed: comment on posts you've read.", {
 				comment: 'Notifications follows filter: no notifications',
 			} ),
 			emptyLink: 'https://wordpress.com/activities/likes/',
@@ -84,13 +87,13 @@ export const Filters = {
 		return {
 			name: 'likes',
 			index: 4,
-			label: i18n.translate( 'Likes', {
+			label: translate( 'Likes', {
 				comment: 'Notifications filter: notifications about users liking your posts or comments',
 			} ),
-			emptyMessage: i18n.translate( 'No new likes to show yet.', {
+			emptyMessage: translate( 'No new likes to show yet.', {
 				comment: 'Notifications likes filter: no Notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( "Get noticed: comment on posts you've read.", {
+			emptyLinkMessage: translate( "Get noticed: comment on posts you've read.", {
 				comment: 'Notifications likes filter: no Notifications',
 			} ),
 			emptyLink: 'https://wordpress.com/activities/likes/',

--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
+import { translate as i18nTranslate, localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -37,12 +34,12 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 function sendSMS( phone ) {
 	function onSuccess( dispatch ) {
-		dispatch( successNotice( i18n.translate( 'SMS Sent. Go check your messages!' ) ) );
+		dispatch( successNotice( i18nTranslate( 'SMS Sent. Go check your messages!' ) ) );
 	}
 
 	function onFailure( dispatch ) {
 		dispatch(
-			errorNotice( i18n.translate( 'We couldn’t send the SMS — double check your number.' ) )
+			errorNotice( i18nTranslate( 'We couldn’t send the SMS — double check your number.' ) )
 		);
 	}
 
@@ -61,7 +58,7 @@ function sendMagicLink( email ) {
 	// https://stackoverflow.com/questions/46765896/react-redux-actions-must-be-plain-objects-use-custom-middleware-for-async-acti
 	return function( dispatch ) {
 		const duration = { duration: 4000 };
-		dispatch( infoNotice( i18n.translate( 'Sending email' ), duration ) );
+		dispatch( infoNotice( i18nTranslate( 'Sending email' ), duration ) );
 
 		return wpcom
 			.undocumented()
@@ -71,10 +68,10 @@ function sendMagicLink( email ) {
 				scheme: 'wordpress',
 			} )
 			.then( () => {
-				dispatch( successNotice( i18n.translate( 'Email Sent. Check your mail app!' ), duration ) );
+				dispatch( successNotice( i18nTranslate( 'Email Sent. Check your mail app!' ), duration ) );
 			} )
 			.catch( error => {
-				dispatch( errorNotice( i18n.translate( 'Sorry, we couldn’t send the email.' ), duration ) );
+				dispatch( errorNotice( i18nTranslate( 'Sorry, we couldn’t send the email.' ), duration ) );
 				return Promise.reject( error );
 			} );
 	};

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -1,9 +1,15 @@
-/** @format */
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import {
+	localize,
+	getLocale,
+	registerTranslateHook,
+	registerComponentUpdateHook,
+	on as i18nOn,
+	off as i18nOff,
+} from 'i18n-calypso';
 import debugModule from 'debug';
 import { find, isEmpty } from 'lodash';
 /**
@@ -35,26 +41,26 @@ class CommunityTranslator extends Component {
 		this.setLanguage();
 
 		// wrap translations from i18n
-		i18n.registerTranslateHook( ( translation, options ) =>
+		registerTranslateHook( ( translation, options ) =>
 			this.wrapTranslation( options.original, translation, options )
 		);
 
 		// callback when translated component changes.
 		// the callback is overwritten by the translator on load/unload, so we're returning it within an anonymous function.
-		i18n.registerComponentUpdateHook( () => {} );
-		i18n.on( 'change', this.refresh );
+		registerComponentUpdateHook( () => {} );
+		i18nOn( 'change', this.refresh );
 		user.on( 'change', this.refresh );
 		userSettings.on( 'change', this.refresh );
 	}
 
 	componentWillUnmount() {
-		i18n.off( 'change', this.refresh );
+		i18nOff( 'change', this.refresh );
 		user.removeListener( 'change', this.refresh );
 		userSettings.removeListener( 'change', this.refresh );
 	}
 
 	setLanguage() {
-		this.languageJson = i18n.getLocale() || { '': {} };
+		this.languageJson = getLocale() || { '': {} };
 		// The '' here is a Jed convention used for storing configuration data
 		// alongside translations in the same dictionary (because '' will never
 		// be a legitimately translatable string)

--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { getLocaleSlug, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -25,9 +22,9 @@ export default function emailVerification( context, next ) {
 		setTimeout( () => {
 			// TODO: unify these once translations catch up
 			const message =
-				i18n.getLocaleSlug() === 'en'
-					? i18n.translate( 'Email confirmed!' )
-					: i18n.translate(
+				getLocaleSlug() === 'en'
+					? translate( 'Email confirmed!' )
+					: translate(
 							"Email confirmed! Now that you've confirmed your email address you can publish posts on your blog."
 					  );
 			const notice = successNotice( message, { duration: 10000 } );

--- a/client/components/faq/README.md
+++ b/client/components/faq/README.md
@@ -13,7 +13,7 @@ The FAQ component is made of two parts:
 ```jsx
 import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export default class MyFaq extends React.Component {
 	static displayName = 'MyFaq';
@@ -26,8 +26,8 @@ export default class MyFaq extends React.Component {
 					answer="Need help deciding which plan works for you? Our happiness engineers are available for any questions you may have."
 				/>
 				<FAQItem
-					question={ i18n.translate( 'A translated question?' ) }
-					answer={ i18n.translate( 'Yeah, we got you covered!' ) }
+					question={ translate( 'A translated question?' ) }
+					answer={ translate( 'Yeah, we got you covered!' ) }
 				/>
 			</FAQ>
 		);

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -18,7 +18,7 @@ import {
 	mapValues,
 } from 'lodash';
 import classNames from 'classnames';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -299,7 +299,7 @@ class KeyedSuggestions extends React.Component {
 				<div className="keyed-suggestions__category" key={ key }>
 					<span className="keyed-suggestions__category-name">{ key }</span>
 					<span className="keyed-suggestions__category-counter">
-						{ i18n.translate( '%(filtered)s of %(total)s', {
+						{ translate( '%(filtered)s of %(total)s', {
 							args: { filtered, total },
 						} ) }
 					</span>
@@ -307,14 +307,14 @@ class KeyedSuggestions extends React.Component {
 						<SuggestionsButtonAll
 							onClick={ this.onShowAllClick }
 							category={ key }
-							label={ i18n.translate( 'Show all' ) }
+							label={ translate( 'Show all' ) }
 						/>
 					) }
 					{ key === this.state.showAll && (
 						<SuggestionsButtonAll
 							onClick={ this.onShowAllClick }
 							category={ '' }
-							label={ i18n.translate( 'Show less' ) }
+							label={ translate( 'Show less' ) }
 						/>
 					) }
 				</div>

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { keys } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -32,7 +32,7 @@ const ALT_TEXT = {
 	placeholder: '',
 	unionpay: 'UnionPay',
 	visa: 'Visa',
-	wechat: i18n.translate( 'WeChat Pay', {
+	wechat: translate( 'WeChat Pay', {
 		comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
 	} ),
 	sofort: 'Sofort',

--- a/client/components/rtl/index.js
+++ b/client/components/rtl/index.js
@@ -4,7 +4,7 @@
 import React, { forwardRef } from 'react';
 import { useSubscription } from 'use-subscription';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import i18n from 'i18n-calypso';
+import { on as i18nOn, off as i18nOff } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,8 +17,8 @@ const RtlSubscription = {
 		return isLocaleRtl( getLocaleSlug() );
 	},
 	subscribe( callback ) {
-		i18n.on( 'change', callback );
-		return () => i18n.off( 'change', callback );
+		i18nOn( 'change', callback );
+		return () => i18nOff( 'change', callback );
 	},
 };
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { debounce, noop, uniqueId } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 
 /**
@@ -307,7 +307,7 @@ class Search extends Component {
 
 	render() {
 		const searchValue = this.state.keyword;
-		const placeholder = this.props.placeholder || i18n.translate( 'Search…', { textOnly: true } );
+		const placeholder = this.props.placeholder || translate( 'Search…', { textOnly: true } );
 		const inputLabel = this.props.inputLabel;
 		const enableOpenIcon = this.props.pinned && ! this.state.isOpen;
 		const isOpenUnpinnedOrQueried =
@@ -343,7 +343,7 @@ class Search extends Component {
 					tabIndex={ enableOpenIcon ? '0' : null }
 					onKeyDown={ enableOpenIcon ? this.openListener : null }
 					aria-controls={ 'search-component-' + this.instanceId }
-					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }
+					aria-label={ translate( 'Open Search', { context: 'button label' } ) }
 				>
 					{ ! this.props.hideOpenIcon && <Gridicon icon="search" className="search__open-icon" /> }
 				</div>
@@ -353,7 +353,7 @@ class Search extends Component {
 						id={ 'search-component-' + this.instanceId }
 						autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 						aria-describedby={ this.props.describedBy }
-						aria-label={ inputLabel ? inputLabel : i18n.translate( 'Search' ) }
+						aria-label={ inputLabel ? inputLabel : translate( 'Search' ) }
 						aria-hidden={ ! isOpenUnpinnedOrQueried }
 						className={ inputClass }
 						placeholder={ placeholder }
@@ -398,7 +398,7 @@ class Search extends Component {
 					tabIndex="0"
 					onKeyDown={ this.closeListener }
 					aria-controls={ 'search-component-' + this.instanceId }
-					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }
+					aria-label={ translate( 'Close Search', { context: 'button label' } ) }
 				>
 					<Gridicon icon="cross" className="search__close-icon" />
 				</div>

--- a/client/components/tinymce/i18n.js
+++ b/client/components/tinymce/i18n.js
@@ -1,94 +1,91 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * @see wp_mce_translation() in src/wp-includes/class-wp-editor.php from WordPress
  * In short, TinyMCE uses these strings to translate its internal strings
  */
 export default {
-	Formats: i18n.translate( 'Formats', { context: 'TinyMCE' } ),
-	Headings: i18n.translate( 'Headings', { context: 'TinyMCE' } ),
-	'Heading 1': i18n.translate( 'Heading 1' ),
-	'Heading 2': i18n.translate( 'Heading 2' ),
-	'Heading 3': i18n.translate( 'Heading 3' ),
-	'Heading 4': i18n.translate( 'Heading 4' ),
-	'Heading 5': i18n.translate( 'Heading 5' ),
-	'Heading 6': i18n.translate( 'Heading 6' ),
+	Formats: translate( 'Formats', { context: 'TinyMCE' } ),
+	Headings: translate( 'Headings', { context: 'TinyMCE' } ),
+	'Heading 1': translate( 'Heading 1' ),
+	'Heading 2': translate( 'Heading 2' ),
+	'Heading 3': translate( 'Heading 3' ),
+	'Heading 4': translate( 'Heading 4' ),
+	'Heading 5': translate( 'Heading 5' ),
+	'Heading 6': translate( 'Heading 6' ),
 
-	Blocks: i18n.translate( 'Blocks', { context: 'TinyMCE', comment: 'block tags' } ),
-	Paragraph: i18n.translate( 'Paragraph' ),
-	Blockquote: i18n.translate( 'Blockquote' ),
-	Div: i18n.translate( 'Div', { context: 'HTML tag' } ),
-	Pre: i18n.translate( 'Pre', { context: 'HTML tag' } ),
-	Preformatted: i18n.translate( 'Preformatted', { context: 'HTML tag' } ),
-	Address: i18n.translate( 'Address', { context: 'HTML tag' } ),
+	Blocks: translate( 'Blocks', { context: 'TinyMCE', comment: 'block tags' } ),
+	Paragraph: translate( 'Paragraph' ),
+	Blockquote: translate( 'Blockquote' ),
+	Div: translate( 'Div', { context: 'HTML tag' } ),
+	Pre: translate( 'Pre', { context: 'HTML tag' } ),
+	Preformatted: translate( 'Preformatted', { context: 'HTML tag' } ),
+	Address: translate( 'Address', { context: 'HTML tag' } ),
 
-	Inline: i18n.translate( 'Inline', { context: 'HTML elements' } ),
-	Underline: i18n.translate( 'Underline' ),
-	Strikethrough: i18n.translate( 'Strikethrough' ),
-	Subscript: i18n.translate( 'Subscript' ),
-	Superscript: i18n.translate( 'Superscript' ),
-	'Clear formatting': i18n.translate( 'Clear formatting' ),
-	Bold: i18n.translate( 'Bold' ),
-	Italic: i18n.translate( 'Italic' ),
-	'Source code': i18n.translate( 'Source code' ),
-	'Font Family': i18n.translate( 'Font Family' ),
-	'Font Sizes': i18n.translate( 'Font Sizes' ),
+	Inline: translate( 'Inline', { context: 'HTML elements' } ),
+	Underline: translate( 'Underline' ),
+	Strikethrough: translate( 'Strikethrough' ),
+	Subscript: translate( 'Subscript' ),
+	Superscript: translate( 'Superscript' ),
+	'Clear formatting': translate( 'Clear formatting' ),
+	Bold: translate( 'Bold' ),
+	Italic: translate( 'Italic' ),
+	'Source code': translate( 'Source code' ),
+	'Font Family': translate( 'Font Family' ),
+	'Font Sizes': translate( 'Font Sizes' ),
 
-	'Align center': i18n.translate( 'Align center' ),
-	'Align right': i18n.translate( 'Align right' ),
-	'Align left': i18n.translate( 'Align left' ),
-	Justify: i18n.translate( 'Justify' ),
-	'Increase indent': i18n.translate( 'Increase indent' ),
-	'Decrease indent': i18n.translate( 'Decrease indent' ),
+	'Align center': translate( 'Align center' ),
+	'Align right': translate( 'Align right' ),
+	'Align left': translate( 'Align left' ),
+	Justify: translate( 'Justify' ),
+	'Increase indent': translate( 'Increase indent' ),
+	'Decrease indent': translate( 'Decrease indent' ),
 
-	Cut: i18n.translate( 'Cut' ),
-	Copy: i18n.translate( 'Copy' ),
-	Paste: i18n.translate( 'Paste' ),
-	'Select all': i18n.translate( 'Select all' ),
-	Undo: i18n.translate( 'Undo' ),
-	Redo: i18n.translate( 'Redo' ),
+	Cut: translate( 'Cut' ),
+	Copy: translate( 'Copy' ),
+	Paste: translate( 'Paste' ),
+	'Select all': translate( 'Select all' ),
+	Undo: translate( 'Undo' ),
+	Redo: translate( 'Redo' ),
 
-	Ok: i18n.translate( 'OK' ),
-	Cancel: i18n.translate( 'Cancel' ),
-	Close: i18n.translate( 'Close' ),
-	'Visual aids': i18n.translate( 'Visual aids' ),
+	Ok: translate( 'OK' ),
+	Cancel: translate( 'Cancel' ),
+	Close: translate( 'Close' ),
+	'Visual aids': translate( 'Visual aids' ),
 
 	'Paste is now in plain text mode. Contents will now be pasted as plain text until you toggle this option off.':
-		i18n.translate(
+		translate(
 			'Paste is now in plain text mode. Contents will now be pasted as plain text until you toggle this option off.'
 		) +
 		'\n\n' +
-		i18n.translate(
+		translate(
 			'If you’re looking to paste rich content from Microsoft Word, try turning this option off. The editor will clean up text pasted from Word automatically.'
 		),
-	'Rich Text Area. Press ALT-F9 for menu. Press ALT-F10 for toolbar. Press ALT-0 for help': i18n.translate(
+	'Rich Text Area. Press ALT-F9 for menu. Press ALT-F10 for toolbar. Press ALT-0 for help': translate(
 		'Rich Text Area. Press Alt-Shift-H for help'
 	),
-	'You have unsaved changes are you sure you want to navigate away?': i18n.translate(
+	'You have unsaved changes are you sure you want to navigate away?': translate(
 		'The changes you made will be lost if you navigate away from this page.'
 	),
-	"Your browser doesn't support direct access to the clipboard. Please use the Ctrl+X/C/V keyboard shortcuts instead.": i18n.translate(
+	"Your browser doesn't support direct access to the clipboard. Please use the Ctrl+X/C/V keyboard shortcuts instead.": translate(
 		'Your browser does not support direct access to the clipboard. Please use keyboard shortcuts or your browser’s edit menu instead.'
 	),
-	'Bullet list': i18n.translate( 'Bulleted list' ),
-	'Numbered list': i18n.translate( 'Numbered list' ),
+	'Bullet list': translate( 'Bulleted list' ),
+	'Numbered list': translate( 'Numbered list' ),
 
-	'Toolbar Toggle': i18n.translate( 'Toolbar Toggle' ),
-	'Insert Read More tag': i18n.translate( 'Insert Read More tag' ),
-	'Insert Page Break tag': i18n.translate( 'Insert Page Break tag' ),
+	'Toolbar Toggle': translate( 'Toolbar Toggle' ),
+	'Insert Read More tag': translate( 'Insert Read More tag' ),
+	'Insert Page Break tag': translate( 'Insert Page Break tag' ),
 	// Tooltip for the 'alignnone' button in the image toolbar
-	'No alignment': i18n.translate( 'No alignment' ),
+	'No alignment': translate( 'No alignment' ),
 	// Tooltip for the 'remove' button in the image toolbar
-	Remove: i18n.translate( 'Remove' ),
+	Remove: translate( 'Remove' ),
 	// Tooltip for the 'edit' button in the image toolbar
-	'Edit ': i18n.translate( 'Edit' ), // eslint-disable-line
-	'Horizontal line': i18n.translate( 'Horizontal line' ),
-	'Text color': i18n.translate( 'Text color' ),
-	'Paste as text': i18n.translate( 'Paste as text' ),
+	'Edit ': translate( 'Edit' ), // eslint-disable-line
+	'Horizontal line': translate( 'Horizontal line' ),
+	'Text color': translate( 'Text color' ),
+	'Paste as text': translate( 'Paste as text' ),
 };

--- a/client/components/tinymce/plugins/contact-form/dialog/locales.js
+++ b/client/components/tinymce/plugins/contact-form/dialog/locales.js
@@ -1,30 +1,32 @@
-/** @format */
-import i18n from 'i18n-calypso';
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
 
 const labels = {
 	name() {
-		return i18n.translate( 'Name' );
+		return translate( 'Name' );
 	},
 	email() {
-		return i18n.translate( 'Email Address' );
+		return translate( 'Email Address' );
 	},
 	checkbox() {
-		return i18n.translate( 'Checkbox' );
+		return translate( 'Checkbox' );
 	},
 	select() {
-		return i18n.translate( 'Dropdown' );
+		return translate( 'Dropdown' );
 	},
 	radio() {
-		return i18n.translate( 'Radio Button' );
+		return translate( 'Radio Button' );
 	},
 	text() {
-		return i18n.translate( 'Text' );
+		return translate( 'Text' );
 	},
 	textarea() {
-		return i18n.translate( 'Text Area' );
+		return translate( 'Text Area' );
 	},
 	url() {
-		return i18n.translate( 'Web Address' );
+		return translate( 'Web Address' );
 	},
 };
 

--- a/client/components/tinymce/plugins/contact-form/plugin.jsx
+++ b/client/components/tinymce/plugins/contact-form/plugin.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import tinymce from 'tinymce/tinymce';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import React, { createElement } from 'react';
 import { unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -95,7 +92,7 @@ function wpcomContactForm( editor ) {
 
 	editor.addButton( 'wpcom_add_contact_form', {
 		classes: 'btn wpcom-icon-button contact-form',
-		title: i18n.translate( 'Add Contact Form' ),
+		title: translate( 'Add Contact Form' ),
 		cmd: 'wpcomContactForm',
 		onPostRender() {
 			this.innerHtml(

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -39,7 +36,7 @@ export const menuItems = [
 		item: (
 			<GridiconButton
 				icon={ <Gridicon icon="image" /> }
-				label={ i18n.translate( 'Media' ) }
+				label={ translate( 'Media' ) }
 				e2e="media"
 			/>
 		),
@@ -54,7 +51,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 			item: (
 				<GridiconButton
 					icon={ <Gridicon icon="shutter" /> }
-					label={ i18n.translate( 'Google Photos library' ) }
+					label={ translate( 'Google Photos library' ) }
 					e2e="google-media"
 				/>
 			),
@@ -68,7 +65,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 			item: (
 				<GridiconButton
 					icon={ <Gridicon icon="image-multiple" /> }
-					label={ i18n.translate( 'Free photo library' ) }
+					label={ translate( 'Free photo library' ) }
 					e2e="stock-media-pexels"
 				/>
 			),
@@ -83,7 +80,7 @@ menuItems.push( {
 	item: (
 		<GridiconButton
 			icon={ <Gridicon icon="mention" /> }
-			label={ i18n.translate( 'Contact form' ) }
+			label={ translate( 'Contact form' ) }
 			e2e="contact-form"
 		/>
 	),
@@ -95,7 +92,7 @@ menuItems.push( {
 	item: (
 		<GridiconButton
 			icon={ <Gridicon icon="money" /> }
-			label={ i18n.translate( 'Payment button' ) }
+			label={ translate( 'Payment button' ) }
 			e2e="payment-button"
 		/>
 	),

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -1,11 +1,10 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import tinymce from 'tinymce/tinymce';
 import { renderToString } from 'react-dom/server';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -32,17 +31,14 @@ function initialize( editor ) {
 
 	editor.addButton( 'wpcom_insert_menu', {
 		type: 'menubutton',
-		title: i18n.translate( 'Add content' ),
+		title: translate( 'Add content' ),
 		classes: 'btn wpcom-insert-menu insert-menu',
 		menu: filteredMenuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
 			const [ insertContentElm ] = this.$el[ 0 ].children;
 
 			insertContentElm.innerHTML = renderToString(
-				<GridiconButton
-					icon={ <Gridicon icon="add-outline" /> }
-					label={ i18n.translate( 'Add' ) }
-				/>
+				<GridiconButton icon={ <Gridicon icon="add-outline" /> } label={ translate( 'Add' ) } />
 			);
 		},
 	} );

--- a/client/components/tinymce/plugins/media/advanced/index.jsx
+++ b/client/components/tinymce/plugins/media/advanced/index.jsx
@@ -1,11 +1,10 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -63,7 +62,7 @@ export default function( editor ) {
 	}
 
 	editor.addButton( 'wp_img_advanced', {
-		tooltip: i18n.translate( 'Edit', { context: 'verb' } ),
+		tooltip: translate( 'Edit', { context: 'verb' } ),
 
 		classes: 'toolbar-segment-start',
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -7,7 +6,7 @@ import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import tinymce from 'tinymce/tinymce';
 import { assign, debounce, find, findLast, pick, values } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { parse, stringify } from 'lib/shortcode';
 import closest from 'component-closest';
 
@@ -448,7 +447,7 @@ function mediaButton( editor ) {
 	editor.addButton( 'wpcom_add_media', {
 		classes: 'btn wpcom-icon-button media',
 		cmd: 'wpcomAddMedia',
-		title: i18n.translate( 'Add Media' ),
+		title: translate( 'Add Media' ),
 		onPostRender: function() {
 			this.innerHtml(
 				ReactDomServer.renderToStaticMarkup(
@@ -464,7 +463,7 @@ function mediaButton( editor ) {
 	} );
 
 	editor.addButton( 'wp_img_edit', {
-		tooltip: i18n.translate( 'Edit', { context: 'verb' } ),
+		tooltip: translate( 'Edit', { context: 'verb' } ),
 		classes: 'toolbar-segment-start',
 		icon: 'dashicon dashicons-edit',
 		onclick: function() {
@@ -487,7 +486,7 @@ function mediaButton( editor ) {
 				{
 					visible: true,
 					labels: {
-						confirm: i18n.translate( 'Update', { context: 'verb' } ),
+						confirm: translate( 'Update', { context: 'verb' } ),
 					},
 				},
 				{
@@ -499,7 +498,7 @@ function mediaButton( editor ) {
 	} );
 
 	editor.addButton( 'wp_img_caption', {
-		tooltip: i18n.translate( 'Caption', { context: 'verb' } ),
+		tooltip: translate( 'Caption', { context: 'verb' } ),
 		icon: 'dashicon dashicons-admin-comments',
 		classes: 'toolbar-segment-start toolbar-segment-end',
 		stateSelector: '.wp-caption',
@@ -534,7 +533,7 @@ function mediaButton( editor ) {
 			if ( media && media.caption ) {
 				content = media.caption;
 			} else {
-				content = i18n.translate( 'Enter a caption' );
+				content = translate( 'Enter a caption' );
 			}
 
 			// Assign missing DOM dimensions to image node. The `wpeditimage`
@@ -674,7 +673,7 @@ function mediaButton( editor ) {
 	}
 
 	editor.addButton( 'wpcom_img_size_decrease', {
-		tooltip: i18n.translate( 'Decrease size' ),
+		tooltip: translate( 'Decrease size' ),
 		classes: 'toolbar-segment-start img-size-decrease',
 		icon: 'dashicon dashicons-minus',
 		onPostRender: function() {
@@ -686,7 +685,7 @@ function mediaButton( editor ) {
 	} );
 
 	editor.addButton( 'wpcom_img_size_increase', {
-		tooltip: i18n.translate( 'Increase size' ),
+		tooltip: translate( 'Increase size' ),
 		classes: 'toolbar-segment-end img-size-increase',
 		icon: 'dashicon dashicons-plus',
 		onPostRender: function() {
@@ -743,7 +742,7 @@ function mediaButton( editor ) {
 				visible: true,
 				initialGallerySettings: gallery,
 				labels: {
-					confirm: i18n.translate( 'Update', { context: 'verb' } ),
+					confirm: translate( 'Update', { context: 'verb' } ),
 				},
 			},
 			{

--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -1,8 +1,6 @@
 /**
  * Adapted from the WordPress wp-view TinyMCE plugin.
  *
- *
- * @format
  * @copyright 2015 by the WordPress contributors.
  * @license See CREDITS.md.
  */
@@ -16,7 +14,7 @@ import { debounce } from 'lodash';
 import tinymce from 'tinymce/tinymce';
 import ReactDom from 'react-dom';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -31,14 +29,15 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  * @param {object} editor The TinyMCE instance.
  */
 function wpview( editor ) {
-	let $ = editor.$,
-		selected,
-		Env = tinymce.Env,
-		VK = tinymce.util.VK,
-		TreeWalker = tinymce.dom.TreeWalker,
+	const $ = editor.$;
+	const Env = tinymce.Env;
+	const VK = tinymce.util.VK;
+	const TreeWalker = tinymce.dom.TreeWalker;
+	const isios = /iPad|iPod|iPhone/.test( navigator.userAgent );
+
+	let selected,
 		toRemove = false,
 		firstFocus = true,
-		isios = /iPad|iPod|iPhone/.test( navigator.userAgent ),
 		cursorInterval,
 		lastKeyDownNode,
 		setViewCursorTries,
@@ -60,8 +59,8 @@ function wpview( editor ) {
 		}
 
 		markers.each( function( index, node ) {
-			let text = editor.dom.getAttrib( node, 'data-wpview-text' ),
-				type = editor.dom.getAttrib( node, 'data-wpview-type' );
+			const text = editor.dom.getAttrib( node, 'data-wpview-text' );
+			const type = editor.dom.getAttrib( node, 'data-wpview-type' );
 			editor.dom.replace(
 				editor.dom.createFragment(
 					'<div class="wpview-wrap" data-wpview-text="' +
@@ -153,8 +152,8 @@ function wpview( editor ) {
 	}
 
 	function setViewCursor( before, view ) {
-		let location = before ? 'before' : 'after',
-			offset = before ? 0 : 1;
+		const location = before ? 'before' : 'after';
+		const offset = before ? 0 : 1;
 		deselect();
 		editor.selection.setCursorLocation(
 			editor.dom.select( '.wpview-selection-' + location, view )[ 0 ],
@@ -164,8 +163,8 @@ function wpview( editor ) {
 	}
 
 	function handleEnter( view, before, key ) {
-		let dom = editor.dom,
-			padNode = dom.create( 'p' );
+		const dom = editor.dom;
+		const padNode = dom.create( 'p' );
 
 		if ( ! ( Env.ie && Env.ie < 11 ) ) {
 			padNode.innerHTML = '<br data-mce-bogus="1">';
@@ -198,8 +197,8 @@ function wpview( editor ) {
 	}
 
 	function select( viewNode ) {
-		let clipboard,
-			dom = editor.dom;
+		let clipboard;
+		const dom = editor.dom;
 
 		if ( ! viewNode ) {
 			return;
@@ -248,8 +247,8 @@ function wpview( editor ) {
 	 * Deselect a selected view and remove clipboard
 	 */
 	function deselect() {
-		let clipboard,
-			dom = editor.dom;
+		let clipboard;
+		const dom = editor.dom;
 
 		if ( selected ) {
 			clipboard = editor.dom.select( '.wpview-clipboard', selected )[ 0 ];
@@ -278,14 +277,12 @@ function wpview( editor ) {
 	}
 
 	function setMarkers() {
-		let content, processedContent;
-
 		if ( editor.isHidden() ) {
 			return;
 		}
 
-		content = editor.getContent( { format: 'raw' } );
-		processedContent = views.setMarkers( content );
+		const content = editor.getContent( { format: 'raw' } );
+		const processedContent = views.setMarkers( content );
 
 		if ( content !== processedContent ) {
 			editor.setContent( processedContent, {
@@ -373,22 +370,21 @@ function wpview( editor ) {
 
 	// Set the cursor before or after a view when clicking next to it.
 	editor.on( 'click', function( event ) {
-		let x = event.clientX,
-			y = event.clientY,
-			body = editor.getBody(),
-			bodyRect = body.getBoundingClientRect(),
-			first = body.firstChild,
-			last = body.lastChild,
-			firstRect,
-			lastRect,
-			view;
+		const x = event.clientX;
+		const y = event.clientY;
+		const body = editor.getBody();
+		const bodyRect = body.getBoundingClientRect();
+		const first = body.firstChild;
+		const last = body.lastChild;
+
+		let view;
 
 		if ( ! first || ! last ) {
 			return;
 		}
 
-		firstRect = first.getBoundingClientRect();
-		lastRect = last.getBoundingClientRect();
+		const firstRect = first.getBoundingClientRect();
+		const lastRect = last.getBoundingClientRect();
 
 		if ( y < firstRect.top && ( view = getView( first ) ) ) {
 			setViewCursor( true, view );
@@ -397,8 +393,8 @@ function wpview( editor ) {
 			setViewCursor( false, view );
 			event.preventDefault();
 		} else if ( x < bodyRect.left || x > bodyRect.right ) {
-			tinymce.each( editor.dom.select( '.wpview-wrap' ), function( view ) {
-				const rect = view.getBoundingClientRect();
+			tinymce.each( editor.dom.select( '.wpview-wrap' ), function( v ) {
+				const rect = v.getBoundingClientRect();
 
 				if ( y < rect.top ) {
 					return false;
@@ -406,10 +402,10 @@ function wpview( editor ) {
 
 				if ( y >= rect.top && y <= rect.bottom ) {
 					if ( x < bodyRect.left ) {
-						setViewCursor( true, view );
+						setViewCursor( true, v );
 						event.preventDefault();
 					} else if ( x > bodyRect.right ) {
-						setViewCursor( false, view );
+						setViewCursor( false, v );
 						event.preventDefault();
 					}
 
@@ -420,16 +416,15 @@ function wpview( editor ) {
 	} );
 
 	editor.on( 'init', function() {
-		let scrolled = false,
-			selection = editor.selection,
-			MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+		let scrolled = false;
+		const selection = editor.selection;
+		const MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 
 		// When a view is selected, ensure content that is being pasted
 		// or inserted is added to a text node (instead of the view).
 		editor.on( 'BeforeSetContent', function() {
-			let walker,
-				target,
-				view = getView( selection.getNode() );
+			let walker, target;
+			const view = getView( selection.getNode() );
 
 			// If the selection is not within a view, bail.
 			if ( ! view ) {
@@ -569,16 +564,11 @@ function wpview( editor ) {
 
 	// (De)select views when arrow keys are used to navigate the content of the editor.
 	editor.on( 'keydown', function( event ) {
-		let key = event.keyCode,
-			dom = editor.dom,
-			selection = editor.selection,
-			node,
-			view,
-			cursorBefore,
-			cursorAfter,
-			range,
-			clonedRange,
-			tempRange;
+		const key = event.keyCode;
+		const dom = editor.dom;
+		const selection = editor.selection;
+
+		let node, view, cursorBefore, cursorAfter, range, clonedRange, tempRange;
 
 		if ( selected ) {
 			// Ignore key presses that involve the command or control key, but continue when in combination with backspace or v.
@@ -796,20 +786,20 @@ function wpview( editor ) {
 	} );
 
 	editor.on( 'NodeChange', function( event ) {
-		let dom = editor.dom,
-			views = editor.dom.select( '.wpview-wrap' ),
-			className = event.element.className,
-			view = getView( event.element ),
-			lKDN = lastKeyDownNode;
+		const dom = editor.dom;
+		const wpviewWraps = editor.dom.select( '.wpview-wrap' );
+		const className = event.element.className;
+		const view = getView( event.element );
+		const lKDN = lastKeyDownNode;
 
 		lastKeyDownNode = false;
 
 		clearInterval( cursorInterval );
 
 		// This runs a lot and is faster than replacing each class separately
-		tinymce.each( views, function( view ) {
+		tinymce.each( wpviewWraps, function( wpviewWrap ) {
 			if ( view.className ) {
-				view.className = view.className.replace(
+				wpviewWrap.className = wpviewWrap.className.replace(
 					/ ?\bwpview-(?:selection-before|selection-after|cursor-hide)\b/g,
 					''
 				);
@@ -855,8 +845,8 @@ function wpview( editor ) {
 	} );
 
 	editor.on( 'BeforeExecCommand', function() {
-		let node = editor.selection.getNode(),
-			view;
+		const node = editor.selection.getNode();
+		let view;
 
 		if (
 			node &&
@@ -906,37 +896,33 @@ function wpview( editor ) {
 	} );
 
 	editor.addButton( 'wp_view_edit', {
-		tooltip: i18n.translate( 'Edit', { context: 'verb' } ),
+		tooltip: translate( 'Edit', { context: 'verb' } ),
 		icon: 'dashicon dashicons-edit',
 		onPostRender: function() {
 			editor.on(
 				'wptoolbar',
 				function() {
-					let type;
-
 					if ( ! selected ) {
 						return;
 					}
 
-					type = editor.dom.getAttrib( selected, 'data-wpview-type' );
+					const type = editor.dom.getAttrib( selected, 'data-wpview-type' );
 					this.visible( views.isEditable( type ) );
 				}.bind( this )
 			);
 		},
 		onClick: function() {
-			let type;
-
 			if ( ! selected ) {
 				return;
 			}
 
-			type = editor.dom.getAttrib( selected, 'data-wpview-type' );
+			const type = editor.dom.getAttrib( selected, 'data-wpview-type' );
 			views.edit( type, editor, getText( selected ) );
 		},
 	} );
 
 	editor.addButton( 'wp_view_remove', {
-		tooltip: i18n.translate( 'Remove' ),
+		tooltip: translate( 'Remove' ),
 		icon: 'dashicon dashicons-no',
 		onClick: function() {
 			selected && removeView( selected );

--- a/client/extensions/wp-super-cache/app/controller.js
+++ b/client/extensions/wp-super-cache/app/controller.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -16,7 +13,7 @@ import WPSuperCache from './main';
 export function settings( context, next ) {
 	const { tab = '' } = context.params;
 
-	context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'WP Super Cache', { textOnly: true } ) ) );
 
 	context.primary = <WPSuperCache tab={ tab } />;
 	next();

--- a/client/landing/domains/index.jsx
+++ b/client/landing/domains/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import RenderDom from 'react-dom';
-import i18n from 'i18n-calypso';
+import { setLocale } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ class DomainsLandingPage extends Component {
 function boot() {
 	if ( window.i18nLocaleStrings ) {
 		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
-		i18n.setLocale( i18nLocaleStringsObject );
+		setLocale( i18nLocaleStringsObject );
 	}
 
 	RenderDom.render(

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import i18n, { localize } from 'i18n-calypso';
+import { localize, on as i18nOn, off as i18nOff } from 'i18n-calypso';
 import React, { Fragment } from 'react';
 import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
@@ -55,11 +52,11 @@ class TranslatorLauncher extends React.Component {
 	};
 
 	componentDidMount() {
-		i18n.on( 'change', this.onI18nChange );
+		i18nOn( 'change', this.onI18nChange );
 	}
 
 	componentWillUnmount() {
-		i18n.off( 'change', this.onI18nChange );
+		i18nOff( 'change', this.onI18nChange );
 	}
 
 	onI18nChange = () => {

--- a/client/lib/ads/settings-store.js
+++ b/client/lib/ads/settings-store.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugModule from 'debug';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -91,7 +88,7 @@ WordadsSettingsStore.dispatchToken = Dispatcher.register( function( payload ) {
 			WordadsSettingsStore.emitChange();
 			break;
 		case 'UPDATED_WORDADS_SETTINGS':
-			_notice = i18n.translate( 'WordAds settings saved successfully!' );
+			_notice = translate( 'WordAds settings saved successfully!' );
 		case 'RECEIVE_WORDADS_SETTINGS':
 			debug( 'WordadsSettingsStore UPDATE/RECEIVE_WORDADS_SETTINGS', action );
 			_isLoading = false;

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  *
- * @format
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { isUndefined, isEmpty, pick } from 'lodash';
 import { CPF, CNPJ } from 'cpf_cnpj';
 
@@ -63,27 +62,27 @@ export function isValidCNPJ( cnpj = '' ) {
 export function fullAddressFieldsRules() {
 	return {
 		'street-number': {
-			description: i18n.translate( 'Street Number' ),
+			description: translate( 'Street Number' ),
 			rules: [ 'required', 'validStreetNumber' ],
 		},
 
 		'address-1': {
-			description: i18n.translate( 'Address' ),
+			description: translate( 'Address' ),
 			rules: [ 'required' ],
 		},
 
 		state: {
-			description: i18n.translate( 'State' ),
+			description: translate( 'State' ),
 			rules: [ 'required' ],
 		},
 
 		city: {
-			description: i18n.translate( 'City' ),
+			description: translate( 'City' ),
 			rules: [ 'required' ],
 		},
 
 		'postal-code': {
-			description: i18n.translate( 'Postal Code' ),
+			description: translate( 'Postal Code' ),
 			rules: [ 'required' ],
 		},
 	};
@@ -102,24 +101,24 @@ export function countrySpecificFieldRules( country ) {
 		Object.assign(
 			{
 				document: {
-					description: i18n.translate( 'Taxpayer Identification Number' ),
+					description: translate( 'Taxpayer Identification Number' ),
 					rules: [ 'validBrazilTaxId' ],
 				},
 
 				'phone-number': {
-					description: i18n.translate( 'Phone Number' ),
+					description: translate( 'Phone Number' ),
 					rules: [ 'required' ],
 				},
 				name: {
-					description: i18n.translate( 'Your Name' ),
+					description: translate( 'Your Name' ),
 					rules: [ 'required' ],
 				},
 				pan: {
-					description: i18n.translate( 'PAN - Permanent account number' ),
+					description: translate( 'PAN - Permanent account number' ),
 					rules: [ 'validIndiaPan' ],
 				},
 				'postal-code': {
-					description: i18n.translate( 'Postal Code' ),
+					description: translate( 'Postal Code' ),
 					rules: [ 'required' ],
 				},
 			},
@@ -130,17 +129,17 @@ export function countrySpecificFieldRules( country ) {
 }
 
 export function translatedEbanxError( error ) {
-	let errorMessage = i18n.translate(
+	let errorMessage = translate(
 		'Your payment was not processed this time due to an error, please try to submit it again.'
 	);
 
 	switch ( error.status_code ) {
 		case 'BP-DR-55':
-			errorMessage = { message: { cvv: i18n.translate( 'Invalid credit card CVV number' ) } };
+			errorMessage = { message: { cvv: translate( 'Invalid credit card CVV number' ) } };
 			break;
 		case 'BP-DR-51':
 		case 'BP-DR-95':
-			errorMessage = { message: { name: i18n.translate( 'Please enter your name.' ) } };
+			errorMessage = { message: { name: translate( 'Please enter your name.' ) } };
 			break;
 	}
 

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import creditcards from 'creditcards';
 import { capitalize, compact, isArray, isEmpty, mergeWith, union } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { isValidPostalCode } from 'lib/postal-code';
 
 /**
@@ -25,36 +24,36 @@ import {
 export function getCreditCardFieldRules() {
 	return {
 		name: {
-			description: i18n.translate( 'Cardholder Name', {
+			description: translate( 'Cardholder Name', {
 				comment: 'Cardholder name label on credit card form',
 			} ),
 			rules: [ 'required' ],
 		},
 
 		number: {
-			description: i18n.translate( 'Card Number', {
+			description: translate( 'Card Number', {
 				comment: 'Card number label on credit card form',
 			} ),
 			rules: [ 'validCreditCardNumber' ],
 		},
 
 		'expiration-date': {
-			description: i18n.translate( 'Credit Card Expiration Date' ),
+			description: translate( 'Credit Card Expiration Date' ),
 			rules: [ 'validExpirationDate' ],
 		},
 
 		cvv: {
-			description: i18n.translate( 'Credit Card CVV Code' ),
+			description: translate( 'Credit Card CVV Code' ),
 			rules: [ 'validCvvNumber' ],
 		},
 
 		country: {
-			description: i18n.translate( 'Country' ),
+			description: translate( 'Country' ),
 			rules: [ 'required' ],
 		},
 
 		'postal-code': {
-			description: i18n.translate( 'Postal Code', {
+			description: translate( 'Postal Code', {
 				comment: 'Postal code on credit card form',
 			} ),
 			rules: [ 'required' ],
@@ -69,19 +68,19 @@ export function getCreditCardFieldRules() {
 export function getStripeElementsRules() {
 	return {
 		name: {
-			description: i18n.translate( 'Cardholder Name', {
+			description: translate( 'Cardholder Name', {
 				comment: 'Cardholder name label on credit card form',
 			} ),
 			rules: [ 'required' ],
 		},
 
 		country: {
-			description: i18n.translate( 'Country' ),
+			description: translate( 'Country' ),
 			rules: [ 'required' ],
 		},
 
 		'postal-code': {
-			description: i18n.translate( 'Postal Code', {
+			description: translate( 'Postal Code', {
 				comment: 'Postal code on credit card form',
 			} ),
 			rules: [ 'required' ],
@@ -98,12 +97,12 @@ export function tefPaymentFieldRules() {
 	return Object.assign(
 		{
 			name: {
-				description: i18n.translate( 'Your Name' ),
+				description: translate( 'Your Name' ),
 				rules: [ 'required' ],
 			},
 
 			'tef-bank': {
-				description: i18n.translate( 'Bank' ),
+				description: translate( 'Bank' ),
 				rules: [ 'required' ],
 			},
 		},
@@ -118,14 +117,14 @@ export function tefPaymentFieldRules() {
 export function tokenFieldRules() {
 	return {
 		name: {
-			description: i18n.translate( 'Cardholder Name', {
+			description: translate( 'Cardholder Name', {
 				comment: 'Cardholder name label on credit card form',
 			} ),
 			rules: [ 'required' ],
 		},
 
 		tokenized_payment_data: {
-			description: i18n.translate( 'Tokenized Payment Data', {
+			description: translate( 'Tokenized Payment Data', {
 				comment: 'Tokenized payment data from the token provider',
 			} ),
 			rules: [ 'required' ],
@@ -181,7 +180,7 @@ function parseExpiration( value ) {
 }
 
 function validationError( description ) {
-	return i18n.translate( '%(description)s is invalid', {
+	return translate( '%(description)s is invalid', {
 		args: { description: capitalize( description ) },
 	} );
 }
@@ -194,7 +193,7 @@ validators.required = {
 	},
 
 	error: function( description ) {
-		return i18n.translate( 'Missing required %(description)s field', {
+		return translate( 'Missing required %(description)s field', {
 			args: { description: description },
 		} );
 	},
@@ -244,7 +243,7 @@ validators.validBrazilTaxId = {
 		return isValidCPF( value ) || isValidCNPJ( value );
 	},
 	error: function( description ) {
-		return i18n.translate(
+		return translate(
 			'%(description)s is invalid. Must be in format: 111.444.777-XX or 11.444.777/0001-XX',
 			{
 				args: { description: description },
@@ -263,7 +262,7 @@ validators.validIndiaPan = {
 		return panRegex.test( value );
 	},
 	error: function( description ) {
-		return i18n.translate( '%(description)s is invalid', {
+		return translate( '%(description)s is invalid', {
 			args: { description: capitalize( description ) },
 		} );
 	},
@@ -272,7 +271,7 @@ validators.validIndiaPan = {
 validators.validPostalCodeUS = {
 	isValid: value => isValidPostalCode( value, 'US' ),
 	error: function( description ) {
-		return i18n.translate( '%(description)s is invalid. Must be a 5 digit number', {
+		return translate( '%(description)s is invalid. Must be a 5 digit number', {
 			args: { description: description },
 		} );
 	},
@@ -386,7 +385,7 @@ function getConditionalCreditCardRules( { country } ) {
 		case 'US':
 			return {
 				'postal-code': {
-					description: i18n.translate( 'Postal Code', {
+					description: translate( 'Postal Code', {
 						comment: 'Postal code on credit card form',
 					} ),
 					rules: [ 'required', 'validPostalCodeUS' ],

--- a/client/lib/domains/google-apps-users/index.js
+++ b/client/lib/domains/google-apps-users/index.js
@@ -1,9 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
 import { compact, flatten, includes, isEmpty, mapValues, property, some, values } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import emailValidator from 'email-validator';
 
 export function filter( { users, fields } ) {
@@ -22,20 +21,20 @@ export function validate( { users, fields }, existingUsers = null ) {
 			let error = null;
 
 			if ( isEmpty( field.value ) && key !== 'wasUserEdited' ) {
-				error = i18n.translate( 'This field is required.' );
+				error = translate( 'This field is required.' );
 			} else if ( includes( [ 'firstName', 'lastName' ], key ) ) {
 				if ( field.value.length > 60 ) {
-					error = i18n.translate( "This field can't be longer than 60 characters." );
+					error = translate( "This field can't be longer than 60 characters." );
 				}
 			} else if ( includes( [ 'email', 'username' ], key ) ) {
 				const newEmail = `${ field.value }@${ user.domain.value }`;
 
 				if ( ! /^[0-9a-z_'-](\.?[0-9a-z_'-])*$/i.test( field.value ) ) {
-					error = i18n.translate(
+					error = translate(
 						'Only number, letters, dashes, underscores, apostrophes and periods are allowed.'
 					);
 				} else if ( ! emailValidator.validate( newEmail ) ) {
-					error = i18n.translate( 'Please provide a valid email address.' );
+					error = translate( 'Please provide a valid email address.' );
 				} else if ( null !== existingUsers ) {
 					if (
 						includes(
@@ -45,7 +44,7 @@ export function validate( { users, fields }, existingUsers = null ) {
 							newEmail
 						)
 					) {
-						error = i18n.translate( 'You already have this email address.' );
+						error = translate( 'You already have this email address.' );
 					}
 				}
 			}

--- a/client/lib/form-state/examples/async-initialize.jsx
+++ b/client/lib/form-state/examples/async-initialize.jsx
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import debugModule from 'debug';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -52,7 +49,7 @@ class AsyncInitialize extends React.Component {
 					<input
 						name="firstName"
 						type="text"
-						placeholder={ i18n.translate( 'First Name' ) }
+						placeholder={ translate( 'First Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'firstName' ) }
 					/>
@@ -60,11 +57,12 @@ class AsyncInitialize extends React.Component {
 					<input
 						name="lastName"
 						type="text"
-						placeholder={ i18n.translate( 'Last Name' ) }
+						placeholder={ translate( 'Last Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'lastName' ) }
 					/>
 
+					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<button type="submit" className="button is-primary">
 						Submit
 					</button>

--- a/client/lib/form-state/examples/sync-initialize.jsx
+++ b/client/lib/form-state/examples/sync-initialize.jsx
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import debugModule from 'debug';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -40,7 +37,7 @@ class SyncInitialize extends React.Component {
 					<input
 						name="firstName"
 						type="text"
-						placeholder={ i18n.translate( 'First Name' ) }
+						placeholder={ translate( 'First Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'firstName' ) }
 					/>
@@ -48,11 +45,12 @@ class SyncInitialize extends React.Component {
 					<input
 						name="lastName"
 						type="text"
-						placeholder={ i18n.translate( 'Last Name' ) }
+						placeholder={ translate( 'Last Name' ) }
 						onChange={ this.handleFieldChange.bind( this ) }
 						disabled={ isFieldDisabled( this.state.form, 'lastName' ) }
 					/>
 
+					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<button type="submit" className="button is-primary">
 						Submit
 					</button>

--- a/client/lib/format-number-compact/index.js
+++ b/client/lib/format-number-compact/index.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n, { numberFormat } from 'i18n-calypso';
+import { numberFormat, getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,7 +14,7 @@ import { THOUSANDS } from './thousands';
  * @param   {String}     code                language code e.g. 'es'
  * @returns {?String}                        A formatted string.
  */
-export default function formatNumberCompact( number, code = i18n.getLocaleSlug() ) {
+export default function formatNumberCompact( number, code = getLocaleSlug() ) {
 	//use numberFormat directly from i18n in this case!
 	if ( isNaN( number ) || ! THOUSANDS[ code ] ) {
 		return null;

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import emailValidator from 'email-validator';
-import i18n, { TranslateResult } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 import { countBy, find, includes, groupBy, map, mapValues } from 'lodash';
 
 /**
@@ -43,9 +43,7 @@ const removePreviousErrors = ( { value }: GSuiteNewUserField ): GSuiteNewUserFie
 const requiredField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserField => ( {
 	value,
 	error:
-		! error && ( ! value || '' === value.trim() )
-			? i18n.translate( 'This field is required.' )
-			: error,
+		! error && ( ! value || '' === value.trim() ) ? translate( 'This field is required.' ) : error,
 } );
 
 /*
@@ -55,7 +53,7 @@ const sixtyCharacterField = ( { value, error }: GSuiteNewUserField ): GSuiteNewU
 	value,
 	error:
 		! error && 60 < value.length
-			? i18n.translate( "This field can't be longer than %s characters.", {
+			? translate( "This field can't be longer than %s characters.", {
 					args: '60',
 			  } )
 			: error,
@@ -68,7 +66,7 @@ const validEmailCharacterField = ( { value, error }: GSuiteNewUserField ): GSuit
 	value,
 	error:
 		! error && ! /^[0-9a-z_'-](\.?[0-9a-z_'-])*$/i.test( value )
-			? i18n.translate(
+			? translate(
 					'Only number, letters, dashes, underscores, apostrophes and periods are allowed.'
 			  )
 			: error,
@@ -84,7 +82,7 @@ const validateOverallEmail = (
 	value: mailBox,
 	error:
 		! mailBoxError && ! emailValidator.validate( `${ mailBox }@${ domain }` )
-			? i18n.translate( 'Please provide a valid email address.' )
+			? translate( 'Please provide a valid email address.' )
 			: mailBoxError,
 } );
 
@@ -100,7 +98,7 @@ const validateOverallEmailAgainstExistingEmails = (
 	error:
 		! mailBoxError &&
 		includes( mapValues( existingGSuiteUsers, 'email' ), `${ mailBox }@${ domain }` )
-			? i18n.translate( 'You already have this email address.' )
+			? translate( 'You already have this email address.' )
 			: mailBoxError,
 } );
 
@@ -121,7 +119,7 @@ const validateNewUserMailboxIsUnique = (
 	value: mailBox,
 	error:
 		mailboxesByCount[ mailBox ] > 1
-			? i18n.translate( 'Please use a unique mailbox for each user.' )
+			? translate( 'Please use a unique mailbox for each user.' )
 			: previousError,
 } );
 

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -1,16 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { translate, moment } from 'i18n-calypso';
 
 const MILLIS_IN_MINUTE = 60 * 1000;
 
 export default function humanDate( dateOrMoment, dateFormat = 'll' ) {
-	const now = i18n.moment();
-	dateOrMoment = i18n.moment( dateOrMoment );
+	const now = moment();
+	dateOrMoment = moment( dateOrMoment );
 
 	let millisAgo = now.diff( dateOrMoment );
 	if ( millisAgo < 0 ) {
@@ -18,12 +15,12 @@ export default function humanDate( dateOrMoment, dateFormat = 'll' ) {
 	}
 
 	if ( millisAgo < MILLIS_IN_MINUTE ) {
-		return i18n.translate( 'just now' );
+		return translate( 'just now' );
 	}
 
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 ) {
 		const minutes = Math.ceil( millisAgo / MILLIS_IN_MINUTE );
-		return i18n.translate( '%(minutes)dm ago', {
+		return translate( '%(minutes)dm ago', {
 			args: {
 				minutes: minutes,
 			},
@@ -33,7 +30,7 @@ export default function humanDate( dateOrMoment, dateFormat = 'll' ) {
 
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 * 24 ) {
 		const hours = now.diff( dateOrMoment, 'hours' );
-		return i18n.translate( '%(hours)dh ago', {
+		return translate( '%(hours)dh ago', {
 			args: {
 				hours: hours,
 			},
@@ -43,7 +40,7 @@ export default function humanDate( dateOrMoment, dateFormat = 'll' ) {
 
 	if ( millisAgo < MILLIS_IN_MINUTE * 60 * 24 * 7 ) {
 		const days = now.diff( dateOrMoment, 'days' );
-		return i18n.translate( '%(days)dd ago', {
+		return translate( '%(days)dd ago', {
 			args: {
 				days: days,
 			},

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { getLocaleSlug as i18nGetLocaleSlug } from 'i18n-calypso';
 
 export {
 	addLocaleToPath,
@@ -19,4 +18,4 @@ export {
 	filterLanguageRevisions,
 } from './utils';
 
-export const getLocaleSlug = () => i18n.getLocaleSlug();
+export const getLocaleSlug = () => i18nGetLocaleSlug();

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import {
+	configure as i18nConfigure,
+	setLocale as i18nSetLocale,
+	addTranslations as i18nAddTranslations,
+} from 'i18n-calypso';
 import debugFactory from 'debug';
 import { map, includes } from 'lodash';
 import { parse as parseUrl, format as formatUrl } from 'url';
@@ -113,7 +117,7 @@ export default function switchLocale( localeSlug ) {
 	lastRequestedLocale = targetLocaleSlug;
 
 	if ( isDefaultLocale( targetLocaleSlug ) ) {
-		i18n.configure( { defaultLocaleSlug: targetLocaleSlug } );
+		i18nConfigure( { defaultLocaleSlug: targetLocaleSlug } );
 		setLocaleInDOM( domLocaleSlug, !! language.rtl );
 	} else {
 		getLanguageFile( targetLocaleSlug ).then(
@@ -126,7 +130,7 @@ export default function switchLocale( localeSlug ) {
 						return;
 					}
 
-					i18n.setLocale( body );
+					i18nSetLocale( body );
 
 					setLocaleInDOM( domLocaleSlug, !! language.rtl );
 
@@ -198,7 +202,7 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		credentials: 'include',
 	} )
 		.then( res => res.json() )
-		.then( translations => i18n.addTranslations( translations ) );
+		.then( translations => i18nAddTranslations( translations ) );
 }
 
 /*

--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import Debug from 'debug';
 import { get, isEmpty } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -155,12 +152,12 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, formId, i
 							: Object.keys( data.errors ).length;
 
 					if ( countErrors === usernamesOrEmails.length ) {
-						message = i18n.translate( 'Invitation failed to send', 'Invitations failed to send', {
+						message = translate( 'Invitation failed to send', 'Invitations failed to send', {
 							count: countErrors,
 							context: 'Displayed in a notice when all invitations failed to send.',
 						} );
 					} else {
-						message = i18n.translate(
+						message = translate(
 							'An invitation failed to send',
 							'Some invitations failed to send',
 							{
@@ -175,7 +172,7 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, formId, i
 				} else {
 					dispatch(
 						successNotice(
-							i18n.translate( 'Invitation sent successfully', 'Invitations sent successfully', {
+							translate( 'Invitation sent successfully', 'Invitations sent successfully', {
 								count: usernamesOrEmails.length,
 							} )
 						)

--- a/client/lib/network-connection/index.js
+++ b/client/lib/network-connection/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -51,10 +51,10 @@ const NetworkConnectionApp = {
 		const changeCallback = () => {
 			if ( connected ) {
 				debug( 'Showing notice "Connection restored".' );
-				reduxStore.dispatch( connectionRestored( i18n.translate( 'Connection restored.' ) ) );
+				reduxStore.dispatch( connectionRestored( translate( 'Connection restored.' ) ) );
 			} else {
 				reduxStore.dispatch(
-					connectionLost( i18n.translate( 'Not connected. Some information may be out of sync.' ) )
+					connectionLost( translate( 'Not connected. Some information may be out of sync.' ) )
 				);
 				debug( 'Showing notice "No internet connection".' );
 			}

--- a/client/lib/phone-validation/index.jsx
+++ b/client/lib/phone-validation/index.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import phone from 'phone';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export default function( phoneNumber ) {
 	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/, '' );
@@ -13,28 +10,28 @@ export default function( phoneNumber ) {
 	if ( phoneNumberWithoutPlus.length === 0 ) {
 		return {
 			error: 'phone_number_empty',
-			message: i18n.translate( 'Please enter a phone number' ),
+			message: translate( 'Please enter a phone number' ),
 		};
 	}
 
 	if ( phoneNumberWithoutPlus.length < 8 ) {
 		return {
 			error: 'phone_number_too_short',
-			message: i18n.translate( 'This number is too short' ),
+			message: translate( 'This number is too short' ),
 		};
 	}
 
 	if ( phoneNumber.search( /[a-z,A-Z]/ ) > -1 ) {
 		return {
 			error: 'phone_number_contains_letters',
-			message: i18n.translate( 'Phone numbers cannot contain letters' ),
+			message: translate( 'Phone numbers cannot contain letters' ),
 		};
 	}
 
-	if ( phoneNumber.search( /[^0-9,\+]/ ) > -1 ) {
+	if ( phoneNumber.search( /[^0-9,+]/ ) > -1 ) {
 		return {
 			error: 'phone_number_contains_special_characters',
-			message: i18n.translate( 'Phone numbers cannot contain special characters' ),
+			message: translate( 'Phone numbers cannot contain special characters' ),
 		};
 	}
 
@@ -42,12 +39,12 @@ export default function( phoneNumber ) {
 	if ( ! phone( phoneNumber ).length ) {
 		return {
 			error: 'phone_number_invalid',
-			message: i18n.translate( 'That phone number does not appear to be valid' ),
+			message: translate( 'That phone number does not appear to be valid' ),
 		};
 	}
 
 	return {
 		info: 'phone_number_valid',
-		message: i18n.translate( 'Valid phone number' ),
+		message: translate( 'Valid phone number' ),
 	};
 }

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { invoke } from 'lodash';
 
 /**
@@ -22,7 +20,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_ALL_FREE_FEATURES_JETPACK ]: {
 		getSlug: () => constants.FEATURE_ALL_FREE_FEATURES_JETPACK,
 		getTitle: () =>
-			i18n.translate( '{{a}}All free features{{/a}}', {
+			translate( '{{a}}All free features{{/a}}', {
 				components: {
 					a: (
 						<a
@@ -34,19 +32,19 @@ export const FEATURES_LIST = {
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate( 'Also includes all features offered in the free version of Jetpack.' ),
+			translate( 'Also includes all features offered in the free version of Jetpack.' ),
 	},
 
 	[ constants.FEATURE_ALL_FREE_FEATURES ]: {
 		getSlug: () => constants.FEATURE_ALL_FREE_FEATURES,
-		getTitle: () => i18n.translate( 'All free features' ),
-		getDescription: () => i18n.translate( 'Also includes all features offered in the free plan.' ),
+		getTitle: () => translate( 'All free features' ),
+		getDescription: () => translate( 'Also includes all features offered in the free plan.' ),
 	},
 
 	[ constants.FEATURE_ALL_PERSONAL_FEATURES_JETPACK ]: {
 		getSlug: () => constants.FEATURE_ALL_PERSONAL_FEATURES_JETPACK,
 		getTitle: () =>
-			i18n.translate( '{{a}}All Personal features{{/a}}', {
+			translate( '{{a}}All Personal features{{/a}}', {
 				components: {
 					a: (
 						<a
@@ -57,15 +55,14 @@ export const FEATURES_LIST = {
 					),
 				},
 			} ),
-		getDescription: () =>
-			i18n.translate( 'Also includes all features offered in the Personal plan.' ),
+		getDescription: () => translate( 'Also includes all features offered in the Personal plan.' ),
 	},
 
 	[ constants.FEATURE_ALL_PERSONAL_FEATURES ]: {
 		getSlug: () => constants.FEATURE_ALL_PERSONAL_FEATURES,
-		getTitle: () => i18n.translate( 'All Personal features' ),
+		getTitle: () => translate( 'All Personal features' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Including email and live chat support, an ad-free experience for your visitors, increased storage space, and a custom domain name for one year.'
 			),
 	},
@@ -73,7 +70,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK ]: {
 		getSlug: () => constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 		getTitle: () =>
-			i18n.translate( '{{a}}All Premium features{{/a}}', {
+			translate( '{{a}}All Premium features{{/a}}', {
 				components: {
 					a: (
 						<a
@@ -84,42 +81,41 @@ export const FEATURES_LIST = {
 					),
 				},
 			} ),
-		getDescription: () =>
-			i18n.translate( 'Also includes all features offered in the Premium plan.' ),
+		getDescription: () => translate( 'Also includes all features offered in the Premium plan.' ),
 	},
 
 	[ constants.FEATURE_ALL_PREMIUM_FEATURES ]: {
 		getSlug: () => constants.FEATURE_ALL_PREMIUM_FEATURES,
-		getTitle: () => i18n.translate( 'All Premium features' ),
+		getTitle: () => translate( 'All Premium features' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.'
 			),
 	},
 
 	[ constants.FEATURE_ADVANCED_CUSTOMIZATION ]: {
 		getSlug: () => constants.FEATURE_ADVANCED_CUSTOMIZATION,
-		getTitle: () => i18n.translate( 'Advanced customization' ),
+		getTitle: () => translate( 'Advanced customization' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Customize your selected theme template with extended color schemes, background designs, and complete control over website CSS.'
 			),
 	},
 
 	[ constants.FEATURE_FREE_BLOG_DOMAIN ]: {
 		getSlug: () => constants.FEATURE_FREE_BLOG_DOMAIN,
-		getTitle: () => i18n.translate( 'Free .blog domain for one year' ),
+		getTitle: () => translate( 'Free .blog domain for one year' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Get a free custom .blog domain for one year. Premium domains not included. Your domain will renew at its regular price.'
 			),
 	},
 
 	[ constants.FEATURE_FREE_DOMAIN ]: {
 		getSlug: () => constants.FEATURE_FREE_DOMAIN,
-		getTitle: () => i18n.translate( 'Free Domain for One Year' ),
+		getTitle: () => translate( 'Free Domain for One Year' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Get a free domain for one year. ' +
 					'Premium domains not included. ' +
 					'Your domain will renew at its {{a}}regular price{{/a}}.',
@@ -139,125 +135,123 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_PREMIUM_THEMES ]: {
 		getSlug: () => constants.FEATURE_PREMIUM_THEMES,
-		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
+		getTitle: () => translate( 'Unlimited premium themes' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Unlimited access to all of our advanced premium theme templates, including templates specifically tailored for businesses.'
 			),
 	},
 
 	[ constants.FEATURE_MONETISE ]: {
 		getSlug: () => constants.FEATURE_MONETISE,
-		getTitle: () => i18n.translate( 'Monetize your site with ads' ),
+		getTitle: () => translate( 'Monetize your site with ads' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Add advertising to your site through our WordAds program and earn money from impressions.'
 			),
 	},
 
 	[ constants.FEATURE_UPLOAD_THEMES_PLUGINS ]: {
 		getSlug: () => constants.FEATURE_UPLOAD_THEMES_PLUGINS,
-		getTitle: () => i18n.translate( 'Upload Themes and Plugins' ),
-		getDescription: () => i18n.translate( 'Upload custom themes and plugins on your site.' ),
+		getTitle: () => translate( 'Upload Themes and Plugins' ),
+		getDescription: () => translate( 'Upload custom themes and plugins on your site.' ),
 	},
 
 	[ constants.FEATURE_GOOGLE_ANALYTICS_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_GOOGLE_ANALYTICS_SIGNUP,
-		getTitle: () => i18n.translate( 'Google Analytics' ),
+		getTitle: () => translate( 'Google Analytics' ),
 	},
 
 	[ constants.FEATURE_EMAIL_SUPPORT_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_EMAIL_SUPPORT_SIGNUP,
-		getTitle: () => i18n.translate( 'Email support' ),
+		getTitle: () => translate( 'Email support' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'High quality email support to help you get your website up and running and working how you want it.'
 			),
 	},
 
 	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
-		getTitle: () => i18n.translate( 'Email and live chat support' ),
+		getTitle: () => translate( 'Email and live chat support' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'High quality support to help you get your website up and running and working how you want it.'
 			),
 	},
 
 	[ constants.FEATURE_FREE_THEMES_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_FREE_THEMES_SIGNUP,
-		getTitle: () => i18n.translate( 'Dozens of Free Themes' ),
+		getTitle: () => translate( 'Dozens of Free Themes' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"Access to a wide range of professional theme templates for your website so you can find the exact design you're looking for."
 			),
 	},
 
 	[ constants.FEATURE_WP_SUBDOMAIN_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_WP_SUBDOMAIN_SIGNUP,
-		getTitle: () => i18n.translate( 'WordPress.com subdomain' ),
+		getTitle: () => translate( 'WordPress.com subdomain' ),
 		getDescription: () =>
-			i18n.translate(
-				'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).'
-			),
+			translate( 'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).' ),
 	},
 
 	[ constants.FEATURE_UNLIMITED_STORAGE_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_UNLIMITED_STORAGE_SIGNUP,
-		getTitle: () => i18n.translate( '200 GB storage' ),
+		getTitle: () => translate( '200 GB storage' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"With increased storage space you'll be able to upload more images, videos, audio, and documents to your website."
 			),
 	},
 
 	[ constants.FEATURE_ADVANCED_SEO_TOOLS ]: {
 		getSlug: () => constants.FEATURE_ADVANCED_SEO_TOOLS,
-		getTitle: () => i18n.translate( 'Advanced SEO tools' ),
+		getTitle: () => translate( 'Advanced SEO tools' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"Adds tools to enhance your site's content for better results on search engines and social media."
 			),
 	},
 
 	[ constants.FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP ]: {
 		getSlug: () => constants.FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP,
-		getTitle: () => i18n.translate( 'Unlimited Backup Space' ),
+		getTitle: () => translate( 'Unlimited Backup Space' ),
 	},
 
 	[ constants.FEATURE_FREE_WORDPRESS_THEMES ]: {
 		getSlug: () => constants.FEATURE_FREE_WORDPRESS_THEMES,
-		getTitle: () => i18n.translate( 'Free WordPress Themes' ),
+		getTitle: () => translate( 'Free WordPress Themes' ),
 	},
 
 	[ constants.FEATURE_VIDEO_CDN_LIMITED ]: {
 		getSlug: () => constants.FEATURE_VIDEO_CDN_LIMITED,
-		getTitle: () => i18n.translate( '13GB Video Storage' ),
+		getTitle: () => translate( '13GB Video Storage' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'High-speed video hosting on our CDN, free of ads and watermarks, fully optimized for WordPress.'
 			),
 	},
 
 	[ constants.FEATURE_VIDEO_CDN_UNLIMITED ]: {
 		getSlug: () => constants.FEATURE_VIDEO_CDN_UNLIMITED,
-		getTitle: () => i18n.translate( 'Unlimited Video Storage' ),
+		getTitle: () => translate( 'Unlimited Video Storage' ),
 	},
 
 	[ constants.FEATURE_SEO_PREVIEW_TOOLS ]: {
 		getSlug: () => constants.FEATURE_SEO_PREVIEW_TOOLS,
-		getTitle: () => i18n.translate( 'SEO Tools' ),
+		getTitle: () => translate( 'SEO Tools' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Edit your page titles and meta descriptions, and preview how your content will appear on social media.'
 			),
 	},
 
 	[ constants.FEATURE_GOOGLE_ANALYTICS ]: {
 		getSlug: () => constants.FEATURE_GOOGLE_ANALYTICS,
-		getTitle: () => i18n.translate( 'Google Analytics Integration' ),
+		getTitle: () => translate( 'Google Analytics Integration' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Track website statistics with Google Analytics for a ' +
 					'deeper understanding of your website visitors and customers.'
 			),
@@ -265,9 +259,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_GOOGLE_MY_BUSINESS ]: {
 		getSlug: () => constants.FEATURE_GOOGLE_MY_BUSINESS,
-		getTitle: () => i18n.translate( 'Google My Business' ),
+		getTitle: () => translate( 'Google My Business' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'See how customers find you on Google -- and whether they visited your site ' +
 					'and looked for more info on your business -- by connecting to a Google My Business location.'
 			),
@@ -276,13 +270,13 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_UNLIMITED_STORAGE ]: {
 		getSlug: () => constants.FEATURE_UNLIMITED_STORAGE,
 		getTitle: () =>
-			i18n.translate( '{{strong}}200 GB{{/strong}} Storage Space', {
+			translate( '{{strong}}200 GB{{/strong}} Storage Space', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"With increased storage space you'll be able to upload " +
 					'more images, videos, audio, and documents to your website.'
 			),
@@ -292,17 +286,17 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_BLOG_DOMAIN ]: {
 		getSlug: () => constants.FEATURE_BLOG_DOMAIN,
 		getTitle: () =>
-			i18n.translate( 'Free .blog Domain for One Year', {
+			translate( 'Free .blog Domain for One Year', {
 				context: 'title',
 			} ),
 		getDescription: ( abtest, domainName ) => {
 			if ( domainName ) {
-				return i18n.translate( 'Your domain (%s) is included with this plan.', {
+				return translate( 'Your domain (%s) is included with this plan.', {
 					args: domainName,
 				} );
 			}
 
-			return i18n.translate(
+			return translate(
 				'Get a free custom .blog domain for one year. Premium domains not included. Your domain will renew at its regular price.'
 			);
 		},
@@ -311,17 +305,17 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_CUSTOM_DOMAIN ]: {
 		getSlug: () => constants.FEATURE_CUSTOM_DOMAIN,
 		getTitle: () =>
-			i18n.translate( 'Free Domain for One Year', {
+			translate( 'Free Domain for One Year', {
 				context: 'title',
 			} ),
 		getDescription: ( abtest, domainName ) => {
 			if ( domainName ) {
-				return i18n.translate( 'Your domain (%s) is included with this plan.', {
+				return translate( 'Your domain (%s) is included with this plan.', {
 					args: domainName,
 				} );
 			}
 
-			return i18n.translate(
+			return translate(
 				'Get a free domain for one year. ' +
 					'Premium domains not included. ' +
 					'Your domain will renew at its {{a}}regular price{{/a}}.',
@@ -342,9 +336,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_JETPACK_ESSENTIAL ]: {
 		getSlug: () => constants.FEATURE_JETPACK_ESSENTIAL,
-		getTitle: () => i18n.translate( 'Jetpack Essential Features' ),
+		getTitle: () => translate( 'Jetpack Essential Features' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Speed up your site’s performance and protect it from spammers. ' +
 					'Access detailed records of all activity on your site. ' +
 					'While you’re at it, improve your SEO and automate social media sharing.'
@@ -353,9 +347,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_JETPACK_ADVANCED ]: {
 		getSlug: () => constants.FEATURE_JETPACK_ADVANCED,
-		getTitle: () => i18n.translate( 'Jetpack Advanced Features' ),
+		getTitle: () => translate( 'Jetpack Advanced Features' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Speed up your site’s performance and protect it from spammers. ' +
 					'Access detailed records of all activity on your site and restore your site ' +
 					'to a previous point in time with just a click! While you’re at it, ' +
@@ -366,13 +360,13 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
 		getSlug: () => constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Unlimited{{/strong}} Premium Themes', {
+			translate( '{{strong}}Unlimited{{/strong}} Premium Themes', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Unlimited access to all of our advanced premium theme templates, ' +
 					'including templates specifically tailored for businesses.'
 			),
@@ -381,9 +375,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_VIDEO_UPLOADS ]: {
 		getSlug: () => constants.FEATURE_VIDEO_UPLOADS,
-		getTitle: () => i18n.translate( 'VideoPress Support' ),
+		getTitle: () => translate( 'VideoPress Support' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'The easiest way to upload videos to your website and display them ' +
 					'using a fast, unbranded, customizable player with rich stats.'
 			),
@@ -392,9 +386,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ]: {
 		getSlug: () => constants.FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
-		getTitle: () => i18n.translate( 'VideoPress Support' ),
+		getTitle: () => translate( 'VideoPress Support' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Easy video uploads, and a fast, unbranded, customizable video player, ' +
 					'enhanced with rich stats and unlimited storage space. '
 			),
@@ -404,13 +398,13 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO ]: {
 		getSlug: () => constants.FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Unlimited{{/strong}} Video Hosting', {
+			translate( '{{strong}}Unlimited{{/strong}} Video Hosting', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Easy video uploads, and a fast, unbranded, customizable video player, ' +
 					'enhanced with rich stats and unlimited storage space. '
 			),
@@ -419,19 +413,17 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_AUDIO_UPLOADS ]: {
 		getSlug: () => constants.FEATURE_AUDIO_UPLOADS,
-		getTitle: () => i18n.translate( 'Audio Upload Support' ),
+		getTitle: () => translate( 'Audio Upload Support' ),
 		getDescription: () =>
-			i18n.translate(
-				'The easiest way to upload audio files that use any major audio file format. '
-			),
+			translate( 'The easiest way to upload audio files that use any major audio file format. ' ),
 		getStoreSlug: () => 'videopress',
 	},
 
 	[ constants.FEATURE_BASIC_DESIGN ]: {
 		getSlug: () => constants.FEATURE_BASIC_DESIGN,
-		getTitle: () => i18n.translate( 'Basic Design Customization' ),
+		getTitle: () => translate( 'Basic Design Customization' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Customize your selected theme template with pre-set color schemes, ' +
 					'background designs, and font styles.'
 			),
@@ -441,13 +433,13 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_ADVANCED_DESIGN ]: {
 		getSlug: () => constants.FEATURE_ADVANCED_DESIGN,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Advanced{{/strong}} Design Customization', {
+			translate( '{{strong}}Advanced{{/strong}} Design Customization', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Customize your selected theme template with extended color schemes, ' +
 					'background designs, and complete control over website CSS.'
 			),
@@ -456,9 +448,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_NO_ADS ]: {
 		getSlug: () => constants.FEATURE_NO_ADS,
-		getTitle: () => i18n.translate( 'Remove WordPress.com Ads' ),
+		getTitle: () => translate( 'Remove WordPress.com Ads' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Allow your visitors to visit and read your website without ' +
 					'seeing any WordPress.com advertising.'
 			),
@@ -466,22 +458,22 @@ export const FEATURES_LIST = {
 	},
 	[ constants.FEATURE_REPUBLICIZE ]: {
 		getSlug: () => constants.FEATURE_REPUBLICIZE,
-		getTitle: () => i18n.translate( 'Advanced Social Media' ),
+		getTitle: () => translate( 'Advanced Social Media' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"Schedule your social media updates in advance and promote your posts when it's best for you."
 			),
 	},
 	[ constants.FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_SIMPLE_PAYMENTS,
-		getTitle: () => i18n.translate( 'Simple Payments' ),
-		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
+		getTitle: () => translate( 'Simple Payments' ),
+		getDescription: () => translate( 'Sell anything with a simple PayPal button.' ),
 	},
 	[ constants.FEATURE_NO_BRANDING ]: {
 		getSlug: () => constants.FEATURE_NO_BRANDING,
-		getTitle: () => i18n.translate( 'Remove WordPress.com Branding' ),
+		getTitle: () => translate( 'Remove WordPress.com Branding' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"Keep the focus on your site's brand by removing the WordPress.com footer branding."
 			),
 		getStoreSlug: () => 'no-adverts/no-adverts.php',
@@ -489,57 +481,55 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_BUSINESS_ONBOARDING ]: {
 		getSlug: () => constants.FEATURE_BUSINESS_ONBOARDING,
-		getTitle: () => i18n.translate( 'Get Personalized Help' ),
+		getTitle: () => translate( 'Get Personalized Help' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Schedule a one-on-one orientation with a Happiness Engineer to set up your site and learn more about WordPress.com.'
 			),
 	},
 
 	[ constants.FEATURE_ADVANCED_SEO ]: {
 		getSlug: () => constants.FEATURE_ADVANCED_SEO,
-		getTitle: () => i18n.translate( 'SEO Tools' ),
+		getTitle: () => translate( 'SEO Tools' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"Adds tools to enhance your site's content for better results on search engines and social media."
 			),
 	},
 
 	[ constants.FEATURE_UPLOAD_PLUGINS ]: {
 		getSlug: () => constants.FEATURE_UPLOAD_PLUGINS,
-		getTitle: () => i18n.translate( 'Install Plugins' ),
-		getDescription: () => i18n.translate( 'Install custom plugins on your site.' ),
+		getTitle: () => translate( 'Install Plugins' ),
+		getDescription: () => translate( 'Install custom plugins on your site.' ),
 	},
 
 	[ constants.FEATURE_UPLOAD_THEMES ]: {
 		getSlug: () => constants.FEATURE_UPLOAD_THEMES,
-		getTitle: () => i18n.translate( 'Install Themes' ),
-		getDescription: () => i18n.translate( 'Upload custom themes on your site.' ),
+		getTitle: () => translate( 'Install Themes' ),
+		getDescription: () => translate( 'Upload custom themes on your site.' ),
 	},
 
 	[ constants.FEATURE_WORDADS_INSTANT ]: {
 		getSlug: () => constants.FEATURE_WORDADS_INSTANT,
-		getTitle: () => i18n.translate( 'Site Monetization' ),
+		getTitle: () => translate( 'Site Monetization' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Put your site to work and earn through ad revenue, easy-to-add PayPal buttons, and more.'
 			),
 	},
 
 	[ constants.FEATURE_WP_SUBDOMAIN ]: {
 		getSlug: () => constants.FEATURE_WP_SUBDOMAIN,
-		getTitle: () => i18n.translate( 'WordPress.com Subdomain' ),
+		getTitle: () => translate( 'WordPress.com Subdomain' ),
 		getDescription: () =>
-			i18n.translate(
-				'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).'
-			),
+			translate( 'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).' ),
 	},
 
 	[ constants.FEATURE_FREE_THEMES ]: {
 		getSlug: () => constants.FEATURE_FREE_THEMES,
-		getTitle: () => i18n.translate( 'Dozens of Free Themes' ),
+		getTitle: () => translate( 'Dozens of Free Themes' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Access to a wide range of professional theme templates ' +
 					"for your website so you can find the exact design you're looking for."
 			),
@@ -547,21 +537,21 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_3GB_STORAGE ]: {
 		getSlug: () => constants.FEATURE_3GB_STORAGE,
-		getTitle: () => i18n.translate( '3GB Storage Space' ),
+		getTitle: () => translate( '3GB Storage Space' ),
 		getDescription: () =>
-			i18n.translate( 'Storage space for adding images and documents to your website.' ),
+			translate( 'Storage space for adding images and documents to your website.' ),
 	},
 
 	[ constants.FEATURE_6GB_STORAGE ]: {
 		getSlug: () => constants.FEATURE_6GB_STORAGE,
 		getTitle: () =>
-			i18n.translate( '{{strong}}6GB{{/strong}} Storage Space', {
+			translate( '{{strong}}6GB{{/strong}} Storage Space', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"With increased storage space you'll be able to upload " +
 					'more images, audio, and documents to your website.'
 			),
@@ -570,13 +560,13 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_13GB_STORAGE ]: {
 		getSlug: () => constants.FEATURE_13GB_STORAGE,
 		getTitle: () =>
-			i18n.translate( '{{strong}}13GB{{/strong}} Storage Space', {
+			translate( '{{strong}}13GB{{/strong}} Storage Space', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				"With increased storage space you'll be able to upload " +
 					'more images, videos, audio, and documents to your website.'
 			),
@@ -584,73 +574,71 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_COMMUNITY_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_COMMUNITY_SUPPORT,
-		getTitle: () => i18n.translate( 'Community support' ),
-		getDescription: () => i18n.translate( 'Get support through our ' + 'user community forums.' ),
+		getTitle: () => translate( 'Community support' ),
+		getDescription: () => translate( 'Get support through our ' + 'user community forums.' ),
 	},
 
 	[ constants.FEATURE_EMAIL_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_EMAIL_SUPPORT,
-		getTitle: () => i18n.translate( 'Email Support' ),
+		getTitle: () => translate( 'Email Support' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'High quality email support to help you get your website up and running and working how you want it.'
 			),
 	},
 
 	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-		getTitle: () => i18n.translate( 'Email & Live Chat Support' ),
-		getDescription: () =>
-			i18n.translate( 'Live chat support to help you get started with your site.' ),
+		getTitle: () => translate( 'Email & Live Chat Support' ),
+		getDescription: () => translate( 'Live chat support to help you get started with your site.' ),
 	},
 
 	[ constants.FEATURE_PREMIUM_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_PREMIUM_SUPPORT,
-		getTitle: () => i18n.translate( 'Priority Support' ),
-		getDescription: () =>
-			i18n.translate( 'Live chat support to help you get started with Jetpack.' ),
+		getTitle: () => translate( 'Priority Support' ),
+		getDescription: () => translate( 'Live chat support to help you get started with Jetpack.' ),
 	},
 
 	[ constants.FEATURE_STANDARD_SECURITY_TOOLS ]: {
 		getSlug: () => constants.FEATURE_STANDARD_SECURITY_TOOLS,
-		getTitle: () => i18n.translate( 'Standard Security Tools' ),
+		getTitle: () => translate( 'Standard Security Tools' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Brute force protection, downtime monitoring, secure sign on, ' +
 					'and automatic updates for your plugins.'
 			),
 	},
 	[ constants.FEATURE_SITE_STATS ]: {
 		getSlug: () => constants.FEATURE_SITE_STATS,
-		getTitle: () => i18n.translate( 'Site Stats and Analytics' ),
-		getDescription: () => i18n.translate( 'The most important metrics for your site.' ),
+		getTitle: () => translate( 'Site Stats and Analytics' ),
+		getDescription: () => translate( 'The most important metrics for your site.' ),
 	},
 	[ constants.FEATURE_TRAFFIC_TOOLS ]: {
 		getSlug: () => constants.FEATURE_TRAFFIC_TOOLS,
-		getTitle: () => i18n.translate( 'Traffic and Promotion Tools' ),
+		getTitle: () => translate( 'Traffic and Promotion Tools' ),
 		getDescription: () =>
-			i18n.translate( 'Build and engage your audience with more than a dozen optimization tools.' ),
+			translate( 'Build and engage your audience with more than a dozen optimization tools.' ),
 	},
 	[ constants.FEATURE_MANAGE ]: {
 		getSlug: () => constants.FEATURE_MANAGE,
-		getTitle: () => i18n.translate( 'Centralized Dashboard' ),
-		getDescription: () => i18n.translate( 'Manage all of your WordPress sites from one location.' ),
+		getTitle: () => translate( 'Centralized Dashboard' ),
+		getDescription: () => translate( 'Manage all of your WordPress sites from one location.' ),
 	},
 	[ constants.FEATURE_SPAM_AKISMET_PLUS ]: {
 		getSlug: () => constants.FEATURE_SPAM_AKISMET_PLUS,
-		getTitle: () => i18n.translate( 'Spam Protection' ),
-		getDescription: () => i18n.translate( 'State-of-the-art spam defense, powered by Akismet.' ),
+		getTitle: () => translate( 'Spam Protection' ),
+		getDescription: () => translate( 'State-of-the-art spam defense, powered by Akismet.' ),
 	},
 	[ constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY ]: {
 		getSlug: () => constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Daily{{/strong}} Backups', {
+			translate( '{{strong}}Daily{{/strong}} Backups', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Automatic daily backups of your entire site, with ' +
 					'unlimited, WordPress-optimized secure storage.'
 			),
@@ -658,160 +646,156 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME ]: {
 		getSlug: () => constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Real-time{{/strong}} Backups', {
+			translate( '{{strong}}Real-time{{/strong}} Backups', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Automatic real-time backups of every single aspect of your site. ' +
 					'Stored safely and optimized for WordPress.'
 			),
 	},
 	[ constants.FEATURE_BACKUP_ARCHIVE_30 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_ARCHIVE_30,
-		getTitle: () => i18n.translate( '30-day Backup Archive' ),
-		getDescription: () =>
-			i18n.translate( 'Browse or restore any backup made within the past 30 days.' ),
+		getTitle: () => translate( '30-day Backup Archive' ),
+		getDescription: () => translate( 'Browse or restore any backup made within the past 30 days.' ),
 	},
 	[ constants.FEATURE_BACKUP_ARCHIVE_15 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_ARCHIVE_15,
-		getTitle: () => i18n.translate( '15-day Backup Archive' ),
-		getDescription: () =>
-			i18n.translate( 'Browse or restore any backup made within the past 15 days.' ),
+		getTitle: () => translate( '15-day Backup Archive' ),
+		getDescription: () => translate( 'Browse or restore any backup made within the past 15 days.' ),
 	},
 	[ constants.FEATURE_BACKUP_ARCHIVE_UNLIMITED ]: {
 		getSlug: () => constants.FEATURE_BACKUP_ARCHIVE_UNLIMITED,
-		getTitle: () => i18n.translate( 'Unlimited Backup Archive' ),
+		getTitle: () => translate( 'Unlimited Backup Archive' ),
 		getDescription: () =>
-			i18n.translate( 'Browse or restore any backup made since you activated the service.' ),
+			translate( 'Browse or restore any backup made since you activated the service.' ),
 	},
 	[ constants.FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED ]: {
 		getSlug: () => constants.FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-		getTitle: () => i18n.translate( 'Unlimited Backup Storage Space' ),
-		getDescription: () =>
-			i18n.translate( 'Absolutely no limits on storage space for your backups.' ),
+		getTitle: () => translate( 'Unlimited Backup Storage Space' ),
+		getDescription: () => translate( 'Absolutely no limits on storage space for your backups.' ),
 	},
 	[ constants.FEATURE_AUTOMATED_RESTORES ]: {
 		getSlug: () => constants.FEATURE_AUTOMATED_RESTORES,
-		getTitle: () => i18n.translate( 'Automated Restores' ),
+		getTitle: () => translate( 'Automated Restores' ),
 		getDescription: () =>
-			i18n.translate( 'Restore your site from any available backup with a single click.' ),
+			translate( 'Restore your site from any available backup with a single click.' ),
 	},
 	[ constants.FEATURE_EASY_SITE_MIGRATION ]: {
 		getSlug: () => constants.FEATURE_EASY_SITE_MIGRATION,
-		getTitle: () => i18n.translate( 'Easy Site Migration' ),
+		getTitle: () => translate( 'Easy Site Migration' ),
 		getDescription: () =>
-			i18n.translate( 'Easily and quickly move or duplicate your site to any location.' ),
+			translate( 'Easily and quickly move or duplicate your site to any location.' ),
 	},
 	[ constants.FEATURE_MALWARE_SCANNING_DAILY ]: {
 		getSlug: () => constants.FEATURE_MALWARE_SCANNING_DAILY,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Daily{{/strong}} Malware Scanning', {
+			translate( '{{strong}}Daily{{/strong}} Malware Scanning', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Comprehensive, automated scanning for security vulnerabilities or threats on your site.'
 			),
 	},
 	[ constants.FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND ]: {
 		getSlug: () => constants.FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
-		getTitle: () => i18n.translate( 'Daily and On-demand Malware Scanning' ),
+		getTitle: () => translate( 'Daily and On-demand Malware Scanning' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Automated security scanning with the option to run complete site scans at any time.'
 			),
 	},
 	[ constants.FEATURE_ONE_CLICK_THREAT_RESOLUTION ]: {
 		getSlug: () => constants.FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-		getTitle: () => i18n.translate( 'One-click Threat Resolution' ),
+		getTitle: () => translate( 'One-click Threat Resolution' ),
 		getDescription: () =>
-			i18n.translate( 'Repair any security issues found on your site with just a single click.' ),
+			translate( 'Repair any security issues found on your site with just a single click.' ),
 	},
 	[ constants.FEATURE_AUTOMATIC_SECURITY_FIXES ]: {
 		getSlug: () => constants.FEATURE_AUTOMATIC_SECURITY_FIXES,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Automatic{{/strong}} Security Fixes', {
+			translate( '{{strong}}Automatic{{/strong}} Security Fixes', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Automated and immediate resolution for a large percentage of known security vulnerabilities or threats.'
 			),
 	},
 	[ constants.FEATURE_ACTIVITY_LOG ]: {
 		getSlug: () => constants.FEATURE_ACTIVITY_LOG,
-		getTitle: () => i18n.translate( 'Expanded Site Activity' ),
+		getTitle: () => translate( 'Expanded Site Activity' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Take the guesswork out of site management and debugging with a filterable record of all the activity happening on your site.'
 			),
 	},
 	[ constants.FEATURE_POLLS_PRO ]: {
 		getSlug: () => constants.FEATURE_POLLS_PRO,
-		getTitle: () => i18n.translate( 'Advanced Polls and Ratings' ),
+		getTitle: () => translate( 'Advanced Polls and Ratings' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Custom polls, surveys, ratings, and quizzes for the ultimate in customer and reader engagement.'
 			),
 	},
 
 	[ constants.FEATURE_CORE_JETPACK ]: {
 		getSlug: () => constants.FEATURE_CORE_JETPACK,
-		getTitle: () => i18n.translate( 'Core Jetpack Services' ),
-		getDescription: () => i18n.translate( 'Stats, themes, and promotion tools.' ),
+		getTitle: () => translate( 'Core Jetpack Services' ),
+		getDescription: () => translate( 'Stats, themes, and promotion tools.' ),
 		hideInfoPopover: true,
 	},
 	[ constants.FEATURE_BASIC_SECURITY_JETPACK ]: {
 		getSlug: () => constants.FEATURE_BASIC_SECURITY_JETPACK,
-		getTitle: () => i18n.translate( 'Basic Security' ),
+		getTitle: () => translate( 'Basic Security' ),
 		getDescription: () =>
-			i18n.translate( 'Brute force protection, monitoring, secure logins, updates.' ),
+			translate( 'Brute force protection, monitoring, secure logins, updates.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_BASIC_SUPPORT_JETPACK ]: {
 		getSlug: () => constants.FEATURE_BASIC_SUPPORT_JETPACK,
-		getTitle: () => i18n.translate( 'Basic Support' ),
-		getDescription: () => i18n.translate( 'Free support to help you make the most of Jetpack.' ),
+		getTitle: () => translate( 'Basic Support' ),
+		getDescription: () => translate( 'Free support to help you make the most of Jetpack.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_SPEED_JETPACK ]: {
 		getSlug: () => constants.FEATURE_SPEED_JETPACK,
-		getTitle: () => i18n.translate( 'Speed and Storage' ),
+		getTitle: () => translate( 'Speed and Storage' ),
 		getDescription: () =>
-			i18n.translate( 'Unlimited use of our high speed image content delivery network.' ),
+			translate( 'Unlimited use of our high speed image content delivery network.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_SPEED_ADVANCED_JETPACK ]: {
 		getSlug: () => constants.FEATURE_SPEED_ADVANCED_JETPACK,
-		getTitle: () => i18n.translate( 'Speed and Storage' ),
-		getDescription: () =>
-			i18n.translate( 'Also includes 13Gb of high-speed, ad-free video hosting.' ),
+		getTitle: () => translate( 'Speed and Storage' ),
+		getDescription: () => translate( 'Also includes 13Gb of high-speed, ad-free video hosting.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_SPEED_UNLIMITED_JETPACK ]: {
 		getSlug: () => constants.FEATURE_SPEED_UNLIMITED_JETPACK,
-		getTitle: () => i18n.translate( 'Speed and Storage' ),
+		getTitle: () => translate( 'Speed and Storage' ),
 		getDescription: () =>
-			i18n.translate( 'Also includes unlimited, high-speed, ad-free video hosting.' ),
+			translate( 'Also includes unlimited, high-speed, ad-free video hosting.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_SITE_BACKUPS_JETPACK ]: {
 		getSlug: () => constants.FEATURE_SITE_BACKUPS_JETPACK,
-		getTitle: () => i18n.translate( 'Site Backups' ),
+		getTitle: () => translate( 'Site Backups' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Automated daily backups (unlimited storage), one-click restores, and 30-day archive.'
 			),
 		hideInfoPopover: true,
@@ -819,67 +803,66 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_SECURITY_SCANNING_JETPACK ]: {
 		getSlug: () => constants.FEATURE_SECURITY_SCANNING_JETPACK,
-		getTitle: () => i18n.translate( 'Advanced Security' ),
+		getTitle: () => translate( 'Advanced Security' ),
 		getDescription: () =>
-			i18n.translate( 'Also includes daily scans for malware and security threats.' ),
+			translate( 'Also includes daily scans for malware and security threats.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_REVENUE_GENERATION_JETPACK ]: {
 		getSlug: () => constants.FEATURE_REVENUE_GENERATION_JETPACK,
-		getTitle: () => i18n.translate( 'Revenue Generation' ),
-		getDescription: () => i18n.translate( 'High-quality ads to generate income from your site.' ),
+		getTitle: () => translate( 'Revenue Generation' ),
+		getDescription: () => translate( 'High-quality ads to generate income from your site.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_VIDEO_HOSTING_JETPACK ]: {
 		getSlug: () => constants.FEATURE_VIDEO_HOSTING_JETPACK,
-		getTitle: () => i18n.translate( 'Video Hosting' ),
-		getDescription: () => i18n.translate( '13Gb of high-speed, HD, and ad-free video hosting.' ),
+		getTitle: () => translate( 'Video Hosting' ),
+		getDescription: () => translate( '13Gb of high-speed, HD, and ad-free video hosting.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_SECURITY_ESSENTIALS_JETPACK ]: {
 		getSlug: () => constants.FEATURE_SECURITY_ESSENTIALS_JETPACK,
-		getTitle: () => i18n.translate( 'Essential Security' ),
+		getTitle: () => translate( 'Essential Security' ),
 		getDescription: () =>
-			i18n.translate( 'Daily backups, unlimited storage, one-click restores, spam filtering.' ),
+			translate( 'Daily backups, unlimited storage, one-click restores, spam filtering.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_PRIORITY_SUPPORT_JETPACK ]: {
 		getSlug: () => constants.FEATURE_PRIORITY_SUPPORT_JETPACK,
-		getTitle: () => i18n.translate( 'Priority Support' ),
-		getDescription: () => i18n.translate( 'Faster response times from our security experts.' ),
+		getTitle: () => translate( 'Priority Support' ),
+		getDescription: () => translate( 'Faster response times from our security experts.' ),
 		hideInfoPopover: true,
 	},
 	[ constants.FEATURE_TRAFFIC_TOOLS_JETPACK ]: {
 		getSlug: () => constants.FEATURE_TRAFFIC_TOOLS_JETPACK,
-		getTitle: () => i18n.translate( 'Advanced Traffic Tools' ),
-		getDescription: () =>
-			i18n.translate( 'Automatically re-promote existing content to social media.' ),
+		getTitle: () => translate( 'Advanced Traffic Tools' ),
+		getDescription: () => translate( 'Automatically re-promote existing content to social media.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK ]: {
 		getSlug: () => constants.FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK,
-		getTitle: () => i18n.translate( 'Advanced Traffic Tools' ),
-		getDescription: () => i18n.translate( 'Also includes SEO previews and Google Analytics.' ),
+		getTitle: () => translate( 'Advanced Traffic Tools' ),
+		getDescription: () => translate( 'Also includes SEO previews and Google Analytics.' ),
 		hideInfoPopover: true,
 	},
 
 	[ constants.FEATURE_CONCIERGE_SETUP ]: {
 		getSlug: () => constants.FEATURE_CONCIERGE_SETUP,
-		getTitle: () => i18n.translate( 'Concierge Setup' ),
+		getTitle: () => translate( 'Concierge Setup' ),
 		getDescription: () =>
-			i18n.translate( 'A complimentary one-on-one orientation session with a Jetpack expert.' ),
+			translate( 'A complimentary one-on-one orientation session with a Jetpack expert.' ),
 	},
 
 	[ constants.FEATURE_MARKETING_AUTOMATION ]: {
 		getSlug: () => constants.FEATURE_MARKETING_AUTOMATION,
-		getTitle: () => i18n.translate( 'Social Media Automation' ),
+		getTitle: () => translate( 'Social Media Automation' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Re-share previously published content on social media, or schedule new shares in advance.'
 			),
 	},
@@ -887,67 +870,65 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_SEARCH ]: {
 		getSlug: () => constants.FEATURE_SEARCH,
 		getTitle: () =>
-			i18n.translate( '{{strong}}Enhanced{{/strong}} Site-wide Search', {
+			translate( '{{strong}}Enhanced{{/strong}} Site-wide Search', {
 				components: {
 					strong: <strong />,
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
-				'Fast, relevant search results with custom filtering, powered by Elasticsearch.'
-			),
+			translate( 'Fast, relevant search results with custom filtering, powered by Elasticsearch.' ),
 	},
 
 	[ constants.FEATURE_ACCEPT_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_ACCEPT_PAYMENTS,
-		getTitle: () => i18n.translate( 'Accept Payments in 60+ Countries' ),
+		getTitle: () => translate( 'Accept Payments in 60+ Countries' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Built-in payment processing from leading providers like Stripe, PayPal, and more. Accept payments from customers all over the world.'
 			),
 	},
 
 	[ constants.FEATURE_SHIPPING_CARRIERS ]: {
 		getSlug: () => constants.FEATURE_SHIPPING_CARRIERS,
-		getTitle: () => i18n.translate( 'Integrations with Top Shipping Carriers' ),
+		getTitle: () => translate( 'Integrations with Top Shipping Carriers' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Ship physical products in a snap - show live rates from shipping carriers like UPS and other shipping options.'
 			),
 	},
 
 	[ constants.FEATURE_UNLIMITED_PRODUCTS_SERVICES ]: {
 		getSlug: () => constants.FEATURE_UNLIMITED_PRODUCTS_SERVICES,
-		getTitle: () => i18n.translate( 'Unlimited Products or Services' ),
+		getTitle: () => translate( 'Unlimited Products or Services' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Grow your store as big as you want with the ability to add and sell unlimited products and services.'
 			),
 	},
 
 	[ constants.FEATURE_ECOMMERCE_MARKETING ]: {
 		getSlug: () => constants.FEATURE_ECOMMERCE_MARKETING,
-		getTitle: () => i18n.translate( 'eCommerce Marketing Tools' ),
+		getTitle: () => translate( 'eCommerce Marketing Tools' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Optimize your store for sales by adding in email and social integrations with Facebook and Mailchimp, and more.'
 			),
 	},
 
 	[ constants.FEATURE_PREMIUM_CUSTOMIZABE_THEMES ]: {
 		getSlug: () => constants.FEATURE_PREMIUM_CUSTOMIZABE_THEMES,
-		getTitle: () => i18n.translate( 'Premium Customizable Starter Themes' ),
+		getTitle: () => translate( 'Premium Customizable Starter Themes' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Quickly get up and running with a beautiful store theme and additional design options that you can easily make your own.'
 			),
 	},
 
 	[ constants.FEATURE_ALL_BUSINESS_FEATURES ]: {
 		getSlug: () => constants.FEATURE_ALL_BUSINESS_FEATURES,
-		getTitle: () => i18n.translate( 'All Business Features' ),
+		getTitle: () => translate( 'All Business Features' ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Including the ability to upload plugins and themes, priority support, advanced monetization options, and unlimited premium themes.'
 			),
 	},

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1,11 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
 import { compact, includes } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,20 +11,20 @@ import i18n from 'i18n-calypso';
 import { isEnabled } from 'config';
 import * as constants from './constants';
 
-const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
-const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
+const WPComGetBillingTimeframe = () => translate( 'per month, billed annually' );
+const WPComGetBiennialBillingTimeframe = () => translate( '/month, billed every two years' );
 
 const getPlanBloggerDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_BLOGGER,
-	getTitle: () => i18n.translate( 'Blogger' ),
+	getTitle: () => translate( 'Blogger' ),
 	// @TODO not updating copy for now, we need to update it after the first round of design {{{
-	getAudience: () => i18n.translate( 'Best for bloggers' ),
-	getBlogAudience: () => i18n.translate( 'Best for bloggers' ),
-	getPortfolioAudience: () => i18n.translate( 'Best for bloggers' ),
-	getStoreAudience: () => i18n.translate( 'Best for bloggers' ),
+	getAudience: () => translate( 'Best for bloggers' ),
+	getBlogAudience: () => translate( 'Best for bloggers' ),
+	getPortfolioAudience: () => translate( 'Best for bloggers' ),
+	getStoreAudience: () => translate( 'Best for bloggers' ),
 	getDescription: () =>
-		i18n.translate(
+		translate(
 			'{{strong}}Best for Bloggers:{{/strong}} Brand your blog with a custom .blog domain name, and remove all WordPress.com advertising. Receive additional storage space and email support.',
 			{
 				components: {
@@ -37,7 +35,7 @@ const getPlanBloggerDetails = () => ( {
 			}
 		),
 	getShortDescription: () =>
-		i18n.translate(
+		translate(
 			'Brand your blog with a custom .blog domain name, and remove all WordPress.com advertising. Receive additional storage space and email support.'
 		),
 	// }}}
@@ -73,13 +71,13 @@ const getPlanBloggerDetails = () => ( {
 const getPlanPersonalDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_PERSONAL,
-	getTitle: () => i18n.translate( 'Personal' ),
-	getAudience: () => i18n.translate( 'Best for personal use' ),
-	getBlogAudience: () => i18n.translate( 'Best for personal use' ),
-	getPortfolioAudience: () => i18n.translate( 'Best for personal use' ),
-	getStoreAudience: () => i18n.translate( 'Best for personal use' ),
+	getTitle: () => translate( 'Personal' ),
+	getAudience: () => translate( 'Best for personal use' ),
+	getBlogAudience: () => translate( 'Best for personal use' ),
+	getPortfolioAudience: () => translate( 'Best for personal use' ),
+	getStoreAudience: () => translate( 'Best for personal use' ),
 	getDescription: () =>
-		i18n.translate(
+		translate(
 			'{{strong}}Best for Personal Use:{{/strong}} Boost your' +
 				' website with a custom domain name, and remove all WordPress.com advertising. ' +
 				'Get access to high-quality email and live chat support.',
@@ -92,7 +90,7 @@ const getPlanPersonalDetails = () => ( {
 			}
 		),
 	getShortDescription: () =>
-		i18n.translate(
+		translate(
 			'Boost your website with a custom domain name, and remove all WordPress.com advertising. ' +
 				'Get access to high-quality email and live chat support.'
 		),
@@ -128,13 +126,13 @@ const getPlanPersonalDetails = () => ( {
 const getPlanEcommerceDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_ECOMMERCE,
-	getTitle: () => i18n.translate( 'eCommerce' ),
-	getAudience: () => i18n.translate( 'Best for online stores' ),
-	getBlogAudience: () => i18n.translate( 'Best for online stores' ),
-	getPortfolioAudience: () => i18n.translate( 'Best for online stores' ),
-	getStoreAudience: () => i18n.translate( 'Best for online stores' ),
+	getTitle: () => translate( 'eCommerce' ),
+	getAudience: () => translate( 'Best for online stores' ),
+	getBlogAudience: () => translate( 'Best for online stores' ),
+	getPortfolioAudience: () => translate( 'Best for online stores' ),
+	getStoreAudience: () => translate( 'Best for online stores' ),
 	getDescription: () => {
-		return i18n.translate(
+		return translate(
 			'{{strong}}Best for Online Stores:{{/strong}} Sell products or services with this powerful, ' +
 				'all-in-one online store experience. This plan includes premium integrations and is extendable, ' +
 				'so it’ll grow with you as your business grows.',
@@ -148,13 +146,13 @@ const getPlanEcommerceDetails = () => ( {
 		);
 	},
 	getShortDescription: () =>
-		i18n.translate(
+		translate(
 			'Sell products or services with this powerful, ' +
 				'all-in-one online store experience. This plan includes premium integrations and is extendable, ' +
 				'so it’ll grow with you as your business grows.'
 		),
 	getTagline: () =>
-		i18n.translate(
+		translate(
 			'Learn more about everything included with eCommerce and take advantage of its powerful marketplace features.'
 		),
 	getPlanCompareFeatures: () =>
@@ -217,13 +215,13 @@ const getPlanEcommerceDetails = () => ( {
 const getPlanPremiumDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_PREMIUM,
-	getTitle: () => i18n.translate( 'Premium' ),
-	getAudience: () => i18n.translate( 'Best for freelancers' ),
-	getBlogAudience: () => i18n.translate( 'Best for freelancers' ),
-	getPortfolioAudience: () => i18n.translate( 'Best for freelancers' ),
-	getStoreAudience: () => i18n.translate( 'Best for freelancers' ),
+	getTitle: () => translate( 'Premium' ),
+	getAudience: () => translate( 'Best for freelancers' ),
+	getBlogAudience: () => translate( 'Best for freelancers' ),
+	getPortfolioAudience: () => translate( 'Best for freelancers' ),
+	getStoreAudience: () => translate( 'Best for freelancers' ),
 	getDescription: () =>
-		i18n.translate(
+		translate(
 			'{{strong}}Best for Freelancers:{{/strong}}' +
 				' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
 				' and the ability to monetize your site with ads.',
@@ -236,7 +234,7 @@ const getPlanPremiumDetails = () => ( {
 			}
 		),
 	getShortDescription: () =>
-		i18n.translate(
+		translate(
 			'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
 				' and the ability to monetize your site with ads.'
 		),
@@ -284,13 +282,13 @@ const getPlanPremiumDetails = () => ( {
 const getPlanBusinessDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_BUSINESS,
-	getTitle: () => i18n.translate( 'Business' ),
-	getAudience: () => i18n.translate( 'Best for small businesses' ),
-	getBlogAudience: () => i18n.translate( 'Best for small businesses' ),
-	getPortfolioAudience: () => i18n.translate( 'Best for small businesses' ),
-	getStoreAudience: () => i18n.translate( 'The plan for small businesses' ),
+	getTitle: () => translate( 'Business' ),
+	getAudience: () => translate( 'Best for small businesses' ),
+	getBlogAudience: () => translate( 'Best for small businesses' ),
+	getPortfolioAudience: () => translate( 'Best for small businesses' ),
+	getStoreAudience: () => translate( 'The plan for small businesses' ),
 	getDescription: () =>
-		i18n.translate(
+		translate(
 			'{{strong}}Best for Small Businesses:{{/strong}} Power your' +
 				' business website with custom plugins and themes, unlimited premium and business theme templates,' +
 				' Google Analytics support, 200 GB' +
@@ -304,13 +302,13 @@ const getPlanBusinessDetails = () => ( {
 			}
 		),
 	getShortDescription: () =>
-		i18n.translate(
+		translate(
 			'Power your business website with custom plugins and themes, unlimited premium and business theme templates,' +
 				' Google Analytics support, 200 GB' +
 				' storage, and the ability to remove WordPress.com branding.'
 		),
 	getTagline: () =>
-		i18n.translate(
+		translate(
 			'Learn more about everything included with Business and take advantage of its professional features.'
 		),
 	getPlanCompareFeatures: () =>
@@ -372,16 +370,16 @@ export const PLANS_LIST = {
 		group: constants.GROUP_WPCOM,
 		type: constants.TYPE_FREE,
 		term: constants.TERM_ANNUALLY,
-		getTitle: () => i18n.translate( 'Free' ),
-		getAudience: () => i18n.translate( 'Best for students' ),
-		getBlogAudience: () => i18n.translate( 'Best for students' ),
-		getPortfolioAudience: () => i18n.translate( 'Best for students' ),
-		getStoreAudience: () => i18n.translate( 'Best for students' ),
+		getTitle: () => translate( 'Free' ),
+		getAudience: () => translate( 'Best for students' ),
+		getBlogAudience: () => translate( 'Best for students' ),
+		getPortfolioAudience: () => translate( 'Best for students' ),
+		getStoreAudience: () => translate( 'Best for students' ),
 		getProductId: () => 1,
 		getStoreSlug: () => constants.PLAN_FREE,
 		getPathSlug: () => 'beginner',
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Get a free website and be on your way to publishing your ' +
 					'first post in less than five minutes.'
 			),
@@ -409,7 +407,7 @@ export const PLANS_LIST = {
 			constants.FEATURE_WP_SUBDOMAIN_SIGNUP,
 			constants.FEATURE_FREE_THEMES_SIGNUP,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'for life' ),
+		getBillingTimeFrame: () => translate( 'for life' ),
 	},
 
 	[ constants.PLAN_BLOGGER ]: {
@@ -509,7 +507,7 @@ export const PLANS_LIST = {
 	[ constants.PLAN_BUSINESS_MONTHLY ]: {
 		...getPlanBusinessDetails(),
 		term: constants.TERM_MONTHLY,
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		getBillingTimeFrame: () => translate( 'per month, billed monthly' ),
 		availableFor: plan =>
 			isEnabled( 'upgrades/wpcom-monthly-plans' ) &&
 			includes(
@@ -631,16 +629,16 @@ export const PLANS_LIST = {
 		term: constants.TERM_ANNUALLY,
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_FREE,
-		getTitle: () => i18n.translate( 'Free' ),
-		getAudience: () => i18n.translate( 'Best for students' ),
+		getTitle: () => translate( 'Free' ),
+		getAudience: () => translate( 'Best for students' ),
 		getProductId: () => 2002,
 		getStoreSlug: () => constants.PLAN_JETPACK_FREE,
 		getTagline: () =>
-			i18n.translate(
+			translate(
 				'Upgrade your site to access additional features, including spam protection, backups, and priority support.'
 			),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'The features most needed by WordPress sites' +
 					' — perfectly packaged and optimized for everyone.'
 			),
@@ -658,17 +656,17 @@ export const PLANS_LIST = {
 			constants.FEATURE_TRAFFIC_TOOLS,
 			constants.FEATURE_BLANK,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'for life' ),
-		getSignupBillingTimeFrame: () => i18n.translate( 'for life' ),
+		getBillingTimeFrame: () => translate( 'for life' ),
+		getSignupBillingTimeFrame: () => translate( 'for life' ),
 	},
 
 	[ constants.PLAN_JETPACK_PREMIUM ]: {
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_PREMIUM,
 		term: constants.TERM_ANNUALLY,
-		getTitle: () => i18n.translate( 'Premium' ),
-		getAudience: () => i18n.translate( 'Best for small businesses' ),
-		getSubtitle: () => i18n.translate( 'Protection, speed, and revenue.' ),
+		getTitle: () => translate( 'Premium' ),
+		getAudience: () => translate( 'Best for small businesses' ),
+		getSubtitle: () => translate( 'Protection, speed, and revenue.' ),
 		getProductId: () => 2000,
 		getStoreSlug: () => constants.PLAN_JETPACK_PREMIUM,
 		availableFor: plan =>
@@ -683,12 +681,12 @@ export const PLANS_LIST = {
 			),
 		getPathSlug: () => 'premium',
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Comprehensive, automated scanning for security vulnerabilities, ' +
 					'fast video hosting, and marketing automation.'
 			),
 		getTagline: () =>
-			i18n.translate(
+			translate(
 				'Your site is being secured and you have access to marketing tools and priority support.'
 			),
 		getPlanCompareFeatures: () =>
@@ -718,16 +716,16 @@ export const PLANS_LIST = {
 				constants.FEATURE_ADVANCED_SEO,
 				constants.FEATURE_ALL_PERSONAL_FEATURES_JETPACK,
 			] ),
-		getBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getBillingTimeFrame: () => translate( 'per year' ),
+		getSignupBillingTimeFrame: () => translate( 'per year' ),
 	},
 
 	[ constants.PLAN_JETPACK_PREMIUM_MONTHLY ]: {
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_PREMIUM,
 		term: constants.TERM_MONTHLY,
-		getTitle: () => i18n.translate( 'Premium' ),
-		getAudience: () => i18n.translate( 'Best for small businesses' ),
+		getTitle: () => translate( 'Premium' ),
+		getAudience: () => translate( 'Best for small businesses' ),
 		getProductId: () => 2003,
 		getStoreSlug: () => constants.PLAN_JETPACK_PREMIUM_MONTHLY,
 		getPathSlug: () => 'premium-monthly',
@@ -741,12 +739,12 @@ export const PLANS_LIST = {
 				plan
 			),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Comprehensive, automated scanning for security vulnerabilities, ' +
 					'fast video hosting, and marketing automation.'
 			),
 		getTagline: () =>
-			i18n.translate(
+			translate(
 				'Your site is being secured and you have access to marketing tools and priority support.'
 			),
 		getPlanCompareFeatures: () =>
@@ -776,30 +774,28 @@ export const PLANS_LIST = {
 				constants.FEATURE_ADVANCED_SEO,
 				constants.FEATURE_ALL_PERSONAL_FEATURES_JETPACK,
 			] ),
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
-		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
+		getBillingTimeFrame: () => translate( 'per month, billed monthly' ),
+		getSignupBillingTimeFrame: () => translate( 'per month' ),
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL ]: {
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_PERSONAL,
 		term: constants.TERM_ANNUALLY,
-		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => i18n.translate( 'Best for hobbyists' ),
+		getTitle: () => translate( 'Personal' ),
+		getAudience: () => translate( 'Best for hobbyists' ),
 		getProductId: () => 2005,
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL,
 		availableFor: plan =>
 			includes( [ constants.PLAN_JETPACK_FREE, constants.PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
 		getPathSlug: () => 'jetpack-personal',
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.'
 			),
 		getTagline: () =>
-			i18n.translate(
-				'Your data is being securely backed up and you have access to priority support.'
-			),
+			translate( 'Your data is being securely backed up and you have access to priority support.' ),
 		getPlanCompareFeatures: () => [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -817,29 +813,27 @@ export const PLANS_LIST = {
 			constants.FEATURE_PREMIUM_SUPPORT,
 			constants.FEATURE_ALL_FREE_FEATURES_JETPACK,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getBillingTimeFrame: () => translate( 'per year' ),
+		getSignupBillingTimeFrame: () => translate( 'per year' ),
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL_MONTHLY ]: {
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_PERSONAL,
 		term: constants.TERM_MONTHLY,
-		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => i18n.translate( 'Best for hobbyists' ),
+		getTitle: () => translate( 'Personal' ),
+		getAudience: () => translate( 'Best for hobbyists' ),
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL_MONTHLY,
 		getProductId: () => 2006,
 		getPathSlug: () => 'jetpack-personal-monthly',
 		availableFor: plan => includes( [ constants.PLAN_JETPACK_FREE ], plan ),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.'
 			),
 		getTagline: () =>
-			i18n.translate(
-				'Your data is being securely backed up and you have access to priority support.'
-			),
+			translate( 'Your data is being securely backed up and you have access to priority support.' ),
 		getPlanCompareFeatures: () => [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -857,16 +851,16 @@ export const PLANS_LIST = {
 			constants.FEATURE_PREMIUM_SUPPORT,
 			constants.FEATURE_ALL_FREE_FEATURES_JETPACK,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
-		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
+		getBillingTimeFrame: () => translate( 'per month, billed monthly' ),
+		getSignupBillingTimeFrame: () => translate( 'per month' ),
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS ]: {
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_BUSINESS,
 		term: constants.TERM_ANNUALLY,
-		getTitle: () => i18n.translate( 'Professional' ),
-		getAudience: () => i18n.translate( 'Best for organizations' ),
+		getTitle: () => translate( 'Professional' ),
+		getAudience: () => translate( 'Best for organizations' ),
 		getStoreSlug: () => constants.PLAN_JETPACK_BUSINESS,
 		getProductId: () => 2001,
 		availableFor: plan =>
@@ -883,12 +877,11 @@ export const PLANS_LIST = {
 			),
 		getPathSlug: () => 'professional',
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'The most powerful WordPress sites: real-time backups, ' +
 					'enhanced search, and unlimited premium themes.'
 			),
-		getTagline: () =>
-			i18n.translate( 'You have the full suite of security and performance tools.' ),
+		getTagline: () => translate( 'You have the full suite of security and performance tools.' ),
 		getPlanCompareFeatures: () =>
 			compact( [
 				// pay attention to ordering, shared features should align on /plan page
@@ -917,17 +910,17 @@ export const PLANS_LIST = {
 				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 				constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 			] ),
-		getBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getBillingTimeFrame: () => translate( 'per year' ),
+		getSignupBillingTimeFrame: () => translate( 'per year' ),
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS_MONTHLY ]: {
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_BUSINESS,
 		term: constants.TERM_MONTHLY,
-		getTitle: () => i18n.translate( 'Professional' ),
-		getAudience: () => i18n.translate( 'Best for organizations' ),
-		getSubtitle: () => i18n.translate( 'Ultimate security and traffic tools.' ),
+		getTitle: () => translate( 'Professional' ),
+		getAudience: () => translate( 'Best for organizations' ),
+		getSubtitle: () => translate( 'Ultimate security and traffic tools.' ),
 		getProductId: () => 2004,
 		getStoreSlug: () => constants.PLAN_JETPACK_BUSINESS_MONTHLY,
 		getPathSlug: () => 'professional-monthly',
@@ -943,12 +936,11 @@ export const PLANS_LIST = {
 				plan
 			),
 		getDescription: () =>
-			i18n.translate(
+			translate(
 				'The most powerful WordPress sites: real-time backups, ' +
 					'enhanced search, and unlimited premium themes.'
 			),
-		getTagline: () =>
-			i18n.translate( 'You have the full suite of security and performance tools.' ),
+		getTagline: () => translate( 'You have the full suite of security and performance tools.' ),
 		getPlanCompareFeatures: () =>
 			compact( [
 				// pay attention to ordering, shared features should align on /plan page
@@ -976,8 +968,8 @@ export const PLANS_LIST = {
 				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 				constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 			] ),
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
-		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
+		getBillingTimeFrame: () => translate( 'per month, billed monthly' ),
+		getSignupBillingTimeFrame: () => translate( 'per month' ),
 	},
 };
 

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get, uniqBy } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -135,25 +132,19 @@ export default {
 				if ( translateArg.isMultiSite ) {
 					switch ( combination ) {
 						case '1 site 1 plugin':
-							return i18n.translate( 'Successfully installed %(plugin)s on %(site)s.', {
+							return translate( 'Successfully installed %(plugin)s on %(site)s.', {
 								args: translateArg,
 							} );
 						case '1 site n plugins':
-							return i18n.translate(
-								'Successfully installed %(numberOfPlugins)d plugins on %(site)s.',
-								{
-									args: translateArg,
-								}
-							);
+							return translate( 'Successfully installed %(numberOfPlugins)d plugins on %(site)s.', {
+								args: translateArg,
+							} );
 						case 'n sites 1 plugin':
-							return i18n.translate(
-								'Successfully installed %(plugin)s on %(numberOfSites)d sites.',
-								{
-									args: translateArg,
-								}
-							);
+							return translate( 'Successfully installed %(plugin)s on %(numberOfSites)d sites.', {
+								args: translateArg,
+							} );
 						case 'n sites n plugins':
-							return i18n.translate(
+							return translate(
 								'Successfully installed %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 								{
 									args: translateArg,
@@ -163,25 +154,25 @@ export default {
 				}
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully installed and activated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully installed and activated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully installed and activated %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'Successfully installed and activated %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully installed and activated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -193,22 +184,19 @@ export default {
 			case 'REMOVE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully removed %(plugin)s on %(site)s.', {
+						return translate( 'Successfully removed %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully removed %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully removed %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Successfully removed %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Successfully removed %(plugin)s on %(numberOfSites)d sites.', {
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully removed %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -219,22 +207,19 @@ export default {
 			case 'UPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully updated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully updated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully updated %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully updated %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Successfully updated %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Successfully updated %(plugin)s on %(numberOfSites)d sites.', {
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully updated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -245,25 +230,19 @@ export default {
 			case 'ACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully activated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully activated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully activated %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully activated %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Successfully activated %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully activated %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully activated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -274,25 +253,19 @@ export default {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully deactivated %(plugin)s on %(site)s.', {
+						return translate( 'Successfully deactivated %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Successfully deactivated %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully deactivated %(numberOfPlugins)d plugins on %(site)s.', {
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Successfully deactivated %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully deactivated %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully deactivated %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -303,25 +276,25 @@ export default {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Successfully enabled autoupdates for %(plugin)s on %(site)s.', {
+						return translate( 'Successfully enabled autoupdates for %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully enabled autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'Successfully enabled autoupdates for %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully enabled autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -332,28 +305,25 @@ export default {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate(
-							'Successfully disabled autoupdates for %(plugin)s on %(site)s.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Successfully disabled autoupdates for %(plugin)s on %(site)s.', {
+							args: translateArg,
+						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully disabled autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'Successfully disabled autoupdates for %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Successfully disabled autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -362,7 +332,7 @@ export default {
 				}
 				break;
 			case 'PLUGIN_UPLOAD':
-				return i18n.translate( "You've successfully installed the %(plugin)s plugin.", {
+				return translate( "You've successfully installed the %(plugin)s plugin.", {
 					args: translateArg,
 				} );
 		}
@@ -373,22 +343,22 @@ export default {
 			case 'INSTALL_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Installing %(plugin)s on %(site)s.', {
+						return translate( 'Installing %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Installing %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Installing %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Installing %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Installing %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Installing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -400,70 +370,64 @@ export default {
 			case 'REMOVE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Removing %(plugin)s on %(site)s.', { args: translateArg } );
+						return translate( 'Removing %(plugin)s on %(site)s.', { args: translateArg } );
 					case '1 site n plugins':
-						return i18n.translate( 'Removing %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Removing %(numberOfPlugins)d plugins on %(site)s.', {
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Removing %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Removing %(plugin)s on %(numberOfSites)d sites.', {
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
-							'Removing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Removing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 				}
 				break;
 			case 'UPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Updating %(plugin)s on %(site)s.', {
+						return translate( 'Updating %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Updating %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Updating %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Updating %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Updating %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
-							'Updating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Updating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 				}
 				break;
 			case 'ACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Activating %(plugin)s on %(site)s.', {
+						return translate( 'Activating %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Activating %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Activating %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Activating %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Activating %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Activating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -475,22 +439,22 @@ export default {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Deactivating %(plugin)s on %(site)s', {
+						return translate( 'Deactivating %(plugin)s on %(site)s', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate( 'Deactivating %(numberOfPlugins)d plugins on %(site)s.', {
+						return translate( 'Deactivating %(numberOfPlugins)d plugins on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites 1 plugin':
-						return i18n.translate( 'Deactivating %(plugin)s on %(numberOfSites)d sites.', {
+						return translate( 'Deactivating %(plugin)s on %(numberOfSites)d sites.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Deactivating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -502,28 +466,22 @@ export default {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Enabling autoupdates for %(plugin)s on %(site)s.', {
+						return translate( 'Enabling autoupdates for %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
-							'Enabling autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Enabling autoupdates for %(numberOfPlugins)d plugins on %(site)s.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Enabling autoupdates for %(plugin)s on %(numberOfSites)d sites.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Enabling autoupdates for %(plugin)s on %(numberOfSites)d sites.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Enabling autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -535,12 +493,12 @@ export default {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						return i18n.translate( 'Disabling autoupdates for %(plugin)s on %(site)s.', {
+						return translate( 'Disabling autoupdates for %(plugin)s on %(site)s.', {
 							context: 'In progress message',
 							args: translateArg,
 						} );
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'Disabling autoupdates for %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								context: 'In progress message',
@@ -548,15 +506,12 @@ export default {
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'Disabling autoupdates for %(plugin)s on %(numberOfSites)d sites.',
-							{
-								context: 'In progress message',
-								args: translateArg,
-							}
-						);
+						return translate( 'Disabling autoupdates for %(plugin)s on %(numberOfSites)d sites.', {
+							context: 'In progress message',
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'Disabling autoupdates for %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								context: 'In progress message',
@@ -586,21 +541,21 @@ export default {
 			case 'INSTALL_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors installing %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors installing %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors installing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -611,21 +566,18 @@ export default {
 			case 'REMOVE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors removing %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'There were errors removing %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'There were errors removing %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors removing %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -636,21 +588,18 @@ export default {
 			case 'UPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors updating %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
-							'There were errors updating %(plugin)s on %(numberOfSites)d sites.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'There were errors updating %(plugin)s on %(numberOfSites)d sites.', {
+							args: translateArg,
+						} );
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors updating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -661,21 +610,21 @@ export default {
 			case 'ACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors activating %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors activating %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors activating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -686,21 +635,21 @@ export default {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors deactivating %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors deactivating %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors deactivating %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -711,21 +660,21 @@ export default {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors enabling autoupdates %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors enabling autoupdates %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors enabling autoupdates %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -736,21 +685,21 @@ export default {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors disabling autoupdates %(numberOfPlugins)d plugins on %(site)s.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites 1 plugin':
-						return i18n.translate(
+						return translate(
 							'There were errors disabling autoupdates %(plugin)s on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
 							}
 						);
 					case 'n sites n plugins':
-						return i18n.translate(
+						return translate(
 							'There were errors disabling autoupdates %(numberOfPlugins)d plugins on %(numberOfSites)d sites.',
 							{
 								args: translateArg,
@@ -759,7 +708,7 @@ export default {
 				}
 				break;
 			case 'RECEIVE_PLUGINS':
-				return i18n.translate(
+				return translate(
 					'Error fetching plugins on %(numberOfSites)d site.',
 					'Error fetching plugins on %(numberOfSites)d sites.',
 					{
@@ -773,68 +722,68 @@ export default {
 	additionalExplanation( error_code ) {
 		switch ( error_code ) {
 			case 'no_package':
-				return i18n.translate( "Plugin doesn't exist in the plugin repo." );
+				return translate( "Plugin doesn't exist in the plugin repo." );
 
 			case 'resource_not_found':
-				return i18n.translate( 'The site could not be reached.' );
+				return translate( 'The site could not be reached.' );
 
 			case 'download_failed':
-				return i18n.translate( 'Download failed.' );
+				return translate( 'Download failed.' );
 
 			case 'plugin_already_installed':
-				return i18n.translate( 'Plugin is already installed.' );
+				return translate( 'Plugin is already installed.' );
 
 			case 'incompatible_archive':
-				return i18n.translate( 'Incompatible Archive. The package could not be installed.' );
+				return translate( 'Incompatible Archive. The package could not be installed.' );
 
 			case 'empty_archive_pclzip':
-				return i18n.translate( 'Empty archive.' );
+				return translate( 'Empty archive.' );
 
 			case 'disk_full_unzip_file':
-				return i18n.translate( 'Could not copy files. You may have run out of disk space.' );
+				return translate( 'Could not copy files. You may have run out of disk space.' );
 
 			case 'mkdir_failed_ziparchive':
 			case 'mkdir_failed_pclzip':
-				return i18n.translate( 'Could not create directory.' );
+				return translate( 'Could not create directory.' );
 
 			case 'copy_failed_pclzip':
-				return i18n.translate( 'Could not copy file.' );
+				return translate( 'Could not copy file.' );
 
 			case 'md5_mismatch':
-				return i18n.translate( "The checksum of the files don't match." );
+				return translate( "The checksum of the files don't match." );
 
 			case 'bad_request':
-				return i18n.translate( 'Invalid Data provided.' );
+				return translate( 'Invalid Data provided.' );
 
 			case 'fs_unavailable':
-				return i18n.translate( 'Could not access filesystem.' );
+				return translate( 'Could not access filesystem.' );
 
 			case 'fs_error':
-				return i18n.translate( 'Filesystem error.' );
+				return translate( 'Filesystem error.' );
 
 			case 'fs_no_root_dir':
-				return i18n.translate( 'Unable to locate WordPress Root directory.' );
+				return translate( 'Unable to locate WordPress Root directory.' );
 
 			case 'fs_no_content_dir':
-				return i18n.translate( 'Unable to locate WordPress Content directory (wp-content).' );
+				return translate( 'Unable to locate WordPress Content directory (wp-content).' );
 
 			case 'fs_no_plugins_dir':
-				return i18n.translate( 'Unable to locate WordPress Plugin directory.' );
+				return translate( 'Unable to locate WordPress Plugin directory.' );
 
 			case 'fs_no_folder':
-				return i18n.translate( 'Unable to locate needed folder.' );
+				return translate( 'Unable to locate needed folder.' );
 
 			case 'no_files':
-				return i18n.translate( 'The package contains no files.' );
+				return translate( 'The package contains no files.' );
 
 			case 'folder_exists':
-				return i18n.translate( 'Destination folder already exists.' );
+				return translate( 'Destination folder already exists.' );
 
 			case 'mkdir_failed':
-				return i18n.translate( 'Could not create directory.' );
+				return translate( 'Could not create directory.' );
 
 			case 'files_not_writable':
-				return i18n.translate(
+				return translate(
 					'The update cannot be installed because we will be unable to copy some files. This is usually due to inconsistent file permissions.'
 				);
 		}
@@ -848,7 +797,7 @@ export default {
 			case 'INSTALL_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error installing %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
@@ -858,14 +807,14 @@ export default {
 					default:
 						if ( additionalExplanation ) {
 							translateArg.additionalExplanation = additionalExplanation;
-							return i18n.translate(
+							return translate(
 								'Error installing %(plugin)s on %(site)s. %(additionalExplanation)s',
 								{
 									args: translateArg,
 								}
 							);
 						}
-						return i18n.translate( 'An error occurred while installing %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while installing %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -873,14 +822,11 @@ export default {
 			case 'REMOVE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
-							'Error removing %(plugin)s on %(site)s, remote management is off.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Error removing %(plugin)s on %(site)s, remote management is off.', {
+							args: translateArg,
+						} );
 					default:
-						return i18n.translate( 'An error occurred while removing %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while removing %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -888,23 +834,20 @@ export default {
 			case 'UPDATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
-							'Error updating %(plugin)s on %(site)s, remote management is off.',
-							{
-								args: translateArg,
-							}
-						);
+						return translate( 'Error updating %(plugin)s on %(site)s, remote management is off.', {
+							args: translateArg,
+						} );
 					default:
 						if ( additionalExplanation ) {
 							translateArg.additionalExplanation = additionalExplanation;
-							return i18n.translate(
+							return translate(
 								'Error updating %(plugin)s on %(site)s. %(additionalExplanation)s',
 								{
 									args: translateArg,
 								}
 							);
 						}
-						return i18n.translate( 'An error occurred while updating %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while updating %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -912,14 +855,14 @@ export default {
 			case 'ACTIVATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error activating %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate( 'An error occurred while activating %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while activating %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -927,14 +870,14 @@ export default {
 			case 'DEACTIVATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error deactivating %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate( 'An error occurred while deactivating %(plugin)s on %(site)s.', {
+						return translate( 'An error occurred while deactivating %(plugin)s on %(site)s.', {
 							args: translateArg,
 						} );
 				}
@@ -942,14 +885,14 @@ export default {
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error enabling autoupdates for %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate(
+						return translate(
 							'An error occurred while enabling autoupdates for %(plugin)s on %(site)s.',
 							{
 								args: translateArg,
@@ -960,14 +903,14 @@ export default {
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				switch ( sampleLog.error.error ) {
 					case 'unauthorized_full_access':
-						return i18n.translate(
+						return translate(
 							'Error disabling autoupdates for %(plugin)s on %(site)s, remote management is off.',
 							{
 								args: translateArg,
 							}
 						);
 					default:
-						return i18n.translate(
+						return translate(
 							'An error occurred while disabling autoupdates for %(plugin)s on %(site)s.',
 							{
 								args: translateArg,
@@ -976,7 +919,7 @@ export default {
 				}
 
 			case 'RECEIVE_PLUGINS':
-				return i18n.translate( 'Error fetching plugins on %(site)s.', {
+				return translate( 'Error fetching plugins on %(site)s.', {
 					args: translateArg,
 				} );
 		}
@@ -988,7 +931,7 @@ export default {
 		}
 		log = log.length ? log[ 0 ] : log;
 		if ( log.error.error === 'unauthorized_full_access' ) {
-			return i18n.translate( 'Turn On.' );
+			return translate( 'Turn On.' );
 		}
 		return null;
 	},
@@ -1019,7 +962,7 @@ export default {
 			return null;
 		}
 
-		return i18n.translate( 'Setup' );
+		return translate( 'Setup' );
 	},
 
 	getSuccessHref( log ) {

--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { forEach } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -49,7 +46,7 @@ export default function detectPolls( post, dom ) {
 					'<a target="_blank" rel="external noopener noreferrer" href="https://poll.fm/' +
 					pollId +
 					'">' +
-					i18n.translate( 'Take our poll' ) +
+					translate( 'Take our poll' ) +
 					'</a>';
 				noscript.parentNode.replaceChild( p, noscript );
 			}

--- a/client/lib/post-normalizer/rule-content-detect-surveys.js
+++ b/client/lib/post-normalizer/rule-content-detect-surveys.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { forEach } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export default function detectSurveys( post, dom ) {
 	if ( ! dom ) {
@@ -40,7 +38,7 @@ export default function detectSurveys( post, dom ) {
 			surveyDomain +
 			surveySlug +
 			'">' +
-			i18n.translate( 'Take our survey' ) +
+			translate( 'Take our survey' ) +
 			'</a>';
 
 		// Replace the .pd-embed div with the new paragraph

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -4,7 +4,7 @@
 import React, { Component, ComponentType } from 'react';
 import debugModule from 'debug';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { includes, without } from 'lodash';
 import { Subtract } from 'utility-types';
 
@@ -23,7 +23,7 @@ function warnIfChanged( event: BeforeUnloadEvent ) {
 		return;
 	}
 	debug( 'unsaved form changes detected' );
-	const beforeUnloadText = i18n.translate( 'You have unsaved changes.' );
+	const beforeUnloadText = translate( 'You have unsaved changes.' );
 	( event || window.event ).returnValue = beforeUnloadText;
 	return beforeUnloadText;
 }
@@ -121,7 +121,7 @@ function windowConfirm() {
 	if ( typeof window === 'undefined' ) {
 		return true;
 	}
-	const confirmText = i18n.translate(
+	const confirmText = translate(
 		'You have unsaved changes. Are you sure you want to leave this page?'
 	);
 	return window.confirm( confirmText );

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { camelCase } from 'lodash';
-import i18n from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,7 +17,7 @@ function createPurchaseObject( purchase ) {
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
 		mostRecentRenewDate: purchase.most_recent_renew_date,
 		mostRecentRenewMoment: purchase.most_recent_renew_date
-			? i18n.moment( purchase.most_recent_renew_date )
+			? moment( purchase.most_recent_renew_date )
 			: null,
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
 		canExplicitRenew: Boolean( purchase.can_explicit_renew ),
@@ -37,7 +34,7 @@ function createPurchaseObject( purchase ) {
 		domainRegistrationAgreementUrl: purchase.domain_registration_agreement_url || null,
 		error: null,
 		expiryDate: purchase.expiry_date,
-		expiryMoment: purchase.expiry_date ? i18n.moment( purchase.expiry_date ) : null,
+		expiryMoment: purchase.expiry_date ? moment( purchase.expiry_date ) : null,
 		expiryStatus: camelCase( purchase.expiry_status ),
 		includedDomain: purchase.included_domain,
 		includedDomainPurchaseAmount: purchase.included_domain_purchase_amount,
@@ -68,7 +65,7 @@ function createPurchaseObject( purchase ) {
 		renewDate: purchase.renew_date,
 		// only generate a moment if `renewDate` is present and positive
 		renewMoment:
-			purchase.renew_date && purchase.renew_date > '0' ? i18n.moment( purchase.renew_date ) : null,
+			purchase.renew_date && purchase.renew_date > '0' ? moment( purchase.renew_date ) : null,
 		saleAmount: purchase.sale_amount,
 		siteId: Number( purchase.blog_id ),
 		siteName: purchase.blogname,
@@ -88,9 +85,7 @@ function createPurchaseObject( purchase ) {
 				processor: purchase.payment_card_processor,
 				number: purchase.payment_details,
 				expiryDate: purchase.payment_expiry,
-				expiryMoment: purchase.payment_expiry
-					? i18n.moment( purchase.payment_expiry, 'MM/YY' )
-					: null,
+				expiryMoment: purchase.payment_expiry ? moment( purchase.payment_expiry, 'MM/YY' ) : null,
 			},
 		} );
 
@@ -99,7 +94,7 @@ function createPurchaseObject( purchase ) {
 
 	if ( 'paypal_direct' === purchase.payment_type ) {
 		object.payment.expiryMoment = purchase.payment_expiry
-			? i18n.moment( purchase.payment_expiry, 'MM/YY' )
+			? moment( purchase.payment_expiry, 'MM/YY' )
 			: null;
 	}
 

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { find, includes } from 'lodash';
 import moment from 'moment';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -389,19 +386,19 @@ function paymentLogoType( purchase ) {
 
 function purchaseType( purchase ) {
 	if ( isTheme( purchase ) ) {
-		return i18n.translate( 'Premium Theme' );
+		return translate( 'Premium Theme' );
 	}
 
 	if ( isConciergeSession( purchase ) ) {
-		return i18n.translate( 'One-on-one Support' );
+		return translate( 'One-on-one Support' );
 	}
 
 	if ( isPartnerPurchase( purchase ) ) {
-		return i18n.translate( 'Host Managed Plan' );
+		return translate( 'Host Managed Plan' );
 	}
 
 	if ( isPlan( purchase ) ) {
-		return i18n.translate( 'Site Plan' );
+		return translate( 'Site Plan' );
 	}
 
 	if ( isDomainRegistration( purchase ) ) {

--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -1,17 +1,15 @@
-/** @format **/
-
 /**
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { get } from 'lodash';
 
 // For now the site style step will determine which 'style pack' to use on pub/radcliffe-2
 export const siteStyleOptions = {
 	business: [
 		{
-			description: i18n.translate( 'A gutenberg-ready business variation.', {
+			description: translate( 'A gutenberg-ready business variation.', {
 				comment: 'A description of a WordPress theme style.',
 			} ),
 			id: 'modern',
@@ -31,7 +29,7 @@ export const siteStyleOptions = {
 			),
 		},
 		{
-			description: i18n.translate( 'A gutenberg-ready business variation.', {
+			description: translate( 'A gutenberg-ready business variation.', {
 				comment: 'A description of a WordPress theme style.',
 			} ),
 			id: 'sophisticated',
@@ -52,7 +50,7 @@ export const siteStyleOptions = {
 			),
 		},
 		{
-			description: i18n.translate( 'Simple, yet sophisticated, with subtle, elegant typography.', {
+			description: translate( 'Simple, yet sophisticated, with subtle, elegant typography.', {
 				comment: 'A description of a WordPress theme style.',
 			} ),
 			id: 'professional',
@@ -72,7 +70,7 @@ export const siteStyleOptions = {
 			),
 		},
 		{
-			description: i18n.translate( 'A gutenberg-ready business variation.', {
+			description: translate( 'A gutenberg-ready business variation.', {
 				comment: 'A description of a WordPress theme style.',
 			} ),
 			id: 'calm',

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -1,8 +1,7 @@
-/** @format **/
 /**
  * Exernal dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { find, get } from 'lodash';
 
 /**
@@ -13,31 +12,29 @@ const getSiteTypePropertyDefaults = propertyKey =>
 	get(
 		{
 			// General copy
-			siteMockupHelpTipCopy: i18n.translate(
+			siteMockupHelpTipCopy: translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."
 			),
-			siteMockupHelpTipCopyBottom: i18n.translate( 'Scroll back up to continue.' ),
-			siteMockupTitleFallback: i18n.translate( 'Your New Website' ),
+			siteMockupHelpTipCopyBottom: translate( 'Scroll back up to continue.' ),
+			siteMockupTitleFallback: translate( 'Your New Website' ),
 			// Site title step
-			siteTitleLabel: i18n.translate( 'Give your site a name' ),
-			siteTitleSubheader: i18n.translate(
+			siteTitleLabel: translate( 'Give your site a name' ),
+			siteTitleSubheader: translate(
 				'This will appear at the top of your site and can be changed at anytime.'
 			),
-			siteTitlePlaceholder: i18n.translate( 'default siteTitlePlaceholder' ),
+			siteTitlePlaceholder: translate( 'default siteTitlePlaceholder' ),
 			// Site topic step
-			siteTopicHeader: i18n.translate( 'What is your site about?' ),
-			siteTopicLabel: i18n.translate( 'What is your site about?' ),
-			siteTopicSubheader: i18n.translate(
+			siteTopicHeader: translate( 'What is your site about?' ),
+			siteTopicLabel: translate( 'What is your site about?' ),
+			siteTopicSubheader: translate(
 				"We'll add relevant content to your site to help you get started."
 			),
-			siteTopicInputPlaceholder: i18n.translate( 'Enter a topic or choose one from below.' ),
+			siteTopicInputPlaceholder: translate( 'Enter a topic or choose one from below.' ),
 			// Domains step
-			domainsStepHeader: i18n.translate( 'Give your site an address' ),
-			domainsStepSubheader: i18n.translate(
-				'Enter a keyword that describes your site to get started.'
-			),
+			domainsStepHeader: translate( 'Give your site an address' ),
+			domainsStepSubheader: translate( 'Enter a keyword that describes your site to get started.' ),
 			// Site styles step
-			siteStyleSubheader: i18n.translate(
+			siteStyleSubheader: translate(
 				'This will help you get started with a theme you might like. You can change it later.'
 			),
 		},
@@ -80,26 +77,26 @@ export function getAllSiteTypes() {
 			id: 2, // This value must correspond with its sibling in the /segments API results
 			slug: 'blog',
 			defaultVertical: 'blogging', // used to conduct a vertical search and grab a default vertical for the segment
-			label: i18n.translate( 'Blog' ),
-			description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
+			label: translate( 'Blog' ),
+			description: translate( 'Share and discuss ideas, updates, or creations.' ),
 			theme: 'pub/maywood',
 			designType: 'blog',
-			siteTitleLabel: i18n.translate( "Tell us your blog's name" ),
-			siteTitlePlaceholder: i18n.translate( "E.g., Stevie's blog " ),
-			siteTitleSubheader: i18n.translate(
+			siteTitleLabel: translate( "Tell us your blog's name" ),
+			siteTitlePlaceholder: translate( "E.g., Stevie's blog " ),
+			siteTitleSubheader: translate(
 				'This will appear at the top of your blog and can be changed at anytime.'
 			),
-			siteTopicHeader: i18n.translate( 'What is your blog about?' ),
-			siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
-			siteTopicSubheader: i18n.translate(
+			siteTopicHeader: translate( 'What is your blog about?' ),
+			siteTopicLabel: translate( 'What will your blog be about?' ),
+			siteTopicSubheader: translate(
 				"We'll add relevant content to your blog to help you get started."
 			),
-			siteMockupHelpTipCopy: i18n.translate(
+			siteMockupHelpTipCopy: translate(
 				'Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.'
 			),
-			siteMockupTitleFallback: i18n.translate( 'Your New Blog' ),
-			domainsStepHeader: i18n.translate( 'Give your blog an address' ),
-			domainsStepSubheader: i18n.translate(
+			siteMockupTitleFallback: translate( 'Your New Blog' ),
+			domainsStepHeader: translate( 'Give your blog an address' ),
+			domainsStepSubheader: translate(
 				"Enter your blog's name or some keywords that describe it to get started."
 			),
 		},
@@ -107,15 +104,15 @@ export function getAllSiteTypes() {
 			id: 1, // This value must correspond with its sibling in the /segments API results
 			slug: 'business',
 			defaultVertical: 'business',
-			label: i18n.translate( 'Business' ),
-			description: i18n.translate( 'Promote products and services.' ),
+			label: translate( 'Business' ),
+			description: translate( 'Promote products and services.' ),
 			theme: 'pub/maywood',
 			designType: 'page',
-			siteTitleLabel: i18n.translate( 'Tell us your business’s name' ),
-			siteTitlePlaceholder: i18n.translate( 'E.g., Vail Renovations' ),
-			siteTopicHeader: i18n.translate( 'What does your business do?' ),
-			siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
-			domainsStepSubheader: i18n.translate(
+			siteTitleLabel: translate( 'Tell us your business’s name' ),
+			siteTitlePlaceholder: translate( 'E.g., Vail Renovations' ),
+			siteTopicHeader: translate( 'What does your business do?' ),
+			siteTopicLabel: translate( 'What type of business do you have?' ),
+			domainsStepSubheader: translate(
 				"Enter your business's name or some keywords that describe it to get started."
 			),
 			customerType: 'business',
@@ -124,16 +121,16 @@ export function getAllSiteTypes() {
 			id: 4, // This value must correspond with its sibling in the /segments API results
 			slug: 'professional',
 			defaultVertical: 'designer',
-			label: i18n.translate( 'Professional' ),
-			description: i18n.translate( 'Showcase your portfolio and work.' ),
+			label: translate( 'Professional' ),
+			description: translate( 'Showcase your portfolio and work.' ),
 			theme: 'pub/maywood',
 			designType: 'portfolio',
-			siteTitleLabel: i18n.translate( 'What is your name?' ),
-			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
-			siteTopicHeader: i18n.translate( 'What type of work do you do?' ),
-			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
-			siteTopicInputPlaceholder: i18n.translate( 'Enter your job title or choose one from below.' ),
-			domainsStepSubheader: i18n.translate(
+			siteTitleLabel: translate( 'What is your name?' ),
+			siteTitlePlaceholder: translate( 'E.g., John Appleseed' ),
+			siteTopicHeader: translate( 'What type of work do you do?' ),
+			siteTopicLabel: translate( 'What type of work do you do?' ),
+			siteTopicInputPlaceholder: translate( 'Enter your job title or choose one from below.' ),
+			domainsStepSubheader: translate(
 				'Enter your name or some keywords that describe yourself to get started.'
 			),
 		},
@@ -141,14 +138,14 @@ export function getAllSiteTypes() {
 			id: 3, // This value must correspond with its sibling in the /segments API results
 			slug: 'online-store',
 			defaultVertical: 'business',
-			label: i18n.translate( 'Online store' ),
-			description: i18n.translate( 'Sell your collection of products online.' ),
+			label: translate( 'Online store' ),
+			description: translate( 'Sell your collection of products online.' ),
 			theme: 'pub/dara',
 			designType: 'store',
-			siteTitleLabel: i18n.translate( 'What is the name of your store?' ),
-			siteTitlePlaceholder: i18n.translate( "E.g., Mel's Diner" ),
-			siteTopicHeader: i18n.translate( 'What type of products do you sell?' ),
-			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
+			siteTitleLabel: translate( 'What is the name of your store?' ),
+			siteTitlePlaceholder: translate( "E.g., Mel's Diner" ),
+			siteTopicHeader: translate( 'What type of products do you sell?' ),
+			siteTopicLabel: translate( 'What type of products do you sell?' ),
 			customerType: 'business',
 			purchaseRequired: true,
 			forcePublicSite: true,

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { get } from 'lodash';
 import { withoutHttp } from 'lib/url';
 
@@ -43,12 +42,10 @@ export function getSiteFileModDisableReason( site, action = 'modifyFiles' ) {
 				action === 'autoupdateCore'
 			) {
 				if ( clue === 'has_no_file_system_write_access' ) {
-					return i18n.translate( 'The file permissions on this host prevent editing files.' );
+					return translate( 'The file permissions on this host prevent editing files.' );
 				}
 				if ( clue === 'disallow_file_mods' ) {
-					return i18n.translate(
-						'File modifications are explicitly disabled by a site administrator.'
-					);
+					return translate( 'File modifications are explicitly disabled by a site administrator.' );
 				}
 			}
 
@@ -56,13 +53,11 @@ export function getSiteFileModDisableReason( site, action = 'modifyFiles' ) {
 				( action === 'autoupdateFiles' || action === 'autoupdateCore' ) &&
 				clue === 'automatic_updater_disabled'
 			) {
-				return i18n.translate( 'Any autoupdates are explicitly disabled by a site administrator.' );
+				return translate( 'Any autoupdates are explicitly disabled by a site administrator.' );
 			}
 
 			if ( action === 'autoupdateCore' && clue === 'wp_auto_update_core_disabled' ) {
-				return i18n.translate(
-					'Core autoupdates are explicitly disabled by a site administrator.'
-				);
+				return translate( 'Core autoupdates are explicitly disabled by a site administrator.' );
 			}
 			return null;
 		} )

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -1,12 +1,16 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugModule from 'debug';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import {
+	getLocale,
+	setLocale,
+	reRenderTranslations,
+	registerTranslateHook,
+	registerComponentUpdateHook,
+	on as i18nOn,
+} from 'i18n-calypso';
 import { find, isUndefined } from 'lodash';
 
 /**
@@ -143,7 +147,7 @@ const communityTranslatorJumpstart = {
 	},
 
 	init( isUserSettingsReady ) {
-		const languageJson = i18n.getLocale() || { '': {} };
+		const languageJson = getLocale() || { '': {} };
 		const { localeSlug: localeCode, localeVariant } = languageJson[ '' ];
 
 		if ( localeCode && languageJson ) {
@@ -229,7 +233,7 @@ const communityTranslatorJumpstart = {
 		function activate() {
 			// Wrap DOM elements and then activate the translator
 			_shouldWrapTranslations = true;
-			i18n.reRenderTranslations();
+			reRenderTranslations();
 			window.communityTranslator.load();
 			debug( 'Translator activated' );
 			return true;
@@ -239,7 +243,7 @@ const communityTranslatorJumpstart = {
 			window.communityTranslator.unload();
 			// Remove all the data tags from the DOM
 			_shouldWrapTranslations = false;
-			i18n.reRenderTranslations();
+			reRenderTranslations();
 			debug( 'Translator deactivated' );
 			return false;
 		}
@@ -280,7 +284,7 @@ const communityTranslatorJumpstart = {
 
 	// Merge a Community Translator TranslationPair into the i18n locale
 	updateTranslation( newTranslation ) {
-		const locale = i18n.getLocale(),
+		const locale = getLocale(),
 			key = newTranslation.key,
 			plural = newTranslation.plural,
 			translations = newTranslation.translations;
@@ -296,7 +300,7 @@ const communityTranslatorJumpstart = {
 		);
 		locale[ key ] = [ plural ].concat( translations );
 
-		i18n.setLocale( locale );
+		setLocale( locale );
 	},
 
 	isValidBrowser() {
@@ -309,13 +313,13 @@ const communityTranslatorJumpstart = {
 };
 
 // wrap translations from i18n
-i18n.registerTranslateHook( ( translation, options ) => {
+registerTranslateHook( ( translation, options ) => {
 	return communityTranslatorJumpstart.wrapTranslation( options.original, translation, options );
 } );
 
 // callback when translated component changes.
 // the callback is overwritten by the translator on load/unload, so we're returning it within an anonymous function.
-i18n.registerComponentUpdateHook( () => {
+registerComponentUpdateHook( () => {
 	if ( typeof translationDataFromPage.contentChangedCallback === 'function' ) {
 		return translationDataFromPage.contentChangedCallback();
 	}
@@ -337,7 +341,7 @@ export function trackTranslatorStatus( isTranslatorEnabled ) {
 }
 
 // re-initialize when new locale data is loaded
-i18n.on( 'change', communityTranslatorJumpstart.init.bind( communityTranslatorJumpstart ) );
+i18nOn.on( 'change', communityTranslatorJumpstart.init.bind( communityTranslatorJumpstart ) );
 user.on( 'change', communityTranslatorJumpstart.init.bind( communityTranslatorJumpstart ) );
 
 export default communityTranslatorJumpstart;

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -1,9 +1,8 @@
-/** @format **/
 /**
  * Externel dependencies
  */
 import { noop } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -252,7 +251,7 @@ export function fetchSiteRedirect( siteId ) {
 		} else {
 			Dispatcher.handleServerAction( {
 				type: SITE_REDIRECT_FETCH_FAILED,
-				error: i18n.translate(
+				error: translate(
 					'There was a problem retrieving the redirect settings. Please try again later or contact support.'
 				),
 				siteId,
@@ -275,7 +274,7 @@ export function updateSiteRedirect( siteId, location, onComplete ) {
 				type: SITE_REDIRECT_UPDATE_COMPLETED,
 				location,
 				siteId,
-				success: i18n.translate( 'The redirect settings were updated successfully.' ),
+				success: translate( 'The redirect settings were updated successfully.' ),
 			} );
 
 			success = true;
@@ -288,7 +287,7 @@ export function updateSiteRedirect( siteId, location, onComplete ) {
 		} else {
 			Dispatcher.handleServerAction( {
 				type: SITE_REDIRECT_UPDATE_FAILED,
-				error: i18n.translate(
+				error: translate(
 					'There was a problem updating the redirect settings. Please try again later or contact support.'
 				),
 				siteId,

--- a/client/lib/upgrades/notices.jsx
+++ b/client/lib/upgrades/notices.jsx
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { flatten, get, values } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -35,7 +32,7 @@ function getErrorFromApi( errorMessage ) {
 		return errorMessage;
 	}
 
-	return i18n.translate( 'There was a problem completing the checkout. Please try again.' );
+	return translate( 'There was a problem completing the checkout. Please try again.' );
 }
 
 export function displayError( error ) {

--- a/client/lib/username/index.js
+++ b/client/lib/username/index.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,9 +11,7 @@ import wpcom from 'lib/wp';
 import userFactory from 'lib/user';
 const user = userFactory();
 
-/**
- * Initialize Username with defaults
- */
+// Initialize Username with defaults
 function Username() {
 	if ( ! ( this instanceof Username ) ) {
 		return new Username();
@@ -33,16 +28,14 @@ Username.prototype.validate = function( username ) {
 		if ( username.length < 4 ) {
 			this.validation = {
 				error: 'invalid_input',
-				message: i18n.translate( 'Usernames must be at least 4 characters.' ),
+				message: translate( 'Usernames must be at least 4 characters.' ),
 			};
 
 			this.emit( 'change' );
 		} else if ( ! /^[a-z0-9]+$/.test( username ) ) {
 			this.validation = {
 				error: 'invalid_input',
-				message: i18n.translate(
-					'Usernames can only contain lowercase letters (a-z) and numbers.'
-				),
+				message: translate( 'Usernames can only contain lowercase letters (a-z) and numbers.' ),
 			};
 
 			this.emit( 'change' );

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
+import { getLocaleSlug } from 'i18n-calypso';
 import { find } from 'lodash';
 import { stringify as stringifyQs } from 'qs';
 
@@ -25,7 +25,7 @@ const DEFAULT_FIRST_PAGE = 1;
 const WPORG_THEMES_ENDPOINT = 'https://api.wordpress.org/themes/info/1.1/';
 
 function getWporgLocaleCode() {
-	const currentLocaleCode = i18n.getLocaleSlug();
+	const currentLocaleCode = getLocaleSlug();
 	let wpOrgLocaleCode = find( languages, { langSlug: currentLocaleCode } ).wpLocale;
 
 	if ( wpOrgLocaleCode === '' ) {

--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,7 +17,7 @@ export function account( context, next ) {
 	let showNoticeInitially = false;
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Account Settings', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Account Settings', { textOnly: true } ) ) );
 
 	// Update the url and show the notice after a redirect
 	if ( context.query && context.query.updated === 'success' ) {

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -17,7 +15,7 @@ import BookSkeleton from './book/skeleton';
 import RescheduleCalendarStep from './reschedule/calendar-step';
 import RescheduleConfirmationStep from './reschedule/confirmation-step';
 import RescheduleSkeleton from './reschedule/skeleton';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -70,7 +68,7 @@ const siteSelector = ( context, next ) => {
 	context.store.dispatch( recordTracksEvent( 'calypso_concierge_site_selection_step' ) );
 
 	context.getSiteSelectionHeaderText = () =>
-		i18n.translate( 'Select a site for your {{strong}}Quick Start Session{{/strong}}', {
+		translate( 'Select a site for your {{strong}}Quick Start Session{{/strong}}', {
 			components: { strong: <strong /> },
 		} );
 	next();

--- a/client/me/constants.js
+++ b/client/me/constants.js
@@ -1,14 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export default {
-	sixDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '123456' } } ),
-	sevenDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '1234567' } } ),
-	eightDigitBackupCodePlaceholder: i18n.translate( 'e.g. %(example)s', {
+	sixDigit2faPlaceholder: translate( 'e.g. %(example)s', { args: { example: '123456' } } ),
+	sevenDigit2faPlaceholder: translate( 'e.g. %(example)s', { args: { example: '1234567' } } ),
+	eightDigitBackupCodePlaceholder: translate( 'e.g. %(example)s', {
 		args: { example: '12345678' },
 	} ),
 };

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -1,11 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -25,7 +23,7 @@ export function sidebar( context, next ) {
 
 export function profile( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'My Profile', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'My Profile', { textOnly: true } ) ) );
 
 	const ProfileComponent = require( 'me/profile' ).default;
 
@@ -38,7 +36,7 @@ export function profile( context, next ) {
 
 export function apps( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Get Apps', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( AppsComponent, {
 		userSettings: userSettings,

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -42,7 +39,7 @@ export function loggedOut( context, next ) {
 
 export function help( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Help', { textOnly: true } ) ) );
 
 	context.primary = <HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />;
 	next();

--- a/client/me/help/help-courses/constants.js
+++ b/client/me/help/help-courses/constants.js
@@ -1,13 +1,12 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export const helpCourses = [
 	{
-		title: i18n.translate( 'Everything You Need to Know About SEO and Marketing for Your Website' ),
-		description: i18n.translate(
+		title: translate( 'Everything You Need to Know About SEO and Marketing for Your Website' ),
+		description: translate(
 			'You will leave this 60-minute session with a plan for optimizing your site for search engines ' +
 				'and an overview of basic tactics for increasing your traffic. Our Happiness Engineers will provide a ' +
 				"foundation for making sure that your site meets current SEO standards. We'll also discuss how to " +
@@ -18,8 +17,8 @@ export const helpCourses = [
 		},
 	},
 	{
-		title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
-		description: i18n.translate(
+		title: translate( 'How to Make a Business Site on WordPress.com' ),
+		description: translate(
 			'A 60-minute overview course with two of our Happiness Engineers. In this live group session, ' +
 				'we provide an overview of WordPress.com, discuss features of the WordPress.com Business ' +
 				'plan, provide a basic setup overview to help you get started with your site, and show you ' +

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,7 +16,7 @@ import NotificationSubscriptions from 'me/notification-settings/reader-subscript
 
 export function notifications( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Notifications', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( NotificationsComponent, {
 		userSettings: userSettings,
@@ -29,9 +27,7 @@ export function notifications( context, next ) {
 
 export function comments( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch(
-		setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) )
-	);
+	context.store.dispatch( setTitle( translate( 'Comments on other sites', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( CommentSettingsComponent, {
 		path: context.path,
@@ -42,7 +38,7 @@ export function comments( context, next ) {
 export function updates( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch(
-		setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) )
+		setTitle( translate( 'Updates from WordPress.com', { textOnly: true } ) )
 	);
 
 	context.primary = React.createElement( WPcomSettingsComponent, {
@@ -53,7 +49,7 @@ export function updates( context, next ) {
 
 export function subscriptions( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Notifications', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( NotificationSubscriptions, {
 		userSettings: userSettings,

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -1,23 +1,25 @@
-/** @format */
-import i18n from 'i18n-calypso';
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
 
 export const streamLabels = {
-	timeline: () => i18n.translate( 'Timeline' ),
-	email: () => i18n.translate( 'Email' ),
+	timeline: () => translate( 'Timeline' ),
+	email: () => translate( 'Email' ),
 };
 
 export const settingLabels = {
-	comment_like: () => i18n.translate( 'Likes on my comments' ),
-	comment_reply: () => i18n.translate( 'Replies to my comments' ),
+	comment_like: () => translate( 'Likes on my comments' ),
+	comment_reply: () => translate( 'Replies to my comments' ),
 
-	new_comment: () => i18n.translate( 'Comments on my site' ),
-	post_like: () => i18n.translate( 'Likes on my posts' ),
-	follow: () => i18n.translate( 'Site follows' ),
-	achievement: () => i18n.translate( 'Site achievements' ),
-	mentions: () => i18n.translate( 'Username mentions' ),
-	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),
+	new_comment: () => translate( 'Comments on my site' ),
+	post_like: () => translate( 'Likes on my posts' ),
+	follow: () => translate( 'Site follows' ),
+	achievement: () => translate( 'Site achievements' ),
+	mentions: () => translate( 'Username mentions' ),
+	scheduled_publicize: () => translate( 'Post Publicized' ),
 
-	store_order: () => i18n.translate( 'New order' ),
+	store_order: () => translate( 'New order' ),
 };
 
 export const getLabelForStream = stream =>

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { getCurrencyDefaults } from '@automattic/format-currency';
 
 /**
@@ -54,7 +51,7 @@ const CancelPurchaseRefundInformation = ( {
 
 	if ( isRefundable( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
-			text = i18n.translate(
+			text = translate(
 				'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
 					"you'll receive a refund and it will be removed from your site immediately.",
 				{
@@ -65,7 +62,7 @@ const CancelPurchaseRefundInformation = ( {
 
 		if ( isSubscription( purchase ) ) {
 			text = [
-				i18n.translate(
+				translate(
 					"We're sorry to hear the %(productName)s plan didn't fit your current needs, but thank you for giving it a try.",
 					{
 						args: {
@@ -76,7 +73,7 @@ const CancelPurchaseRefundInformation = ( {
 			];
 			if ( includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
 				text.push(
-					i18n.translate(
+					translate(
 						'This plan includes mapping for the domain %(mappedDomain)s. ' +
 							"Cancelling will remove all the plan's features from your site, including the domain.",
 						{
@@ -85,7 +82,7 @@ const CancelPurchaseRefundInformation = ( {
 							},
 						}
 					),
-					i18n.translate(
+					translate(
 						'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
 						{
 							args: {
@@ -94,7 +91,7 @@ const CancelPurchaseRefundInformation = ( {
 							},
 						}
 					),
-					i18n.translate(
+					translate(
 						'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
 							'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
 						{
@@ -115,7 +112,7 @@ const CancelPurchaseRefundInformation = ( {
 					);
 				if ( isRefundable( includedDomainPurchase ) ) {
 					text.push(
-						i18n.translate(
+						translate(
 							'Your plan included the custom domain %(domain)s. You can cancel your domain as well as the plan, but keep ' +
 								'in mind that when you cancel a domain you risk losing it forever, and visitors to your site may ' +
 								'experience difficulties accessing it.',
@@ -125,7 +122,7 @@ const CancelPurchaseRefundInformation = ( {
 								},
 							}
 						),
-						i18n.translate( "We'd like to offer you two options to choose from:" ),
+						translate( "We'd like to offer you two options to choose from:" ),
 						<FormLabel key="keep_bundled_domain">
 							<FormRadio
 								name="keep_bundled_domain_false"
@@ -134,13 +131,13 @@ const CancelPurchaseRefundInformation = ( {
 								onChange={ onCancelBundledDomainChange }
 							/>
 							<span>
-								{ i18n.translate( 'Cancel the plan, but keep %(domain)s.', {
+								{ translate( 'Cancel the plan, but keep %(domain)s.', {
 									args: {
 										domain: includedDomainPurchase.meta,
 									},
 								} ) }
 								<br />
-								{ i18n.translate(
+								{ translate(
 									"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s " +
 										'plan, minus %(domainCost)s for the domain. There will be no change to your domain ' +
 										"registration, and you're free to use it on WordPress.com or transfer it elsewhere.",
@@ -162,7 +159,7 @@ const CancelPurchaseRefundInformation = ( {
 								onChange={ onCancelBundledDomainChange }
 							/>
 							<span>
-								{ i18n.translate( 'Cancel the plan {{em}}and{{/em}} the domain "%(domain)s."', {
+								{ translate( 'Cancel the plan {{em}}and{{/em}} the domain "%(domain)s."', {
 									args: {
 										domain: includedDomainPurchase.meta,
 									},
@@ -171,7 +168,7 @@ const CancelPurchaseRefundInformation = ( {
 									},
 								} ) }
 								<br />
-								{ i18n.translate(
+								{ translate(
 									"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible " +
 										"you'll lose it permanently.",
 									{
@@ -186,7 +183,7 @@ const CancelPurchaseRefundInformation = ( {
 
 					if ( cancelBundledDomain ) {
 						text.push(
-							i18n.translate(
+							translate(
 								"When you cancel a domain, it becomes unavailable for a while. Anyone may register it once it's " +
 									"available again, so it's possible you won't have another chance to register it in the future. " +
 									"If you'd like to use your domain on a site hosted elsewhere, consider {{a}}updating your name " +
@@ -203,7 +200,7 @@ const CancelPurchaseRefundInformation = ( {
 									onChange={ onConfirmCancelBundledDomainChange }
 								/>
 								<span>
-									{ i18n.translate(
+									{ translate(
 										'I understand that canceling my domain means I might {{strong}}never be able to register it ' +
 											'again{{/strong}}.',
 										{
@@ -218,7 +215,7 @@ const CancelPurchaseRefundInformation = ( {
 					}
 				} else {
 					text.push(
-						i18n.translate(
+						translate(
 							'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
 								'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
 							{
@@ -228,7 +225,7 @@ const CancelPurchaseRefundInformation = ( {
 								},
 							}
 						),
-						i18n.translate(
+						translate(
 							'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
 								'minus %(domainCost)s for the domain.',
 							{
@@ -244,7 +241,7 @@ const CancelPurchaseRefundInformation = ( {
 
 				showSupportLink = false;
 			} else {
-				text = i18n.translate(
+				text = translate(
 					'When you cancel your subscription within %(refundPeriodInDays)d days of purchasing, ' +
 						"you'll receive a refund and it will be removed from your site immediately.",
 					{
@@ -255,7 +252,7 @@ const CancelPurchaseRefundInformation = ( {
 		}
 
 		if ( isOneTimePurchase( purchase ) ) {
-			text = i18n.translate(
+			text = translate(
 				'When you cancel this purchase within %(refundPeriodInDays)d days of purchasing, ' +
 					"you'll receive a refund and it will be removed from your site immediately.",
 				{
@@ -264,7 +261,7 @@ const CancelPurchaseRefundInformation = ( {
 			);
 		}
 	} else if ( isDomainRegistration( purchase ) ) {
-		text = i18n.translate(
+		text = translate(
 			'When you cancel your domain, it will remain registered and active until the registration expires, ' +
 				'at which point it will be automatically removed from your site.'
 		);
@@ -273,7 +270,7 @@ const CancelPurchaseRefundInformation = ( {
 		includedDomainPurchase &&
 		isDomainMapping( includedDomainPurchase )
 	) {
-		text = i18n.translate(
+		text = translate(
 			'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
 				'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
 			{
@@ -288,7 +285,7 @@ const CancelPurchaseRefundInformation = ( {
 		includedDomainPurchase &&
 		isDomainRegistration( includedDomainPurchase )
 	) {
-		text = i18n.translate(
+		text = translate(
 			'This plan includes the custom domain, %(domain)s. ' +
 				'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
 			{
@@ -299,7 +296,7 @@ const CancelPurchaseRefundInformation = ( {
 			}
 		);
 	} else {
-		text = i18n.translate(
+		text = translate(
 			"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
 				'Once it expires, it will be automatically removed from your site.',
 			{
@@ -328,7 +325,7 @@ const CancelPurchaseRefundInformation = ( {
 			{ showSupportLink && (
 				<strong className="cancel-purchase__support-information">
 					{ ! isRefundable( purchase ) && maybeWithinRefundPeriod( purchase )
-						? i18n.translate(
+						? translate(
 								'Have a question? Want to request a refund? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
 								{
 									components: {
@@ -336,7 +333,7 @@ const CancelPurchaseRefundInformation = ( {
 									},
 								}
 						  )
-						: i18n.translate(
+						: translate(
 								'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
 								{
 									components: {

--- a/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
+++ b/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -15,16 +12,16 @@ import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from 'lib/url/suppor
 export default [
 	{
 		value: 'misspelled',
-		label: i18n.translate( 'I misspelled the domain' ),
-		helpMessage: i18n.translate(
+		label: translate( 'I misspelled the domain' ),
+		helpMessage: translate(
 			'If you misspelled the domain name you were attempting to purchase, it’s likely that others will as well, ' +
 				'and you might want to consider keeping the misspelled domain.'
 		),
 	},
 	{
 		value: 'other_host',
-		label: i18n.translate( 'I want to use the domain with another service or host' ),
-		helpMessage: i18n.translate(
+		label: translate( 'I want to use the domain with another service or host' ),
+		helpMessage: translate(
 			'Canceling a domain name causes the domain to become unavailable for a brief period. ' +
 				'Afterward, anyone can repurchase. If you wish to use the domain with another service, ' +
 				'you’ll want to {{a}}update your name servers{{/a}} instead.',
@@ -37,8 +34,8 @@ export default [
 	},
 	{
 		value: 'transfer',
-		label: i18n.translate( 'I want to transfer my domain to another registrar' ),
-		helpMessage: i18n.translate(
+		label: translate( 'I want to transfer my domain to another registrar' ),
+		helpMessage: translate(
 			'Canceling a domain name may cause the domain to become unavailable for a long time before it ' +
 				'can be purchased again, and someone may purchase it before you get a chance. Instead, ' +
 				'please {{a}}use our transfer out feature{{/a}} if you want to use this domain again in the future.',
@@ -51,26 +48,22 @@ export default [
 	},
 	{
 		value: 'expectations',
-		label: i18n.translate( 'The service isn’t what I expected' ),
-		helpMessage: i18n.translate(
+		label: translate( 'The service isn’t what I expected' ),
+		helpMessage: translate(
 			'If you misspelled the domain name you were attempting to purchase, it’s likely that others will as well, ' +
 				'and you might want to consider keeping the misspelled domain.'
 		),
 	},
 	{
 		value: 'wanted_free',
-		label: i18n.translate( 'I meant to get a free blog' ),
-		helpMessage: i18n.translate(
-			'Please provide a brief description of your reasons for canceling:'
-		),
+		label: translate( 'I meant to get a free blog' ),
+		helpMessage: translate( 'Please provide a brief description of your reasons for canceling:' ),
 		showTextarea: true,
 	},
 	{
 		value: 'other',
-		label: i18n.translate( 'Something not listed here' ),
-		helpMessage: i18n.translate(
-			'Please provide a brief description of your reasons for canceling:'
-		),
+		label: translate( 'Something not listed here' ),
+		helpMessage: translate( 'Please provide a brief description of your reasons for canceling:' ),
 		showTextarea: true,
 	},
 ];

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -35,22 +32,22 @@ const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 
 	if ( isPlan( purchase ) ) {
 		url = '/plans/compare/' + selectedSite.slug;
-		text = i18n.translate( 'View Plan Features' );
+		text = translate( 'View Plan Features' );
 	}
 
 	if ( isDomainProduct( purchase ) || isSiteRedirect( purchase ) ) {
 		url = domainManagementEdit( selectedSite.slug, purchase.meta );
-		text = i18n.translate( 'Domain Settings' );
+		text = translate( 'Domain Settings' );
 	}
 
 	if ( isGoogleApps( purchase ) ) {
 		url = getGSuiteSettingsUrl( purchase.meta );
-		text = i18n.translate( 'G Suite Settings' );
+		text = translate( 'G Suite Settings' );
 	}
 
 	if ( isTheme( purchase ) ) {
 		url = productUrl;
-		text = i18n.translate( 'Theme Details' );
+		text = translate( 'Theme Details' );
 
 		if ( ! config.isEnabled( 'manage/themes/details' ) ) {
 			props = { target: '_blank' };

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -1,17 +1,14 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export default {
-	addCreditCard: i18n.translate( 'Add Credit Card' ),
-	cancelPurchase: i18n.translate( 'Cancel Purchase' ),
-	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
-	editCardDetails: i18n.translate( 'Change Credit Card', { comment: 'Credit card' } ),
-	addCardDetails: i18n.translate( 'Add Credit Card', { comment: 'Credit card' } ),
-	managePurchase: i18n.translate( 'Manage Purchase' ),
-	purchases: i18n.translate( 'Purchases' ),
+	addCreditCard: translate( 'Add Credit Card' ),
+	cancelPurchase: translate( 'Cancel Purchase' ),
+	confirmCancelDomain: translate( 'Cancel Domain' ),
+	editCardDetails: translate( 'Change Credit Card', { comment: 'Credit card' } ),
+	addCardDetails: translate( 'Add Credit Card', { comment: 'Credit card' } ),
+	managePurchase: translate( 'Manage Purchase' ),
+	purchases: translate( 'Purchases' ),
 };

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -27,28 +24,28 @@ export default class extends React.Component {
 	getNavtabs = () => {
 		const tabs = [
 			{
-				title: i18n.translate( 'Password' ),
+				title: translate( 'Password' ),
 				path: '/me/security',
 			},
 			config.isEnabled( 'signup/social-management' )
 				? {
-						title: i18n.translate( 'Social Login' ),
+						title: translate( 'Social Login' ),
 						path: '/me/security/social-login',
 				  }
 				: null,
 			{
-				title: i18n.translate( 'Two-Step Authentication' ),
+				title: translate( 'Two-Step Authentication' ),
 				path: '/me/security/two-step',
 			},
 			{
 				title: config.isEnabled( 'signup/social-management' )
 					? // This was shortened from 'Connected Applications' due to space constraints.
-					  i18n.translate( 'Connected Apps' )
-					: i18n.translate( 'Connected Applications' ),
+					  translate( 'Connected Apps' )
+					: translate( 'Connected Applications' ),
 				path: '/me/security/connected-applications',
 			},
 			{
-				title: i18n.translate( 'Account Recovery' ),
+				title: translate( 'Account Recovery' ),
 				path: '/me/security/account-recovery',
 			},
 		].filter( tab => tab !== null );
@@ -62,9 +59,9 @@ export default class extends React.Component {
 	};
 
 	getSelectedText = () => {
-		let text = '',
-			filteredPath = this.getFilteredPath(),
-			found = find( this.getNavtabs(), { path: filteredPath } );
+		let text = '';
+		const filteredPath = this.getFilteredPath();
+		const found = find( this.getNavtabs(), { path: filteredPath } );
 
 		if ( 'undefined' !== typeof found ) {
 			text = String( found.title );

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -1,11 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -21,7 +19,7 @@ import { getSocialServiceFromClientId } from 'lib/login';
 
 export function password( context, next ) {
 	if ( context.query && context.query.updated === 'password' ) {
-		notices.success( i18n.translate( 'Your password was saved successfully.' ), {
+		notices.success( translate( 'Your password was saved successfully.' ), {
 			displayOnNextPage: true,
 		} );
 

--- a/client/my-sites/activity/controller.jsx
+++ b/client/my-sites/activity/controller.jsx
@@ -1,9 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
 import page from 'page';
 import { isEqual } from 'lodash';
 
@@ -57,7 +56,7 @@ function queryFilterToStats( filter ) {
 export function activity( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	const startDate = i18n.moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
+	const startDate = moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
 		? context.query.startDate
 		: undefined;
 

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -46,12 +43,12 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ i18n.translate( 'Get personalized help' ) }
-				description={ i18n.translate(
+				title={ translate( 'Get personalized help' ) }
+				description={ translate(
 					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
 						'your site and learn more about WordPress.com.'
 				) }
-				buttonText={ i18n.translate( 'Schedule a session' ) }
+				buttonText={ translate( 'Schedule a session' ) }
 				href={ `/me/concierge/${ selectedSite.slug }/book` }
 				onClick={ trackOnboardingButtonClick }
 			/>
@@ -59,12 +56,12 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 			{ ! selectedFeature && (
 				<PurchaseDetail
 					icon={ <img alt="" src={ themeImage } /> }
-					title={ i18n.translate( 'Try a New Theme' ) }
-					description={ i18n.translate(
+					title={ translate( 'Try a New Theme' ) }
+					description={ translate(
 						"You've now got access to every premium theme, at no extra cost - that's hundreds of new options. " +
 							'Give one a try!'
 					) }
-					buttonText={ i18n.translate( 'Browse premium themes' ) }
+					buttonText={ translate( 'Browse premium themes' ) }
 					href={ '/themes/' + selectedSite.slug }
 				/>
 			) }
@@ -72,23 +69,23 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) && (
 				<PurchaseDetail
 					icon={ <img alt="" src={ updatesImage } /> }
-					title={ i18n.translate( 'Add a Plugin' ) }
-					description={ i18n.translate(
+					title={ translate( 'Add a Plugin' ) }
+					description={ translate(
 						'Search and add plugins right from your dashboard, or upload a plugin ' +
 							'from your computer with a drag-and-drop interface.'
 					) }
-					buttonText={ i18n.translate( 'Upload a plugin now' ) }
+					buttonText={ translate( 'Upload a plugin now' ) }
 					href={ '/plugins/manage/' + selectedSite.slug }
 				/>
 			) }
 
 			<PurchaseDetail
 				icon={ <img alt="" src={ analyticsImage } /> }
-				title={ i18n.translate( 'Connect to Google Analytics' ) }
-				description={ i18n.translate(
+				title={ translate( 'Connect to Google Analytics' ) }
+				description={ translate(
 					"Complement WordPress.com's stats with Google's in-depth look at your visitors and traffic patterns."
 				) }
-				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
+				buttonText={ translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug }
 			/>
 		</div>

--- a/client/my-sites/checkout/checkout-thank-you/chargeback-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/chargeback-details.jsx
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,11 +15,9 @@ const ChargebackDetails = ( { selectedSite } ) => {
 	return (
 		<PurchaseDetail
 			icon="create"
-			title={ i18n.translate( 'Get back to posting' ) }
-			description={ i18n.translate(
-				'You can now use the full features of your site, without limits.'
-			) }
-			buttonText={ i18n.translate( 'Write a Post' ) }
+			title={ translate( 'Get back to posting' ) }
+			description={ translate( 'You can now use the full features of your site, without limits.' ) }
+			buttonText={ translate( 'Write a Post' ) }
 			href={ newPost( selectedSite ) }
 		/>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -32,15 +29,15 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 				{ ! domainContactEmailVerified && (
 					<PurchaseDetail
 						icon={ <img alt="" src="/calypso/images/upgrades/check-emails-desktop.svg" /> }
-						title={ i18n.translate( 'Verify your email address' ) }
-						description={ i18n.translate(
+						title={ translate( 'Verify your email address' ) }
+						description={ translate(
 							'We sent you an email with a request to verify your new domain. Unverified domains may be suspended.'
 						) }
-						buttonText={ i18n.translate( 'Learn more about verifying your domain' ) }
+						buttonText={ translate( 'Learn more about verifying your domain' ) }
 						href={ EMAIL_VALIDATION_AND_VERIFICATION }
 						target="_blank"
 						rel="noopener noreferrer"
-						requiredText={ i18n.translate( 'Important! Your action is required.' ) }
+						requiredText={ translate( 'Important! Your action is required.' ) }
 						isRequired
 					/>
 				) }
@@ -50,11 +47,11 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/upgrades/wait-time.svg" /> }
-				title={ i18n.translate( 'When will it be ready?', { comment: '"it" refers to a domain' } ) }
-				description={ i18n.translate(
+				title={ translate( 'When will it be ready?', { comment: '"it" refers to a domain' } ) }
+				description={ translate(
 					'Your domain should start working immediately, but may be unreliable during the first 72 hours.'
 				) }
-				buttonText={ i18n.translate( 'Learn more about your domain' ) }
+				buttonText={ translate( 'Learn more about your domain' ) }
 				href={ DOMAIN_WAITING }
 				target="_blank"
 				rel="noopener noreferrer"
@@ -72,8 +69,8 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 							}
 						/>
 					}
-					title={ i18n.translate( 'Your primary domain' ) }
-					description={ i18n.translate(
+					title={ translate( 'Your primary domain' ) }
+					description={ translate(
 						'Your existing domain, {{em}}%(domain)s{{/em}}, is the domain visitors see when they visit your site. ' +
 							'All other custom domains redirect to the primary domain.',
 						{
@@ -81,7 +78,7 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 							components: { em: <em /> },
 						}
 					) }
-					buttonText={ i18n.translate( 'Change primary domain' ) }
+					buttonText={ translate( 'Change primary domain' ) }
 					href={ getDomainManagementUrl( selectedSite, domain ) }
 				/>
 			) }

--- a/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -45,12 +42,12 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ i18n.translate( 'Get personalized help' ) }
-				description={ i18n.translate(
+				title={ translate( 'Get personalized help' ) }
+				description={ translate(
 					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
 						'your site and learn more about WordPress.com.'
 				) }
-				buttonText={ i18n.translate( 'Schedule a session' ) }
+				buttonText={ translate( 'Schedule a session' ) }
 				href={ `/me/concierge/${ selectedSite.slug }/book` }
 				onClick={ trackOnboardingButtonClick }
 			/>
@@ -58,23 +55,23 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) && (
 				<PurchaseDetail
 					icon={ <img alt="" src={ updatesImage } /> }
-					title={ i18n.translate( 'Add a Plugin' ) }
-					description={ i18n.translate(
+					title={ translate( 'Add a Plugin' ) }
+					description={ translate(
 						'Search and add plugins right from your dashboard, or upload a plugin ' +
 							'from your computer with a drag-and-drop interface.'
 					) }
-					buttonText={ i18n.translate( 'Upload a plugin now' ) }
+					buttonText={ translate( 'Upload a plugin now' ) }
 					href={ '/plugins/manage/' + selectedSite.slug }
 				/>
 			) }
 
 			<PurchaseDetail
 				icon={ <img alt="" src={ analyticsImage } /> }
-				title={ i18n.translate( 'Connect to Google Analytics' ) }
-				description={ i18n.translate(
+				title={ translate( 'Connect to Google Analytics' ) }
+				description={ translate(
 					"Complement WordPress.com's stats with Google's in-depth look at your visitors and traffic patterns."
 				) }
-				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
+				buttonText={ translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug }
 			/>
 		</div>

--- a/client/my-sites/checkout/checkout-thank-you/features-header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/features-header.jsx
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -45,7 +42,7 @@ const FeaturesHeader = ( { isDataLoaded, isGenericReceipt, purchases, hasFailedP
 		return <div />;
 	}
 
-	return <div className={ classes }>{ i18n.translate( 'What now?' ) }</div>;
+	return <div className={ classes }>{ translate( 'What now?' ) }</div>;
 };
 
 FeaturesHeader.propTypes = {

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -24,8 +21,8 @@ const GoogleAppsDetails = props => {
 	return (
 		<PurchaseDetail
 			icon="mail"
-			title={ i18n.translate( 'Check your email to finish setting up your G Suite account' ) }
-			description={ i18n.translate(
+			title={ translate( 'Check your email to finish setting up your G Suite account' ) }
+			description={ translate(
 				'We emailed you at {{strong}}%(email)s{{/strong}} with login information ' +
 					'so you can start using new professional email addresses and other G Suite apps. ' +
 					'If you can’t find it, try searching “G Suite” in your email inbox. {{link}}Learn more about G Suite{{/link}}',
@@ -46,7 +43,7 @@ const GoogleAppsDetails = props => {
 					},
 				}
 			) }
-			requiredText={ i18n.translate( 'Almost done! One step remaining…' ) }
+			requiredText={ translate( 'Almost done! One step remaining…' ) }
 			isRequired
 		/>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/site-redirect-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/site-redirect-details.jsx
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -19,15 +16,15 @@ const SiteRedirectDetails = ( { selectedSite, domain } ) => {
 		<div>
 			<PurchaseDetail
 				icon="external"
-				title={ i18n.translate( 'Test the redirect' ) }
-				description={ i18n.translate(
+				title={ translate( 'Test the redirect' ) }
+				description={ translate(
 					'Visitors to your site will be automatically redirected to {{em}}%(url)s{{/em}}.',
 					{
 						args: { url: domain },
 						components: { em: <em /> },
 					}
 				) }
-				buttonText={ i18n.translate( 'Try it now' ) }
+				buttonText={ translate( 'Try it now' ) }
 				href={ `${ selectedSite.options.unmapped_url }` }
 				target="_blank"
 				rel="noopener noreferrer"
@@ -35,11 +32,11 @@ const SiteRedirectDetails = ( { selectedSite, domain } ) => {
 
 			<PurchaseDetail
 				icon="cog"
-				title={ i18n.translate( 'Change redirect settings' ) }
-				description={ i18n.translate(
+				title={ translate( 'Change redirect settings' ) }
+				description={ translate(
 					'Disable the redirect by choosing a different primary domain, or change the target address.'
 				) }
-				buttonText={ i18n.translate( 'Manage redirect' ) }
+				buttonText={ translate( 'Manage redirect' ) }
 				href={ getDomainManagementUrl( selectedSite, domain ) }
 			/>
 		</div>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import React from 'react';
 import { get, isEmpty } from 'lodash';
 import page from 'page';
@@ -47,7 +46,7 @@ export function checkout( context, next ) {
 	}
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
+	context.store.dispatch( setTitle( translate( 'Checkout' ) ) );
 
 	context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
 
@@ -93,7 +92,7 @@ export function checkoutThankYou( context, next ) {
 	context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) );
+	context.store.dispatch( setTitle( translate( 'Thank You' ) ) );
 
 	context.primary = (
 		<CheckoutThankYouComponent

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import page from 'page';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { get, noop, some, startsWith, uniq } from 'lodash';
 
 /**
@@ -123,7 +122,7 @@ function renderNoVisibleSites( context ) {
 	removeSidebar( context );
 
 	context.primary = React.createElement( EmptyContentComponent, {
-		title: i18n.translate(
+		title: translate(
 			'You have %(hidden)d hidden WordPress site.',
 			'You have %(hidden)d hidden WordPress sites.',
 			{
@@ -132,7 +131,7 @@ function renderNoVisibleSites( context ) {
 			}
 		),
 
-		line: i18n.translate(
+		line: translate(
 			'To manage it here, set it to visible.',
 			'To manage them here, set them to visible.',
 			{
@@ -140,9 +139,9 @@ function renderNoVisibleSites( context ) {
 			}
 		),
 
-		action: i18n.translate( 'Change Visibility' ),
+		action: translate( 'Change Visibility' ),
 		actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
-		secondaryAction: i18n.translate( 'Create New Site' ),
+		secondaryAction: translate( 'Create New Site' ),
 		secondaryActionURL: `${ signup_url }?ref=calypso-nosites`,
 	} );
 
@@ -291,7 +290,7 @@ function showMissingPrimaryError( currentUser, dispatch ) {
 
 	if ( currentUser.primary_blog_is_jetpack ) {
 		dispatch(
-			warningNotice( i18n.translate( "Please check your Primary Site's Jetpack connection" ), {
+			warningNotice( translate( "Please check your Primary Site's Jetpack connection" ), {
 				button: 'wp-admin',
 				href: `${ currentUser.primary_blog_url }/wp-admin`,
 			} )
@@ -451,7 +450,7 @@ export function navigation( context, next ) {
 export function sites( context, next ) {
 	if ( context.query.verified === '1' ) {
 		notices.success(
-			i18n.translate(
+			translate(
 				"Email verified! Now that you've confirmed your email address you can publish posts on your blog."
 			)
 		);

--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import React from 'react';
 
 /**
@@ -13,7 +12,7 @@ import CustomizeComponent from 'my-sites/customize/main';
 
 export function customize( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Customizer', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Customizer', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( CustomizeComponent, {
 		domain: context.params.domain || '',

--- a/client/my-sites/guided-transfer/guided-transfer.jsx
+++ b/client/my-sites/guided-transfer/guided-transfer.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
@@ -25,18 +25,18 @@ import './style.scss';
 
 const guidedTransferHosts = {
 	bluehost: {
-		label: i18n.translate( 'Bluehost' ),
+		label: translate( 'Bluehost' ),
 		logo: '/calypso/images/guided-transfer/bluehost-logo.png',
 		url: 'https://bluehost.com/track/wpgt?page=/web-hosting/signup',
 	},
 	siteground: {
 		logo: '/calypso/images/guided-transfer/siteground-logo.png',
-		label: i18n.translate( 'SiteGround' ),
+		label: translate( 'SiteGround' ),
 		url: 'https://www.siteground.com/wordpress-hosting.htm?afcode=134c903505c0a2296bd25772edebf669',
 	},
 	pressable: {
 		logo: '/calypso/images/guided-transfer/pressable-logo.png',
-		label: i18n.translate( 'Pressable' ),
+		label: translate( 'Pressable' ),
 		url: 'https://pressable.com',
 	},
 };

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -7,7 +6,7 @@ import store from 'store';
 import page from 'page';
 import { find, get, isEmpty, pick } from 'lodash';
 import debugModule from 'debug';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -45,7 +44,7 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 
 export function acceptInvite( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Accept Invite', { textOnly: true } ) ) );
 
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import { get } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export function acceptedNotice( invite, displayOnNextPage = true ) {
 	const site = (
@@ -16,11 +15,11 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 	switch ( get( invite, 'role' ) ) {
 		case 'follower':
 			return [
-				i18n.translate( 'You are now following {{site/}}', {
+				translate( 'You are now following {{site/}}', {
 					components: { site },
 				} ),
 				{
-					button: i18n.translate( 'Visit Site' ),
+					button: translate( 'Visit Site' ),
 					href: get( invite, 'site.URL' ),
 					displayOnNextPage,
 				},
@@ -28,11 +27,11 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 
 		case 'viewer':
 			return [
-				i18n.translate( 'You are now a viewer of: {{site/}}', {
+				translate( 'You are now a viewer of: {{site/}}', {
 					components: { site },
 				} ),
 				{
-					button: i18n.translate( 'Visit Site' ),
+					button: translate( 'Visit Site' ),
 					href: get( invite, 'site.URL' ),
 					displayOnNextPage,
 				},
@@ -42,12 +41,12 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 			return [
 				<div>
 					<h3 className="invites__title">
-						{ i18n.translate( "You're now an Administrator of: {{site/}}", {
+						{ translate( "You're now an Administrator of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
 					<p className="invites__intro">
-						{ i18n.translate(
+						{ translate(
 							'This is your site dashboard where you will be able to manage all aspects of %(site)s',
 							{
 								args: { site: get( invite, 'site.title' ) },
@@ -55,12 +54,9 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 						) }
 					</p>
 					<p>
-						{ i18n.translate(
-							'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.',
-							{
-								components: { a: <a href="http://learn.wordpress.com" /> },
-							}
-						) }
+						{ translate( 'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.', {
+							components: { a: <a href="http://learn.wordpress.com" /> },
+						} ) }
 					</p>
 				</div>,
 				{ displayOnNextPage },
@@ -70,23 +66,20 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 			return [
 				<div>
 					<h3 className="invites__title">
-						{ i18n.translate( "You're now an Editor of: {{site/}}", {
+						{ translate( "You're now an Editor of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
 					<p className="invites__intro">
-						{ i18n.translate(
+						{ translate(
 							'This is your site dashboard where you can publish and manage your ' +
 								'own posts and the posts of others, as well as upload media.'
 						) }
 					</p>
 					<p>
-						{ i18n.translate(
-							'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.',
-							{
-								components: { a: <a href="http://learn.wordpress.com" /> },
-							}
-						) }
+						{ translate( 'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.', {
+							components: { a: <a href="http://learn.wordpress.com" /> },
+						} ) }
 					</p>
 				</div>,
 				{ displayOnNextPage },
@@ -96,23 +89,20 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 			return [
 				<div>
 					<h3 className="invites__title">
-						{ i18n.translate( "You're now an Author of: {{site/}}", {
+						{ translate( "You're now an Author of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
 					<p className="invites__intro">
-						{ i18n.translate(
+						{ translate(
 							'This is your site dashboard where you can publish and ' +
 								'edit your own posts as well as upload media.'
 						) }
 					</p>
 					<p>
-						{ i18n.translate(
-							'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.',
-							{
-								components: { a: <a href="http://learn.wordpress.com" /> },
-							}
-						) }
+						{ translate( 'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.', {
+							components: { a: <a href="http://learn.wordpress.com" /> },
+						} ) }
 					</p>
 				</div>,
 				{ displayOnNextPage },
@@ -122,12 +112,12 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 			return [
 				<div>
 					<h3 className="invites__title">
-						{ i18n.translate( "You're now a Contributor of: {{site/}}", {
+						{ translate( "You're now a Contributor of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
 					<p className="invites__intro">
-						{ i18n.translate(
+						{ translate(
 							'This is your site dashboard where you can write and manage your own posts.'
 						) }
 					</p>
@@ -137,14 +127,14 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 
 		case 'subscriber':
 			return [
-				i18n.translate( "You're now a Subscriber of: {{site/}}", {
+				translate( "You're now a Subscriber of: {{site/}}", {
 					components: { site },
 				} ),
 				{ displayOnNextPage },
 			];
 		default:
 			return [
-				i18n.translate( "You're now a new member of: {{site/}}", {
+				translate( "You're now a new member of: {{site/}}", {
 					components: { site },
 				} ),
 				{ displayOnNextPage },

--- a/client/my-sites/marketing/buttons/preview-widget.js
+++ b/client/my-sites/marketing/buttons/preview-widget.js
@@ -1,18 +1,15 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { stringify } from 'qs';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 const baseUrl = '//widgets.wp.com/sharing-buttons-preview/';
 
 export default {
 	generatePreviewUrlFromButtons: function( buttons, showMore ) {
-		let numberOfCustomButtons = 0,
-			query = {};
+		let numberOfCustomButtons = 0;
+		const query = {};
 
 		// Build the query parameter array of services names to be rendered
 		// by the official sharing buttons preview widget
@@ -32,7 +29,7 @@ export default {
 		} );
 
 		if ( showMore ) {
-			query.more = i18n.translate( 'More' );
+			query.more = translate( 'More' );
 		}
 
 		return baseUrl + '?' + stringify( query );

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 
 /**
@@ -22,7 +20,7 @@ export default {
 
 		// Page Title
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
+		context.store.dispatch( setTitle( translate( 'Media', { textOnly: true } ) ) );
 
 		const mediaId = context.params.mediaId ? parseInt( context.params.mediaId ) : null;
 		// Render

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -67,7 +66,7 @@ function renderPeopleList( context, next ) {
 	const filter = context.params.filter;
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'People', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( PeopleList, {
 		filter: filter,
@@ -80,7 +79,7 @@ function renderInvitePeople( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 
-	context.store.dispatch( setTitle( i18n.translate( 'Invite People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( translate( 'Invite People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 	context.primary = React.createElement( InvitePeople, {
 		site: site,
@@ -89,14 +88,14 @@ function renderInvitePeople( context, next ) {
 }
 
 function renderPeopleInvites( context, next ) {
-	context.store.dispatch( setTitle( i18n.translate( 'Invites', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Invites', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( PeopleInvites );
 	next();
 }
 
 function renderPeopleInviteDetails( context, next ) {
-	context.store.dispatch( setTitle( i18n.translate( 'Invite Details', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( translate( 'Invite Details', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( PeopleInviteDetails, {
 		inviteKey: context.params.invite_key,
@@ -105,7 +104,7 @@ function renderPeopleInviteDetails( context, next ) {
 }
 
 function renderSingleTeamMember( context, next ) {
-	context.store.dispatch( setTitle( i18n.translate( 'View Team Member', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( translate( 'View Team Member', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 	context.primary = React.createElement( EditTeamMember, {
 		userLogin: context.params.user_login,

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -77,19 +74,19 @@ class PeopleNotices extends React.Component {
 		const log = this.state.inProgress[ 0 ];
 		switch ( log.action ) {
 			case 'UPDATE_SITE_USER':
-				return i18n.translate( 'Updating @%(user)s', {
+				return translate( 'Updating @%(user)s', {
 					args: translateArg( log ),
 					context: 'In progress message while a site is performing actions on users.',
 				} );
 			case 'DELETE_SITE_USER':
 				if ( isMultisite( this.props.site ) ) {
-					return i18n.translate( 'Removing @%(user)s', {
+					return translate( 'Removing @%(user)s', {
 						args: translateArg( log ),
 						context: 'In progress message while a site is performing actions on users.',
 					} );
 				}
 
-				return i18n.translate( 'Deleting @%(user)s', {
+				return translate( 'Deleting @%(user)s', {
 					args: translateArg( log ),
 					context: 'In progress message while a site is performing actions on users.',
 				} );
@@ -101,14 +98,14 @@ class PeopleNotices extends React.Component {
 		switch ( log.action ) {
 			case 'RECEIVE_UPDATE_SITE_USER_FAILURE':
 				// Generic update error. Use `localStorage.setItem( 'debug', 'calypso:users:actions' ) for a more detailed error.
-				return i18n.translate( 'There was an error updating @%(user)s', {
+				return translate( 'There was an error updating @%(user)s', {
 					args: translateArg( log ),
 					context: 'Error message after A site has failed to perform actions on a user.',
 				} );
 			case 'RECEIVE_DELETE_SITE_USER_FAILURE':
 				if ( 'user_owns_domain_subscription' === log.error.error ) {
 					const numDomains = log.error.message.split( ',' ).length;
-					return i18n.translate(
+					return translate(
 						'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 						'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 						{
@@ -124,23 +121,23 @@ class PeopleNotices extends React.Component {
 					);
 				}
 				if ( isMultisite( this.props.site ) ) {
-					return i18n.translate( 'There was an error removing @%(user)s', {
+					return translate( 'There was an error removing @%(user)s', {
 						args: translateArg( log ),
 						context: 'Error message after A site has failed to perform actions on a user.',
 					} );
 				}
-				return i18n.translate( 'There was an error deleting @%(user)s', {
+				return translate( 'There was an error deleting @%(user)s', {
 					args: translateArg( log ),
 					context: 'Error message after A site has failed to perform actions on a user.',
 				} );
 			case 'RECEIVE_USERS':
-				return i18n.translate( 'There was an error retrieving users' );
+				return translate( 'There was an error retrieving users' );
 			case 'RECEIVE_FOLLOWERS':
-				return i18n.translate( 'There was an error retrieving followers' );
+				return translate( 'There was an error retrieving followers' );
 			case 'RECEIVE_EMAIL_FOLLOWERS':
-				return i18n.translate( 'There was an error retrieving email followers' );
+				return translate( 'There was an error retrieving email followers' );
 			case 'RECEIVE_VIEWERS':
-				return i18n.translate( 'There was an error retrieving viewers' );
+				return translate( 'There was an error retrieving viewers' );
 		}
 	};
 
@@ -148,18 +145,18 @@ class PeopleNotices extends React.Component {
 		const log = this.state.completed[ this.state.completed.length - 1 ];
 		switch ( log.action ) {
 			case 'RECEIVE_UPDATE_SITE_USER_SUCCESS':
-				return i18n.translate( 'Successfully updated @%(user)s', {
+				return translate( 'Successfully updated @%(user)s', {
 					args: translateArg( log ),
 					context: 'Success message after a user has been modified.',
 				} );
 			case 'RECEIVE_DELETE_SITE_USER_SUCCESS':
 				if ( isMultisite( this.props.site ) ) {
-					return i18n.translate( 'Successfully removed @%(user)s', {
+					return translate( 'Successfully removed @%(user)s', {
 						args: translateArg( log ),
 						context: 'Success message after a user has been modified.',
 					} );
 				}
-				return i18n.translate( 'Successfully deleted @%(user)s', {
+				return translate( 'Successfully deleted @%(user)s', {
 					args: translateArg( log ),
 					context: 'Success message after a user has been modified.',
 				} );

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { localize, moment, translate } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { get, isEmpty } from 'lodash';
@@ -105,7 +102,7 @@ class PluginInformation extends React.Component {
 
 	renderLastUpdated = () => {
 		if ( this.props.plugin && this.props.plugin.last_updated ) {
-			const dateFromNow = i18n.moment
+			const dateFromNow = moment
 				.utc( this.props.plugin.last_updated, 'YYYY-MM-DD hh:mma' )
 				.fromNow();
 			const syncIcon = this.props.hasUpdate ? <Gridicon icon="sync" size={ 18 } /> : null;
@@ -145,6 +142,7 @@ class PluginInformation extends React.Component {
 			versionView = (
 				<div className="plugin-information__version-limit">
 					{ this.props.translate(
+						// eslint-disable-next-line wpcalypso/i18n-no-collapsible-whitespace
 						'{{wpIcon/}}  Compatible with %(minVersion)s to {{span}} %(maxVersion)s {{versionCheck/}}{{/span}}',
 						{
 							args: { minVersion: limits.minVersion, maxVersion: limits.maxVersion },
@@ -210,7 +208,7 @@ class PluginInformation extends React.Component {
 			adminUrl += 'admin.php?page=vaultpress'; // adminUrl has a trailing slash
 		}
 
-		return adminUrl ? { [ i18n.translate( 'WP Admin' ) ]: adminUrl } : null;
+		return adminUrl ? { [ translate( 'WP Admin' ) ]: adminUrl } : null;
 	};
 
 	renderPlaceholder = () => {

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -1,14 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import React from 'react';
 import debugFactory from 'debug';
+import { translate } from 'i18n-calypso';
+
 const debug = debugFactory( 'calypso:my-sites:posts' );
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -56,7 +54,7 @@ export default {
 		}
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Blog Posts', { textOnly: true } ) ) );
+		context.store.dispatch( setTitle( translate( 'Blog Posts', { textOnly: true } ) ) );
 
 		context.primary = React.createElement( Posts, {
 			context,

--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -21,20 +20,20 @@ const DeleteSiteWarningDialog = ( { isVisible, onClose } ) => (
 	<Dialog
 		isVisible={ isVisible }
 		buttons={ [
-			{ action: 'dismiss', label: i18n.translate( 'Dismiss' ) },
+			{ action: 'dismiss', label: translate( 'Dismiss' ) },
 			<a
 				className="button is-primary" // eslint-disable-line wpcalypso/jsx-classname-namespace
 				href={ purchasesRoot }
 			>
-				{ i18n.translate( 'Manage Purchases', { context: 'button label' } ) }
+				{ translate( 'Manage Purchases', { context: 'button label' } ) }
 			</a>,
 		] }
 		onClose={ onClose }
 		className="delete-site-warning-dialog"
 	>
-		<h1>{ i18n.translate( 'Premium Upgrades' ) }</h1>
+		<h1>{ translate( 'Premium Upgrades' ) }</h1>
 		<p>
-			{ i18n.translate(
+			{ translate(
 				'You have active premium upgrades on your site. ' +
 					'Please cancel your upgrades prior to deleting your site.'
 			) }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { moment, translate } from 'i18n-calypso';
 import { find, pick, get } from 'lodash';
 
 /**
@@ -51,7 +51,7 @@ function rangeOfPeriod( period, date ) {
 
 function getNumPeriodAgo( momentSiteZone, date, period ) {
 	const endOfCurrentPeriod = momentSiteZone.endOf( period );
-	const durationAgo = i18n.moment.duration( endOfCurrentPeriod.diff( date ) );
+	const durationAgo = moment.duration( endOfCurrentPeriod.diff( date ) );
 	let numPeriodAgo;
 
 	switch ( period ) {
@@ -74,51 +74,51 @@ function getNumPeriodAgo( momentSiteZone, date, period ) {
 function getSiteFilters( siteId ) {
 	const filters = [
 		{
-			title: i18n.translate( 'Insights' ),
+			title: translate( 'Insights' ),
 			path: '/stats/insights/' + siteId,
 			id: 'stats-insights',
 		},
 		{
-			title: i18n.translate( 'Days' ),
+			title: translate( 'Days' ),
 			path: '/stats/day/' + siteId,
 			id: 'stats-day',
 			period: 'day',
 		},
 		{
-			title: i18n.translate( 'Weeks' ),
+			title: translate( 'Weeks' ),
 			path: '/stats/week/' + siteId,
 			id: 'stats-week',
 			period: 'week',
 		},
 		{
-			title: i18n.translate( 'Months' ),
+			title: translate( 'Months' ),
 			path: '/stats/month/' + siteId,
 			id: 'stats-month',
 			period: 'month',
 		},
 		{
-			title: i18n.translate( 'Years' ),
+			title: translate( 'Years' ),
 			path: '/stats/year/' + siteId,
 			id: 'stats-year',
 			period: 'year',
 		},
 		{
-			title: i18n.translate( 'WordAds - Days' ),
+			title: translate( 'WordAds - Days' ),
 			path: '/stats/ads/day/' + siteId,
 			period: 'day',
 		},
 		{
-			title: i18n.translate( 'WordAds - Weeks' ),
+			title: translate( 'WordAds - Weeks' ),
 			id: 'stats-wordads-week',
 			period: 'week',
 		},
 		{
-			title: i18n.translate( 'WordAds - Months' ),
+			title: translate( 'WordAds - Months' ),
 			id: 'stats-wordads-month',
 			period: 'month',
 		},
 		{
-			title: i18n.translate( 'WordAds - Years' ),
+			title: translate( 'WordAds - Years' ),
 			id: 'stats-wordads-year',
 			period: 'year',
 		},
@@ -129,7 +129,7 @@ function getSiteFilters( siteId ) {
 
 function getMomentSiteZone( state, siteId ) {
 	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
-	return i18n.moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
+	return moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
 }
 
 export default {
@@ -170,20 +170,20 @@ export default {
 		const filters = function() {
 			return [
 				{
-					title: i18n.translate( 'Days' ),
+					title: translate( 'Days' ),
 					path: '/stats/day',
 					altPaths: [ '/stats' ],
 					id: 'stats-day',
 					period: 'day',
 				},
-				{ title: i18n.translate( 'Weeks' ), path: '/stats/week', id: 'stats-week', period: 'week' },
+				{ title: translate( 'Weeks' ), path: '/stats/week', id: 'stats-week', period: 'week' },
 				{
-					title: i18n.translate( 'Months' ),
+					title: translate( 'Months' ),
 					path: '/stats/month',
 					id: 'stats-month',
 					period: 'month',
 				},
-				{ title: i18n.translate( 'Years' ), path: '/stats/year', id: 'stats-year', period: 'year' },
+				{ title: translate( 'Years' ), path: '/stats/year', id: 'stats-year', period: 'year' },
 			];
 		};
 
@@ -244,11 +244,10 @@ export default {
 		}
 
 		const momentSiteZone = getMomentSiteZone( state, siteId );
-		const isValidStartDate =
-			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
+		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 
 		const date = isValidStartDate
-			? i18n.moment( queryOptions.startDate ).locale( 'en' )
+			? moment( queryOptions.startDate ).locale( 'en' )
 			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
 
 		const parsedPeriod = isValidStartDate
@@ -306,7 +305,7 @@ export default {
 			'searchterms',
 			'annualstats',
 		];
-		let momentSiteZone = i18n.moment();
+		let momentSiteZone = moment();
 
 		const site = getSite( context.store.getState(), siteId );
 		siteId = site ? site.ID || 0 : 0;
@@ -329,12 +328,11 @@ export default {
 
 		const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
 		if ( Number.isFinite( gmtOffset ) ) {
-			momentSiteZone = i18n.moment().utcOffset( gmtOffset );
+			momentSiteZone = moment().utcOffset( gmtOffset );
 		}
-		const isValidStartDate =
-			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
+		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 		const date = isValidStartDate
-			? i18n.moment( queryOptions.startDate ).locale( 'en' )
+			? moment( queryOptions.startDate ).locale( 'en' )
 			: momentSiteZone.endOf( activeFilter.period ).locale( 'en' );
 		const period = rangeOfPeriod( activeFilter.period, date );
 
@@ -432,11 +430,10 @@ export default {
 		}
 
 		const momentSiteZone = getMomentSiteZone( state, siteId );
-		const isValidStartDate =
-			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
+		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 
 		const date = isValidStartDate
-			? i18n.moment( queryOptions.startDate ).locale( 'en' )
+			? moment( queryOptions.startDate ).locale( 'en' )
 			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
 
 		const parsedPeriod = isValidStartDate

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { max, throttle, values } from 'lodash';
-import i18n, { localize } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -129,8 +126,7 @@ class PostTrends extends React.Component {
 		const months = [];
 
 		for ( let i = 11; i >= 0; i-- ) {
-			const startDate = i18n
-				.moment()
+			const startDate = moment()
 				.subtract( i, 'months' )
 				.startOf( 'month' );
 			months.push(
@@ -197,14 +193,12 @@ class PostTrends extends React.Component {
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const query = {
-		startDate: i18n
-			.moment()
+		startDate: moment()
 			.locale( 'en' )
 			.subtract( 1, 'year' )
 			.startOf( 'month' )
 			.format( 'YYYY-MM-DD' ),
-		endDate: i18n
-			.moment()
+		endDate: moment()
 			.locale( 'en' )
 			.endOf( 'month' )
 			.format( 'YYYY-MM-DD' ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import classNames from 'classnames';
 import titlecase from 'to-title-case';
 import Gridicon from 'components/gridicon';
@@ -185,7 +185,7 @@ class ThemeSheet extends React.Component {
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = this.props.name || placeholder;
 		const tag = this.props.author
-			? i18n.translate( 'by %(author)s', { args: { author: this.props.author } } )
+			? translate( 'by %(author)s', { args: { author: this.props.author } } )
 			: placeholder;
 
 		return (
@@ -236,7 +236,7 @@ class ThemeSheet extends React.Component {
 		return (
 			<div className="theme__sheet-preview-link">
 				<span className="theme__sheet-preview-link-text">
-					{ i18n.translate( 'Open Live Demo', {
+					{ translate( 'Open Live Demo', {
 						context: 'Individual theme live preview button',
 					} ) }
 				</span>
@@ -252,7 +252,7 @@ class ThemeSheet extends React.Component {
 		const photonSrc = screenshotFull && photon( screenshotFull, { width } );
 		const img = screenshotFull && (
 			<img
-				alt={ i18n.translate( 'Screenshot of the %(themeName)s theme', {
+				alt={ translate( 'Screenshot of the %(themeName)s theme', {
 					args: { themeName },
 				} ) }
 				className="theme__sheet-img"
@@ -280,9 +280,9 @@ class ThemeSheet extends React.Component {
 
 	renderSectionNav = currentSection => {
 		const filterStrings = {
-			'': i18n.translate( 'Overview', { context: 'Filter label for theme content' } ),
-			setup: i18n.translate( 'Setup', { context: 'Filter label for theme content' } ),
-			support: i18n.translate( 'Support', { context: 'Filter label for theme content' } ),
+			'': translate( 'Overview', { context: 'Filter label for theme content' } ),
+			setup: translate( 'Setup', { context: 'Filter label for theme content' } ),
+			support: translate( 'Support', { context: 'Filter label for theme content' } ),
 		};
 
 		const { siteSlug, id } = this.props;
@@ -305,7 +305,7 @@ class ThemeSheet extends React.Component {
 						onClick={ this.previewAction }
 						className="theme__sheet-preview-nav-item"
 					>
-						{ i18n.translate( 'Open Live Demo', {
+						{ translate( 'Open Live Demo', {
 							context: 'Individual theme live preview button',
 						} ) }
 					</NavItem>
@@ -355,7 +355,7 @@ class ThemeSheet extends React.Component {
 		const sitePart = siteSlug ? `/${ siteSlug }` : '';
 
 		const nextThemeHref = `/theme/${ next }${ sitePart }`;
-		return <SectionHeader href={ nextThemeHref } label={ i18n.translate( 'Next theme' ) } />;
+		return <SectionHeader href={ nextThemeHref } label={ translate( 'Next theme' ) } />;
 	};
 
 	renderOverviewTab = () => {
@@ -392,15 +392,15 @@ class ThemeSheet extends React.Component {
 			<Card className="theme__sheet-card-support">
 				<Gridicon icon="help-outline" size={ 48 } />
 				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Need extra help?' ) }
-					<small>{ i18n.translate( 'Get in touch with our support team' ) }</small>
+					{ translate( 'Need extra help?' ) }
+					<small>{ translate( 'Get in touch with our support team' ) }</small>
 				</div>
 				<Button
 					primary={ buttonCount === 1 }
 					href={ '/help/contact/' }
 					onClick={ this.trackContactUsClick }
 				>
-					{ i18n.translate( 'Contact us' ) }
+					{ translate( 'Contact us' ) }
 				</Button>
 			</Card>
 		);
@@ -412,14 +412,14 @@ class ThemeSheet extends React.Component {
 		}
 
 		const description = this.props.isPremium
-			? i18n.translate( 'Get in touch with the theme author' )
-			: i18n.translate( 'Get help from volunteers and staff' );
+			? translate( 'Get in touch with the theme author' )
+			: translate( 'Get help from volunteers and staff' );
 
 		return (
 			<Card className="theme__sheet-card-support">
 				<Gridicon icon="comment" size={ 48 } />
 				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Have a question about this theme?' ) }
+					{ translate( 'Have a question about this theme?' ) }
 					<small>{ description }</small>
 				</div>
 				<Button
@@ -427,7 +427,7 @@ class ThemeSheet extends React.Component {
 					href={ this.props.forumUrl }
 					onClick={ this.trackThemeForumClick }
 				>
-					{ i18n.translate( 'Visit forum' ) }
+					{ translate( 'Visit forum' ) }
 				</Button>
 			</Card>
 		);
@@ -438,15 +438,15 @@ class ThemeSheet extends React.Component {
 			<Card className="theme__sheet-card-support">
 				<Gridicon icon="briefcase" size={ 48 } />
 				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Need CSS help? ' ) }
-					<small>{ i18n.translate( 'Get help from the experts in our CSS forum' ) }</small>
+					{ translate( 'Need CSS help? ' ) }
+					<small>{ translate( 'Get help from the experts in our CSS forum' ) }</small>
 				</div>
 				<Button
 					primary={ buttonCount === 1 }
 					href="//en.forums.wordpress.com/forum/css-customization"
 					onClick={ this.trackCssClick }
 				>
-					{ i18n.translate( 'Visit forum' ) }
+					{ translate( 'Visit forum' ) }
 				</Button>
 			</Card>
 		);
@@ -472,9 +472,9 @@ class ThemeSheet extends React.Component {
 					<Card className="theme__sheet-card-support">
 						<Gridicon icon="notice-outline" size={ 48 } />
 						<div className="theme__sheet-card-support-details">
-							{ i18n.translate( 'This theme is unsupported' ) }
+							{ translate( 'This theme is unsupported' ) }
 							<small>
-								{ i18n.translate( "Maybe it's a custom theme? Sorry about that.", {
+								{ translate( "Maybe it's a custom theme? Sorry about that.", {
 									context: 'Support message when we no support links are available',
 								} ) }
 							</small>
@@ -488,9 +488,9 @@ class ThemeSheet extends React.Component {
 				<Card className="theme__sheet-card-support">
 					<Gridicon icon="help" size={ 48 } />
 					<div className="theme__sheet-card-support-details">
-						{ i18n.translate( 'Have a question about this theme?' ) }
+						{ translate( 'Have a question about this theme?' ) }
 						<small>
-							{ i18n.translate( 'Pick this design and start a site with us, we can help!', {
+							{ translate( 'Pick this design and start a site with us, we can help!', {
 								context: 'Logged out theme support message',
 							} ) }
 						</small>
@@ -509,15 +509,15 @@ class ThemeSheet extends React.Component {
 			return (
 				<span className="theme__sheet-customize-button">
 					<Gridicon icon="external" />
-					{ i18n.translate( 'Customize site' ) }
+					{ translate( 'Customize site' ) }
 				</span>
 			);
 		} else if ( isLoggedIn ) {
 			if ( isPremium && ! isPurchased ) {
 				// purchase
-				return i18n.translate( 'Pick this design' );
+				return translate( 'Pick this design' );
 			} // else: activate
-			return i18n.translate( 'Activate this design' );
+			return translate( 'Activate this design' );
 		}
 		return defaultOption.label;
 	};
@@ -529,16 +529,16 @@ class ThemeSheet extends React.Component {
 					<Gridicon icon="cross-circle" size={ 48 } />
 					<div className="theme__retired-theme-message-details">
 						<div className="theme__retired-theme-message-details-title">
-							{ i18n.translate( 'This theme is retired' ) }
+							{ translate( 'This theme is retired' ) }
 						</div>
 						<div>
-							{ i18n.translate(
+							{ translate(
 								'We invite you to try out a newer theme; start by browsing our WordPress theme directory.'
 							) }
 						</div>
 					</div>
 					<Button primary={ true } href={ '/themes/' }>
-						{ i18n.translate( 'See All Themes' ) }
+						{ translate( 'See All Themes' ) }
 					</Button>
 				</Card>
 
@@ -554,7 +554,7 @@ class ThemeSheet extends React.Component {
 		if ( ! this.isLoaded() || this.props.isActive ) {
 			price = '';
 		} else if ( ! this.props.isPremium ) {
-			price = i18n.translate( 'Free' );
+			price = translate( 'Free' );
 		}
 
 		const className = classNames( 'theme__sheet-action-bar-cost', {
@@ -603,7 +603,7 @@ class ThemeSheet extends React.Component {
 			isPremium,
 			isJetpack,
 			isVip,
-			translate,
+			translate: translateProp,
 			hasUnlimitedPremiumThemes,
 			previousRoute,
 		} = this.props;
@@ -620,7 +620,7 @@ class ThemeSheet extends React.Component {
 		const { canonicalUrl, currentUserId, description, name: themeName } = this.props;
 		const title =
 			themeName &&
-			i18n.translate( '%(themeName)s Theme', {
+			translateProp( '%(themeName)s Theme', {
 				args: { themeName },
 			} );
 
@@ -688,7 +688,7 @@ class ThemeSheet extends React.Component {
 				{ pageUpsellBanner }
 				<HeaderCake
 					className="theme__sheet-action-bar"
-					backText={ previousRoute ? i18n.translate( 'Back' ) : i18n.translate( 'All Themes' ) }
+					backText={ previousRoute ? translateProp( 'Back' ) : translateProp( 'All Themes' ) }
 					onClick={ this.goBack }
 				>
 					{ ! retired && this.renderButton() }

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { has, identity, mapValues, pickBy } from 'lodash';
 
 /**
@@ -38,11 +35,11 @@ import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edi
 
 const purchase = config.isEnabled( 'upgrades/checkout' )
 	? {
-			label: i18n.translate( 'Purchase', {
+			label: translate( 'Purchase', {
 				context: 'verb',
 			} ),
-			extendedLabel: i18n.translate( 'Purchase this design' ),
-			header: i18n.translate( 'Purchase on:', {
+			extendedLabel: translate( 'Purchase this design' ),
+			header: translate( 'Purchase on:', {
 				context: 'verb',
 				comment: 'label for selecting a site for which to purchase a theme',
 			} ),
@@ -58,13 +55,13 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 
 const upgradePlan = config.isEnabled( 'upgrades/checkout' )
 	? {
-			label: i18n.translate( 'Upgrade to activate', {
+			label: translate( 'Upgrade to activate', {
 				comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
 			} ),
-			extendedLabel: i18n.translate( 'Upgrade to activate', {
+			extendedLabel: translate( 'Upgrade to activate', {
 				comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
 			} ),
-			header: i18n.translate( 'Upgrade on:', {
+			header: translate( 'Upgrade on:', {
 				context: 'verb',
 				comment: 'label for selecting a site for which to upgrade a plan',
 			} ),
@@ -80,9 +77,9 @@ const upgradePlan = config.isEnabled( 'upgrades/checkout' )
 	: {};
 
 const activate = {
-	label: i18n.translate( 'Activate' ),
-	extendedLabel: i18n.translate( 'Activate this design' ),
-	header: i18n.translate( 'Activate on:', {
+	label: translate( 'Activate' ),
+	extendedLabel: translate( 'Activate this design' ),
+	header: translate( 'Activate on:', {
 		comment: 'label for selecting a site on which to activate a theme',
 	} ),
 	action: activateAction,
@@ -95,7 +92,7 @@ const activate = {
 };
 
 const deleteTheme = {
-	label: i18n.translate( 'Delete' ),
+	label: translate( 'Delete' ),
 	action: confirmDelete,
 	hideForTheme: ( state, themeId, siteId, origin ) =>
 		! isJetpackSite( state, siteId ) ||
@@ -104,9 +101,9 @@ const deleteTheme = {
 };
 
 const customize = {
-	label: i18n.translate( 'Customize' ),
-	extendedLabel: i18n.translate( 'Customize this design' ),
-	header: i18n.translate( 'Customize on:', {
+	label: translate( 'Customize' ),
+	extendedLabel: translate( 'Customize this design' ),
+	header: translate( 'Customize on:', {
 		comment: 'label in the dialog for selecting a site for which to customize a theme',
 	} ),
 	icon: 'customize',
@@ -117,9 +114,9 @@ const customize = {
 };
 
 const tryandcustomize = {
-	label: i18n.translate( 'Try & Customize' ),
-	extendedLabel: i18n.translate( 'Try & Customize' ),
-	header: i18n.translate( 'Try & Customize on:', {
+	label: translate( 'Try & Customize' ),
+	extendedLabel: translate( 'Try & Customize' ),
+	header: translate( 'Try & Customize on:', {
 		comment: 'label in the dialog for opening the Customizer with the theme in preview',
 	} ),
 	action: tryAndCustomizeAction,
@@ -136,13 +133,13 @@ const tryandcustomize = {
 };
 
 const preview = {
-	label: i18n.translate( 'Live demo', {
+	label: translate( 'Live demo', {
 		comment: 'label for previewing the theme demo website',
 	} ),
 	action: themePreview,
 };
 
-const signupLabel = i18n.translate( 'Pick this design', {
+const signupLabel = translate( 'Pick this design', {
 	comment: 'when signing up for a WordPress.com account with a selected theme',
 } );
 
@@ -158,7 +155,7 @@ const separator = {
 };
 
 const info = {
-	label: i18n.translate( 'Info', {
+	label: translate( 'Info', {
 		comment: 'label for displaying the theme info sheet',
 	} ),
 	icon: 'info',
@@ -166,14 +163,14 @@ const info = {
 };
 
 const support = {
-	label: i18n.translate( 'Setup' ),
+	label: translate( 'Setup' ),
 	icon: 'help',
 	getUrl: getThemeSupportUrl,
 	hideForTheme: ( state, themeId ) => ! isThemePremium( state, themeId ),
 };
 
 const help = {
-	label: i18n.translate( 'Support' ),
+	label: translate( 'Support' ),
 	getUrl: getThemeHelpUrl,
 };
 

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop, intersection } from 'lodash';
@@ -13,7 +10,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { taxonomiesWelcomeWhitelist, taxonomyToGridicon } from './taxonomies-config.js';
 
 class MagicSearchWelcome extends React.Component {
@@ -62,7 +59,7 @@ class MagicSearchWelcome extends React.Component {
 				this.movePositionBy( -1 );
 				event.preventDefault();
 				break;
-			case 'Enter':
+			case 'Enter': {
 				const position = this.state.suggestionPosition;
 				if ( position !== -1 ) {
 					this.props.suggestionsCallback( this.visibleTaxonomies[ position ] + ':' );
@@ -71,6 +68,7 @@ class MagicSearchWelcome extends React.Component {
 					return true;
 				}
 				break;
+			}
 		}
 		return false;
 	};
@@ -110,9 +108,7 @@ class MagicSearchWelcome extends React.Component {
 	render() {
 		return (
 			<div className="themes-magic-search-card__welcome">
-				<div className="themes-magic-search-card__welcome-header">
-					{ i18n.translate( 'Search by' ) }
-				</div>
+				<div className="themes-magic-search-card__welcome-header">{ translate( 'Search by' ) }</div>
 				<div className="themes-magic-search-card__welcome-taxonomies">
 					{ this.renderTaxonomies() }
 				</div>

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import ReactDomServer from 'react-dom/server';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
@@ -101,7 +98,7 @@ function getPressThisContent( query ) {
 	pieces.push(
 		ReactDomServer.renderToStaticMarkup(
 			<p>
-				{ i18n.translate( 'via {{anchor/}}', {
+				{ translate( 'via {{anchor/}}', {
 					components: {
 						anchor: <a href={ url }>{ title }</a>,
 					},

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External Dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import moment from 'moment';
 
 /**
@@ -55,7 +54,7 @@ export function setPageTitle( context, title ) {
 	// @todo Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch(
 		setTitle(
-			i18n.translate( '%s ‹ Reader', {
+			translate( '%s ‹ Reader', {
 				args: title,
 				comment: '%s is the section name. For example: "My Likes"',
 			} )

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External Dependencies
  */
 import React from 'react';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -134,12 +133,12 @@ const exported = {
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		recordTrack( 'calypso_reader_following_loaded' );
 
-		setPageTitle( context, i18n.translate( 'Following' ) );
+		setPageTitle( context, translate( 'Following' ) );
 
 		// warn: don't async load this only. we need it to keep feed-post-store in the reader bundle
 		context.primary = React.createElement( StreamComponent, {
 			key: 'following',
-			listName: i18n.translate( 'Followed Sites' ),
+			listName: translate( 'Followed Sites' ),
 			streamKey: 'following',
 			startDate,
 			recsStreamKey: 'custom_recs_posts_with_images',

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -1,10 +1,9 @@
-/** @format */
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,7 +15,7 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class FeedError extends React.Component {
 	static defaultProps = {
-		message: i18n.translate( "Sorry, we can't find that site." ),
+		message: translate( "Sorry, we can't find that site." ),
 	};
 
 	recordAction = () => {

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -1,9 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -21,7 +20,7 @@ const exported = {
 		const mcKey = 'following_manage';
 		const { q: sitesQuery, s: subsQuery, sort: subsSortOrder, showMoreResults } = context.query;
 
-		setPageTitle( context, i18n.translate( 'Manage Followed Sites' ) );
+		setPageTitle( context, translate( 'Manage Followed Sites' ) );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 

--- a/client/reader/search/utils.js
+++ b/client/reader/search/utils.js
@@ -1,9 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 export function getSearchPlaceholderText() {
-	return i18n.translate( 'Search' );
+	return translate( 'Search' );
 }

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { noop } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -70,7 +68,7 @@ export function generateSteps( {
 			providesDependencies: [ 'themeSlugWithRepo' ],
 			apiRequestFunction: setThemeOnSite,
 			props: {
-				headerText: i18n.translate( 'Choose a theme for your new site.' ),
+				headerText: translate( 'Choose a theme for your new site.' ),
 			},
 		},
 
@@ -84,8 +82,8 @@ export function generateSteps( {
 				showExampleSuggestions: false,
 				includeWordPressDotCom: false,
 				showSkipButton: true,
-				headerText: i18n.translate( 'Getting ready to launch, pick a domain' ),
-				subHeaderText: i18n.translate( 'Select a domain name for your website' ),
+				headerText: translate( 'Getting ready to launch, pick a domain' ),
+				subHeaderText: translate( 'Select a domain name for your website' ),
 			},
 			dependencies: [ 'siteSlug' ],
 		},
@@ -208,9 +206,9 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
 			props: {
-				headerText: i18n.translate( 'Getting ready to launch your website' ),
-				subHeaderText: i18n.translate( "Pick a plan that's right for you." ),
-				fallbackHeaderText: i18n.translate( "Almost there, pick a plan that's right for you." ),
+				headerText: translate( 'Getting ready to launch your website' ),
+				subHeaderText: translate( "Pick a plan that's right for you." ),
+				fallbackHeaderText: translate( "Almost there, pick a plan that's right for you." ),
 				isLaunchPage: true,
 			},
 		},
@@ -267,8 +265,8 @@ export function generateSteps( {
 			apiRequestFunction: createAccount,
 			providesToken: true,
 			props: {
-				headerText: i18n.translate( 'Create an account for Jetpack' ),
-				subHeaderText: i18n.translate( "You're moments away from connecting Jetpack." ),
+				headerText: translate( 'Create an account for Jetpack' ),
+				subHeaderText: translate( "You're moments away from connecting Jetpack." ),
 			},
 			providesDependencies: [ 'bearer_token', 'username' ],
 		},
@@ -313,8 +311,8 @@ export function generateSteps( {
 		'site-or-domain': {
 			stepName: 'site-or-domain',
 			props: {
-				headerText: i18n.translate( 'Choose how you want to use your domain.' ),
-				subHeaderText: i18n.translate(
+				headerText: translate( 'Choose how you want to use your domain.' ),
+				subHeaderText: translate(
 					"Don't worry you can easily add a site later if you're not ready."
 				),
 			},
@@ -331,7 +329,7 @@ export function generateSteps( {
 			stepName: 'site-picker',
 			apiRequestFunction: createSiteOrDomain,
 			props: {
-				headerText: i18n.translate( 'Choose your site?' ),
+				headerText: translate( 'Choose your site?' ),
 			},
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo' ],
 			dependencies: [ 'cartItem', 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo' ],

--- a/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,7 +20,7 @@ import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transforme
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 export const fetch = action => {
-	const notice = successNotice( i18n.translate( 'Obtaining your credentials…' ) );
+	const notice = successNotice( translate( 'Obtaining your credentials…' ) );
 	const {
 		notice: { noticeId },
 	} = notice;
@@ -48,7 +45,7 @@ export const storeAndAnnounce = ( { siteId, noticeId }, { rewind_state } ) => [
 		siteId,
 	},
 
-	successNotice( i18n.translate( 'Your credentials have been auto configured.' ), {
+	successNotice( translate( 'Your credentials have been auto configured.' ), {
 		duration: 4000,
 		id: noticeId,
 	} ),
@@ -71,7 +68,7 @@ export const storeAndAnnounce = ( { siteId, noticeId }, { rewind_state } ) => [
 ];
 
 export const announceFailure = ( { noticeId } ) =>
-	errorNotice( i18n.translate( 'Error auto configuring your credentials.' ), {
+	errorNotice( translate( 'Error auto configuring your credentials.' ), {
 		duration: 4000,
 		id: noticeId,
 	} );

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 
 /**
@@ -49,7 +48,7 @@ export const primeHappychat = ( { dispatch, getState } ) => {
 };
 
 export const request = action => {
-	const notice = successNotice( i18n.translate( 'Testing connection…' ), { duration: 30000 } );
+	const notice = successNotice( translate( 'Testing connection…' ), { duration: 30000 } );
 	const {
 		notice: { noticeId },
 	} = notice;
@@ -84,7 +83,7 @@ export const success = ( action, { rewind_state } ) => [
 		},
 		siteId: action.siteId,
 	},
-	successNotice( i18n.translate( 'Your site is now connected.' ), {
+	successNotice( translate( 'Your site is now connected.' ), {
 		duration: 4000,
 		id: action.noticeId,
 	} ),
@@ -145,10 +144,10 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 	switch ( error.error ) {
 		case 'service_unavailable':
 			announce(
-				i18n.translate(
+				translate(
 					'A error occurred when we were trying to validate your site information. Please make sure your credentials and host URL are correct and try again. If you need help, please click on the support chat link.'
 				),
-				{ button: i18n.translate( 'Support chat' ), onClick: getHelp }
+				{ button: translate( 'Support chat' ), onClick: getHelp }
 			);
 			spreadHappiness(
 				'Rewind Credentials: update request failed on timeout (could be us or remote site)'
@@ -157,14 +156,14 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 
 		case 'missing_args':
 			announce(
-				i18n.translate( 'Something seems to be missing — please fill out all the required fields.' )
+				translate( 'Something seems to be missing — please fill out all the required fields.' )
 			);
 			spreadHappiness( 'Rewind Credentials: missing API args (contact a dev)' );
 			break;
 
 		case 'invalid_args':
 			announce(
-				i18n.translate(
+				translate(
 					"The information you entered seems to be incorrect. Let's take " +
 						'another look to ensure everything is in the right place.'
 				)
@@ -174,7 +173,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 
 		case 'invalid_credentials':
 			announce(
-				i18n.translate(
+				translate(
 					"We couldn't connect to your site. Please verify your credentials and give it another try."
 				)
 			);
@@ -183,29 +182,29 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 
 		case 'invalid_wordpress_path':
 			announce(
-				i18n.translate(
+				translate(
 					'We looked for `wp-config.php` in the WordPress installation ' +
 						"path you provided but couldn't find it."
 				),
-				{ button: i18n.translate( 'Get help' ), onClick: getHelp }
+				{ button: translate( 'Get help' ), onClick: getHelp }
 			);
 			spreadHappiness( "Rewind Credentials: can't find WordPress installation files" );
 			break;
 
 		case 'read_only_install':
 			announce(
-				i18n.translate(
+				translate(
 					'It looks like your server is read-only. ' +
 						'To create backups and rewind your site, we need permission to write to your server.'
 				),
-				{ button: i18n.translate( 'Get help' ), onClick: getHelp }
+				{ button: translate( 'Get help' ), onClick: getHelp }
 			);
 			spreadHappiness( 'Rewind Credentials: creds only seem to provide read-only access' );
 			break;
 
 		case 'unreachable_path':
 			announce(
-				i18n.translate(
+				translate(
 					'We tried to access your WordPress installation through its publicly available URL, ' +
 						"but it didn't work. Please make sure the directory is accessible and try again."
 				)
@@ -214,7 +213,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 			break;
 
 		default:
-			announce( i18n.translate( 'Error saving. Please check your credentials and try again.' ) );
+			announce( translate( 'Error saving. Please check your credentials and try again.' ) );
 			spreadHappiness( 'Rewind Credentials: unknown failure saving credentials' );
 	}
 };

--- a/client/state/data-layer/wpcom/sites/alerts/fix.js
+++ b/client/state/data-layer/wpcom/sites/alerts/fix.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
 export const request = action => {
-	const notice = successNotice( i18n.translate( 'Fixing threat…' ), { duration: 30000 } );
+	const notice = successNotice( translate( 'Fixing threat…' ), { duration: 30000 } );
 	const {
 		notice: { noticeId },
 	} = notice;
@@ -36,7 +35,7 @@ export const request = action => {
 
 export const success = ( action, rewind_state ) => [
 	successNotice(
-		i18n.translate(
+		translate(
 			"We're hard at work fixing this threat in the background. Please check back shortly."
 		),
 		{
@@ -60,7 +59,7 @@ export const success = ( action, rewind_state ) => [
 ];
 
 export const failure = action =>
-	errorNotice( i18n.translate( 'Error fixing threat. Please contact support.' ), {
+	errorNotice( translate( 'Error fixing threat. Please contact support.' ), {
 		duration: 10000,
 		id: action.noticeId,
 	} );

--- a/client/state/data-layer/wpcom/sites/alerts/ignore.js
+++ b/client/state/data-layer/wpcom/sites/alerts/ignore.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
 export const request = action => {
-	const notice = successNotice( i18n.translate( 'Ignoring threat…' ), { duration: 30000 } );
+	const notice = successNotice( translate( 'Ignoring threat…' ), { duration: 30000 } );
 	const {
 		notice: { noticeId },
 	} = notice;
@@ -35,7 +34,7 @@ export const request = action => {
 };
 
 export const success = ( action, rewind_state ) => [
-	successNotice( i18n.translate( 'Threat ignored.' ), {
+	successNotice( translate( 'Threat ignored.' ), {
 		duration: 4000,
 		id: action.noticeId,
 	} ),
@@ -55,7 +54,7 @@ export const success = ( action, rewind_state ) => [
 ];
 
 export const failure = action =>
-	errorNotice( i18n.translate( 'Error ignoring threat. Please contact support.' ), {
+	errorNotice( translate( 'Error ignoring threat. Please contact support.' ), {
 		duration: 10000,
 		id: action.noticeId,
 	} );

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -28,7 +25,7 @@ const fetchFilters = action =>
 
 const storeFilters = ( action, data ) => ( { type: THEME_FILTERS_ADD, filters: data } );
 
-const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme filters.' ) );
+const reportError = () => errorNotice( translate( 'Problem fetching theme filters.' ) );
 
 registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 	[ THEME_FILTERS_REQUEST ]: [

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,8 +22,8 @@ import { requestHappychatEligibility } from 'state/happychat/user/actions';
 import wp from 'lib/wp';
 const wpcom = wp.undocumented();
 
-const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );
-const PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase.' );
+const PURCHASES_FETCH_ERROR_MESSAGE = translate( 'There was an error retrieving purchases.' );
+const PURCHASE_REMOVE_ERROR_MESSAGE = translate( 'There was an error removing the purchase.' );
 
 export const clearPurchases = () => dispatch => {
 	dispatch( { type: PURCHASES_REMOVE } );

--- a/client/state/receipts/actions.js
+++ b/client/state/receipts/actions.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -27,7 +24,7 @@ export function fetchReceipt( receiptId ) {
 				.getReceipt( receiptId, ( error, data ) => {
 					if ( error ) {
 						const errorMessage =
-							error.message || i18n.translate( 'There was a problem retrieving your receipt.' );
+							error.message || translate( 'There was a problem retrieving your receipt.' );
 
 						dispatch( {
 							type: RECEIPT_FETCH_FAILED,

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { omit } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -131,7 +128,7 @@ export function requestSite( siteFragment ) {
 					return dispatch( {
 						type: SITE_REQUEST_FAILURE,
 						siteId: siteFragment,
-						error: i18n.translate( 'No access to manage the site' ),
+						error: translate( 'No access to manage the site' ),
 					} );
 				}
 

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -1,12 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import { map } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 const debug = debugFactory( 'calypso:site-plans:actions' );
 
@@ -57,7 +54,7 @@ export function cancelSitePlanTrial( siteId, planId ) {
 
 					const errorMessage =
 						error.message ||
-						i18n.translate(
+						translate(
 							'There was a problem canceling the plan trial. Please try again later or contact support.'
 						);
 
@@ -107,7 +104,7 @@ export function fetchSitePlans( siteId ) {
 
 					const errorMessage =
 						error.message ||
-						i18n.translate(
+						translate(
 							'There was a problem fetching site plans. Please try again later or contact support.'
 						);
 

--- a/client/state/sites/selectors/get-jetpack-site-update-files-disabled-reasons.js
+++ b/client/state/sites/selectors/get-jetpack-site-update-files-disabled-reasons.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { compact } from 'lodash';
 
 /**
@@ -39,12 +39,10 @@ export default function getJetpackSiteUpdateFilesDisabledReasons(
 				action === 'autoupdateCore'
 			) {
 				if ( clue === 'has_no_file_system_write_access' ) {
-					return i18n.translate( 'The file permissions on this host prevent editing files.' );
+					return translate( 'The file permissions on this host prevent editing files.' );
 				}
 				if ( clue === 'disallow_file_mods' ) {
-					return i18n.translate(
-						'File modifications are explicitly disabled by a site administrator.'
-					);
+					return translate( 'File modifications are explicitly disabled by a site administrator.' );
 				}
 			}
 
@@ -52,13 +50,11 @@ export default function getJetpackSiteUpdateFilesDisabledReasons(
 				( action === 'autoupdateFiles' || action === 'autoupdateCore' ) &&
 				clue === 'automatic_updater_disabled'
 			) {
-				return i18n.translate( 'Any autoupdates are explicitly disabled by a site administrator.' );
+				return translate( 'Any autoupdates are explicitly disabled by a site administrator.' );
 			}
 
 			if ( action === 'autoupdateCore' && clue === 'wp_auto_update_core_disabled' ) {
-				return i18n.translate(
-					'Core autoupdates are explicitly disabled by a site administrator.'
-				);
+				return translate( 'Core autoupdates are explicitly disabled by a site administrator.' );
 			}
 			return null;
 		} )

--- a/client/state/sites/selectors/has-default-site-title.js
+++ b/client/state/sites/selectors/has-default-site-title.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { startsWith } from 'lodash';
 
 /**
@@ -24,5 +24,5 @@ export default function hasDefaultSiteTitle( state, siteId ) {
 	}
 	const slug = getSiteSlug( state, siteId );
 	// we are using startsWith here, as getSiteSlug returns "slug.wordpress.com"
-	return site.name === i18n.translate( 'Site Title' ) || startsWith( slug, site.name );
+	return site.name === translate( 'Site Title' ) || startsWith( slug, site.name );
 }

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get, isArray, map, flatten } from 'lodash';
-import i18n from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -79,7 +76,7 @@ export const getSiteStatsPostStreakData = treeSelect(
 		// ensure streakData.data exists and it is not an array
 		if ( streakData && streakData.data && ! isArray( streakData.data ) ) {
 			Object.keys( streakData.data ).forEach( timestamp => {
-				const postDay = i18n.moment.unix( timestamp ).locale( 'en' );
+				const postDay = moment.unix( timestamp ).locale( 'en' );
 				const datestamp = postDay.utcOffset( gmtOffset ).format( 'YYYY-MM-DD' );
 
 				if ( 'undefined' === typeof response[ datestamp ] ) {

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -50,7 +49,7 @@ export const fetchStoredCards = () => dispatch => {
 		.catch( error => {
 			dispatch( {
 				type: STORED_CARDS_FETCH_FAILED,
-				error: error.message || i18n.translate( 'There was a problem retrieving stored cards.' ),
+				error: error.message || translate( 'There was a problem retrieving stored cards.' ),
 			} );
 		} );
 };
@@ -78,7 +77,7 @@ export const deleteStoredCard = card => dispatch => {
 			dispatch( {
 				type: STORED_CARDS_DELETE_FAILED,
 				card,
-				error: error.message || i18n.translate( 'There was a problem deleting the stored card.' ),
+				error: error.message || translate( 'There was a problem deleting the stored card.' ),
 			} );
 		} );
 };

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -72,7 +72,7 @@ import { getSiteTitle, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import prependThemeFilterKeys from 'state/selectors/prepend-theme-filter-keys';
 import { requestSitePosts } from 'state/posts/actions';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import accept from 'lib/accept';
 
 import 'state/data-layer/wpcom/theme-filters';
@@ -844,18 +844,18 @@ export function confirmDelete( themeId, siteId ) {
 		const { name: themeName } = getTheme( getState(), siteId, themeId );
 		const siteTitle = getSiteTitle( getState(), siteId );
 		accept(
-			i18n.translate( 'Are you sure you want to delete %(themeName)s from %(siteTitle)s?', {
+			translate( 'Are you sure you want to delete %(themeName)s from %(siteTitle)s?', {
 				args: { themeName, siteTitle },
 				comment: 'Themes: theme delete confirmation dialog',
 			} ),
 			accepted => {
 				accepted && dispatch( deleteTheme( themeId, siteId ) );
 			},
-			i18n.translate( 'Delete %(themeName)s', {
+			translate( 'Delete %(themeName)s', {
 				args: { themeName },
 				comment: 'Themes: theme delete dialog confirm button',
 			} ),
-			i18n.translate( 'Back', { context: 'go back (like the back button in a browser)' } )
+			translate( 'Back', { context: 'go back (like the back button in a browser)' } )
 		);
 	};
 }

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { find, includes, isEqual, omit, some, get, uniq } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import createSelector from 'lib/create-selector';
 
 /**
@@ -732,7 +729,7 @@ export function getPremiumThemePrice( state, themeId, siteId ) {
 	}
 
 	if ( isJetpackSite( state, siteId ) ) {
-		return i18n.translate( 'Upgrade', {
+		return translate( 'Upgrade', {
 			comment:
 				'Used to indicate a premium theme is available to the user once they upgrade their plan',
 		} );

--- a/client/state/ui/editor/contact-form/reducer.js
+++ b/client/state/ui/editor/contact-form/reducer.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { cloneDeep, merge } from 'lodash';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -42,7 +39,7 @@ export default function( state = initialState, action ) {
 			state.fields.splice( index, 1 );
 			break;
 		}
-		case EDITOR_CONTACT_FORM_FIELD_UPDATE:
+		case EDITOR_CONTACT_FORM_FIELD_UPDATE: {
 			state = cloneDeep( state );
 			state.fields[ index ] = Object.assign( {}, state.fields[ index ], field );
 
@@ -51,13 +48,14 @@ export default function( state = initialState, action ) {
 			if ( newField.type !== 'radio' && newField.type !== 'select' ) {
 				delete newField.options;
 			} else if ( newField.options === undefined ) {
-				newField.options = i18n.translate( 'Option One,Option Two', {
+				newField.options = translate( 'Option One,Option Two', {
 					comment:
 						'Default options for drop down lists and radio buttons. Must be separated by a comma without extra spaces.',
 				} );
 			}
 
 			break;
+		}
 		case EDITOR_CONTACT_FORM_SETTINGS_UPDATE:
 			state = merge( {}, state, settings );
 			break;

--- a/client/state/ui/language/actions.js
+++ b/client/state/ui/language/actions.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import switchLocale from 'lib/i18n-utils/switch-locale';
-import i18n from 'i18n-calypso';
+import { setLocale as i18nSetLocale } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -35,7 +32,7 @@ export const setLocale = ( localeSlug, localeVariant = null ) => {
  * @returns {Object} Action
  */
 export const setLocaleRawData = localeData => {
-	i18n.setLocale( localeData );
+	i18nSetLocale( localeData );
 
 	const { localeSlug, localeVariant = null } = localeData[ '' ];
 

--- a/packages/eslint-plugin-wpcalypso/docs/rules/i18n-no-this-translate.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/i18n-no-this-translate.md
@@ -17,8 +17,8 @@ class MyComponent extends React.Component {
 The following patterns are not warnings:
 
 ```js
-import i18n from 'i18n-calypso';
-i18n.translate( 'Hello World' );
+import { translate } from 'i18n-calypso';
+translate( 'Hello World' );
 ```
 
 ```js

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,5 +1,11 @@
+Unreleased
+------
+
+* Remove default export
+* Remove `I18N` export
+
 4.0.0
------
+------
 
 * Move i18n-calypso into Calypso repository.
 * Refactor i18n-calypso to Calypso standards.

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
@@ -8,8 +6,6 @@ import localizeFactory from './localize';
 import useTranslateFactory from './use-translate';
 
 const i18n = new I18N();
-export { I18N };
-export default i18n;
 export const moment = i18n.moment;
 export const numberFormat = i18n.numberFormat.bind( i18n );
 export const translate = i18n.translate.bind( i18n );

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -8,7 +8,7 @@ import ReactDomServer from 'react-dom/server';
  * Internal dependencies
  */
 import data from './data';
-import i18n, { numberFormat, translate } from '../src';
+import { numberFormat, translate, setLocale, configure, addTranslations } from '../src';
 
 /**
  * Pass in a react-generated html string to remove react-specific attributes
@@ -22,17 +22,17 @@ function stripReactAttributes( string ) {
 
 describe( 'I18n', function() {
 	beforeEach( function() {
-		i18n.setLocale( data.locale );
+		setLocale( data.locale );
 	} );
 
 	afterEach( function() {
-		i18n.configure(); // ensure everything is reset
+		configure(); // ensure everything is reset
 	} );
 
 	describe( 'setLocale()', function() {
 		describe( 'adding a new locale source from the same language', function() {
 			beforeEach( function() {
-				i18n.setLocale( {
+				setLocale( {
 					'': data.locale[ '' ],
 					test1: [ 'translation1-1' ],
 					test2: [ 'translation2' ],
@@ -54,7 +54,7 @@ describe( 'I18n', function() {
 
 		describe( 'adding a new locale source from a different language', function() {
 			beforeEach( function() {
-				i18n.setLocale( {
+				setLocale( {
 					'': Object.assign( {}, data.locale[ '' ], {
 						localeSlug: 'fr',
 						'Plural-Forms': 'nplurals=2; plural=n > 1;',
@@ -191,14 +191,14 @@ describe( 'I18n', function() {
 
 		describe( 'adding new translations', function() {
 			it( 'should find a new translation after it has been added', function() {
-				i18n.addTranslations( {
+				addTranslations( {
 					'test-does-not-exist': [ 'translation3' ],
 				} );
 
 				expect( translate( 'test-does-not-exist' ) ).toBe( 'translation3' );
 			} );
 			it( 'should return the new translation if it has been overwritten', function() {
-				i18n.addTranslations( {
+				addTranslations( {
 					'test-will-overwrite': [ 'not-translation1' ],
 				} );
 
@@ -251,7 +251,7 @@ describe( 'I18n', function() {
 
 	describe( 'hashed locale data', function() {
 		it( 'should find keys when looked up by simple hash', function() {
-			i18n.setLocale( {
+			setLocale( {
 				'': {
 					localeSlug: 'xx-pig-latin',
 					'key-hash': 'sha1',
@@ -262,7 +262,7 @@ describe( 'I18n', function() {
 		} );
 
 		it( 'should find keys when looked up by single length hash', function() {
-			i18n.setLocale( {
+			setLocale( {
 				'': {
 					localeSlug: 'xx-pig-latin',
 					'key-hash': 'sha1-1',
@@ -273,7 +273,7 @@ describe( 'I18n', function() {
 		} );
 
 		it( 'should find keys when looked up by multi length hash', function() {
-			i18n.setLocale( {
+			setLocale( {
 				'': {
 					localeSlug: 'xx-pig-latin',
 					'key-hash': 'sha1-1-2',

--- a/packages/i18n-calypso/test/localize.js
+++ b/packages/i18n-calypso/test/localize.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 /**
  * Internal dependencies
  */
-import i18n, { localize } from '../src';
+import { localize, getLocaleSlug } from '../src';
 
 describe( 'localize()', () => {
 	it( 'should be named using the variable name of the composed component', () => {
@@ -53,6 +51,6 @@ describe( 'localize()', () => {
 		expect( result.props.translate ).toBeInstanceOf( Function );
 		expect( result.props.moment ).toBeInstanceOf( Function );
 		expect( result.props.numberFormat ).toBeInstanceOf( Function );
-		expect( result.props.locale ).toBe( i18n.getLocaleSlug() );
+		expect( result.props.locale ).toBe( getLocaleSlug() );
 	} );
 } );

--- a/packages/i18n-calypso/test/moment.js
+++ b/packages/i18n-calypso/test/moment.js
@@ -2,15 +2,15 @@
  * Internal dependencies
  */
 import data from './data';
-import i18n, { moment } from '../src';
+import { moment, setLocale, configure } from '../src';
 
 describe( 'I18n', function() {
 	beforeEach( function() {
-		i18n.setLocale( data.locale );
+		setLocale( data.locale );
 	} );
 
 	afterEach( function() {
-		i18n.configure(); // ensure everything is reset
+		configure(); // ensure everything is reset
 	} );
 
 	describe( 'moment()', function() {

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -11,7 +11,7 @@ import { act } from 'react-dom/test-utils';
 /**
  * Internal dependencies
  */
-import i18n, { useTranslate } from '../src';
+import { useTranslate, setLocale } from '../src';
 
 function Label() {
 	const translate = useTranslate();
@@ -23,7 +23,7 @@ describe( 'useTranslate()', () => {
 
 	beforeEach( () => {
 		// reset to default locale
-		i18n.setLocale();
+		setLocale();
 
 		// create container
 		container = document.createElement( 'div' );
@@ -39,7 +39,7 @@ describe( 'useTranslate()', () => {
 
 	test( 'renders a translated string', () => {
 		// set some locale data
-		i18n.setLocale( {
+		setLocale( {
 			'': { localeSlug: 'cs' },
 			'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
 		} );
@@ -63,7 +63,7 @@ describe( 'useTranslate()', () => {
 
 		// change locale and ensure that React UI is rerendered
 		act( () => {
-			i18n.setLocale( {
+			setLocale( {
 				'': { localeSlug: 'cs' },
 				'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
 			} );
@@ -74,7 +74,7 @@ describe( 'useTranslate()', () => {
 
 	test( 'rerenders after update of current locale translations', () => {
 		// set some locale data
-		i18n.setLocale( {
+		setLocale( {
 			'': { localeSlug: 'cs' },
 			'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
 		} );
@@ -89,7 +89,7 @@ describe( 'useTranslate()', () => {
 
 		// update the translations for the current locale
 		act( () => {
-			i18n.setLocale( {
+			setLocale( {
 				'': { localeSlug: 'cs' },
 				'hook (%(lang)s)': [ 'hák (%(lang)s)' ],
 			} );

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -7,106 +7,101 @@
 import * as React from 'react';
 import moment from 'moment';
 
-declare namespace i18nCalypso {
-	type NormalizedTranslateArgs =
-		| ( TranslateOptions & { original: string } )
-		| ( TranslateOptions & {
-				original: string;
-				plural: string;
-				count: number;
-		  } );
+type NormalizedTranslateArgs =
+	| ( TranslateOptions & { original: string } )
+	| ( TranslateOptions & {
+			original: string;
+			plural: string;
+			count: number;
+	  } );
 
-	export type Substitution = string | number;
+export type Substitution = string | number;
 
-	export type Substitutions =
-		| Substitution
-		| Substitution[]
-		| { [ placeholder: string ]: Substitution };
+export type Substitutions =
+	| Substitution
+	| Substitution[]
+	| { [ placeholder: string ]: Substitution };
 
-	export interface ComponentInterpolations {
-		[ placeholder: string ]: React.ReactElement;
-	}
-
-	export interface TranslateOptions {
-		/**
-		 * Arguments you would pass into sprintf to be run against the text for string substitution.
-		 */
-		args?: Substitutions;
-
-		/**
-		 * Comment that will be shown to the translator for anything that may need to be explained about the translation.
-		 */
-		comment?: string;
-
-		/**
-		 * Components to be interpolated in the translated string.
-		 */
-		components?: ComponentInterpolations;
-
-		/**
-		 * Provides the ability for the translator to provide a different translation for the same text in two locations (dependent on context). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
-		 */
-		context?: string;
-	}
-
-	// This deprecated signature is still supported
-	export interface DeprecatedTranslateOptions extends TranslateOptions {
-		original: string | { single: string; plural: string; count: number };
-	}
-
-	// Translate hooks force us to open up this type.
-	export type TranslateResult = string | React.ReactFragment;
-
-	export function translate( options: DeprecatedTranslateOptions ): TranslateResult;
-	export function translate( original: string ): TranslateResult;
-	export function translate( original: string, options: TranslateOptions ): TranslateResult;
-	export function translate(
-		original: string,
-		plural: string,
-		options: TranslateOptions & { count: number }
-	): TranslateResult;
-
-	export function hasTranslation( original: string ): boolean;
-
-	export interface NumberFormatOptions {
-		decimals?: number;
-		decPoint?: string;
-		thousandsSep?: string;
-	}
-
-	export function numberFormat( number: number, numberOfDecimalPlaces: number );
-	export function numberFormat( number: number, options: NumberFormatOptions );
-
-	export interface LocalizeProps {
-		locale: string;
-		translate: typeof translate;
-		numberFormat: typeof numberFormat;
-		moment: typeof moment;
-	}
-
-	// Infers prop type from component C
-	export type GetProps< C > = C extends React.ComponentType< infer P > ? P : never;
-
-	export type WithoutLocalizedProps< OrigProps > = Pick<
-		OrigProps,
-		Exclude< keyof OrigProps, keyof LocalizeProps >
-	>;
-
-	export type LocalizedComponent< C > = React.ComponentClass<
-		WithoutLocalizedProps< GetProps< C > >
-	>;
-
-	export function localize< C >( component: C ): LocalizedComponent< C >;
-
-	export function useTranslate(): typeof translate;
-
-	export type TranslateHook = (
-		translation: TranslateResult,
-		options: NormalizedTranslateArgs
-	) => TranslateResult;
-
-	export function registerTranslateHook( hook: TranslateHook ): void;
+export interface ComponentInterpolations {
+	[ placeholder: string ]: React.ReactElement;
 }
 
-export = i18nCalypso;
-export as namespace i18nCalypso;
+export interface TranslateOptions {
+	/**
+	 * Arguments you would pass into sprintf to be run against the text for string substitution.
+	 */
+	args?: Substitutions;
+
+	/**
+	 * Comment that will be shown to the translator for anything that may need to be explained about the translation.
+	 */
+	comment?: string;
+
+	/**
+	 * Components to be interpolated in the translated string.
+	 */
+	components?: ComponentInterpolations;
+
+	/**
+	 * Provides the ability for the translator to provide a different translation for the same text in two locations (dependent on context). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
+	 */
+	context?: string;
+}
+
+// This deprecated signature is still supported
+export interface DeprecatedTranslateOptions extends TranslateOptions {
+	original: string | { single: string; plural: string; count: number };
+}
+
+// Translate hooks force us to open up this type.
+export type TranslateResult = string | React.ReactFragment;
+
+export function translate( options: DeprecatedTranslateOptions ): TranslateResult;
+export function translate( original: string ): TranslateResult;
+export function translate( original: string, options: TranslateOptions ): TranslateResult;
+export function translate(
+	original: string,
+	plural: string,
+	options: TranslateOptions & { count: number }
+): TranslateResult;
+
+export function hasTranslation( original: string ): boolean;
+
+export interface NumberFormatOptions {
+	decimals?: number;
+	decPoint?: string;
+	thousandsSep?: string;
+}
+
+export function numberFormat( number: number, numberOfDecimalPlaces: number );
+export function numberFormat( number: number, options: NumberFormatOptions );
+
+export interface LocalizeProps {
+	locale: string;
+	translate: typeof translate;
+	numberFormat: typeof numberFormat;
+	moment: typeof moment;
+}
+
+// Infers prop type from component C
+export type GetProps< C > = C extends React.ComponentType< infer P > ? P : never;
+
+export type WithoutLocalizedProps< OrigProps > = Pick<
+	OrigProps,
+	Exclude< keyof OrigProps, keyof LocalizeProps >
+>;
+
+export type LocalizedComponent< C > = React.ComponentClass<
+	WithoutLocalizedProps< GetProps< C > >
+>;
+
+export function localize< C >( component: C ): LocalizedComponent< C >;
+
+export function useTranslate(): typeof translate;
+
+export type TranslateHook = (
+	translation: TranslateResult,
+	options: NormalizedTranslateArgs
+) => TranslateResult;
+
+export function registerTranslateHook( hook: TranslateHook ): void;


### PR DESCRIPTION
`i18n-calypso` exports its functions both as a monolithic default export, and as individual named functions. This is unnecessary, and makes large code migrations harder, because they need to account for both syntaxes.

This PR removes the default export from `i18n-calypso` (as well as the unused `I18N` named export), and it updates all Calypso code to used the named exports instead.

This PR should also make it easier to split `i18n-calypso` further, by e.g. keeping portions of it while migrating other parts to different libraries.

Note that this PR touches a lot of files, but most of the changes are mechanical. They weren't done via a codemod, as the codemod development time would have likely taken significant longer than doing everything manually, and wouldn't have removed the need for checking the validity of the output (e.g. name collisions).

#### Changes proposed in this Pull Request

* Remove default export from `i18n-calypso`
* Remove unused `I18N` named export from `i18n-calypso`
* Update all `i18n-calypso` tests
* Update all `i18n-calypso`-using Calypso code to only use named exports
* Some lint fixes to modified files

#### Testing instructions

There are no specific testing instructions. Compile-time checks and unit tests should pick up any mechanical errors, and the E2E suite should pick up any semantic errors (e.g. having a name collision somewhere).
