### PR TITLE
Components: Add support for header checkbox to ProductCard

### DIFF
--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -15,6 +15,16 @@ has purchase options, they will be listed below the description.
 
 See p1HpG7-7nT-p2 for more details.
 
+## <a name="how-checked-works"></a>How `checked` works
+
+The component header can optionally render and control a checkbox, and supports these cases:
+* `checked` is `true` - the checkbox will be rendered as checked.
+* `checked` is `false` - the checkbox will be rendered as unchecked.
+* `checked` is `null` - the checkbox will be rendered as uncontrolled and will be freely checkable by the user.
+* `checked` is `undefined` or not specified - the checkbox will not be rendered.
+
+Additionally, the `onSelect` prop is used if we need an external component to control what happens when the checkbox is (un)checked.
+
 ## Usage
 
 ```jsx
@@ -40,6 +50,7 @@ export default class extends React.Component {
 The following props can be passed to the Product Card component:
 
 * `billingTimeFrame`: ( string ) Billing time frame label
+* `checked`: ( bool ) Whether the header checkbox is checked. [Read more about the way this prop works](#how-checked-works)
 * `currencyCode`: ( string ) Currency code
 * `description`: ( string | element ) Product description. It can be a string or a React element (e.g. `<Fragment>`)
 * `discountedPrice`: ( number | array ) Discounted price of the product. If an array of 2 numbers is passed, it will be
@@ -48,6 +59,7 @@ The following props can be passed to the Product Card component:
   a price range
 * `isPurchased`: ( bool ) Flag indicating if the product has already been purchased. [Read more about the way this flag
   works](#how-isPurchased-flag-works)
+* `onSelect`: ( func ) Handle the header checkbox clicks (checking and unchecking the checkbox).
 * `subtitle`: ( string | element ) Product subtitle. It's used if the product has already been purchased, but can be
   used also in other use-cases. It can be a string or a React element (e.g. `<Fragment>`)
 * `title`: ( string | element ) Product title. It can be a string or a React element (e.g. `<Fragment>`)

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -1,93 +1,139 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../index';
 
-function ProductCardExample() {
-	return (
-		<Fragment>
-			<h3>Product Card - default</h3>
-			<ProductCard
-				title="Jetpack Scan"
-				billingTimeFrame="per year"
-				fullPrice={ 25 }
-				description={
-					<Fragment>
-						Automatic scanning and one-click fixes keep your site one step ahead of security
-						threats. <a href="/plans">More info</a>
-					</Fragment>
-				}
-			/>
+class ProductCardExample extends Component {
+	displayName = 'ProductCard';
 
-			<h3>Product Card - with a discount</h3>
-			<ProductCard
-				title="Jetpack Scan"
-				billingTimeFrame="per year"
-				fullPrice={ 25.99 }
-				discountedPrice={ 16.99 }
-				description={
-					<Fragment>
-						Automatic scanning and one-click fixes keep your site one step ahead of security
-						threats. <a href="/plans">More info</a>
-					</Fragment>
-				}
-			/>
+	state = {
+		checked: false,
+	};
 
-			<h3>Product Card - with a discounted price range</h3>
-			<ProductCard
-				title="Jetpack Backup"
-				billingTimeFrame="per year"
-				fullPrice={ [ 16, 25 ] }
-				discountedPrice={ [ 12, 16 ] }
-				description={
-					<Fragment>
-						Always-on backups ensure you never lose your site. Choose from real-time or daily
-						backups. <a href="/plans">Which one do I need?</a>
-					</Fragment>
-				}
-			/>
+	handleProductSelection = () => {
+		this.setState( {
+			checked: ! this.state.checked,
+		} );
+	};
 
-			<h3>Product Card - already purchased</h3>
-			<ProductCard
-				title={
-					<Fragment>
-						Jetpack Backup <strong>Daily</strong>
-					</Fragment>
-				}
-				subtitle="Purchased 2019-09-13"
-				description={
-					<Fragment>
-						<strong>Looking for more?</strong> With Real-time backups:, we save as you edit and
-						you’ll get unlimited backup archives
-					</Fragment>
-				}
-				isPurchased
-			/>
+	render() {
+		return (
+			<Fragment>
+				<h3>Product Card - default</h3>
+				<ProductCard
+					title="Jetpack Scan"
+					billingTimeFrame="per year"
+					fullPrice={ 25 }
+					description={
+						<Fragment>
+							Automatic scanning and one-click fixes keep your site one step ahead of security
+							threats. <a href="/plans">More info</a>
+						</Fragment>
+					}
+				/>
 
-			<h3>Product Card - part of Jetpack plan</h3>
-			<ProductCard
-				title={
-					<Fragment>
-						Jetpack Backup <em>Real-Time</em>
-					</Fragment>
-				}
-				subtitle={
-					<Fragment>
-						Included in your <a href="/my-plan">Personal Plan</a>
-					</Fragment>
-				}
-				description="Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives"
-				isPurchased
-			/>
-		</Fragment>
-	);
+				<h3>Product Card - with a discount</h3>
+				<ProductCard
+					title="Jetpack Scan"
+					billingTimeFrame="per year"
+					fullPrice={ 25.99 }
+					discountedPrice={ 16.99 }
+					description={
+						<Fragment>
+							Automatic scanning and one-click fixes keep your site one step ahead of security
+							threats. <a href="/plans">More info</a>
+						</Fragment>
+					}
+				/>
+
+				<h3>Product Card - with a discounted price range</h3>
+				<ProductCard
+					title="Jetpack Backup"
+					billingTimeFrame="per year"
+					fullPrice={ [ 16, 25 ] }
+					discountedPrice={ [ 12, 16 ] }
+					description={
+						<Fragment>
+							Always-on backups ensure you never lose your site. Choose from real-time or daily
+							backups. <a href="/plans">Which one do I need?</a>
+						</Fragment>
+					}
+				/>
+
+				<h3>Product Card - already purchased</h3>
+				<ProductCard
+					title={
+						<Fragment>
+							Jetpack Backup <strong>Daily</strong>
+						</Fragment>
+					}
+					subtitle="Purchased 2019-09-13"
+					description={
+						<Fragment>
+							<strong>Looking for more?</strong> With Real-time backups:, we save as you edit and
+							you’ll get unlimited backup archives
+						</Fragment>
+					}
+					isPurchased
+				/>
+
+				<h3>Product Card - part of Jetpack plan</h3>
+				<ProductCard
+					title={
+						<Fragment>
+							Jetpack Backup <em>Real-Time</em>
+						</Fragment>
+					}
+					subtitle={
+						<Fragment>
+							Included in your <a href="/my-plan">Personal Plan</a>
+						</Fragment>
+					}
+					description="Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives"
+					isPurchased
+				/>
+
+				<h3>Product Card - with a static checkbox (checked)</h3>
+				<ProductCard
+					title="Jetpack Scan"
+					billingTimeFrame="per year"
+					fullPrice={ 25 }
+					description={
+						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+					}
+					checked
+				/>
+
+				<h3>Product Card - with a static checkbox (unchecked)</h3>
+				<ProductCard
+					title="Jetpack Scan"
+					billingTimeFrame="per year"
+					fullPrice={ 25 }
+					description={
+						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+					}
+					checked={ false }
+				/>
+
+				<h3>Product Card - with a dynamic checkbox</h3>
+				<ProductCard
+					title="Jetpack Scan"
+					billingTimeFrame="per year"
+					fullPrice={ 25 }
+					description={
+						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+					}
+					checked={ this.state.checked }
+					onSelect={ this.handleProductSelection }
+				/>
+			</Fragment>
+		);
+	}
 }
-
-ProductCardExample.displayName = 'ProductCard';
 
 export default ProductCardExample;

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -9,6 +9,8 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import ProductCardPriceGroup from './price-group';
 
 /**
@@ -19,6 +21,7 @@ import './style.scss';
 class ProductCard extends Component {
 	static propTypes = {
 		billingTimeFrame: PropTypes.string,
+		checked: PropTypes.bool,
 		currencyCode: PropTypes.string,
 		description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 		discountedPrice: PropTypes.oneOfType( [
@@ -27,6 +30,7 @@ class ProductCard extends Component {
 		] ),
 		fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
 		isPurchased: PropTypes.bool,
+		onSelect: PropTypes.func,
 		subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 	};
@@ -34,16 +38,28 @@ class ProductCard extends Component {
 	renderHeader() {
 		const {
 			billingTimeFrame,
+			checked,
 			currencyCode,
 			discountedPrice,
 			fullPrice,
 			isPurchased,
+			onSelect,
 			subtitle,
 			title,
 		} = this.props;
 
 		return (
 			<div className="product-card__header">
+				{ checked !== undefined && (
+					<FormLabel>
+						<FormCheckbox
+							className="product-card__checkbox"
+							checked={ checked }
+							onChange={ onSelect }
+							readOnly={ ! onSelect }
+						/>
+					</FormLabel>
+				) }
 				{ title && (
 					<div className="product-card__header-primary">
 						<h3 className="product-card__title">{ title }</h3>

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -25,6 +25,10 @@
 	}
 }
 
+input[type='checkbox'].product-card__checkbox {
+	margin-right: 0.333em;
+}
+
 .product-card__title {
 	font-size: 22px;
 	line-height: 22px;


### PR DESCRIPTION
This PR implements a support for header checkboxes in the `ProductCard` component. This is necessary for the follow-up of #36812, where we will be implementing a cart and a checkout button on the `ProductSelector` block.

Note: This PR doesn't attempt to perfect the CSS, it only adds some minimal CSS so it doesn't look awkward.

#### Changes proposed in this Pull Request

* Components: Add support for header checkbox to ProductCard

#### Preview

Before:
![](https://cldup.com/mp0jdqlI6A.png)

After:
![](https://cldup.com/_Gaws6hDoH.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs/design/product-card
* Verify all examples still look and work well. All but the last 3 examples shouldn't have a checkbox.
* Take a look at the last 3 examples, and verify they work as expected:
  * Checked, readonly
  * Unchecked, readonly
  * Controlled, can be checked and unchecked.
* Verify there are no console errors.

