### PR TITLE
End an old test

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -37,10 +37,7 @@ export default function stepsForProductAndSurvey(
 			return [ steps.INITIAL_STEP, steps.BUSINESS_AT_STEP, steps.FINAL_STEP ];
 		}
 
-		if (
-			includesProduct( PERSONAL_PREMIUM_PLANS, product ) &&
-			abtest( 'ATUpgradeOnCancel' ) === 'show'
-		) {
+		if ( includesProduct( PERSONAL_PREMIUM_PLANS, product ) ) {
 			return [ steps.INITIAL_STEP, steps.UPGRADE_AT_STEP, steps.FINAL_STEP ];
 		}
 	}

--- a/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
@@ -177,67 +177,31 @@ describe( 'stepsForProductAndSurvey', () => {
 	describe( 'question one answer is "could not install"', () => {
 		const survey = { questionOneRadio: 'couldNotInstall' };
 
-		test( 'should include AT upgrade step if product is personal plan and abtest variant is show', () => {
+		test( 'should include AT upgrade step if product is personal plan', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
 			);
 		} );
 
-		test( 'should include AT upgrade step if product is personal plan and abtest variant is show (2y)', () => {
+		test( 'should include AT upgrade step if product is personal plan (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
 			);
 		} );
 
-		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide', () => {
-			const product = { product_slug: plans.PLAN_PERSONAL };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
-				PLAN_SURVEY_STEPS
-			);
-		} );
-
-		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide (2y)', () => {
-			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
-				PLAN_SURVEY_STEPS
-			);
-		} );
-
-		test( 'should include AT upgrade step if product is premium plan and abtest variant is show', () => {
+		test( 'should include AT upgrade step if product is premium plan', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
 			);
 		} );
 
-		test( 'should include AT upgrade step if product is premium plan and abtest variant is show (2y)', () => {
+		test( 'should include AT upgrade step if product is premium plan (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
-			);
-		} );
-
-		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide', () => {
-			const product = { product_slug: plans.PLAN_PREMIUM };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
-				PLAN_SURVEY_STEPS
-			);
-		} );
-
-		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide (2y)', () => {
-			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
-			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
-				PLAN_SURVEY_STEPS
 			);
 		} );
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,15 +27,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	ATUpgradeOnCancel: {
-		datestamp: '20170515',
-		variations: {
-			hide: 20,
-			show: 80,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This test has been running since 2017 because of low traffic and other reasons.

#### Testing instructions

1. Make sure that you have a user that's not been assigned to a variation of this test
2. Buy a Personal or Premium plan
3. Go to manage purchase and try to cancel the plan. In the prompt, select that you couldn't install a plugin
4. You should see an intermediate step that offers you an upgrade to Business because Business supports plugins
5. Confirm that you didn't get assigned to a variation

Fixes #
