### PR TITLE
OAuth: Fix brand colors in login screen

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -75,27 +75,9 @@ export class Auth extends Component {
 		this.setState( { [ name ]: value } );
 	};
 
-	hasLoginDetails() {
-		if ( this.state.login === '' || this.state.password === '' ) {
-			return false;
-		}
-
-		return true;
-	}
-
 	canSubmitForm() {
 		// No submission until the ajax has finished
-		if ( this.state.inProgress ) {
-			return false;
-		}
-
-		// If we have 2fa set then don't allow submission until a code is entered
-		if ( this.state.requires2fa ) {
-			return parseInt( this.state.auth_code, 10 ) > 0;
-		}
-
-		// Don't allow submission until username+password is entered
-		return this.hasLoginDetails();
+		return ! this.state.inProgress;
 	}
 
 	render() {

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -27,7 +27,8 @@
 }
 
 .auth.main {
-	background: var( --color-primary );
+	// Use WordPress.com’s brand color for the auth background
+	background: var( --color-wordpress-com );
 	float: none;
 	height: 100%;
 	display: flex;

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -90,12 +90,6 @@
 		width: calc( 100% - 20px );
 	}
 
-	.form-buttons-bar button,
-	.form-buttons-bar .button.is-primary[disabled] {
-		background: #00a8db;
-		border: #00a8db;
-	}
-
 	.form-buttons-bar .button.is-primary[disabled],
 	.form-fieldset input[type='password']:disabled,
 	.form-fieldset input[type='text']:disabled {

--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -37,13 +37,8 @@ describe( 'LoginTest', () => {
 		} );
 	} );
 
-	test( 'can submit without login details entered', done => {
-		expect( page.find( FormButton ).props().disabled ).to.be.true;
-		page.setState( { login: 'test', password: 'test', inProgress: false }, function() {
-			page.update();
-			expect( page.find( FormButton ).props().disabled ).to.be.true;
-			done();
-		} );
+	test( 'can submit without login details entered', () => {
+		expect( page.find( FormButton ).props().disabled ).to.be.false;
 	} );
 
 	test( 'shows OTP box with valid login', done => {

--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -37,11 +37,11 @@ describe( 'LoginTest', () => {
 		} );
 	} );
 
-	test( 'cannot submit until login details entered', done => {
+	test( 'can submit without login details entered', done => {
 		expect( page.find( FormButton ).props().disabled ).to.be.true;
 		page.setState( { login: 'test', password: 'test', inProgress: false }, function() {
 			page.update();
-			expect( page.find( FormButton ).props().disabled ).to.be.false;
+			expect( page.find( FormButton ).props().disabled ).to.be.true;
 			done();
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #35949 we missed the OAuth login screen (only used in the desktop app), so it is currently using a wrong color for its background. 

This PR uses the proper color var for the background screen, so the WP.com's brand color is used (same color as sign up). It also makes the sign it button enabled by default and removes the custom blue color used on it,  so it is displayed with the same pink used in other primary action buttons.

| Before | After | 
|---|---|
| <img width="1165" alt="Screen Shot 2019-10-16 at 15 56 21" src="https://user-images.githubusercontent.com/1233880/66926026-9aa1cb80-f02d-11e9-8248-c86d13259604.png"> | <img width="1165" alt="Screen Shot 2019-10-16 at 17 16 40" src="https://user-images.githubusercontent.com/1233880/66933280-266d2500-f039-11e9-80c5-16303eaf1b86.png"> |

#### Testing instructions

This needs to be tested on the desktop app, so make sure you have the dev environment [installed and running](https://github.com/Automattic/wp-desktop/blob/468ecd4d68cdafbc2935facfcd15953f46db98ce/docs/install.md) (more info about how to set up the secrets at paaHJt-7y-p2).

- In the desktop repo, point the calypso submodule to this branch: `cd calypso && git fetch && git checkout fix/bg-color-oauth-login && cd ..`.
- Generate  a new build: `make build` (this can take a few minutes).
- Open the built app in the `release/<YOUR_OS>` folder (i.e. `release/mac/WordPress.com.app`).
- Sign out if you're logged in.
- Make sure the WordPress.com's brand color is used as the login background and the sign in button appears in pink and enabled by default:
<img width="1165" alt="Screen Shot 2019-10-16 at 17 16 40" src="https://user-images.githubusercontent.com/1233880/66933280-266d2500-f039-11e9-80c5-16303eaf1b86.png"> 


Fixes https://github.com/Automattic/wp-desktop/issues/676
