### PR TITLE
Store: Go to Customer Home (if enabled) when navigating back

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -8,7 +8,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,16 +15,11 @@ import { get } from 'lodash';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Site from 'blocks/site';
-import { canCurrentUserUseCustomerHome } from 'state/sites/selectors';
-import { getStatsDefaultSitePage } from 'lib/route/path';
+import { getSiteHomeUrl } from 'state/sites/selectors';
 
-const StoreGroundControl = ( { canUserUseCustomerHome, site, translate } ) => {
+const StoreGroundControl = ( { site, siteHomeUrl, translate } ) => {
 	const isPlaceholder = ! site;
-	const siteSlug = get( site, 'slug', '' );
-	const backDestination = canUserUseCustomerHome
-		? `/home/${ siteSlug }`
-		: getStatsDefaultSitePage( siteSlug );
-	const backUrl = isPlaceholder ? '' : backDestination;
+	const backUrl = isPlaceholder ? '' : siteHomeUrl;
 
 	return (
 		<div className="store-sidebar__ground-control">
@@ -46,13 +40,13 @@ const StoreGroundControl = ( { canUserUseCustomerHome, site, translate } ) => {
 };
 
 StoreGroundControl.propTypes = {
-	canUserUseCustomerHome: PropTypes.bool.isRequired,
 	site: PropTypes.shape( {
 		slug: PropTypes.string,
 	} ).isRequired,
+	siteHomeUrl: PropTypes.string.isRequired,
 	translate: PropTypes.func.isRequired,
 };
 
 export default connect( state => ( {
-	canUserUseCustomerHome: canCurrentUserUseCustomerHome( state ),
+	siteHomeUrl: getSiteHomeUrl( state ),
 } ) )( localize( StoreGroundControl ) );

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,10 +15,12 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Site from 'blocks/site';
+import { canCurrentUserUseCustomerHome } from 'state/sites/selectors';
 
-const StoreGroundControl = ( { site, translate } ) => {
+const StoreGroundControl = ( { canUserUseCustomerHome, site, translate } ) => {
 	const isPlaceholder = ! site;
-	const backLink = isPlaceholder ? '' : '/stats/day/' + site.slug;
+	const backDestination = canUserUseCustomerHome ? '/home/' : '/stats/day/';
+	const backUrl = isPlaceholder ? '' : backDestination + site.slug;
 
 	return (
 		<div className="store-sidebar__ground-control">
@@ -25,7 +28,7 @@ const StoreGroundControl = ( { site, translate } ) => {
 				borderless
 				className="store-sidebar__ground-control-back"
 				disabled={ isPlaceholder }
-				href={ backLink }
+				href={ backUrl }
 				aria-label={ translate( 'Close Store' ) }
 			>
 				<Gridicon icon="cross" />
@@ -38,9 +41,13 @@ const StoreGroundControl = ( { site, translate } ) => {
 };
 
 StoreGroundControl.propTypes = {
+	canUserUseCustomerHome: PropTypes.bool.isRequired,
 	site: PropTypes.shape( {
 		slug: PropTypes.string,
-	} ),
+	} ).isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
-export default localize( StoreGroundControl );
+export default connect( state => ( {
+	canUserUseCustomerHome: canCurrentUserUseCustomerHome( state ),
+} ) )( localize( StoreGroundControl ) );

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -8,6 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,11 +17,15 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Site from 'blocks/site';
 import { canCurrentUserUseCustomerHome } from 'state/sites/selectors';
+import { getStatsDefaultSitePage } from 'lib/route/path';
 
 const StoreGroundControl = ( { canUserUseCustomerHome, site, translate } ) => {
 	const isPlaceholder = ! site;
-	const backDestination = canUserUseCustomerHome ? '/home/' : '/stats/day/';
-	const backUrl = isPlaceholder ? '' : backDestination + site.slug;
+	const siteSlug = get( site, 'slug', '' );
+	const backDestination = canUserUseCustomerHome
+		? `/home/${ siteSlug }`
+		: getStatsDefaultSitePage( siteSlug );
+	const backUrl = isPlaceholder ? '' : backDestination;
 
 	return (
 		<div className="store-sidebar__ground-control">

--- a/client/state/sites/selectors/can-current-user-use-customer-home.js
+++ b/client/state/sites/selectors/can-current-user-use-customer-home.js
@@ -17,7 +17,7 @@ import getSite from './get-site';
  * Returns true if the current user should be able to use the customer home screen
  *
  * @param  {Object}   state  Global state tree
- * @param  {Number}   siteId Site ID
+ * @param  {?Number}  siteId Site ID
  * @return {?Boolean}        Whether the site can use the customer home screen
  */
 export default function canCurrentUserUseCustomerHome( state, siteId = null ) {

--- a/client/state/sites/selectors/get-site-home-url.ts
+++ b/client/state/sites/selectors/get-site-home-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { canCurrentUserUseCustomerHome, getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getStatsDefaultSitePage } from 'lib/route/path';
+
+/**
+ * Determine the default section to show for the specified site.
+ *
+ * @param  {Object}  state  Global state tree.
+ * @param  {?Number} siteId Site ID.
+ * @return {String}         Url of the site home.
+ */
+export default function getSiteHomeUrl( state: object, siteId?: number ): string {
+	const selectedSiteId = siteId || getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, selectedSiteId );
+
+	return canCurrentUserUseCustomerHome( state, selectedSiteId )
+		? `/home/${ siteSlug }`
+		: getStatsDefaultSitePage( siteSlug );
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -28,6 +28,7 @@ export { default as getSiteComputedAttributes } from './get-site-computed-attrib
 export { default as getSiteDomain } from './get-site-domain';
 export { default as getSiteFrontPage } from './get-site-front-page';
 export { default as getSiteFrontPageType } from './get-site-front-page-type';
+export { default as getSiteHomeUrl } from './get-site-home-url';
 export { default as getSiteOption } from './get-site-option';
 export { default as getSitePlan } from './get-site-plan';
 export { default as getSitePlanSlug } from './get-site-plan-slug';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When navigating back from the Store section, go to Customer Home, if enabled

<img width="946" alt="Screen Shot 2019-10-16 at 10 13 59" src="https://user-images.githubusercontent.com/1699996/66932817-cd33d000-effd-11e9-8f8d-77aa589c4170.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Without Customer Home**
1. On an Atomic site with a Business plan, created _before_ 2019-08-06, with WooCommerce installed, to `/store/{site}`
1. Click on the "X" to go back, you should go to the Stats section

**With Customer Home**
1. On an Atomic site with a Business plan, created _after_ 2019-08-06, with WooCommerce installed, to `/store/{site}`
1. Click on the "X" to go back, you should go to the Customer Home