### PR TITLE
Customer Home: Minor string update

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -333,7 +333,7 @@ class Home extends Component {
 					<Card>
 						<CardHeading>{ translate( 'Support' ) }</CardHeading>
 						<h6 className="customer-home__card-subheader">
-							{ translate( 'Get all of the help you need' ) }
+							{ translate( 'Get all the help you need' ) }
 						</h6>
 						<div className="customer-home__card-support">
 							<img


### PR DESCRIPTION
This change replaces the string `Get all of the help you need` with `Get all the help you need`.

Though still grammatically correct, the `of` in the existing copy doesn't add any substance to the existing messaging and can be removed to make it easier to visually parse.

|Before|After|
|---|---|
|![Screen Shot 2019-10-16 at 11 59 14 AM](https://user-images.githubusercontent.com/1587282/66937040-bd6fb800-f00c-11e9-9447-4c3bf03d60f4.png)|![Screen Shot 2019-10-16 at 12 03 47 PM](https://user-images.githubusercontent.com/1587282/66937199-0b84bb80-f00d-11e9-85c6-14146d250e28.png)|


