### PR TITLE
Remove i18n-calypso moment from woocommerce

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -7,13 +6,15 @@ import config from 'config';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { dashboardListLimit } from 'woocommerce/app/store-stats/constants';
 import DashboardWidget from 'woocommerce/components/dashboard-widget';
 import { getLink } from 'woocommerce/lib/nav-utils';
@@ -62,9 +63,9 @@ class StatsWidget extends Component {
 	};
 
 	dateForDisplay = () => {
-		const { translate, unit } = this.props;
+		const { translate, unit, moment: localizedMoment } = this.props;
 
-		const localizedDate = moment( moment().format( 'YYYY-MM-DD' ) );
+		const localizedDate = localizedMoment( localizedMoment().format( 'YYYY-MM-DD' ) );
 		let formattedDate;
 		switch ( unit ) {
 			case 'week':
@@ -135,8 +136,8 @@ class StatsWidget extends Component {
 	};
 
 	renderOrders = () => {
-		const { site, translate, unit, orderData, queries } = this.props;
-		const date = getEndPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const { site, translate, unit, orderData, queries, moment: localizedMoment } = this.props;
+		const date = getEndPeriod( localizedMoment().format( 'YYYY-MM-DD' ), unit );
 		const delta = getDelta( orderData.deltas, date, 'orders' );
 		return (
 			<Stat
@@ -155,8 +156,8 @@ class StatsWidget extends Component {
 	};
 
 	renderSales = () => {
-		const { site, translate, unit, orderData, queries } = this.props;
-		const date = getEndPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const { site, translate, unit, orderData, queries, moment: localizedMoment } = this.props;
+		const date = getEndPeriod( localizedMoment().format( 'YYYY-MM-DD' ), unit );
 		const delta = getDelta( orderData.deltas, date, 'total_sales' );
 		return (
 			<Stat
@@ -175,8 +176,8 @@ class StatsWidget extends Component {
 	};
 
 	renderVisitors = () => {
-		const { site, translate, unit, visitorData, queries } = this.props;
-		const date = getStartPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const { site, translate, unit, visitorData, queries, moment: localizedMoment } = this.props;
+		const date = getStartPeriod( localizedMoment().format( 'YYYY-MM-DD' ), unit );
 		const delta = getDeltaFromData( visitorData, date, 'visitors', unit );
 		return (
 			<Stat
@@ -195,8 +196,16 @@ class StatsWidget extends Component {
 	};
 
 	renderConversionRate = () => {
-		const { site, translate, unit, visitorData, orderData, queries } = this.props;
-		const date = getUnitPeriod( moment().format( 'YYYY-MM-DD' ), unit );
+		const {
+			site,
+			translate,
+			unit,
+			visitorData,
+			orderData,
+			queries,
+			moment: localizedMoment,
+		} = this.props;
+		const date = getUnitPeriod( localizedMoment().format( 'YYYY-MM-DD' ), unit );
 		const data = getConversionRateData( visitorData, orderData.data, unit );
 		const delta = getDeltaFromData( data, date, 'conversionRate', unit );
 		return (
@@ -397,4 +406,4 @@ function mapDispatchToProps( dispatch ) {
 export default connect(
 	mapStateToProps,
 	mapDispatchToProps
-)( localize( StatsWidget ) );
+)( localize( withLocalizedMoment( StatsWidget ) ) );

--- a/client/extensions/woocommerce/app/order/order-activity-log/events.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/events.js
@@ -1,12 +1,12 @@
-/** @format */
 /**
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { keys, last, noop, sortBy } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -1,11 +1,11 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import page from 'page';
 import { includes } from 'lodash';
-import { moment, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -90,7 +90,7 @@ export default function StatsController( context, next ) {
 				/>
 			);
 			break;
-		case 'referrers':
+		case 'referrers': {
 			const { referrerQuery } = getQueries( props.unit, props.queryDate );
 			asyncComponent = (
 				<AsyncLoad
@@ -101,6 +101,7 @@ export default function StatsController( context, next ) {
 				/>
 			);
 			break;
+		}
 		default:
 			asyncComponent = (
 				<AsyncLoad

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -1,11 +1,10 @@
-/** @format */
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -1,15 +1,11 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import page from 'page';
 import { findIndex, find } from 'lodash';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,6 +13,7 @@ import { moment } from 'i18n-calypso';
 import Card from 'components/card';
 import ElementChart from 'components/chart';
 import Legend from 'components/chart/legend';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import { getWidgetPath, formatValue } from 'woocommerce/app/store-stats/utils';
 import { UNITS } from 'woocommerce/app/store-stats/constants';
@@ -74,7 +71,7 @@ class StoreStatsChart extends Component {
 	};
 
 	createTooltipDate = item => {
-		const { unit } = this.props;
+		const { unit, moment } = this.props;
 		const dateFormat = UNITS[ unit ].shortFormat;
 		const date = moment( item.period );
 		if ( unit === 'week' ) {
@@ -164,4 +161,4 @@ class StoreStatsChart extends Component {
 		);
 	}
 }
-export default StoreStatsChart;
+export default withLocalizedMoment( StoreStatsChart );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/index.js
@@ -1,17 +1,14 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { withLocalizedMoment } from 'components/localized-moment';
 import StoreStatsChart from 'woocommerce/app/store-stats/store-stats-chart';
 import Delta from 'woocommerce/components/delta';
 import { getPeriodFormat } from 'state/stats/lists/utils';
@@ -38,7 +35,7 @@ class StoreStatsOrdersChart extends Component {
 	};
 
 	renderTabs = ( { chartData, selectedIndex, selectedTabIndex, selectedDate, unit, tabClick } ) => {
-		const { deltas } = this.props;
+		const { deltas, moment } = this.props;
 		return (
 			<Tabs data={ chartData }>
 				{ tabs.map( ( tab, tabIndex ) => {
@@ -102,4 +99,4 @@ export default connect( ( state, { query, siteId } ) => {
 		deltas: statsData.deltas,
 		isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsOrders', query ),
 	};
-} )( StoreStatsOrdersChart );
+} )( withLocalizedMoment( StoreStatsOrdersChart ) );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -1,19 +1,17 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { findIndex } from 'lodash';
-import { moment, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { withLocalizedMoment } from 'components/localized-moment';
 import Delta from 'woocommerce/components/delta';
 import { formatValue, getDelta } from '../utils';
 import { getPeriodFormat } from 'state/stats/lists/utils';
@@ -34,7 +32,7 @@ class StoreStatsWidgetList extends Component {
 	};
 
 	render() {
-		const { data, deltas, query, selectedDate, widgets } = this.props;
+		const { data, deltas, query, selectedDate, widgets, moment } = this.props;
 		const { unit } = query;
 		const selectedIndex = findIndex( data, d => d.period === selectedDate );
 		const firstRealKey = Object.keys( deltas[ selectedIndex ] ).filter(
@@ -132,4 +130,4 @@ export default connect( ( state, { siteId, statType, query } ) => {
 		data: siteStats.data,
 		deltas: siteStats.deltas,
 	};
-} )( StoreStatsWidgetList );
+} )( withLocalizedMoment( StoreStatsWidgetList ) );

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -1,12 +1,12 @@
-/** @format */
 /**
  * External dependencies
  */
 import { find, includes, forEach, findIndex, round } from 'lodash';
 import classnames from 'classnames';
-import { moment, translate, numberFormat } from 'i18n-calypso';
+import { translate, numberFormat } from 'i18n-calypso';
 import qs from 'qs';
 import formatCurrency from '@automattic/format-currency';
+import moment from 'moment'; // No localization needed in this file.
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

This PR focuses on the `woocommerce` extension.

**Note**: If I added you and you feel you're not the right person to review these changes, I apologise for that; please feel free to ignore or remove yourself. I just went with the default GitHub suggestions since I had no idea who to add 🤷‍♂ 

#### Changes proposed in this Pull Request

* Replace non-localized usage of `i18n-calypso` `moment` with vanilla `moment`
* Replace localized usage of `i18n-calypso` `moment` with `withLocalizedMoment`

#### Testing instructions

The changes are simple, so there shouldn't be much need for testing beyond ensuring the modified Woo functionality continues to work correctly, particularly where it comes to date-related functionality in non-English locales.
