### PR TITLE
Fix broken client tests that use section-header

### DIFF
--- a/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
@@ -1,4 +1,4 @@
-/** @format */
+/** @jest-environment jsdom */
 /**
  * External dependencies
  */

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,4 +1,4 @@
-/** @format */
+/** @jest-environment jsdom */
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -1,4 +1,4 @@
-/** @format */
+/** @jest-environment jsdom */
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -1,4 +1,4 @@
-/** @format */
+/** @jest-environment jsdom */
 /**
  * External dependencies
  */


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* Section-header uses popover which uses click-outside, which uses an unguarded window ref. Until we get rid of click-outside, add jsdom to tests that use section-header.

#### Testing instructions

* No functional changes, client tests should pass

