### PR TITLE
Use correct asset.php file for Webpack dependency extraction

### DIFF
--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -13,7 +13,7 @@ This app contains:
 /full-site-editing-plugin
   /dist
     full-site-editing-plugin.css
-    full-site-editing-plugin.assets.php
+    full-site-editing-plugin.asset.php
     full-site-editing-plugin.js
     full-site-editing-plugin.rtl.css
   class-a8c-rest-template-controller.php
@@ -29,7 +29,7 @@ This app contains:
       style.scss
   /dist
     a8c-posts-list.css
-    a8c-posts-list.assets.php
+    a8c-posts-list.asset.php
     a8c-posts-list.js
     a8c-posts-list.rtl.css
   /templates

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -154,7 +154,7 @@ class Full_Site_Editing {
 	 * Enqueue assets.
 	 */
 	public function enqueue_script_and_style() {
-		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/full-site-editing.assets.php';
+		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/full-site-editing.asset.php';
 		$script_dependencies = $asset_file['dependencies'];
 		wp_enqueue_script(
 			'a8c-full-site-editing-script',

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
@@ -20,10 +20,10 @@ class Posts_List_Block {
 	private static $instance = null;
 
 	/**
- 	 * Whether we are in the process of rendering the block.
- 	 *
- 	 * @var bool
- 	 */
+	 * Whether we are in the process of rendering the block.
+	 *
+	 * @var bool
+	 */
 	private $rendering_block = false;
 
 	/**
@@ -52,7 +52,7 @@ class Posts_List_Block {
 	 * Enqueue block editor scripts.
 	 */
 	public function enqueue_scripts() {
-		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/posts-list-block.assets.php';
+		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/posts-list-block.asset.php';
 		$script_dependencies = $asset_file['dependencies'];
 		wp_enqueue_script(
 			'a8c-posts-list-script',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5653,25 +5653,25 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"resolved": false,
 							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"optional": true,
 							"requires": {
@@ -5681,13 +5681,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"resolved": false,
 							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"optional": true,
 							"requires": {
@@ -5697,37 +5697,37 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 							"optional": true,
 							"requires": {
@@ -5736,25 +5736,25 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"resolved": false,
 							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+							"resolved": false,
 							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 							"optional": true,
 							"requires": {
@@ -5763,13 +5763,13 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"resolved": false,
 							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"optional": true,
 							"requires": {
@@ -5785,7 +5785,7 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+							"resolved": false,
 							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 							"optional": true,
 							"requires": {
@@ -5799,13 +5799,13 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"resolved": false,
 							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"optional": true,
 							"requires": {
@@ -5814,7 +5814,7 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 							"optional": true,
 							"requires": {
@@ -5823,7 +5823,7 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"resolved": false,
 							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"optional": true,
 							"requires": {
@@ -5833,19 +5833,19 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"resolved": false,
 							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"resolved": false,
 							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"optional": true,
 							"requires": {
@@ -5854,13 +5854,13 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"resolved": false,
 							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"optional": true,
 							"requires": {
@@ -5869,13 +5869,13 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"resolved": false,
 							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+							"resolved": false,
 							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 							"optional": true,
 							"requires": {
@@ -5885,7 +5885,7 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 							"optional": true,
 							"requires": {
@@ -5894,7 +5894,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"optional": true,
 							"requires": {
@@ -5903,13 +5903,13 @@
 						},
 						"ms": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 							"optional": true,
 							"requires": {
@@ -5920,7 +5920,7 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 							"optional": true,
 							"requires": {
@@ -5938,7 +5938,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"optional": true,
 							"requires": {
@@ -5948,13 +5948,13 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 							"optional": true,
 							"requires": {
@@ -5964,7 +5964,7 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"resolved": false,
 							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"optional": true,
 							"requires": {
@@ -5976,19 +5976,19 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"optional": true,
 							"requires": {
@@ -5997,19 +5997,19 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"resolved": false,
 							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"optional": true,
 							"requires": {
@@ -6019,19 +6019,19 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"resolved": false,
 							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"optional": true,
 							"requires": {
@@ -6043,7 +6043,7 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"resolved": false,
 									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"optional": true
 								}
@@ -6051,7 +6051,7 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"optional": true,
 							"requires": {
@@ -6066,7 +6066,7 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+							"resolved": false,
 							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 							"optional": true,
 							"requires": {
@@ -6075,43 +6075,43 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"resolved": false,
 							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"resolved": false,
 							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"resolved": false,
 							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"optional": true,
 							"requires": {
@@ -6122,7 +6122,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"optional": true,
 							"requires": {
@@ -6131,7 +6131,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"optional": true,
 							"requires": {
@@ -6140,13 +6140,13 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+							"resolved": false,
 							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 							"optional": true,
 							"requires": {
@@ -6161,13 +6161,13 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"resolved": false,
 							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"optional": true,
 							"requires": {
@@ -6176,13 +6176,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+							"resolved": false,
 							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 							"optional": true
 						}

--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -64,7 +64,7 @@ That `webpack.config.js` introduces one rather WordPress/Gutenberg specific "env
 
 The impact of this option is twofold:
 
-1. It will make Webpack use `@wordpress/dependency-extraction-webpack-plugin` to infer NPM packages that are commonly used by Gutenberg blocks (anything in the `@wordpress/` scope, `lodash`, React, jQuery, etc) from the source files it bundles, and produce a `.assets.php` file containing an array of those dependencies for use with `wp_enqueue_script`. For more information, see `@wordpress/dependency-extraction-webpack-plugin`'s [docs](https://developer.wordpress.org/block-editor/packages/packages-dependency-extraction-webpack-plugin/).
+1. It will make Webpack use `@wordpress/dependency-extraction-webpack-plugin` to infer NPM packages that are commonly used by Gutenberg blocks (anything in the `@wordpress/` scope, `lodash`, React, jQuery, etc) from the source files it bundles, and produce a `.asset.php` file containing an array of those dependencies for use with `wp_enqueue_script`. For more information, see `@wordpress/dependency-extraction-webpack-plugin`'s [docs](https://developer.wordpress.org/block-editor/packages/packages-dependency-extraction-webpack-plugin/).
 
 2. It will transpile JSX to [`@wordpress/element`](https://www.npmjs.com/package/@wordpress/element) rather than React components. This is also required for Gutenberg blocks.
 


### PR DESCRIPTION
We first thought it was assets.php (plural) which is not the case.

#### Changes proposed in this Pull Request

* Use `.asset.php` instead of `.assets.php`

#### Testing instructions
* Build Full Site Editing and actually run it on a site to verify that no warnings or errors are generated.

Fixes #36206