### PR TITLE
Customer Home: Point the block editor button back to /home

### DIFF
--- a/client/state/selectors/get-editor-close-url.js
+++ b/client/state/selectors/get-editor-close-url.js
@@ -5,6 +5,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import getPostTypeAllPostsUrl from 'state/selectors/get-post-type-all-posts-url';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import isLastNonEditorRouteChecklist from 'state/selectors/is-last-non-editor-route-checklist';
+import getLastNonEditorRoute from 'state/selectors/get-last-non-editor-route';
 
 /**
  * Gets the URL for the close button for the block editor, dependent previous referral state
@@ -24,6 +25,10 @@ export default function getEditorCloseUrl( state, siteId, postType, fseParentPag
 	// Checking if we should navigate back to the checklist
 	if ( isLastNonEditorRouteChecklist( state ) ) {
 		return `/checklist/${ getSiteSlug( state, siteId ) }`;
+	}
+
+	if ( getLastNonEditorRoute( state ).match( /^\/home\/?/ ) ) {
+		return `/home/${ getSiteSlug( state, siteId ) }`;
 	}
 
 	// Otherwise, just return to post type listings

--- a/client/state/selectors/get-editor-close-url.js
+++ b/client/state/selectors/get-editor-close-url.js
@@ -9,11 +9,12 @@ import getLastNonEditorRoute from 'state/selectors/get-last-non-editor-route';
 
 /**
  * Gets the URL for the close button for the block editor, dependent previous referral state
- * @param {Object} state  Global state tree
- * @param {Object} siteId Site ID
+ *
+ * @param {object} state  Global state tree
+ * @param {object} siteId Site ID
  * @param {string} postType The type of the current post being edited
  * @param {string} fseParentPageId The ID of the parent post for the FSE template part
- * @return {string} The URL that should be used when the block editor close button is clicked
+ * @returns {string} The URL that should be used when the block editor close button is clicked
  */
 
 export default function getEditorCloseUrl( state, siteId, postType, fseParentPageId ) {

--- a/client/state/selectors/get-last-non-editor-route.js
+++ b/client/state/selectors/get-last-non-editor-route.js
@@ -15,7 +15,7 @@ import createSelector from 'lib/create-selector';
  * @param {Object} state  Global state tree
  * @return {string} The last non block editor route -- empty string if none.
  */
-export default createSelector(
+const getLastNonEditorRoute = createSelector(
 	state => {
 		const previousPath = getPreviousPath( state );
 		const blockEditorPattern = /^\/block-editor/;
@@ -38,3 +38,5 @@ export default createSelector(
 	},
 	state => [ getPreviousPath( state ), getRouteHistory( state ) ]
 );
+
+export default getLastNonEditorRoute;

--- a/client/state/selectors/get-last-non-editor-route.js
+++ b/client/state/selectors/get-last-non-editor-route.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { dropRightWhile, get, last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRouteHistory } from 'state/ui/action-log/selectors';
+import getPreviousPath from 'state/selectors/get-previous-path';
+import createSelector from 'lib/create-selector';
+
+/**
+ * Get the last non-editor route while ignoring navigation in block editor.
+ * @param {Object} state  Global state tree
+ * @return {string} The last non block editor route -- empty string if none.
+ */
+export default createSelector(
+	state => {
+		const previousPath = getPreviousPath( state );
+		const blockEditorPattern = /^\/block-editor/;
+
+		if ( previousPath && ! blockEditorPattern.test( previousPath ) ) {
+			return previousPath;
+		}
+
+		// Fall back to reading from the action log
+		return get(
+			last(
+				dropRightWhile(
+					getRouteHistory( state ),
+					( { path } ) => path && blockEditorPattern.test( path )
+				)
+			),
+			'path',
+			''
+		);
+	},
+	state => [ getPreviousPath( state ), getRouteHistory( state ) ]
+);

--- a/client/state/selectors/get-last-non-editor-route.js
+++ b/client/state/selectors/get-last-non-editor-route.js
@@ -12,8 +12,9 @@ import createSelector from 'lib/create-selector';
 
 /**
  * Get the last non-editor route while ignoring navigation in block editor.
- * @param {Object} state  Global state tree
- * @return {string} The last non block editor route -- empty string if none.
+ *
+ * @param {object} state  Global state tree
+ * @returns {string} The last non block editor route -- empty string if none.
  */
 const getLastNonEditorRoute = createSelector(
 	state => {

--- a/client/state/selectors/test/get-editor-close-url.js
+++ b/client/state/selectors/test/get-editor-close-url.js
@@ -10,18 +10,26 @@ import getEditorCloseUrl from 'state/selectors/get-editor-close-url';
 import getPostTypeAllPostsUrl from 'state/selectors/get-post-type-all-posts-url';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import PostQueryManager from 'lib/query-manager/post';
+import { ROUTE_SET } from 'state/action-types';
 
 const postType = 'post';
 const pagePostType = 'page';
 const templatePostType = 'wp_template_part';
 const siteId = 1;
+const siteSlug = 'fake.url.wordpress.com';
+const siteUrl = `https://${ siteSlug }`;
+const checklistUrl = `/checklist/${ siteSlug }`;
+const customerHomeUrl = `/home/${ siteSlug }`;
+const blockEditorAction = { type: ROUTE_SET, path: '/block-editor/page/1' };
+const checklistAction = { type: ROUTE_SET, path: checklistUrl };
+const customerHomeAction = { type: ROUTE_SET, path: customerHomeUrl };
 
 describe( 'getEditorCloseUrl()', () => {
 	test( 'should return URL for post type listings as default', () => {
 		const state = {
 			sites: {
 				items: {
-					[ siteId ]: { URL: 'https://fake.url.wordpress.com' },
+					[ siteId ]: { URL: siteUrl },
 				},
 			},
 			ui: { selectedSiteId: siteId, actionLog: [] },
@@ -38,7 +46,7 @@ describe( 'getEditorCloseUrl()', () => {
 		const state = {
 			sites: {
 				items: {
-					[ siteId ]: { URL: 'https://fake.url.wordpress.com' },
+					[ siteId ]: { URL: siteUrl },
 				},
 			},
 			posts: {
@@ -68,13 +76,10 @@ describe( 'getEditorCloseUrl()', () => {
 	} );
 
 	test( 'should return URL for checklist if previous nav was from the checklist', () => {
-		const siteSlug = 'fake.url.wordpress.com';
-		const checklistUrl = `/checklist/${ siteSlug }`;
-
 		const state = {
 			sites: {
 				items: {
-					[ siteId ]: { URL: `https://${ siteSlug }` },
+					[ siteId ]: { URL: siteUrl },
 				},
 			},
 			ui: {
@@ -89,5 +94,58 @@ describe( 'getEditorCloseUrl()', () => {
 		};
 
 		expect( getEditorCloseUrl( state, siteId, postType ) ).to.equal( checklistUrl );
+	} );
+
+	test( 'should return URL for checklist if most recent non-editor nav was from the checklist', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			ui: {
+				selectedSiteId: siteId,
+				actionLog: [ customerHomeAction, checklistAction, blockEditorAction ],
+			},
+		};
+
+		expect( getEditorCloseUrl( state, siteId, postType, '' ) ).to.equal( checklistUrl );
+	} );
+
+	test( 'should return URL for customer home if previous nav was from the customer home', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			ui: {
+				route: {
+					path: {
+						previous: customerHomeUrl,
+					},
+				},
+				selectedSiteId: siteId,
+				actionLog: [],
+			},
+		};
+
+		expect( getEditorCloseUrl( state, siteId, postType, '' ) ).to.equal( customerHomeUrl );
+	} );
+
+	test( 'should return URL for customer home if most recent non-editor nav was from the customer home', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			ui: {
+				selectedSiteId: siteId,
+				actionLog: [ checklistAction, customerHomeAction, blockEditorAction ],
+			},
+		};
+
+		expect( getEditorCloseUrl( state, siteId, postType, '' ) ).to.equal( customerHomeUrl );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the most recent browsing history is from the customer home, navigate back to `/home` when clicking the "close" button in the editor
* Added test coverage for these cases for `getEditorCloseUrl`
* Extracted a new selector `getLastNonEditorRoute` (from `isLastNonEditorRouteChecklist`)

#### Testing instructions

* Browse to `/home`
* Click `Edit Homepage`
* Click the "left chevron" button (close button)
  * You should be taken back to the customer home
* Repeat with all customer home interactions that take you to the editor
  * You should be taken back to the customer home
* Open the editor from various other places that are not the customer home
  * You should not be taken to the customer home, but to the same location you are taken in production

##### Automated tests:

`npm run test-client client/state/selectors/test/get-editor-close-url`

fixes #35452