### PR TITLE
FSE Fix copy page flow. (WIP)

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -615,11 +615,6 @@ class Full_Site_Editing {
 	public function remove_wp_admin_menu_items() {
 		global $submenu;
 
-		// For safety.
-		if ( ! \A8C\FSE\is_full_site_editing_active() ) {
-			return;
-		}
-
 		// Remove widget submenu.
 		remove_submenu_page( 'themes.php', 'widgets.php' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -549,7 +549,7 @@ class Full_Site_Editing {
 
 		$inner_blocks_template = array();
 		foreach ( $inner_blocks as $inner_block ) {
-			$inner_blocks[] = fse_map_block_to_editor_template_setting( $inner_block );
+			$inner_blocks[] = $this->fse_map_block_to_editor_template_setting( $inner_block );
 		}
 		return array( $block_name, $attrs, $inner_blocks_template );
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -56,7 +56,7 @@ class Full_Site_Editing {
 		// NOTE: Priority for default_content must be set to 11 so that it executes
 		// after the filter set in Jetpack_Copy_Post. If copy_post gets the last say in things,
 		// we would not be able to insert the header/footer data into the default editor content.
-		add_filter( 'default_content', [ $this, 'get_default_copy' ], 11, 2 );
+		add_filter( 'default_content', [ $this, 'get_default_page_content' ], 11, 2 );
 		add_action( 'after_switch_theme', [ $this, 'insert_default_data' ] );
 		add_filter( 'body_class', array( $this, 'add_fse_body_class' ) );
 		add_filter( 'post_row_actions', [ $this, 'remove_trash_row_action_for_template_post_types' ], 10, 2 );
@@ -402,7 +402,6 @@ class Full_Site_Editing {
 			return;
 		}
 		$post->post_content = preg_replace( '@(<!-- wp:a8c/post-content)(.*?)(/-->)@', "$1$2-->$post->post_content<!-- /wp:a8c/post-content -->", $template_content );
-		l( 'post content replacement' );
 	}
 
 	/**


### PR DESCRIPTION
Wow, this is a surprisingly difficult problem to solve because both Jetpack's copy_post and FSE are really hacking the existing filters/actions to load post content as they want and the approaches are not compatible.

**Problems fixed by this PR:**
1. The copy page function completely deletes the block template from the editor settings, so we now set the block template after that happens (priority 11).
2. On new pages, the existing post content is used as the "initial edits" to load into Gutenberg. That post content did not include the header/footer. We now merge the page template into the default post content for the editor instance.

However, though these are all necessary, the result of this PR is that the post content does not display when the post is copied, just the header/footer and post title. The good news is that we know what causes this bug. The bad news is that it's a systematic issue in Gutenberg: nested templates are f****d. (see [here](https://github.com/Automattic/wp-calypso/issues/35605#issuecomment-542931228) for more explanation)

We tell Gutenberg that our template is "template part, then post content, then another template part", but Gutenberg validates that against post content _including_ all of the nested post content blocks. There is no way to skip validation of nested blocks, which means when the editor is set up, those nested blocks are removed because they don't exist in the block template.

A solution might be to add all of the post content blocks as innerBlocks of the post content block in the block template, so that the blocks all exist in the template during validation. This is 💯hacky, but if we want this fixed for FSE soon, that's the way to go. I tried to get this working today, but couldn't get all the parsing working as expected, so it's not in this PR yet.

However, I already have https://github.com/WordPress/gutenberg/issues/11681 on my radar, and my plan is to work on a solution at the source as part of the work involved with that. 

### Testing instructions
Copy a page and see if the editor loads as expected :)
- SPT should not display
- Headers and footers should display.
- Post content from copied post should display. (note: not working)
- Additionally, smoke test normal page creation and editing routes.

Fixes #35605
