### PR TITLE
Preview IFrame - Add fall back to opening preview in full window if iframe load fails

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -222,7 +222,11 @@ export class WebPreviewContent extends Component {
 		} else {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
-		if ( caller === 'iframe-onload' && ! this.state.loaded ) {
+		if (
+			caller === 'iframe-onload' &&
+			! this.state.loaded &&
+			this.state.iframeUrl !== 'about:blank'
+		) {
 			if ( this.props.showClose ) {
 				window.open( this.state.iframeUrl, '_blank' );
 				this.props.onClose();

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -223,8 +223,12 @@ export class WebPreviewContent extends Component {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
 		if ( caller === 'iframe-onload' && ! this.state.loaded ) {
-			window.open( this.state.iframeUrl, '_blank' );
-			this.props.onClose();
+			if ( this.props.showClose ) {
+				window.open( this.state.iframeUrl, '_blank' );
+				this.props.onClose();
+			} else {
+				window.location.replace( this.state.iframeUrl );
+			}
 		} else {
 			this.setState( { loaded: true, isLoadingSubpage: false } );
 		}

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -104,7 +104,7 @@ export class WebPreviewContent extends Component {
 				this.props.onClose();
 				return;
 			case 'partially-loaded':
-				this.setLoaded();
+				this.setLoaded( 'iframe-message' );
 				return;
 			case 'location-change':
 				this.handleLocationChange( data.payload );
@@ -207,7 +207,7 @@ export class WebPreviewContent extends Component {
 		this.setDeviceViewport( 'seo' );
 	};
 
-	setLoaded = () => {
+	setLoaded = caller => {
 		if ( this.state.loaded && ! this.state.isLoadingSubpage ) {
 			debug( 'already loaded' );
 			return;
@@ -222,18 +222,15 @@ export class WebPreviewContent extends Component {
 		} else {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
-		this.setState( { loaded: true, isLoadingSubpage: false } );
-
+		if ( caller === 'iframe-onload' && ! this.state.loaded ) {
+			window.open( this.state.iframeUrl, '_blank' );
+			this.props.onClose();
+		} else {
+			this.setState( { loaded: true, isLoadingSubpage: false } );
+		}
 		// Sometimes we force inline help open in the preview. In this case we don't want to hide it when the iframe loads
 		if ( ! this.props.isInlineHelpPopoverVisible ) {
 			this.focusIfNeeded();
-		}
-	};
-
-	setIframeLoaded = () => {
-		if ( ! this.state.loaded ) {
-			window.open( this.state.iframeUrl, '_blank' );
-			this.props.onClose();
 		}
 	};
 
@@ -286,7 +283,7 @@ export class WebPreviewContent extends Component {
 							ref={ this.setIframeInstance }
 							className="web-preview__frame"
 							src="about:blank"
-							onLoad={ this.setIframeLoaded }
+							onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 							title={ this.props.iframeTitle || translate( 'Preview' ) }
 						/>
 					</div>

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -233,6 +233,7 @@ export class WebPreviewContent extends Component {
 	setIframeLoaded = () => {
 		if ( ! this.state.loaded ) {
 			window.open( this.state.iframeUrl, '_blank' );
+			this.props.onClose();
 		}
 	};
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -232,7 +232,7 @@ export class WebPreviewContent extends Component {
 
 	setIframeLoaded = () => {
 		if ( ! this.state.loaded ) {
-			window.location.href = this.state.iframeUrl;
+			window.open( this.state.iframeUrl, '_blank' );
 		}
 	};
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -230,6 +230,12 @@ export class WebPreviewContent extends Component {
 		}
 	};
 
+	setIframeLoaded = () => {
+		if ( ! this.state.loaded ) {
+			window.location.href = this.state.iframeUrl;
+		}
+	};
+
 	render() {
 		const { translate } = this.props;
 
@@ -279,7 +285,7 @@ export class WebPreviewContent extends Component {
 							ref={ this.setIframeInstance }
 							className="web-preview__frame"
 							src="about:blank"
-							onLoad={ this.setLoaded }
+							onLoad={ this.setIframeLoaded }
 							title={ this.props.iframeTitle || translate( 'Preview' ) }
 						/>
 					</div>

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -222,11 +222,7 @@ export class WebPreviewContent extends Component {
 		} else {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
-		if (
-			caller === 'iframe-onload' &&
-			! this.state.loaded &&
-			this.state.iframeUrl !== 'about:blank'
-		) {
+		if ( this.checkForIframeLoadFailure( caller ) ) {
 			if ( this.props.showClose ) {
 				window.open( this.state.iframeUrl, '_blank' );
 				this.props.onClose();
@@ -241,6 +237,17 @@ export class WebPreviewContent extends Component {
 			this.focusIfNeeded();
 		}
 	};
+
+	// In cases where loading of the iframe content is blocked by the browser for cross-origin reasons the
+	// iframe onload event is still fired, so we need to validate that the actual content was loaded by seeing
+	// if state.loaded was set to true by the receipt of a postMessage from the iframe. The check for
+	// 'about:blank' prevents the check for failing in the context of previews in the block editor  - in this
+	// context a postMessage is not received from the iframe.
+	checkForIframeLoadFailure( caller ) {
+		return (
+			caller === 'iframe-onload' && ! this.state.loaded && this.state.iframeUrl !== 'about:blank'
+		);
+	}
 
 	render() {
 		const { translate } = this.props;

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -114,6 +114,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	mediaSelectPort: MessagePort | null = null;
 	revisionsPort: MessagePort | null = null;
 	templatePorts: [ T.PostId, MessagePort ][] = [];
+	successfullIframeLoad = false;
 
 	componentDidMount() {
 		MediaStore.on( 'change', this.updateImageBlocks );
@@ -144,6 +145,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.iframeRef.current &&
 			this.iframeRef.current.contentWindow
 		) {
+			this.successfullIframeLoad = true;
 			const { port1: iframePortObject, port2: transferredPortObject } = new MessageChannel();
 
 			this.iframePort = iframePortObject;
@@ -518,6 +520,14 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			: `Block Editor > ${ postTypeText } > New`;
 	};
 
+	onIframeLoaded = ( iframeUrl: string ) => {
+		if ( ! this.successfullIframeLoad ) {
+			window.location.href = iframeUrl;
+			return;
+		}
+		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
+	};
+
 	render() {
 		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
 		const {
@@ -560,9 +570,9 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
 							// Iframe url needs to be kept in state to prevent editor reloading if frame_nonce changes
 							// in Jetpack sites
-							onLoad={ () =>
-								this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } )
-							}
+							onLoad={ () => {
+								this.onIframeLoaded( iframeUrl );
+							} }
 						/>
 					) }
 				</div>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -114,7 +114,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	mediaSelectPort: MessagePort | null = null;
 	revisionsPort: MessagePort | null = null;
 	templatePorts: [ T.PostId, MessagePort ][] = [];
-	successfullIframeLoad = false;
 
 	componentDidMount() {
 		MediaStore.on( 'change', this.updateImageBlocks );
@@ -145,7 +144,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.iframeRef.current &&
 			this.iframeRef.current.contentWindow
 		) {
-			this.successfullIframeLoad = true;
 			const { port1: iframePortObject, port2: transferredPortObject } = new MessageChannel();
 
 			this.iframePort = iframePortObject;
@@ -520,14 +518,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			: `Block Editor > ${ postTypeText } > New`;
 	};
 
-	onIframeLoaded = ( iframeUrl: string ) => {
-		if ( ! this.successfullIframeLoad ) {
-			window.location.href = iframeUrl;
-			return;
-		}
-		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
-	};
-
 	render() {
 		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
 		const {
@@ -570,9 +560,9 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
 							// Iframe url needs to be kept in state to prevent editor reloading if frame_nonce changes
 							// in Jetpack sites
-							onLoad={ () => {
-								this.onIframeLoaded( iframeUrl );
-							} }
+							onLoad={ () =>
+								this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } )
+							}
 						/>
 					) }
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If load of preview content into iframe fails due to cross origin issues, eg. if a Jetpack site is setting X-Frame-Options to same-origin at the web server level, then load preview in new tab instead

#### Testing instructions

*  Create a standard Jurassic Ninja site and connect it to your WordPress.com account.
* Activate the Hello Dolly plugin, and with the Plugin Editor, add this line to it: `add_action( 'init', 'send_frame_options_header', 99 );`
* Open View Post for the Hello World post on your local Calypso install on `master`, and see the sad browser header failure.
* Switch to this branch.
* Open the same View Post, and see the preview load in a new tab.

Before:

![before-preview](https://user-images.githubusercontent.com/3629020/66975523-3c431e80-f0fb-11e9-829e-ea4d44f5049e.gif)

After:

![after-preview](https://user-images.githubusercontent.com/3629020/66975535-4533f000-f0fb-11e9-8f5f-59a62985640a.gif)

Fixes #36824
