### PR TITLE
Fixup site icon positioning in compact version of Site component

### DIFF
--- a/client/blocks/site/docs/example.jsx
+++ b/client/blocks/site/docs/example.jsx
@@ -16,7 +16,7 @@ import { getSite } from 'state/sites/selectors';
 
 const SiteExample = ( { site } ) => (
 	<Card style={ { padding: 0 } }>
-		<Site site={ site } />
+		<Site site={ site } homeLink />
 		<Site compact site={ site } homeLink={ true } />
 	</Card>
 );

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -39,6 +39,10 @@
 	}
 
 	&.is-compact {
+		.site-icon {
+			align-self: center;
+		}
+
 		.site__content {
 			padding: 0 16px;
 		}
@@ -54,6 +58,8 @@
 		.site__home {
 			top: 11px;
 			line-height: 18px;
+			width: 24px;
+			height: 24px;
 		}
 
 		.site__home .gridicon {
@@ -149,11 +155,6 @@
 	.gridicon {
 		margin-top: 5px;
 		vertical-align: middle;
-	}
-
-	.site.is-compact & {
-		width: 24px;
-		height: 24px;
 	}
 
 	@include breakpoint( '<660px' ) {


### PR DESCRIPTION
Regressed in #35882. This patch adds centering style to `.site.is-compact .site-icon` and unifies `.site.is-compact .site__home` styles into one rule.

**How to test:**
Verify that `<Site compact>` is shown with correct icon placement in `/devdocs/blocks/site`:
<img width="338" alt="Screenshot 2019-10-17 at 10 14 13" src="https://user-images.githubusercontent.com/664258/66990724-084e0600-f0c7-11e9-9dbd-7e255b9e8bea.png">
(verify the correct "home" icon placement, too)

and also in Classic Editor masterbar:
<img width="481" alt="Screenshot 2019-10-17 at 10 13 48" src="https://user-images.githubusercontent.com/664258/66990690-fcfada80-f0c6-11e9-92ca-4a7ebfdd5883.png">

