### PR TITLE
Blocks: Implement product options handling in ProductSelector (take 2)

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -20,6 +20,7 @@ const products = [
 			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
 		},
+		optionsLabel: 'Backup options',
 	}
 ];
 

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -25,6 +25,20 @@ const products = [
 		},
 		optionsLabel: 'Backup options',
 	},
+	{
+		title: 'Jetpack Plan',
+		description: <Fragment>A Jetpack subscription of your choice.</Fragment>,
+		id: 'jetpack_plan',
+		options: {
+			yearly: [ 'jetpack_personal', 'jetpack_premium', 'jetpack_business' ],
+			monthly: [
+				'jetpack_personal_monthly',
+				'jetpack_premium_monthly',
+				'jetpack_business_monthly',
+			],
+		},
+		optionsLabel: 'Plan options',
+	},
 ];
 
 class ProductSelectorExample extends Component {

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -23,6 +23,7 @@ const products = [
 			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
 		},
+		optionsLabel: 'Backup options',
 	},
 ];
 

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { flattenDeep, isEmpty, map, uniq } from 'lodash';
@@ -10,6 +10,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import Card from 'components/card';
 import ProductCard from 'components/product-card';
 import QueryProductsList from 'components/data/query-products-list';
 import { extractProductSlugs, filterByProductSlugs } from './utils';
@@ -48,6 +51,14 @@ export class ProductSelector extends Component {
 		}
 	}
 
+	handleProductOptionSelect( stateKey, productSlug ) {
+		return () => {
+			this.setState( {
+				[ stateKey ]: productSlug,
+			} );
+		};
+	}
+
 	renderProducts() {
 		const { currencyCode, intervalType, products, storeProducts } = this.props;
 
@@ -60,16 +71,58 @@ export class ProductSelector extends Component {
 			const productObject = storeProducts[ selectedProductSlug ];
 
 			return (
-				<ProductCard
-					key={ product.id }
-					title={ product.title }
-					billingTimeFrame={ this.getBillingTimeFrameLabel() }
-					fullPrice={ productObject.cost }
-					description={ product.description }
-					currencyCode={ currencyCode }
-				/>
+				<Fragment key={ 'product-' + product.id }>
+					<ProductCard
+						key={ product.id }
+						title={ product.title }
+						billingTimeFrame={ this.getBillingTimeFrameLabel() }
+						fullPrice={ productObject.cost }
+						description={ product.description }
+						currencyCode={ currencyCode }
+					/>
+
+					{ this.renderProductOptions( product ) }
+				</Fragment>
 			);
 		} );
+	}
+
+	renderProductOptions( product ) {
+		const { intervalType, storeProducts } = this.props;
+		const productSlugs = product.options[ intervalType ];
+		const stateKey = this.getStateKey( product.id, intervalType );
+
+		return (
+			<Card>
+				<h4>{ product.optionsLabel }</h4>
+
+				{ productSlugs.map( productSlug => {
+					const productObject = storeProducts[ productSlug ];
+
+					/**
+					 * TODO: Replace with a ProductOption component.
+					 *
+					 * This will eventually render a product options component and we'll pass it some props like:
+					 * - handleSelect={ this.handleProductOptionSelect( stateKey, productSlug ) }
+					 * - checked={ productSlug === this.state[ stateKey ] }
+					 * - product={ productObject }
+					 */
+					return (
+						<Fragment key={ 'product-option-' + productSlug }>
+							<FormLabel>
+								<FormRadio
+									checked={ productSlug === this.state[ stateKey ] }
+									onChange={ this.handleProductOptionSelect( stateKey, productSlug ) }
+								/>
+								<span>
+									{ productObject.product_name } - { productObject.cost_display }
+								</span>
+							</FormLabel>
+						</Fragment>
+					);
+				} ) }
+			</Card>
+		);
 	}
 
 	render() {


### PR DESCRIPTION
This PR implements product options handling in `ProductSelector`, and adds a new product to the block example to allow for it to be tested easier.

Note that this is not the final look, we're going to work on styling it separately.

It also uses simple components for the form radios/labels because this will soon be replaced with a new product option component that @delawski is working on.

This is take 2 (take 1 broke the build - https://github.com/Automattic/wp-calypso/pull/36812) - I'll investigate.

#### Changes proposed in this Pull Request

* Implement product options handling in ProductSelector
* Add a second product to ProductSelector example for demonstration

#### Preview

Screenshot:
![](https://cldup.com/TTEvY231Ks.png)

Video preview:
https://cloudup.com/cSW6fS-Bkco

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector
* Play with the monthly/yearly toggle and verify it updates prices and products correctly.
* Play with the product options, and verify they update prices properly.
* Verify that selected product options for each product persist as we switch between different billing intervals.
