### PR TITLE
Cart Synchronizer: rewrite handleDispatch method to classic function

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -70,7 +70,7 @@ function CartSynchronizer( cartKey, wpcom ) {
 
 Emitter( CartSynchronizer.prototype );
 
-CartSynchronizer.prototype.handleDispatch = ( { action } ) => {
+CartSynchronizer.prototype.handleDispatch = function( { action } ) {
 	switch ( action.type ) {
 		case TRANSACTION_STEP_SET:
 			if ( action.step.first && ! action.step.last ) {


### PR DESCRIPTION
Arrow function has the wrong `this` and throws exception when trying to call `this.pause()` or `this.resume()`. Regressed in #36764.

**How to test:**
Try to buy any plan upgrade. Pay with credits. Verify that the checkout and payment finishes without console errors and weird UI behavior.