### PR TITLE
Masterbar Publish Button: remove withRtl logic for Popover

### DIFF
--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -18,7 +18,6 @@ import { preload } from 'sections-helper';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 import MasterbarDrafts from './drafts';
-import { withRtl } from 'components/rtl';
 import TranslatableString from 'components/translatable/proptype';
 import { getEditorUrl } from 'state/selectors/get-editor-url';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
@@ -34,7 +33,6 @@ class MasterbarItemNew extends React.Component {
 		// connected props
 		shouldOpenSiteSelector: PropTypes.bool,
 		editorUrl: PropTypes.string,
-		isRtl: PropTypes.bool,
 	};
 
 	state = {
@@ -64,17 +62,7 @@ class MasterbarItemNew extends React.Component {
 	preloadPostEditor = () => preload( 'post-editor' );
 
 	getPopoverPosition() {
-		const { isRtl } = this.props;
-
-		if ( isMobile() ) {
-			return 'bottom';
-		}
-
-		if ( isRtl ) {
-			return 'bottom right';
-		}
-
-		return 'bottom left';
+		return isMobile() ? 'bottom' : 'bottom left';
 	}
 
 	onSiteSelect = siteId => {
@@ -151,4 +139,4 @@ export default connect(
 		return { shouldOpenSiteSelector, editorUrl };
 	},
 	{ openEditor }
-)( withRtl( MasterbarItemNew ) );
+)( MasterbarItemNew );


### PR DESCRIPTION
Removes the `withRtl`/`isRtl` logic that changes the popover arrow position in RTL mode. That LTR/RTL flipping is already done inside the `Popover` component (see its `adjustRtlPosition` method) and doing it twice defeats the purpose.

**How to test:**
Before: in RTL mode (e.g., Hebrew locale), the arrow would be centered, because the requested position is `bottom left` (flipped twice by two `withRtl`s) and that doesn't fit into the available space on the left:
<img width="332" alt="Screenshot 2019-10-17 at 12 58 58" src="https://user-images.githubusercontent.com/664258/67005720-8d471880-f0e3-11e9-8479-ae676c6c2390.png">

After: the popover hangs to the right:
<img width="338" alt="Screenshot 2019-10-17 at 12 57 37" src="https://user-images.githubusercontent.com/664258/67005760-a2bc4280-f0e3-11e9-9f5a-0f159e4aba52.png">

It's completely symmetrical to the LTR version:
<img width="348" alt="Screenshot 2019-10-17 at 12 58 01" src="https://user-images.githubusercontent.com/664258/67005776-ad76d780-f0e3-11e9-962d-ad503f1ca4ae.png">
