### PR TITLE
G Suite: Fix white screen while trying to add G Suite for a WPcom primary sub-domain

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import formatCurrency from '@automattic/format-currency';
-import { get, includes, some, endsWith, find } from 'lodash';
+import { endsWith, get, includes, some, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -74,27 +74,25 @@ function getAnnualPrice( cost, currencyCode ) {
 }
 
 /**
- * Retrieves the first domain that is eligible to G Suite in the order:
+ * Retrieves the first domain that is eligible to G Suite in this order:
  *
- *   - The domain from the site currently selected i.e. `selectedDomainName`
+ *   - The domain from the site currently selected, if eligible
  *   - The primary domain of the site, if eligible
- *   - The first eligible domain
+ *   - The first non-primary domain eligible found
  *
  * @param {String} selectedDomainName - domain name for the site currently selected by the user
  * @param {Array} domains - list of domain objects
- * @returns {String} - Eligible domain name
+ * @returns {String} - the name of the first eligible domain found
  */
 function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 	if ( selectedDomainName && canDomainAddGSuite( selectedDomainName ) ) {
 		return selectedDomainName;
 	}
-	const supportedDomains = getGSuiteSupportedDomains( domains );
-	const primaryDomain = find( supportedDomains, 'isPrimary' );
-	const primaryDomainName = get( primaryDomain, 'name', '' );
-	if ( ! primaryDomainName && supportedDomains.length ) {
-		return get( supportedDomains[ 0 ], 'name', '' );
-	}
-	return primaryDomainName;
+
+	// Orders domains with the primary domain in first position, if any
+	const supportedDomains = sortBy( getGSuiteSupportedDomains( domains ), ( domain ) => ! domain.isPrimary );
+
+	return get( supportedDomains, '[0].name', '' );
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -74,10 +74,11 @@ function getAnnualPrice( cost, currencyCode ) {
 }
 
 /**
- * Retrieves the first domain that is eligible to G Suite either from, and in that order:
+ * Retrieves the first domain that is eligible to G Suite in the order:
  *
- *   - The domain from the site currently selected
- *   - The primary domain of the site
+ *   - The domain from the site currently selected i.e. `selectedDomainName`
+ *   - The primary domain of the site, if eligible
+ *   - The first eligible domain
  *
  * @param {String} selectedDomainName - domain name for the site currently selected by the user
  * @param {Array} domains - list of domain objects
@@ -87,12 +88,13 @@ function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 	if ( selectedDomainName && canDomainAddGSuite( selectedDomainName ) ) {
 		return selectedDomainName;
 	}
-
 	const supportedDomains = getGSuiteSupportedDomains( domains );
-
 	const primaryDomain = find( supportedDomains, 'isPrimary' );
-
-	return get( primaryDomain, 'name', '' );
+	const primaryDomainName = get( primaryDomain, 'name', '' );
+	if ( ! primaryDomainName && supportedDomains.length ) {
+		return get( supportedDomains[ 0 ], 'name', '' );
+	}
+	return primaryDomainName;
 }
 
 /**


### PR DESCRIPTION
#### Summary

* Refactors `getEligibleGSuiteDomain` function to return the first eligible domain with a preference for the primary domain. This fixes a blank screen displayed instead of the usual form where one can specify their list of G Suite users.

#### Testing instructions

1. Open a [live branch](https://calypso.live/?branch=fix/gsuite-unable-to-add-user-when-default-address-set-as-primary)
2. Log into an account with a domain but not G Suite
3. Set the primary domain to the default free `*.wordpress.com` address
4. Navigate to the [`Email` page](http://calypso.localhost:3000/email)
5. Click the `Add G Suite` button
6. Assert that you are presented with the form where you can add G Suite users