### PR TITLE
Hosting Panel: Add dummy API data

### DIFF
--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -16,7 +16,7 @@ import CardHeading from 'components/card-heading';
 import MaterialIcon from 'components/material-icon';
 import Button from 'components/button';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
+import { requestHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 const requestId = siteId => `pma-link-request-${ siteId }`;
@@ -41,10 +41,10 @@ export const requestPmaLink = siteId =>
 
 const PhpMyAdminCard = ( { translate, siteId, pmaLink, loading } ) => {
 	useEffect( () => {
-		if ( pmaLink ) {
+		if ( pmaLink && ! loading ) {
 			window.open( pmaLink );
 		}
-	}, [ pmaLink ] );
+	}, [ pmaLink, loading ] );
 
 	return (
 		<Card>
@@ -68,11 +68,19 @@ const PhpMyAdminCard = ( { translate, siteId, pmaLink, loading } ) => {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
-	const pmaLinkRequest = getHttpData( requestId( siteId ) );
+	// const pmaLinkRequest = getHttpData( requestId( siteId ) );
+
+	// @TODO Replace below dummy data when endpoint is concretely figured out.
+	const pmaLinkRequest = {
+		status: 'pending',
+		data: {
+			pmaUrl: 'https://fake.phpmyadmin.localhost/',
+		},
+	};
 
 	return {
 		pmaLink: get( pmaLinkRequest, 'data.pmaUrl', null ),
-		loading: get( pmaLinkRequest, 'status', null ) === 'pending',
+		loading: pmaLinkRequest.status === 'pending',
 		siteId,
 	};
 } )( localize( PhpMyAdminCard ) );

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -68,7 +68,6 @@ const PhpMyAdminCard = ( { translate, siteId, pmaLink, loading } ) => {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
-	// const pmaLinkRequest = getHttpData( requestId( siteId ) );
 
 	// @TODO Replace below dummy data when endpoint is concretely figured out.
 	const pmaLinkRequest = {

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -17,11 +17,6 @@ import CardHeading from 'components/card-heading';
 import MaterialIcon from 'components/material-icon';
 import Button from 'components/button';
 import { getSelectedSiteId } from 'state/ui/selectors';
-/* import {
-	requestAtomicSFTPDetails,
-	resetAtomicSFTPUserPassword,
-	createAtomicSFTPUser,
-} from 'state/data-getters'; */
 
 // @TODO derive API request details from props when API is merged & remove component state
 const SFTPCard = ( { translate, siteId } ) => {
@@ -126,17 +121,7 @@ const SFTPCard = ( { translate, siteId } ) => {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
-	// @TODO dummy data is added here and in component state; remove when API is merged
-	// const sftpDetails = requestAtomicSFTPDetails( siteId );
-
-	// const username = get( sftpDetails, 'data.username', null );
-	// const errorCode = get( sftpDetails, 'error.status', null );
-
 	return {
 		siteId,
-		// username,
-		// noSftpUser: errorCode === 404,
-		// password: get( sftpDetails, 'data.password', null ),
-		// loading: sftpDetails.status === 'pending' || ! username,
 	};
 } )( localize( SFTPCard ) );

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -43,7 +43,6 @@ const SFTPCard = ( { translate, siteId } ) => {
 			status: 'success',
 			data: {
 				username: 'test_user_testsite.wordpress.com_1234',
-				password: 'a.t.e.s.t.p.a.s.s.word',
 			},
 		} );
 	};


### PR DESCRIPTION
### Summary

This PR adds dummy data to the hosting panel, allowing the UI to function, while we finish up finalizing the API sections for the PMA panel and the SFTP users.

Also, a couple of code tweaks. Ultimately, ripping out the test data will only involve deleting one marked chunk in both cards, and un-commenting out the previous API methods. All other changes are small code tweaks and will not need to be un-done.

### Testing

* Spin up a local Calypso dev instance, without any diffs applied to your sandbox.
* Go to `http://calypso.localhost:3000/hosting/your.atomic.site`.
* Ensure that the page loads without errors.
* Click on the 'Create SFTP User' button and notice that the UI displays the dummy data. Click on the 'Reset Password' button and notice that the same thing occurs, although this time displaying the password. (A bit of a departure from our previous flows, but allowing access to both UI states in the interim. The correct user flows are preserved in the comments.)
