### PR TITLE
Add "Manage subscription" link to the <ProductCard /> component

### DIFF
--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -55,6 +55,8 @@ The following props can be passed to the Product Card component:
  displayed as a price range
 * `fullPrice`: ( number | array ) Full price of a product. If an array of 2 numbers is passed, it will be displayed as
  a price range
+* `hasManageSubscriptionLink`: ( bool ) Flag indicating if a "Manage subscription" link should be rendered in the card's
+ content area
 * `isPlaceholder`: ( bool ) Flag indicating if a product price is in a loading state and should be rendered as a
   placeholder
 * `isPurchased`: ( bool ) Flag indicating if a product has already been purchased. [Read more about the way this flag

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -31,10 +31,10 @@ function ProductCardExample() {
 				billingTimeFrame={ isPlaceholder ? null : 'per year' }
 				fullPrice={ isPlaceholder ? null : 25 }
 				description={
-					<Fragment>
+					<p>
 						Automatic scanning and one-click fixes keep your site one step ahead of security
 						threats. <a href="/plans">More info</a>
-					</Fragment>
+					</p>
 				}
 			/>
 
@@ -46,10 +46,10 @@ function ProductCardExample() {
 				fullPrice={ isPlaceholder ? null : [ 16, 25 ] }
 				discountedPrice={ isPlaceholder ? null : [ 12, 16 ] }
 				description={
-					<Fragment>
+					<p>
 						Always-on backups ensure you never lose your site. Choose from real-time or daily
 						backups. <a href="/plans">Which one do I need?</a>
-					</Fragment>
+					</p>
 				}
 			>
 				<ProductCardOptions
@@ -82,11 +82,12 @@ function ProductCardExample() {
 				}
 				subtitle="Purchased 2019-09-13"
 				description={
-					<Fragment>
+					<p>
 						<strong>Looking for more?</strong> With Real-time backups:, we save as you edit and
 						you’ll get unlimited backup archives
-					</Fragment>
+					</p>
 				}
+				hasManageSubscriptionLink
 				isPlaceholder={ isPlaceholder }
 				isPurchased
 			/>
@@ -103,7 +104,12 @@ function ProductCardExample() {
 						Included in your <a href="/my-plan">Personal Plan</a>
 					</Fragment>
 				}
-				description="Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives"
+				description={
+					<p>
+						Always-on backups ensure you never lose your site. Your changes are saved as you edit
+						and you have unlimited backup archives
+					</p>
+				}
 				isPlaceholder={ isPlaceholder }
 				isPurchased
 			/>

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -61,7 +61,7 @@ const ProductCard = ( {
 			<div className="product-card__description">
 				{ hasManageSubscriptionLink && (
 					<p>
-						<a href="/my-plan">{ translate( 'Manage subscription' ) }</a>
+						<a href="/my-plan">{ translate( 'Manage Subscription' ) }</a>
 					</p>
 				) }
 				{ description }

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -61,7 +61,7 @@ const ProductCard = ( {
 			<div className="product-card__description">
 				{ hasManageSubscriptionLink && (
 					<p>
-						<a href="/my-plan">{ translate( 'Manage subscriptions' ) }</a>
+						<a href="/my-plan">{ translate( 'Manage Subscriptions' ) }</a>
 					</p>
 				) }
 				{ description }

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -61,7 +61,7 @@ const ProductCard = ( {
 			<div className="product-card__description">
 				{ hasManageSubscriptionLink && (
 					<p>
-						<a href="/my-plan">{ translate( 'Manage Subscription' ) }</a>
+						<a href="/my-plan">{ translate( 'Manage subscriptions' ) }</a>
 					</p>
 				) }
 				{ description }

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,11 +25,13 @@ const ProductCard = ( {
 	description,
 	discountedPrice,
 	fullPrice,
+	hasManageSubscriptionLink,
 	isPlaceholder,
 	isPurchased,
 	subtitle,
 	title,
 } ) => {
+	const translate = useTranslate();
 	const cardClassNames = classNames( 'product-card', {
 		'is-placeholder': isPlaceholder,
 		'is-purchased': isPurchased,
@@ -55,7 +58,14 @@ const ProductCard = ( {
 					) }
 				</div>
 			</div>
-			{ description && <p className="product-card__description">{ description }</p> }
+			<div className="product-card__description">
+				{ hasManageSubscriptionLink && (
+					<p>
+						<a href="/my-plan">{ translate( 'Manage subscription' ) }</a>
+					</p>
+				) }
+				{ description }
+			</div>
 			{ children }
 		</Card>
 	);
@@ -70,6 +80,7 @@ ProductCard.propTypes = {
 		PropTypes.arrayOf( PropTypes.number ),
 	] ),
 	fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+	hasManageSubscriptionLink: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	isPurchased: PropTypes.bool,
 	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -126,10 +126,13 @@
 	font-size: 14px;
 	line-height: 20px;
 	color: var( --color-text-subtle );
-	margin: 0;
 
 	a {
 		@extend %product-card-link-plain;
+	}
+
+	p:last-child {
+		margin: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add "Manage subscription" link to the `<ProductCard />` component
* Make `description` prop more free-form (it's no longer wrapped up in a `<p>` tag)

![Screenshot 2019-10-17 at 17 14 53](https://user-images.githubusercontent.com/478735/67022538-ae1e6680-f101-11e9-872f-e2ea83ae9c7b.png)

#### Testing instructions

* Go to devdocs -> UI Components -> Product Card
* Confirm that a "Manage subscription" link is displayed in the card representing a purchased product.

Fixes n/a
