### PR TITLE
Classic editor: vertically align site icon

### DIFF
--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -3,7 +3,7 @@
 	position: relative;
 	overflow: hidden;
 	align-self: center;
-	margin: 0;
+	margin: auto 0;
 	text-align: center;
 
 	// Globe icon for sites without an icon


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There is a bug in Classic Editor now which is causing Site Icon to be misaligned. 

| Before | After |
|-|-|
|<img width="273" alt="Screenshot 2019-10-17 at 18 28 56" src="https://user-images.githubusercontent.com/1182160/67028666-0490a280-f10c-11e9-98e9-9f9d4f34cf6f.png">|<img width="278" alt="Screenshot 2019-10-17 at 18 23 54" src="https://user-images.githubusercontent.com/1182160/67028563-d4e19a80-f10b-11e9-9c4d-14c01962e8d4.png">|

#### Testing instructions

1. Use a test site that hasn't opted in to Gutenberg or opt out on your test site.
2. Open up the post editor.
3. Verify that the Site Icon is centered vertically.
4. Make sure that this is not causing visual regressions in other places.
