### PR TITLE
Revert "Classic editor: vertically align site icon"

### DIFF
--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -3,7 +3,7 @@
 	position: relative;
 	overflow: hidden;
 	align-self: center;
-	margin: auto 0;
+	margin: 0;
 	text-align: center;
 
 	// Globe icon for sites without an icon


### PR DESCRIPTION
Reverts Automattic/wp-calypso#36866

@shaunandrews reported a different visual regression in the site card sidebar

<img width="262" alt="67033447-c8e1e280-f0e3-11e9-9bd0-88317f189983" src="https://user-images.githubusercontent.com/1270189/67033962-a80d9300-f0cb-11e9-9c2d-4fc8e35acb53.png">
