### PR TITLE
Classic editor: vertically align site icon

### DIFF
--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -3,7 +3,7 @@
 	position: relative;
 	overflow: hidden;
 	align-self: center;
-	margin: auto 0;
+	margin: 0;
 	text-align: center;
 
 	// Globe icon for sites without an icon
@@ -13,6 +13,11 @@
 			color: var( --color-surface );
 			z-index: z-index( 'root', '.site-icon.is-blank .gridicon' );
 		}
+	}
+
+	// Vertically center site icon in Classic editor
+	.editor-ground-control & {
+		margin: auto 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Vertically aligns site icon in Classic editor without changing position in site picker and site card.

Before | After
------------ | -------------
<img width="243" alt="Screen Shot 2019-10-17 at 2 01 49 PM" src="https://user-images.githubusercontent.com/448298/67035395-92a66200-f0e7-11e9-8c25-d94f007d30f2.png"> | <img width="232" alt="Screen Shot 2019-10-17 at 2 00 11 PM" src="https://user-images.githubusercontent.com/448298/67035403-9803ac80-f0e7-11e9-8a77-11636904a56d.png">

**Site Card**
<img width="139" alt="Screen Shot 2019-10-17 at 1 51 13 PM" src="https://user-images.githubusercontent.com/448298/67035443-abaf1300-f0e7-11e9-96ea-d54bb45baa6b.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a test site that hasn't opted in to Gutenberg or opt out on your test site.
* Open up the post editor.
* Verify that the Site Icon is centered vertically.
* Make sure that this is not causing visual regressions in other places. (Site Card, Site Picker, etc.)


