### PR TITLE
Fix broken selector in e2e tests

### DIFF
--- a/test/e2e/lib/components/shopping-cart-widget-component.js
+++ b/test/e2e/lib/components/shopping-cart-widget-component.js
@@ -14,13 +14,13 @@ import AsyncBaseContainer from '../async-base-container';
 
 export default class ShoppingCartWidgetComponent extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.cart-toggle-button' ) );
+		super( driver, by.css( '.popover-cart .header-button' ) );
 	}
 
 	async open() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			by.css( '.cart-toggle-button' ),
+			by.css( '.popover-cart .header-button' ),
 			this.explicitWaitMS
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The cart selector was changed in https://github.com/Automattic/wp-calypso/pull/34421 and two manage domains tests started failing.

#### Testing instructions
* Ensure all e2e tests pass in CircleCI
