### PR TITLE
SPT: Do not display on copy-page flow

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -157,6 +157,7 @@ function load_starter_page_templates() {
 	if ( isset( $_GET['jetpack-copy'] ) ) {
 		return;
 	}
+
 	/**
 	 * Can be used to disable the Starter Page Templates.
 	 *

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -152,6 +152,11 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_posts_list_block' );
  * Load Starter_Page_Templates.
  */
 function load_starter_page_templates() {
+	// We don't want the user to choose a template when copying a post.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_GET['jetpack-copy'] ) ) {
+		return;
+	}
 	/**
 	 * Can be used to disable the Starter Page Templates.
 	 *


### PR DESCRIPTION
Per @kwight's suggestion, I split this into a separate PR from #36839.

Checks for the jetpack copy URL param and if it exists, does not display the template selector.

#### Testing instructions
1. Pull this branch, run FSE, and sync to your sandbox.
2. On a sandboxed site, choose "copy page" from the page list. 
3. The template selector should now show up.

_Note: the page still does not copy correctly, which is tracked in #35605._

Fixes #35604
