### PR TITLE
Fix Partner Plan Illustration

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -33,7 +33,6 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { isPartnerPurchase, getPartnerName } from 'lib/purchases';
 import CartData from 'components/data/cart';
 
-
 class Plans extends React.Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
@@ -91,7 +90,7 @@ class Plans extends React.Component {
 					<div id="plans" className="plans plans__has-sidebar">
 						<PlansNavigation path={ context.path } />
 						<EmptyContent
-							illustration="/calypso/images/illustrations/jetpack-header.svg"
+							illustration="/calypso/images/illustrations/illustration-jetpack.svg"
 							title={ translate( 'Your plan is managed by %(partnerName)s', {
 								args: { partnerName },
 							} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change illustration on plans page when your have a partner plan

**Before**
<img width="1118" alt="Screen Shot 2019-10-17 at 3 10 11 PM" src="https://user-images.githubusercontent.com/2810519/67051641-7d820100-f0f0-11e9-9319-f9ce505635d2.png">
**After**
<img width="1005" alt="Screen Shot 2019-10-17 at 3 09 47 PM" src="https://user-images.githubusercontent.com/2810519/67051645-7f4bc480-f0f0-11e9-9f52-89d2e2a3ad6b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to `/plans/:siteSlug` on a site with a paid partner plan
* confirm it matches the after screenshot above

