### PR TITLE
Add A/B test to swap domain step and site title step

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -151,4 +151,13 @@ export default {
 		},
 		defaultVariation: 'default',
 	},
+	prefillSiteTitleWithDomainQuery: {
+		datestamp: '20191017',
+		variations: {
+			variant: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { assign, get, includes, indexOf, reject } from 'lodash';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -68,6 +69,17 @@ const flows = generateFlows( {
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 } );
+
+if ( flows.onboarding && 'variant' === abtest( 'prefillSiteTitleWithDomainQuery' ) ) {
+	flows.onboarding.steps = [
+		'user',
+		'site-type',
+		'site-topic-with-preview',
+		'domains-with-preview',
+		'site-title-with-preview',
+		'plans',
+	];
+}
 
 function removeUserStepFromFlow( flow ) {
 	if ( ! flow ) {


### PR DESCRIPTION
Add an A/B test to swap domain step and site title step in the onboarding flow, and pre-fill the site title using the keywords entered in the domain step.

This is a follow-up to the `prefillDomainStepValue` A/B test, and in this test we are testing doing things the other-way-around.

![ab-test-swap-domain-and-site-title](https://user-images.githubusercontent.com/14988353/67072336-5ef33700-f1d0-11e9-807d-cb14da029c80.gif)

#### Changes proposed in this Pull Request

* Add `prefillSiteTitleWithDomainQuery` A/B test
* In the `variant` of that A/B test, swap the order of the `site-title` and the `domains-with-preview` steps, so that the domain step comes first
* At the site title step, for users in the variation and in the onboarding flow, use pre-fill the site title with the query terms last used in the domains step

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `http://calypso.localhost:3000/jetpack/new`
2. Set the A/B test `prefillSiteTitleWithDomainQuery` to variant

![image](https://user-images.githubusercontent.com/14988353/67071380-1c305f80-f1ce-11e9-90b7-3be7502c50b9.png)

3. Select one of blog, business, or professional site types.
4. At the domains step, enter a search term e.g. "My fake website"
5. Select a domain or free sub-domain, and at the site title step you should see that search term pre-entered
6. Complete signup and double-check under Settings that the site title is persisted correctly.

##### More testing and double checking this works correctly

1. Repeat the above steps, getting to the site title step
2. Change the site title
3. Click back and select a domain
4. Your changed site title should be preserved
5. Clear the site title
6. Click back to the domain step
7. Select a domain
8. The site title should be pre-filled from the domain search terms again

##### Ensure the standard flow works as intended

1. Swap yourself to the `control` of this A/B test
2. Complete the signup as normal, where the site title step should come before the domains-with-preview step
3. Ensure creating a site as normal works as expected.


