### PR TITLE
Improve HeaderButton component and its usage for cart toggle

### DIFF
--- a/client/components/header-button/index.jsx
+++ b/client/components/header-button/index.jsx
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'components/gridicon';
 
@@ -16,18 +15,16 @@ import Button from 'components/button';
  */
 import './style.scss';
 
-class HeaderButton extends Component {
-	render() {
-		const { icon, label, ...rest } = this.props;
+const HeaderButton = React.forwardRef( ( props, ref ) => {
+	const { icon, label, ...rest } = props;
 
-		return (
-			<Button className="header-button" { ...rest }>
-				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
-				<span className="header-button__text">{ label }</span>
-			</Button>
-		);
-	}
-}
+	return (
+		<Button { ...rest } className="header-button" ref={ ref }>
+			{ icon && <Gridicon icon={ icon } size={ 18 } /> }
+			<span className="header-button__text">{ label }</span>
+		</Button>
+	);
+} );
 
 HeaderButton.propTypes = {
 	icon: PropTypes.string,

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -231,36 +231,6 @@
 	}
 }
 
-.cart-toggle-button {
-	// Hide the text
-	display: flex;
-	position: relative;
-	height: 48px;
-	width: 48px;
-	white-space: nowrap;
-	cursor: pointer; // Needed for Safari
-
-	.gridicon {
-		color: var( --color-neutral-70 );
-		cursor: pointer;
-		position: absolute;
-		top: 12px;
-		right: 12px;
-
-		&:hover {
-			color: var( --color-primary );
-		}
-	}
-
-	&:focus {
-		outline: none;
-
-		.accessible-focus & {
-			box-shadow: inset 0 0 0 2px var( --color-primary-light );
-		}
-	}
-}
-
 .popover-cart {
 	position: relative;
 	display: inline-block;

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -64,7 +64,8 @@ class PlansNavigation extends React.Component {
 		const sectionTitle = this.getSectionTitle( path );
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 		const canManageDomain = userCanManageOptions && ( isATEnabled( site ) || ! isJetpack );
-		const hasPinnedItems = isMobile() && this.cartToggleButton();
+		const cartToggleButton = this.cartToggleButton();
+		const hasPinnedItems = isMobile() && cartToggleButton != null;
 
 		return (
 			site && (
@@ -104,7 +105,7 @@ class PlansNavigation extends React.Component {
 							</NavItem>
 						) }
 					</NavTabs>
-					{ this.cartToggleButton() }
+					{ cartToggleButton }
 				</SectionNav>
 			)
 		);


### PR DESCRIPTION
Series of tiny followups to @danielwrobert's work in #34421:
- refactor `HeaderButton` to functional component, using `React.forwardRef` to make it reffable.
- remove the unused `.cart-toggle-button` CSS style
- fix a React proptype warning in `PlansNavigation`, making `hasPinnedItems` to be a boolean value, rather than a truthy object

<img width="832" alt="Screenshot 2019-10-18 at 10 48 12" src="https://user-images.githubusercontent.com/664258/67080856-55e57400-f196-11e9-9f51-c4075ee2a501.png">
