### PR TITLE
Contact Details Form: fix refs to the phone field

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -533,13 +533,18 @@ export class ContactDetailsFormFields extends Component {
 						label: translate( 'Email' ),
 					} ) }
 
-					{ this.createField( 'phone', FormPhoneMediaInput, {
-						label: translate( 'Phone' ),
-						onChange: this.handlePhoneChange,
-						countriesList: this.props.countriesList,
-						countryCode: this.state.phoneCountryCode,
-						enableStickyCountry: false,
-					} ) }
+					{ this.createField(
+						'phone',
+						FormPhoneMediaInput,
+						{
+							label: translate( 'Phone' ),
+							onChange: this.handlePhoneChange,
+							countriesList: this.props.countriesList,
+							countryCode: this.state.phoneCountryCode,
+							enableStickyCountry: false,
+						},
+						true
+					) }
 				</div>
 
 				<div className="contact-details-form-fields__row">

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -466,10 +466,10 @@ export class ContactDetailsFormFields extends Component {
 	};
 
 	createField = ( name, componentClass, additionalProps, needsChildRef ) => {
-		return createElement(
-			componentClass,
-			Object.assign( {}, { ...this.getFieldProps( name, needsChildRef ) }, { ...additionalProps } )
-		);
+		return createElement( componentClass, {
+			...this.getFieldProps( name, needsChildRef ),
+			...additionalProps,
+		} );
 	};
 
 	getCountryCode() {

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -97,6 +97,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         enableStickyCountry={false}
         errorMessage=""
         eventFormName="Domain contact details form"
+        inputRef={[Function]}
         isError={false}
         label="Phone"
         labelClass="contact-details-form-fields__label"

--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -24,6 +24,7 @@ export default function FormPhoneMediaInput( {
 	onChange,
 	countriesList,
 	enableStickyCountry,
+	inputRef,
 	children,
 } ) {
 	return (
@@ -31,6 +32,7 @@ export default function FormPhoneMediaInput( {
 			<div>
 				<FormLabel htmlFor={ name }>{ label }</FormLabel>
 				<PhoneInput
+					inputRef={ inputRef }
 					name={ name }
 					onChange={ onChange }
 					value={ value }

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -44,16 +44,9 @@ class PhoneInput extends React.PureComponent {
 		enableStickyCountry: true,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			freezeSelection: false,
-		};
-
-		this.handleInput = this.handleInput.bind( this );
-		this.handleCountrySelection = this.handleCountrySelection.bind( this );
-	}
+	state = {
+		freezeSelection: false,
+	};
 
 	/**
 	 * Returns the country meta with default values for countries with missing metadata. Never returns null.
@@ -175,7 +168,7 @@ class PhoneInput extends React.PureComponent {
 		return formatNumber( value, this.getCountry( countryCode ) );
 	}
 
-	handleInput( event ) {
+	handleInput = event => {
 		const inputValue = event.target.value;
 		if ( inputValue === this.props.value ) {
 			// nothing changed
@@ -190,7 +183,7 @@ class PhoneInput extends React.PureComponent {
 		);
 
 		this.props.onChange( { value, countryCode } );
-	}
+	};
 
 	/**
 	 * Calculates the input and country
@@ -206,7 +199,7 @@ class PhoneInput extends React.PureComponent {
 		return { value: calculatedValue, countryCode: calculatedCountryCode };
 	}
 
-	handleCountrySelection( event ) {
+	handleCountrySelection = event => {
 		const newCountryCode = event.target.value;
 		if ( newCountryCode === this.props.countryCode ) {
 			return;
@@ -237,7 +230,7 @@ class PhoneInput extends React.PureComponent {
 			value: this.format( inputValue, newCountryCode ),
 		} );
 		this.setState( { freezeSelection: this.props.enableStickyCountry } );
-	}
+	};
 
 	setNumberInputRef = c => ( this.numberInput = c );
 

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -48,6 +48,24 @@ class PhoneInput extends React.PureComponent {
 		freezeSelection: false,
 	};
 
+	numberInput = undefined;
+
+	setNumberInputRef = element => {
+		this.numberInput = element;
+
+		const { inputRef } = this.props;
+
+		if ( ! inputRef ) {
+			return;
+		}
+
+		if ( typeof inputRef === 'function' ) {
+			inputRef( element );
+		} else {
+			inputRef.current = element;
+		}
+	};
+
 	/**
 	 * Returns the country meta with default values for countries with missing metadata. Never returns null.
 	 * @param {string} [countryCode=this.props.countryCode] - The country code
@@ -231,8 +249,6 @@ class PhoneInput extends React.PureComponent {
 		} );
 		this.setState( { freezeSelection: this.props.enableStickyCountry } );
 	};
-
-	setNumberInputRef = c => ( this.numberInput = c );
 
 	render() {
 		return (


### PR DESCRIPTION
This PR fixed the following React warning:

<img width="899" alt="Screenshot 2019-10-18 at 10 29 47" src="https://user-images.githubusercontent.com/664258/67086256-9e099400-f1a0-11e9-96c0-d8ad143813ae.png">

and also an actual user visible bug where validating an incorrect phone number (after pressing "Continue") will fail to focus the invalid field and throws errors around:

<img width="838" alt="Screenshot 2019-10-18 at 11 39 40" src="https://user-images.githubusercontent.com/664258/67086320-c3969d80-f1a0-11e9-92ea-0005b048952d.png">

The fix adds an `inputRef` prop to `PhoneInput` and `FormPhoneMediaInput` components and uses it in `ContactDetailsFormFields`.

**How to test:**
Add a domain to your cart and proceed to checkout. In the contact details form you're presented with, enter an invalid phone number and click "Continue". Verify that all the warnings and error notices disappeared (except the one red error under the field) and that the phone field gets focused.

Props to @sgomes for the tricky code that can set two refs of any type at once! 🙂 