### PR TITLE
Add <ProductCardAction /> child component

### DIFF
--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -7,6 +7,10 @@ information.
 It can have a [`<ProductCardOptions />`](#product-card-options) component passed as a child that will render product
 purchase options under the product description.
 
+In some cases, e.g. when a lower-tier product has been already purchased, an upgrade button can be displayed using a
+[`<ProductCardAction />`](#product-card-action) component. Like the `<ProductCardOptions />` component, it should be
+passed as a child to the `<ProductCard />`.
+
 It's used e.g. on `my-plans` page near the bundle plans grid and is intended to render a product card (not a regular
 plan).
 
@@ -26,10 +30,10 @@ export default class extends React.Component {
 				billingTimeFrame={ 'per year' }
 				fullPrice={ 25 }
 				description={
-					<Fragment>
+					<p>
 						Automatic scanning and one-click fixes keep your site one step ahead of security
 						threats. <a href="/plans">More info</a>
-					</Fragment>
+					</p>
 				}
 			/>
 		);
@@ -87,10 +91,10 @@ export default class extends React.Component {
 				fullPrice={ [ 16, 25 ] }
 				discountedPrice={ [ 12, 16 ] }
 				description={
-					<Fragment>
+					<p>
 						Always-on backups ensure you never lose your site. Choose from real-time or daily
 						backups. <a href="/plans">Which one do I need?</a>
-					</Fragment>
+					</p>
 				}
 			>
 				<ProductCardOptions
@@ -137,3 +141,55 @@ The following props can be passed to the Product Card Options component:
   * `options.slug`: ( string ) Option slug
 * `optionsLabel`: ( string ) Label that is displayed above the list of product options
 * `selectedSlug`: ( string ) Currently selected product option slug
+
+<a name="product-card-action"></a>Product Card Action
+=======
+
+Product Card Action is a Product Card's sub-component for rendering action section. It consists of an intro
+text (optional) and a button.
+
+### How to use the `<ProductCardAction />`
+
+```jsx
+import React from 'react';
+import ProductCard from 'components/product-card';
+import ProductCardAction from 'components/product-card-action';
+
+export default class extends React.Component {
+	render() {
+		return (
+			<ProductCard
+				title={
+					<Fragment>
+						Jetpack Backup <strong>Daily</strong>
+					</Fragment>
+				}
+				subtitle="Purchased 2019-09-13"
+				description={
+					<p>
+						<strong>Looking for more?</strong> With Real-time backups:, we save as you edit and
+						you’ll get unlimited backup archives
+					</p>
+				}
+				hasManageSubscriptionLink
+				isPlaceholder={ isPlaceholder }
+				isPurchased
+			>
+				<ProductCardAction
+					intro="Get Real-Time Backups $16 /year"
+					label="Upgrade to Real-Time Backups"
+				/>
+			</ProductCard>
+		);
+	}
+}
+```
+
+### `<ProductCardAction />` Props
+
+The following props can be passed to the Product Card Action component:
+
+* `billingTimeFrame`: ( string ) Billing time frame label
+* `intro`: ( string ) Intro text to be displayed above the action button
+* `label`: ( string ) Action button text
+* `onClick`: ( func ) Action button click event handler

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -14,7 +14,7 @@ passed as a child to the `<ProductCard />`.
 It's used e.g. on `my-plans` page near the bundle plans grid and is intended to render a product card (not a regular
 plan).
 
-See p1HpG7-7nT-p2 for more details.
+See p1HpG7-7ET-p2 for more details.
 
 ### How to use the `<ProductCard />`
 
@@ -171,9 +171,6 @@ export default class extends React.Component {
 						you’ll get unlimited backup archives
 					</p>
 				}
-				hasManageSubscriptionLink
-				isPlaceholder={ isPlaceholder }
-				isPurchased
 			>
 				<ProductCardAction
 					intro="Get Real-Time Backups $16 /year"
@@ -189,7 +186,6 @@ export default class extends React.Component {
 
 The following props can be passed to the Product Card Action component:
 
-* `billingTimeFrame`: ( string ) Billing time frame label
 * `intro`: ( string ) Intro text to be displayed above the action button
 * `label`: ( string ) Action button text
 * `onClick`: ( func ) Action button click event handler

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const ProductCardAction = ( { intro, label, onClick } ) => {
+	if ( ! label ) {
+		return null;
+	}
+
+	return (
+		<div className="product-card__action">
+			{ intro && <h4 className="product-card__action-intro">{ intro }</h4> }
+			<Button className="product-card__action-button" onClick={ onClick } primary>
+				{ label }
+			</Button>
+		</div>
+	);
+};
+
+ProductCardAction.propTypes = {
+	intro: PropTypes.string,
+	label: PropTypes.string,
+	onClick: PropTypes.func,
+};
+
+export default ProductCardAction;

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -9,24 +9,18 @@ import PropTypes from 'prop-types';
  */
 import Button from 'components/button';
 
-const ProductCardAction = ( { intro, label, onClick } ) => {
-	if ( ! label ) {
-		return null;
-	}
-
-	return (
-		<div className="product-card__action">
-			{ intro && <h4 className="product-card__action-intro">{ intro }</h4> }
-			<Button className="product-card__action-button" onClick={ onClick } primary>
-				{ label }
-			</Button>
-		</div>
-	);
-};
+const ProductCardAction = ( { intro, label, onClick } ) => (
+	<div className="product-card__action">
+		{ intro && <h4 className="product-card__action-intro">{ intro }</h4> }
+		<Button className="product-card__action-button" onClick={ onClick } primary>
+			{ label }
+		</Button>
+	</div>
+);
 
 ProductCardAction.propTypes = {
 	intro: PropTypes.string,
-	label: PropTypes.string,
+	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
 };
 

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -8,6 +8,7 @@ import React, { Fragment, useState } from 'react';
  */
 import Button from 'components/button';
 import ProductCard from '../index';
+import ProductCardAction from '../action';
 import ProductCardOptions from '../options';
 
 const purchase = {
@@ -98,7 +99,12 @@ function ProductCardExample() {
 				}
 				isPlaceholder={ isPlaceholder }
 				purchase={ purchase }
-			/>
+			>
+				<ProductCardAction
+					intro="Get Real-Time Backups $16 /year"
+					label="Upgrade to Real-Time Backups"
+				/>
+			</ProductCard>
 
 			<h3>Product Card - part of Jetpack plan</h3>
 			<ProductCard
@@ -120,7 +126,12 @@ function ProductCardExample() {
 				}
 				isPlaceholder={ isPlaceholder }
 				purchase={ purchase }
-			/>
+			>
+				<ProductCardAction
+					intro="Get Real-Time backups"
+					label="Upgrade to Professional $299/year"
+				/>
+			</ProductCard>
 		</Fragment>
 	);
 }

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -225,6 +225,23 @@
 	}
 }
 
+// Action
+.product-card__action {
+	margin: 16px auto;
+	text-align: center;
+}
+
+.product-card__action-intro {
+	margin-bottom: 12px;
+	font-size: 14px;
+	font-weight: 600;
+	color: var( --color-neutral-90 );
+}
+
+.product-card__action-button {
+	width: 100%;
+	max-width: 320px;
+}
 
 // Loading state
 .product-card.is-placeholder .product-card__price-group {


### PR DESCRIPTION
In order to limit the size of the `<ProductCard />` component and the number of props, I decided to make `<ProductCardAction />` a child component. It's the same approach as we took with the `<ProductCardOptions />` component. In fact, they have similar roles and in most cases will be used interchangeably.

In the future we can also think of some smart way to auto-generate the action element inside the `<ProductCard />` using the `purchased` object data and probably some additional props.

#### Changes proposed in this Pull Request

* Add a `<ProductCardAction />` component to the `<ProductCard />` parent component

![Screenshot 2019-10-18 at 12 49 57](https://user-images.githubusercontent.com/478735/67088611-e1b2cc80-f1a5-11e9-9846-cfddf4d69eeb.png)

#### Testing instructions

* Go to devdocs -> UI Components -> Product Card
* Confirm that an action button along with an intro text is displayed in the cards representing purchased products.

Fixes n/a
