### PR TITLE
Blocks: Implement purchase, subtitle and subscription link in ProductSelector > ProductCard

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -41,3 +41,4 @@ The following props can be passed to the Product Selector block:
 
 * `intervalType`: ( string ) Billing interval - `monthly`, `yearly` or `2yearly`.
 * `products`: ( array ) Products to render - see example above for the structure.
+* `siteId`: ( number ) ID of the site we're retrieving purchases for. Used to fetch information about the associated purchases of the selected products.

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -7,6 +7,7 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import SegmentedControl from 'components/segmented-control';
+import SitesDropdown from 'components/sites-dropdown';
 import ProductSelector from '../';
 
 const products = [
@@ -44,6 +45,7 @@ const products = [
 class ProductSelectorExample extends Component {
 	state = {
 		interval: 'yearly',
+		siteId: 0,
 	};
 
 	handleIntervalChange( interval ) {
@@ -73,7 +75,21 @@ class ProductSelectorExample extends Component {
 				</SegmentedControl>
 
 				<div style={ { maxWidth: 520, margin: '0 auto' } }>
-					<ProductSelector products={ products } intervalType={ this.state.interval } />
+					<div style={ { maxWidth: 300, margin: '0 auto 10px' } }>
+						<SitesDropdown onSiteSelect={ siteId => this.setState( { siteId } ) } />
+					</div>
+
+					{ this.state.siteId ? (
+						<ProductSelector
+							products={ products }
+							intervalType={ this.state.interval }
+							siteId={ this.state.siteId }
+						/>
+					) : (
+						<p style={ { textAlign: 'center' } }>
+							Please, select a Jetpack site to experience the full demo.
+						</p>
+					) }
 				</div>
 			</Fragment>
 		);

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { flattenDeep, isEmpty, map, uniq } from 'lodash';
+import { find, flattenDeep, includes, isEmpty, map, uniq } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,9 +15,12 @@ import FormRadio from 'components/forms/form-radio';
 import Card from 'components/card';
 import ProductCard from 'components/product-card';
 import QueryProductsList from 'components/data/query-products-list';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import { extractProductSlugs, filterByProductSlugs } from './utils';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSitePurchases } from 'state/purchases/selectors';
 
 export class ProductSelector extends Component {
 	constructor( props ) {
@@ -51,6 +54,13 @@ export class ProductSelector extends Component {
 		}
 	}
 
+	getPurchaseByProduct( product ) {
+		const { intervalType, purchases } = this.props;
+		const productSlugs = product.options[ intervalType ];
+
+		return find( purchases, purchase => includes( productSlugs, purchase.productSlug ) );
+	}
+
 	handleProductOptionSelect( stateKey, productSlug ) {
 		return () => {
 			this.setState( {
@@ -79,6 +89,7 @@ export class ProductSelector extends Component {
 						fullPrice={ productObject.cost }
 						description={ product.description }
 						currencyCode={ currencyCode }
+						purchase={ this.getPurchaseByProduct( product ) }
 					/>
 
 					{ this.renderProductOptions( product ) }
@@ -126,9 +137,12 @@ export class ProductSelector extends Component {
 	}
 
 	render() {
+		const { selectedSiteId } = this.props;
+
 		return (
 			<div className="product-selector">
 				<QueryProductsList />
+				<QuerySitePurchases siteId={ selectedSiteId } />
 
 				{ this.renderProducts() }
 			</div>
@@ -144,22 +158,29 @@ ProductSelector.propTypes = {
 			options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
 		} )
 	).isRequired,
+	siteId: PropTypes.number,
 
 	// Connected props
+	currencyCode: PropTypes.string,
 	productSlugs: PropTypes.arrayOf( PropTypes.string ),
+	purchases: PropTypes.array,
+	selectedSiteId: PropTypes.number,
 	storeProducts: PropTypes.object,
 
 	// From localize() HoC
 	translate: PropTypes.func.isRequired,
 };
 
-export default connect( ( state, { products } ) => {
+export default connect( ( state, { products, siteId } ) => {
+	const selectedSiteId = siteId || getSelectedSiteId( state );
 	const productSlugs = uniq( flattenDeep( products.map( extractProductSlugs ) ) );
 	const availableProducts = getAvailableProductsList( state );
 
 	return {
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		productSlugs,
+		purchases: getSitePurchases( state, selectedSiteId ),
+		selectedSiteId,
 		storeProducts: filterByProductSlugs( availableProducts, productSlugs ),
 	};
 } )( localize( ProductSelector ) );

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -55,8 +55,6 @@ The following props can be passed to the Product Card component:
  displayed as a price range
 * `fullPrice`: ( number | array ) Full price of a product. If an array of 2 numbers is passed, it will be displayed as
  a price range
-* `hasManageSubscriptionLink`: ( bool ) Flag indicating if a "Manage subscription" link should be rendered in the card's
- content area
 * `isPlaceholder`: ( bool ) Flag indicating if a product price is in a loading state and should be rendered as a
   placeholder
 * `purchase`: ( object ) A purchase object, associated with the product. [Read more about the way this flag

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -37,12 +37,12 @@ export default class extends React.Component {
 }
 ```
 
-### <a name="how-is-purchased-flag-works"></a>How `isPurchased` flag works
+### <a name="how-purchase-prop-works"></a>How `purchase` prop works
 
 The component can be in two visual and functional states:
-* `isPurchased` flag is not set - the product plan prices will be rendered below the highlighted title. If the product
+* `purchase` prop is not set - the product plan prices will be rendered below the highlighted title. If the product
 has purchase options, they will be listed below the description.
-* `isPurchased` flag is set - the content area will not contain product options (if they exist).
+* `purchase` prop is set - the content area will not contain product options (if they exist).
 
 ### `<ProductCard />` props
 
@@ -59,8 +59,8 @@ The following props can be passed to the Product Card component:
  content area
 * `isPlaceholder`: ( bool ) Flag indicating if a product price is in a loading state and should be rendered as a
   placeholder
-* `isPurchased`: ( bool ) Flag indicating if a product has already been purchased. [Read more about the way this flag
- works](#how-is-purchased-flag-works)
+* `purchase`: ( object ) A purchase object, associated with the product. [Read more about the way this flag
+ works](#how-purchase-prop-works)
 * `subtitle`: ( string | element ) Product subtitle. It's used if the product has already been purchased, but can be
  used also in other use-cases. It can be a string or a React element (e.g. `<Fragment>`)
 * `title`: ( string | element ) Product title. It can be a string or a React element (e.g. `<Fragment>`)

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -10,6 +10,14 @@ import Button from 'components/button';
 import ProductCard from '../index';
 import ProductCardOptions from '../options';
 
+const purchase = {
+	active: true,
+	id: 999999999,
+	productName: 'Jetpack Backup (Daily)',
+	productSlug: 'jetpack_backup_daily',
+	subscribedDate: '2019-10-18T10:37:04+00:00',
+};
+
 function ProductCardExample() {
 	const [ selectedProductOption, selectProductOption ] = useState(
 		'jetpack_backup_realtime_monthly'
@@ -89,7 +97,7 @@ function ProductCardExample() {
 				}
 				hasManageSubscriptionLink
 				isPlaceholder={ isPlaceholder }
-				isPurchased
+				purchase={ purchase }
 			/>
 
 			<h3>Product Card - part of Jetpack plan</h3>
@@ -111,7 +119,7 @@ function ProductCardExample() {
 					</p>
 				}
 				isPlaceholder={ isPlaceholder }
-				isPurchased
+				purchase={ purchase }
 			/>
 		</Fragment>
 	);

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -12,6 +12,7 @@ import ProductCardOptions from '../options';
 
 const purchase = {
 	active: true,
+	domain: 'yourjetpack.blog',
 	id: 999999999,
 	productName: 'Jetpack Backup (Daily)',
 	productSlug: 'jetpack_backup_daily',
@@ -95,7 +96,6 @@ function ProductCardExample() {
 						you’ll get unlimited backup archives
 					</p>
 				}
-				hasManageSubscriptionLink
 				isPlaceholder={ isPlaceholder }
 				purchase={ purchase }
 			/>

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -12,6 +12,7 @@ import { useTranslate } from 'i18n-calypso';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import ProductCardPriceGroup from './price-group';
+import { managePurchase } from 'me/purchases/paths';
 
 /**
  * Style dependencies
@@ -25,7 +26,6 @@ const ProductCard = ( {
 	description,
 	discountedPrice,
 	fullPrice,
-	hasManageSubscriptionLink,
 	isPlaceholder,
 	purchase,
 	subtitle,
@@ -59,9 +59,11 @@ const ProductCard = ( {
 				</div>
 			</div>
 			<div className="product-card__description">
-				{ hasManageSubscriptionLink && (
+				{ purchase && (
 					<p>
-						<a href="/my-plan">{ translate( 'Manage Subscriptions' ) }</a>
+						<a href={ managePurchase( purchase.domain, purchase.id ) }>
+							{ translate( 'Manage Subscription' ) }
+						</a>
 					</p>
 				) }
 				{ description }
@@ -80,7 +82,6 @@ ProductCard.propTypes = {
 		PropTypes.arrayOf( PropTypes.number ),
 	] ),
 	fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
-	hasManageSubscriptionLink: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	purchase: PropTypes.object,
 	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -27,14 +27,14 @@ const ProductCard = ( {
 	fullPrice,
 	hasManageSubscriptionLink,
 	isPlaceholder,
-	isPurchased,
+	purchase,
 	subtitle,
 	title,
 } ) => {
 	const translate = useTranslate();
 	const cardClassNames = classNames( 'product-card', {
 		'is-placeholder': isPlaceholder,
-		'is-purchased': isPurchased,
+		'is-purchased': !! purchase,
 	} );
 
 	return (
@@ -42,13 +42,13 @@ const ProductCard = ( {
 			<div className="product-card__header">
 				{ title && (
 					<div className="product-card__header-primary">
-						{ isPurchased && <Gridicon icon="checkmark" size={ 18 } /> }
+						{ purchase && <Gridicon icon="checkmark" size={ 18 } /> }
 						<h3 className="product-card__title">{ title }</h3>
 					</div>
 				) }
 				<div className="product-card__header-secondary">
 					{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
-					{ ! isPurchased && (
+					{ ! purchase && (
 						<ProductCardPriceGroup
 							billingTimeFrame={ billingTimeFrame }
 							currencyCode={ currencyCode }
@@ -82,7 +82,7 @@ ProductCard.propTypes = {
 	fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
 	hasManageSubscriptionLink: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
-	isPurchased: PropTypes.bool,
+	purchase: PropTypes.object,
 	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 };


### PR DESCRIPTION
This PR implements the selected site, purchase object and subtitle in `ProductSelector`. These are respectively passed to the ProductCard, so it can be aware of when and how to display:

* Purchased state, including the subtitle.
* Manage subscription link.

One thing that I decided to keep away from this PR, and leave for another PR is:
* Creating the "plan contains products" dependencies 
* Implementing logic to consume the above dependencies.

#### Changes proposed in this Pull Request

* Implement `siteId` and `purchase` object in the `ProductSelector`. Document the changes.
* Replace `isPurchased` in ProductCard with `purchase` object.
* Replace `hasManageSubscriptionLink` in ProductCard with logic coming from the `purchase` object.
* Implement `subtitle` based on the `purchase` object.

#### Preview

Non-purchased product:
![](https://cldup.com/Zh5yOWASyc.png)

Purchased product:
![](https://cldup.com/6Ea4mD0RH8.png)

#### Testing instructions

* You'll need D34201-code to add a Jetpack Backup product to your site. Follow the instructions there.
* Add a Jetpack backup to your site.
* Make sure you have a Jetpack plan too.
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector
* Select your Jetpack site that you added plan and backup product for.
* Test all the cases, make sure everything makes sense and is relevant to your current store state and purchased products/plans:
  * When a product/plan has been purchased, you will see its purchase date, and a Manage Subscription link.
  * When a product/plan has not been purchased, you will see its price.
* Go to http://calypso.localhost:3000/devdocs/design/product-card
* Verify all examples work well just like before.
