### PR TITLE
Add <ProductCard /> CSS overrides if rendered in Jetpack Connect context

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -12,28 +12,42 @@
 // Header
 .product-card__header {
 	margin: -16px -16px 16px;
-	padding: 16px 40px;
 	border-bottom: solid 2px var( --color-jetpack-plan-free );
 
 	@include breakpoint( '>480px' ) {
 		margin: -24px -24px 24px;
-		padding: 24px 40px;
 	}
 
 	@include breakpoint( '>660px' ) {
 		display: flex;
 		align-items: baseline;
-		padding: 12px 16px;
+	}
+}
+
+.product-card__header-primary,
+.product-card__header-secondary {
+	padding-left: 40px;
+	padding-right: 40px;
+
+	@include breakpoint( '>660px' ) {
+		padding-left: 16px;
+		padding-right: 16px;
 	}
 }
 
 .product-card__header-primary {
 	display: flex;
-	margin-bottom: 8px;
+	padding-top: 16px;
+	padding-bottom: 8px;
+
+	@include breakpoint( '>480px' ) {
+		padding-top: 24px;
+	}
 
 	@include breakpoint( '>660px' ) {
 		flex-grow: 1;
-		margin-bottom: 0;
+		padding-top: 12px;
+		padding-bottom: 0;
 	}
 
 	.gridicon {
@@ -45,6 +59,19 @@
 			height: 16px;
 			margin-left: 0;
 		}
+	}
+}
+
+.product-card__header-secondary {
+	position: relative;
+	padding-bottom: 16px;
+
+	@include breakpoint( '>480px' ) {
+		padding-bottom: 24px;
+	}
+
+	@include breakpoint( '>660px' ) {
+		padding-bottom: 12px;
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -600,17 +600,17 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		margin-top: 11px;
 	}
 
-	.plan-price.is-original {
+	.plan-features .plan-price.is-original {
 		align-self: center;
 		margin-top: 6px;
 	}
 
-	.plan-price.is-original .plan-price__currency-symbol,
-	.plan-price.is-original .plan-price__fraction {
+	.plan-features .plan-price.is-original .plan-price__currency-symbol,
+	.plan-features .plan-price.is-original .plan-price__fraction {
 		font-size: 8px;
 	}
 
-	.plan-price.is-discounted {
+	.plan-features .plan-price.is-discounted {
 		margin-right: 0;
 	}
 
@@ -1094,5 +1094,82 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 	.button .gridicon {
 		padding-left: 4px;
 		margin-right: -5px;
+	}
+}
+
+// <ProductCard /> overrides
+.is-section-jetpack-connect {
+	.product-card {
+		@include breakpoint( '>660px' ) {
+			text-align: left;
+		}
+	}
+
+	.product-card__header {
+		@include breakpoint( '<660px' ) {
+			border-bottom: none;
+		}
+	}
+
+	.product-card__header-primary {
+		padding-top: 20px;
+		padding-bottom: 20px;
+	}
+
+	.product-card__header-secondary {
+		padding-top: 20px;
+		padding-bottom: 20px;
+
+		@include breakpoint( '<660px' ) {
+			padding-bottom: 8px;
+			border-top: solid 2px var( --color-jetpack-plan-free );
+		}
+
+		&::after {
+			bottom: auto;
+			top: 0;
+		}
+	}
+
+	.product-card__title,
+	.product-card__title:not( .is-purchased ) {
+		font-size: 20px;
+		color: var( --color-neutral-70 );
+
+		@include breakpoint( '>660px' ) {
+			font-size: 22px;
+			font-weight: 600;
+		}
+	}
+
+	.product-card__price-group {
+		justify-content: center;
+	}
+
+	.plan-price.is-discounted,
+	.plan-price.is-discounted .plan-price__currency-symbol,
+	.product-card__price-group.is-discounted .product-card__billing-timeframe,
+	.product-card__option .product-card__price-group.is-discounted .product-card__billing-timeframe {
+		color: var( --color-neutral-70 );
+	}
+
+	@include breakpoint( '>660px' ) {
+		.plan-price,
+		.plan-price__currency-symbol,
+		.plan-price__integer,
+		.plan-price__fraction,
+		.product-card__billing-timeframe {
+			font-size: 14px;
+			font-weight: 600;
+			font-style: normal;
+		}
+
+		.product-card__billing-timeframe {
+			color: var( --color-neutral-70 );
+		}
+	}
+
+	.product-card__option-name {
+		text-align: left;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `<ProductCard />` CSS overrides if rendered in Jetpack Connect context
* Change the way product card header spacing is applied to make it more flexible when used in Jetpack Connect
* Adjust fonts, colors and spacing of the `<ProductCard />` elements to match design

**Mobile:**
![Screenshot 2019-10-18 at 15 09 11](https://user-images.githubusercontent.com/478735/67096902-5b07ea80-f1b9-11e9-8c61-030dd30dead8.png)

**Desktop:**
![Screenshot 2019-10-18 at 15 09 33](https://user-images.githubusercontent.com/478735/67096914-5fcc9e80-f1b9-11e9-8023-78247dc9ee7e.png)

#### Testing instructions

There is no easy way to test it locally since the `<ProductCard />` is not yet part of the `/jetpack/connect/store` route.

You can put the card there manually just for the sake of testing like this:
* Go to [`plans-grid.jsx`](https://github.com/Automattic/wp-calypso/blob/2b390def2d8728cb647d0fd93cddcee2f5087f80/client/jetpack-connect/plans-grid.jsx#L62)
* Paste the following code right after the opening `<div id="plans">` tag:
```js
<div style={ { maxWidth: 600, margin: '40px auto' } }>
	<ProductCard
		title="Jetpack Backup"
		billingTimeFrame={ 'per year' }
		fullPrice={ [ 16, 25 ] }
		discountedPrice={ [ 12, 16 ] }
		description={
			<p>
				Always-on backups ensure you never lose your site. Choose from real-time or daily
				backups. <a href="/plans">Which one do I need?</a>
			</p>
		}
	>
		<ProductCardOptions
			billingTimeFrame={ 'per year' }
			optionsLabel="Backup options:"
			options={ [
				{
					discountedPrice: 12,
					fullPrice: 14,
					slug: 'jetpack_backup_daily_monthly',
					title: 'Daily Backups',
				},
				{
					fullPrice: 25,
					slug: 'jetpack_backup_realtime_monthly',
					title: 'Real-Time Backups',
				},
			] }
			selectedSlug={ 'jetpack_backup_realtime_monthly' }
			handleSelect={ () => { return null; }}
		/>
	</ProductCard>
</div>
```
* Remember to import the required dependencies:
```js
import ProductCard from 'components/product-card';
import ProductCardOptions from 'components/product-card/options';
```
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Confirm that the product card looks as in the designs on various screen sizes

Fixes n/a