### PR TITLE
Add link to Jetpack placements settings and more info to terms checkbox

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -40,8 +40,7 @@ export function canAccessAds( site ) {
 
 export function isWordadsInstantActivationEligible( site ) {
 	if (
-		! site.jetpack &&
-		( isBusiness( site.plan ) || isPremium( site.plan ) ) &&
+		( isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan ) ) &&
 		userCan( 'activate_wordads', site )
 	) {
 		return true;

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -213,6 +213,12 @@ class AdsFormSettings extends Component {
 		}, 0 );
 	}
 
+	jetpckPlacementControls() {
+		const linkHref = '/marketing/traffic/' + this.props.site.slug;
+
+		return <Card href={ linkHref }>Manage Ad Placements in Marketing Settings</Card>;
+	}
+
 	showAdsToOptions() {
 		const { translate } = this.props;
 
@@ -501,12 +507,20 @@ class AdsFormSettings extends Component {
 					/>
 					<span>
 						{ translate(
-							'I have read and agree to the {{a}}Automattic Ads Terms of Service{{/a}}.',
+							'I have read and agree to the {{a}}Automattic Ads Terms of Service{{/a}}. {{br/}}I agree to post only {{b}}family-friendly content{{/b}} and will not purchase non-human traffic.',
 							{
 								components: {
 									a: (
 										<a
 											href="https://wordpress.com/automattic-ads-tos/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									br: <br />,
+									b: (
+										<a
+											href="https://wordads.co/2012/09/06/wordads-is-for-family-safe-sites/"
 											target="_blank"
 											rel="noopener noreferrer"
 										/>
@@ -526,6 +540,8 @@ class AdsFormSettings extends Component {
 
 		return (
 			<Fragment>
+				{ this.props.siteIsJetpack ? this.jetpckPlacementControls() : null }
+
 				<SectionHeader label={ translate( 'Ads Settings' ) }>
 					<Button compact primary onClick={ this.handleSubmit } disabled={ isPending }>
 						{ isPending ? translate( 'Saving…' ) : translate( 'Save Settings' ) }

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -213,7 +213,7 @@ class AdsFormSettings extends Component {
 		}, 0 );
 	}
 
-	jetpckPlacementControls() {
+	jetpackPlacementControls() {
 		const linkHref = '/marketing/traffic/' + this.props.site.slug;
 
 		return <Card href={ linkHref }>Manage Ad Placements in Marketing Settings</Card>;
@@ -541,7 +541,7 @@ class AdsFormSettings extends Component {
 		return (
 			<Fragment>
 				{ this.props.siteIsJetpack && this.props.site.options.wordads
-					? this.jetpckPlacementControls()
+					? this.jetpackPlacementControls()
 					: null }
 
 				<SectionHeader label={ translate( 'Ads Settings' ) }>

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -537,15 +537,19 @@ class AdsFormSettings extends Component {
 	render() {
 		const { translate } = this.props;
 		const isPending = this.state.isLoading || this.state.isSubmitting;
+		const isWordAds = this.props.site.options.wordads;
 
 		return (
 			<Fragment>
-				{ this.props.siteIsJetpack && this.props.site.options.wordads
-					? this.jetpackPlacementControls()
-					: null }
+				{ this.props.siteIsJetpack && isWordAds ? this.jetpackPlacementControls() : null }
 
 				<SectionHeader label={ translate( 'Ads Settings' ) }>
-					<Button compact primary onClick={ this.handleSubmit } disabled={ isPending }>
+					<Button
+						compact
+						primary
+						onClick={ this.handleSubmit }
+						disabled={ isPending || ! isWordAds }
+					>
 						{ isPending ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
 					</Button>
 				</SectionHeader>

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -540,7 +540,9 @@ class AdsFormSettings extends Component {
 
 		return (
 			<Fragment>
-				{ this.props.siteIsJetpack ? this.jetpckPlacementControls() : null }
+				{ this.props.siteIsJetpack && this.props.site.options.wordads
+					? this.jetpckPlacementControls()
+					: null }
 
 				<SectionHeader label={ translate( 'Ads Settings' ) }>
 					<Button compact primary onClick={ this.handleSubmit } disabled={ isPending }>

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -216,7 +216,7 @@ class AdsFormSettings extends Component {
 	jetpackPlacementControls() {
 		const linkHref = '/marketing/traffic/' + this.props.site.slug;
 
-		return <Card href={ linkHref }>Manage Ad Placements in Marketing Settings</Card>;
+		return <Card href={ linkHref }>Manage ad placements</Card>;
 	}
 
 	showAdsToOptions() {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -28,7 +28,6 @@ import {
 } from 'state/wordads/approve/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import QueryWordadsStatus from 'components/data/query-wordads-status';
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
 import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -67,12 +66,10 @@ class AdsWrapper extends Component {
 	};
 
 	renderInstantActivationToggle( component ) {
-		const { siteId, translate, adsProgramName } = this.props;
+		const { translate, adsProgramName } = this.props;
 
 		return (
 			<div>
-				<QueryWordadsStatus siteId={ siteId } />
-
 				{ this.props.wordAdsError && (
 					<Notice
 						classname="ads__activate-notice"

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -153,7 +153,7 @@ class AdsWrapper extends Component {
 					<ActionCard
 						headerText={ 'Start Earning Income from Your Site' }
 						mainText={ translate(
-							'%(program)s is the leading advertising optimization platform for WordPress sites, ' +
+							'WordAds is the leading advertising optimization platform for WordPress sites, ' +
 								'where the internet’s top ad suppliers bid against each other to deliver their ads to your site, maximizing your revenue.' +
 								'{{br/}}{{br/}}{{em}}Because you have a paid plan, you can skip the review process and activate %(program)s instantly.{{/em}}' +
 								'{{br/}}{{br/}}{{a}}Learn more about the program{{/a}}',

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -28,6 +28,7 @@ import {
 } from 'state/wordads/approve/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import QueryWordadsStatus from 'components/data/query-wordads-status';
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
 import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -66,10 +67,12 @@ class AdsWrapper extends Component {
 	};
 
 	renderInstantActivationToggle( component ) {
-		const { translate, adsProgramName } = this.props;
+		const { siteId, translate, adsProgramName } = this.props;
 
 		return (
 			<div>
+				<QueryWordadsStatus siteId={ siteId } />
+
 				{ this.props.wordAdsError && (
 					<Notice
 						classname="ads__activate-notice"

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -36,6 +36,12 @@ import { isSiteWordadsUnsafe } from 'state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import ActionCard from 'components/action-card';
+
+/**
+ * Image dependencies
+ */
+import wordAdsImage from 'assets/images/illustrations/dotcom-wordads.svg';
 
 /**
  * Style dependencies
@@ -61,14 +67,76 @@ class AdsWrapper extends Component {
 	};
 
 	renderInstantActivationToggle( component ) {
-		const { siteId, translate } = this.props;
+		const { siteId, translate, adsProgramName } = this.props;
 
 		return (
 			<div>
 				<QueryWordadsStatus siteId={ siteId } />
+
+				{ this.props.wordAdsError && (
+					<Notice
+						classname="ads__activate-notice"
+						status="is-error"
+						onDismissClick={ this.handleDismissWordAdsError }
+					>
+						{ this.props.wordAdsError }
+					</Notice>
+				) }
+				{ this.props.isUnsafe === 'mature' && (
+					<Notice
+						classname="ads__activate-notice"
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate(
+							'Your site has been identified as serving mature content. ' +
+								'Our advertisers would like to include only family-friendly sites in the program.'
+						) }
+					>
+						<NoticeAction
+							href="https://wordads.co/2012/09/06/wordads-is-for-family-safe-sites/"
+							external={ true }
+						>
+							{ translate( 'Learn more' ) }
+						</NoticeAction>
+					</Notice>
+				) }
+				{ this.props.isUnsafe === 'spam' && (
+					<Notice
+						classname="ads__activate-notice"
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate(
+							'Your site has been identified as serving automatically created or copied content. ' +
+								'We cannot serve WordAds on these kind of sites.'
+						) }
+					/>
+				) }
+				{ this.props.isUnsafe === 'private' && (
+					<Notice
+						classname="ads__activate-notice"
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate(
+							'Your site is marked as private. It needs to be public so that visitors can see the ads.'
+						) }
+					>
+						<NoticeAction href={ '/settings/general/' + this.props.siteSlug }>
+							{ translate( 'Change privacy settings' ) }
+						</NoticeAction>
+					</Notice>
+				) }
+				{ this.props.isUnsafe === 'other' && (
+					<Notice
+						classname="ads__activate-notice"
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate( 'Your site cannot participate in WordAds program.' ) }
+					/>
+				) }
+
 				<Card className="ads__activate-wrapper">
 					<div className="ads__activate-header">
-						<h2 className="ads__activate-header-title">{ translate( 'WordAds Disabled' ) }</h2>
+						<h2 className="ads__activate-header-title">{ translate( 'Apply to Join WordAds' ) }</h2>
 						<div className="ads__activate-header-toggle">
 							<FormButton
 								disabled={
@@ -82,79 +150,30 @@ class AdsWrapper extends Component {
 							</FormButton>
 						</div>
 					</div>
-					{ this.props.wordAdsError && (
-						<Notice
-							classname="ads__activate-notice"
-							status="is-error"
-							onDismissClick={ this.handleDismissWordAdsError }
-						>
-							{ this.props.wordAdsError }
-						</Notice>
-					) }
-					{ this.props.isUnsafe === 'mature' && (
-						<Notice
-							classname="ads__activate-notice"
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate(
-								'Your site has been identified as serving mature content. ' +
-									'Our advertisers would like to include only family-friendly sites in the program.'
-							) }
-						>
-							<NoticeAction
-								href="https://wordads.co/2012/09/06/wordads-is-for-family-safe-sites/"
-								external={ true }
-							>
-								{ translate( 'Learn more' ) }
-							</NoticeAction>
-						</Notice>
-					) }
-					{ this.props.isUnsafe === 'spam' && (
-						<Notice
-							classname="ads__activate-notice"
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate(
-								'Your site has been identified as serving automatically created or copied content. ' +
-									'We cannot serve WordAds on these kind of sites.'
-							) }
-						/>
-					) }
-					{ this.props.isUnsafe === 'private' && (
-						<Notice
-							classname="ads__activate-notice"
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate(
-								'Your site is marked as private. It needs to be public so that visitors can see the ads.'
-							) }
-						>
-							<NoticeAction href={ '/settings/general/' + this.props.siteSlug }>
-								{ translate( 'Change privacy settings' ) }
-							</NoticeAction>
-						</Notice>
-					) }
-					{ this.props.isUnsafe === 'other' && (
-						<Notice
-							classname="ads__activate-notice"
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate( 'Your site cannot participate in WordAds program.' ) }
-						/>
-					) }
-					<p className="ads__activate-description">
-						{ translate(
-							'WordAds allows you to make money from advertising that runs on your site. ' +
-								'Because you have a WordPress.com %(plan)s plan, you can skip the review process and activate WordAds instantly. ' +
-								'{{a}}Learn more about the program.{{/a}}',
+					<ActionCard
+						headerText={ 'Start Earning Income from Your Site' }
+						mainText={ translate(
+							'%(program)s is the leading advertising optimization platform for WordPress sites, ' +
+								'where the internet’s top ad suppliers bid against each other to deliver their ads to your site, maximizing your revenue.' +
+								'{{br/}}{{br/}}{{em}}Because you have a paid plan, you can skip the review process and activate %(program)s instantly.{{/em}}' +
+								'{{br/}}{{br/}}{{a}}Learn more about the program{{/a}}',
 							{
-								args: { plan: this.props.site.plan.product_name_short },
+								args: { program: adsProgramName },
 								components: {
-									a: <a href={ 'http://wordads.co' } />,
+									a: <a href="http://wordads.co" target="_blank" rel="noopener noreferrer" />,
+									em: <em />,
+									br: <br />,
 								},
 							}
 						) }
-					</p>
+						buttonText={ 'Learn More on WordAds.co' }
+						buttonIcon="external"
+						buttonPrimary={ false }
+						buttonHref="https://wordads.co"
+						buttonTarget="_blank"
+					>
+						<img src={ wordAdsImage } width="170" height="143" alt="WordPress logo" />
+					</ActionCard>
 				</Card>
 				<FeatureExample>{ component }</FeatureExample>
 			</div>

--- a/client/state/data-layer/wpcom/wordads/status/index.js
+++ b/client/state/data-layer/wpcom/wordads/status/index.js
@@ -18,7 +18,7 @@ registerHandlers( 'state/data-layer/wpcom/wordads/status/index.js', {
 				http(
 					{
 						method: 'GET',
-						path: `/sites/${ action.siteId }/wordads/status`,
+						path: `/sites/${ action.siteId }/wordads/account`,
 					},
 					action
 				),


### PR DESCRIPTION
### Signup View
<img width="1059" alt="Screen Shot 2019-10-18 at 5 02 44 PM" src="https://user-images.githubusercontent.com/2522431/67128434-9f9b8200-f1c9-11e9-8653-5e46df23c033.png">

### Prevented Signup View
Sites with an issue that prevents ads activation will show a notice like the following:
<img width="1060" alt="Screen Shot 2019-10-18 at 5 02 15 PM" src="https://user-images.githubusercontent.com/2522431/67128467-be9a1400-f1c9-11e9-96e8-99a8470f3b9e.png">

### Signup Success View
Following signup, this is what the user will see:
<img width="1059" alt="Screen Shot 2019-10-18 at 5 02 58 PM" src="https://user-images.githubusercontent.com/2522431/67128462-b3df7f00-f1c9-11e9-917f-9b08c887234f.png">

---
#### Changes proposed in this Pull Request

* Adds a notice with link where Jetpack sites can access placement controls.
* Adds a new like to the terms checkbox affirming that the user agrees to only post family-friendly content and not purchase non-human traffic.
* Allows Jetpack sites to activate WordAds
* Improves the instant activation toggle display

Companion patch in D34231-code

#### Testing instructions

* Take a jetpack site with a premium plan or above and navigate to Earn > Ads to ensure the form displays the same as the screenshot above.
* Make sure the placements link goes to the correct section.
* Try signing up with a wp.com site and make sure nothing else is broken :)