### PR TITLE
Google My Business: Back links go to Marketing Tools, rather than Stats

### DIFF
--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -75,6 +75,7 @@ class GoogleMyBusinessNewAccount extends Component {
 	render() {
 		const { siteSlug, translate } = this.props;
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main className="gmb-new-account" wideLayout>
 				<PageViewTracker path="/google-my-business/new/:site" title="Google My Business > New" />
@@ -123,7 +124,10 @@ class GoogleMyBusinessNewAccount extends Component {
 								{ translate( 'Use another Google Account' ) }
 							</KeyringConnectButton>
 
-							<Button href={ `/stats/${ siteSlug }` } onClick={ this.handleNoThanksClick }>
+							<Button
+								href={ `/marketing/tools/${ siteSlug }` }
+								onClick={ this.handleNoThanksClick }
+							>
 								{ translate( 'No thanks' ) }
 							</Button>
 						</div>

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -52,7 +52,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	};
 
 	goBack = () => {
-		page.back( `/stats/day/${ this.props.siteSlug }` );
+		page.back( `/marketing/tools/${ this.props.siteSlug }` );
 	};
 
 	handleConnect = keyringConnection => {
@@ -167,6 +167,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 	render() {
 		const { siteId, translate } = this.props;
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main className="gmb-select-business-type" wideLayout>
 				<PageViewTracker
@@ -184,6 +185,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
+				{  }
 				<Card className="gmb-select-business-type__explanation">
 					<div className="gmb-select-business-type__explanation-main">
 						<CardHeading tagName="h1" size={ 24 }>

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -185,7 +185,6 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
-				{  }
 				<Card className="gmb-select-business-type__explanation">
 					<div className="gmb-select-business-type__explanation-main">
 						<CardHeading tagName="h1" size={ 24 }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Google My Business is part of marketing tools. It's likely that users exploring the feature are also interested in other marketing tools, so that's where we should send them in these cases:

* Back link on the `/google-my-business/select-business-type/{site}` page goes to `/marketing/tools` rather than `/stats/day`
* "No Thanks" button on the `/google-my-business/new/{site}` page goes to `/marketing/tools` rather than `/stats/day`

Note that `/* eslint-disable wpcalypso/jsx-classname-namespace */` is added because updating class names and css in these components are not in the scope of this PR.

(Found while creating https://github.com/Automattic/wp-calypso/pull/36840)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On a WordPress.com site with a Business plan

- Visit `/google-my-business/new/` and click on "No Thanks"; you should be taken to `/marketing/tools`
- Visit `/google-my-business/select-business-type` and click on "Back" (in the header cake); you should be taken to `/marketing/tools`


