### PR TITLE
Rename getSiteHomeUrl selector to getMySitesDefaultPage

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -19,7 +19,7 @@ import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteHomeUrl } from 'state/sites/selectors';
+import { getMySitesDefaultPage } from 'state/sites/selectors';
 import { isLoaded as arePluginsLoaded } from 'state/plugins/installed/selectors';
 import { isStoreSetupComplete } from 'woocommerce/state/sites/setup-choices/selectors';
 import Main from 'components/main';
@@ -42,7 +42,7 @@ class App extends Component {
 		isAtomicSite: PropTypes.bool.isRequired,
 		isDashboard: PropTypes.bool.isRequired,
 		pluginsLoaded: PropTypes.bool.isRequired,
-		siteHomeUrl: PropTypes.string.isRequired,
+		mySitesDefaultPage: PropTypes.string.isRequired,
 		siteId: PropTypes.number,
 		translate: PropTypes.func.isRequired,
 	};
@@ -80,7 +80,7 @@ class App extends Component {
 	}
 
 	redirect() {
-		window.location.href = this.props.siteHomeUrl;
+		window.location.href = this.props.mySitesDefaultPage;
 	}
 
 	renderPlaceholder() {
@@ -186,7 +186,7 @@ function mapStateToProps( state ) {
 		isSetupComplete,
 		hasPendingAutomatedTransfer: siteId ? hasPendingAutomatedTransfer : false,
 		pluginsLoaded,
-		siteHomeUrl: getSiteHomeUrl( state, siteId ),
+		mySitesDefaultPage: getMySitesDefaultPage( state, siteId ),
 		siteId,
 	};
 }

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -15,11 +15,11 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Site from 'blocks/site';
-import { getSiteHomeUrl } from 'state/sites/selectors';
+import { getMySitesDefaultPage } from 'state/sites/selectors';
 
-const StoreGroundControl = ( { site, siteHomeUrl, translate } ) => {
+const StoreGroundControl = ( { site, mySitesDefaultPage, translate } ) => {
 	const isPlaceholder = ! site;
-	const backUrl = isPlaceholder ? '' : siteHomeUrl;
+	const backUrl = isPlaceholder ? '' : mySitesDefaultPage;
 
 	return (
 		<div className="store-sidebar__ground-control">
@@ -43,10 +43,10 @@ StoreGroundControl.propTypes = {
 	site: PropTypes.shape( {
 		slug: PropTypes.string,
 	} ).isRequired,
-	siteHomeUrl: PropTypes.string.isRequired,
+	mySitesDefaultPage: PropTypes.string.isRequired,
 	translate: PropTypes.func.isRequired,
 };
 
 export default connect( state => ( {
-	siteHomeUrl: getSiteHomeUrl( state ),
+	mySitesDefaultPage: getMySitesDefaultPage( state ),
 } ) )( localize( StoreGroundControl ) );

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -79,7 +79,7 @@ import { fetchAtomicTransfer } from 'state/atomic-transfer/actions';
 import { transferStates } from 'state/atomic-transfer/constants';
 import getAtomicTransfer from 'state/selectors/get-atomic-transfer';
 import isFetchingTransfer from 'state/selectors/is-fetching-atomic-transfer';
-import { getSiteHomeUrl, getSiteSlug } from 'state/sites/selectors';
+import { getMySitesDefaultPage, getSiteSlug } from 'state/sites/selectors';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getActiveTheme } from 'state/themes/selectors';
@@ -116,7 +116,7 @@ export class CheckoutThankYou extends React.Component {
 		gsuiteReceiptId: PropTypes.number,
 		selectedFeature: PropTypes.string,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
-		siteHomeUrl: PropTypes.string.isRequired,
+		mySitesDefaultPage: PropTypes.string.isRequired,
 		transferComplete: PropTypes.bool,
 	};
 
@@ -309,7 +309,7 @@ export class CheckoutThankYou extends React.Component {
 			}
 		}
 
-		return page( this.props.siteHomeUrl );
+		return page( this.props.mySitesDefaultPage );
 	};
 
 	isEligibleForLiveChat = () => {
@@ -624,7 +624,7 @@ export default connect(
 				get( getAtomicTransfer( state, siteId ), 'status', transferStates.PENDING ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			selectedSiteSlug: getSiteSlug( state, siteId ),
-			siteHomeUrl: getSiteHomeUrl( state, siteId ),
+			mySitesDefaultPage: getMySitesDefaultPage( state, siteId ),
 			customizeUrl: getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId ),
 		};
 	},

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -16,7 +16,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business-locations';
 import isGoogleMyBusinessLocationConnected from 'state/selectors/is-google-my-business-location-connected';
 import isSiteGoogleMyBusinessEligible from 'state/selectors/is-site-google-my-business-eligible';
-import { getSiteHomeUrl } from 'state/sites/selectors';
+import { getMySitesDefaultPage } from 'state/sites/selectors';
 import { requestKeyringServices } from 'state/sharing/services/actions';
 import { requestSiteKeyrings } from 'state/site-keyrings/actions';
 import { getSiteKeyringsForService } from 'state/site-keyrings/selectors';
@@ -44,7 +44,7 @@ const redirectUnauthorized = ( context, next ) => {
 	const siteIsGMBEligible = isSiteGoogleMyBusinessEligible( state, siteId );
 	const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	if ( ! siteIsGMBEligible || ! canUserManageOptions ) {
-		page.redirect( getSiteHomeUrl( state, siteId ) );
+		page.redirect( getMySitesDefaultPage( state, siteId ) );
 	}
 
 	next();
@@ -98,7 +98,7 @@ export default function( router ) {
 			} else if ( hasLocationsAvailable && siteIsGMBEligible ) {
 				page.redirect( `/google-my-business/select-location/${ context.params.site }` );
 			} else {
-				page.redirect( getSiteHomeUrl( state, siteId ) );
+				page.redirect( getMySitesDefaultPage( state, siteId ) );
 			}
 		},
 		stats,

--- a/client/my-sites/index.js
+++ b/client/my-sites/index.js
@@ -12,7 +12,7 @@ import { get } from 'lodash';
  */
 import { siteSelection, sites } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
-import { getSiteBySlug, getSiteHomeUrl } from 'state/sites/selectors';
+import { getSiteBySlug, getMySitesDefaultPage } from 'state/sites/selectors';
 
 export default function() {
 	page( '/sites/:site', context => {
@@ -20,7 +20,7 @@ export default function() {
 		const site = getSiteBySlug( state, context.params.site );
 		// The site may not be loaded into state yet.
 		const siteId = get( site, 'ID' );
-		page.redirect( getSiteHomeUrl( state, siteId ) );
+		page.redirect( getMySitesDefaultPage( state, siteId ) );
 	} );
 	page( '/sites', siteSelection, sites, makeLayout, clientRender );
 }

--- a/client/state/sites/selectors/get-my-sites-default-page.ts
+++ b/client/state/sites/selectors/get-my-sites-default-page.ts
@@ -9,10 +9,10 @@ import { getStatsDefaultSitePage } from 'lib/route/path';
  * Determine the default section to show for the specified site.
  *
  * @param  {Object}  state  Global state tree.
- * @param  {?Number} siteId Site ID.
- * @return {String}         Url of the site home.
+ * @param  {?Number} siteId Site ID (fallback to selected site).
+ * @return {String}         Path of the default section for the site.
  */
-export default function getSiteHomeUrl( state: object, siteId?: number ): string {
+export default function getMySitesDefaultPage( state: object, siteId?: number ): string {
 	const selectedSiteId = siteId || getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, selectedSiteId );
 

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -16,6 +16,7 @@ export {
 export {
 	default as getJetpackSiteUpdateFilesDisabledReasons,
 } from './get-jetpack-site-update-files-disabled-reasons';
+export { default as getMySitesDefaultPage } from './get-my-sites-default-page';
 export { default as getSeoTitle } from './get-seo-title';
 export { default as getSeoTitleFormats } from './get-seo-title-formats';
 export { default as getSeoTitleFormatsForSite } from './get-seo-title-formats-for-site';
@@ -28,7 +29,6 @@ export { default as getSiteComputedAttributes } from './get-site-computed-attrib
 export { default as getSiteDomain } from './get-site-domain';
 export { default as getSiteFrontPage } from './get-site-front-page';
 export { default as getSiteFrontPageType } from './get-site-front-page-type';
-export { default as getSiteHomeUrl } from './get-site-home-url';
 export { default as getSiteOption } from './get-site-option';
 export { default as getSitePlan } from './get-site-plan';
 export { default as getSitePlanSlug } from './get-site-plan-slug';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename the `getSiteHomeUrl` selector added in https://github.com/Automattic/wp-calypso/pull/36819 to `getMySitesDefaultPage` to clarify that it doesn't always go to the My Home section.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Here are all the places this selector is used. The Customer Home is available on sites created after 2019-08-06.

**Back from Store with an Atomic site**

- On an Atomic site with a Business plan (not eCommerce plan), to `/store/{site}`, then click on the "X" to go back
- You should be redirected to the Customer Home if it's available on your site, otherwise `/stats/day/{site}`

**Redirect for store on non-Atomic sites**

- Visit `/store/{site}?flags=-woocommerce/store-on-non-atomic-sites` (the Store can be viewed on non-Atomic sites in all environment but production, so you need to turn that feature flag off to test)
- You should be redirected to the Customer Home if it's available on your site, otherwise `/stats/day/{site}`

**Redirect for Google My Business stats**

- Visit `/google-my-business/stats/{site}` on a site without a Google My Business connection
- You should be redirected to the Customer Home if it's available on your site, otherwise `/stats/day/{site}`

**/sites/{site} path**

- Visit `/sites/{site}`
- You should be redirected to the Customer Home if it's available on your site, otherwise `/stats/day/{site}`
- You may be redirected to `/stats/day` (all sites contexxt) if the site isn't loaded into state yet

**/sites path**

- Visit `/sites`
- If you select a site with Customer Home enabled, you should be redirected to the Customer Home, otherwise `/stats/day/{site}`

Note that I didn't see an immediate way to test the checkout thank you page with a default cta. But locally you can comment out other paths in [`primaryCta`](https://github.com/Automattic/wp-calypso/blob/update/rename-get-site-home-url-selector/client/my-sites/checkout/checkout-thank-you/index.jsx#L287) (everything except for line `312`), upgrade the plan on a site, and click on "View my new features" on the checkout thank you page to test.
