### PR TITLE
Change Url For Google My Business Button

### DIFF
--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -41,7 +41,7 @@ const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 	const handleConnectToGoogleMyBusinessClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_connect_to_google_my_business_button_click' );
 
-		page( `/google-my-business/new/${ selectedSiteSlug || '' }` );
+		page( `/google-my-business/${ selectedSiteSlug || '' }` );
 	};
 
 	const handleGoToGoogleMyBusinessClick = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the URL to send users to connect to Google My Business

Noticed this while testing #36898

#### Testing instructions

1. Navigate to `/marketing/tools/:siteSlug` for a site with a business plan and not connected to GMB
2. Click "Connect to Google My Business"
3. Confirm you are taken to `/google-my-business/select-business-type/:siteSlug` and not `/google-my-business/new/:siteSlug`

