### PR TITLE
Removed extra render of sidebarNavigation

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -139,7 +139,6 @@ class Home extends Component {
 			<Main className="customer-home__main is-wide-layout">
 				<PageViewTracker path={ `/home/:site` } title={ translate( 'Customer Home' ) } />
 				<DocumentHead title={ translate( 'Customer Home' ) } />
-				<SidebarNavigation />
 				<StatsBanners siteId={ siteId } slug={ siteSlug } />
 				{ renderChecklistCompleteBanner && (
 					<Banner
@@ -182,6 +181,7 @@ class Home extends Component {
 			isStaticHomePage && `/block-editor/page/${ siteSlug }/${ staticHomePageId }`;
 		return (
 			<div className="customer-home__layout">
+				<SidebarNavigation />
 				<div className="customer-home__layout-col">
 					<Card>
 						<CardHeading>{ translate( 'My Site' ) }</CardHeading>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On mobile web, the `SidebarNavigation` is appearing twice on the "CustomerHome/Checklist" screen. 

To fix, I moved `SidebarNavigation` into `renderCustomerHome`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On a mobile device/resized browser, go through onboarding to land on the Checklist.
2. Confirm there is only one header bar.

**Before:**

![calypso localhost_3000_checklist_canada36908683 wordpress com(iPhone 6_7_8)](https://user-images.githubusercontent.com/181733/67155046-de116980-f2bb-11e9-95d4-6902db992263.png)

**After:**

![calypso localhost_3000_home_cats775809278 wordpress com(iPhone 6_7_8) (8)](https://user-images.githubusercontent.com/181733/67155056-37799880-f2bc-11e9-98f1-d2d520a5c650.png)

