### PR TITLE
Add in link to pma token instead of pma login url

### DIFF
--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -80,7 +80,7 @@ export default connect( state => {
 
 	return {
 		token: get( pmaTokenRequest.data, 'token', null ),
-		loading: pmaTokenRequest.status === 'pending',
+		loading: pmaTokenRequest.state === 'pending',
 		siteId,
 	};
 } )( localize( PhpMyAdminCard ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a working pma login link to the hosting dashboard

#### Testing instructions

1. Apply D34245-code to your sandbox
2. Apply this PR to your local calypso dev environment
4. Sandbox both the API and wordpress.com
5. Go to http://calypso.localhost:3000/hosting/{atomic_site_domain}
6. Try the Access PMA button
