### PR TITLE
Vertical suggested themes: Create site with theme annotation if using vertical-suggested theme 

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -15,7 +15,7 @@ import { parse as parseURL } from 'url';
 import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
-import { getSavedVariations } from 'lib/abtest';
+import { abtest, getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import {
 	updatePrivacyForDomain,
@@ -142,6 +142,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	const siteType = getSiteType( state ).trim();
 	const siteStyle = getSiteStyle( state ).trim();
 	const siteSegment = getSiteTypePropertyValue( 'slug', siteType, 'id' );
+	const defaultSiteTypeTheme = getSiteTypePropertyValue( 'slug', siteType, 'theme' );
 
 	const newSiteParams = {
 		blog_title: siteTitle,
@@ -166,6 +167,16 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	// flowName isn't always passed in
 	const flowToCheck = flowName || lastKnownFlow;
+
+	if (
+		flowToCheck === 'onboarding' &&
+		newSiteParams.options.theme !== defaultSiteTypeTheme &&
+		abtest( 'verticalSuggestedThemes' ) === 'test'
+	) {
+		// Tell headstart to use the theme annotation, even though
+		// segment/vertical options are provided.
+		newSiteParams.options.use_theme_annotation = true;
+	}
 
 	if ( ! siteUrl && isDomainStepSkippable( flowToCheck ) ) {
 		newSiteParams.blog_name =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sends `use_theme_annotation` option to `/sites/new` if the user is getting a vertical-suggested theme

Leaving `site_segment` and `site_vertical` options empty for site creation causes the site to be headstarted using the content from the theme's demo site. This is the ~same~ way the `with-theme` flow works (creating a site from the theme gallery you end up with content from the theme demo site).

~The segment and vertical values eventually become site options. As far as I know leaving these site options blank shouldn't break anything (it's already possible for these options to be blank), but if this AB test is successful we might want to find a way to retain the site options.~
Update: changed PR so vertical/segment site options are set.

Parent issue Automattic/zelda-private#108

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox and apply D34295-code
* Opt user into `verticalSuggestedThemes` test group
* Ensure sure user language is `en`
* `/start` and create a new site, choose business, choose "Restaurants" for site topic
  * The new site should have the Rockfield theme
  * Site will have been headstarted with content from https://rockfielddemo.wordpress.com/
* Check the new site's options for segment and vertical are `1` and `p1` respectively

**Known issue:**
~The images from the rockfield demo site aren't headstarted properly. This bug is also in production using the `with-theme` flow. See: `/start/with-theme?ref=calypshowcase&theme=rockfield`~
~Can be fixed by applying D34247-code~
Update: fixed!
