### PR TITLE
Vertical suggested themes: Signup preview uses photon to impro…

### DIFF
--- a/client/components/signup-site-preview/screenshot.tsx
+++ b/client/components/signup-site-preview/screenshot.tsx
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import { noop } from 'lodash';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 /**
  * Internal dependencies
  */
-import ImagePreloader from 'components/image-preloader';
 import Spinner from 'components/spinner';
 import classNames from 'classnames';
 
@@ -28,21 +27,42 @@ export default function SignupSitePreviewScreenshot( {
 	onPreviewClick = noop,
 	translate,
 }: Props ) {
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	useEffect( () => {
+		setIsLoading( true );
+	}, [ screenshotUrl ] );
+
 	const className = classNames( {
 		'signup-site-preview__scrolling-screenshot': scrolling,
 	} );
 
 	const isPhone = defaultViewportDevice === 'phone';
 
+	const { hostname, pathname } = new URL( screenshotUrl );
+	const zoom = window.devicePixelRatio;
+	const w = isPhone ? 280 : 904;
+	const src = `https://i0.wp.com/${ hostname }${ pathname }?w=${ w }`;
+	const srcset = `https://i0.wp.com/${ hostname }${ pathname }?w=${ w }&zoom=${ zoom } ${ zoom }x`;
+
+	const onLoad = ( event: React.SyntheticEvent< HTMLImageElement > ) => {
+		setWrapperHeight( event.currentTarget.height );
+		setIsLoading( false );
+	};
+
 	return (
 		<div className={ className }>
-			<ImagePreloader
-				src={ screenshotUrl }
-				placeholder={
-					<Spinner className="signup-site-preview__screenshot-spinner" size={ isPhone ? 20 : 40 } />
-				}
+			{ isLoading && (
+				<Spinner className="signup-site-preview__screenshot-spinner" size={ isPhone ? 20 : 40 } />
+			) }
+			{ /* The onClick is being used for analytics purposes, there's no user interaction implemented with this click handler */ }
+			{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }
+			<img
+				style={ isLoading ? { display: 'none' } : undefined }
+				src={ src }
+				srcSet={ srcset }
 				onClick={ () => onPreviewClick( defaultViewportDevice ) }
-				onLoad={ ( e: any ) => setWrapperHeight( e.target.height ) }
+				onLoad={ onLoad }
 				alt={
 					isPhone
 						? translate( 'Preview of site with phone layout', {

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -48,22 +48,13 @@ export function getSiteVerticalPreview( state ) {
 }
 
 export function getSiteVerticalPreviewScreenshot( state, viewportDevice ) {
-	const screenshotPropName = getScreenshotPropName( viewportDevice );
-	return get( getSiteVerticalData( state ), [ 'previewScreenshots', screenshotPropName ] );
-}
+	const screenshots = get( getSiteVerticalData( state ), 'previewScreenshots' );
 
-function getScreenshotPropName( viewportDevice ) {
-	if ( window.devicePixelRatio === 1 ) {
-		if ( viewportDevice === 'phone' ) {
-			return 'phoneLowDpi';
-		}
-		return 'desktopLowDpi';
-	}
-
-	if ( viewportDevice === 'phone' ) {
-		return 'phoneHighDpi';
-	}
-	return 'desktopHighDpi';
+	return get(
+		screenshots,
+		viewportDevice,
+		get( screenshots, viewportDevice === 'phone' ? 'phoneHighDpi' : 'desktopHighDpi' )
+	);
 }
 
 export function getSiteVerticalPreviewStyles( state ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use [photon](https://developer.wordpress.com/docs/photon/) to improve screenshot preview performance
* Use vanilla `<img>` instead of `<ImagePreloader>` to render preview (the component doesn't support the `srcset` attribute
* Use new API response names if available

  With the client now using photon to scale images for retina, there's no need for separate highDpi and lowDpi versions of the screenshots. If a simple `phone` or `desktop` prop is provided by the API the client will use that screenshot instead.

  tl;dr I'm renaming the API response propery (WIP D34252-code)

Parent issue: Automattic/zelda-private#108

#### Testing instructions

Same as #36517

* Test with user where `locale = en`
* In A/B test picker choose "test" group for `verticalSuggestedThemes` test
* Create a site starting from `/start`
  * Choose *Business* site type
    * Choose *Restaurants* vertical
      * You should see the Rockfield theme in the preview
      * Create the site, the new site has the Rockfield theme
    * Choose *any other vertical*
      * You see the regular DOM based preview
      * Create the site, the new site has the Maywood theme
  * Choose *Blog* site type
    * Choose *Restaurants* vertical
      * You see the regular DOM based preview
      * Create the site, the new site has the Maywood theme
* `calypso_signup_site_preview_mockup_clicked` still fires when preview is clicked
* Try it on non-retina somehow. (I'm thinking browserstack might do the trick)
