### PR TITLE
Remove unneeded domain add/remove cart actions

### DIFF
--- a/client/lib/cart/actions.js
+++ b/client/lib/cart/actions.js
@@ -22,7 +22,6 @@ import {
 	CART_TAX_POSTAL_CODE_SET,
 } from './action-types';
 import Dispatcher from 'dispatcher';
-import { domainRegistration } from 'lib/cart-values/cart-items';
 import { MARKETING_COUPONS_KEY } from 'lib/analytics/utils';
 
 // We need to load the CartStore to make sure the store is registered with the
@@ -98,29 +97,11 @@ export function replaceItem( oldItem, newItem ) {
 	} );
 }
 
-export function addDomainToCart( domainSuggestion ) {
-	addItem(
-		domainRegistration( {
-			domain: domainSuggestion.domain_name,
-			productSlug: domainSuggestion.product_slug,
-		} )
-	);
-}
-
 export function addGoogleAppsRegistrationData( registrationData ) {
 	Dispatcher.handleViewAction( {
 		type: CART_GOOGLE_APPS_REGISTRATION_DATA_ADD,
 		registrationData: registrationData,
 	} );
-}
-
-export function removeDomainFromCart( domainSuggestion ) {
-	removeItem(
-		domainRegistration( {
-			domain: domainSuggestion.domain_name,
-			productSlug: domainSuggestion.product_slug,
-		} )
-	);
 }
 
 export function applyCoupon( coupon ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -19,7 +19,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import RegisterDomainStep from 'components/domains/register-domain-step';
 import PlansNavigation from 'my-sites/plans/navigation';
 import Main from 'components/main';
-import { addItem, addItems, removeDomainFromCart } from 'lib/cart/actions';
+import { addItem, removeItem } from 'lib/cart/actions';
 import { isGSuiteRestricted, canDomainAddGSuite } from 'lib/gsuite';
 import {
 	hasDomainInCart,
@@ -121,7 +121,7 @@ class DomainSearch extends Component {
 			domainRegistration = updatePrivacyForDomain( domainRegistration, true );
 		}
 
-		addItems( [ domainRegistration ] );
+		addItem( domainRegistration );
 
 		if ( ! isGSuiteRestricted() && canDomainAddGSuite( domain ) ) {
 			page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
@@ -132,7 +132,12 @@ class DomainSearch extends Component {
 
 	removeDomain( suggestion ) {
 		this.props.recordRemoveDomainButtonClick( suggestion.domain_name );
-		removeDomainFromCart( suggestion );
+		removeItem(
+			domnRegistration( {
+				domain: suggestion.domain_name,
+				productSlug: suggestion.product_slug,
+			} )
+		);
 	}
 
 	render() {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -25,7 +25,7 @@ import {
 	hasDomainInCart,
 	domainMapping,
 	domainTransfer,
-	domainRegistration as domnRegistration,
+	domainRegistration,
 	updatePrivacyForDomain,
 } from 'lib/cart-values/cart-items';
 import { currentUserHasFlag } from 'state/current-user/selectors';
@@ -111,17 +111,17 @@ class DomainSearch extends Component {
 
 		this.props.recordAddDomainButtonClick( domain, 'domains' );
 
-		let domainRegistration = domnRegistration( {
+		let registration = domainRegistration( {
 			domain,
 			productSlug,
 			extra: { privacy_available: supportsPrivacy },
 		} );
 
 		if ( supportsPrivacy ) {
-			domainRegistration = updatePrivacyForDomain( domainRegistration, true );
+			registration = updatePrivacyForDomain( registration, true );
 		}
 
-		addItem( domainRegistration );
+		addItem( registration );
 
 		if ( ! isGSuiteRestricted() && canDomainAddGSuite( domain ) ) {
 			page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
@@ -133,7 +133,7 @@ class DomainSearch extends Component {
 	removeDomain( suggestion ) {
 		this.props.recordRemoveDomainButtonClick( suggestion.domain_name );
 		removeItem(
-			domnRegistration( {
+			domainRegistration( {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug,
 			} )


### PR DESCRIPTION
Remove two Cart actions:
- `addDomainToCart`: not used anywhere
- `removeDomainToCart`: used only at one place, easy to replace with `removeItem( domainRegistration( ... ) )`

There is nothing special about domains here when compared to other kinds of products: they don't need dedicated actions in the Cart module.

Little step towards making Cart more self contained and independent from specific products.