### PR TITLE
Integrate <ProductCardOptions /> with <ProductSelector /> block

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { find, flattenDeep, flowRight as compose, includes, isEmpty, map, uniq } from 'lodash';
@@ -10,10 +10,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
-import Card from 'components/card';
 import ProductCard from 'components/product-card';
+import ProductCardOptions from 'components/product-card/options';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { extractProductSlugs, filterByProductSlugs } from './utils';
@@ -84,12 +82,26 @@ export class ProductSelector extends Component {
 		} );
 	}
 
+	getProductOptions( product ) {
+		const { intervalType, storeProducts } = this.props;
+		const productSlugs = product.options[ intervalType ];
+
+		return productSlugs.map( productSlug => {
+			const productObject = storeProducts[ productSlug ];
+			return {
+				billingTimeFrame: this.getBillingTimeFrameLabel(),
+				currencyCode: productObject.currency_code,
+				fullPrice: productObject.cost,
+				slug: productSlug,
+				title: productObject.product_name,
+			};
+		} );
+	}
+
 	handleProductOptionSelect( stateKey, productSlug ) {
-		return () => {
-			this.setState( {
-				[ stateKey ]: productSlug,
-			} );
-		};
+		this.setState( {
+			[ stateKey ]: productSlug,
+		} );
 	}
 
 	renderProducts() {
@@ -102,62 +114,28 @@ export class ProductSelector extends Component {
 		return map( products, product => {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 			const productObject = storeProducts[ selectedProductSlug ];
+			const stateKey = this.getStateKey( product.id, intervalType );
 
 			return (
-				<Fragment key={ 'product-' + product.id }>
-					<ProductCard
-						key={ product.id }
-						title={ product.title }
-						billingTimeFrame={ this.getBillingTimeFrameLabel() }
-						fullPrice={ productObject.cost }
-						description={ product.description }
-						currencyCode={ currencyCode }
-						purchase={ this.getPurchaseByProduct( product ) }
-						subtitle={ this.getSubtitleByProduct( product ) }
+				<ProductCard
+					key={ product.id }
+					title={ product.title }
+					billingTimeFrame={ this.getBillingTimeFrameLabel() }
+					fullPrice={ productObject.cost }
+					description={ <p>{ product.description }</p> }
+					currencyCode={ currencyCode }
+					purchase={ this.getPurchaseByProduct( product ) }
+					subtitle={ this.getSubtitleByProduct( product ) }
+				>
+					<ProductCardOptions
+						optionsLabel={ product.optionsLabel }
+						options={ this.getProductOptions( product ) }
+						selectedSlug={ this.state[ stateKey ] }
+						handleSelect={ productSlug => this.handleProductOptionSelect( stateKey, productSlug ) }
 					/>
-
-					{ this.renderProductOptions( product ) }
-				</Fragment>
+				</ProductCard>
 			);
 		} );
-	}
-
-	renderProductOptions( product ) {
-		const { intervalType, storeProducts } = this.props;
-		const productSlugs = product.options[ intervalType ];
-		const stateKey = this.getStateKey( product.id, intervalType );
-
-		return (
-			<Card>
-				<h4>{ product.optionsLabel }</h4>
-
-				{ productSlugs.map( productSlug => {
-					const productObject = storeProducts[ productSlug ];
-
-					/**
-					 * TODO: Replace with a ProductOption component.
-					 *
-					 * This will eventually render a product options component and we'll pass it some props like:
-					 * - handleSelect={ this.handleProductOptionSelect( stateKey, productSlug ) }
-					 * - checked={ productSlug === this.state[ stateKey ] }
-					 * - product={ productObject }
-					 */
-					return (
-						<Fragment key={ 'product-option-' + productSlug }>
-							<FormLabel>
-								<FormRadio
-									checked={ productSlug === this.state[ stateKey ] }
-									onChange={ this.handleProductOptionSelect( stateKey, productSlug ) }
-								/>
-								<span>
-									{ productObject.product_name } - { productObject.cost_display }
-								</span>
-							</FormLabel>
-						</Fragment>
-					);
-				} ) }
-			</Card>
-		);
 	}
 
 	render() {

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -83,7 +83,7 @@ export default class extends React.Component {
 		return (
 			<ProductCard
 				title="Jetpack Backup"
-				billingTimeFrame={ 'per year' }
+				billingTimeFrame={ 'per month' }
 				fullPrice={ [ 16, 25 ] }
 				discountedPrice={ [ 12, 16 ] }
 				description={
@@ -97,14 +97,14 @@ export default class extends React.Component {
 					optionsLabel="Backup options:"
 					options={ [
 						{
-							billingTimeFrame={ 'per year' }
+							billingTimeFrame={ 'per month' }
 							discountedPrice: 12,
 							fullPrice: 14,
 							slug: 'jetpack_backup_daily_monthly',
 							title: 'Daily Backups',
 						},
 						{
-							billingTimeFrame={ 'per year' }
+							billingTimeFrame={ 'per month' }
 							fullPrice: 25,
 							slug: 'jetpack_backup_realtime_monthly',
 							title: 'Real-Time Backups',

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -94,16 +94,17 @@ export default class extends React.Component {
 				}
 			>
 				<ProductCardOptions
-					billingTimeFrame={ 'per year' }
 					optionsLabel="Backup options:"
 					options={ [
 						{
+							billingTimeFrame={ 'per year' }
 							discountedPrice: 12,
 							fullPrice: 14,
 							slug: 'jetpack_backup_daily_monthly',
 							title: 'Daily Backups',
 						},
 						{
+							billingTimeFrame={ 'per year' }
 							fullPrice: 25,
 							slug: 'jetpack_backup_realtime_monthly',
 							title: 'Real-Time Backups',
@@ -122,12 +123,12 @@ export default class extends React.Component {
 
 The following props can be passed to the Product Card Options component:
 
-* `billingTimeFrame`: ( string ) Billing time frame label
-* `currencyCode`: ( string ) Currency code
 * `handleSelect`: ( func ) Handler function for option selection. A product option `slug` is passed as an argument to
  the handler function
 * `options`: ( array ) List of product options to render Each option should be an object. The shape of an option
  object is as follows:
+  * `options.billingTimeFrame`: ( string ) Billing time frame label
+  * `options.currencyCode`: ( string ) Currency code
   * `options.discountedPrice`: ( number | array ) Discounted price of a product option. If an array of 2 numbers is
    passed, it will be displayed as a price range
   * `options.fullPrice`: ( number | array ) Full price of a product option. If an array of 2 numbers is passed, it

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -62,16 +62,17 @@ function ProductCardExample() {
 				}
 			>
 				<ProductCardOptions
-					billingTimeFrame={ isPlaceholder ? null : 'per year' }
 					optionsLabel="Backup options:"
 					options={ [
 						{
+							billingTimeFrame: isPlaceholder ? null : 'per year',
 							discountedPrice: isPlaceholder ? null : 12,
 							fullPrice: isPlaceholder ? null : 14,
 							slug: 'jetpack_backup_daily_monthly',
 							title: 'Daily Backups',
 						},
 						{
+							billingTimeFrame: isPlaceholder ? null : 'per year',
 							fullPrice: isPlaceholder ? null : 25,
 							slug: 'jetpack_backup_realtime_monthly',
 							title: 'Real-Time Backups',

--- a/client/components/product-card/options.jsx
+++ b/client/components/product-card/options.jsx
@@ -55,7 +55,7 @@ ProductCardOptions.propTypes = {
 			slug: PropTypes.string.isRequired,
 			title: PropTypes.string,
 		} )
-	).isRequired,
+	),
 	optionsLabel: PropTypes.string,
 	selectedSlug: PropTypes.string,
 };

--- a/client/components/product-card/options.jsx
+++ b/client/components/product-card/options.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,15 +12,8 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import ProductCardPriceGroup from './price-group';
 
-const ProductCardOptions = ( {
-	billingTimeFrame,
-	currencyCode,
-	handleSelect,
-	options,
-	optionsLabel,
-	selectedSlug,
-} ) => {
-	if ( ! options ) {
+const ProductCardOptions = ( { handleSelect, options, optionsLabel, selectedSlug } ) => {
+	if ( isEmpty( options ) ) {
 		return null;
 	}
 
@@ -35,8 +29,8 @@ const ProductCardOptions = ( {
 					<div className="product-card__option-description">
 						<div className="product-card__option-name">{ option.title }</div>
 						<ProductCardPriceGroup
-							billingTimeFrame={ billingTimeFrame }
-							currencyCode={ currencyCode }
+							billingTimeFrame={ option.billingTimeFrame }
+							currencyCode={ option.currencyCode }
 							discountedPrice={ option.discountedPrice }
 							fullPrice={ option.fullPrice }
 						/>
@@ -48,11 +42,11 @@ const ProductCardOptions = ( {
 };
 
 ProductCardOptions.propTypes = {
-	billingTimeFrame: PropTypes.string,
-	currencyCode: PropTypes.string,
 	handleSelect: PropTypes.func,
 	options: PropTypes.arrayOf(
 		PropTypes.shape( {
+			billingTimeFrame: PropTypes.string,
+			currencyCode: PropTypes.string,
 			discountedPrice: PropTypes.oneOfType( [
 				PropTypes.number,
 				PropTypes.arrayOf( PropTypes.number ),
@@ -61,7 +55,7 @@ ProductCardOptions.propTypes = {
 			slug: PropTypes.string.isRequired,
 			title: PropTypes.string,
 		} )
-	),
+	).isRequired,
 	optionsLabel: PropTypes.string,
 	selectedSlug: PropTypes.string,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Integrate `<ProductCardOptions />` UI sub-component with `<ProductSelector />` block
* Remove `renderProductOptions()` method in favour of just placing the `<ProductCardOptions />` inside the `<ProductCard />`
* Fix the `handleProductOptionSelect()` method (before it returned an anonymous function that never got called)
* Make `billingTimeFrame` and `currencyCode` option-level property so that it fits the product object data shape

![Screenshot 2019-10-21 at 17 08 17](https://user-images.githubusercontent.com/478735/67217660-695a3e80-f425-11e9-823f-0461c8311571.png)

#### Testing instructions

* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector
* Select one of your Jetpack sites
* Confirm that the product options are now displayed as in the Figma mockups
* Confirm that you can select products options and that product options price change if you switch the billing time frame

Master thread: p1HpG7-7ET-p2

Fixes n/a