### PR TITLE
Domains: Revert to the old .blog recommendation logic

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -313,14 +313,31 @@ class DomainsStep extends React.Component {
 	};
 
 	shouldIncludeDotBlogSubdomain() {
-		// Disable for domain only sites
-		if ( this.props.isDomainOnly ) {
+		const { flowName, isDomainOnly, siteGoals, signupDependencies } = this.props;
+		const siteGoalsArray = siteGoals ? siteGoals.split( ',' ) : [];
+
+		// 'subdomain' flow coming from .blog landing pages
+		if ( flowName === 'subdomain' ) {
+			return true;
+		}
+
+		// 'blog' flow, starting with blog themes
+		if ( flowName === 'blog' ) {
+			return true;
+		}
+
+		// No .blog subdomains for domain only sites
+		if ( isDomainOnly ) {
 			return false;
 		}
 
-		// Enable if the query includes ".blog"
-		const lastQuery = get( this.props.step, 'domainForm.lastQuery' );
-		return typeof lastQuery === 'string' && lastQuery.includes( '.blog' );
+		// If we detect a 'blog' site type from Signup data
+		return (
+			// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
+			( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
+			// Users choose `Blog` as their site type
+			'blog' === get( signupDependencies, 'siteType' )
+		);
 	}
 
 	domainForm = () => {


### PR DESCRIPTION
In August we merged https://github.com/Automattic/wp-calypso/pull/35347 . However we've misinterpreted how this PR would change the .blog subdomain suggestions. We've discussed internally and we're reverting back to the old behaviour for now and we'll actually run a test to find out if this has any positive/negative impact

See the internal discussion in p99Zz8-ML-p2

#### Changes proposed in this Pull Request

* reverts https://github.com/Automattic/wp-calypso/pull/35347

#### Testing instructions

* check that .blog subdomains are only suggested if you've chosen a "Blog" as your site type
