### PR TITLE
Move code for recording product purchase to cart-analytics module

### DIFF
--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -13,14 +13,14 @@ import analytics from 'lib/analytics';
 import { getAllCartItems } from 'lib/cart-values/cart-items';
 
 export function recordEvents( previousCart, nextCart ) {
-	const previousItems = getAllCartItems( previousCart ),
-		nextItems = getAllCartItems( nextCart );
+	const previousItems = getAllCartItems( previousCart );
+	const nextItems = getAllCartItems( nextCart );
 
 	each( differenceWith( nextItems, previousItems, isEqual ), recordAddEvent );
 	each( differenceWith( previousItems, nextItems, isEqual ), recordRemoveEvent );
 }
 
-export function removeNestedProperties( cartItem ) {
+function removeNestedProperties( cartItem ) {
 	return omit( cartItem, [ 'extra' ] );
 }
 
@@ -42,4 +42,11 @@ export function recordUnrecognizedPaymentMethod( action ) {
 	};
 
 	analytics.tracks.recordEvent( 'calypso_cart_unrecognized_payment_method', eventArgs );
+}
+
+export function recordProductPurchase( cartItem ) {
+	analytics.tracks.recordEvent(
+		'calypso_checkout_product_purchase',
+		removeNestedProperties( cartItem )
+	);
 }

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -54,7 +54,7 @@ import {
 } from 'lib/store-transactions/step-types';
 import { getTld } from 'lib/domains';
 import { displayError, clear } from 'lib/upgrades/notices';
-import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
+import { recordProductPurchase } from 'lib/cart/store/cart-analytics';
 import { isEbanxCreditCardProcessingEnabledForCountry } from 'lib/checkout/processor-specific';
 import { planHasFeature } from 'lib/plans';
 import { FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
@@ -314,12 +314,7 @@ export class SecurePaymentForm extends Component {
 						total_cost: cartValue.total_cost,
 					} );
 
-					cartValue.products.forEach( function( cartItem ) {
-						analytics.tracks.recordEvent(
-							'calypso_checkout_product_purchase',
-							removeNestedProperties( cartItem )
-						);
-					} );
+					cartValue.products.forEach( recordProductPurchase );
 
 					this.recordDomainRegistrationAnalytics( {
 						cart: cartValue,

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -296,10 +296,7 @@ export class SecurePaymentForm extends Component {
 						reason: this.formatError( step.error ),
 					} );
 
-					this.recordDomainRegistrationAnalytics( {
-						cart: cartValue,
-						success: false,
-					} );
+					this.recordDomainRegistrationAnalytics( { cart: cartValue, success: false } );
 				} else if ( step.data ) {
 					// Makes sure free trials are not recorded as purchases in ad trackers since they are products with
 					// zero-value cost and would thus lead to a wrong computation of conversions
@@ -316,10 +313,7 @@ export class SecurePaymentForm extends Component {
 
 					cartValue.products.forEach( recordProductPurchase );
 
-					this.recordDomainRegistrationAnalytics( {
-						cart: cartValue,
-						success: true,
-					} );
+					this.recordDomainRegistrationAnalytics( { cart: cartValue, success: true } );
 				}
 				break;
 
@@ -333,10 +327,7 @@ export class SecurePaymentForm extends Component {
 		}
 	}
 
-	recordDomainRegistrationAnalytics( parameters ) {
-		const cart = parameters.cart,
-			success = parameters.success;
-
+	recordDomainRegistrationAnalytics( { cart, success } ) {
 		getDomainRegistrations( cart ).forEach( function( cartItem ) {
 			analytics.ga.recordEvent( 'Checkout', 'calypso_domain_registration', cartItem.meta );
 


### PR DESCRIPTION
Two little code reshuffles of the code that reports analytics on finished purchase transaction.

First, avoid exporting the `removeNestedProperties` helper from `cart-analytics`, which is an unimportant internal detail. Exporting `recordProductPurchase` makes more sense, doesn't it?

Second, reformat the definition and usage of `recordDomainRegistrationAnalytics`.

**How to test:**
Set Calypso Analytics console debugging on (`localStorage.debug = 'calypso:analytics:*'`) and verify that events get posted after finishing a purchase transaction.