### PR TITLE
Full Site Editing: Fix custom font size not working

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -33,7 +33,9 @@ const NavigationMenuEdit = ( {
 	setTextColor,
 	textColor,
 } ) => {
-	const { textAlign } = attributes;
+	const { customFontSize, textAlign } = attributes;
+
+	const actualFontSize = customFontSize || fontSize.size;
 
 	return (
 		<Fragment>
@@ -47,7 +49,7 @@ const NavigationMenuEdit = ( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
-					<FontSizePicker onChange={ setFontSize } value={ fontSize.size } />
+					<FontSizePicker onChange={ setFontSize } value={ actualFontSize } />
 				</PanelBody>
 				<PanelColorSettings
 					title={ __( 'Color Settings' ) }
@@ -70,7 +72,7 @@ const NavigationMenuEdit = ( {
 							textColor: textColor.color,
 							backgroundColor: backgroundColor.color,
 						} }
-						fontSize={ fontSize.size }
+						fontSize={ actualFontSize }
 					/>
 				</PanelColorSettings>
 			</InspectorControls>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -49,10 +49,10 @@ function render_navigation_menu_block( $attributes ) {
 		$styles .= ' background-color: ' . $attributes['customBackgroundColor'] . ';';
 	}
 
-	if ( isset( $attributes['fontSize'] ) ) {
-		$class .= ' has-' . $attributes['fontSize'] . '-font-size';
-	} elseif ( isset( $attributes['customFontSize'] ) ) {
+	if ( isset( $attributes['customFontSize'] ) ) {
 		$styles .= ' font-size: ' . $attributes['customFontSize'] . 'px;';
+	} elseif ( isset( $attributes['fontSize'] ) ) {
+		$class .= ' has-' . $attributes['fontSize'] . '-font-size';
 	} else {
 		$class .= ' has-small-font-size';
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -46,7 +46,9 @@ function SiteDescriptionEdit( {
 	shouldUpdateSiteOption,
 	textColor,
 } ) {
-	const { textAlign } = attributes;
+	const { customFontSize, textAlign } = attributes;
+
+	const actualFontSize = customFontSize || fontSize.size;
 
 	const inititalDescription = __( 'Site description loading…' );
 
@@ -73,7 +75,7 @@ function SiteDescriptionEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
-					<FontSizePicker onChange={ setFontSize } value={ fontSize.size } />
+					<FontSizePicker onChange={ setFontSize } value={ actualFontSize } />
 				</PanelBody>
 				<PanelColorSettings
 					title={ __( 'Color Settings' ) }
@@ -96,7 +98,7 @@ function SiteDescriptionEdit( {
 							textColor: textColor.color,
 							backgroundColor: backgroundColor.color,
 						} }
-						fontSize={ fontSize.size }
+						fontSize={ actualFontSize }
 					/>
 				</PanelColorSettings>
 			</InspectorControls>
@@ -109,7 +111,7 @@ function SiteDescriptionEdit( {
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 					[ backgroundColor.class ]: backgroundColor.class,
 					[ textColor.class ]: textColor.class,
-					[ fontSize.class ]: fontSize.class,
+					[ fontSize.class ]: ! customFontSize && fontSize.class,
 				} ) }
 				identifier="content"
 				onChange={ value => handleChange( value ) }
@@ -119,7 +121,7 @@ function SiteDescriptionEdit( {
 				style={ {
 					backgroundColor: backgroundColor.color,
 					color: textColor.color,
-					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+					fontSize: actualFontSize ? actualFontSize + 'px' : undefined,
 				} }
 				tagName="p"
 				value={ option }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -43,7 +43,9 @@ function SiteTitleEdit( {
 	shouldUpdateSiteOption,
 	textColor,
 } ) {
-	const { textAlign } = attributes;
+	const { customFontSize, textAlign } = attributes;
+
+	const actualFontSize = customFontSize || fontSize.size;
 
 	const inititalTitle = __( 'Site title loading…' );
 
@@ -70,7 +72,7 @@ function SiteTitleEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
-					<FontSizePicker onChange={ setFontSize } value={ fontSize.size } />
+					<FontSizePicker onChange={ setFontSize } value={ actualFontSize } />
 				</PanelBody>
 				<PanelColorSettings
 					title={ __( 'Color Settings' ) }
@@ -91,7 +93,7 @@ function SiteTitleEdit( {
 					'has-text-color': textColor.color,
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 					[ textColor.class ]: textColor.class,
-					[ fontSize.class ]: fontSize.class,
+					[ fontSize.class ]: ! customFontSize && fontSize.class,
 				} ) }
 				identifier="content"
 				onChange={ value => handleChange( value ) }
@@ -100,7 +102,7 @@ function SiteTitleEdit( {
 				placeholder={ __( 'Add a Site Title' ) }
 				style={ {
 					color: textColor.color,
-					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+					fontSize: actualFontSize ? actualFontSize + 'px' : undefined,
 				} }
 				tagName="h1"
 				value={ option }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm not exactly sure why, but the custom font size doesn't get used correctly in the editor.
While it's value is saved, and used appropriately in the front end, it doesn't stick across reloads in the editor.

* Make sure that the FSE blocks actually use the `customFontSize` attribute if set, or the `fontSize.size` prop otherwise (which means, either the font size is one of the predefined sizes, or nothing is set, and it falls back to the default predefined size).
* Turn around the font size checks in the Navigation Menu server side renderer, to avoid using the "Normal" predefined size instead of the custom size.

| Before | After |
| - | - |
| ![Oct-21-2019 17-45-41](https://user-images.githubusercontent.com/2070010/67225297-e4722380-f42a-11e9-91c7-44194979b6e5.gif) | ![Oct-21-2019 17-47-15](https://user-images.githubusercontent.com/2070010/67225307-e9cf6e00-f42a-11e9-8627-73e8a39a76a7.gif) |

#### Testing instructions

Try this on all three FSE blocks.

* Set a custom font size (e.g. 100, so that it's super visible), and observe that the size is instantly applied to the block preview.
* Save the template part and reload.
* Make sure the block still shows the custom font size.
* Back to the page editor, make sure the custom font size is correct in the template part preview.
* View the page in the front end, and make sure the FSE block has the correct font size.
* Now try setting a predefined font size instead (e.g. "Huge").
* Check in the template part editor, page editor, and front end if the font size is correct.