### PR TITLE
Launch Site: Enable checklist completion, but remind customers to launch site in Customer Home

### DIFF
--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import React, { Children, PureComponent, cloneElement } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { isFunction, times } from 'lodash';
+import { get, isFunction, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import TaskPlaceholder from './task-placeholder';
 import Card from 'components/card';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 class Checklist extends PureComponent {
 	static propTypes = {
@@ -36,9 +37,18 @@ class Checklist extends PureComponent {
 		this.notifyCompletion();
 	}
 
-	componentWillReceiveProps( { siteId } ) {
+	componentWillReceiveProps( { siteId, siteIsUnlaunched } ) {
 		if ( siteId !== this.props.siteId ) {
 			this.setState( { expandedTaskIndex: undefined } );
+			return;
+		}
+		if ( ! siteIsUnlaunched && this.props.siteIsUnlaunched ) {
+			const { expandedTaskIndex } = this.state;
+			if (
+				'site_launched' === get( this, [ 'props', 'children', expandedTaskIndex, 'props', 'id' ] )
+			) {
+				this.setState( { expandedTaskIndex: undefined } );
+			}
 		}
 	}
 
@@ -155,6 +165,10 @@ class Checklist extends PureComponent {
 	}
 }
 
-export default connect( state => ( {
-	siteId: getSelectedSiteId( state ),
-} ) )( localize( Checklist ) );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
+		siteId,
+	};
+} )( localize( Checklist ) );

--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import React, { Children, PureComponent, cloneElement } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { get, isFunction, times } from 'lodash';
+import { isFunction, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import TaskPlaceholder from './task-placeholder';
 import Card from 'components/card';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 class Checklist extends PureComponent {
 	static propTypes = {
@@ -37,18 +36,9 @@ class Checklist extends PureComponent {
 		this.notifyCompletion();
 	}
 
-	componentWillReceiveProps( { siteId, siteIsUnlaunched } ) {
+	componentWillReceiveProps( { siteId } ) {
 		if ( siteId !== this.props.siteId ) {
 			this.setState( { expandedTaskIndex: undefined } );
-			return;
-		}
-		if ( ! siteIsUnlaunched && this.props.siteIsUnlaunched ) {
-			const { expandedTaskIndex } = this.state;
-			if (
-				'site_launched' === get( this, [ 'props', 'children', expandedTaskIndex, 'props', 'id' ] )
-			) {
-				this.setState( { expandedTaskIndex: undefined } );
-			}
 		}
 	}
 
@@ -165,10 +155,6 @@ class Checklist extends PureComponent {
 	}
 }
 
-export default connect( state => {
-	const siteId = getSelectedSiteId( state );
-	return {
-		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
-		siteId,
-	};
-} )( localize( Checklist ) );
+export default connect( state => ( {
+	siteId: getSelectedSiteId( state ),
+} ) )( localize( Checklist ) );

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -21,13 +21,14 @@ import Spinner from 'components/spinner';
 class Task extends PureComponent {
 	static propTypes = {
 		buttonText: PropTypes.node,
-		collapsed: PropTypes.bool,
+		collapsed: PropTypes.bool, // derived from ui state
 		completed: PropTypes.bool,
 		completedButtonText: PropTypes.node,
 		completedTitle: PropTypes.node,
 		description: PropTypes.node,
 		disableIcon: PropTypes.bool,
 		duration: PropTypes.string,
+		forceCollapsed: PropTypes.bool, // derived from API state
 		href: PropTypes.string,
 		inProgress: PropTypes.bool,
 		isButtonDisabled: PropTypes.bool,
@@ -134,6 +135,7 @@ class Task extends PureComponent {
 			completedTitle,
 			description,
 			duration,
+			forceCollapsed,
 			href,
 			isButtonDisabled,
 			inProgress,
@@ -147,12 +149,15 @@ class Task extends PureComponent {
 			showSkip,
 		} = this.props;
 
+		const _collapsed = forceCollapsed || collapsed;
+
 		// A task that's being automatically completed ("in progress") cannot be expanded.
 		// An uncompleted task by definition has a call-to-action, which can only be accessed by
 		// expanding it, so an uncompleted task is always expandable.
 		// A completed task may or may not have a call-to-action, which can be best inferred from
 		// the `completedButtonText` prop.
-		const isExpandable = ! inProgress && ( ! completed || completedButtonText );
+		const isExpandable =
+			! forceCollapsed || ( ! inProgress && ( ! completed || completedButtonText ) );
 		const taskActionButtonText = completed
 			? completedButtonText
 			: buttonText || translate( 'Try it' );
@@ -164,7 +169,7 @@ class Task extends PureComponent {
 					'is-completed': completed,
 					'is-in-progress': inProgress,
 					'is-unexpandable': ! isExpandable,
-					'is-collapsed': collapsed,
+					'is-collapsed': _collapsed,
 				} ) }
 			>
 				<div className="checklist__task-wrapper">
@@ -183,7 +188,7 @@ class Task extends PureComponent {
 						) }
 					</h3>
 
-					{ ! collapsed && (
+					{ ! _collapsed && (
 						<div className="checklist__task-content">
 							<p className="checklist__task-description">{ description }</p>
 
@@ -201,7 +206,7 @@ class Task extends PureComponent {
 											disabled={ isButtonDisabled }
 											href={ href }
 											onClick={ onClick }
-											primary={ ! collapsed }
+											primary={ ! _collapsed }
 											target={ target }
 										>
 											{ taskActionButtonText }

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -195,16 +195,18 @@ class Task extends PureComponent {
 								) }
 
 								<div className="checklist__task-action-wrapper">
-									<Button
-										className="checklist__task-action"
-										disabled={ isButtonDisabled }
-										href={ href }
-										onClick={ onClick }
-										primary={ ! collapsed }
-										target={ target }
-									>
-										{ taskActionButtonText }
-									</Button>
+									{ !! taskActionButtonText && (
+										<Button
+											className="checklist__task-action"
+											disabled={ isButtonDisabled }
+											href={ href }
+											onClick={ onClick }
+											primary={ ! collapsed }
+											target={ target }
+										>
+											{ taskActionButtonText }
+										</Button>
+									) }
 									{ ! completed && showSkip && (
 										<Button className="checklist__task-skip" onClick={ onDismiss }>
 											{ translate( 'Skip' ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -188,7 +188,8 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	handleLaunchSite = task => () => {
-		if ( task.isCompleted ) {
+		const { siteIsUnlaunched } = this.props;
+		if ( task.isCompleted && ! siteIsUnlaunched ) {
 			return;
 		}
 
@@ -588,7 +589,7 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	renderSiteLaunchedTask = ( TaskComponent, baseProps, task ) => {
-		const { needsVerification, translate } = this.props;
+		const { needsVerification, siteIsUnlaunched, translate } = this.props;
 		const disabled = ! baseProps.completed && needsVerification;
 
 		return (
@@ -596,10 +597,25 @@ class WpcomChecklistComponent extends PureComponent {
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/launch.svg"
 				buttonText={ translate( 'Launch site' ) }
-				completedTitle={ translate( 'You launched your site' ) }
-				description={ translate(
-					"Your site is private and only visible to you. When you're ready, launch your site to make it public."
-				) }
+				completedButtonText={ siteIsUnlaunched && translate( 'Launch site' ) }
+				completedTitle={
+					siteIsUnlaunched
+						? translate( 'You skipped launching your site' )
+						: translate( 'You launched your site' )
+				}
+				description={
+					siteIsUnlaunched
+						? translate(
+								"Your site is private and only visible to you. When you're ready, launch your site to make it public."
+						  )
+						: /*
+						   * This string should not actually show.
+						   * If the site is launched, the `completedButtonText` will be false above.
+						   * That should prevent the task from being expanded.
+						   * Let's go ahead and include it anyway just in case so we aren't incorrectly telling people their site is unlaunched
+						   */
+						  translate( 'Congratulations! Your site is visible to the world.' )
+				}
 				disableIcon={ disabled }
 				isButtonDisabled={ disabled }
 				noticeText={
@@ -607,6 +623,7 @@ class WpcomChecklistComponent extends PureComponent {
 				}
 				onClick={ this.handleLaunchSite( task ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
+				showSkip={ true }
 				title={ translate( 'Launch your site' ) }
 			/>
 		);
@@ -1023,7 +1040,7 @@ export default connect(
 			taskList,
 			userEmail: ( user && user.email ) || '',
 			needsVerification: ! isCurrentUserEmailVerified( state ),
-			isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
+			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 			domains: getDomainsBySiteId( state, siteId ),
 			isPaidPlan: isCurrentPlanPaid( state, siteId ),
 		};

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -587,6 +587,7 @@ class WpcomChecklistComponent extends PureComponent {
 		return (
 			<TaskComponent
 				{ ...baseProps }
+				forceCollapsed={ task.isCompleted && ! siteIsUnlaunched }
 				bannerImageSrc="/calypso/images/stats/tasks/launch.svg"
 				buttonText={ translate( 'Launch site' ) }
 				completedButtonText={ siteIsUnlaunched && translate( 'Launch site' ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -187,11 +187,8 @@ class WpcomChecklistComponent extends PureComponent {
 		} );
 	};
 
-	handleLaunchSite = task => () => {
-		const { siteId, siteIsUnlaunched } = this.props;
-		if ( task.isCompleted && ! siteIsUnlaunched ) {
-			return;
-		}
+	handleLaunchSite = () => {
+		const { siteId } = this.props;
 		this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId );
 	};
 
@@ -614,7 +611,7 @@ class WpcomChecklistComponent extends PureComponent {
 				noticeText={
 					disabled ? translate( 'Confirm your email address before launching your site.' ) : null
 				}
-				onClick={ this.handleLaunchSite( task ) }
+				onClick={ this.handleLaunchSite }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				showSkip={ true }
 				title={ translate( 'Launch your site' ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -21,6 +21,7 @@ import ChecklistPromptTask from './checklist-prompt/task';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import getSiteTaskList from 'state/selectors/get-site-task-list';
 import QueryPosts from 'components/data/query-posts';
+import QuerySites from 'components/data/query-sites';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { successNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -270,6 +271,7 @@ class WpcomChecklistComponent extends PureComponent {
 
 		return (
 			<>
+				{ siteId && <QuerySites siteId={ siteId } /> }
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				{ siteId && <QueryPosts siteId={ siteId } query={ FIRST_TEN_SITE_POSTS_QUERY } /> }
 				<ChecklistComponent

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -24,13 +24,13 @@ import QueryPosts from 'components/data/query-posts';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { successNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteOption, getSiteSlug, isCurrentPlanPaid } from 'state/sites/selectors';
+import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
-import { launchSite } from 'state/sites/launch/actions';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import getChecklistTaskUrls, {
 	FIRST_TEN_SITE_POSTS_QUERY,
@@ -188,18 +188,11 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	handleLaunchSite = task => () => {
-		const { siteIsUnlaunched } = this.props;
-		if ( task.isCompleted && ! siteIsUnlaunched ) {
+		const { siteId } = this.props;
+		if ( task.isCompleted ) {
 			return;
 		}
-
-		const { siteId, domains, isPaidPlan, siteSlug } = this.props;
-
-		if ( isPaidPlan && domains.length > 1 ) {
-			this.props.launchSite( siteId );
-		} else {
-			location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
-		}
+		this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId );
 	};
 
 	verificationTaskButtonText() {
@@ -1042,7 +1035,6 @@ export default connect(
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 			domains: getDomainsBySiteId( state, siteId ),
-			isPaidPlan: isCurrentPlanPaid( state, siteId ),
 		};
 	},
 	{
@@ -1050,7 +1042,7 @@ export default connect(
 		recordTracksEvent,
 		requestGuidedTour,
 		requestSiteChecklistTaskUpdate,
-		launchSite,
+		launchSiteOrRedirectToLaunchSignupFlow,
 		showInlineHelpPopover,
 		showChecklistPrompt,
 		setChecklistPromptTaskId,

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -188,8 +188,8 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	handleLaunchSite = task => () => {
-		const { siteId } = this.props;
-		if ( task.isCompleted ) {
+		const { siteId, siteIsUnlaunched } = this.props;
+		if ( task.isCompleted && ! siteIsUnlaunched ) {
 			return;
 		}
 		this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId );

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -600,13 +600,7 @@ class WpcomChecklistComponent extends PureComponent {
 						? translate(
 								"Your site is private and only visible to you. When you're ready, launch your site to make it public."
 						  )
-						: /*
-						   * This string should not actually show.
-						   * If the site is launched, the `completedButtonText` will be false above.
-						   * That should prevent the task from being expanded.
-						   * Let's go ahead and include it anyway just in case so we aren't incorrectly telling people their site is unlaunched
-						   */
-						  translate( 'Congratulations! Your site is visible to the world.' )
+						: null
 				}
 				disableIcon={ disabled }
 				isButtonDisabled={ disabled }

--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -94,11 +94,11 @@ export default connect( ( state, ownProps ) => {
 	const siteSegment = get( siteChecklist, 'segment' );
 	const siteVerticals = get( siteChecklist, 'vertical' );
 	const taskStatuses = get( siteChecklist, 'tasks' );
-	const isSiteUnlaunched = isUnlaunchedSite( state, siteId );
+	const siteIsUnlaunched = isUnlaunchedSite( state, siteId );
 	const taskList = getTaskList( {
 		taskStatuses,
 		designType,
-		isSiteUnlaunched,
+		siteIsUnlaunched,
 		siteSegment,
 		siteVerticals,
 	} );

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -15,7 +15,7 @@ const debug = debugModule( 'calypso:wpcom-task-list' );
 
 function getTasks( {
 	designType,
-	isSiteUnlaunched,
+	siteIsUnlaunched,
 	phase2,
 	siteSegment,
 	siteVerticals,
@@ -72,7 +72,7 @@ function getTasks( {
 	addTask( 'custom_domain_registered' );
 	addTask( 'mobile_app_installed' );
 
-	if ( get( taskStatuses, 'email_verified.completed' ) && isSiteUnlaunched ) {
+	if ( get( taskStatuses, 'email_verified.completed' ) && siteIsUnlaunched ) {
 		addTask( 'site_launched' );
 	}
 
@@ -157,7 +157,7 @@ export const getTaskList = memoize(
 		const key = pick( params, [
 			'taskStatuses',
 			'designType',
-			'isSiteUnlaunched',
+			'siteIsUnlaunched',
 			'siteSegment',
 			'siteVerticals',
 		] );

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -47,12 +47,12 @@ import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sid
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import StatsBanners from 'my-sites/stats/stats-banners';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 const ActionBox = ( { href, onClick, target, iconSrc, label } ) => {
 	const buttonAction = { href, onClick, target };

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -172,9 +172,9 @@ class Home extends Component {
 						dismissTemporary={ true }
 						icon="info"
 						callToAction={ translate( 'Launch site' ) }
-						title={ translate( 'Your site is not launched' ) }
+						title={ translate( 'Your site is private' ) }
 						description={ translate(
-							"If you don't launch your site, it will only be accessbile to specified site members."
+							'Only you and those you invite can view your site. Launch your site to make it visible to the public.'
 						) }
 						onClick={ this.onLaunchBannerClick }
 					/>

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -1,16 +1,32 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SITE_LAUNCH } from 'state/action-types';
-
 import 'state/data-layer/wpcom/sites/launch';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { getSiteSlug, isCurrentPlanPaid } from 'state/sites/selectors';
+import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 
-export function launchSite( siteId ) {
-	return {
-		type: SITE_LAUNCH,
-		siteId,
-	};
-}
+export const launchSite = siteId => ( {
+	type: SITE_LAUNCH,
+	siteId,
+} );
+
+export const launchSiteOrRedirectToLaunchSignupFlow = siteId => ( dispatch, getState ) => {
+	if ( ! isUnlaunchedSite( getState(), siteId ) ) {
+		return;
+	}
+
+	if (
+		isCurrentPlanPaid( getState(), siteId ) &&
+		getDomainsBySiteId( getState(), siteId ).length > 1
+	) {
+		dispatch( launchSite( siteId ) );
+		return;
+	}
+
+	const siteSlug = getSiteSlug( getState(), siteId );
+
+	// TODO: consider using the `page` library instead of calling using `location.href` here
+	location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Explicitly allow skipping the `Launch Site` task
* Set title to `You skipped launching your site` when the item was skipped
* Set the completed button text to `Launch site` so the task can be expanded and the CTA is still active if customers skip the task but the checklist is not complete
* Rename `isSiteUnlaunched` to `siteIsUnlaunched` throughout for consistency sake
* Add a (temporarily dismissable) `Banner` to the top of the Customer Home page if a site is unlaunched
* Extract `launchSiteOrRedirectToLaunchSignupFlow` from conditional logic in `wpcom-checklist/component`

#### Checklist Item
|Before|After|
|---|---|
|![Screen Shot 2019-10-21 at 1 22 26 PM](https://user-images.githubusercontent.com/1587282/67227788-f5f50480-f405-11e9-85cb-534bf740b5b8.png)|![Screen Shot 2019-10-21 at 1 23 05 PM](https://user-images.githubusercontent.com/1587282/67227808-00170300-f406-11e9-85d7-62265d6d3f6f.png)|

#### Customer Home Nudge
![Screen Shot 2019-10-21 at 1 24 40 PM](https://user-images.githubusercontent.com/1587282/67227896-2ccb1a80-f406-11e9-94b7-23c952b2a893.png)


#### Testing instructions

* Apply patch in D34170-code & sandbox the WPCOM REST API
* Create a new free site
  * It should be unlaunched by default
* Browse to https://wordpress.com/home/<site>
  * You should see the site checklist
* Click the circle beside each task to mark it complete
  * You should be taken to the Customer Home & **NOT** redirected back to the checklist screen as described in the reports
  * You should see a Banner at the top of the Customer Home screen reminding you to launch your site
    * The CTA in the banner should "work" (if you have a plan, the site should launch immediately, else, you should be taken to the signup launch flow for the appropriate blog ID)
* Repeat the above, but use the `Skip` button on the `Launch Site` task
  * It should behave predictably & identically to clicking the circle to skip
* Repeat, but skip the `Launch Site` task before completing the others
  * It should behave predictably & You should be able to toggle / expand the `Launch Site` task and complete it
* Repeat, but click the `Launch Site` button in the checklist task
  * It should "work" (if you have a plan, the site should launch immediately, else, you should be taken to the signup launch flow for the appropriate blog ID)
* The Customer Home page should otherwise be unaffected

Fixes Automattic/zelda-private#169
