### PR TITLE
Update wpcom.undocumented().transactions() requests

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -356,7 +356,7 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 
 	this._pushStep( { name: SUBMITTING_WPCOM_REQUEST } );
 	return new Promise( resolve => {
-		wpcom.transactions( 'POST', transaction, ( error, data ) => {
+		wpcom.transactions( transaction, ( error, data ) => {
 			if ( error ) {
 				this._pushStep( {
 					name: RECEIVED_WPCOM_RESPONSE,

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -351,55 +351,31 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 	const transaction = {
 		cart: omit( this._initialData.cart, [ 'messages' ] ), // messages contain reference to DOMNode
 		domain_details: this._initialData.domainDetails,
-		payment: payment,
+		payment,
 	};
 
 	this._pushStep( { name: SUBMITTING_WPCOM_REQUEST } );
-	return new Promise( resolve => {
-		wpcom.transactions( transaction, ( error, data ) => {
-			if ( error ) {
-				this._pushStep( {
-					name: RECEIVED_WPCOM_RESPONSE,
-					error,
-					last: true,
-				} );
-				// This should probably reject but since the error is already
-				// reported just above, that might risk double-reporting or
-				// changing the step to the wrong one, so this just resolves
-				// without data instead.
-				resolve();
-				return;
-			}
-
+	return wp
+		.undocumented()
+		.transactions( transaction )
+		.then( data => {
 			if ( data.message ) {
-				this._pushStep( {
-					name: MODAL_AUTHORIZATION,
-					data: data,
-					last: false,
-				} );
-				resolve( data );
-				return;
+				this._pushStep( { name: MODAL_AUTHORIZATION, data, last: false } );
+			} else if ( data.redirect_url ) {
+				this._pushStep( { name: REDIRECTING_FOR_AUTHORIZATION, data, last: true } );
+			} else {
+				this._pushStep( { name: RECEIVED_WPCOM_RESPONSE, data, last: true } );
 			}
 
-			if ( data.redirect_url ) {
-				this._pushStep( {
-					name: REDIRECTING_FOR_AUTHORIZATION,
-					data: data,
-					last: true,
-				} );
-				resolve( data );
-				return;
-			}
-
-			this._pushStep( {
-				name: RECEIVED_WPCOM_RESPONSE,
-				data,
-				last: true,
-			} );
-
-			resolve( data );
+			return data;
+		} )
+		.catch( error => {
+			this._pushStep( { name: RECEIVED_WPCOM_RESPONSE, error, last: true } );
+			// This should probably reject the error but since the error is already
+			// reported just above, that might risk double-reporting or
+			// changing the step to the wrong one, so this just resolves
+			// without data instead.
 		} );
-	} );
 };
 
 TransactionFlow.prototype.stripeModalAuth = async function( stripeConfiguration, response ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1108,9 +1108,8 @@ Undocumented.prototype.updateConnection = function( siteId, connectionId, data, 
 };
 
 /**
- * GET/POST transactions
+ * POST create a payment transaction
  *
- * @param {string} [method] The request method
  * @param {object} [data] The REQUEST data
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
@@ -1125,25 +1124,8 @@ Undocumented.prototype.updateConnection = function( siteId, connectionId, data, 
  *		locale: {string} Locale for translating strings in response data,
  * }
  */
-Undocumented.prototype.transactions = function( method, data, fn ) {
-	debug( '/me/transactions query' );
-
-	if ( 'function' === typeof method ) {
-		fn = method;
-		method = 'get';
-		data = {};
-	} else {
-		data = mapKeysRecursively( data, snakeCase );
-	}
-
-	return this._sendRequest(
-		{
-			path: '/me/transactions',
-			method: method,
-			body: data,
-		},
-		fn
-	);
+Undocumented.prototype.transactions = function( data, fn ) {
+	return this.wpcom.req.post( '/me/transactions', mapKeysRecursively( data, snakeCase ), fn );
 };
 
 Undocumented.prototype.updateCreditCard = function( params, fn ) {

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -169,9 +169,24 @@ export class RedirectPaymentBox extends PureComponent {
 		};
 
 		// get the redirect URL from rest endpoint
-		wpcom.undocumented().transactions( dataForApi, ( error, result ) => {
-			let errorMessage;
-			if ( error ) {
+		wpcom
+			.undocumented()
+			.transactions( dataForApi )
+			.then( result => {
+				if ( result.redirect_url ) {
+					this.setSubmitState( {
+						info: translate( 'Redirecting you to the payment partner to complete the payment.' ),
+						disabled: true,
+					} );
+					analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Redirect Payment Button' );
+					analytics.tracks.recordEvent(
+						'calypso_checkout_with_redirect_' + snakeCase( this.props.paymentType )
+					);
+					location.href = result.redirect_url;
+				}
+			} )
+			.catch( error => {
+				let errorMessage;
 				if ( error.message ) {
 					errorMessage = error.message;
 				} else {
@@ -182,18 +197,7 @@ export class RedirectPaymentBox extends PureComponent {
 					error: errorMessage,
 					disabled: false,
 				} );
-			} else if ( result.redirect_url ) {
-				this.setSubmitState( {
-					info: translate( 'Redirecting you to the payment partner to complete the payment.' ),
-					disabled: true,
-				} );
-				analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Redirect Payment Button' );
-				analytics.tracks.recordEvent(
-					'calypso_checkout_with_redirect_' + snakeCase( this.props.paymentType )
-				);
-				location.href = result.redirect_url;
-			}
-		} );
+			} );
 	};
 
 	renderButtonText() {

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -169,7 +169,7 @@ export class RedirectPaymentBox extends PureComponent {
 		};
 
 		// get the redirect URL from rest endpoint
-		wpcom.undocumented().transactions( 'POST', dataForApi, ( error, result ) => {
+		wpcom.undocumented().transactions( dataForApi, ( error, result ) => {
 			let errorMessage;
 			if ( error ) {
 				if ( error.message ) {


### PR DESCRIPTION
**Improve the `wpcom.undocumented().transactions()` API**
The `/me/transactions` REST endpoint supports only POST request. The support for GET is a very old relict that dates back to pre-OSS era. Let's improve and simplify the API for the endpoint.

**Promisify calls to `wpcom.undocumented().transactions()`**
Instead of using the callback version of the API and wrap it in a promise, just use promises from beginning to end!

**How to test:**
Verify that a payment transaction can be submitted and is successful (REST request to `/me/transactions`.

Also verify that payment methods that involve a redirect continue to work.
