### PR TITLE
composite-checkout: Hide review summary when active

### DIFF
--- a/packages/composite-checkout/src/components/basics.js
+++ b/packages/composite-checkout/src/components/basics.js
@@ -144,14 +144,14 @@ export const StepNumber = styled.span`
 
 export const StepContent = styled.div`
 	color: ${props => props.theme.colors.gray80};
-	display: ${props => ( props.isActive ? 'block' : 'none' )};
+	display: ${props => ( props.isVisible ? 'block' : 'none' )};
 	padding-left: 35px;
 `;
 
 export const StepSummary = styled.div`
 	color: ${props => props.theme.colors.gray50};
 	font-size: 14px;
-	display: ${props => ( props.showSummary ? 'block' : 'none' )};
+	display: ${props => ( props.isVisible ? 'block' : 'none' )};
 	padding-left: 35px;
 `;
 

--- a/packages/composite-checkout/src/components/checkout-review-order.js
+++ b/packages/composite-checkout/src/components/checkout-review-order.js
@@ -15,11 +15,11 @@ import {
 	OrderReviewSection,
 } from './order-review-line-items';
 
-export default function CheckoutReviewOrder( { summary } ) {
+export default function CheckoutReviewOrder( { summary, className } ) {
 	const [ items, total ] = useCheckoutLineItems();
 	if ( summary ) {
 		return (
-			<div>
+			<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
 				<OrderReviewSection>
 					<OrderReviewLineItems items={ items } />
 				</OrderReviewSection>
@@ -30,7 +30,7 @@ export default function CheckoutReviewOrder( { summary } ) {
 		);
 	}
 	return (
-		<div>
+		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
 			<OrderReviewSection withDivider>
 				<OrderReviewLineItems items={ items } />
 			</OrderReviewSection>
@@ -44,6 +44,7 @@ export default function CheckoutReviewOrder( { summary } ) {
 CheckoutReviewOrder.propTypes = {
 	isActive: PropTypes.bool.isRequired,
 	summary: PropTypes.bool,
+	className: PropTypes.string,
 };
 
 function LineItem( { item, className } ) {

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -21,7 +21,6 @@ export default function CheckoutStep( {
 	finalStep,
 	stepSummary,
 	stepContent,
-	showSummary,
 } ) {
 	const classNames = [
 		className,
@@ -43,14 +42,11 @@ export default function CheckoutStep( {
 				isComplete={ isComplete }
 				onEdit={ onEdit }
 			/>
-			<StepContent className="checkout-step__content" isActive={ isActive }>
+			<StepContent className="checkout-step__content" isVisible={ isActive }>
 				{ stepContent }
 			</StepContent>
 			{ stepSummary && (
-				<StepSummary
-					className="checkout-step__summary"
-					showSummary={ ( showSummary && ! isActive ) || isComplete }
-				>
+				<StepSummary className="checkout-step__summary" isVisible={ ! isActive }>
 					{ stepSummary }
 				</StepSummary>
 			) }
@@ -67,7 +63,6 @@ CheckoutStep.propTypes = {
 	stepContent: PropTypes.node.isRequired,
 	isActive: PropTypes.bool.isRequired,
 	isComplete: PropTypes.bool.isRequired,
-	showSummary: PropTypes.bool,
 };
 
 function CheckoutStepHeader( { className, stepNumber, title, isActive, isComplete, onEdit } ) {

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -43,8 +43,12 @@ export default function CheckoutStep( {
 				isComplete={ isComplete }
 				onEdit={ onEdit }
 			/>
-			<StepContent isActive={ isActive }>{ stepContent }</StepContent>
-			<StepSummary showSummary={ isComplete || showSummary }>{ stepSummary }</StepSummary>
+			<StepContent className="checkout-step__content" isActive={ isActive }>
+				{ stepContent }
+			</StepContent>
+			<StepSummary className="checkout-step__summary" showSummary={ isComplete || showSummary }>
+				{ stepSummary }
+			</StepSummary>
 		</StepWrapper>
 	);
 }

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -46,9 +46,14 @@ export default function CheckoutStep( {
 			<StepContent className="checkout-step__content" isActive={ isActive }>
 				{ stepContent }
 			</StepContent>
-			<StepSummary className="checkout-step__summary" showSummary={ isComplete || showSummary }>
-				{ stepSummary }
-			</StepSummary>
+			{ stepSummary && (
+				<StepSummary
+					className="checkout-step__summary"
+					showSummary={ ( showSummary && ! isActive ) || isComplete }
+				>
+					{ stepSummary }
+				</StepSummary>
+			) }
 		</StepWrapper>
 	);
 }
@@ -59,7 +64,7 @@ CheckoutStep.propTypes = {
 	title: PropTypes.string.isRequired,
 	finalStep: PropTypes.bool,
 	stepSummary: PropTypes.node,
-	stepContent: PropTypes.node,
+	stepContent: PropTypes.node.isRequired,
 	isActive: PropTypes.bool.isRequired,
 	isComplete: PropTypes.bool.isRequired,
 	showSummary: PropTypes.bool,

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -219,7 +219,6 @@ function ReviewOrderStep( { isActive, isComplete } ) {
 				isComplete={ isComplete }
 				stepNumber={ 3 }
 				title={ isComplete ? localize( 'Review your order' ) : localize( 'Review your order' ) }
-				showSummary={ true }
 				stepContent={ <CheckoutReviewOrder isActive={ isActive } /> }
 				stepSummary={ <CheckoutReviewOrder summary isActive={ isActive } /> }
 			/>

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -20,13 +20,19 @@ export function ApplePayLabel() {
 	);
 }
 
-export function ApplePayBillingForm( { setPaymentData, paymentData, isActive, isComplete } ) {
+export function ApplePayBillingForm( {
+	summary,
+	setPaymentData,
+	paymentData,
+	isActive,
+	isComplete,
+} ) {
 	const localize = useLocalize();
-	if ( ! isActive && ! isComplete ) {
-		return null;
-	}
-	if ( ! isActive && isComplete ) {
+	if ( summary && isComplete ) {
 		return <ApplePayBillingFormSummary paymentData={ paymentData } />;
+	}
+	if ( ! isActive ) {
+		return null;
 	}
 	const { billingName = '', billingNameError = null } = paymentData || {};
 	const onChange = value => setPaymentData( { ...( paymentData || {} ), billingName: value } );
@@ -65,8 +71,13 @@ export function ApplePaySubmitButton() {
 }
 
 function ApplePayBillingFormSummary( { paymentData } ) {
+	const localize = useLocalize();
 	const { billingName = '' } = paymentData || {};
-	return <span>{ billingName }</span>;
+	return (
+		<span>
+			<em>{ localize( 'Name' ) }</em> { billingName }
+		</span>
+	);
 }
 
 function ApplePayIcon() {


### PR DESCRIPTION
This fixes a bug which makes the review summary always visible, even when the step is active.

Depends on #36720 

It also removes the `showSummary` prop on `CheckoutStep`. The prop previously was used to force the step to show the summary when it was inactive, but incomplete. I think that using the prop that way is confusing, since it creates a complex implicit behavior for every step's visibility. By removing it, the step summary is always displayed when the step is inactive, and if the step wishes to hide its summary in certain cases, it can do so itself rather than relying on its parent to do so.