### PR TITLE
Disable passwordless signup form when user creation is completed

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -940,11 +940,13 @@ class SignupForm extends Component {
 				<div className={ classNames( 'signup-form', this.props.className ) }>
 					{ this.getNotice() }
 					<PasswordlessSignupForm
+						step={ this.props.step }
 						stepName={ this.props.stepName }
 						flowName={ this.props.flowName }
 						goToNextStep={ this.props.goToNextStep }
 						renderTerms={ this.termsOfServiceLink }
 						logInUrl={ logInUrl }
+						disabled={ this.props.disabled }
 					/>
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -127,6 +127,7 @@ class PasswordlessSignupForm extends Component {
 				);
 		}
 	}
+
 	submitStep = data => {
 		const { flowName, stepName, goToNextStep, submitCreateAccountStep } = this.props;
 		submitCreateAccountStep(
@@ -143,12 +144,14 @@ class PasswordlessSignupForm extends Component {
 		this.submitTracksEvent( true, { action_message: 'Successful login', username: data.username } );
 		goToNextStep();
 	};
+
 	onInputChange = ( { target: { value } } ) =>
 		this.setState( {
 			email: value,
 			errorMessages: null,
 			isEmailAddressValid: emailValidator.validate( value ),
 		} );
+
 	renderNotice() {
 		return (
 			<Notice showDismiss={ false } status="is-error">
@@ -158,12 +161,43 @@ class PasswordlessSignupForm extends Component {
 			</Notice>
 		);
 	}
+
+	userCreationComplete() {
+		return this.props.step && 'completed' === this.props.step.status;
+	}
+
+	formFooter() {
+		const { isSubmitting, isEmailAddressValid } = this.state;
+		if ( this.userCreationComplete() ) {
+			return (
+				<LoggedOutFormFooter>
+					<Button primary onClick={ () => this.props.goToNextStep() }>
+						{ this.props.translate( 'Continue' ) }
+					</Button>
+				</LoggedOutFormFooter>
+			);
+		}
+		const submitButtonText = isSubmitting
+			? this.props.translate( 'Creating Your Account…' )
+			: this.props.translate( 'Create your account' );
+		return (
+			<LoggedOutFormFooter>
+				<Button
+					type="submit"
+					primary
+					busy={ isSubmitting }
+					disabled={ isSubmitting || ! isEmailAddressValid || !! this.props.disabled }
+				>
+					{ submitButtonText }
+				</Button>
+			</LoggedOutFormFooter>
+		);
+	}
+
 	render() {
 		const { translate } = this.props;
-		const { errorMessages, isSubmitting, isEmailAddressValid } = this.state;
-		const submitButtonText = isSubmitting
-			? translate( 'Creating Your Account…' )
-			: translate( 'Create your account' );
+		const { errorMessages, isSubmitting } = this.state;
+
 		return (
 			<div className="signup-form__passwordless-form-wrapper">
 				<LoggedOutForm onSubmit={ this.onFormSubmit } noValidate>
@@ -175,20 +209,11 @@ class PasswordlessSignupForm extends Component {
 							type="email"
 							name="email"
 							onChange={ this.onInputChange }
-							disabled={ isSubmitting }
+							disabled={ isSubmitting || !! this.props.disabled }
 						/>
 					</ValidationFieldset>
 					{ this.props.renderTerms() }
-					<LoggedOutFormFooter>
-						<Button
-							type="submit"
-							primary
-							busy={ isSubmitting }
-							disabled={ isSubmitting || ! isEmailAddressValid }
-						>
-							{ submitButtonText }
-						</Button>
-					</LoggedOutFormFooter>
+					{ this.formFooter() }
 				</LoggedOutForm>
 			</div>
 		);

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -19,7 +19,7 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import ValidationFieldset from 'signup/validation-fieldset';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
-import { submitSignupStep } from 'state/signup/progress/actions';
+import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 
 class PasswordlessSignupForm extends Component {
 	static propTypes = {
@@ -32,7 +32,7 @@ class PasswordlessSignupForm extends Component {
 
 	state = {
 		isSubmitting: false,
-		email: '',
+		email: this.props.step && this.props.step.form ? this.props.step.form.email : '',
 		errorMessages: null,
 	};
 
@@ -59,6 +59,20 @@ class PasswordlessSignupForm extends Component {
 
 		this.setState( {
 			isSubmitting: true,
+		} );
+
+		// Save form state in a format that is compatible with the standard SignupForm used in the user step.
+		const form = {
+			firstName: '',
+			lastName: '',
+			email: this.state.email,
+			username: '',
+			password: '',
+		};
+
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			form,
 		} );
 
 		wpcom
@@ -208,6 +222,7 @@ class PasswordlessSignupForm extends Component {
 							className="signup-form__passwordless-email"
 							type="email"
 							name="email"
+							value={ this.state.email }
 							onChange={ this.onInputChange }
 							disabled={ isSubmitting || !! this.props.disabled }
 						/>
@@ -223,6 +238,7 @@ export default connect(
 	null,
 	{
 		recordTracksEvent,
+		saveSignupStep,
 		submitCreateAccountStep: submitSignupStep,
 	}
 )( localize( PasswordlessSignupForm ) );


### PR DESCRIPTION
This allows for better behaviour when a user clicks `back` after signing up with the passwordless signup form in the `passwordlessSignup` A/B test.

Previously, if a user signs up, and then clicks back from the site type step, they will see the notice that their account has already been created, but the form is just an empty signup form, and they will be stuck on the user step. This change brings some of the logic from the standard signup form to the passwordless form so that if a user account has already been created, the form is disabled and the submit button is changed to "Continue".

~Note: in this change, the email address form field is empty after a user clicks `Back` — this is because the passwordless form does not save the email address to Redux state. While this could be added as an enhancement, it didn't feel necessary to me to resolve this issue, so I've opted out of doing it. Please do comment if you think it's crucial for the user to understand that their account has been created, and I can look into that — at this stage, I wanted to avoid adding any unnecessary complexity.~

***Update:*** I have added in the behaviour to store the email address to state, so the the form field isn't empty after a user clicks Back.

### Before

![image](https://user-images.githubusercontent.com/14988353/67262387-56607080-f4f0-11e9-9173-d562da5e45b8.png)

### After

![image](https://user-images.githubusercontent.com/14988353/67456548-e16e7180-f67c-11e9-9f60-32180e0dbcc6.png)

#### Changes proposed in this Pull Request

* Allow the passwordless signup form to be disabled if the `disabled` prop is passed down.
* Change the submit button to `Continue` and set the `onClick` handler to go to the next step if the user account has already been created.
* Save form state when the form is submitted (after validation and before the API call) to ensure that if a user clicks Back after submitting the step, the form field retains their email address.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Set the passwordlessSignup A/B test:

![image](https://user-images.githubusercontent.com/14988353/67262201-a428a900-f4ef-11e9-9795-fdeaf61fbfd0.png)

* Go to `http://calypso.localhost:3000/jetpack/new` and click to create a new WordPress.com site
* On the passwordless user step, create a new account
* From the site type step, click Back to get back to the user step
* You should see the notice that a user account has already been created, the form should be disabled, and the Continue button should take you to the site type step again.
* Complete signup as normal and ensure that a site can be created.
