### PR TITLE
Gutenboarding: Add Onboarding Block stub, lock Editor

### DIFF
--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -32,6 +32,9 @@ import Sidebar from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
 import './style.scss';
 
+registerCoreBlocks();
+registerBlockType( name, settings );
+
 export function Gutenboard() {
 	const [ blocks, updateBlocks ] = useState( [] );
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( true );
@@ -67,7 +70,3 @@ export function Gutenboard() {
 		</div>
 	);
 }
-
-registerCoreBlocks();
-
-registerBlockType( name, settings );

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -12,8 +12,7 @@ import {
 	ObserveTyping,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
-import { registerBlockType } from '@wordpress/blocks';
-import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
 import '@wordpress/edit-post/build-style/style.css';
 import '@wordpress/components/build-style/style.css';
@@ -32,11 +31,11 @@ import Sidebar from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
 import './style.scss';
 
-registerCoreBlocks();
 registerBlockType( name, settings );
 
+const onboardingBlock = createBlock( name, {} );
+
 export function Gutenboard() {
-	const [ blocks, updateBlocks ] = useState( [] );
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( true );
 
 	function toggleGeneralSidebar() {
@@ -51,7 +50,7 @@ export function Gutenboard() {
 			/>
 			<SlotFillProvider>
 				<DropZoneProvider>
-					<BlockEditorProvider value={ blocks } onInput={ updateBlocks } onChange={ updateBlocks }>
+					<BlockEditorProvider value={ [ onboardingBlock ] }>
 						<div className="gutenboarding__block-editor">
 							<BlockEditorKeyboardShortcuts />
 

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -17,9 +17,6 @@ import '@wordpress/format-library';
 import '@wordpress/edit-post/build-style/style.css';
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
-import '@wordpress/block-library/build-style/style.css';
-import '@wordpress/block-library/build-style/editor.css';
-import '@wordpress/block-library/build-style/theme.css';
 import '@wordpress/format-library/build-style/style.css';
 
 /**

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -12,6 +12,7 @@ import {
 	ObserveTyping,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
+import { registerBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import '@wordpress/format-library';
 import '@wordpress/edit-post/build-style/style.css';
@@ -26,6 +27,7 @@ import '@wordpress/format-library/build-style/style.css';
  * Internal dependencies
  */
 import { Header } from 'gutenboarding/components/header';
+import { name, settings } from './onboarding-block';
 import Sidebar from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
 import './style.scss';
@@ -67,3 +69,5 @@ export function Gutenboard() {
 }
 
 registerCoreBlocks();
+
+registerBlockType( name, settings );

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { BlockSaveProps } from '@wordpress/blocks';
+import { sprintf, __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+import { BlockEditProps } from '@wordpress/blocks';
 import React from 'react';
 
 /**
@@ -12,14 +13,24 @@ import { Attributes } from '.';
 
 export default function OnboardingEdit( {
 	attributes: { siteType },
-}: BlockSaveProps< Attributes > ) {
+	setAttributes,
+}: BlockEditProps< Attributes > ) {
 	if ( ! siteType ) {
 		return (
 			<>
 				<h1>{ __( "Let's set up your website -- it takes only a moment" ) }</h1>
-				<p>{ __( 'I want to create a website' ) }</p>
+				{ __( 'I want to create a website ' ) }
+				<SelectControl< Attributes[ 'siteType' ] >
+					onChange={ v => setAttributes( { siteType: v } ) }
+					options={ [
+						{ label: __( 'with a blog.' ), value: 'blog' },
+						{ label: __( 'for a store.' ), value: 'store' },
+						{ label: __( 'to write a story.' ), value: 'story' },
+					] }
+					value={ siteType || 'blog' }
+				/>
 			</>
 		);
 	}
-	return null;
+	return sprintf( __( 'Cool, you have a %s' ), siteType );
 }

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -32,5 +32,5 @@ export default function OnboardingEdit( {
 			</>
 		);
 	}
-	return sprintf( __( 'Cool, you have a %s' ), siteType );
+	return <div>{ sprintf( __( 'Cool, you have a %s' ), siteType ) }</div>;
 }

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function OnboardingEdit() {
+	return __( 'I want to create' );
+}

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -2,9 +2,17 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { BlockEditProps } from '@wordpress/blocks';
 import React from 'react';
 
-export default function OnboardingEdit( { attributes: { siteType } } ) {
+/**
+ * Internal dependencies
+ */
+import { Attributes } from '.';
+
+export default function OnboardingEdit( {
+	attributes: { siteType },
+}: BlockEditProps< Attributes > ) {
 	if ( ! siteType ) {
 		return (
 			<>
@@ -13,4 +21,5 @@ export default function OnboardingEdit( { attributes: { siteType } } ) {
 			</>
 		);
 	}
+	return null;
 }

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -4,11 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 
-export default function OnboardingEdit() {
-	return (
-		<>
-			<h1>{ __( "Let's set up your website -- it takes only a moment" ) }</h1>
-			<p>{ __( 'I want to create' ) }</p>
-		</>
-	);
+export default function OnboardingEdit( { attributes: { siteType } } ) {
+	if ( ! siteType ) {
+		return (
+			<>
+				<h1>{ __( "Let's set up your website -- it takes only a moment" ) }</h1>
+				<p>{ __( 'I want to create a website' ) }</p>
+			</>
+		);
+	}
 }

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Attributes } from '.';
+import { Attributes, SiteType } from '.';
 
 export default function OnboardingEdit( {
 	attributes: { siteType },
@@ -20,14 +20,14 @@ export default function OnboardingEdit( {
 			<>
 				<h1>{ __( "Let's set up your website -- it takes only a moment" ) }</h1>
 				{ __( 'I want to create a website ' ) }
-				<SelectControl< Attributes[ 'siteType' ] >
+				<SelectControl< SiteType >
 					onChange={ v => setAttributes( { siteType: v } ) }
 					options={ [
 						{ label: __( 'with a blog.' ), value: 'blog' },
 						{ label: __( 'for a store.' ), value: 'store' },
 						{ label: __( 'to write a story.' ), value: 'story' },
 					] }
-					value={ siteType || 'blog' }
+					value={ siteType || SiteType.BLOG }
 				/>
 			</>
 		);

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockEditProps } from '@wordpress/blocks';
+import { BlockSaveProps } from '@wordpress/blocks';
 import React from 'react';
 
 /**
@@ -12,7 +12,7 @@ import { Attributes } from '.';
 
 export default function OnboardingEdit( {
 	attributes: { siteType },
-}: BlockEditProps< Attributes > ) {
+}: BlockSaveProps< Attributes > ) {
 	if ( ! siteType ) {
 		return (
 			<>

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import React from 'react';
 
 export default function OnboardingEdit() {
-	return __( 'I want to create' );
+	return (
+		<>
+			<h1>{ __( "Let's set up your website -- it takes only a moment" ) }</h1>
+			<p>{ __( 'I want to create' ) }</p>
+		</>
+	);
 }

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -44,6 +44,9 @@ export const settings: BlockConfiguration< Attributes > = {
 	supports: {
 		align: [ 'full' ],
 		html: false,
+		inserter: true, // @TODO: Should not appear in inserter
+		multiple: false,
+		reusable: false,
 	},
 	icon: 'universal-access-alt',
 	edit,

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -50,7 +50,7 @@ export const settings: BlockConfiguration< Attributes > = {
 	supports: {
 		align: [ 'full' ],
 		html: false,
-		inserter: true, // @TODO: Should not appear in inserter
+		inserter: false,
 		multiple: false,
 		reusable: false,
 	},

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+
+export const name = 'automattic/onboarding';
+
+export const settings = {
+	title: __( 'Onboarding' ),
+	category: 'layout', // TODO
+	// keywords: [
+	// 	_x( 'image', 'block search term', 'jetpack' ),
+	// 	_x( 'gallery', 'block search term', 'jetpack' ),
+	// 	_x( 'slider', 'block search term', 'jetpack' ),
+	// ],
+	description: __( 'Onboarding wizard block' ),
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'full',
+		},
+		siteTitle: {
+			type: 'string',
+		},
+		siteType: {
+			type: 'string',
+		},
+		theme: {
+			type: 'string',
+		},
+		vertical: {
+			type: 'string',
+		},
+	},
+	supports: {
+		align: [ 'full' ],
+		html: false,
+	},
+	icon: 'universal-access-alt',
+	edit,
+	save: edit,
+	// transforms,
+	// example: {
+	// 	attributes: exampleAttributes,
+	// },
+};

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -20,7 +20,7 @@ export enum SiteType {
 export interface Attributes {
 	align: 'full';
 	siteTitle: string;
-	siteType: undefined | SiteType;
+	siteType?: SiteType;
 	theme: string;
 	vertical: string;
 }

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -22,11 +22,6 @@ export interface Attributes {
 export const settings: BlockConfiguration< Attributes > = {
 	title: __( 'Onboarding' ),
 	category: 'layout', // TODO
-	// keywords: [
-	// 	_x( 'image', 'block search term', 'jetpack' ),
-	// 	_x( 'gallery', 'block search term', 'jetpack' ),
-	// 	_x( 'slider', 'block search term', 'jetpack' ),
-	// ],
 	description: __( 'Onboarding wizard block' ),
 	attributes: {
 		align: {
@@ -53,8 +48,4 @@ export const settings: BlockConfiguration< Attributes > = {
 	icon: 'universal-access-alt',
 	edit,
 	save: edit,
-	// transforms,
-	// example: {
-	// 	attributes: exampleAttributes,
-	// },
 };

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Block } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import edit from './edit';
 
 export const name = 'automattic/onboarding';
 
-export const settings = {
+export const settings: Block = {
 	title: __( 'Onboarding' ),
 	category: 'layout', // TODO
 	// keywords: [

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Block } from '@wordpress/blocks';
+import { BlockConfiguration } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -11,7 +11,15 @@ import edit from './edit';
 
 export const name = 'automattic/onboarding';
 
-export const settings: Block = {
+export interface Attributes {
+	align: string; // TODO: kind of an enum!
+	siteTitle: string;
+	siteType: string;
+	theme: string;
+	vertical: string;
+}
+
+export const settings: BlockConfiguration< Attributes > = {
 	title: __( 'Onboarding' ),
 	category: 'layout', // TODO
 	// keywords: [

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -13,7 +13,7 @@ export const name = 'automattic/onboarding';
 
 export interface Attributes {
 	align: string; // TODO: kind of an enum!
-	siteTitle: string;
+	siteTitle: 'blog' | 'store' | 'story';
 	siteType: string;
 	theme: string;
 	vertical: string;
@@ -50,5 +50,5 @@ export const settings: BlockConfiguration< Attributes > = {
 	},
 	icon: 'universal-access-alt',
 	edit,
-	save: edit,
+	save: () => null,
 };

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -11,10 +11,16 @@ import edit from './edit';
 
 export const name = 'automattic/onboarding';
 
+export enum SiteType {
+	BLOG = 'blog',
+	STORE = 'store',
+	STORY = 'story',
+}
+
 export interface Attributes {
-	align: string; // TODO: kind of an enum!
-	siteTitle: 'blog' | 'store' | 'story';
-	siteType: string;
+	align: 'full';
+	siteTitle: string;
+	siteType: undefined | SiteType;
 	theme: string;
 	vertical: string;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implementing the Onboarding Block (formerly known as the Site Block), which is supposed to become kind of a centerpiece to the new onboarding flow. Furthermore, we're locking the block editor to _only_ display that block; we don't allow insertion of any other blocks, and even remove registration of core blocks.

We're only implementing the first step (site type) for now. Note that UI wise, it doesn't look like the Figma file; we will add styling (and possibly different behavior) later.

Also note that we're using block attributes to store information for now. This is mostly to get started easily (component state might be just as good a choice this point). Later, we will probably introduce a `@wordpress/data` store that holds this kind of information, so it can inform the surrounding editor UI: we will connect the block to it through the custom sources concept.

#### Testing instructions

- Visit `calypso.localhost:3000/gutenboarding`.
- Insert the Onboarding block from the block.
- Select an option from the dropdown.
- Verify that you see a message confirming your selection.

#### Next steps

- Add more steps (as seen in the Figma)
- _Done_ ~Lock the editor: Show only the onboarding block, disallow insertion of other blocks. (Likely means fiddling with `BlockEditorProvider`'s attributes: https://github.com/Automattic/wp-calypso/blob/bfdfc5ae7d06668a6ec6feb517ebc8403e4393e1/client/gutenboarding/gutenboard.tsx#L49~
- Remove block toolbar: We don't want to 'Remove the block' from the block toolbar, and we most likely don't want any icon there.
- Fix UI to reflect the Figma better
- Introduce `@wordpress/data` store to hold information obtained through the block, inform the editor's UI elements by it.

/cc @Automattic/luna 