### PR TITLE
Blocks: Add tests for ProductSelector block utils

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { find, flattenDeep, flowRight as compose, includes, isEmpty, map, uniq } from 'lodash';
+import { find, flowRight as compose, includes, isEmpty, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -200,7 +200,7 @@ ProductSelector.propTypes = {
 
 const connectComponent = connect( ( state, { products, siteId } ) => {
 	const selectedSiteId = siteId || getSelectedSiteId( state );
-	const productSlugs = uniq( flattenDeep( products.map( extractProductSlugs ) ) );
+	const productSlugs = extractProductSlugs( products );
 	const availableProducts = getAvailableProductsList( state );
 
 	return {

--- a/client/blocks/product-selector/test/utils.js
+++ b/client/blocks/product-selector/test/utils.js
@@ -1,0 +1,88 @@
+/**
+ * Internal dependencies
+ */
+import { extractProductSlugs, filterByProductSlugs } from '../utils';
+
+describe( 'extractProductSlugs', () => {
+	test( 'should retrieve flat list of product slugs from product options of the products', () => {
+		const products = [
+			{
+				id: 'test',
+				options: {
+					monthly: [ 'monthly_option_1', 'monthly_option_2' ],
+					yearly: [ 'yearly_option_1', 'yearly_option_2' ],
+				},
+			},
+		];
+
+		const expected = [
+			'monthly_option_1',
+			'monthly_option_2',
+			'yearly_option_1',
+			'yearly_option_2',
+		];
+		expect( extractProductSlugs( products ) ).toEqual( expected );
+	} );
+
+	test( 'should only return unique product slugs out of each product', () => {
+		const products = [
+			{
+				id: 'test',
+				options: {
+					monthly: [ 'option_1', 'option_2' ],
+					yearly: [ 'option_1', 'option_2' ],
+				},
+			},
+		];
+
+		const expected = [ 'option_1', 'option_2' ];
+		expect( extractProductSlugs( products ) ).toEqual( expected );
+	} );
+
+	test( 'should only return unique product slugs out the entire product set', () => {
+		const products = [
+			{
+				id: 'test1',
+				options: {
+					monthly: [ 'monthly_option_1', 'monthly_option_2' ],
+					yearly: [ 'yearly_option_1', 'yearly_option_2' ],
+				},
+			},
+			{
+				id: 'test2',
+				options: {
+					monthly: [ 'monthly_option_1', 'monthly_option_2' ],
+					yearly: [ 'yearly_option_1', 'yearly_option_2' ],
+				},
+			},
+		];
+
+		const expected = [
+			'monthly_option_1',
+			'monthly_option_2',
+			'yearly_option_1',
+			'yearly_option_2',
+		];
+		expect( extractProductSlugs( products ) ).toEqual( expected );
+	} );
+} );
+
+describe( 'filterByProductSlugs', () => {
+	test( 'should retrieve products that match the product slug', () => {
+		const product1 = {
+			id: 1,
+			product_slug: 'monthly_test_1',
+		};
+		const product2 = {
+			id: 2,
+			product_slug: 'yearly_test_1',
+		};
+		const products = {
+			monthly_test_1: product1,
+			yearly_test_1: product2,
+		};
+
+		const slugs = [ 'monthly_test_1' ];
+		expect( filterByProductSlugs( products, slugs ) ).toEqual( { monthly_test_1: product1 } );
+	} );
+} );

--- a/client/blocks/product-selector/utils.js
+++ b/client/blocks/product-selector/utils.js
@@ -1,22 +1,23 @@
 /**
  * External dependencies
  */
-import { pickBy } from 'lodash';
+import { flattenDeep, pickBy, uniq } from 'lodash';
 
 /**
- * Extract the product slugs out of a product object.
+ * Extract the product slugs out of an array of product objects.
  *
- * @param {object} product Product object (see `products` propTypes definition below).
+ * @param {array} products Array of product objects.
  * @returns {array} Array of the product slugs.
  */
-export const extractProductSlugs = product => Object.values( product.options );
+export const extractProductSlugs = products =>
+	uniq( flattenDeep( products.map( product => Object.values( product.options ) ) ) );
 
 /**
  * Filter products to the ones that are within specified slugs.
  *
  * @param {object} products Product objects.
  * @param {array} slugs Slugs to filter by.
- * @returns {array} Filtered products.
+ * @returns {object} Filtered products.
  */
 export const filterByProductSlugs = ( products, slugs ) =>
 	pickBy( products, ( product, productSlug ) => slugs.indexOf( productSlug ) >= 0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `extractProductSlugs` util to handle flattening and unique-ness.
* Improve `ProductSelector` utils inline docs.
* Blocks: Add tests for ProductSelector block utils.

#### Testing instructions

* Checkout this branch.
* Verify that http://calypso.localhost:3000/devdocs/blocks/product-selector works the same way
* Verify tests pass: `npm run test-client client/blocks/product-selector/`
