### PR TITLE
Blocks: Remove outdated ProductSelector TODOs

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -59,8 +59,6 @@ export class ProductSelector extends Component {
 		const { intervalType, purchases } = this.props;
 		const productSlugs = product.options[ intervalType ];
 
-		// TODO: Implement logic for plans that contan certain Jetpack products.
-
 		return find(
 			purchases,
 			purchase => purchase.active && includes( productSlugs, purchase.productSlug )
@@ -74,8 +72,6 @@ export class ProductSelector extends Component {
 		if ( ! purchase ) {
 			return;
 		}
-
-		// TODO: Implement logic for plans that contan certain Jetpack products.
 
 		return translate( 'Purchased %(purchaseDate)s', {
 			args: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Blocks: Remove outdated ProductSelector TODOs

We won't be needing those, because we'll be hiding the product options when a product is purchased.

#### Testing instructions

* Not needed, this is only removing inline comments.
