### PR TITLE
Blocks: Hide options when product purchased in ProductSelector

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -115,6 +115,7 @@ export class ProductSelector extends Component {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 			const productObject = storeProducts[ selectedProductSlug ];
 			const stateKey = this.getStateKey( product.id, intervalType );
+			const purchase = this.getPurchaseByProduct( product );
 
 			return (
 				<ProductCard
@@ -124,15 +125,19 @@ export class ProductSelector extends Component {
 					fullPrice={ productObject.cost }
 					description={ <p>{ product.description }</p> }
 					currencyCode={ currencyCode }
-					purchase={ this.getPurchaseByProduct( product ) }
+					purchase={ purchase }
 					subtitle={ this.getSubtitleByProduct( product ) }
 				>
-					<ProductCardOptions
-						optionsLabel={ product.optionsLabel }
-						options={ this.getProductOptions( product ) }
-						selectedSlug={ this.state[ stateKey ] }
-						handleSelect={ productSlug => this.handleProductOptionSelect( stateKey, productSlug ) }
-					/>
+					{ ! purchase && (
+						<ProductCardOptions
+							optionsLabel={ product.optionsLabel }
+							options={ this.getProductOptions( product ) }
+							selectedSlug={ this.state[ stateKey ] }
+							handleSelect={ productSlug =>
+								this.handleProductOptionSelect( stateKey, productSlug )
+							}
+						/>
+					) }
 				</ProductCard>
 			);
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide product options when product has been purchased in `ProductSelector`.

#### Testing instructions

* Checkout this branch.
* Purchase a Jetpack plan of some billing interval.
* Navigate to http://calypso.localhost:3000/devdocs/blocks/product-selector
* Verify that when you're on the same billing interval as the plan you purchased, the Jetpack plan product options aren't visible.
