### PR TITLE
Split HTTP utils in `lib/url`

### DIFF
--- a/client/lib/url/http-utils.ts
+++ b/client/lib/url/http-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import { URL as TypedURL, SiteSlug } from 'types';
+import { Falsey } from 'utility-types';
+
+const urlWithoutHttpRegex = /^https?:\/\//;
+
+/**
+ * Returns the supplied URL without the initial http(s).
+ * @param  url The URL to remove http(s) from
+ * @return     URL without the initial http(s)
+ */
+export function withoutHttp( url: '' ): '';
+export function withoutHttp( url: Falsey ): null;
+export function withoutHttp( url: TypedURL ): TypedURL;
+export function withoutHttp( url: TypedURL | Falsey ): TypedURL | null {
+	if ( url === '' ) {
+		return '';
+	}
+
+	if ( ! url ) {
+		return null;
+	}
+
+	return url.replace( urlWithoutHttpRegex, '' );
+}
+
+export function urlToSlug( url: Falsey ): null;
+export function urlToSlug( url: TypedURL ): SiteSlug;
+export function urlToSlug( url: TypedURL | Falsey ): SiteSlug | null {
+	if ( ! url ) {
+		return null;
+	}
+
+	return withoutHttp( url ).replace( /\//g, '::' );
+}
+
+/**
+ * Removes the `http(s)://` part and the trailing slash from an URL.
+ * "http://blog.wordpress.com" will be converted into "blog.wordpress.com".
+ * "https://www.wordpress.com/blog/" will be converted into "www.wordpress.com/blog".
+ *
+ * @param  urlToConvert The URL to convert
+ * @return              The URL's domain and path
+ */
+export function urlToDomainAndPath( urlToConvert: TypedURL ): TypedURL {
+	return withoutHttp( urlToConvert ).replace( /\/$/, '' );
+}

--- a/client/lib/url/http-utils.ts
+++ b/client/lib/url/http-utils.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { URL as TypedURL, SiteSlug } from 'types';
-import { Falsey } from 'utility-types';
+import { Falsy } from 'utility-types';
 
 const urlWithoutHttpRegex = /^https?:\/\//;
 

--- a/client/lib/url/http-utils.ts
+++ b/client/lib/url/http-utils.ts
@@ -37,7 +37,7 @@ export function urlToSlug( url: TypedURL | Falsey ): SiteSlug | null {
 }
 
 /**
- * Removes the `http(s)://` part and the trailing slash from an URL.
+ * Removes the `http(s)://` part and the trailing slash from a URL.
  * "http://blog.wordpress.com" will be converted into "blog.wordpress.com".
  * "https://www.wordpress.com/blog/" will be converted into "www.wordpress.com/blog".
  *

--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -9,10 +9,14 @@ import { has, isString, omit, startsWith } from 'lodash';
  */
 import config from 'config';
 import { isLegacyRoute } from 'lib/route/legacy-routes';
-import { URL, SiteSlug, Scheme } from 'types';
+import { URL, Scheme } from 'types';
 import { Falsey } from 'utility-types';
 
+/**
+ * Re-exports
+ */
 export { addQueryArgs } from 'lib/route';
+export { withoutHttp, urlToSlug, urlToDomainAndPath } from './http-utils';
 
 /**
  * Check if a URL is located outside of Calypso.
@@ -66,27 +70,6 @@ export function isHttps( url: URL ): boolean {
 }
 
 const schemeRegex = /^\w+:\/\//;
-const urlWithoutHttpRegex = /^https?:\/\//;
-
-/**
- * Returns the supplied URL without the initial http(s).
- * @param  url The URL to remove http(s) from
- * @return     URL without the initial http(s)
- */
-export function withoutHttp( url: '' ): '';
-export function withoutHttp( url: Falsey ): null;
-export function withoutHttp( url: URL ): URL;
-export function withoutHttp( url: URL | Falsey ): URL | null {
-	if ( url === '' ) {
-		return '';
-	}
-
-	if ( ! url ) {
-		return null;
-	}
-
-	return url.replace( urlWithoutHttpRegex, '' );
-}
 
 export function addSchemeIfMissing( url: URL, scheme: Scheme ): URL {
 	if ( false === schemeRegex.test( url ) ) {
@@ -107,28 +90,6 @@ export function setUrlScheme( url: URL, scheme: Scheme ) {
 	}
 
 	return url.replace( schemeRegex, schemeWithSlashes );
-}
-
-export function urlToSlug( url: Falsey ): null;
-export function urlToSlug( url: URL ): SiteSlug;
-export function urlToSlug( url: URL | Falsey ): SiteSlug | null {
-	if ( ! url ) {
-		return null;
-	}
-
-	return withoutHttp( url ).replace( /\//g, '::' );
-}
-
-/**
- * Removes the `http(s)://` part and the trailing slash from an URL.
- * "http://blog.wordpress.com" will be converted into "blog.wordpress.com".
- * "https://www.wordpress.com/blog/" will be converted into "www.wordpress.com/blog".
- *
- * @param  urlToConvert The URL to convert
- * @return              The URL's domain and path
- */
-export function urlToDomainAndPath( urlToConvert: URL ): URL {
-	return withoutHttp( urlToConvert ).replace( /\/$/, '' );
 }
 
 /**

--- a/client/lib/url/package.json
+++ b/client/lib/url/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/client/lib/url/test/http-utils.js
+++ b/client/lib/url/test/http-utils.js
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { withoutHttp, urlToSlug } from '../http-utils';
+
+describe( 'withoutHttp', () => {
+	test( 'should return null if URL is not provided', () => {
+		expect( withoutHttp() ).toBeNull;
+	} );
+
+	test( 'should return URL without initial http', () => {
+		const urlWithHttp = 'http://example.com';
+		const urlWithoutHttp = withoutHttp( urlWithHttp );
+
+		expect( urlWithoutHttp ).toEqual( 'example.com' );
+	} );
+
+	test( 'should return URL without initial https', () => {
+		const urlWithHttps = 'https://example.com';
+		const urlWithoutHttps = withoutHttp( urlWithHttps );
+
+		expect( urlWithoutHttps ).toEqual( 'example.com' );
+	} );
+
+	test( 'should return URL without initial http and query string if has any', () => {
+		const urlWithHttpAndQueryString = 'http://example.com?foo=bar#anchor';
+		const urlWithoutHttpAndQueryString = withoutHttp( urlWithHttpAndQueryString );
+
+		expect( urlWithoutHttpAndQueryString ).toEqual( 'example.com?foo=bar#anchor' );
+	} );
+
+	test( "should return provided URL if it doesn't include http(s)", () => {
+		const urlWithoutHttp = 'example.com';
+
+		expect( withoutHttp( urlWithoutHttp ) ).toEqual( urlWithoutHttp );
+	} );
+
+	test( 'should return empty string if URL is empty string', () => {
+		const urlEmptyString = '';
+
+		expect( withoutHttp( urlEmptyString ) ).toEqual( '' );
+	} );
+} );
+
+describe( 'urlToSlug()', () => {
+	test( 'should return null if URL is not provided', () => {
+		expect( urlToSlug() ).toBeNull;
+	} );
+
+	test( 'should return null if URL is empty string', () => {
+		const urlEmptyString = '';
+
+		expect( urlToSlug( urlEmptyString ) ).toBeNull;
+	} );
+
+	test( 'should return URL without initial http', () => {
+		const urlWithHttp = 'http://example.com';
+		const urlWithoutHttp = urlToSlug( urlWithHttp );
+
+		expect( urlWithoutHttp ).toEqual( 'example.com' );
+	} );
+
+	test( 'should return URL without initial https', () => {
+		const urlWithHttps = 'https://example.com';
+		const urlWithoutHttps = urlToSlug( urlWithHttps );
+
+		expect( urlWithoutHttps ).toEqual( 'example.com' );
+	} );
+
+	test( 'should return URL without initial http and query string if has any', () => {
+		const urlWithHttpAndQueryString = 'http://example.com?foo=bar#anchor';
+		const urlWithoutHttpAndQueryString = urlToSlug( urlWithHttpAndQueryString );
+
+		expect( urlWithoutHttpAndQueryString ).toEqual( 'example.com?foo=bar#anchor' );
+	} );
+
+	test( "should return provided URL if it doesn't include http(s)", () => {
+		const urlWithoutHttp = 'example.com';
+
+		expect( urlToSlug( urlWithoutHttp ) ).toEqual( urlWithoutHttp );
+	} );
+
+	test( 'should return a slug with forward slashes converted to double colons', () => {
+		const urlWithHttp = 'http://example.com/example/test123';
+		const urlWithoutHttp = urlToSlug( urlWithHttp );
+
+		expect( urlWithoutHttp ).toEqual( 'example.com::example::test123' );
+	} );
+} );

--- a/client/lib/url/test/http-utils.js
+++ b/client/lib/url/test/http-utils.js
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { withoutHttp, urlToSlug } from '../http-utils';
+import { withoutHttp, urlToSlug, urlToDomainAndPath } from '../http-utils';
 
 describe( 'withoutHttp', () => {
 	test( 'should return null if URL is not provided', () => {
@@ -89,5 +89,37 @@ describe( 'urlToSlug()', () => {
 		const urlWithoutHttp = urlToSlug( urlWithHttp );
 
 		expect( urlWithoutHttp ).toEqual( 'example.com::example::test123' );
+	} );
+} );
+
+describe( 'urlToDomainAndPath', () => {
+	test( 'should return null if URL is not provided', () => {
+		expect( withoutHttp() ).toBeNull;
+	} );
+
+	test( 'should return URL without initial http', () => {
+		const urlWithHttp = 'http://example.com/';
+		const urlWithoutHttp = urlToDomainAndPath( urlWithHttp );
+
+		expect( urlWithoutHttp ).toEqual( 'example.com' );
+	} );
+
+	test( 'should return URL without initial https', () => {
+		const urlWithHttps = 'https://example.com/';
+		const urlWithoutHttps = urlToDomainAndPath( urlWithHttps );
+
+		expect( urlWithoutHttps ).toEqual( 'example.com' );
+	} );
+
+	test( "should return provided URL if it doesn't include http(s)", () => {
+		const urlWithoutHttp = 'example.com/';
+
+		expect( urlToDomainAndPath( urlWithoutHttp ) ).toEqual( 'example.com' );
+	} );
+
+	test( 'should return empty string if URL is empty string', () => {
+		const urlEmptyString = '';
+
+		expect( urlToDomainAndPath( urlEmptyString ) ).toEqual( '' );
 	} );
 } );

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -1,5 +1,4 @@
 /**
- * @format
  * @jest-environment jsdom
  */
 
@@ -11,54 +10,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import {
-	isExternal,
-	withoutHttp,
-	addSchemeIfMissing,
-	setUrlScheme,
-	urlToSlug,
-	resemblesUrl,
-	omitUrlParams,
-} from '../';
-
-describe( 'withoutHttp', () => {
-	test( 'should return null if URL is not provided', () => {
-		expect( withoutHttp() ).to.be.null;
-	} );
-
-	test( 'should return URL without initial http', () => {
-		const urlWithHttp = 'http://example.com';
-		const urlWithoutHttp = withoutHttp( urlWithHttp );
-
-		expect( urlWithoutHttp ).to.equal( 'example.com' );
-	} );
-
-	test( 'should return URL without initial https', () => {
-		const urlWithHttps = 'https://example.com';
-		const urlWithoutHttps = withoutHttp( urlWithHttps );
-
-		expect( urlWithoutHttps ).to.equal( 'example.com' );
-	} );
-
-	test( 'should return URL without initial http and query string if has any', () => {
-		const urlWithHttpAndQueryString = 'http://example.com?foo=bar#anchor';
-		const urlWithoutHttpAndQueryString = withoutHttp( urlWithHttpAndQueryString );
-
-		expect( urlWithoutHttpAndQueryString ).to.equal( 'example.com?foo=bar#anchor' );
-	} );
-
-	test( "should return provided URL if it doesn't include http(s)", () => {
-		const urlWithoutHttp = 'example.com';
-
-		expect( withoutHttp( urlWithoutHttp ) ).to.equal( urlWithoutHttp );
-	} );
-
-	test( 'should return empty string if URL is empty string', () => {
-		const urlEmptyString = '';
-
-		expect( withoutHttp( urlEmptyString ) ).to.equal( '' );
-	} );
-} );
+import { isExternal, addSchemeIfMissing, setUrlScheme, resemblesUrl, omitUrlParams } from '../';
 
 describe( 'isExternal', () => {
 	test( 'should return false for relative path-only url', () => {
@@ -241,52 +193,6 @@ describe( 'setUrlScheme()', () => {
 		const actual = setUrlScheme( source, 'http' );
 
 		expect( actual ).to.equal( expected );
-	} );
-} );
-
-describe( 'urlToSlug()', () => {
-	test( 'should return null if URL is not provided', () => {
-		expect( urlToSlug() ).to.be.null;
-	} );
-
-	test( 'should return null if URL is empty string', () => {
-		const urlEmptyString = '';
-
-		expect( urlToSlug( urlEmptyString ) ).to.be.null;
-	} );
-
-	test( 'should return URL without initial http', () => {
-		const urlWithHttp = 'http://example.com';
-		const urlWithoutHttp = urlToSlug( urlWithHttp );
-
-		expect( urlWithoutHttp ).to.equal( 'example.com' );
-	} );
-
-	test( 'should return URL without initial https', () => {
-		const urlWithHttps = 'https://example.com';
-		const urlWithoutHttps = urlToSlug( urlWithHttps );
-
-		expect( urlWithoutHttps ).to.equal( 'example.com' );
-	} );
-
-	test( 'should return URL without initial http and query string if has any', () => {
-		const urlWithHttpAndQueryString = 'http://example.com?foo=bar#anchor';
-		const urlWithoutHttpAndQueryString = urlToSlug( urlWithHttpAndQueryString );
-
-		expect( urlWithoutHttpAndQueryString ).to.equal( 'example.com?foo=bar#anchor' );
-	} );
-
-	test( "should return provided URL if it doesn't include http(s)", () => {
-		const urlWithoutHttp = 'example.com';
-
-		expect( urlToSlug( urlWithoutHttp ) ).to.equal( urlWithoutHttp );
-	} );
-
-	test( 'should return a slug with forward slashes converted to double colons', () => {
-		const urlWithHttp = 'http://example.com/example/test123';
-		const urlWithoutHttp = urlToSlug( urlWithHttp );
-
-		expect( urlWithoutHttp ).to.equal( 'example.com::example::test123' );
 	} );
 } );
 


### PR DESCRIPTION
This is one of several PRs aiming at splitting up `lib/url` into several files for tree-shaking, replacing usage of the browserified node `url` module with native functionality, and generally improving it.

This PR focuses on three methods, which I'm consolidating into an `http-utils` module.

This PR was split out from #36531, which got too big.

#### Changes proposed in this Pull Request

* Split out HTTP utils in `lib/url`
* Split out corresponding tests into their own file too
* Add missing tests for `urlToDomainAndPath`
* Fix a small existing typo in `http-utils`

#### Testing instructions

There are no behaviour changes in this PR, only code being moved around. As such, the unit tests should suffice in ensuring nothing got broken.