### PR TITLE
Revert back to `Falsey` in `lib/url`, as `Falsy` isn't defined.

### DIFF
--- a/client/lib/url/http-utils.ts
+++ b/client/lib/url/http-utils.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { URL as TypedURL, SiteSlug } from 'types';
-import { Falsy } from 'utility-types';
+import { Falsey } from 'utility-types';
 
 const urlWithoutHttpRegex = /^https?:\/\//;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert back to `Falsey`, as `Falsy` isn't defined.

#### Testing instructions

Ensure the file compiles correctly with the TypeScript compiler.

Fixes issue introduced in #36938.