### PR TITLE
Adding PageViewTracker to Install theme

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -262,9 +262,11 @@ class Upload extends React.Component {
 			return this.renderNotAvailableForMultisite();
 		}
 
+		const title = translate( 'Themes > Install' );
+
 		return (
 			<Main>
-				<PageViewTracker path="/themes/upload/:site" title="Install Theme" />
+				<PageViewTracker path="/themes/upload/:site" title={ title } />
 				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -262,11 +262,9 @@ class Upload extends React.Component {
 			return this.renderNotAvailableForMultisite();
 		}
 
-		const title = translate( 'Themes > Install' );
-
 		return (
 			<Main>
-				<PageViewTracker path="/themes/upload/:site" title={ title } />
+				<PageViewTracker path="/themes/upload/:site" title="Themes > Install" />
 				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -21,6 +21,7 @@ import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 // Necessary for ThanksModal
 import QueryActiveTheme from 'components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
@@ -263,6 +264,7 @@ class Upload extends React.Component {
 
 		return (
 			<Main>
+				<PageViewTracker path="/themes/upload/:site" title="Install Theme" />
 				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding PageViewTracker to /themes/upload for reporting purposes.

#### Testing instructions

- Go to `/themes/upload/:site`
- Open Dev Console and using React Developer tools check a `PageViewTracker` component exists in the page:

![image](https://user-images.githubusercontent.com/538790/67282005-f3abac80-f4d0-11e9-8022-59ca9fbab160.png)

Fixes #
