### PR TITLE
Gutenboarding: update canvas styles

### DIFF
--- a/client/gutenboarding/components/header/index.tsx
+++ b/client/gutenboarding/components/header/index.tsx
@@ -17,7 +17,7 @@ interface Props {
 	toggleGeneralSidebar: () => void;
 }
 
-export function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
+export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
 	const { siteTitle, siteType } = useOnboardingState();
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/gutenboarding/gutenberg-styles/_animations.scss
+++ b/client/gutenboarding/gutenberg-styles/_animations.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable */
+
 @mixin edit-post__fade-in-animation($speed: 0.2s, $delay: 0s) {
 	animation: edit-post__fade-in-animation $speed ease-out $delay;
 	animation-fill-mode: forwards;

--- a/client/gutenboarding/gutenberg-styles/_breakpoints.scss
+++ b/client/gutenboarding/gutenberg-styles/_breakpoints.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable */
+
 /**
  * Breakpoints & Media Queries
  */

--- a/client/gutenboarding/gutenberg-styles/_colors.scss
+++ b/client/gutenboarding/gutenberg-styles/_colors.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable */
+
 /**
  * Colors
  */

--- a/client/gutenboarding/gutenberg-styles/_mixins.scss
+++ b/client/gutenboarding/gutenberg-styles/_mixins.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable */
+
 /**
  * Breakpoint mixins
  */
@@ -496,9 +498,7 @@
 				display: inline-block;
 				vertical-align: middle;
 				width: 16px;
-				/* stylelint-disable */
 				font: normal 30px/1 dashicons;
-				/* stylelint-enable */
 				speak: none;
 				-webkit-font-smoothing: antialiased;
 				-moz-osx-font-smoothing: grayscale;

--- a/client/gutenboarding/gutenberg-styles/_variables.scss
+++ b/client/gutenboarding/gutenberg-styles/_variables.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable */
+
 /**
  * Often re-used variables
  */

--- a/client/gutenboarding/gutenberg-styles/_z-index.scss
+++ b/client/gutenboarding/gutenberg-styles/_z-index.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable */
+
 // Stores a list of z-index values in a central location.  For clarity, when a
 // specific value is needed, add a comment explaining why (what other rules the
 // value is designed to work with).

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -14,10 +14,6 @@ import {
 import { Popover, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
-import '@wordpress/edit-post/build-style/style.css';
-import '@wordpress/components/build-style/style.css';
-import '@wordpress/block-editor/build-style/style.css';
-import '@wordpress/format-library/build-style/style.css';
 
 /**
  * Internal dependencies

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -15,6 +15,7 @@ import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useState } from 'react';
+import '@wordpress/components/build-style/style.css';
 
 /**
  * Internal dependencies

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -18,7 +18,7 @@ import '@wordpress/format-library';
 /**
  * Internal dependencies
  */
-import { Header } from 'gutenboarding/components/header';
+import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import Sidebar from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import '@wordpress/editor'; // This shouldn't be necessary
-
-import React, { useState } from 'react';
+import { __ } from '@wordpress/i18n';
 import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
@@ -14,6 +13,8 @@ import {
 import { Popover, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
+import classnames from 'classnames';
+import React, { useState } from 'react';
 
 /**
  * Internal dependencies
@@ -36,30 +37,48 @@ export function Gutenboard() {
 		updateIsEditorSidebarOpened( ! isEditorSidebarOpened );
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="gutenboarding">
-			<Header
-				isEditorSidebarOpened={ isEditorSidebarOpened }
-				toggleGeneralSidebar={ toggleGeneralSidebar }
-			/>
+		<div className="gutenboarding block-editor__container">
 			<SlotFillProvider>
 				<DropZoneProvider>
-					<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
-						<div className="gutenboarding__block-editor">
-							<BlockEditorKeyboardShortcuts />
-
+					<div
+						className={ classnames( 'edit-post-layout', {
+							'is-sidebar-opened': isEditorSidebarOpened,
+						} ) }
+					>
+						<Header
+							isEditorSidebarOpened={ isEditorSidebarOpened }
+							toggleGeneralSidebar={ toggleGeneralSidebar }
+						/>
+						<div className="edit-post-layout__content">
+							<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
+								<div className="gutenboarding__block-editor">
+									<BlockEditorKeyboardShortcuts />
+									<div
+										className="edit-post-visual-editor editor-styles-wrapper"
+										role="region"
+										aria-label={ __( 'Onboarding screen content' ) }
+										tabIndex="-1"
+									>
+										<WritingFlow>
+											<ObserveTyping>
+												<BlockList />
+											</ObserveTyping>
+										</WritingFlow>
+									</div>
+								</div>
+								<Popover.Slot />
+							</BlockEditorProvider>
+						</div>
+						<div>
 							<SettingsSidebar isActive={ isEditorSidebarOpened } />
 							<Sidebar.Slot />
-							<WritingFlow>
-								<ObserveTyping>
-									<BlockList />
-								</ObserveTyping>
-							</WritingFlow>
 						</div>
-						<Popover.Slot />
-					</BlockEditorProvider>
+					</div>
 				</DropZoneProvider>
 			</SlotFillProvider>
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -54,20 +54,18 @@ export function Gutenboard() {
 						/>
 						<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
 							<div className="edit-post-layout__content">
-								<div className="gutenboarding__block-editor">
-									<BlockEditorKeyboardShortcuts />
-									<div
-										className="edit-post-visual-editor editor-styles-wrapper"
-										role="region"
-										aria-label={ __( 'Onboarding screen content' ) }
-										tabIndex="-1"
-									>
-										<WritingFlow>
-											<ObserveTyping>
-												<BlockList />
-											</ObserveTyping>
-										</WritingFlow>
-									</div>
+								<BlockEditorKeyboardShortcuts />
+								<div
+									className="edit-post-visual-editor editor-styles-wrapper"
+									role="region"
+									aria-label={ __( 'Onboarding screen content' ) }
+									tabIndex="-1"
+								>
+									<WritingFlow>
+										<ObserveTyping>
+											<BlockList />
+										</ObserveTyping>
+									</WritingFlow>
 								</div>
 								<Popover.Slot />
 							</div>

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -51,8 +51,8 @@ export function Gutenboard() {
 							isEditorSidebarOpened={ isEditorSidebarOpened }
 							toggleGeneralSidebar={ toggleGeneralSidebar }
 						/>
-						<div className="edit-post-layout__content">
-							<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
+						<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
+							<div className="edit-post-layout__content">
 								<div className="gutenboarding__block-editor">
 									<BlockEditorKeyboardShortcuts />
 									<div
@@ -69,12 +69,12 @@ export function Gutenboard() {
 									</div>
 								</div>
 								<Popover.Slot />
-							</BlockEditorProvider>
-						</div>
-						<div>
-							<SettingsSidebar isActive={ isEditorSidebarOpened } />
-							<Sidebar.Slot />
-						</div>
+							</div>
+							<div>
+								<SettingsSidebar isActive={ isEditorSidebarOpened } />
+								<Sidebar.Slot />
+							</div>
+						</BlockEditorProvider>
 					</div>
 				</DropZoneProvider>
 			</SlotFillProvider>

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -1,5 +1,12 @@
 @import './gutenberg-styles/styles';
 
+// Override core variables: we don't have wp-admin header and sidebar in Calypso
+$admin-bar-height: 0;
+$admin-bar-height-big: 0;
+$admin-sidebar-width: 0;
+$admin-sidebar-width-big: 0;
+$admin-sidebar-width-collapsed: 0;
+
 // Section wrapper resets
 .is-section-gutenboarding {
 	background: $white;

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -37,7 +37,6 @@ $admin-sidebar-width-collapsed: 0;
 
 	// Gutenberg styles
 	@import '~@wordpress/edit-post/src/style.scss';
-	@import '~@wordpress/components/src/style.scss';
 	@import '~@wordpress/block-editor/src/style.scss';
 	@import '~@wordpress/format-library/src/style.scss';
 }

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -39,9 +39,6 @@ $admin-sidebar-width-collapsed: 0;
 	@import '~@wordpress/edit-post/src/style.scss';
 	@import '~@wordpress/components/src/style.scss';
 	@import '~@wordpress/block-editor/src/style.scss';
-	@import '~@wordpress/block-library/src/style.scss';
-	@import '~@wordpress/block-library/src/editor.scss';
-	@import '~@wordpress/block-library/src/theme.scss';
 	@import '~@wordpress/format-library/src/style.scss';
 }
 

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -13,6 +13,20 @@
 .gutenboarding {
 	@include reset;
 
+	// Reset some Calypso base styles
+	input[type='text'],
+	input[type='search'],
+	input[type='email'],
+	input[type='number'],
+	input[type='password'],
+	input[type='checkbox'],
+	input[type='radio'],
+	input[type='tel'],
+	input[type='url'],
+	textarea {
+		width: auto;
+	}
+
 	// Block editor styles
 	@import '~@wordpress/edit-post/src/style.scss';
 	@import '~@wordpress/components/src/style.scss';

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -1,5 +1,15 @@
 @import './gutenberg-styles/styles';
 
+// Section wrapper resets
+.is-section-gutenboarding {
+	background: $white;
+
+	.layout__content {
+		margin: 0;
+		padding: 0;
+	}
+}
+
 .gutenboarding {
 	@include reset;
 

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -2,6 +2,15 @@
 
 .gutenboarding {
 	@include reset;
+
+	// Block editor styles
+	@import '~@wordpress/edit-post/src/style.scss';
+	@import '~@wordpress/components/src/style.scss';
+	@import '~@wordpress/block-editor/src/style.scss';
+	@import '~@wordpress/block-library/src/style.scss';
+	@import '~@wordpress/block-library/src/editor.scss';
+	@import '~@wordpress/block-library/src/theme.scss';
+	@import '~@wordpress/format-library/src/style.scss';
 }
 
 .gutenboarding__block-editor *,

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -18,3 +18,16 @@
 .gutenboarding__block-editor ::before {
 	box-sizing: border-box;
 }
+
+// These are default block editor styles in case the theme doesn't provide them.
+.wp-block {
+	max-width: $content-width;
+
+	&[data-align='wide'] {
+		max-width: 1100px;
+	}
+
+	&[data-align='full'] {
+		max-width: none;
+	}
+}

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -7,7 +7,7 @@ $admin-sidebar-width: 0;
 $admin-sidebar-width-big: 0;
 $admin-sidebar-width-collapsed: 0;
 
-// Section wrapper resets
+// Calypso section wrapper resets
 .is-section-gutenboarding {
 	background: $white;
 
@@ -18,8 +18,6 @@ $admin-sidebar-width-collapsed: 0;
 }
 
 .gutenboarding {
-	@include reset;
-
 	// Reset some Calypso base styles
 	input[type='text'],
 	input[type='search'],
@@ -34,7 +32,10 @@ $admin-sidebar-width-collapsed: 0;
 		width: auto;
 	}
 
-	// Block editor styles
+	// Gutenberg reset
+	@include reset;
+
+	// Gutenberg styles
 	@import '~@wordpress/edit-post/src/style.scss';
 	@import '~@wordpress/components/src/style.scss';
 	@import '~@wordpress/block-editor/src/style.scss';

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -8,6 +8,7 @@ $admin-sidebar-width-big: 0;
 $admin-sidebar-width-collapsed: 0;
 
 // Calypso section wrapper resets
+// @TODO: maybe remove once Calypso main styles aren't loaded for Gutenboarding section.
 .is-section-gutenboarding {
 	background: $white;
 
@@ -19,6 +20,7 @@ $admin-sidebar-width-collapsed: 0;
 
 .gutenboarding {
 	// Reset some Calypso base styles
+	// @TODO: remove once Calypso main styles aren't loaded for Gutenboarding section.
 	input[type='text'],
 	input[type='search'],
 	input[type='email'],
@@ -32,7 +34,8 @@ $admin-sidebar-width-collapsed: 0;
 		width: auto;
 	}
 
-	// Gutenberg reset
+	// Gutenberg resets
+	// Not an actual "CSS reset", but an opiniated base style for HTML elements in Gutenberg views.
 	@include reset;
 
 	// Gutenberg styles

--- a/client/gutenboarding/style.scss
+++ b/client/gutenboarding/style.scss
@@ -44,12 +44,6 @@ $admin-sidebar-width-collapsed: 0;
 	@import '~@wordpress/format-library/src/style.scss';
 }
 
-.gutenboarding__block-editor *,
-.gutenboarding__block-editor ::after,
-.gutenboarding__block-editor ::before {
-	box-sizing: border-box;
-}
-
 // These are default block editor styles in case the theme doesn't provide them.
 .wp-block {
 	max-width: $content-width;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87168/67282920-615cd600-f4db-11e9-9346-c3687104fa29.png)


#### Changes proposed in this Pull Request

* Re-organises HTML structure for the editor to match more that of `edit-post` package in the core, because we're currently re-using some of the styles from it.
* Override some Calypso CSS for the section
* Add basic alignment styles for `wp-block`
* Import scss styles from core packages instead of CSS. This way they'll use sass variables that we can override.
* Change how `Header` is imported

#### Testing instructions

- Open `/gutenboarding` in development mode. Does it look more or less ok?
- No global styles leaking to elsewhere in Calypso?