### PR TITLE
Gutenboarding: Lock the editor

### DIFF
--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -10,6 +10,7 @@ import {
 	BlockList,
 	WritingFlow,
 	ObserveTyping,
+	EditorSettings,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
@@ -47,7 +48,14 @@ export function Gutenboard() {
 			/>
 			<SlotFillProvider>
 				<DropZoneProvider>
-					<BlockEditorProvider value={ [ onboardingBlock ] }>
+					<BlockEditorProvider
+						value={ [ onboardingBlock ] }
+						settings={
+							{ templateLock: 'all' } as Partial<
+								EditorSettings
+							> /* @FIXME: `templateLock` should be in EditorSettings */
+						}
+					>
 						<div className="gutenboarding__block-editor">
 							<BlockEditorKeyboardShortcuts />
 

--- a/client/gutenboarding/gutenboard.tsx
+++ b/client/gutenboarding/gutenboard.tsx
@@ -10,7 +10,6 @@ import {
 	BlockList,
 	WritingFlow,
 	ObserveTyping,
-	EditorSettings,
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
@@ -48,14 +47,7 @@ export function Gutenboard() {
 			/>
 			<SlotFillProvider>
 				<DropZoneProvider>
-					<BlockEditorProvider
-						value={ [ onboardingBlock ] }
-						settings={
-							{ templateLock: 'all' } as Partial<
-								EditorSettings
-							> /* @FIXME: `templateLock` should be in EditorSettings */
-						}
-					>
+					<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
 						<div className="gutenboarding__block-editor">
 							<BlockEditorKeyboardShortcuts />
 


### PR DESCRIPTION
The Gutenboarding editor should contain exactly 1 controlled block that cannot be removed. Use `templateLock: 'all'` to lock the editor canvas.

#### Testing instructions

* Visit `/gutenboarding` and ensure that the onboarding block cannot be removed.

