### PR TITLE
Blocks: Implement basic checkout to ProductSelector

### DIFF
--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -26,20 +26,6 @@ const products = [
 		},
 		optionsLabel: 'Backup options',
 	},
-	{
-		title: 'Jetpack Plan',
-		description: <Fragment>A Jetpack subscription of your choice.</Fragment>,
-		id: 'jetpack_plan',
-		options: {
-			yearly: [ 'jetpack_personal', 'jetpack_premium', 'jetpack_business' ],
-			monthly: [
-				'jetpack_personal_monthly',
-				'jetpack_premium_monthly',
-				'jetpack_business_monthly',
-			],
-		},
-		optionsLabel: 'Plan options',
-	},
 ];
 
 class ProductSelectorExample extends Component {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import page from 'page';
 import { connect } from 'react-redux';
 import { find, flattenDeep, flowRight as compose, includes, isEmpty, map, uniq } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -11,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ProductCard from 'components/product-card';
+import ProductCardAction from 'components/product-card/action';
 import ProductCardOptions from 'components/product-card/options';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
@@ -19,6 +21,7 @@ import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 
 export class ProductSelector extends Component {
@@ -98,10 +101,33 @@ export class ProductSelector extends Component {
 		} );
 	}
 
+	handleCheckoutForProduct = productObject => {
+		const { selectedSiteSlug } = this.props;
+
+		return () => {
+			page( '/checkout/' + selectedSiteSlug + '/' + productObject.product_slug );
+		};
+	};
+
 	handleProductOptionSelect( stateKey, productSlug ) {
 		this.setState( {
 			[ stateKey ]: productSlug,
 		} );
+	}
+
+	renderCheckoutButton( productObject ) {
+		const { translate } = this.props;
+
+		return (
+			<ProductCardAction
+				onClick={ this.handleCheckoutForProduct( productObject ) }
+				label={ translate( 'Upgrade to %(productName)s', {
+					args: {
+						productName: productObject.product_name,
+					},
+				} ) }
+			/>
+		);
 	}
 
 	renderProducts() {
@@ -129,14 +155,18 @@ export class ProductSelector extends Component {
 					subtitle={ this.getSubtitleByProduct( product ) }
 				>
 					{ ! purchase && (
-						<ProductCardOptions
-							optionsLabel={ product.optionsLabel }
-							options={ this.getProductOptions( product ) }
-							selectedSlug={ this.state[ stateKey ] }
-							handleSelect={ productSlug =>
-								this.handleProductOptionSelect( stateKey, productSlug )
-							}
-						/>
+						<Fragment>
+							<ProductCardOptions
+								optionsLabel={ product.optionsLabel }
+								options={ this.getProductOptions( product ) }
+								selectedSlug={ this.state[ stateKey ] }
+								handleSelect={ productSlug =>
+									this.handleProductOptionSelect( stateKey, productSlug )
+								}
+							/>
+
+							{ this.renderCheckoutButton( productObject ) }
+						</Fragment>
 					) }
 				</ProductCard>
 			);
@@ -191,6 +221,7 @@ const connectComponent = connect( ( state, { products, siteId } ) => {
 		productSlugs,
 		purchases: getSitePurchases( state, selectedSiteId ),
 		selectedSiteId,
+		selectedSiteSlug: getSiteSlug( state, selectedSiteId ),
 		storeProducts: filterByProductSlugs( availableProducts, productSlugs ),
 	};
 } );

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -42,6 +42,7 @@ import {
 	isFreeWordPressComDomain,
 	isGoogleApps,
 	isJetpackPlan,
+	isJetpackProduct,
 	isNoAds,
 	isPlan,
 	isBlogger,
@@ -151,6 +152,11 @@ export function cartItemShouldReplaceCart( cartItem, cart ) {
 
 	if ( isJetpackPlan( cartItem ) ) {
 		// adding a jetpack bundle should replace the cart
+		return true;
+	}
+
+	if ( isJetpackProduct( cartItem ) ) {
+		// adding a Jetpack product should replace the cart
 		return true;
 	}
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -778,6 +778,12 @@ export function conciergeSessionItem() {
 	};
 }
 
+export function jetpackProductItem( slug ) {
+	return {
+		product_slug: slug,
+	};
+}
+
 /**
  * Creates a new shopping cart item for the specified plan.
  *

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, difference, get, isEmpty, pick } from 'lodash';
+import { assign, difference, get, includes, isEmpty, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -199,6 +199,20 @@ export function isVipPlan( product ) {
 
 export function isJetpackMonthlyPlan( product ) {
 	return isMonthly( product ) && isJetpackPlan( product );
+}
+
+export function isJetpackProduct( product ) {
+	const jetpackProducts = [
+		'jetpack_backup_daily',
+		'jetpack_backup_realtime',
+		'jetpack_backup_daily_monthly',
+		'jetpack_backup_realtime_monthly',
+	];
+
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return includes( jetpackProducts, product.product_slug );
 }
 
 export function isMonthly( rawProduct ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -37,6 +37,7 @@ import {
 	hasPlan,
 	hasOnlyRenewalItems,
 	hasTransferProduct,
+	jetpackProductItem,
 } from 'lib/cart-values/cart-items';
 import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
@@ -293,6 +294,10 @@ export class Checkout extends React.Component {
 
 		if ( startsWith( this.props.product, 'concierge-session' ) ) {
 			cartItem = ! hasConciergeSession( cart ) && conciergeSessionItem();
+		}
+
+		if ( startsWith( this.props.product, 'jetpack_backup' ) ) {
+			cartItem = jetpackProductItem( this.props.product );
 		}
 
 		if ( cartItem ) {


### PR DESCRIPTION
This PR implements a basic support for Jetpack products to the cart and checkout, removes the second product from the devdocs example and implements a basic checkout functionality for the ProductSelector block, allowing for the user to checkout with a selected product option.

We need to follow-up with several things:
* Option names (reflected in the checkout button too) need to be shortened as per design.
* We need to add support for "upgrade" buttons when there is an upsell opportunity.

#### Changes proposed in this Pull Request

* Blocks: Remove Jetpack plans from ProductSelector example
* Cart: Add support for Jetpack product items.
* Checkout: Add support for Jetpack product items.
* Blocks: Implement basic checkout to ProductSelector

#### Preview
![](https://cldup.com/4i0HqItVju.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector
* Pick a Jetpack site without any Backup products purchased.
* Verify that the product you select gets added to the cart and you can see it in the checkout page.
* Verify you can purchase the selected Jetpack backup product.
* Now try after you've purchased the product.
* Verify you don't see the purchase button, just like you don't see the product options.
