### PR TITLE
Customer Home Styles Refactoring

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -182,7 +182,7 @@ class Home extends Component {
 		return (
 			<div className="customer-home__layout">
 				<SidebarNavigation />
-				<div className="customer-home__layout-col">
+				<div className="customer-home__layout-col customer-home__layout-col-left">
 					<Card>
 						<CardHeading>{ translate( 'My Site' ) }</CardHeading>
 						<h6 className="customer-home__card-subheader">
@@ -303,7 +303,7 @@ class Home extends Component {
 						</div>
 					</Card>
 				</div>
-				<div className="customer-home__layout-col">
+				<div className="customer-home__layout-col customer-home__layout-col-right">
 					<Card>
 						<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>
 						<h6 className="customer-home__card-subheader">

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -308,7 +308,7 @@ class Home extends Component {
 					</Card>
 				</div>
 				<div className="customer-home__layout-col customer-home__layout-col-right">
-					<Card>
+					<Card className="customer-home__grow-earn">
 						<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>
 						<h6 className="customer-home__card-subheader">
 							{ translate( 'Grow my audience and earn money' ) }
@@ -343,6 +343,8 @@ class Home extends Component {
 							<img
 								src="/calypso/images/customer-home/happiness.png"
 								alt={ translate( 'Support' ) }
+								height="119"
+								width="137"
 							/>
 							<VerticalNav className="customer-home__card-links">
 								<VerticalNavItem
@@ -362,20 +364,12 @@ class Home extends Component {
 							</VerticalNav>
 						</div>
 					</Card>
-					<Card>
+					<Card className="customer-home__go-mobile">
 						<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
 						<h6 className="customer-home__card-subheader">
 							{ translate( 'Make updates on the go' ) }
 						</h6>
 						<div className="customer-home__card-button-pair customer-home__card-mobile">
-							<AppsBadge
-								storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
-								storeName={ 'android' }
-								titleText={ translate( 'Download the WordPress Android mobile app.' ) }
-								altText={ translate( 'Google Play Store download badge' ) }
-							>
-								<img src="/calypso/images/customer-home/google-play.png" alt="" />
-							</AppsBadge>
 							<AppsBadge
 								storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
 								storeName={ 'ios' }
@@ -383,6 +377,14 @@ class Home extends Component {
 								altText={ translate( 'Apple App Store download badge' ) }
 							>
 								<img src="/calypso/images/customer-home/apple-store.png" alt="" />
+							</AppsBadge>
+							<AppsBadge
+								storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
+								storeName={ 'android' }
+								titleText={ translate( 'Download the WordPress Android mobile app.' ) }
+								altText={ translate( 'Google Play Store download badge' ) }
+							>
+								<img src="/calypso/images/customer-home/google-play.png" alt="" />
 							</AppsBadge>
 						</div>
 					</Card>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -188,31 +188,35 @@ class Home extends Component {
 						<h6 className="customer-home__card-subheader">
 							{ translate( 'Review and update my site' ) }
 						</h6>
-						<div className="customer-home__card-button-pair">
-							<Button
-								href={ site.URL }
-								primary
-								onClick={ () => trackAction( 'my_site', 'view_site' ) }
-							>
-								{ translate( 'View Site' ) }
-							</Button>
-							{ isStaticHomePage ? (
+						<div className="customer-home__card-col">
+							<div className="customer-home__card-col-left">
 								<Button
-									href={ editHomePageUrl }
-									onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
+									href={ site.URL }
+									primary
+									onClick={ () => trackAction( 'my_site', 'view_site' ) }
 								>
-									{ translate( 'Edit Homepage' ) }
+									{ translate( 'View Site' ) }
 								</Button>
-							) : (
-								<Button
-									onClick={ () => {
-										trackAction( 'my_site', 'write_post' );
-										page( `/post/${ siteSlug }` );
-									} }
-								>
-									{ translate( 'Write Blog Post' ) }
-								</Button>
-							) }
+							</div>
+							<div className="customer-home__card-col-right">
+								{ isStaticHomePage ? (
+									<Button
+										href={ editHomePageUrl }
+										onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
+									>
+										{ translate( 'Edit Homepage' ) }
+									</Button>
+								) : (
+									<Button
+										onClick={ () => {
+											trackAction( 'my_site', 'write_post' );
+											page( `/post/${ siteSlug }` );
+										} }
+									>
+										{ translate( 'Write Blog Post' ) }
+									</Button>
+								) }
+							</div>
 						</div>
 					</Card>
 					<Card className="customer-home__card-boxes">

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -95,7 +95,21 @@
 		}
 
 		@include breakpoint('>960px') {
-			width: 49%;
+			width: 50%;
+		}
+	}
+	&__layout-col-left {
+		@include breakpoint('>960px') {
+			.card {
+				margin-right: 8px;
+			}
+		}
+	}
+	&__layout-col-right {
+		@include breakpoint('>960px') {
+			.card {
+				margin-left: 8px;
+			}
 		}
 	}
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -9,7 +9,7 @@
 			min-height: 85px;
 			min-width: 100%;
 			padding: 24px;
-	    text-align: center;
+			text-align: center;
 		}
 		.button:hover {
 			box-shadow: 0 2px 3px 0 rgba( 98, 109, 118, 0.15 );
@@ -24,11 +24,11 @@
 			width: 50%;
 
 			.button {
-		    margin: 0 12px;
-		    min-height: 105px;
-		    min-width: 90%;
-		    padding: 30px 24px;
-		  }
+				margin: 0 12px;
+				min-height: 105px;
+				min-width: 90%;
+				padding: 30px 24px;
+			}
 		}
 	}
 	&__boxes {
@@ -88,7 +88,7 @@
 		}
 	}
 	&__card-mobile {
-	  justify-content: space-around;
+		justify-content: space-around;
 	}
 	&__card-subheader {
 		color: var( --color-text-subtle );

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,32 +1,34 @@
 .customer-home {
 	&__box-action {
-		margin-bottom: 6%;
-		width: 47%;
+		margin-bottom: 16px;
+		width: 100%;
 
 		.button {
-			align-items: center;
 			border-width: 1px;
-			display: flex;
-			flex-direction: column;
-			height: 100px;
-			justify-content: space-evenly;
-			padding: 1rem 0;
-			width: 100%;
-
-			img {
-				transition: transform 0.3s ease-out;
-			}
+			display: block;
+			min-height: 85px;
+			min-width: 100%;
+			padding: 24px;
+	    text-align: center;
 		}
 		.button:hover {
 			box-shadow: 0 2px 3px 0 rgba( 98, 109, 118, 0.15 );
-
-			img {
-				transform: scale( 1.2 );
-			}
 		}
 
 		span {
 			display: block;
+		}
+
+		@include breakpoint('>1280px') {
+			margin-bottom: 24px;
+			width: 50%;
+
+			.button {
+		    margin: 0 12px;
+		    min-height: 105px;
+		    min-width: 90%;
+		    padding: 30px 24px;
+		  }
 		}
 	}
 	&__boxes {
@@ -36,15 +38,53 @@
 	}
 	&__card-boxes {
 		margin-top: rem( -15px );
+		padding: 24px 24px 0;
+
+		@include breakpoint('>1280px') {
+			padding: 24px 12px 0;
+		}
 	}
-	&__card-button-pair {
-		align-items: center;
-		display: flex;
-		justify-content: space-between;
-		
+	&__card-col {
+		display: block;
+
 		.button {
-			width: 49%;
+			display: block;
 			text-align:center;
+			width: 100%;
+		}
+
+		@include breakpoint('>1040px') {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+
+			.button {
+				width: auto;
+			}
+		}
+	}
+	&__card-col-left {
+		margin-bottom: 16px;
+		width: 100%;
+
+		@include breakpoint('>1040px') {
+			margin-bottom: 0;
+			width: 50%;
+
+			.button {
+				margin-right: 12px;
+			}
+		}
+	}
+	&__card-col-right {
+		width: 100%;
+
+		@include breakpoint('>1040px') {
+			width: 50%;
+		
+			.button {
+				margin-left: 12px;
+			}
 		}
 	}
 	&__card-mobile {
@@ -77,7 +117,7 @@
 	}
 	&__layout-col {
 		.card-heading {
-			margin-top: 0;
+			margin-top: -8px;
 		}
 
 		.vertical-nav-item {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -19,7 +19,7 @@
 			display: block;
 		}
 
-		@include breakpoint('>1280px') {
+		@mixin box-action-two-col {
 			margin-bottom: 24px;
 			width: 50%;
 
@@ -29,6 +29,12 @@
 				min-width: 90%;
 				padding: 30px 24px;
 			}
+		}
+		@include breakpoint('>1280px') {
+			@include box-action-two-col;
+		}
+		@include breakpoint('800px-960px') {
+			@include box-action-two-col;
 		}
 	}
 	&__boxes {
@@ -43,6 +49,9 @@
 		@include breakpoint('>1280px') {
 			padding: 24px 12px 0;
 		}
+		@include breakpoint('800px-960px') {
+			padding: 24px 12px 0;
+		}
 	}
 	&__card-col {
 		display: block;
@@ -53,7 +62,7 @@
 			width: 100%;
 		}
 
-		@include breakpoint('>1040px') {
+		@mixin card-col-two-col {
 			align-items: center;
 			display: flex;
 			justify-content: space-between;
@@ -62,24 +71,47 @@
 				width: auto;
 			}
 		}
+		@include breakpoint('>1040px') {
+			@include card-col-two-col;
+		}
+		@include breakpoint('800px-960px') {
+			@include card-col-two-col;
+		}
 	}
-	&__card-col-left,
-	&__card-col-right {
+	&__card-col-left {
+		margin-bottom: 16px;
 		width: 100%;
 
-		@include breakpoint('>1040px') {
+		@mixin card-col-left-two-col {
+			margin-bottom: 0;
 			width: 50%;
 
 			.button {
 				margin-right: 12px;
 			}
 		}
-	}
-	&__card-col-left {
-		margin-bottom: 16px;
-
 		@include breakpoint('>1040px') {
-			margin-bottom: 0;
+			@include card-col-left-two-col;
+		}
+		@include breakpoint('800px-960px') {
+			@include card-col-left-two-col;
+		}
+	}
+	&__card-col-right {
+		width: 100%;
+
+		@mixin card-col-right-two-col {
+			width: 50%;
+
+			.button {
+				margin-left: 12px;
+			}
+		}
+		@include breakpoint('>1040px') {
+			@include card-col-right-two-col;
+		}
+		@include breakpoint('800px-960px') {
+			@include card-col-right-two-col;
 		}
 	}
 	&__card-mobile {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -63,12 +63,11 @@
 			}
 		}
 	}
-	&__card-col-left {
-		margin-bottom: 16px;
+	&__card-col-left,
+	&__card-col-right {
 		width: 100%;
 
 		@include breakpoint('>1040px') {
-			margin-bottom: 0;
 			width: 50%;
 
 			.button {
@@ -76,15 +75,11 @@
 			}
 		}
 	}
-	&__card-col-right {
-		width: 100%;
+	&__card-col-left {
+		margin-bottom: 16px;
 
 		@include breakpoint('>1040px') {
-			width: 50%;
-		
-			.button {
-				margin-left: 12px;
-			}
+			margin-bottom: 0;
 		}
 	}
 	&__card-mobile {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,110 +1,101 @@
-.customer-home__layout-col {
-	@include breakpoint('>960px') {
-		width: 49%;
-	}
-}
+.customer-home {
+	&__box-action {
+		margin-bottom: 6%;
+		width: 47%;
 
-.customer-home__card-subheader {
-	color: var( --color-text-subtle );
-	margin: -0.5rem 0 1rem;
-    font-size: 0.85rem;
-}
+		.button {
+			align-items: center;
+			border-width: 1px;
+			display: flex;
+			flex-direction: column;
+			height: 100px;
+			justify-content: space-evenly;
+			padding: 1rem 0;
+			width: 100%;
 
-.customer-home__layout {
-	@include breakpoint('>960px') {
-		display: flex;
-		justify-content: space-between;
-	}
-}
-
-.customer-home__card-button-pair {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-
-	.button {
-		width: 49%;
-		text-align:center;
-	}
-}
-
-.customer-home__card-boxes {
-	margin-top: rem( -15px );
-}
-
-.customer-home__boxes {
-	display: flex;
-	flex-flow: row wrap;
-	justify-content: space-between;
-}
-
-.customer-home__box-action {
-	width: 47%;
-    margin-bottom: 6%;
-
-	.button {
-		border-width: 1px;
-		display: flex;
-		width: 100%;
-		height: 100px;
-		align-items: center;
-		justify-content: space-evenly;
-		flex-direction: column;
-		padding: 1rem 0;
-
-		img {
-			transition: transform 0.3s ease-out;
+			img {
+				transition: transform 0.3s ease-out;
+			}
 		}
-
-		&:hover {
+		.button:hover {
 			box-shadow: 0 2px 3px 0 rgba( 98, 109, 118, 0.15 );
 
 			img {
 				transform: scale( 1.2 );
 			}
 		}
-	}
 
-	span {
-		display: block;
-	}
-}
-
-.customer-home__layout-col {
-	.card-heading {
-		margin-top: 0;
-	}
-
-	.vertical-nav-item {
-		border-bottom: 1px solid #ccc;
-		box-shadow: none;
-		padding: 0.5rem 0;
-
-		.gridicon {
-			right: 0;
+		span {
+			display: block;
 		}
 	}
-
-	a:last-child .vertical-nav-item {
-		border-bottom: none;
+	&__boxes {
+		display: flex;
+		flex-flow: row wrap;
+		justify-content: space-between;
 	}
-}
-
-.customer-home__card-support {
-	display: flex;
-	justify-content: space-between;
-
-	img {
-		width: 40%;
-		margin: 0 5%;
-		height: 100%;
+	&__card-boxes {
+		margin-top: rem( -15px );
 	}
-
-	.vertical-nav {
-		width: 50%;
+	&__card-button-pair {
+		align-items: center;
+		display: flex;
+		justify-content: space-between;
+		
+		.button {
+			width: 49%;
+			text-align:center;
+		}
 	}
-}
+	&__card-mobile {
+	  justify-content: space-around;
+	}
+	&__card-subheader {
+		color: var( --color-text-subtle );
+		font-size: 0.85rem;
+		margin: -0.5rem 0 1rem;
+	}
+	&__card-support {
+		display: flex;
+		justify-content: space-between;
 
-.customer-home__card-mobile {
-    justify-content: space-around;
+		img {
+			height: 100%;
+			margin: 0 5%;
+			width: 40%;
+		}
+
+		.vertical-nav {
+			width: 50%;
+		}
+	}
+	&__layout {
+		@include breakpoint('>960px') {
+			display: flex;
+			justify-content: space-between;
+		}
+	}
+	&__layout-col {
+		.card-heading {
+			margin-top: 0;
+		}
+
+		.vertical-nav-item {
+			border-bottom: 1px solid #ccc;
+			box-shadow: none;
+			padding: 0.5rem 0;
+
+			.gridicon {
+				right: 0;
+			}
+		}
+
+		a:last-child .vertical-nav-item {
+			border-bottom: none;
+		}
+
+		@include breakpoint('>960px') {
+			width: 49%;
+		}
+	}
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -100,14 +100,16 @@
 		justify-content: space-between;
 
 		img {
-			height: 100%;
-			margin: 0 5%;
-			width: 40%;
+			margin: 0 7%;
 		}
 
 		.vertical-nav {
 			width: 50%;
 		}
+	}
+	&__go-mobile,
+	&__grow-earn {
+		padding-bottom: 12px;
 	}
 	&__layout {
 		@include breakpoint('>960px') {
@@ -118,16 +120,6 @@
 	&__layout-col {
 		.card-heading {
 			margin-top: -8px;
-		}
-
-		.vertical-nav-item {
-			border-bottom: 1px solid #ccc;
-			box-shadow: none;
-			padding: 0.5rem 0;
-
-			.gridicon {
-				right: 0;
-			}
 		}
 
 		a:last-child .vertical-nav-item {
@@ -146,9 +138,36 @@
 		}
 	}
 	&__layout-col-right {
+		h6 {
+			margin-bottom: 6px;
+		}
+
+		.vertical-nav {
+			margin-top: 0;
+		}
+
+		.vertical-nav-item {
+			border-bottom: 1px solid var( --color-neutral-5 );
+			box-shadow: none;
+			padding: 12px 0;
+
+			.gridicon {
+				right: 0;
+			}
+		}
+
 		@include breakpoint('>960px') {
 			.card {
 				margin-left: 8px;
+			}
+
+			.card.vertical-nav-item {
+				margin-left: 0;
+			}
+		}
+		@include breakpoint('960px-1040px') {
+			.android-app-badge {
+				margin-left: -8px;
 			}
 		}
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request

There were a number of items that were visually off when compared to the [HTML prototype](https://codepen.io/lessbloat/pen/PMEwXE?editors=1100). Changes include:

- Refactored CSS in customer-home/styles.scss in https://github.com/Automattic/wp-calypso/commit/b7bbf154ba466a675dd53b23ab78a77350b224ef 
- Fixed layout column spacing in https://github.com/Automattic/wp-calypso/commit/4682a32a883f52ea1fb5f3d6b64e5fcc24a3d456
- Tightened up styles in left column in https://github.com/Automattic/wp-calypso/commit/21c0257e5fc4881b1d84fdc624274db7efca22f3
- Tightened up styles in right column in https://github.com/Automattic/wp-calypso/commit/7a90023d95939fa79395bcd406abd20164467556

## Preview

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/5634774/67293899-15963680-f4b3-11e9-9f4a-89469a4fc7f2.png) | ![after](https://user-images.githubusercontent.com/5634774/67294063-52fac400-f4b3-11e9-8e4f-884782f00eb2.png) |
