### PR TITLE
Update radios so that content appears inside radio border

### DIFF
--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -70,6 +70,7 @@ function PaymentMethod( { id, LabelComponent, PaymentMethodComponent, checked, o
 		<RadioButton
 			name="paymentMethod"
 			value={ id }
+			id={ id }
 			checked={ checked }
 			onChange={ onClick ? () => onClick( id ) : null }
 			label={ <LabelComponent /> }

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -73,10 +73,10 @@ function PaymentMethod( { id, LabelComponent, PaymentMethodComponent, checked, o
 				value={ id }
 				checked={ checked }
 				onChange={ onClick ? () => onClick( id ) : null }
+				label={ <LabelComponent /> }
 			>
-				<LabelComponent />
+				{ PaymentMethodComponent && <PaymentMethodComponent isActive={ checked } /> }
 			</RadioButton>
-			{ PaymentMethodComponent && <PaymentMethodComponent isActive={ checked } /> }
 		</React.Fragment>
 	);
 }

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -67,17 +67,15 @@ CheckoutPaymentMethods.propTypes = {
 
 function PaymentMethod( { id, LabelComponent, PaymentMethodComponent, checked, onClick } ) {
 	return (
-		<React.Fragment>
-			<RadioButton
-				name="paymentMethod"
-				value={ id }
-				checked={ checked }
-				onChange={ onClick ? () => onClick( id ) : null }
-				label={ <LabelComponent /> }
-			>
-				{ PaymentMethodComponent && <PaymentMethodComponent isActive={ checked } /> }
-			</RadioButton>
-		</React.Fragment>
+		<RadioButton
+			name="paymentMethod"
+			value={ id }
+			checked={ checked }
+			onChange={ onClick ? () => onClick( id ) : null }
+			label={ <LabelComponent /> }
+		>
+			{ PaymentMethodComponent && <PaymentMethodComponent isActive={ checked } /> }
+		</RadioButton>
 	);
 }
 

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -5,25 +5,16 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-const Label = styled.label`
+const RadioButtonWrapper = styled.div`
 	position: relative;
-	padding: 16px 14px;
 	margin-top: 8px;
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	align-items: center;
 	outline: ${getOutline};
 
 	:first-child {
 		margin: 0;
-	}
-
-	:hover {
-		cursor: pointer;
 	}
 
 	:before {
@@ -53,19 +44,24 @@ const Label = styled.label`
 `;
 
 const Radio = styled.input`
-	margin-right: 7px;
-	position: relative;
-	display: inline-block;
+	position: absolute;
 	opacity: 0;
 `;
 
-const LabelContent = styled.span`
-	flex: 1;
-	display: flex;
-	justify-content: space-between;
+const Label = styled.label`
 	position: relative;
-	font-size: 14px;
-	transform: translateY( -1px );
+	padding: 16px 14px 16px 40px;
+	border-radius: 3px;
+	box-sizing: border-box;
+	width: 100%;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+
+	:hover {
+		cursor: pointer;
+	}
 
 	:after {
 		display: block;
@@ -74,8 +70,9 @@ const LabelContent = styled.span`
 		content: '';
 		border: ${getRadioBorderWidth} solid ${getBorderColor};
 		border-radius: 100%;
-		top: 01px;
-		left: -23px;
+		top: 50%;
+		transform: translateY( -50% );
+		left: 16px;
 		position: absolute;
 		background: ${props => props.theme.colors.white};
 		box-sizing: border-box;
@@ -106,13 +103,14 @@ function getOutline( { isFocused, theme } ) {
 	return '0';
 }
 
-export default function RadioButton( { checked, name, value, onChange, children } ) {
+export default function RadioButton( { checked, name, value, onChange, children, label } ) {
 	const [ isFocused, changeFocus ] = useState( false );
 	return (
-		<Label isFocused={ isFocused } checked={ checked }>
+		<RadioButtonWrapper isFocused={ isFocused } checked={ checked }>
 			<Radio
 				type="radio"
 				name={ name }
+				id={ value }
 				value={ value }
 				checked={ checked }
 				onChange={ onChange }
@@ -124,13 +122,17 @@ export default function RadioButton( { checked, name, value, onChange, children 
 				} }
 				readOnly={ ! onChange }
 			/>
-			<LabelContent checked={ checked }>{ children }</LabelContent>
-		</Label>
+			<Label checked={ checked } htmlFor={ value }>
+				{ label }
+			</Label>
+			{ children }
+		</RadioButtonWrapper>
 	);
 }
 
 RadioButton.propTypes = {
 	name: PropTypes.string.isRequired,
+	label: PropTypes.node.isRequired,
 	checked: PropTypes.bool,
 	value: PropTypes.string.isRequired,
 	onChange: PropTypes.func,

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -58,6 +58,7 @@ const Label = styled.label`
 	flex-wrap: wrap;
 	justify-content: space-between;
 	align-items: center;
+	font-size: 14px;
 
 	:hover {
 		cursor: pointer;

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -104,14 +104,14 @@ function getOutline( { isFocused, theme } ) {
 	return '0';
 }
 
-export default function RadioButton( { checked, name, value, onChange, children, label } ) {
+export default function RadioButton( { checked, name, value, onChange, children, label, id } ) {
 	const [ isFocused, changeFocus ] = useState( false );
 	return (
 		<RadioButtonWrapper isFocused={ isFocused } checked={ checked }>
 			<Radio
 				type="radio"
 				name={ name }
-				id={ value }
+				id={ id }
 				value={ value }
 				checked={ checked }
 				onChange={ onChange }
@@ -123,7 +123,7 @@ export default function RadioButton( { checked, name, value, onChange, children,
 				} }
 				readOnly={ ! onChange }
 			/>
-			<Label checked={ checked } htmlFor={ value }>
+			<Label checked={ checked } htmlFor={ id }>
 				{ label }
 			</Label>
 			{ children }
@@ -133,6 +133,7 @@ export default function RadioButton( { checked, name, value, onChange, children,
 
 RadioButton.propTypes = {
 	name: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
 	label: PropTypes.node.isRequired,
 	checked: PropTypes.bool,
 	value: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Radio button component with cleaner, more semantic markup and visually displays the contents of the RadioButton component inside the radio borders. I will add the credit card fields and their styles in a separate PR. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/67294592-04015e80-f4b4-11e9-9d77-7496e0881595.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/67294551-f5b34280-f4b3-11e9-9911-52674f6d9493.png)


#### Testing instructions
Same at https://github.com/Automattic/wp-calypso/pull/36720
