### PR TITLE
Insert <ProductSelector /> above the plans grid on Plans page

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -1,6 +1,15 @@
-// products constants
+// Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
 export const PRODUCT_JETPACK_BACKUP_REALTIME = 'jetpack_backup_realtime';
 export const PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY = 'jetpack_backup_daily_monthly';
 export const PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY = 'jetpack_backup_realtime_monthly';
+
+export const JETPACK_BACKUP_PRODUCTS = [
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+];
+export const JETPACK_BACKUP_PRODUCTS_MONTHLY = [
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+];

--- a/client/lib/products/constants.js
+++ b/client/lib/products/constants.js
@@ -1,0 +1,6 @@
+// products constants
+export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
+export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
+export const PRODUCT_JETPACK_BACKUP_REALTIME = 'jetpack_backup_realtime';
+export const PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY = 'jetpack_backup_daily_monthly';
+export const PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY = 'jetpack_backup_realtime_monthly';

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import classNames from 'classnames';
@@ -28,12 +28,10 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 import {
+	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_BACKUP_PRODUCTS_MONTHLY,
 	PRODUCT_JETPACK_BACKUP,
-	PRODUCT_JETPACK_BACKUP_DAILY,
-	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-	PRODUCT_JETPACK_BACKUP_REALTIME,
-	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
-} from 'lib/products/constants';
+} from 'lib/products-values/constants';
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
 import WpcomFAQ from './wpcom-faq';
@@ -73,6 +71,25 @@ import { getSiteTypePropertyValue } from 'lib/signup/site-type';
  * Style dependencies
  */
 import './style.scss';
+
+// @todo: Add translations to `jetpackProducts` once the final copy is provided.
+const jetpackProducts = [
+	{
+		title: 'Jetpack Backup',
+		description: (
+			<p>
+				Automatic scanning and one-click fixes keep your site one step ahead of security threats.{' '}
+				<a href="https://jetpack.com/">More info</a>
+			</p>
+		),
+		id: PRODUCT_JETPACK_BACKUP,
+		options: {
+			yearly: JETPACK_BACKUP_PRODUCTS,
+			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
+		},
+		optionsLabel: 'Backup options',
+	},
+];
 
 export class PlansFeaturesMain extends Component {
 	componentDidUpdate( prevProps ) {
@@ -393,36 +410,17 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { intervalType, siteId, translate } = this.props;
-		const products = [
-			{
-				title: 'Jetpack Backup',
-				description: (
-					<p>
-						Automatic scanning and one-click fixes keep your site one step ahead of security
-						threats. <a href="https://jetpack.com/">More info</a>
-					</p>
-				),
-				id: PRODUCT_JETPACK_BACKUP,
-				options: {
-					yearly: [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_REALTIME ],
-					monthly: [
-						PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-						PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
-					],
-				},
-				optionsLabel: 'Backup options',
-			},
-		];
+		const { intervalType } = this.props;
 
+		// @todo: Add translations in FormattedHeader once the final copy is provided.
 		return (
-			<Fragment>
+			<div className="plans-features-main__group plans-features-main__group--narrow">
 				<FormattedHeader
-					headerText={ translate( 'Single Products' ) }
-					subHeaderText={ translate( 'Just looking for a backups? We’ve got you covered.' ) }
+					headerText="Single Products"
+					subHeaderText="Just looking for backups? We’ve got you covered."
 				/>
-				<ProductSelector products={ products } intervalType={ intervalType } siteId={ siteId } />
-			</Fragment>
+				<ProductSelector products={ jetpackProducts } intervalType={ intervalType } />
+			</div>
 		);
 	}
 
@@ -440,10 +438,10 @@ export class PlansFeaturesMain extends Component {
 				<div className="plans-features-main__notice" />
 				{ ! plansWithScroll && this.renderToggle() }
 				{ plansWithScroll && this.renderFreePlanBanner() }
-				{ this.renderProductsSelector() }
 				<QueryPlans />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
+				{ this.renderProductsSelector() }
 				{ this.getPlanFeatures() }
 				<CartData>
 					<PaymentMethods />

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -414,7 +414,7 @@ export class PlansFeaturesMain extends Component {
 
 		// @todo: Add translations in FormattedHeader once the final copy is provided.
 		return (
-			<div className="plans-features-main__group plans-features-main__group--narrow">
+			<div className="plans-features-main__group is-narrow">
 				<FormattedHeader
 					headerText="Single Products"
 					subHeaderText="Just looking for backups? We’ve got you covered."

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import classNames from 'classnames';
@@ -27,6 +27,13 @@ import {
 	GROUP_WPCOM,
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
+import {
+	PRODUCT_JETPACK_BACKUP,
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+} from 'lib/products/constants';
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
 import WpcomFAQ from './wpcom-faq';
@@ -48,6 +55,8 @@ import {
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import PaymentMethods from 'blocks/payment-methods';
+import ProductSelector from 'blocks/product-selector';
+import FormattedHeader from 'components/formatted-header';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import { getDiscountByName } from 'lib/discounts';
@@ -379,6 +388,44 @@ export class PlansFeaturesMain extends Component {
 		return false;
 	}
 
+	renderProductsSelector() {
+		if ( ! isEnabled( 'plans/jetpack-backup' ) ) {
+			return null;
+		}
+
+		const { intervalType, siteId, translate } = this.props;
+		const products = [
+			{
+				title: 'Jetpack Backup',
+				description: (
+					<p>
+						Automatic scanning and one-click fixes keep your site one step ahead of security
+						threats. <a href="https://jetpack.com/">More info</a>
+					</p>
+				),
+				id: PRODUCT_JETPACK_BACKUP,
+				options: {
+					yearly: [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_REALTIME ],
+					monthly: [
+						PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+						PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+					],
+				},
+				optionsLabel: 'Backup options',
+			},
+		];
+
+		return (
+			<Fragment>
+				<FormattedHeader
+					headerText={ translate( 'Single Products' ) }
+					subHeaderText={ translate( 'Just looking for a backups? We’ve got you covered.' ) }
+				/>
+				<ProductSelector products={ products } intervalType={ intervalType } siteId={ siteId } />
+			</Fragment>
+		);
+	}
+
 	render() {
 		const { displayJetpackPlans, isInSignup, siteId, plansWithScroll } = this.props;
 		let faqs = null;
@@ -393,6 +440,7 @@ export class PlansFeaturesMain extends Component {
 				<div className="plans-features-main__notice" />
 				{ ! plansWithScroll && this.renderToggle() }
 				{ plansWithScroll && this.renderFreePlanBanner() }
+				{ this.renderProductsSelector() }
 				<QueryPlans />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,11 +1,19 @@
-
+// Content group
 .plans-features-main__group {
-	@include breakpoint( '>1040px' ) {
+	& + & {
 		padding-top: 19px; // popular banner height adjustment
 	}
 
 	+ .faq {
 		margin-top: 20px;
+	}
+}
+
+.plans-features-main__group--narrow {
+	@include breakpoint( '>960px' ) {
+		max-width: 520px;
+		margin-left: auto;
+		margin-right: auto;
 	}
 }
 

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -7,13 +7,13 @@
 	+ .faq {
 		margin-top: 20px;
 	}
-}
 
-.plans-features-main__group--narrow {
-	@include breakpoint( '>960px' ) {
-		max-width: 520px;
-		margin-left: auto;
-		margin-right: auto;
+	&.is-narrow {
+		@include breakpoint( '>960px' ) {
+			max-width: 520px;
+			margin-left: auto;
+			margin-right: auto;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds a `<ProductSelector />` block to the Plans page. It creates a bunch of new constants which describe various Jetpack Backup product types/options.

#### Changes proposed in this Pull Request

* Insert `<ProductSelector />` above the plans grid on the Plans page
* Insert `<FormattedHeader />` above the new product selector block
* Add Jetpack Backup products constants
* Add minor CSS adjustments to the `<PlansFeaturesMain />` in order lay out `<ProductSelector />` block correctly.

#### Testing instructions

* Go to http://calypso.localhost:3000/plans/ and select one of your sites
* Confirm you can see the product selector along with the "Single Product" header above

Fixes n/a
