### PR TITLE
composite-checkout: add credit card fields to checkout package

### DIFF
--- a/packages/composite-checkout/demo/index.html
+++ b/packages/composite-checkout/demo/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Checkout Sample</title>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<style>
+		body {
+			margin: 0;
+			padding: 0;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+			-webkit-font-smoothing: antialiased;
+			-moz-osx-font-smoothing: grayscale;
+			background: #F3F4F5;
+		}
+	</style>
+</head>
+
+<body>
+	<div id="root"></div>
+	<noscript>
+		You need to enable JavaScript to run this app.
+	</noscript>
+	<script src="../dist/bundle.js"></script>
+</body>
+
+</html>

--- a/packages/composite-checkout/src/components/credit-card-fields.js
+++ b/packages/composite-checkout/src/components/credit-card-fields.js
@@ -11,10 +11,6 @@ import Field from './field';
 import GridRow from './grid-row';
 import { useLocalize } from '../lib/localize';
 
-/**
- * Styles
- */
-
 const CreditCardFieldsWrapper = styled.div`
 	padding: 16px;
 	position: relative;
@@ -53,10 +49,6 @@ const LockIconGraphic = styled.svg`
 	height: 17px;
 	display: block;
 `;
-
-/**
- * Component
- */
 
 export default function CreditCardFields() {
 	const localize = useLocalize();
@@ -99,7 +91,7 @@ export default function CreditCardFields() {
 	);
 }
 
-export function CVV( { className } ) {
+function CVV( { className } ) {
 	const localize = useLocalize();
 
 	return (
@@ -128,7 +120,7 @@ export function CVV( { className } ) {
 	);
 }
 
-export function LockIcon( { className } ) {
+function LockIcon( { className } ) {
 	return (
 		<LockIconGraphic
 			className={ className }

--- a/packages/composite-checkout/src/components/credit-card-fields.js
+++ b/packages/composite-checkout/src/components/credit-card-fields.js
@@ -1,0 +1,151 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import Field from './field';
+import GridRow from './grid-row';
+import { useLocalize } from '../lib/localize';
+
+/**
+ * Styles
+ */
+
+const CreditCardFieldsWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+
+	:after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${props => props.theme.colors.gray5};
+		position: absolute;
+		top: 0;
+		left: 3px;
+	}
+`;
+
+const CreditCardField = styled( Field )`
+	margin-top: 16px;
+
+	:first-child {
+		margin-top: 0;
+	}
+`;
+const FieldRow = styled( GridRow )`
+	margin-top: 16px;
+`;
+
+const CVVImage = styled( CVV )`
+	margin-top: 21px;
+	display: block;
+	width: 100%;
+`;
+
+const LockIconGraphic = styled.svg`
+	width: 17px;
+	height: 17px;
+	display: block;
+`;
+
+/**
+ * Component
+ */
+
+export default function CreditCardFields() {
+	const localize = useLocalize();
+
+	return (
+		<CreditCardFieldsWrapper>
+			<CreditCardField
+				id="creditCardNumber"
+				type="Number"
+				label={ localize( 'Card number' ) }
+				placeholder="1234 1234 1234 1234"
+				icon={ <LockIcon /> }
+				isIconVisible={ true }
+			/>
+			<FieldRow gap="4%" columnWidths="48% 48%">
+				<Field
+					id="expiryDate"
+					type="Number"
+					label={ localize( 'Expiry Date' ) }
+					placeholder="MM / YY"
+				/>
+				<GridRow gap="4%" columnWidths="67% 29%">
+					<Field
+						id="securityCode"
+						type="Number"
+						label={ localize( 'Security Code' ) }
+						placeholder="111"
+					/>
+					<CVVImage />
+				</GridRow>
+			</FieldRow>
+
+			<CreditCardField
+				id="cardholderName"
+				type="Text"
+				label={ localize( 'Cardholder name' ) }
+				description={ localize( 'Enter your name as it’s written on the card' ) }
+			/>
+		</CreditCardFieldsWrapper>
+	);
+}
+
+export function CVV( { className } ) {
+	const localize = useLocalize();
+
+	return (
+		<svg
+			className={ className }
+			width="68"
+			height="41"
+			viewBox="0 0 68 41"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-labelledby="cvv-image-title"
+			role="img"
+		>
+			<title id="cvv-image-title">
+				{ localize( 'An image of the back of the card where you find the security code' ) }
+			</title>
+			<rect x="0.919922" y="0.508789" width="67.0794" height="39.9263" rx="3" fill="#D7DADE" />
+			<rect x="0.919922" y="5.75043" width="67.0794" height="10.4828" fill="#23282D" />
+			<rect x="6.84361" y="21.3398" width="35.087" height="8.63682" fill="white" />
+			<path
+				d="M49.8528 23.2869C50.2903 23.2869 50.6262 23.4753 50.8606 23.8523C51.0969 24.2273 51.2151 24.7546 51.2151 25.4343C51.2151 26.0925 51.1008 26.615 50.8723 27.0017C50.6438 27.3865 50.3039 27.5789 49.8528 27.5789C49.4172 27.5789 49.0813 27.3914 48.845 27.0164C48.6086 26.6414 48.4905 26.114 48.4905 25.4343C48.4905 24.7742 48.6047 24.2517 48.8332 23.8669C49.0637 23.4802 49.4036 23.2869 49.8528 23.2869ZM49.8528 27.157C50.1418 27.157 50.3557 27.0203 50.4944 26.7468C50.635 26.4714 50.7053 26.0339 50.7053 25.4343C50.7053 24.8328 50.635 24.3962 50.4944 24.1248C50.3557 23.8513 50.1418 23.7146 49.8528 23.7146C49.5676 23.7146 49.3547 23.8542 49.2141 24.1335C49.0735 24.4128 49.0032 24.8464 49.0032 25.4343C49.0032 26.03 49.0725 26.4666 49.2112 26.7439C49.3518 27.0193 49.5657 27.157 49.8528 27.157ZM49.8411 24.9949C49.9641 24.9949 50.0676 25.0378 50.1516 25.1238C50.2375 25.2078 50.2805 25.3113 50.2805 25.4343C50.2805 25.5613 50.2375 25.6707 50.1516 25.7625C50.0657 25.8523 49.9622 25.8972 49.8411 25.8972C49.7219 25.8972 49.6194 25.8523 49.5334 25.7625C49.4495 25.6707 49.4075 25.5613 49.4075 25.4343C49.4075 25.3093 49.4485 25.2048 49.5305 25.1208C49.6145 25.0369 49.718 24.9949 49.8411 24.9949ZM54.5373 27.4998H52.2639V27.1511C52.8401 26.5085 53.2141 26.0779 53.386 25.8591C53.5579 25.6404 53.6975 25.4109 53.8049 25.1707C53.9123 24.9304 53.9661 24.6912 53.9661 24.4529C53.9661 24.2224 53.8957 24.0408 53.7551 23.908C53.6164 23.7751 53.4211 23.7087 53.1692 23.7087C52.9758 23.7087 52.7161 23.7683 52.3899 23.8875L52.3225 23.4744C52.6174 23.3494 52.926 23.2869 53.2483 23.2869C53.6174 23.2869 53.9143 23.3914 54.1389 23.6003C54.3655 23.8074 54.4788 24.0847 54.4788 24.4324C54.4788 24.6804 54.4202 24.9265 54.303 25.1707C54.1877 25.4148 54.0393 25.6492 53.8577 25.8738C53.676 26.0984 53.3225 26.5007 52.7971 27.0808H54.5373V27.4998ZM57.3235 25.2791C57.5754 25.3494 57.7776 25.4783 57.9299 25.6658C58.0823 25.8513 58.1584 26.0603 58.1584 26.2927C58.1584 26.656 58.0168 26.9617 57.7336 27.2097C57.4504 27.4558 57.1164 27.5789 56.7317 27.5789C56.4036 27.5789 56.1096 27.5066 55.8498 27.3621L55.9436 26.9666C56.2151 27.0935 56.4836 27.157 56.7493 27.157C56.9993 27.157 57.2122 27.0798 57.3879 26.9255C57.5657 26.7693 57.6545 26.5691 57.6545 26.325C57.6545 26.0847 57.5598 25.8894 57.3704 25.739C57.1809 25.5886 56.9299 25.5134 56.6174 25.5134H56.4914V25.1179H56.5266C56.8274 25.1179 57.0754 25.0476 57.2707 24.907C57.4661 24.7644 57.5637 24.573 57.5637 24.3328C57.5637 24.1375 57.4934 23.9851 57.3528 23.8757C57.2122 23.7644 57.0188 23.7087 56.7727 23.7087C56.5598 23.7087 56.3215 23.7664 56.0579 23.8816L55.9934 23.4685C56.259 23.3474 56.5266 23.2869 56.7961 23.2869C57.1653 23.2869 57.469 23.3845 57.7073 23.5798C57.9475 23.7732 58.0676 24.0222 58.0676 24.3269C58.0676 24.5378 57.9944 24.7351 57.8479 24.9187C57.7034 25.1003 57.5286 25.2146 57.3235 25.2615V25.2791Z"
+				fill="black"
+			/>
+			<rect x="44.7258" y="18.9998" width="17.4205" height="13.3329" stroke="#C9356E" />
+		</svg>
+	);
+}
+
+export function LockIcon( { className } ) {
+	return (
+		<LockIconGraphic
+			className={ className }
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			aria-hidden="true"
+		>
+			<g fill="none">
+				<path d="M0 0h24v24H0V0z" />
+				<path opacity=".87" d="M0 0h24v24H0V0z" />
+			</g>
+			<path
+				fill="#8E9196"
+				d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zM9 6c0-1.66 1.34-3 3-3s3 1.34 3 3v2H9V6zm9 14H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+			/>
+		</LockIconGraphic>
+	);
+}

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import Button from './button';
+
+const Label = styled.label`
+	display: block;
+	color: ${props => ( props.isError ? props.theme.colors.red50 : props.theme.colors.gray80 )};
+	font-weight: 700;
+	font-size: 14px;
+	margin-bottom: 8px;
+
+	:hover {
+		cursor: pointer;
+	}
+`;
+
+const Input = styled.input`
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	font-size: 16px;
+	border: 1px solid ${props => props.theme.colors.gray20};
+	padding: 12px ${props => ( props.icon ? '40px' : '10px' )} 12px 10px;
+
+	::-webkit-inner-spin-button,
+	::-webkit-outer-spin-button {
+		-webkit-appearance: none;
+	}
+
+	[type='number'],
+	[type='number'] {
+		-moz-appearance: none;
+		appearance: none;
+	}
+`;
+
+const InputWrapper = styled.div`
+	position: relative;
+`;
+
+const FieldIcon = styled.div`
+	position: absolute;
+	top: 50%;
+	transform: translateY( -50% );
+	right: 10px;
+`;
+
+const ButtonIconUI = styled.div`
+	position: absolute;
+	top: 0;
+	right: 0;
+
+	button {
+		border: 1px solid transparent;
+		box-shadow: none;
+	}
+
+	button:hover {
+		background: none;
+		border: 1px solid transparent;
+		box-shadow: none;
+
+		filter: brightness( 0 ) saturate( 100% ) invert( 35% ) sepia( 22% ) saturate( 3465% )
+			hue-rotate( 300deg ) brightness( 88% ) contrast( 98% );
+	}
+`;
+
+const Description = styled.p`
+	margin: 8px 0 0 0;
+	color: ${props => ( props.isError ? props.theme.colors.red50 : props.theme.colors.gray50 )};
+	font-style: italic;
+	font-size: 14px;
+`;
+
+function RenderedIcon( { icon, iconAction, isIconVisible } ) {
+	if ( ! isIconVisible ) {
+		return null;
+	}
+
+	if ( iconAction ) {
+		return (
+			<ButtonIconUI>
+				<Button onClick={ iconAction }>{ icon }</Button>
+			</ButtonIconUI>
+		);
+	}
+
+	if ( icon ) {
+		return <FieldIcon>{ icon }</FieldIcon>;
+	}
+
+	return null;
+}
+
+function RenderedDescription( { description, isError, errorMessage } ) {
+	if ( description || isError ) {
+		return <Description isError={ isError }>{ isError ? errorMessage : description }</Description>;
+	}
+	return null;
+}
+
+export default function Field( {
+	type,
+	id,
+	className,
+	isError,
+	onChange,
+	label,
+	value,
+	icon,
+	iconAction,
+	isIconVisible,
+	placeholder,
+	tabIndex,
+	description,
+	errorMessage,
+} ) {
+	const fieldOnChange = event => {
+		if ( onChange ) {
+			onChange( event.target.value );
+		}
+
+		return null;
+	};
+
+	const onBlurField = () => {
+		return null;
+	};
+
+	return (
+		<div className={ className }>
+			<Label htmlFor={ id } isError={ isError }>
+				{ label }
+			</Label>
+			<InputWrapper>
+				<Input
+					id={ id }
+					icon={ icon }
+					value={ value }
+					type={ type }
+					onChange={ fieldOnChange }
+					onBlur={ onBlurField }
+					placeholder={ placeholder }
+					tabIndex={ tabIndex }
+				/>
+				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
+			</InputWrapper>
+			<RenderedDescription
+				isError={ isError }
+				description={ description }
+				errorMessage={ errorMessage }
+			/>
+		</div>
+	);
+}

--- a/packages/composite-checkout/src/components/grid-row.js
+++ b/packages/composite-checkout/src/components/grid-row.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const Row = styled.div`
+	display: grid;
+	width: 100%;
+	grid-template-columns: ${props => props.columnWidths};
+	grid-column-gap: ${props => props.gap};
+	justify-items: stretch;
+`;
+
+export default function GridRow( { gap, columnWidths, className, children } ) {
+	return (
+		<Row gap={ gap } columnWidths={ columnWidths } className={ className }>
+			{ children }
+		</Row>
+	);
+}
+
+GridRow.propTypes = {
+	gap: PropTypes.string,
+	columnWidths: PropTypes.string,
+	className: PropTypes.string,
+	children: PropTypes.node,
+};

--- a/packages/composite-checkout/src/components/grid-row.js
+++ b/packages/composite-checkout/src/components/grid-row.js
@@ -22,8 +22,7 @@ export default function GridRow( { gap, columnWidths, className, children } ) {
 }
 
 GridRow.propTypes = {
-	gap: PropTypes.string,
-	columnWidths: PropTypes.string,
+	gap: PropTypes.string.required,
+	columnWidths: PropTypes.string.required,
 	className: PropTypes.string,
-	children: PropTypes.node,
 };

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalize } from '../../lib/localize';
+import { useCheckoutLineItems, renderDisplayValueMarkdown } from '../../index';
+import { BillingFormFields, FormField } from '../../components/basics';
+import Button from '../../components/button';
+
+export function ApplePayLabel() {
+	return (
+		<React.Fragment>
+			<span>Apple Pay</span>
+			<ApplePayIcon />
+		</React.Fragment>
+	);
+}
+
+export function ApplePayBillingForm( { setPaymentData, paymentData, isActive, isComplete } ) {
+	const localize = useLocalize();
+	if ( ! isActive && ! isComplete ) {
+		return null;
+	}
+	if ( ! isActive && isComplete ) {
+		return <ApplePayBillingFormSummary paymentData={ paymentData } />;
+	}
+	const { billingName = '', billingNameError = null } = paymentData || {};
+	const onChange = value => setPaymentData( { ...( paymentData || {} ), billingName: value } );
+	return (
+		<BillingFormFields>
+			<FormField
+				id="billingName"
+				type="Text"
+				label={ localize( 'Name' ) }
+				error={ billingNameError }
+				errorMessage={ localize( 'This is a required field' ) }
+				value={ billingName }
+				onChange={ onChange }
+			/>
+		</BillingFormFields>
+	);
+}
+
+export function ApplePaySubmitButton() {
+	const localize = useLocalize();
+	const [ , total ] = useCheckoutLineItems();
+	// TODO: we need to use a placeholder for the value so the localization string can be generic
+	const buttonString = localize(
+		`Pay ${ renderDisplayValueMarkdown( total.amount.displayValue ) }`
+	);
+	return (
+		<Button
+			onClick={ submitApplePayPayment }
+			buttonState="primary"
+			buttonType="apple-pay"
+			fullWidth
+		>
+			{ buttonString }
+		</Button>
+	);
+}
+
+function ApplePayBillingFormSummary( { paymentData } ) {
+	const { billingName = '' } = paymentData || {};
+	return <span>{ billingName }</span>;
+}
+
+function ApplePayIcon() {
+	return (
+		<svg
+			width="38"
+			height="16"
+			viewBox="0 0 38 16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M7.41541 2.16874C7.85525 1.626 8.15372 0.897268 8.075 0.152588C7.43114 0.184172 6.64544 0.571647 6.19055 1.11481C5.78212 1.57994 5.42062 2.33919 5.51486 3.05265C6.23762 3.1145 6.95971 2.69625 7.41541 2.16874Z"
+				fill="black"
+			/>
+			<path
+				d="M8.06647 3.19212C7.01685 3.13044 6.12441 3.77982 5.62317 3.77982C5.12164 3.77982 4.35406 3.2232 3.52387 3.2382C2.44331 3.25386 1.44069 3.8566 0.892353 4.81523C-0.235478 6.73296 0.594719 9.57763 1.69147 11.1395C2.22408 11.9122 2.86597 12.763 3.71175 12.7325C4.51087 12.7015 4.8241 12.222 5.79546 12.222C6.76612 12.222 7.04826 12.7325 7.89418 12.717C8.77142 12.7015 9.31985 11.9439 9.85246 11.1705C10.4635 10.2896 10.7136 9.43906 10.7293 9.39237C10.7136 9.3769 9.03775 8.74266 9.02221 6.84087C9.00639 5.24847 10.3379 4.49103 10.4006 4.44406C9.64866 3.34691 8.47379 3.2232 8.06647 3.19212Z"
+				fill="black"
+			/>
+			<path
+				d="M17.2059 1.03678C19.4872 1.03678 21.0758 2.58817 21.0758 4.84688C21.0758 7.11366 19.4545 8.67311 17.1487 8.67311H14.6228V12.6359H12.7979V1.03677H17.2059V1.03678ZM14.6228 7.16188H16.7168C18.3057 7.16188 19.21 6.31796 19.21 4.85494C19.21 3.39208 18.3057 2.55607 16.725 2.55607H14.6228V7.16188V7.16188Z"
+				fill="black"
+			/>
+			<path
+				d="M21.5527 10.2322C21.5527 8.7531 22.7016 7.84484 24.7387 7.73228L27.0851 7.59568V6.94464C27.0851 6.00413 26.4414 5.44147 25.3661 5.44147C24.3474 5.44147 23.7118 5.92367 23.5572 6.67936H21.895C21.9928 5.152 23.3126 4.02667 25.4311 4.02667C27.5088 4.02667 28.8368 5.11184 28.8368 6.80789V12.6356H27.1502V11.245H27.1096C26.6127 12.1855 25.5289 12.7803 24.4046 12.7803C22.7261 12.7803 21.5527 11.7514 21.5527 10.2322ZM27.0851 9.46864V8.80148L24.9747 8.93002C23.9237 9.00242 23.329 9.46058 23.329 10.184C23.329 10.9234 23.9482 11.4058 24.8933 11.4058C26.1236 11.4058 27.0851 10.5698 27.0851 9.46864Z"
+				fill="black"
+			/>
+			<path
+				d="M30.4291 15.7465V14.3398C30.5592 14.3719 30.8525 14.3719 30.9993 14.3719C31.814 14.3719 32.254 14.0344 32.5228 13.1663C32.5228 13.1501 32.6777 12.6518 32.6777 12.6438L29.5817 4.17947H31.488L33.6556 11.0603H33.688L35.8555 4.17947H37.7132L34.5027 13.0777C33.7697 15.1276 32.9223 15.7867 31.146 15.7867C30.9993 15.7867 30.5592 15.7706 30.4291 15.7465Z"
+				fill="black"
+			/>
+		</svg>
+	);
+}
+
+function submitApplePayPayment() {
+	alert( 'Thank you!' );
+}

--- a/packages/composite-checkout/src/lib/payment-methods/registered-methods.js
+++ b/packages/composite-checkout/src/lib/payment-methods/registered-methods.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { registerPaymentMethod } from '../../lib/payment-methods';
+import { ApplePayBillingForm, ApplePaySubmitButton, ApplePayLabel } from './apple-pay';
+import CreditCardFields from '../../components/credit-card-fields';
+
+export default function loadPaymentMethods() {
+	registerPaymentMethod( {
+		id: 'apple-pay',
+		LabelComponent: ApplePayLabel,
+		PaymentMethodComponent: () => null,
+		BillingContactComponent: ApplePayBillingForm,
+		SubmitButtonComponent: ApplePaySubmitButton,
+	} );
+
+	registerPaymentMethod( {
+		id: 'card',
+		LabelComponent: () => <span>Credit Card</span>,
+		PaymentMethodComponent: ( { isActive } ) => ( isActive ? <CreditCardFields /> : null ),
+		BillingContactComponent: ApplePayBillingForm, // TODO: replace this
+		SubmitButtonComponent: () => <button>Pay</button>,
+	} );
+
+	registerPaymentMethod( {
+		id: 'paypal',
+		LabelComponent: () => <span>PayPal</span>,
+		PaymentMethodComponent: () => null,
+		BillingContactComponent: ApplePayBillingForm, // TODO: replace this
+		SubmitButtonComponent: () => <button>Pay</button>,
+	} );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR stubs out the credit card fields for our checkout package. This PR depends on https://github.com/Automattic/wp-calypso/pull/36950 for some additional styling.

![image](https://user-images.githubusercontent.com/6981253/67303512-90b21980-f4c0-11e9-85fe-fa7acac99cda.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same at https://github.com/Automattic/wp-calypso/pull/36720
