### PR TITLE
composite-checkout: Make usePaymentMethodData global

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -530,7 +530,7 @@ A React Hook that will return an object containing all the information about the
 
 ### usePaymentMethodData()
 
-A React Hook that will return a two element array. The first element is an object representing the current state stored for the currently selected payment method (or null if none is selected). The second element is a function that will replace the state of the currently selected payment method (the function will be null if no payment method is selected).
+A React Hook that will return a two element array. It can be used to store and share data entered into the payment forms. The first element is an object representing the current state. The second element is a function that will replace the state.
 
 ### usePaymentMethodId()
 

--- a/packages/composite-checkout/src/lib/payment-methods/index.js
+++ b/packages/composite-checkout/src/lib/payment-methods/index.js
@@ -59,13 +59,7 @@ export function usePaymentMethod() {
 
 export function usePaymentMethodData() {
 	const { paymentMethodData, setPaymentMethodData } = useContext( CheckoutContext );
-	const paymentMethod = usePaymentMethod();
-	if ( ! paymentMethod ) {
-		return [ null, null ];
-	}
-	const setData = newData =>
-		setPaymentMethodData( { ...paymentMethodData, [ paymentMethod.id ]: newData } );
-	return [ paymentMethodData[ paymentMethod.id ], setData ];
+	return [ paymentMethodData, setPaymentMethodData ];
 }
 
 loadPaymentMethods();


### PR DESCRIPTION
In order for different payment methods to share data, this simplifies
the `usePaymentMethodData` hook so that its object is not separated by
payment method id (eg: if you enter billing data and then change the
payment method we might want to re-use some of that data in the new
billing form).
