### PR TITLE
Jetpack: NUX: Fix issue where partner plan provisions do not redirect correctly

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -288,7 +288,7 @@ export class JetpackAuthorize extends Component {
 		}
 
 		// If partner ID query param is set, then assume that the connection is from the Jetpack Start flow.
-		return partnerID;
+		return !! partnerID;
 	}
 
 	handleSignIn = () => {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -76,6 +76,7 @@ import {
 	isSiteBlacklistedError as isSiteBlacklistedSelector,
 } from 'state/jetpack-connect/selectors';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
+import getPartnerIdFromQuery from 'state/selectors/get-partner-id-from-query';
 
 /**
  * Constants
@@ -274,15 +275,15 @@ export class JetpackAuthorize extends Component {
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {
-		const { partnerSlug } = props;
-		const partnerRedirectFlag = config.isEnabled(
+		const { partnerSlug, partnerID } = props;
+		const pressableRedirectFlag = config.isEnabled(
 			'jetpack/connect-redirect-pressable-credential-approval'
 		);
 
 		// If the redirect flag is set, then we conditionally redirect the Pressable client to
 		// a credential approval screen. Otherwise, we need to redirect all other partners back
 		// to wp-admin.
-		return partnerRedirectFlag ? partnerSlug && 'pressable' !== partnerSlug : partnerSlug;
+		return pressableRedirectFlag ? partnerID && 'pressable' !== partnerSlug : partnerID;
 	}
 
 	handleSignIn = () => {
@@ -739,6 +740,7 @@ const connectComponent = connect(
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 			partnerSlug: getPartnerSlugFromQuery( state ),
+			partnerID: getPartnerIdFromQuery( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -75,8 +75,8 @@ import {
 	isRemoteSiteOnSitesList,
 	isSiteBlacklistedError as isSiteBlacklistedSelector,
 } from 'state/jetpack-connect/selectors';
-import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import getPartnerIdFromQuery from 'state/selectors/get-partner-id-from-query';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 /**
  * Constants

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -742,10 +742,10 @@ const connectComponent = connect(
 			isSiteBlacklisted: isSiteBlacklistedSelector( state ),
 			isVip: isVipSite( state, authQuery.clientId ),
 			mobileAppRedirect,
+			partnerID: getPartnerIdFromQuery( state ),
+			partnerSlug: getPartnerSlugFromQuery( state ),
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
-			partnerSlug: getPartnerSlugFromQuery( state ),
-			partnerID: getPartnerIdFromQuery( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -283,7 +283,12 @@ export class JetpackAuthorize extends Component {
 		// If the redirect flag is set, then we conditionally redirect the Pressable client to
 		// a credential approval screen. Otherwise, we need to redirect all other partners back
 		// to wp-admin.
-		return pressableRedirectFlag ? partnerID && 'pressable' !== partnerSlug : partnerID;
+		if ( pressableRedirectFlag ) {
+			return partnerID && 'pressable' !== partnerSlug;
+		}
+
+		// If partner ID query param is set, then assume that the connection is from the Jetpack Start flow.
+		return partnerID;
 	}
 
 	handleSignIn = () => {


### PR DESCRIPTION
This issue was originally reported by @brbrr in parMIr-jL-p2. 

To summarize that post. @brbrr was creating e2e testing based on the Jetpack Start flow that he observed. But, he noticed that the flow was not consistent. Specifically, there were some issues with redirects. The inconsistency that he reported was that sometimes a user would be redirected to the `/plans/$site` route after connecting and other times a user would be redirected back to a wp-admin login screen.

This was quite confusing to me, as the standard Jetpack Start flow sends the user back to wp-admin after approving the connection, logging the user in via SSO in the process.

After quite a bit of digging, and @brbrr helping me get setup with e2e testing, I was able to determine exactly what was happening:

- First, the e2e testing key wasn't whitelisted as a partner in Calypso. Therefore, the e2e tester didn't get automatically redirected to wp-admin as would be expected.
- Because of this, the user is initially redirected to the Jetpack Connect plans page (/jetpack/connect/plans)
- But, once the site receives a plan, which is done via a background job, and the site is refreshed in Calypso, the user is redirected to /plans/$site


Now that doesn't cover the issue where the user is sometimes directed directly to the `wp-login.php` screen. What I've been able to figure out for that, is that the issue happens when authorizing the connection fails for some reason. In that case, Jetpack Connect automatically attempts to refresh the connection by redirecting the user to their site, rebuilding the connection URL, and then redirecting the user to back to Jetpack Connect via that connection URL. I was able to determine this by noting the `connect_url_redirect=true` query arg in the `wp-login.php` URL that @brbrr shared with me.

I don't believe that this is an issue specifically with Jetpack Start, though I think it's _more_ of an issue because the user is not typically logged into their remote WordPress site when going through Jetpack Start. 

This PR seeks to fix the issue of the partner not being whitelisted, which will at least fix the redirect issues. To handle the `wp-login.php` issue that occasionally comes up, we'll likely need to look into that deeper if it is still an issue.

#### Changes proposed in this Pull Request

* Do not require that partner/client IDs exist in the switch in `getPartnerSlugFromQuery`. Instead, assume that if the `partner_id` query argument exists in the URL, that the request came from a partner, and instead redirect the user back to wp-admin.

#### Testing instructions

- Check out this patch
- `npm start` in Calypso
- On a fresh Jetpack site, perhaps using https://jurassic.ninja, attempt to connect Jetpack
- On the resulting Jetpack Connect URL that you end up on, replace `wordpress.com` with `calypso.localhost:3000`
- Add `&partner_id=67097` (the e2e testing partner ID)
- Reload the Jetpack Connect URL that we have modified
- Approve the connection
- Verify that you are redirected back to your `wp-admin`

To test the logic changes that are applicable for Pressable:

- Check out this patch
- `npm start` in Calypso
- Create a site in Pressable
- Go to "Settings" tab for that site in Pressable control panel
- Click "Activate" in Jetpack banner
- Click the link to finish activation, which should land you on a Jetpack Connect page
- Replace `wordpress.com` in the URL with `calypso.localhost:3000` and reload page
- Approve the connection
- Verify that you are redirected to a page that asks you to share credentials
