### PR TITLE
Analytics: fix unsaved settings alert after updating GA tracking id

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
-import { flowRight, isEqual, keys, omit, pick, isNaN } from 'lodash';
+import { flowRight, isEqual, isObjectLike, keys, omit, pick, isNaN } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
@@ -93,8 +93,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			// Compute the dirty fields by comparing the persisted and the current fields
 			const previousDirtyFields = this.props.dirtyFields;
 			/*eslint-disable eqeqeq*/
-			const nextDirtyFields = previousDirtyFields.filter(
-				field => ! ( currentFields[ field ] == persistedFields[ field ] )
+			const nextDirtyFields = previousDirtyFields.filter( field =>
+				isObjectLike( currentFields[ field ] )
+					? ! isEqual( currentFields[ field ], persistedFields[ field ] )
+					: ! ( currentFields[ field ] == persistedFields[ field ] )
 			);
 			/*eslint-enable eqeqeq*/
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prevent showing a "You have unsaved changes..." alert after the GA Tracking ID has already been saved.

When comparing current and previous values for settings fields using [`wrapSettingsForm`](https://github.com/Automattic/wp-calypso/pull/36976), use a deep comparison (`_.isEquals`) for object-like values, while maintaining the existing `==` comparison for other values.

According to https://github.com/Automattic/wp-calypso/pull/12006, the non-strict equality comparison is necessary because some settings might have values of different types that are still equivalent. However, the Google Analytics field value is an object (`{ code: 'UA-9999999-9' }`), so this comparison fails.

<img width="848" alt="Screen Shot 2019-10-22 at 22 11 46" src="https://user-images.githubusercontent.com/1699996/67354098-d6e79700-f519-11e9-8999-2a804bf8a49d.png">
<img width="452" alt="Screen Shot 2019-10-22 at 22 12 10" src="https://user-images.githubusercontent.com/1699996/67354100-d6e79700-f519-11e9-88ff-71e9bec06c3f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**GA Tracking ID**

* Visit `/marketing/traffic/{site}` in a site with a Business plan.
* Update the "Google Analytics Tracking ID" value and save the settings.
* Navigate to another page or reload the browser -- you should *not* see an alert that "You have unsaved changes".

**Other settings**

* Try updating and saving other settings on the page, as well as in the settings section.
* When navigating to another page or reloading the browser without saving a field, you should see an alert that "You have unsaved changes".
* When navigating to another page or reloading the browser after saving a field, you should not see that alert.
* Also check that you don't see any errors in the console.
* Note that the "Page Title Structure" settings don't currently trigger an alert.
