### PR TITLE
Editor IFrame - Add fall back to opening editor in full window if iframe load fails

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -230,13 +230,6 @@ export class WebPreviewContent extends Component {
 		}
 	};
 
-	setIframeLoaded = () => {
-		if ( ! this.state.loaded ) {
-			window.open( this.state.iframeUrl, '_blank' );
-			this.props.onClose();
-		}
-	};
-
 	render() {
 		const { translate } = this.props;
 
@@ -286,7 +279,7 @@ export class WebPreviewContent extends Component {
 							ref={ this.setIframeInstance }
 							className="web-preview__frame"
 							src="about:blank"
-							onLoad={ this.setIframeLoaded }
+							onLoad={ this.setLoaded }
 							title={ this.props.iframeTitle || translate( 'Preview' ) }
 						/>
 					</div>

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -233,6 +233,7 @@ export class WebPreviewContent extends Component {
 	setIframeLoaded = () => {
 		if ( ! this.state.loaded ) {
 			window.open( this.state.iframeUrl, '_blank' );
+			this.props.onClose();
 		}
 	};
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -232,7 +232,7 @@ export class WebPreviewContent extends Component {
 
 	setIframeLoaded = () => {
 		if ( ! this.state.loaded ) {
-			window.location.href = this.state.iframeUrl;
+			window.open( this.state.iframeUrl, '_blank' );
 		}
 	};
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -230,6 +230,12 @@ export class WebPreviewContent extends Component {
 		}
 	};
 
+	setIframeLoaded = () => {
+		if ( ! this.state.loaded ) {
+			window.location.href = this.state.iframeUrl;
+		}
+	};
+
 	render() {
 		const { translate } = this.props;
 
@@ -279,7 +285,7 @@ export class WebPreviewContent extends Component {
 							ref={ this.setIframeInstance }
 							className="web-preview__frame"
 							src="about:blank"
-							onLoad={ this.setLoaded }
+							onLoad={ this.setIframeLoaded }
 							title={ this.props.iframeTitle || translate( 'Preview' ) }
 						/>
 					</div>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -522,7 +522,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 	onIframeLoaded = ( iframeUrl: string ) => {
 		if ( ! this.successfulIframeLoad ) {
-			window.location.href = iframeUrl;
+			window.location.replace( iframeUrl );
 			return;
 		}
 		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -114,7 +114,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	mediaSelectPort: MessagePort | null = null;
 	revisionsPort: MessagePort | null = null;
 	templatePorts: [ T.PostId, MessagePort ][] = [];
-	successfullIframeLoad = false;
+	successfulIframeLoad = false;
 
 	componentDidMount() {
 		MediaStore.on( 'change', this.updateImageBlocks );
@@ -145,7 +145,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.iframeRef.current &&
 			this.iframeRef.current.contentWindow
 		) {
-			this.successfullIframeLoad = true;
+			this.successfulIframeLoad = true;
 			const { port1: iframePortObject, port2: transferredPortObject } = new MessageChannel();
 
 			this.iframePort = iframePortObject;
@@ -521,7 +521,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	};
 
 	onIframeLoaded = ( iframeUrl: string ) => {
-		if ( ! this.successfullIframeLoad ) {
+		if ( ! this.successfulIframeLoad ) {
 			window.location.href = iframeUrl;
 			return;
 		}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -114,6 +114,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	mediaSelectPort: MessagePort | null = null;
 	revisionsPort: MessagePort | null = null;
 	templatePorts: [ T.PostId, MessagePort ][] = [];
+	successfullIframeLoad = false;
 
 	componentDidMount() {
 		MediaStore.on( 'change', this.updateImageBlocks );
@@ -144,6 +145,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.iframeRef.current &&
 			this.iframeRef.current.contentWindow
 		) {
+			this.successfullIframeLoad = true;
 			const { port1: iframePortObject, port2: transferredPortObject } = new MessageChannel();
 
 			this.iframePort = iframePortObject;
@@ -518,6 +520,14 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			: `Block Editor > ${ postTypeText } > New`;
 	};
 
+	onIframeLoaded = ( iframeUrl: string ) => {
+		if ( ! this.successfullIframeLoad ) {
+			window.location.href = iframeUrl;
+			return;
+		}
+		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
+	};
+
 	render() {
 		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
 		const {
@@ -560,9 +570,9 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
 							// Iframe url needs to be kept in state to prevent editor reloading if frame_nonce changes
 							// in Jetpack sites
-							onLoad={ () =>
-								this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } )
-							}
+							onLoad={ () => {
+								this.onIframeLoaded( iframeUrl );
+							} }
 						/>
 					) }
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If load of editor into iframe fails due to cross origin issues, eg. if a Jetpack site is setting X-Frame-Options to same-origin at the web server level, then redirect editor to wp-admin

#### Testing instructions

*  Create a standard Jurassic Ninja site and connect it to your WordPress.com account.
* Activate the Hello Dolly plugin, and with the Plugin Editor, add this line to it: `add_action( 'init', 'send_frame_options_header', 99 );`
* Create or Edit a  post on your local Calypso install on `master`, and see the sad browser header failure.
* Switch to this branch.
* Create or Edit a post again, and see the redirect to wp-admin.
* Make sure that clicking browser back button after redirect to wp-admin editor does not end in a redirect loop.
Before:

![before-edit](https://user-images.githubusercontent.com/3629020/66975546-4fee8500-f0fb-11e9-86a8-76e699e77aa0.gif)

After:

![after-edit](https://user-images.githubusercontent.com/3629020/66975566-5bda4700-f0fb-11e9-9e85-964f713bc3ea.gif)
