### PR TITLE
Checkout: disable phone field

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -21,8 +21,6 @@ import InfoPopover from 'components/info-popover';
 import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
 import FormInputValidation from 'components/forms/form-input-validation';
-import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
-import { abtest } from 'lib/abtest';
 import { useStripe } from 'lib/stripe';
 
 const CardNumberElementWithValidation = withStripeElementValidation( CardNumberElement );
@@ -258,11 +256,6 @@ export class CreditCardFormFields extends React.Component {
 		isNewTransaction: false,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = { userSelectedPhoneCountryCode: '' };
-	}
-
 	createField = ( fieldName, componentClass, props ) => {
 		const errorMessage = this.props.getErrorMessage( fieldName ) || [];
 		return React.createElement(
@@ -315,11 +308,6 @@ export class CreditCardFormFields extends React.Component {
 		this.updateFieldValues( event.target.name, event.target.value );
 	};
 
-	handlePhoneFieldChange = ( { value, countryCode } ) => {
-		this.updateFieldValues( 'phone-number', value );
-		this.setState( { userSelectedPhoneCountryCode: countryCode } );
-	};
-
 	shouldRenderCountrySpecificFields() {
 		// The add/update card endpoints do not process Ebanx payment details
 		// so we only show Ebanx fields at checkout,
@@ -337,8 +325,6 @@ export class CreditCardFormFields extends React.Component {
 			'credit-card-form-fields__extras': true,
 			'ebanx-details-required': countryDetailsRequired,
 		} );
-		const shouldShowPhoneField =
-			! countryDetailsRequired && abtest( 'checkoutCollectPhoneNumber' ) === 'show';
 
 		return (
 			<div className="credit-card-form-fields">
@@ -392,42 +378,10 @@ export class CreditCardFormFields extends React.Component {
 							placeholder: ' ',
 						} )
 					) }
-
-					{ shouldShowPhoneField && (
-						<PhoneNumberField
-							countriesList={ countriesList }
-							onChange={ this.handlePhoneFieldChange }
-							createField={ this.createField }
-							countryCode={
-								this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' )
-							}
-							translate={ translate }
-						/>
-					) }
 				</div>
 			</div>
 		);
 	}
-}
-
-function PhoneNumberField( { countriesList, translate, createField, onChange, countryCode } ) {
-	const label = (
-		<React.Fragment>
-			{ translate( 'Phone Number' ) }
-			<span className="credit-card-form-fields__explainer">{ translate( 'Optional' ) }</span>
-		</React.Fragment>
-	);
-
-	return (
-		<React.Fragment>
-			{ createField( 'phone-number', FormPhoneMediaInput, {
-				onChange,
-				countriesList,
-				countryCode: countryCode || 'US',
-				label: label,
-			} ) }
-		</React.Fragment>
-	);
 }
 
 export default localize( CreditCardFormFields );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,16 +115,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	checkoutCollectPhoneNumber: {
-		datestamp: '20191007',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	verticalSuggestedThemes: {
 		datestamp: '20191011',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The phone field in checkout was introduced in #35750. The test has concluded, and we're now removing the field

#### Testing instructions

- Add a plan to your cart.
- Visit the checkout page and (if necessary) click the link to add a new card.
- From the "bug" icon in the lower right corner, select "ABTESTS" and make sure the `checkoutCollectPhoneNumber` test is not listed. 
- There should be no phone field in the credit card form
- Make sure checkout completes successfully with a test card like 5555 5555 5555 4444 (with store sandbox on).