### PR TITLE
Update CTA button label in HandleEmailedLinkForm to say 'Continue'

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -157,7 +157,7 @@ class HandleEmailedLinkForm extends React.Component {
 		const action = (
 			<Button primary disabled={ this.state.hasSubmitted } onClick={ this.handleSubmit }>
 				{ this.props.isImmediateLoginAttempt
-					? translate( 'Confirm Login' )
+					? translate( 'Confirm Login to WordPress.com' )
 					: translate( 'Continue to WordPress.com' ) }
 			</Button>
 		);

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -158,7 +158,7 @@ class HandleEmailedLinkForm extends React.Component {
 			<Button primary disabled={ this.state.hasSubmitted } onClick={ this.handleSubmit }>
 				{ this.props.isImmediateLoginAttempt
 					? translate( 'Confirm Login' )
-					: translate( 'Finish Login' ) }
+					: translate( 'Continue' ) }
 			</Button>
 		);
 

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -158,19 +158,17 @@ class HandleEmailedLinkForm extends React.Component {
 			<Button primary disabled={ this.state.hasSubmitted } onClick={ this.handleSubmit }>
 				{ this.props.isImmediateLoginAttempt
 					? translate( 'Confirm Login' )
-					: translate( 'Continue' ) }
+					: translate( 'Continue to WordPress.com' ) }
 			</Button>
 		);
 
 		let title;
 		if ( this.props.isManualRenewalImmediateLoginAttempt ) {
-			title = translate(
-				'Continue to WordPress.com to update your payment details and renew your subscription'
-			);
+			title = translate( 'Update your payment details and renew your subscription' );
 		} else {
 			title =
 				this.props.clientId === config( 'wpcom_signup_id' )
-					? translate( 'Continue to WordPress.com' )
+					? translate( 'Welcome back!' )
 					: translate( 'Continue to WordPress.com on your WordPress app' );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the CTA button label in `HandleEmailedLinkForm` to say `Continue` instead of `Finish Login` — p7DVsv-71C-p2#comment-23545

The button below previously said "Finish Login"

![image](https://user-images.githubusercontent.com/14988353/67367392-1ddc9780-f5c1-11e9-8fdc-51aed9cfd6eb.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing this is a little bit fiddly, but can be done with the following:

* Go to `http://calypso.localhost:3000/log-in/link` to request a log in link
* Open up your email and copy the URL for the `Log in to WordPress.com` CTA from your login email.
* From that URL, just take the string following `redirect_to=` and before you get to the `&sr=`. Take that string, and in a JavaScript console run `unescape( 'put-the-string-here' );`
* In the unescaped string, replace `https://wordpress.com/` with `http://calypso.localhost:3000/` and pop that into your browser window, and you should be taken to a page beginning with `http://calypso.localhost:3000/log-in/link/use?token=` that looks like the above screenshot.
