### PR TITLE
FSE: update template part translation string

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -172,7 +172,7 @@ const TemplateEdit = compose(
 						<Placeholder className="template-block__overlay">
 							{ navigateToTemplate && (
 								<div className="template-block__loading">
-									<Spinner /> { sprintf( __( 'Loading %s Editor' ), templateTitle ) }
+									<Spinner /> { sprintf( __( 'Loading editor for: %s' ), templateTitle ) }
 								</div>
 							) }
 							<Button


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Previously it was hard for translators to work with this, because template name could be anything, and it's not clear what translation to show depending on the gender of the variable.

props @akirk for pointing this out

#### Testing instructions

* Click on Edit button for Header and Footer on your test site.
* Verify that the transition text is now `Loading editor for: Header` or `Loading editor for: Footer`.
