### PR TITLE
Gutenboarding: Add wp-data to window

### DIFF
--- a/client/gutenboarding/devtools.ts
+++ b/client/gutenboarding/devtools.ts
@@ -1,0 +1,16 @@
+// Don't complain about window.wp.data types in our debug function
+declare const window: any;
+
+export const wpDataDebugMiddleware: PageJS.Callback = ( context, next ) => {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( typeof window === 'object' ) {
+			if ( ! window.wp ) {
+				window.wp = {};
+			}
+			if ( ! window.wp.data ) {
+				window.wp.data = require( '@wordpress/data' );
+			}
+		}
+	}
+	next();
+};

--- a/client/gutenboarding/devtools.ts
+++ b/client/gutenboarding/devtools.ts
@@ -1,5 +1,9 @@
+interface MagicWindow extends Window {
+	wp: undefined | Record< string, any >;
+}
+
 // Don't complain about window.wp.data types in our debug function
-declare const window: any;
+declare const window: undefined | MagicWindow;
 
 export const wpDataDebugMiddleware: PageJS.Callback = ( context, next ) => {
 	if ( process.env.NODE_ENV !== 'production' ) {

--- a/client/gutenboarding/index.ts
+++ b/client/gutenboarding/index.ts
@@ -9,6 +9,29 @@ import page from 'page';
 import { hideMasterbar, main, redirectIfNotEnabled } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
+// Don't complain about window.wp.data types in our debug function
+declare const window: any;
+
 export default function() {
-	page( '/gutenboarding', redirectIfNotEnabled, hideMasterbar, main, makeLayout, clientRender );
+	page(
+		'/gutenboarding',
+		redirectIfNotEnabled,
+		( context, next ) => {
+			if ( process.env.NODE_ENV !== 'production' ) {
+				if ( typeof window === 'object' ) {
+					if ( ! window.wp ) {
+						window.wp = {};
+					}
+					if ( ! window.wp.data ) {
+						window.wp.data = require( '@wordpress/data' );
+					}
+				}
+			}
+			next();
+		},
+		hideMasterbar,
+		main,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/gutenboarding/index.ts
+++ b/client/gutenboarding/index.ts
@@ -8,27 +8,13 @@ import page from 'page';
  */
 import { hideMasterbar, main, redirectIfNotEnabled } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
-
-// Don't complain about window.wp.data types in our debug function
-declare const window: any;
+import { wpDataDebugMiddleware } from './devtools';
 
 export default function() {
 	page(
 		'/gutenboarding',
 		redirectIfNotEnabled,
-		( context, next ) => {
-			if ( process.env.NODE_ENV !== 'production' ) {
-				if ( typeof window === 'object' ) {
-					if ( ! window.wp ) {
-						window.wp = {};
-					}
-					if ( ! window.wp.data ) {
-						window.wp.data = require( '@wordpress/data' );
-					}
-				}
-			}
-			next();
-		},
+		wpDataDebugMiddleware,
 		hideMasterbar,
 		main,
 		makeLayout,


### PR DESCRIPTION
Add `wp.data` to the window in non-production environments.

#### Testing instructions

* Calypso.live - no change. At https://calypso.live/gutenboarding?branch=add/gutenboarding-wp-debug you can't access `wp.data.select`
* Production - no change
* Local development: load `/gutenboarding` and type `wp.data.select('core/block-editor').getBlockCount()` in the console.