### PR TITLE
Restore wpcalypso badge colors

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -59,8 +59,8 @@
 			color: var( --color-warning-80 );
 		}
 		&.is-wpcalypso {
-			background-color: var( --color-green-5 );
-			color: var( --color-green-80 );
+			background-color: var( --studio-celadon-40 );
+			color: var( --studio-white );
 		}
 		&.is-dev {
 			background-color: var( --color-error );

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -54,22 +54,26 @@
 				transform: scale( 1.1 );
 			}
 		}
+
+		@mixin env-bug-style( $color-name ) {
+			background-color: var( --studio-#{ $color-name }-20 );
+			color: var( --studio-#{ $color-name }-90 );
+		}
+
 		&.is-staging {
-			background-color: var( --color-warning-20 );
-			color: var( --color-warning-80 );
+			@include env-bug-style( 'orange' );
 		}
 		&.is-wpcalypso {
-			background-color: var( --studio-celadon-40 );
-			color: var( --studio-white );
+			@include env-bug-style( 'celadon' );
 		}
 		&.is-dev {
-			background-color: var( --color-error );
-			color: var( --color-text-inverted );
+			@include env-bug-style( 'purple' );
 		}
 		&.is-horizon,
 		&.is-feedback {
-			background-color: var( --color-primary-light );
+			@include env-bug-style( 'blue' );
 		}
+
 		&.branch-name {
 			text-transform: inherit;
 			background-color: var( --color-neutral-70 );


### PR DESCRIPTION
`--color-green-*` css properties are no longer available. This results in a transparent environment bug on calypso.live and at wpcalypso.wordpress.com.

Update to similar (from memory) colors.

#### Before

![before staging](https://user-images.githubusercontent.com/841763/67508626-a7f43100-f691-11e9-9c4e-cb8ed471b101.png)
![before wpcalypso](https://user-images.githubusercontent.com/841763/67508629-a88cc780-f691-11e9-952d-8cf368e555b1.png)
![before horizon](https://user-images.githubusercontent.com/841763/67508627-a88cc780-f691-11e9-9a6f-9eab9a314b41.png)
![before dev](https://user-images.githubusercontent.com/841763/67508630-a88cc780-f691-11e9-83fd-2cc2fe9b2948.png)


#### After

![after staging](https://user-images.githubusercontent.com/841763/67508647-b0e50280-f691-11e9-8568-0083e469d34a.png)
![after wpcalypso](https://user-images.githubusercontent.com/841763/67508648-b17d9900-f691-11e9-919f-77cfbb9e67f2.png)
![after horizon](https://user-images.githubusercontent.com/841763/67508649-b17d9900-f691-11e9-8831-6972f8aba4f7.png)
![after dev](https://user-images.githubusercontent.com/841763/67508650-b17d9900-f691-11e9-9e6a-fc4b9852e9b7.png)


#### Testing instructions

* The environment bug here is transparent: http://wpcalypso.wordpress.com
* The environment bug on this branch has an appropriate color: https://calypso.live/?branch=update/wpcalypso-badge-color