### PR TITLE
 Split `resemblesUrl` in `lib/url`

### DIFF
--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -16,6 +16,7 @@ import { Falsey } from 'utility-types';
 export { addQueryArgs } from 'lib/route';
 export { withoutHttp, urlToSlug, urlToDomainAndPath } from './http-utils';
 export { default as isExternal } from './is-external';
+export { default as resemblesUrl } from './resembles-url';
 
 /**
  * Check if a URL is located outside of Calypso.
@@ -55,45 +56,6 @@ export function setUrlScheme( url: URL, scheme: Scheme ) {
 	}
 
 	return url.replace( schemeRegex, schemeWithSlashes );
-}
-
-/**
- * Checks if the supplied string appears to be a URL.
- * Looks only for the absolute basics:
- *  - does it have a .suffix?
- *  - does it have at least two parts separated by a dot?
- *
- * @param  query The string to check
- * @return       Does it appear to be a URL?
- */
-export function resemblesUrl( query: string ): boolean {
-	if ( ! query ) {
-		return false;
-	}
-
-	let parsedUrl = parseUrl( query );
-
-	// Make sure the query has a protocol - hostname ends up blank otherwise
-	if ( ! parsedUrl.protocol ) {
-		parsedUrl = parseUrl( 'http://' + query );
-	}
-
-	if ( ! parsedUrl.hostname || parsedUrl.hostname.indexOf( '.' ) === -1 ) {
-		return false;
-	}
-
-	// Check for a valid-looking TLD
-	if ( parsedUrl.hostname.lastIndexOf( '.' ) > parsedUrl.hostname.length - 3 ) {
-		return false;
-	}
-
-	// Make sure the hostname has at least two parts separated by a dot
-	const hostnameParts = parsedUrl.hostname.split( '.' ).filter( Boolean );
-	if ( hostnameParts.length < 2 ) {
-		return false;
-	}
-
-	return true;
 }
 
 /**

--- a/client/lib/url/resembles-url.ts
+++ b/client/lib/url/resembles-url.ts
@@ -1,0 +1,51 @@
+/**
+ * Checks if the supplied string appears to be a URL.
+ * Looks only for the absolute basics:
+ *  - does it have a .suffix?
+ *  - does it have at least two parts separated by a dot?
+ *
+ * @param  query The string to check
+ * @return       Does it appear to be a URL?
+ */
+export default function resemblesUrl( query: string ): boolean {
+	if ( ! query ) {
+		return false;
+	}
+
+	let parsedUrl;
+	try {
+		parsedUrl = new URL( query );
+	} catch {
+		// Do nothing.
+	}
+
+	// If we got an invalid URL, add a protocol and try again.
+	if ( parsedUrl === undefined ) {
+		try {
+			parsedUrl = new URL( 'http://' + query );
+		} catch {
+			// Do nothing.
+		}
+	}
+
+	if ( ! parsedUrl ) {
+		return false;
+	}
+
+	if ( ! parsedUrl.hostname || parsedUrl.hostname.indexOf( '.' ) === -1 ) {
+		return false;
+	}
+
+	// Check for a valid-looking TLD
+	if ( parsedUrl.hostname.lastIndexOf( '.' ) > parsedUrl.hostname.length - 3 ) {
+		return false;
+	}
+
+	// Make sure the hostname has at least two parts separated by a dot
+	const hostnameParts = parsedUrl.hostname.split( '.' ).filter( Boolean );
+	if ( hostnameParts.length < 2 ) {
+		return false;
+	}
+
+	return true;
+}

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -10,7 +10,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { addSchemeIfMissing, setUrlScheme, resemblesUrl, omitUrlParams } from '../';
+import { addSchemeIfMissing, setUrlScheme, omitUrlParams } from '../';
 
 describe( 'addSchemeIfMissing()', () => {
 	test( 'should add scheme if missing', () => {
@@ -58,48 +58,6 @@ describe( 'setUrlScheme()', () => {
 		const actual = setUrlScheme( source, 'http' );
 
 		expect( actual ).to.equal( expected );
-	} );
-} );
-
-describe( 'resemblesUrl()', () => {
-	test( 'should detect a URL', () => {
-		const source = 'http://example.com/path';
-		expect( resemblesUrl( source ) ).to.equal( true );
-	} );
-
-	test( 'should detect a URL without protocol', () => {
-		const source = 'example.com';
-		expect( resemblesUrl( source ) ).to.equal( true );
-	} );
-
-	test( 'should detect a URL with a query string', () => {
-		const source = 'http://example.com/path?query=banana&query2=pineapple';
-		expect( resemblesUrl( source ) ).to.equal( true );
-	} );
-
-	test( 'should detect a URL with a short suffix', () => {
-		const source = 'http://example.cc';
-		expect( resemblesUrl( source ) ).to.equal( true );
-	} );
-
-	test( 'should return false with adjacent dots', () => {
-		const source = '..com';
-		expect( resemblesUrl( source ) ).to.equal( false );
-	} );
-
-	test( 'should return false with spaced dots', () => {
-		const source = '. . .com';
-		expect( resemblesUrl( source ) ).to.equal( false );
-	} );
-
-	test( 'should return false with a single dot', () => {
-		const source = '.';
-		expect( resemblesUrl( source ) ).to.equal( false );
-	} );
-
-	test( 'should return false if the string is not a URL', () => {
-		const source = 'exampledotcom';
-		expect( resemblesUrl( source ) ).to.equal( false );
 	} );
 } );
 

--- a/client/lib/url/test/resembles-url.js
+++ b/client/lib/url/test/resembles-url.js
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import resemblesUrl from '../resembles-url';
+
+describe( 'resemblesUrl()', () => {
+	test( 'should detect a URL', () => {
+		const source = 'http://example.com/path';
+		expect( resemblesUrl( source ) ).toBe( true );
+	} );
+
+	test( 'should detect a URL without protocol', () => {
+		const source = 'example.com';
+		expect( resemblesUrl( source ) ).toBe( true );
+	} );
+
+	test( 'should detect a URL with a query string', () => {
+		const source = 'http://example.com/path?query=banana&query2=pineapple';
+		expect( resemblesUrl( source ) ).toBe( true );
+	} );
+
+	test( 'should detect a URL with a short suffix', () => {
+		const source = 'http://example.cc';
+		expect( resemblesUrl( source ) ).toBe( true );
+	} );
+
+	test( 'should return false with adjacent dots', () => {
+		const source = '..com';
+		expect( resemblesUrl( source ) ).toBe( false );
+	} );
+
+	test( 'should return false with spaced dots', () => {
+		const source = '. . .com';
+		expect( resemblesUrl( source ) ).toBe( false );
+	} );
+
+	test( 'should return false with a single dot', () => {
+		const source = '.';
+		expect( resemblesUrl( source ) ).toBe( false );
+	} );
+
+	test( 'should return false if the string is not a URL', () => {
+		const source = 'exampledotcom';
+		expect( resemblesUrl( source ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
This is one of several PRs aiming at splitting up `lib/url` into several files for tree-shaking, replacing usage of the browserified node `url` module with native functionality, and generally improving it.

This PR focuses on `resemblesUrl`, which I'm splitting into its own module and reimplementing using native functionality.

This PR was split out from #36531, which got too big.

#### Changes proposed in this Pull Request

* Split out `resemblesUrl` in `lib/url`. Reimplement using native functionality.
* Split out corresponding tests into their own file too. Drop `chai` and use `jest` expectations exclusively.

#### Testing instructions

The unit tests for this method are pretty extensive, so they should be enough in ensuring that there are no undesirable behaviour changes.