### PR TITLE
Update FormattedHeader to support compact layout on mobile

### DIFF
--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -3,7 +3,7 @@ FormattedHeader (JSX)
 
 This component displays a header and optional sub-header.
 
-When the `responsive` flag is set, the header renders in a compact way on smaller screen sizes.
+When the `compactOnMobile` flag is set, the header renders in a compact way on smaller screen sizes.
 
 #### How to use:
 
@@ -25,4 +25,4 @@ render() {
 * `id` (`string`) - ID for the header (optional)
 * `headerText` (`string`) - The main header text
 * `subHeaderText` (`node`) - Sub header text (optional)
-* `responsive` (`bool`) - Flag indicating the header should be responsive (optional)
+* `compactOnMobile` (`bool`) - Display a compact header on small screens (optional)

--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -3,6 +3,8 @@ FormattedHeader (JSX)
 
 This component displays a header and optional sub-header.
 
+When the `responsive` flag is set, the header renders in a compact way on smaller screen sizes.
+
 #### How to use:
 
 ```js
@@ -23,3 +25,4 @@ render() {
 * `id` (`string`) - ID for the header (optional)
 * `headerText` (`string`) - The main header text
 * `subHeaderText` (`node`) - Sub header text (optional)
+* `responsive` (`bool`) - Flag indicating the header should be responsive (optional)

--- a/client/components/formatted-header/docs/example.jsx
+++ b/client/components/formatted-header/docs/example.jsx
@@ -24,7 +24,7 @@ export default class FormattedHeaderExample extends PureComponent {
 				<FormattedHeader
 					headerText="This is the responsive header."
 					subHeaderText="This is the optional subheader."
-					responsive
+					compactOnMobile
 				/>
 			</Fragment>
 		);

--- a/client/components/formatted-header/docs/example.jsx
+++ b/client/components/formatted-header/docs/example.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 
 /**
  * Internal dependencies
@@ -16,10 +16,17 @@ export default class FormattedHeaderExample extends PureComponent {
 
 	render() {
 		return (
-			<FormattedHeader
-				headerText="This is the header."
-				subHeaderText="This is the optional subheader."
-			/>
+			<Fragment>
+				<FormattedHeader
+					headerText="This is the header."
+					subHeaderText="This is the optional subheader."
+				/>
+				<FormattedHeader
+					headerText="This is the responsive header."
+					subHeaderText="This is the optional subheader."
+					responsive
+				/>
+			</Fragment>
 		);
 	}
 }

--- a/client/components/formatted-header/docs/example.jsx
+++ b/client/components/formatted-header/docs/example.jsx
@@ -22,7 +22,7 @@ export default class FormattedHeaderExample extends PureComponent {
 					subHeaderText="This is the optional subheader."
 				/>
 				<FormattedHeader
-					headerText="This is the responsive header."
+					headerText="This is the compact on mobile header."
 					subHeaderText="This is the optional subheader."
 					compactOnMobile
 				/>

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -18,10 +18,10 @@ import { preventWidows } from 'lib/formatting';
  */
 import './style.scss';
 
-function FormattedHeader( { id, headerText, subHeaderText, className, responsive } ) {
+function FormattedHeader( { id, headerText, subHeaderText, className, compactOnMobile } ) {
 	const classes = classNames( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
-		'is-responsive': responsive,
+		'is-compact-on-mobile': compactOnMobile,
 	} );
 
 	return (
@@ -37,7 +37,7 @@ function FormattedHeader( { id, headerText, subHeaderText, className, responsive
 FormattedHeader.propTypes = {
 	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
-	responsive: PropTypes.bool,
+	compactOnMobile: PropTypes.bool,
 };
 
 export default FormattedHeader;

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -18,9 +18,10 @@ import { preventWidows } from 'lib/formatting';
  */
 import './style.scss';
 
-function FormattedHeader( { id, headerText, subHeaderText, className } ) {
+function FormattedHeader( { id, headerText, subHeaderText, className, responsive } ) {
 	const classes = classNames( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
+		'is-responsive': responsive,
 	} );
 
 	return (
@@ -36,6 +37,7 @@ function FormattedHeader( { id, headerText, subHeaderText, className } ) {
 FormattedHeader.propTypes = {
 	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
+	responsive: PropTypes.bool,
 };
 
 export default FormattedHeader;

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -37,8 +37,8 @@
 	}
 }
 
-// Responsive header
-.formatted-header.is-responsive {
+// Compact header on small screens
+.formatted-header.is-compact-on-mobile {
 	@include breakpoint( '<660px' ) {
 		text-align: left;
 

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -36,3 +36,20 @@
 		padding: 0 20px 24px;
 	}
 }
+
+// Responsive header
+.formatted-header.is-responsive {
+	@include breakpoint( '<660px' ) {
+		text-align: left;
+
+		.formatted-header__title {
+			font-size: 17px;
+			font-weight: 600;
+			padding: 0 24px;
+		}
+
+		.formatted-header__subtitle {
+			padding: 0 24px 12px;
+		}
+	}
+}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -418,7 +418,7 @@ export class PlansFeaturesMain extends Component {
 				<FormattedHeader
 					headerText="Single Products"
 					subHeaderText="Just looking for backups? We’ve got you covered."
-					responsive
+					compactOnMobile
 				/>
 				<ProductSelector products={ jetpackProducts } intervalType={ intervalType } />
 			</div>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -418,6 +418,7 @@ export class PlansFeaturesMain extends Component {
 				<FormattedHeader
 					headerText="Single Products"
 					subHeaderText="Just looking for backups? We’ve got you covered."
+					responsive
 				/>
 				<ProductSelector products={ jetpackProducts } intervalType={ intervalType } />
 			</div>


### PR DESCRIPTION
So far the `<FormattedHeader />` displayed in almost the same way no matter what the screen size is. This PR adds a `compactOnMobile ` flag to the component so that it can be rendered in a compact way on smaller screen sizes.

We need that in order to implement new Jetpack single products.

**Larger screen sizes:**

![Screenshot 2019-10-23 at 14 39 30](https://user-images.githubusercontent.com/478735/67393593-fecf0d00-f5a2-11e9-9408-c680d71e67bc.png)

**Small screens:**

![Screenshot 2019-10-23 at 14 39 37](https://user-images.githubusercontent.com/478735/67393587-fd054980-f5a2-11e9-99fa-7dc8de5b846c.png)

#### Changes proposed in this Pull Request

* Add `compactOnMobile ` flag to the `<FormattedHeader />`
* Update docs and example file
* Use new responsive header in the `<PlansFeaturesMain />` component

#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/plans/ and select one of you Jetpack sites
* Observe if the formatted header ("Single Products") changes its layout and font size based on the screen size

Fixes n/a