### PR TITLE
Products: Update isJetpackProduct to use the product constants

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -8,6 +8,7 @@ import { assign, difference, get, includes, isEmpty, pick } from 'lodash';
 /**
  * Internal dependencies
  */
+import { JETPACK_BACKUP_PRODUCTS } from './constants';
 import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -202,12 +203,7 @@ export function isJetpackMonthlyPlan( product ) {
 }
 
 export function isJetpackProduct( product ) {
-	const jetpackProducts = [
-		'jetpack_backup_daily',
-		'jetpack_backup_realtime',
-		'jetpack_backup_daily_monthly',
-		'jetpack_backup_realtime_monthly',
-	];
+	const jetpackProducts = [ ...JETPACK_BACKUP_PRODUCTS ];
 
 	product = formatProduct( product );
 	assertValidProduct( product );


### PR DESCRIPTION
This is a follow-up to https://github.com/Automattic/wp-calypso/pull/36988/files/ab88680fd1b8677cfc273351afb5ab8709c9feec#diff-199e3967ae413c2ff48db966abbf8386 and an enhancement to `isJetpackProduct` to use the existing product constants we introduced recently.

#### Changes proposed in this Pull Request

* Products: Update isJetpackProduct to use the product constants

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/checkout/:site/jetpack_backup_daily
* Verify you can still purchase a plan properly.
