### PR TITLE
Product Select: Add placeholder

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -130,7 +130,16 @@ export class ProductSelector extends Component {
 		const { currencyCode, intervalType, products, storeProducts } = this.props;
 
 		if ( isEmpty( storeProducts ) ) {
-			return null;
+			return map( products, product => {
+				return (
+					<ProductCard
+						key={ product.id }
+						title={ product.title }
+						isPlaceholder={ true }
+						description={ product.description ? product.description : null }
+					/>
+				);
+			} );
 		}
 
 		return map( products, product => {
@@ -145,7 +154,7 @@ export class ProductSelector extends Component {
 					title={ product.title }
 					billingTimeFrame={ this.getBillingTimeFrameLabel() }
 					fullPrice={ productObject.cost }
-					description={ <p>{ product.description }</p> }
+					description={ product.description }
 					currencyCode={ currencyCode }
 					purchase={ purchase }
 					subtitle={ this.getSubtitleByProduct( product ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The current Product Select Block doesn't have a place holder yet.
This PR add a place holder. 

#### Testing instructions
* Navigate to the plans page http://calypso.localhost:3000/plans 
of a Jetpack site.
* Clear the local strorage with `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` 
* Reload the page
* Notice the placeholders Do they look as expected.

The placeholder should look like this.
![Screen Shot 2019-10-23 at 3 52 27 PM](https://user-images.githubusercontent.com/115071/67399896-2dea7c00-f5ad-11e9-8a13-8e374830a7f6.png)


