### PR TITLE
Fix/plans spacing production

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -528,6 +528,10 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plans-features-main__group.is-wpcom {
+	padding-top: 19px;
+}
+
 // This is the customer type buttons that let
 // you toggle the visible plans in signup.
 // The #primary id is included to increase specificity

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -410,8 +410,10 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { intervalType } = this.props;
-
+		const { intervalType, isJetpack } = this.props;
+		if ( ! isJetpack ) {
+			return null;
+		}
 		// @todo: Add translations in FormattedHeader once the final copy is provided.
 		return (
 			<div className="plans-features-main__group is-narrow">


### PR DESCRIPTION
Update the spacing between the selection and the product grid. 

This PR also removes the product selection for non .com sites.

#### Changes proposed in this Pull Request
Before:
![Screen Shot 2019-10-23 at 4 47 24 PM](https://user-images.githubusercontent.com/115071/67405302-dc45ef80-f5b4-11e9-9a5b-4498d79f72a9.png)
After:

![Screen Shot 2019-10-23 at 4 46 34 PM](https://user-images.githubusercontent.com/115071/67405303-dc45ef80-f5b4-11e9-88ae-19babfc887f2.png)

#### Testing instructions
Go to the plans page for a .com site. 
Does it look like it is suppose to?
