### PR TITLE
Plans: use Chicago style for storage space consistently

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -232,7 +232,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_VIDEO_CDN_LIMITED ]: {
 		getSlug: () => constants.FEATURE_VIDEO_CDN_LIMITED,
-		getTitle: () => i18n.translate( '13GB Video Storage' ),
+		getTitle: () => i18n.translate( '13 GB Video Storage' ),
 		getDescription: () =>
 			i18n.translate(
 				'High-speed video hosting on our CDN, free of ads and watermarks, fully optimized for WordPress.'
@@ -547,7 +547,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_3GB_STORAGE ]: {
 		getSlug: () => constants.FEATURE_3GB_STORAGE,
-		getTitle: () => i18n.translate( '3GB Storage Space' ),
+		getTitle: () => i18n.translate( '3 GB Storage Space' ),
 		getDescription: () =>
 			i18n.translate( 'Storage space for adding images and documents to your website.' ),
 	},
@@ -555,7 +555,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_6GB_STORAGE ]: {
 		getSlug: () => constants.FEATURE_6GB_STORAGE,
 		getTitle: () =>
-			i18n.translate( '{{strong}}6GB{{/strong}} Storage Space', {
+			i18n.translate( '{{strong}}6 GB{{/strong}} Storage Space', {
 				components: {
 					strong: <strong />,
 				},
@@ -570,7 +570,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_13GB_STORAGE ]: {
 		getSlug: () => constants.FEATURE_13GB_STORAGE,
 		getTitle: () =>
-			i18n.translate( '{{strong}}13GB{{/strong}} Storage Space', {
+			i18n.translate( '{{strong}}13 GB{{/strong}} Storage Space', {
 				components: {
 					strong: <strong />,
 				},
@@ -795,7 +795,7 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_SPEED_ADVANCED_JETPACK,
 		getTitle: () => i18n.translate( 'Speed and Storage' ),
 		getDescription: () =>
-			i18n.translate( 'Also includes 13Gb of high-speed, ad-free video hosting.' ),
+			i18n.translate( 'Also includes 13 GB of high-speed, ad-free video hosting.' ),
 		hideInfoPopover: true,
 	},
 
@@ -835,7 +835,7 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_VIDEO_HOSTING_JETPACK ]: {
 		getSlug: () => constants.FEATURE_VIDEO_HOSTING_JETPACK,
 		getTitle: () => i18n.translate( 'Video Hosting' ),
-		getDescription: () => i18n.translate( '13Gb of high-speed, HD, and ad-free video hosting.' ),
+		getDescription: () => i18n.translate( '13 GB of high-speed, HD, and ad-free video hosting.' ),
 		hideInfoPopover: true,
 	},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update storage space strings such as `13GB` to `13 GB` to follow the guidelines we've been using on landing pages also (and in Calypso, too, in some places)

#### Testing instructions

* open Calypso Live link
* go to /plans/ for a Jetpack site
* ensure storage space strings now display as intended
* repeat for a WordPress.com site
