### PR TITLE
Disable main e2e canaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,10 +686,10 @@ workflows:
                 - master
                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
                 - /pull\/[0-9]+/
-      - test-e2e-canary:
-          requires:
-            - wait-calypso-live
-          test-flags: '-C -S $CIRCLE_SHA1'
+#      - test-e2e-canary:
+#          requires:
+#            - wait-calypso-live
+#          test-flags: '-C -S $CIRCLE_SHA1'
       - test-e2e-canary:
           name: test-e2e-canary-ie
           requires:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we are running a full e2e suite against every PR we are planning to disable main e2e canaries because those tests are duplicated now. That also means 2 signup tests less for every PR, which can help us not to hit signup rate limit 😬 

#### Testing instructions

`ci/circleci: test-e2e-canary` job should not be present on a PRR

