### PR TITLE
Full Site Editing: Add edit template tracking

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -5,7 +5,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { get, noop } from 'lodash';
+import { endsWith, get, noop, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -40,11 +40,33 @@ const TemplateEdit = compose(
 		} );
 		const selectedBlock = getSelectedBlock();
 
+		const templatePartType = reduce(
+			get( template, 'template_part_types' ),
+			( type, typeId ) => {
+				if ( type ) {
+					return type;
+				}
+				const typeName = get(
+					getEntityRecord( 'taxonomy', 'wp_template_part_type', typeId ),
+					'name',
+					''
+				);
+				if ( endsWith( typeName, '-header' ) ) {
+					return 'header';
+				}
+				if ( endsWith( typeName, '-footer' ) ) {
+					return 'footer';
+				}
+			},
+			undefined
+		);
+
 		return {
 			currentPostId,
 			editTemplateUrl,
 			template,
 			templateBlock: getBlock( templateClientId ),
+			templatePartType,
 			templateTitle: get( template, [ 'title', 'rendered' ], '' ),
 			isDirty: isEditedPostDirty(),
 			isEditorSidebarOpened: !! isEditorSidebarOpened(),
@@ -78,6 +100,7 @@ const TemplateEdit = compose(
 		receiveTemplateBlocks,
 		template,
 		templateBlock,
+		templatePartType,
 		templateTitle,
 		isDirty,
 		savePost,
@@ -177,6 +200,7 @@ const TemplateEdit = compose(
 							) }
 							<Button
 								className={ navigateToTemplate ? 'hidden' : null }
+								data-template-part-type={ templatePartType }
 								href={ editTemplateUrl }
 								onClick={ save }
 								isDefault

--- a/apps/wpcom-block-editor/src/common/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/common/tracking/delegate-event-tracking.js
@@ -7,6 +7,7 @@ import debugFactory from 'debug';
  */
 import wpcomBlockPickerSearchTerm from './wpcom-block-picker-search-term-handler';
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
+import wpcomBlockEditorEditTemplatePart from './wpcom-block-editor-edit-template-part';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
@@ -17,7 +18,11 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
  *
  * @type {Array}
  */
-const EVENTS_MAPPING = [ wpcomBlockEditorCloseClick(), wpcomBlockPickerSearchTerm() ];
+const EVENTS_MAPPING = [
+	wpcomBlockEditorCloseClick(),
+	wpcomBlockPickerSearchTerm(),
+	wpcomBlockEditorEditTemplatePart(),
+];
 
 /**
  * Checks the event for a selector which matches

--- a/apps/wpcom-block-editor/src/common/tracking/wpcom-block-editor-edit-template-part.js
+++ b/apps/wpcom-block-editor/src/common/tracking/wpcom-block-editor-edit-template-part.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { debounce, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,12 +17,12 @@ const trackFullSiteEditingEditTemplatePart = ( event, target ) => {
 };
 
 /**
- * Return the event definition object to track `wpcom_block_editor_close_click`.
+ * Return the event definition object to track `wpcom_block_editor_a8c_fse_edit_template_part`.
  *
  * @return {{handler: function, selector: string, type: string}} event object definition.
  */
 export default () => ( {
 	selector: '.template__block-container .template-block__overlay a',
 	type: 'click',
-	handler: trackFullSiteEditingEditTemplatePart,
+	handler: debounce( trackFullSiteEditingEditTemplatePart, 1000, { leading: true } ),
 } );

--- a/apps/wpcom-block-editor/src/common/tracking/wpcom-block-editor-edit-template-part.js
+++ b/apps/wpcom-block-editor/src/common/tracking/wpcom-block-editor-edit-template-part.js
@@ -1,0 +1,28 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+const trackFullSiteEditingEditTemplatePart = ( event, target ) => {
+	const templatePartType = get( target, [ 'dataset', 'templatePartType' ] );
+	tracksRecordEvent( 'wpcom_block_editor_a8c_fse_edit_template_part', {
+		template_part: templatePartType,
+	} );
+};
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_close_click`.
+ *
+ * @return {{handler: function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.template__block-container .template-block__overlay a',
+	type: 'click',
+	handler: trackFullSiteEditingEditTemplatePart,
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new `wpcom_block_editor_a8c_fse_edit_template_part` Tracks event that is recorded when the user clicks on the "Edit" button in the Template Part block. Its only custom property is the edited template part type (e.g. header or footer).

This reuses the block editor tracking logic introduced in #34655 (see also p7H4VZ-2hb-p2).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing this PR involves building FSE and WPCOM Block Editor, and copying their dist folders on WPCOM. To make things easier, I've already done this and I've opened a test diff. (It's not intended to be deployed, but just for testing purposes!)

* Checkout D34386-code, sandbox an FSE site and `widgets.wp.com`.
* Open the site and run `localStorage.debug = '*' ` in the console, and make sure to check the "preserve log" option.
* Filter the console by `wpcom-block-editor:analytics:tracks`.
* Edit a page, and click on "Edit Header" or "Edit Footer".
* Make sure there is a `wpcom_block_editor_a8c_fse_edit_template_part` log in the console with the expected `template_part` property.

Fixes #36891 
