### PR TITLE
Composite checkout: Fix/edit button appearance

### DIFF
--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -10,6 +10,7 @@ import styled from 'styled-components';
  */
 import joinClasses from '../lib/join-classes';
 import { useLocalize } from '../lib/localize';
+import Button from './button';
 
 export default function CheckoutStep( {
 	className,
@@ -76,9 +77,9 @@ function CheckoutStepHeader( { className, stepNumber, title, isActive, isComplet
 				{ title }
 			</StepTitle>
 			{ onEdit && isComplete && ! isActive && (
-				<button className="checkout-step__edit" onClick={ onEdit }>
+				<Button buttonState="text-button" className="checkout-step__edit" onClick={ onEdit }>
 					{ localize( 'Edit' ) }
-				</button>
+				</Button>
 			) }
 		</StepHeader>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the look of the Edit button for completed steps.

**Before**
![image](https://user-images.githubusercontent.com/6981253/67413423-1c927700-f58f-11e9-92d9-ea80c4e82510.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/67413402-113f4b80-f58f-11e9-8016-e2eb7c1a9845.png)


#### Testing instructions
* To run the test server:
`npm install && npm run composite-checkout-demo`
* Then visit http://localhost:3000/