### PR TITLE
Update node-sass to 4.12.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -46,7 +46,7 @@
 				"jest-config": "24.9.0",
 				"jest-enzyme": "7.1.1",
 				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
-				"node-sass": "4.11.0",
+				"node-sass": "4.12.0",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
 				"recursive-copy": "2.0.10",
@@ -339,6 +339,11 @@
 			"version": "file:packages/calypso-color-schemes",
 			"dev": true
 		},
+		"@automattic/color-studio": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.2.0.tgz",
+			"integrity": "sha512-ttIF8rPSRJ5hKkDxKESDXyGmbqV3Eg4WCVUmKJp5BQXlbQOtwZ1EqUHmZo+IofXXpO2ngn2GiFz+KGt56C5WMA=="
+		},
 		"@automattic/components": {
 			"version": "file:packages/components",
 			"requires": {
@@ -348,11 +353,6 @@
 				"prop-types": "^15.7.2",
 				"react": "^16.8.3"
 			}
-		},
-		"@automattic/color-studio": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.2.0.tgz",
-			"integrity": "sha512-ttIF8rPSRJ5hKkDxKESDXyGmbqV3Eg4WCVUmKJp5BQXlbQOtwZ1EqUHmZo+IofXXpO2ngn2GiFz+KGt56C5WMA=="
 		},
 		"@automattic/composite-checkout": {
 			"version": "file:packages/composite-checkout",
@@ -421,6 +421,19 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1568,9 +1581,9 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -2735,6 +2748,19 @@
 				"rimraf": "^2.6.2"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -3232,9 +3258,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "12.7.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-			"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+			"version": "12.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+			"integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -5523,13 +5549,20 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.1.tgz",
+			"integrity": "sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000989",
-				"electron-to-chromium": "^1.3.247",
-				"node-releases": "^1.1.29"
+				"caniuse-lite": "^1.0.30000999",
+				"electron-to-chromium": "^1.3.284",
+				"node-releases": "^1.1.36"
+			},
+			"dependencies": {
+				"caniuse-lite": {
+					"version": "1.0.30001002",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz",
+					"integrity": "sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g=="
+				}
 			}
 		},
 		"browserslist-useragent": {
@@ -5550,9 +5583,9 @@
 			}
 		},
 		"bser": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-			"integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
 			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
@@ -5666,9 +5699,9 @@
 			},
 			"dependencies": {
 				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -5984,26 +6017,22 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+							"bundled": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": false,
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+							"bundled": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"resolved": false,
-							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"delegates": "^1.0.0",
@@ -6012,14 +6041,12 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": false,
-							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+							"bundled": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": false,
-							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
@@ -6028,38 +6055,32 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+							"bundled": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": false,
-							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+							"bundled": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": false,
-							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+							"bundled": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": false,
-							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+							"bundled": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+							"bundled": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"resolved": false,
-							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"ms": "^2.1.1"
@@ -6067,26 +6088,22 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"resolved": false,
-							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+							"bundled": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"resolved": false,
-							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+							"bundled": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"resolved": false,
-							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+							"bundled": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"resolved": false,
-							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -6094,14 +6111,12 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"resolved": false,
-							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+							"bundled": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"resolved": false,
-							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"aproba": "^1.0.3",
@@ -6116,8 +6131,7 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"resolved": false,
-							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
@@ -6130,14 +6144,12 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": false,
-							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+							"bundled": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"resolved": false,
-							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"safer-buffer": ">= 2.1.2 < 3"
@@ -6145,8 +6157,7 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"resolved": false,
-							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"minimatch": "^3.0.4"
@@ -6154,8 +6165,7 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": false,
-							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"once": "^1.3.0",
@@ -6164,20 +6174,17 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"resolved": false,
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+							"bundled": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"resolved": false,
-							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+							"bundled": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": false,
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
@@ -6185,14 +6192,12 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"resolved": false,
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"bundled": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": false,
-							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
@@ -6200,14 +6205,12 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": false,
-							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+							"bundled": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"resolved": false,
-							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -6216,8 +6219,7 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"resolved": false,
-							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -6225,8 +6227,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": false,
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
@@ -6234,14 +6235,12 @@
 						},
 						"ms": {
 							"version": "2.1.1",
-							"resolved": false,
-							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+							"bundled": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"resolved": false,
-							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"debug": "^4.1.0",
@@ -6251,8 +6250,7 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"resolved": false,
-							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"detect-libc": "^1.0.2",
@@ -6269,8 +6267,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": false,
-							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"abbrev": "1",
@@ -6279,14 +6276,12 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"resolved": false,
-							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+							"bundled": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"resolved": false,
-							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"ignore-walk": "^3.0.1",
@@ -6295,8 +6290,7 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": false,
-							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
@@ -6307,20 +6301,17 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": false,
-							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+							"bundled": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"resolved": false,
-							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+							"bundled": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": false,
-							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"wrappy": "1"
@@ -6328,20 +6319,17 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+							"bundled": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+							"bundled": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"resolved": false,
-							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
@@ -6350,20 +6338,17 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"resolved": false,
-							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+							"bundled": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"resolved": false,
-							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+							"bundled": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"resolved": false,
-							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"deep-extend": "^0.6.0",
@@ -6374,16 +6359,14 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": false,
-									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+									"bundled": true,
 									"optional": true
 								}
 							}
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -6397,8 +6380,7 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"resolved": false,
-							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"glob": "^7.1.3"
@@ -6406,44 +6388,37 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"resolved": false,
-							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"bundled": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"resolved": false,
-							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+							"bundled": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"resolved": false,
-							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+							"bundled": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"resolved": false,
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"bundled": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"resolved": false,
-							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+							"bundled": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"resolved": false,
-							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+							"bundled": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -6453,8 +6428,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -6462,8 +6436,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": false,
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
@@ -6471,14 +6444,12 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"resolved": false,
-							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+							"bundled": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"resolved": false,
-							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"chownr": "^1.1.1",
@@ -6492,14 +6463,12 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+							"bundled": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"resolved": false,
-							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"string-width": "^1.0.2 || 2"
@@ -6507,14 +6476,12 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+							"bundled": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"resolved": false,
-							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+							"bundled": true,
 							"optional": true
 						}
 					}
@@ -7444,6 +7411,19 @@
 				"run-queue": "^1.0.0"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -7465,12 +7445,12 @@
 			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
 		},
 		"core-js-compat": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.2.tgz",
-			"integrity": "sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.3.tgz",
+			"integrity": "sha512-GNZkENsx5pMnS7Inwv7ZO/s3B68a9WU5kIjxqrD/tkNR8mtfXJRk8fAKRlbvWZSGPc59/TkiOBDYl5Cb65pTVA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.7.0",
+				"browserslist": "^4.7.1",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -8157,9 +8137,9 @@
 			"integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
 		},
 		"d3-time-format": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
-			"integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.1.tgz",
+			"integrity": "sha512-VA6WqORO1+H1SvSzgl2oT0z3niANh3opa8Cencpen1LFthw/bEX71R/DgjPlWw78J4UHmD0jCPP1W0HpwMkhjg==",
 			"requires": {
 				"d3-time": "1"
 			}
@@ -8198,9 +8178,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.4.1.tgz",
-			"integrity": "sha512-2RhmH/sjDSCYW2F3ZQxOUx/I7PvzXpi89aQL2d3OAxSTwLx6NilATeUbe0menFE3Lu5lFkOFci36ivimwYHHxw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.6.0.tgz",
+			"integrity": "sha512-F55YxqRdEfP/eYQmQjLN798v0AwLjmZ8nMBjdQvNwEE3N/zWVrlkkqT+9seBlPlsbkybG4JmWg3Ee3dIV9BcGQ==",
 			"dev": true
 		},
 		"date-now": {
@@ -8814,9 +8794,9 @@
 			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.282",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
-			"integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ=="
+			"version": "1.3.293",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.293.tgz",
+			"integrity": "sha512-DQSBRuU2Z1vG+CEWUIfCEVMHtuaGlhVojzg39mX5dx7PLSFDJ7DSrGUWzaPFFgWR1jo26hj1nXXRQZvFwk7F8w=="
 		},
 		"elliptic": {
 			"version": "6.5.1",
@@ -9142,9 +9122,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
@@ -9575,12 +9555,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -10595,9 +10575,9 @@
 			"dev": true
 		},
 		"functions-have-names": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.1.1.tgz",
-			"integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.0.tgz",
+			"integrity": "sha512-zKXyzksTeaCSw5wIX79iCA40YAa6CJMJgNg9wdkU/ERBrIdPSimPICYiLp65lRbSBqtiHql/HZfS2DyI/AH6tQ=="
 		},
 		"fuse.js": {
 			"version": "3.4.4",
@@ -11003,6 +10983,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -11090,6 +11071,21 @@
 				"ignore": "^4.0.3",
 				"pify": "^4.0.1",
 				"slash": "^2.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"globjoin": {
@@ -11174,9 +11170,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-			"integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+			"integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -11671,9 +11667,9 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+			"integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
@@ -12096,6 +12092,21 @@
 				"semver": "2.x || 3.x || 4 || 5",
 				"validate-npm-package-license": "^3.0.1",
 				"validate-npm-package-name": "^3.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"inquirer": {
@@ -13158,29 +13169,25 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13190,15 +13197,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13208,43 +13213,37 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13253,29 +13252,25 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13284,15 +13279,13 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13308,8 +13301,7 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13323,15 +13315,13 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13340,8 +13330,7 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13350,8 +13339,7 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13361,22 +13349,19 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13385,15 +13370,13 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13402,15 +13385,13 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13420,8 +13401,7 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13430,8 +13410,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13440,15 +13419,13 @@
 						},
 						"ms": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13459,8 +13436,7 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13478,8 +13454,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13489,15 +13464,13 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13507,8 +13480,7 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13520,22 +13492,19 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13544,22 +13513,19 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13569,22 +13535,19 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13596,8 +13559,7 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+									"bundled": true,
 									"dev": true,
 									"optional": true
 								}
@@ -13605,8 +13567,7 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13621,8 +13582,7 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13631,50 +13591,43 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13685,8 +13638,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13695,8 +13647,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13705,15 +13656,13 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13728,15 +13677,13 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13745,15 +13692,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						}
@@ -14614,12 +14559,6 @@
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
-		"lodash.assign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-			"dev": true
-		},
 		"lodash.assignin": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -14736,12 +14675,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
 			"dev": true
 		},
 		"lodash.pick": {
@@ -14919,15 +14852,15 @@
 			}
 		},
 		"make-fetch-happen": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
-			"integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
+			"integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
 			"requires": {
 				"agentkeepalive": "^3.4.1",
 				"cacache": "^12.0.0",
 				"http-cache-semantics": "^3.8.1",
 				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^2.2.1",
+				"https-proxy-agent": "^2.2.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"node-fetch-npm": "^2.0.2",
@@ -15612,6 +15545,19 @@
 				"run-queue": "^1.0.3"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -15845,6 +15791,19 @@
 				"which": "1"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -15957,9 +15916,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.35",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
-			"integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.38.tgz",
+			"integrity": "sha512-/5NZAaOyTj134Oy5Cp/J8mso8OD/D9CSuL+6TOXXsTKO8yjc5e4up75SRPCganCjwFKMj2jbp5tR0dViVdox7g==",
 			"requires": {
 				"semver": "^6.3.0"
 			},
@@ -15972,9 +15931,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-			"integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+			"integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -15984,12 +15943,10 @@
 				"get-stdin": "^4.0.1",
 				"glob": "^7.0.3",
 				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
+				"lodash": "^4.17.11",
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
-				"nan": "^2.10.0",
+				"nan": "^2.13.2",
 				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
 				"request": "^2.88.0",
@@ -16276,6 +16233,21 @@
 				"object-hash": "^1.3.1",
 				"postcss-scss": "^2.0.0",
 				"resolve": "^1.10.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"node-sass-package-importer": {
@@ -16359,20 +16331,17 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"bundled": true,
 					"dev": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"bundled": true,
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -16382,14 +16351,12 @@
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"bundled": true,
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -16403,8 +16370,7 @@
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -16412,26 +16378,22 @@
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+					"bundled": true,
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -16439,20 +16401,17 @@
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"bundled": true,
 					"dev": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
@@ -16460,8 +16419,7 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -16470,8 +16428,7 @@
 				},
 				"lru-cache": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
@@ -16480,8 +16437,7 @@
 				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -16489,20 +16445,17 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+					"bundled": true,
 					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"bundled": true,
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -16510,8 +16463,7 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -16519,14 +16471,12 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"bundled": true,
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
@@ -16536,20 +16486,17 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+					"bundled": true,
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+					"bundled": true,
 					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -16557,44 +16504,37 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"bundled": true,
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+					"bundled": true,
 					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"bundled": true,
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"bundled": true,
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -16602,20 +16542,17 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"bundled": true,
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -16625,8 +16562,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -16634,14 +16570,12 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+					"bundled": true,
 					"dev": true
 				},
 				"which": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -16649,14 +16583,12 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"bundled": true,
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -16665,20 +16597,17 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"bundled": true,
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"bundled": true,
 					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cliui": "^3.2.0",
@@ -16697,14 +16626,12 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"bundled": true,
 							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"string-width": "^1.0.1",
@@ -16714,8 +16641,7 @@
 							"dependencies": {
 								"string-width": {
 									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+									"bundled": true,
 									"dev": true,
 									"requires": {
 										"code-point-at": "^1.0.0",
@@ -16727,8 +16653,7 @@
 						},
 						"string-width": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
@@ -16737,14 +16662,12 @@
 							"dependencies": {
 								"is-fullwidth-code-point": {
 									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+									"bundled": true,
 									"dev": true
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+									"bundled": true,
 									"dev": true,
 									"requires": {
 										"ansi-regex": "^3.0.0"
@@ -16756,8 +16679,7 @@
 				},
 				"yargs-parser": {
 					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -16765,8 +16687,7 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+							"bundled": true,
 							"dev": true
 						}
 					}
@@ -20001,9 +19922,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.10.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-			"integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+			"integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
 		},
 		"react-lazily-render": {
 			"version": "1.1.0",
@@ -20242,6 +20163,19 @@
 				"slash": "^1.0.0"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -20551,9 +20485,9 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
 		},
 		"regjsparser": {
 			"version": "0.6.0",
@@ -23314,14 +23248,14 @@
 			}
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
+			"integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.19.0",
+				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.10"
+				"source-map-support": "~0.5.12"
 			},
 			"dependencies": {
 				"source-map": {
@@ -23368,23 +23302,12 @@
 						"ssri": "^6.0.1",
 						"unique-filename": "^1.1.1",
 						"y18n": "^4.0.0"
-					},
-					"dependencies": {
-						"rimraf": {
-							"version": "2.7.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						}
 					}
 				},
 				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"version": "7.1.5",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+					"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -23404,11 +23327,31 @@
 						"yallist": "^3.0.2"
 					}
 				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
 				},
 				"y18n": {
 					"version": "4.0.0",
@@ -24512,17 +24455,6 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
-				"terser": {
-					"version": "4.3.9",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
-					"integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
-					"dev": true,
-					"requires": {
-						"commander": "^2.20.0",
-						"source-map": "~0.6.1",
-						"source-map-support": "~0.5.12"
-					}
-				},
 				"terser-webpack-plugin": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
@@ -25246,6 +25178,21 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -25332,27 +25279,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
-					}
-				},
-				"webpack-dev-middleware": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-					"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
-					"dev": true,
-					"requires": {
-						"memory-fs": "^0.4.1",
-						"mime": "^2.4.4",
-						"mkdirp": "^0.5.1",
-						"range-parser": "^1.2.1",
-						"webpack-log": "^2.0.0"
-					},
-					"dependencies": {
-						"mime": {
-							"version": "2.4.4",
-							"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-							"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-							"dev": true
-						}
 					}
 				},
 				"ws": {
@@ -25520,9 +25446,9 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
 		]
 	},
 	"dependencies": {
-		"@automattic/components": "file:./packages/components",
 		"@automattic/color-studio": "2.2.0",
+		"@automattic/components": "file:./packages/components",
 		"@automattic/format-currency": "file:./packages/format-currency",
 		"@automattic/load-script": "file:./packages/load-script",
 		"@automattic/material-design-icons": "file:./packages/material-design-icons",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",
@@ -60,7 +60,7 @@
 		"jest-config": "24.9.0",
 		"jest-enzyme": "7.1.1",
 		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
-		"node-sass": "4.11.0",
+		"node-sass": "4.12.0",
 		"postcss-custom-properties": "8.0.9",
 		"postcss-loader": "3.0.0",
 		"recursive-copy": "2.0.10",


### PR DESCRIPTION
Also update all transitive dependencies because of a need to run update-deps

#### Changes proposed in this Pull Request

* Update to node-sass@4.12.0, which gives us Node@12 support

#### Testing instructions

* CSS should generate just the same as it does now.
