### PR TITLE
Vertical-suggested themes: Use photon package to generate urls in signup preview

### DIFF
--- a/client/components/signup-site-preview/screenshot.tsx
+++ b/client/components/signup-site-preview/screenshot.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from 'react';
  */
 import Spinner from 'components/spinner';
 import classNames from 'classnames';
+import photon from 'photon';
 
 interface Props {
 	defaultViewportDevice: string;
@@ -38,12 +39,8 @@ export default function SignupSitePreviewScreenshot( {
 	} );
 
 	const isPhone = defaultViewportDevice === 'phone';
-
-	const { hostname, pathname } = new URL( screenshotUrl );
 	const zoom = window.devicePixelRatio;
-	const w = isPhone ? 280 : 904;
-	const src = `https://i0.wp.com/${ hostname }${ pathname }?w=${ w }`;
-	const srcset = `https://i0.wp.com/${ hostname }${ pathname }?w=${ w }&zoom=${ zoom } ${ zoom }x`;
+	const width = isPhone ? 280 : 904;
 
 	const onLoad = ( event: React.SyntheticEvent< HTMLImageElement > ) => {
 		setWrapperHeight( event.currentTarget.height );
@@ -59,8 +56,8 @@ export default function SignupSitePreviewScreenshot( {
 			{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }
 			<img
 				style={ isLoading ? { display: 'none' } : undefined }
-				src={ src }
-				srcSet={ srcset }
+				src={ photon( screenshotUrl, { width } ) }
+				srcSet={ photon( screenshotUrl, { width, zoom } ) + ` ${ zoom }x` }
 				onClick={ () => onPreviewClick( defaultViewportDevice ) }
 				onLoad={ onLoad }
 				alt={


### PR DESCRIPTION
Context: the vertical-suggested theme AB test displays screenshots in the site preview, which are delivered through the [photon](https://developer.wordpress.com/docs/photon/) service.

#### Changes proposed in this Pull Request

* Delete code! We already have a package to do this.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with user where `locale = en`
* In A/B test picker choose "test" group for `verticalSuggestedThemes` test
* Create a site starting from `/start`
* Choose *Business* site type
* Choose *Restaurants* vertical
* Screenshots of the Rockfield demo site should appear
* Try it on non-retina somehow. (I'm thinking browserstack might do the trick)
