### PR TITLE
Use preferred ComponentProps[ With | Without ]Ref

### DIFF
--- a/client/components/draggable/index.tsx
+++ b/client/components/draggable/index.tsx
@@ -1,13 +1,7 @@
 /**
  * External dependencies
  */
-import React, {
-	Component,
-	ComponentProps,
-	CSSProperties,
-	MouseEventHandler,
-	TouchEventHandler,
-} from 'react';
+import React, { Component } from 'react';
 
 interface Props {
 	onDrag: ( x: number, y: number ) => void;
@@ -59,7 +53,10 @@ function isEventWithTouches( event: HasTouches | HasPageCoords ): event is HasTo
 	);
 }
 
-type DivProps = Omit< ComponentProps< 'div' >, 'style' | 'onMouseDown' | 'onTouchStart' >;
+type DivProps = Omit<
+	React.ComponentPropsWithoutRef< 'div' >,
+	'style' | 'onMouseDown' | 'onTouchStart'
+>;
 
 export default class Draggable extends Component< Props & DivProps, State > {
 	static defaultProps = {
@@ -141,7 +138,7 @@ export default class Draggable extends Component< Props & DivProps, State > {
 		this.props.onStop();
 	};
 
-	onTouchStartHandler: TouchEventHandler< HTMLDivElement > = event => {
+	onTouchStartHandler: React.TouchEventHandler< HTMLDivElement > = event => {
 		event.preventDefault();
 
 		// Call draggingStartedHandler first
@@ -150,7 +147,7 @@ export default class Draggable extends Component< Props & DivProps, State > {
 		document.addEventListener( 'touchend', this.draggingEndedHandler );
 	};
 
-	onMouseDownHandler: MouseEventHandler< HTMLDivElement > = event => {
+	onMouseDownHandler: React.MouseEventHandler< HTMLDivElement > = event => {
 		event.preventDefault();
 
 		// Call draggingStartedHandler first
@@ -195,7 +192,7 @@ export default class Draggable extends Component< Props & DivProps, State > {
 	render() {
 		// Discard "our" props and leave divProps for the div
 		const { onDrag, onStop, width, height, x, y, controlled, bounds, ...divProps } = this.props;
-		const style: CSSProperties = {
+		const style: React.CSSProperties = {
 			transform: 'translate(' + this.state.x + 'px, ' + this.state.y + 'px)',
 		};
 

--- a/client/components/forms/multi-checkbox/index.tsx
+++ b/client/components/forms/multi-checkbox/index.tsx
@@ -23,7 +23,7 @@ interface Props {
 	name?: string;
 }
 
-type DivProps = React.ComponentProps< 'div' >;
+type DivProps = Omit< React.ComponentPropsWithoutRef< 'div' >, 'className' >;
 
 export default function MultiCheckbox( props: Props & DivProps ) {
 	const {

--- a/client/components/image-preloader/index.tsx
+++ b/client/components/image-preloader/index.tsx
@@ -23,7 +23,7 @@ interface Props {
 	onError?: ImageEventHandler;
 }
 
-type ImgProps = Omit< React.ComponentProps< 'img' >, 'src' >;
+type ImgProps = Omit< React.ComponentPropsWithoutRef< 'img' >, 'src' >;
 
 export default function ImagePreloader( props: Props & ImgProps ) {
 	const { children, src, placeholder, onLoad, onError, ...imageProps } = props;

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -43,7 +43,7 @@ interface Props {
 	style?: React.CSSProperties;
 }
 
-type DivProps = Omit< React.ComponentProps< 'button' >, 'style' | 'onClick' >;
+type DivProps = Omit< React.ComponentPropsWithoutRef< 'button' >, 'style' | 'onClick' >;
 
 export default class MediaLibraryListItem extends React.Component< Props & DivProps > {
 	static defaultProps = {


### PR DESCRIPTION
ComponentProps[ With | Without ]Ref is preferred over simple
ComponentProps. Use the preferred method. [See comment in types.](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7d4caa8dd6f01035092c0b28b6b160ac93f35ca1/types/react/index.d.ts#L761-L776)

Type-only changes.

#### Testing instructions

* Type-only changes. No extensive testing necessary. Canaries and tests should pass.