### PR TITLE
Update getting started section to include npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ You can try out the user-side of Calypso on [WordPress.com](https://wordpress.co
 1.	Make sure you have [`git`](https://git-scm.com/), [`node`](https://nodejs.org/), and [`npm`](https://www.npmjs.com/get-npm) installed.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4.	Execute `npm start` from the root directory of the repository.
-5.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
+4.	Execute `npm install` from the root directory of the repository.
+5.	Execute `npm start` from the root directory of the repository.
+6.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 Need more detailed installation instructions? [We have them](./docs/install.md).
 


### PR DESCRIPTION
If you currently follow the getting started section step by step the first thing you are getting is an error that he node modules are not installed. 

This of course is the case, but I believe it might be more frictionless for first time contributors when every step is included in the list.

## Changes proposed in this Pull Request

* Added step 4 to the getting started list