### PR TITLE
Analytics Ad Tracking: promisify some helper functions

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -12,14 +12,13 @@ import { v4 as uuid } from 'uuid';
 import config from 'config';
 import productsValues from 'lib/products-values';
 import userModule from 'lib/user';
-import { loadScript as loadScriptCallback } from '@automattic/load-script';
+import { loadScript } from '@automattic/load-script';
 import {
 	isAdTrackingAllowed,
 	hashPii,
 	costToUSD,
 	getNormalizedHashedUserEmail,
 } from 'lib/analytics/utils';
-import { promisify } from '../../utils';
 import { doNotTrack, isPiiUrl, mayWeTrackCurrentUserGdpr } from './utils';
 
 /**
@@ -348,8 +347,6 @@ function setupAdRollGlobal() {
 		};
 	}
 }
-
-const loadScript = promisify( loadScriptCallback );
 
 async function loadTrackingScripts( callback ) {
 	debug( `loadTrackingScripts: state is ${ trackingState }` );

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -447,20 +447,15 @@ const loadTrackingScripts = attemptLoad( async () => {
  *
  * @returns {void}
  */
-export function retarget( urlPath ) {
-	if ( maybeRefreshCountryCodeCookieGdpr( retarget.bind( null, urlPath ) ) ) {
-		return;
-	}
+export async function retarget( urlPath ) {
+	await refreshCountryCodeCookieGdpr();
 
 	if ( ! isAdTrackingAllowed() ) {
 		debug( 'retarget: [Skipping] ad tracking is not allowed', urlPath );
 		return;
 	}
 
-	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
-		loadTrackingScripts( retarget.bind( null, urlPath ) );
-		return;
-	}
+	await loadTrackingScripts();
 
 	debug( 'retarget:', urlPath );
 
@@ -617,20 +612,15 @@ function splitWpcomJetpackCartInfo( cart ) {
 	};
 }
 
-export function recordRegistration() {
-	if ( maybeRefreshCountryCodeCookieGdpr( recordRegistration.bind( null ) ) ) {
-		return;
-	}
+export async function recordRegistration() {
+	await refreshCountryCodeCookieGdpr();
 
 	if ( ! isAdTrackingAllowed() ) {
 		debug( 'recordRegistration: [Skipping] ad tracking is not allowed' );
 		return;
 	}
 
-	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
-		loadTrackingScripts( recordRegistration.bind( null ) );
-		return;
-	}
+	await loadTrackingScripts();
 
 	// Google Ads Gtag
 
@@ -691,20 +681,15 @@ export function recordRegistration() {
  * @param {String} slug - Signup slug.
  * @returns {void}
  */
-export function recordSignup( slug ) {
-	if ( maybeRefreshCountryCodeCookieGdpr( recordSignup.bind( null, slug ) ) ) {
-		return;
-	}
+export async function recordSignup( slug ) {
+	await refreshCountryCodeCookieGdpr();
 
 	if ( ! isAdTrackingAllowed() ) {
 		debug( 'recordSignup: [Skipping] ad tracking is disallowed' );
 		return;
 	}
 
-	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
-		loadTrackingScripts( recordSignup.bind( null, slug ) );
-		return;
-	}
+	await loadTrackingScripts();
 
 	// Synthesize a cart object for signup tracking.
 	const syntheticCart = {
@@ -860,20 +845,15 @@ export function retargetViewPlans() {
  * @param {Object} cartItem - The item added to the cart
  * @returns {void}
  */
-export function recordAddToCart( cartItem ) {
-	if ( maybeRefreshCountryCodeCookieGdpr( recordAddToCart.bind( null, cartItem ) ) ) {
-		return;
-	}
+export async function recordAddToCart( cartItem ) {
+	await refreshCountryCodeCookieGdpr();
 
 	if ( ! isAdTrackingAllowed() ) {
 		debug( 'recordAddToCart: [Skipping] ad tracking is not allowed' );
 		return;
 	}
 
-	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
-		loadTrackingScripts( recordAddToCart.bind( null, cartItem ) );
-		return;
-	}
+	await loadTrackingScripts();
 
 	debug( 'recordAddToCart:', cartItem );
 
@@ -999,20 +979,15 @@ export function recordViewCheckout( cart ) {
  * @param {Number} orderId - the order id
  * @returns {void}
  */
-export function recordOrder( cart, orderId ) {
-	if ( maybeRefreshCountryCodeCookieGdpr( recordOrder.bind( null, cart, orderId ) ) ) {
-		return;
-	}
+export async function recordOrder( cart, orderId ) {
+	await refreshCountryCodeCookieGdpr();
 
 	if ( ! isAdTrackingAllowed() ) {
 		debug( 'recordOrder: [Skipping] ad tracking is not allowed' );
 		return;
 	}
 
-	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
-		loadTrackingScripts( recordOrder.bind( null, cart, orderId ) );
-		return;
-	}
+	await loadTrackingScripts();
 
 	if ( cart.is_signup ) {
 		return;
@@ -1591,16 +1566,13 @@ function recordPlansViewInCriteo() {
  *
  * @returns {void}
  */
-function recordInCriteo( eventName, eventProps ) {
+async function recordInCriteo( eventName, eventProps ) {
 	if ( ! isAdTrackingAllowed() || ! isCriteoEnabled ) {
 		debug( 'recordInCriteo: [Skipping] ad tracking is not allowed' );
 		return;
 	}
 
-	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
-		loadTrackingScripts( recordInCriteo.bind( null, eventName, eventProps ) );
-		return;
-	}
+	await loadTrackingScripts();
 
 	const events = [];
 	events.push( { event: 'setAccount', account: TRACKING_IDS.criteo } );

--- a/client/lib/analytics/utils/index.js
+++ b/client/lib/analytics/utils/index.js
@@ -14,3 +14,4 @@ export { default as urlParseAmpCompatible } from './url-parse-amp-compatible';
 export { default as shouldReportOmitBlogId } from './should-report-omit-blog-id';
 export { default as saveCouponQueryArgument } from './save-coupon-query-argument';
 export { default as getNormalizedHashedUserEmail } from './get-normalized-hashed-user-email';
+export { default as refreshCountryCodeCookieGdpr } from './refresh-country-code-cookie-gdpr';

--- a/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
+++ b/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import cookie from 'cookie';
+
+/**
+ * Internal dependencies
+ */
+import debug from './debug';
+
+/**
+ * Refreshes the GDPR `country_code` cookie every 6 hours (like A8C_Analytics wpcom plugin).
+ * @returns {Promise<void>} Promise that resolves when the refreshing is done (or immediately)
+ */
+export default async function refreshCountryCodeCookieGdpr() {
+	const cookies = cookie.parse( document.cookie );
+	if ( cookies.country_code ) {
+		debug( 'refreshCountryCodeCookieGdpr: country_code cookie is fresh: %s', cookies.country_code );
+		return;
+	}
+
+	try {
+		// cache buster
+		const v = new Date().getTime();
+		const res = await fetch( 'https://public-api.wordpress.com/geo/?v=' + v );
+		if ( ! res.ok ) {
+			throw new Error( await res.body() );
+		}
+
+		const json = await res.json();
+		setCountryCodeCookie( json.country_short );
+	} catch ( err ) {
+		debug( 'refreshCountryCodeCookieGdpr: error: ', err );
+		setCountryCodeCookie( 'unknown' );
+	}
+}
+
+function setCountryCodeCookie( countryCode ) {
+	const maxAge = 6 * 60 * 60; // 6 hours in seconds
+	document.cookie = cookie.serialize( 'country_code', countryCode, { path: '/', maxAge } );
+	debug( 'refreshCountryCodeCookieGdpr: country_code cookie set to %s', countryCode );
+}


### PR DESCRIPTION
In the Ad Tracking module, refactor functions for refreshing the `country_code` GDPR cookie and for loading the tracking scripts to use promises and async/await instead of bound continuation callbacks.

One of many steps to make the Ad Tracking code more modular and support async-loading only the pieces that are needed at the moment. Currently, `ad-tracking.js` is a 2000+ line module that's difficult to break up.

**Refreshing the GDPR cookie**
Many tracking functions make sure that the `country_code` cookie is up to date before checking it to decide whether to track the user or not. That's now implemented as `refreshCountryCodeCookieGdpr` helper in the `analytics/utils` module.

**How to test:**
1. Turn on `utils` debugging by setting `localStorage.debug = 'calypso:analytics:utils'`
2. Load Calypso with the `?flags=ad-tracking` URL to enable ad tracking in dev mode
3. Verify that the `country_code` cookie is present and has 6 hours expiration. When it's not present (you can delete it in devtools), it should be refreshed on any page view.

**Loading the tracking scripts**
The `loadTrackingScripts` function got promisified, and functions that `await` it are suspended until the load succeeds (potentially after multiple attempts).

**How to test:**
1. Turn on the `calypso:analytics:ad-tracking` debugging and load Calypso with the `ad-tracking` flag enabled.
2. When loading Calypso (i.e., the default Reader), verify that loading the tracking scripts (Bing, Quantcast, ...) is reported in the console. And also that various HTTP requests are sent to bing.com or quantserve.com domains (network panel in devtools).
3. When adding a plan or domain to your cart, verify that "add to cart" tracking events are reported. Both in console and network panel.

**Some quirks in the `loadTrackingScripts` function:**
The function has some suboptimal behavior: when loading **any** of the tracking scripts fail, all recording is suspended and is done only after **all** scripts load on later attempts.

A better behavior would be to fail more gracefully. E.g., when Quantcast scripts fail, we can still report Bing or Google events. That's a topic for a future refactor. Now, I tried to preserve the existing behavior as closely as possible.
