### PR TITLE
Render on Jetpack sites and in connect flow but not on atomic sites

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -57,6 +57,7 @@ import ProductSelector from 'blocks/product-selector';
 import FormattedHeader from 'components/formatted-header';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import { getDiscountByName } from 'lib/discounts';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import { getSiteOption, getSitePlan, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
@@ -410,10 +411,11 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { intervalType, isJetpack } = this.props;
-		if ( ! isJetpack ) {
+		const { intervalType, isAtomicSite, isInSignup, isJetpack } = this.props;
+		if ( ( ! isInSignup && ! isJetpack ) || isAtomicSite ) {
 			return null;
 		}
+
 		// @todo: Add translations in FormattedHeader once the final copy is provided.
 		return (
 			<div className="plans-features-main__group is-narrow">
@@ -526,6 +528,7 @@ export default connect(
 			plansWithScroll: ! props.displayJetpackPlans && props.plansWithScroll,
 			customerType,
 			domains: getDecoratedSiteDomains( state, siteId ),
+			isAtomicSite: isSiteAtomic( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack: isJetpackSite( state, siteId ),
 			siteId,


### PR DESCRIPTION
Currently the `<ProductsSelector />` is rendered for any Jetpack site, even if it's atomic. On the other hand, the [recent fix](https://github.com/Automattic/wp-calypso/pull/36999/) prevents it from rendering in the Jetpack Connect flow.

This PR  attempts to address those issues.

#### Changes proposed in this Pull Request

* Render on Jetpack sites and in connect flow but not on atomic sites

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/ and test the following cases:
 * pick a .com site and confirm **there is no** product selector rendered,
 * pick an atomic site and confirm **there is no** product selector rendered,
 * pick a Jetpack site and confirm **there is** a product selector rendered.
* Go to http://calypso.localhost:3000/jetpack/connect/store and confirm **there is** a product selector rendered.

Fixes n/a
