### PR TITLE
Blocks: Support custom option names in ProductSelector, provide them in Plans

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -51,5 +51,14 @@ The following props can be passed to the Product Selector block:
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
 		}
 		```
+	* `optionNames`: ( object ) Optional names of the product options. Each key is a product slug, and the value is the corresponding title. Example:
+		```
+		optionsNames: {
+			jetpack_backup_daily: 'Daily Backups',
+			jetpack_backup_daily_monthly: 'Daily Backups',
+			jetpack_backup_realtime: 'Real-Time Backups',
+			jetpack_backup_realtime_monthly: 'Real-Time Backups',
+		}
+		```
 	* `optionsLabel`: ( string ) Title of the product options section.
 * `siteId`: ( number ) ID of the site we're retrieving purchases for. Used to fetch information about the associated purchases of the selected products.

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -24,6 +24,12 @@ const products = [
 			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
 		},
+		optionNames: {
+			jetpack_backup_daily: 'Daily Backups',
+			jetpack_backup_daily_monthly: 'Daily Backups',
+			jetpack_backup_realtime: 'Real-Time Backups',
+			jetpack_backup_realtime_monthly: 'Real-Time Backups',
+		},
 		optionsLabel: 'Backup options',
 	},
 ];

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -22,7 +22,6 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import { JETPACK_BACKUP_PRODUCT_NAMES } from 'lib/products-values/constants';
 import { withLocalizedMoment } from 'components/localized-moment';
 
 export class ProductSelector extends Component {
@@ -82,9 +81,9 @@ export class ProductSelector extends Component {
 		} );
 	}
 
-	getProductName( productSlug ) {
-		if ( JETPACK_BACKUP_PRODUCT_NAMES[ productSlug ] ) {
-			return JETPACK_BACKUP_PRODUCT_NAMES[ productSlug ];
+	getProductName( product, productSlug ) {
+		if ( product.optionNames && product.optionNames[ productSlug ] ) {
+			return product.optionNames[ productSlug ];
 		}
 
 		const { storeProducts } = this.props;
@@ -109,7 +108,7 @@ export class ProductSelector extends Component {
 				currencyCode: productObject.currency_code,
 				fullPrice: productObject.cost,
 				slug: productSlug,
-				title: this.getProductName( productSlug ),
+				title: this.getProductName( product, productSlug ),
 			};
 		} );
 	}
@@ -128,15 +127,17 @@ export class ProductSelector extends Component {
 		} );
 	}
 
-	renderCheckoutButton( productObject ) {
-		const { translate } = this.props;
+	renderCheckoutButton( product ) {
+		const { intervalType, storeProducts, translate } = this.props;
+		const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
+		const productObject = storeProducts[ selectedProductSlug ];
 
 		return (
 			<ProductCardAction
 				onClick={ this.handleCheckoutForProduct( productObject ) }
 				label={ translate( 'Get %(productName)s', {
 					args: {
-						productName: this.getProductName( productObject.product_slug ),
+						productName: this.getProductName( product, productObject.product_slug ),
 					},
 				} ) }
 			/>
@@ -187,7 +188,7 @@ export class ProductSelector extends Component {
 								}
 							/>
 
-							{ this.renderCheckoutButton( productObject ) }
+							{ this.renderCheckoutButton( product ) }
 						</Fragment>
 					) }
 				</ProductCard>

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -22,6 +22,7 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import { JETPACK_BACKUP_PRODUCT_NAMES } from 'lib/products-values/constants';
 import { withLocalizedMoment } from 'components/localized-moment';
 
 export class ProductSelector extends Component {
@@ -81,18 +82,34 @@ export class ProductSelector extends Component {
 		} );
 	}
 
+	getProductName( productSlug ) {
+		if ( JETPACK_BACKUP_PRODUCT_NAMES[ productSlug ] ) {
+			return JETPACK_BACKUP_PRODUCT_NAMES[ productSlug ];
+		}
+
+		const { storeProducts } = this.props;
+		if ( ! storeProducts ) {
+			return null;
+		}
+
+		const productObject = storeProducts[ productSlug ];
+
+		return productObject.product_name;
+	}
+
 	getProductOptions( product ) {
 		const { intervalType, storeProducts } = this.props;
 		const productSlugs = product.options[ intervalType ];
 
 		return productSlugs.map( productSlug => {
 			const productObject = storeProducts[ productSlug ];
+
 			return {
 				billingTimeFrame: this.getBillingTimeFrameLabel(),
 				currencyCode: productObject.currency_code,
 				fullPrice: productObject.cost,
 				slug: productSlug,
-				title: productObject.product_name,
+				title: this.getProductName( productSlug ),
 			};
 		} );
 	}
@@ -117,9 +134,9 @@ export class ProductSelector extends Component {
 		return (
 			<ProductCardAction
 				onClick={ this.handleCheckoutForProduct( productObject ) }
-				label={ translate( 'Upgrade to %(productName)s', {
+				label={ translate( 'Get %(productName)s', {
 					args: {
-						productName: productObject.product_name,
+						productName: this.getProductName( productObject.product_slug ),
 					},
 				} ) }
 			/>

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -17,3 +17,11 @@ export const JETPACK_BACKUP_PRODUCTS = [
 	...JETPACK_BACKUP_PRODUCTS_YEARLY,
 	...JETPACK_BACKUP_PRODUCTS_MONTHLY,
 ];
+
+// @TODO: Translate those strings once we have confirmed the copy.
+export const JETPACK_BACKUP_PRODUCT_NAMES = {
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 'Daily Backups',
+	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 'Daily Backups',
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 'Real-Time Backups',
+	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 'Real-Time Backups',
+};

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -28,6 +28,7 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 import {
+	JETPACK_BACKUP_PRODUCT_NAMES,
 	JETPACK_BACKUP_PRODUCTS_MONTHLY,
 	JETPACK_BACKUP_PRODUCTS_YEARLY,
 	PRODUCT_JETPACK_BACKUP,
@@ -86,6 +87,9 @@ const jetpackProducts = [
 		options: {
 			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
 			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
+		},
+		optionNames: {
+			...JETPACK_BACKUP_PRODUCT_NAMES,
 		},
 		optionsLabel: 'Backup options',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Products: Add mapping between Jetpack Backup products and their corresponding short titles.
* Blocks: Add support for custom option names in ProductSelector (and document that change)
* Plans: Use the custom name mapping for the options.

#### Preview

Before:
![](https://cldup.com/9MKC9vKK6w.png)

After:
![](https://cldup.com/sfDdsiJeEN.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site slug.
* Play with product options and with billing intervals.
* Verify you can see the short titles for the product option names and the checkout button.
