### PR TITLE
Plans: Add price matrix for Jetpack backups, add support in ProductSelector

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -52,4 +52,7 @@ The following props can be passed to the Product Selector block:
 		}
 		```
 	* `optionsLabel`: ( string ) Title of the product options section.
+* `productPriceMatrix`: ( object ) Matrix of product price relationships. Each key is a product slug, and each value is an object with the following structure:
+	* `relatedProduct`: ( string ) Slug of the related product.
+	* `ratio`: ( number ) Ratio between original plan and related plan. Example: for a `yearly` to `monthly` plan, this should be `12`.
 * `siteId`: ( number ) ID of the site we're retrieving purchases for. Used to fetch information about the associated purchases of the selected products.

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -90,7 +90,8 @@ export class ProductSelector extends Component {
 			return {
 				billingTimeFrame: this.getBillingTimeFrameLabel(),
 				currencyCode: productObject.currency_code,
-				fullPrice: productObject.cost,
+				fullPrice: this.getProductOptionFullPrice( productSlug ),
+				discountedPrice: this.getProductOptionDiscountedPrice( productSlug ),
 				slug: productSlug,
 				title: productObject.product_name,
 			};
@@ -126,6 +127,40 @@ export class ProductSelector extends Component {
 		);
 	}
 
+	getProductOptionFullPrice( productSlug ) {
+		const { productPriceMatrix, storeProducts } = this.props;
+
+		if ( isEmpty( storeProducts ) ) {
+			return null;
+		}
+
+		const productObject = storeProducts[ productSlug ];
+		const relatedProductObject = productPriceMatrix[ productSlug ];
+
+		if ( relatedProductObject ) {
+			return storeProducts[ relatedProductObject.relatedProduct ].cost * relatedProductObject.ratio;
+		}
+
+		return productObject.cost;
+	}
+
+	getProductOptionDiscountedPrice( productSlug ) {
+		const { productPriceMatrix, storeProducts } = this.props;
+
+		if ( isEmpty( storeProducts ) ) {
+			return null;
+		}
+
+		const productObject = storeProducts[ productSlug ];
+		const relatedProductObject = productPriceMatrix[ productSlug ];
+
+		if ( relatedProductObject ) {
+			return productObject.cost;
+		}
+
+		return null;
+	}
+
 	renderProducts() {
 		const { currencyCode, intervalType, products, storeProducts } = this.props;
 
@@ -153,7 +188,8 @@ export class ProductSelector extends Component {
 					key={ product.id }
 					title={ product.title }
 					billingTimeFrame={ this.getBillingTimeFrameLabel() }
-					fullPrice={ productObject.cost }
+					fullPrice={ this.getProductOptionFullPrice( selectedProductSlug ) }
+					discountedPrice={ this.getProductOptionDiscountedPrice( selectedProductSlug ) }
 					description={ product.description }
 					currencyCode={ currencyCode }
 					purchase={ purchase }
@@ -197,9 +233,16 @@ ProductSelector.propTypes = {
 	products: PropTypes.arrayOf(
 		PropTypes.shape( {
 			title: PropTypes.string,
+			id: PropTypes.string,
+			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 			options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
+			optionsLabel: PropTypes.string,
 		} )
 	).isRequired,
+	productPriceMatrix: PropTypes.shape( {
+		relatedProduct: PropTypes.string,
+		ratio: PropTypes.number,
+	} ),
 	siteId: PropTypes.number,
 
 	// Connected props

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -31,6 +31,10 @@ import {
 	JETPACK_BACKUP_PRODUCTS_MONTHLY,
 	JETPACK_BACKUP_PRODUCTS_YEARLY,
 	PRODUCT_JETPACK_BACKUP,
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
 } from 'lib/products-values/constants';
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
@@ -91,6 +95,17 @@ const jetpackProducts = [
 		optionsLabel: 'Backup options',
 	},
 ];
+
+const jetpackProductPriceMatrix = {
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: {
+		relatedProduct: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+		ratio: 12,
+	},
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: {
+		relatedProduct: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+		ratio: 12,
+	},
+};
 
 export class PlansFeaturesMain extends Component {
 	componentDidUpdate( prevProps ) {
@@ -424,7 +439,11 @@ export class PlansFeaturesMain extends Component {
 					subHeaderText="Just looking for backups? We’ve got you covered."
 					compactOnMobile
 				/>
-				<ProductSelector products={ jetpackProducts } intervalType={ intervalType } />
+				<ProductSelector
+					products={ jetpackProducts }
+					intervalType={ intervalType }
+					productPriceMatrix={ jetpackProductPriceMatrix }
+				/>
 			</div>
 		);
 	}


### PR DESCRIPTION
Currently, we're displaying only full prices on the `ProductSelector`. But by design, we have to display discounted prices for when purchasing at a yearly billing interval.

This PR adds the price matrix support to the `ProductSelector`, and adds a price matrix for the existing product to the plans page.

Note that prices aren't accurate right now: for example, for euros, I get 13 per month and 158 per year for daily backup, and that's wrong (yearly should be cheaper). But the prices are currently placeholders, and will be changed later in the store, therefore will be resolved when retrieved from the API.

#### Changes proposed in this Pull Request

* Blocks: Add price matrix support to ProductSelector
* Plans: Define a Jetpack backup product price matrix

#### Preview

Before:
![](https://cldup.com/KUSfrztP9a.png)

After:
![](https://cldup.com/Zjgznf6VeP.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/yearly/:site where `:site` is a Jetpack site.
* Verify you get the discounted prices for yearly, and normal prices for monthly.
* Verify calculations are right: discounted price for yearly is calculated `monthly price * 12`.
