### PR TITLE
Domains: Change the .blog subdomain suggestion logic

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -332,12 +332,17 @@ class DomainsStep extends React.Component {
 		}
 
 		// If we detect a 'blog' site type from Signup data
-		return (
+		if (
 			// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
 			( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
 			// Users choose `Blog` as their site type
 			'blog' === get( signupDependencies, 'siteType' )
-		);
+		) {
+			return true;
+		}
+
+		const lastQuery = get( this.props.step, 'domainForm.lastQuery' );
+		return typeof lastQuery === 'string' && lastQuery.includes( '.blog' );
 	}
 
 	domainForm = () => {


### PR DESCRIPTION
We want to provide .blog subdomains if the search query contains .blog . Combined with D34454-code it'll also force a .blog subdomain if it is explicitly provided in the search query.

#### Changes proposed in this Pull Request

* provide a .blog subdomain suggestion if you search for any .blog domain (ex. something.blog) no matter of the selected site type
* force a .blog subdomain if it was provided in the search box (ex. something.art.blog) overriding the vertical

#### Testing instructions

* apply D34454-code in your sandbox
* chose a different site type than a blog
* search for any query not containing .blog - you should get a wordpress.com subdomain
* search for something ending with .blog - you should get a .blog subdomain
* search for something ending with .art.blog/photo.blog - you should get a .art.blog/photo.blog suggestion
* chose blog site type and enter random query - you should always get a .blog subdomain
