### PR TITLE
Components: remove global CSS reset in button

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -80,6 +80,10 @@ body {
 	color: var( --color-text );
 }
 
+button {
+	font-size: 14px;
+}
+
 body,
 button,
 input,

--- a/client/assets/stylesheets/shared/_reset.scss
+++ b/client/assets/stylesheets/shared/_reset.scss
@@ -128,7 +128,7 @@ button {
 	appearance: none;
 	background: transparent;
 	border: none;
-	font-size: 14px;
+	font-size: inherit;
 	outline: 0;
 	padding: 0;
 	vertical-align: baseline;

--- a/client/assets/stylesheets/shared/_reset.scss
+++ b/client/assets/stylesheets/shared/_reset.scss
@@ -123,6 +123,16 @@ a:active {
 a img {
 	border: 0;
 }
+button {
+	-webkit-appearance: none;
+	appearance: none;
+	background: transparent;
+	border: none;
+	font-size: 14px;
+	outline: 0;
+	padding: 0;
+	vertical-align: baseline;
+}
 
 // Reset the default styling on form inputs in Webkit/iOS
 input,

--- a/client/assets/stylesheets/shared/_reset.scss
+++ b/client/assets/stylesheets/shared/_reset.scss
@@ -124,7 +124,6 @@ a img {
 	border: 0;
 }
 button {
-	-webkit-appearance: none;
 	appearance: none;
 	background: transparent;
 	border: none;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- Remove global scope CSS reset for `button` element in Button component.
+
 # 2.0.0
 
 - Add Card

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,9 +1,7 @@
-# Next
+# @automattic/components 1.0.0
 
-- Remove global scope CSS reset for `button` element in Button component.
-
-# 2.0.0
-
+- Rename package from `@automattic/calypso-ui` to `@automattic/components`, keep version at 1.0.0
+- Add Button
 - Add Card
 - Add Ribbon
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,22 +1,9 @@
-/** @format */
-
 // ==========================================================================
 // Buttons
 // ==========================================================================
 
-// resets button styles
-button {
-	background: transparent;
-	border: none;
-	outline: 0;
-	padding: 0;
-	font-size: 14px;
-	-webkit-appearance: none;
-	appearance: none;
-	vertical-align: baseline;
-}
-
 .button {
+	background: transparent;
 	border-style: solid;
 	border-width: 1px 1px 2px;
 	cursor: pointer;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -20,7 +20,6 @@
 	line-height: 21px;
 	border-radius: 4px;
 	padding: 7px 14px 9px;
-	-webkit-appearance: none;
 	appearance: none;
 
 	&.hidden {


### PR DESCRIPTION
## Changes proposed in this Pull Request

Remove `button` CSS reset from the button component and add it to Calypso CSS reset stylesheet.

I looked at each reset rule separately — 

**Needed**
- `background`: this reset is needed in the component. Only related style `.button` sets is `background-color`.

**Not needed**
- `border`: [the shorthand](https://developer.mozilla.org/en-US/docs/Web/CSS/border) sets `border-width`, `border-style`, and `border-color` and each of those already is in the `.button`. Should this still be included in case someone removes one of those in the future?

**Were already in `.button` and can be removed as duplicate**
- `outline`
- `padding`	
- `font-size`	
- `-webkit-appearance`
- `appearance`
- `vertical-align`

We cannot use `all:unset` rule here since it lacks IE support: https://developer.mozilla.org/en-US/docs/Web/CSS/all#Browser_compatibility :-(


## Testing instructions

* Confirm Button components don't change appearance across Calypso
* Confirm `<button>` elements without `.button` class don't change
* Lastly, check `http://calypso.localhost:3000/devdocs/design/button`
