### PR TITLE
Address design feedback for ProductsSelector and ProductCard

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -79,13 +79,8 @@
 	font-size: 22px;
 	line-height: 24px;
 
-	.product-card:not( .is-purchased ) & {
-		color: var( --color-primary-50 );
-	}
-
 	@include breakpoint( '>660px' ) {
 		font-size: 17px;
-		font-weight: 400;
 	}
 
 	em,
@@ -93,6 +88,14 @@
 	span {
 		font-weight: 600;
 		font-style: italic;
+	}
+
+	.product-card:not( .is-purchased ) & {
+		color: var( --color-primary-50 );
+
+		@include breakpoint( '>660px' ) {
+			font-weight: 600;
+		}
 	}
 }
 
@@ -112,38 +115,85 @@
 	display: flex;
 	flex-flow: row wrap;
 	align-items: baseline;
+}
 
+.product-card {
 	.plan-price {
 		margin-right: 0.333em;
-	}
 
-	@include breakpoint( '>660px' ) {
-		.plan-price,
-		.plan-price__currency-symbol,
-		.plan-price__integer,
-		.plan-price__fraction {
-			font-size: 14px;
-			vertical-align: baseline;
+		&,
+		& * {
+			@include breakpoint( '>660px' ) {
+				font-size: 14px;
+				vertical-align: baseline;
+			}
 		}
 	}
 }
 
 .product-card__billing-timeframe {
-	width: 100%;
 	font-size: 13px;
-	font-style: italic;
 	font-weight: 400;
 	line-height: 13px;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '>660px' ) {
-		width: auto;
+	@include breakpoint( '<660px' ) {
+		font-style: italic;
+	}
+
+	@include breakpoint( '>960px' ) {
 		font-size: 12px;
 	}
 
-	&.is-discounted {
-		@include breakpoint( '>960px' ) {
+	.is-discounted & {
+		@include breakpoint( '>660px' ) {
 			color: var( --color-success );
+		}
+	}
+}
+
+// Adjust price group styles when part of product card header
+.product-card__header {
+	.plan-price,
+	.plan-price * {
+		@include breakpoint( '>660px' ) {
+			font-weight: 600;
+		}
+	}
+
+	.product-card__billing-timeframe {
+		width: 100%;
+
+		@include breakpoint( '>660px' ) {
+			width: auto;
+			font-size: 12px;
+			font-weight: 600;
+		}
+	}
+}
+
+// Adjust price group styles when part of product option
+.product-card__option {
+	.plan-price,
+	.plan-price * {
+		font-size: 16px;
+		font-weight: 400;
+		vertical-align: baseline;
+
+		@include breakpoint( '>960px' ) {
+			font-size: 14px;
+		}
+	}
+
+	.is-discounted .product-card__billing-timeframe {
+		color: var( --color-success );
+	}
+
+	@include breakpoint( '>960px' ) {
+		.plan-price.is-discounted,
+		.plan-price.is-discounted *,
+		.is-discounted .product-card__billing-timeframe {
+			color: var( --color-text-subtle );
 		}
 	}
 }
@@ -220,35 +270,6 @@
 		flex: 0 0 100%;
 		font-size: 14px;
 		line-height: 20px;
-	}
-}
-
-// Adjust price group styles when part of product option
-.product-card__option {
-	.plan-price,
-	.plan-price__currency-symbol,
-	.plan-price__integer,
-	.plan-price__fraction {
-		font-size: 16px;
-		font-weight: 400;
-		vertical-align: baseline;
-
-		@include breakpoint( '>960px' ) {
-			font-size: 14px;
-		}
-	}
-
-	.product-card__billing-timeframe {
-		width: auto;
-		font-size: 13px;
-
-		@include breakpoint( '>960px' ) {
-			font-size: 12px;
-		}
-	}
-
-	.product-card__price-group.is-discounted .product-card__billing-timeframe {
-		color: var( --color-success );
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1097,12 +1097,15 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 	}
 }
 
-// <ProductCard /> overrides
-.is-section-jetpack-connect {
-	.product-card {
-		@include breakpoint( '>660px' ) {
-			text-align: left;
-		}
+// ProductSelector and ProductCard overrides
+.is-section-jetpack-connect .product-selector {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
+.is-section-jetpack-connect .product-card {
+	@include breakpoint( '>660px' ) {
+		text-align: left;
 	}
 
 	.product-card__header {
@@ -1112,8 +1115,12 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 	}
 
 	.product-card__header-primary {
-		padding-top: 20px;
-		padding-bottom: 20px;
+		padding-top: 13px;
+		padding-bottom: 14px;
+
+		@include breakpoint( '<660px' ) {
+			justify-content: center;
+		}
 	}
 
 	.product-card__header-secondary {
@@ -1146,26 +1153,43 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 		justify-content: center;
 	}
 
-	.plan-price.is-discounted,
-	.plan-price.is-discounted .plan-price__currency-symbol,
-	.product-card__price-group.is-discounted .product-card__billing-timeframe,
-	.product-card__option .product-card__price-group.is-discounted .product-card__billing-timeframe {
+	.plan-price,
+	.plan-price *,
+	.product-card__billing-timeframe,
+	.product-card__option .product-card__price-group .product-card__billing-timeframe {
 		color: var( --color-neutral-70 );
+		font-style: normal;
+		vertical-align: baseline;
 	}
 
-	@include breakpoint( '>660px' ) {
-		.plan-price,
-		.plan-price__currency-symbol,
-		.plan-price__integer,
-		.plan-price__fraction,
-		.product-card__billing-timeframe {
-			font-size: 14px;
-			font-weight: 600;
-			font-style: normal;
-		}
+	.plan-price.is-original,
+	.plan-price.is-original * {
+		color: var( --color-neutral-light );
+	}
 
+	.product-card__header .product-card__price-group {
+		.plan-price,
+		.plan-price *,
 		.product-card__billing-timeframe {
-			color: var( --color-neutral-70 );
+			font-size: 16px;
+			font-weight: 500;
+			line-height: 20px;
+
+			@include breakpoint( '>660px' ) {
+				font-size: 20px;
+				font-weight: 600;
+				font-style: normal;
+			}
+		}
+	}
+
+	.product-card__option .product-card__price-group {
+		.plan-price.is-discounted,
+		.plan-price.is-discounted *,
+		.product-card__billing-timeframe {
+			@include breakpoint( '>660px' ) {
+				font-weight: 600;
+			}
 		}
 	}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1145,7 +1145,6 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 
 		@include breakpoint( '>660px' ) {
 			font-size: 22px;
-			font-weight: 600;
 		}
 	}
 
@@ -1167,7 +1166,7 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 		color: var( --color-neutral-light );
 	}
 
-	.product-card__header .product-card__price-group {
+	.product-card__header {
 		.plan-price,
 		.plan-price *,
 		.product-card__billing-timeframe {
@@ -1178,12 +1177,11 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 			@include breakpoint( '>660px' ) {
 				font-size: 20px;
 				font-weight: 600;
-				font-style: normal;
 			}
 		}
 	}
 
-	.product-card__option .product-card__price-group {
+	.product-card__option {
 		.plan-price.is-discounted,
 		.plan-price.is-discounted *,
 		.product-card__billing-timeframe {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clean up and fix issues in product price CSS
* Address design feedback for products selector in Jetpack Connect flow

![Screenshot 2019-10-24 at 15 55 19](https://user-images.githubusercontent.com/478735/67492475-c0a31d80-f676-11e9-859d-de4297f7c567.png)

![Screenshot 2019-10-24 at 15 55 27](https://user-images.githubusercontent.com/478735/67492484-c3057780-f676-11e9-9179-8a9d73753f72.png)

#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/devdocs/design/product-card and confirm that the product cards look as expected and match the design in Figma on various screen sizes
* Go to http://calypso.localhost:3000/jetpack/connect/store and confirm the products selector renders correctly (as in the Figma designs) on various screen sizes

Fixes n/a