### PR TITLE
i18n: Use language revisions when loading a new language

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -73,7 +73,7 @@ function setLocaleInDOM( localeSlug, isRTL ) {
 }
 
 async function getLanguageFile( targetLocaleSlug ) {
-	const url = getLanguageFileUrl( targetLocaleSlug );
+	const url = getLanguageFileUrl( targetLocaleSlug, 'json', window.languageRevisions || {} );
 
 	const response = await dedupedGet( url );
 	if ( response.ok ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When switching languages without reload (e.g. in the Quick Language Switcher), the new language file is loaded without a cache buster. This adds it to the URL.

#### Testing instructions

* Load Calypso with `?flags=quick-language-switcher` and observe the Network panel when switching languages. The URL should now contain a `?v=` parameter.
* This is actually hard to test on a local copy because the file http://widgets.wp.com/languages/calypso/lang-revisions.json won't be included with normal boot, you'd have to go the Docker route. I've tested by just populating the object from the Console in the Dev Inspector.
