### PR TITLE
composite-checkout: Add aria labels to UI elements

### DIFF
--- a/packages/composite-checkout/src/components/checkout-next-step-button.js
+++ b/packages/composite-checkout/src/components/checkout-next-step-button.js
@@ -8,9 +8,9 @@ import React from 'react';
  */
 import Button from './button';
 
-export default function CheckoutNextStepButton( { value, onClick } ) {
+export default function CheckoutNextStepButton( { value, onClick, ariaLabel } ) {
 	return (
-		<Button onClick={ onClick } buttonState="primary">
+		<Button onClick={ onClick } buttonState="primary" aria-label={ ariaLabel }>
 			{ value }
 		</Button>
 	);

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -10,7 +10,9 @@ import styled from 'styled-components';
  */
 import joinClasses from '../lib/join-classes';
 import { getPaymentMethods } from '../lib/payment-methods';
+import { getAriaLabelForPaymentMethodSelector } from '../lib/payment-methods/registered-methods';
 import RadioButton from './radio-button';
+import { useLocalize } from '../lib/localize';
 
 export default function CheckoutPaymentMethods( {
 	summary,
@@ -21,6 +23,8 @@ export default function CheckoutPaymentMethods( {
 	paymentMethod,
 	onChange,
 } ) {
+	const localize = useLocalize();
+
 	const paymentMethods = getPaymentMethods();
 	const paymentMethodsToDisplay = availablePaymentMethods
 		? paymentMethods.filter( method => availablePaymentMethods.includes( method.id ) )
@@ -48,6 +52,7 @@ export default function CheckoutPaymentMethods( {
 						key={ method.id }
 						checked={ paymentMethod.id === method.id }
 						onClick={ onChange }
+						ariaLabel={ getAriaLabelForPaymentMethodSelector( method.id, localize ) }
 					/>
 				) ) }
 			</RadioButtons>
@@ -65,7 +70,14 @@ CheckoutPaymentMethods.propTypes = {
 	onChange: PropTypes.func.isRequired,
 };
 
-function PaymentMethod( { id, LabelComponent, PaymentMethodComponent, checked, onClick } ) {
+function PaymentMethod( {
+	id,
+	LabelComponent,
+	PaymentMethodComponent,
+	checked,
+	onClick,
+	ariaLabel,
+} ) {
 	return (
 		<RadioButton
 			name="paymentMethod"
@@ -73,6 +85,7 @@ function PaymentMethod( { id, LabelComponent, PaymentMethodComponent, checked, o
 			id={ id }
 			checked={ checked }
 			onChange={ onClick ? () => onClick( id ) : null }
+			ariaLabel={ ariaLabel }
 			label={ <LabelComponent /> }
 		>
 			{ PaymentMethodComponent && <PaymentMethodComponent isActive={ checked } /> }
@@ -86,6 +99,7 @@ PaymentMethod.propTypes = {
 	checked: PropTypes.bool.isRequired,
 	PaymentMethodComponent: PropTypes.func,
 	LabelComponent: PropTypes.func,
+	ariaLabel: PropTypes.string.isRequired,
 };
 
 export const RadioButtons = styled.div`

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -66,7 +66,15 @@ CheckoutStep.propTypes = {
 	isComplete: PropTypes.bool.isRequired,
 };
 
-function CheckoutStepHeader( { className, stepNumber, title, isActive, isComplete, onEdit } ) {
+function CheckoutStepHeader( {
+	className,
+	stepNumber,
+	title,
+	isActive,
+	isComplete,
+	onEdit,
+	editButtonAriaLabel,
+} ) {
 	const localize = useLocalize();
 	return (
 		<StepHeader className={ joinClasses( [ className, 'checkout-step__header' ] ) }>
@@ -77,7 +85,7 @@ function CheckoutStepHeader( { className, stepNumber, title, isActive, isComplet
 				{ title }
 			</StepTitle>
 			{ onEdit && isComplete && ! isActive && (
-				<Button buttonState="text-button" className="checkout-step__edit" onClick={ onEdit }>
+				<Button buttonState="text-button" className="checkout-step__edit" onClick={ onEdit } aria-label={ editButtonAriaLabel }>
 					{ localize( 'Edit' ) }
 				</Button>
 			) }

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -154,6 +154,7 @@ function PaymentMethodsStep( { setStepNumber, isActive, isComplete, availablePay
 				stepNumber={ 1 }
 				title={ isComplete ? localize( 'Payment method' ) : localize( 'Pick a payment method' ) }
 				onEdit={ () => setStepNumber( 1 ) }
+				editButtonAriaLabel={ localize( 'Edit the payment method' ) }
 				stepContent={
 					<React.Fragment>
 						<CheckoutPaymentMethods
@@ -167,6 +168,7 @@ function PaymentMethodsStep( { setStepNumber, isActive, isComplete, availablePay
 						<CheckoutNextStepButton
 							value={ localize( 'Continue' ) }
 							onClick={ () => setStepNumber( 2 ) }
+							ariaLabel={ localize( 'Continue with the selected payment method' ) }
 						/>
 					</React.Fragment>
 				}
@@ -216,6 +218,7 @@ function BillingDetailsStep( { isActive, isComplete, setStepNumber, onChangeBill
 					isComplete ? localize( 'Billing details' ) : localize( 'Enter your billing details' )
 				}
 				onEdit={ () => setStepNumber( 2 ) }
+				editButtonAriaLabel={ localize( 'Edit the billing details' ) }
 				stepContent={
 					<React.Fragment>
 						<BillingContactComponent
@@ -227,6 +230,7 @@ function BillingDetailsStep( { isActive, isComplete, setStepNumber, onChangeBill
 						<CheckoutNextStepButton
 							value={ localize( 'Continue' ) }
 							onClick={ () => setStepNumber( 3 ) }
+							ariaLabel={ localize( 'Continue with the entered billing details' ) }
 						/>
 					</React.Fragment>
 				}

--- a/packages/composite-checkout/src/components/order-review-line-items.js
+++ b/packages/composite-checkout/src/components/order-review-line-items.js
@@ -34,10 +34,13 @@ const OrderReviewSectionArea = styled.div`
 `;
 
 function LineItem( { item, className } ) {
+	const itemSpanId = `checkout-line-item-${ item.id }`;
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
-			<span>{ item.label }</span>
-			<span>{ renderDisplayValueMarkdown( item.amount.displayValue ) }</span>
+			<span id={ itemSpanId }>{ item.label }</span>
+			<span aria-labelledby={ itemSpanId }>
+				{ renderDisplayValueMarkdown( item.amount.displayValue ) }
+			</span>
 		</div>
 	);
 }

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -5,7 +5,16 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-export default function RadioButton( { checked, name, value, onChange, children, label, id } ) {
+export default function RadioButton( {
+	checked,
+	name,
+	value,
+	onChange,
+	children,
+	label,
+	id,
+	ariaLabel,
+} ) {
 	const [ isFocused, changeFocus ] = useState( false );
 	return (
 		<RadioButtonWrapper isFocused={ isFocused } checked={ checked }>
@@ -23,6 +32,7 @@ export default function RadioButton( { checked, name, value, onChange, children,
 					changeFocus( false );
 				} }
 				readOnly={ ! onChange }
+				aria-label={ ariaLabel }
 			/>
 			<Label checked={ checked } htmlFor={ id }>
 				{ label }
@@ -39,6 +49,7 @@ RadioButton.propTypes = {
 	checked: PropTypes.bool,
 	value: PropTypes.string.isRequired,
 	onChange: PropTypes.func,
+	ariaLabel: PropTypes.string.isRequired,
 };
 
 const RadioButtonWrapper = styled.div`

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -70,6 +70,7 @@ export function ApplePaySubmitButton() {
 			onClick={ submitApplePayPayment }
 			buttonState="primary"
 			buttonType="apple-pay"
+			aria-label="Submit payment with Apple Pay"
 			fullWidth
 		>
 			<ButtonApplePayIcon fill="white" />

--- a/packages/composite-checkout/src/lib/payment-methods/registered-methods.js
+++ b/packages/composite-checkout/src/lib/payment-methods/registered-methods.js
@@ -37,3 +37,16 @@ export default function loadPaymentMethods() {
 		SubmitButtonComponent: PaypalSubmitButton,
 	} );
 }
+
+export function getAriaLabelForPaymentMethodSelector( methodSlug, localize ) {
+	switch ( methodSlug ) {
+		case 'apple-pay':
+			return localize( 'Check out with Apple Pay' );
+		case 'card':
+			return localize( 'Check out with a credit card' );
+		case 'paypal':
+			return localize( 'Check out with PayPal' );
+		default:
+			throw new Error( `Unrecognized payment method slug ${ methodSlug }` );
+	}
+}


### PR DESCRIPTION
We're starting to use react-testing-library to write unit tests for this package, and that framework (very intentionally) encourages you to write code to be _testable_ in a way that also makes it more _accessible_. This PR adds some aria labels to the checkout component which we'll use for testing.

#### Changes proposed in this Pull Request

* Add ARIA labels to checkout UI elements

#### Testing instructions

* TBD
