### PR TITLE
Types: Add some helpful types

### DIFF
--- a/client/types.ts
+++ b/client/types.ts
@@ -31,3 +31,12 @@ export type TimeoutMS = NonUndefined< Parameters< typeof setTimeout >[ 1 ] >;
 export type TimestampMS = ReturnType< typeof Date.now >;
 export type TimerHandle = ReturnType< typeof setTimeout >;
 export type IntervalHandle = ReturnType< typeof setInterval >;
+
+/**
+ * This is an `any` type alias.
+ * It is intended to signify an `any` type that is impossible or impractical to type more strictly.
+ * It should be accompanied by a comment describing the conditions for its use and when it can be replaced.
+ *
+ * **Please, use sparingly!**
+ */
+export type __TodoAny__ = any;

--- a/client/types.ts
+++ b/client/types.ts
@@ -33,6 +33,13 @@ export type TimerHandle = ReturnType< typeof setTimeout >;
 export type IntervalHandle = ReturnType< typeof setInterval >;
 
 /**
+ * Calypso application state
+ *
+ * Calypso application state is not yet well typed.
+ */
+export type AppState = __TodoAny__;
+
+/**
  * This is an `any` type alias.
  * It is intended to signify an `any` type that is impossible or impractical to type more strictly.
  * It should be accompanied by a comment describing the conditions for its use and when it can be replaced.


### PR DESCRIPTION
- Adds `__TodoAny__` type, which is an `any` alias intended to be replaced when possible
- Adds `AppState` type, which is `__TodoAny__` until the state can be properly typed.

Extracted from several different PRs, most recently #36867.