### PR TITLE
Fix some selector siteId types

### DIFF
--- a/client/state/sites/selectors/get-customizer-url.js
+++ b/client/state/sites/selectors/get-customizer-url.js
@@ -16,7 +16,7 @@ import isJetpackSite from './is-jetpack-site';
  * Returns the customizer URL for a site, or null if it cannot be determined.
  *
  * @param  {Object} state  Global state tree
- * @param  {Number} siteId Site ID
+ * @param  {?Number} siteId Site ID
  * @param  {String} panel  Optional panel to autofocus
  * @return {String}        Customizer URL
  */

--- a/client/state/sites/selectors/get-site-admin-url.js
+++ b/client/state/sites/selectors/get-site-admin-url.js
@@ -10,7 +10,7 @@ import getSiteOption from './get-site-option';
  * @see https://developer.wordpress.org/reference/functions/get_admin_url/
  *
  * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
+ * @param  {?Number}  siteId Site ID
  * @param  {?String} path   Admin screen path
  * @return {?String}        Admin URL
  */

--- a/client/state/sites/selectors/get-site-option.js
+++ b/client/state/sites/selectors/get-site-option.js
@@ -12,7 +12,7 @@ import getSiteOptions from 'state/selectors/get-site-options';
  * Returns a site option for a site
  *
  * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
+ * @param  {?Number}  siteId Site ID
  * @param  {String}  optionName The option key
  * @return {*}  The value of that option or null
  */

--- a/client/state/sites/selectors/is-jetpack-site.js
+++ b/client/state/sites/selectors/is-jetpack-site.js
@@ -8,7 +8,7 @@ import getRawSite from 'state/selectors/get-raw-site';
  * WordPress.com, or null if the site is unknown.
  *
  * @param  {Object}   state  Global state tree
- * @param  {Number}   siteId Site ID
+ * @param  {?Number}   siteId Site ID
  * @return {?Boolean}        Whether site is a Jetpack site
  */
 export default function isJetpackSite( state, siteId ) {


### PR DESCRIPTION
Relax `siteId` in some selector JSDoc types. This was causing errors in TypeScript. SiteId can usually be `number | null` in the application, and selectors are generally resilient to this. With this change, these selector JSDocs reflect that.

Extracted from #36867