### PR TITLE
Add spacing before and after Uploaded themes text and Install Theme button

### DIFF
--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -10,11 +10,11 @@
 
 		@include breakpoint( '<660px' ) {
 			margin-top: 18px;
+			margin-right: 15px;
 		}
 
 		@include breakpoint( '<480px' ) {
 			margin-top: 24px;
-			margin-right: 15px;
 			font-size: 0;
 			.gridicon {
 				padding: 0;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -9,12 +9,11 @@
 		}
 
 		@include breakpoint( '<660px' ) {
-			margin-top: 18px;
+			margin-top: 24px;
 			margin-right: 15px;
 		}
 
 		@include breakpoint( '<480px' ) {
-			margin-top: 24px;
 			font-size: 0;
 			.gridicon {
 				padding: 0;

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -11,9 +11,14 @@
 		background-image: none;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint( '<660px' ) {
 		.card {
 			padding-left: 15px;
+		}
+	}
+
+	@include breakpoint( '<480px' ) {
+		.card {
 			padding-right: 15px;
 		}
 	}

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -4,7 +4,7 @@
 		border-color: transparent;
 		box-shadow: none;
 		padding: 24px 0 0;
-		margin-bottom: 4px;
+		margin-top: 12px;
 	}
 
 	.section-header__label::before {

--- a/client/my-sites/themes/themes-selection.scss
+++ b/client/my-sites/themes/themes-selection.scss
@@ -1,3 +1,3 @@
 .themes__selection .themes-list {
-	margin-top: 24px;
+	margin-top: 13px;
 }


### PR DESCRIPTION
This PR adds spacing between the Install Theme button/Uploaded themes
text and edges of viewport for widths below 660px.

Before:
![spacing_before](https://user-images.githubusercontent.com/17905991/67523927-a0c32800-f67d-11e9-8334-6c6a4bcf83a9.png)

After: 
![spacing_after](https://user-images.githubusercontent.com/17905991/67523938-a7519f80-f67d-11e9-94c8-6f102b6ecfba.png)

#### Testing instructions

* Select My Sites and choose any site
* Select the Themes menu
* Using dev tools, select a width over 480px and below 660px

See this comment from #36719: https://github.com/Automattic/wp-calypso/pull/36719#issuecomment-544295641
