### PR TITLE
List Views: Add a "Copy Link" menu item for each post and page.

### DIFF
--- a/client/components/popover/menu-item-clipboard.jsx
+++ b/client/components/popover/menu-item-clipboard.jsx
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop } from 'lodash';
+import classNames from 'classnames';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Internal dependencies
+ */
+import ClipboardButton from 'components/forms/clipboard-button';
+
+function PopoverMenuItemClipboard( {
+	children,
+	className,
+	text,
+	onCopy = noop,
+	icon = 'clipboard',
+	...rest
+} ) {
+	return (
+		<ClipboardButton
+			text={ text }
+			onCopy={ onCopy }
+			role="menuitem"
+			tabIndex="-1"
+			className={ classNames( 'popover__menu-item', className ) }
+			{ ...rest }
+		>
+			<Gridicon icon={ icon } size={ 18 } />
+			{ children }
+		</ClipboardButton>
+	);
+}
+
+PopoverMenuItemClipboard.propTypes = {
+	className: PropTypes.string,
+	icon: PropTypes.string,
+	onCopy: PropTypes.func,
+	text: PropTypes.string,
+};
+
+export default PopoverMenuItemClipboard;

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -328,7 +328,7 @@ class Page extends Component {
 		const { page, translate } = this.props;
 		return (
 			<PopoverMenuItemClipboard text={ page.URL } onCopy={ this.copyPageLink }>
-				{ translate( 'Copy Link', { context: 'verb' } ) }
+				{ translate( 'Copy Link' ) }
 			</PopoverMenuItemClipboard>
 		);
 	}

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -36,7 +36,7 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { savePost, deletePost, trashPost, restorePost } from 'state/posts/actions';
-import { withoutNotice } from 'state/notices/actions';
+import { infoNotice, withoutNotice } from 'state/notices/actions';
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
@@ -666,6 +666,9 @@ class Page extends Component {
 	};
 
 	copyPageLink = () => {
+		this.props.infoNotice( this.props.translate( 'Link copied to clipboard.' ), {
+			duration: 3000,
+		} );
 		this.props.recordEvent( 'Clicked Copy Page Link' );
 	};
 
@@ -704,6 +707,7 @@ const mapState = ( state, props ) => {
 };
 
 const mapDispatch = {
+	infoNotice,
 	savePost: withoutNotice( savePost ),
 	deletePost: withoutNotice( deletePost ),
 	trashPost: withoutNotice( trashPost ),

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -18,6 +18,7 @@ import CompactCard from 'components/card/compact';
 import Gridicon from 'components/gridicon';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import PopoverMenuItemClipboard from 'components/popover/menu-item-clipboard';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import SiteIcon from 'blocks/site-icon';
@@ -323,6 +324,15 @@ class Page extends Component {
 		);
 	}
 
+	getCopyLinkItem() {
+		const { page, translate } = this.props;
+		return (
+			<PopoverMenuItemClipboard text={ page.URL } onCopy={ this.copyPageLink }>
+				{ translate( 'Copy Link', { context: 'verb' } ) }
+			</PopoverMenuItemClipboard>
+		);
+	}
+
 	getRestoreItem() {
 		if ( this.props.page.status !== 'trash' || ! utils.userCan( 'delete_post', this.props.page ) ) {
 			return null;
@@ -422,6 +432,7 @@ class Page extends Component {
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
 		const copyPageItem = this.getCopyPageItem();
+		const copyLinkItem = this.getCopyLinkItem();
 		const statsItem = this.getStatsItem();
 		const moreInfoItem = this.popoverMoreInfo();
 		const hasMenuItems =
@@ -445,6 +456,7 @@ class Page extends Component {
 				{ viewItem }
 				{ statsItem }
 				{ copyPageItem }
+				{ copyLinkItem }
 				{ restoreItem }
 				{ frontPageItem }
 				{ postsPageItem }
@@ -651,6 +663,10 @@ class Page extends Component {
 
 	copyPage = () => {
 		this.props.recordEvent( 'Clicked Copy Page' );
+	};
+
+	copyPageLink = () => {
+		this.props.recordEvent( 'Clicked Copy Page Link' );
 	};
 
 	handleMenuToggle = isVisible => {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -306,7 +306,7 @@ class Page extends Component {
 		];
 	}
 
-	getCopyItem() {
+	getCopyPageItem() {
 		const { wpAdminGutenberg, page: post, duplicateUrl } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
@@ -318,7 +318,7 @@ class Page extends Component {
 		return (
 			<PopoverMenuItem onClick={ this.copyPage } href={ duplicateUrl }>
 				<Gridicon icon="clipboard" size={ 18 } />
-				{ this.props.translate( 'Copy' ) }
+				{ this.props.translate( 'Copy Page' ) }
 			</PopoverMenuItem>
 		);
 	}
@@ -421,7 +421,7 @@ class Page extends Component {
 		const postsPageItem = this.getPostsPageItem();
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
-		const copyItem = this.getCopyItem();
+		const copyPageItem = this.getCopyPageItem();
 		const statsItem = this.getStatsItem();
 		const moreInfoItem = this.popoverMoreInfo();
 		const hasMenuItems =
@@ -444,7 +444,7 @@ class Page extends Component {
 				{ publishItem }
 				{ viewItem }
 				{ statsItem }
-				{ copyItem }
+				{ copyPageItem }
 				{ restoreItem }
 				{ frontPageItem }
 				{ postsPageItem }

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -327,7 +327,7 @@ class Page extends Component {
 	getCopyLinkItem() {
 		const { page, translate } = this.props;
 		return (
-			<PopoverMenuItemClipboard text={ page.URL } onCopy={ this.copyPageLink }>
+			<PopoverMenuItemClipboard text={ page.URL } onCopy={ this.copyPageLink } icon={ 'link' }>
 				{ translate( 'Copy Link' ) }
 			</PopoverMenuItemClipboard>
 		);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenuItemClipboard from 'components/popover/menu-item-clipboard';
+import { getPost } from 'state/posts/selectors';
+import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
+import { bumpStatGenerator } from './utils';
+
+function PostActionsEllipsisMenuCopyLink( { onCopyLinkClick, copyLink, translate } ) {
+	return (
+		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopyLinkClick }>
+			{ translate( 'Copy Link', { context: 'verb' } ) }
+		</PopoverMenuItemClipboard>
+	);
+}
+
+PostActionsEllipsisMenuCopyLink.propTypes = {
+	onCopyLinkClick: PropTypes.func,
+	copyLink: PropTypes.string,
+	translate: PropTypes.func,
+};
+
+const mapStateToProps = ( state, { globalId } ) => {
+	const post = getPost( state, globalId );
+	if ( ! post ) {
+		return {};
+	}
+
+	return {
+		copyLink: post.URL,
+	};
+};
+
+const mapDispatchToProps = { bumpStat, recordTracksEvent };
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const bumpCopyLinkStat = bumpStatGenerator( stateProps.type, 'copyLink', dispatchProps.bumpStat );
+	const onCopyLinkClick = () => {
+		bumpCopyLinkStat();
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_permalink' );
+	};
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, { onCopyLinkClick } );
+};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	mergeProps
+)( localize( PostActionsEllipsisMenuCopyLink ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,18 +17,9 @@ import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { infoNotice } from 'state/notices/actions';
 
-function PostActionsEllipsisMenuCopyLink( {
-	onCopyLinkClick,
-	copyLink,
-	infoNotice: showInfoNotice,
-	translate,
-} ) {
-	const onCopy = () => {
-		onCopyLinkClick();
-		showInfoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } );
-	};
+function PostActionsEllipsisMenuCopyLink( { onCopyLinkClick, copyLink } ) {
 	return (
-		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopy } icon={ 'link' }>
+		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopyLinkClick } icon={ 'link' }>
 			{ translate( 'Copy Link' ) }
 		</PopoverMenuItemClipboard>
 	);
@@ -57,6 +48,7 @@ const mapDispatchToProps = { bumpStat, infoNotice, recordTracksEvent };
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpCopyLinkStat = bumpStatGenerator( stateProps.type, 'copyLink', dispatchProps.bumpStat );
 	const onCopyLinkClick = () => {
+		dispatchProps.infoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } );
 		bumpCopyLinkStat();
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_copy_link' );
 	};

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -46,7 +46,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpStat, infoNotice, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpCopyLinkStat = bumpStatGenerator( stateProps.type, 'copyLink', dispatchProps.bumpStat );
+	const bumpCopyLinkStat = bumpStatGenerator( stateProps.type, 'copy_link', dispatchProps.bumpStat );
 	const onCopyLinkClick = () => {
 		dispatchProps.infoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } );
 		bumpCopyLinkStat();

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -19,7 +19,7 @@ import { bumpStatGenerator } from './utils';
 function PostActionsEllipsisMenuCopyLink( { onCopyLinkClick, copyLink, translate } ) {
 	return (
 		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopyLinkClick }>
-			{ translate( 'Copy Link', { context: 'verb' } ) }
+			{ translate( 'Copy Link' ) }
 		</PopoverMenuItemClipboard>
 	);
 }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -47,7 +47,7 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpCopyLinkStat = bumpStatGenerator( stateProps.type, 'copyLink', dispatchProps.bumpStat );
 	const onCopyLinkClick = () => {
 		bumpCopyLinkStat();
-		dispatchProps.recordTracksEvent( 'calypso_post_type_list_permalink' );
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_copy_link' );
 	};
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { onCopyLinkClick } );
 };

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -23,7 +23,7 @@ function PostActionsEllipsisMenuCopyLink( { onCopyLinkClick, copyLink, infoNotic
 		infoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } );
 	};
 	return (
-		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopy }>
+		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopy } icon={ 'link' }>
 			{ translate( 'Copy Link' ) }
 		</PopoverMenuItemClipboard>
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -17,10 +17,15 @@ import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { infoNotice } from 'state/notices/actions';
 
-function PostActionsEllipsisMenuCopyLink( { onCopyLinkClick, copyLink, infoNotice, translate } ) {
+function PostActionsEllipsisMenuCopyLink( {
+	onCopyLinkClick,
+	copyLink,
+	infoNotice: showInfoNotice,
+	translate,
+} ) {
 	const onCopy = () => {
 		onCopyLinkClick();
-		infoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } );
+		showInfoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } );
 	};
 	return (
 		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopy } icon={ 'link' }>

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -43,6 +43,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 
 	return {
 		copyLink: post.URL,
+		type: post.type,
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/copy-link.jsx
@@ -15,10 +15,15 @@ import PopoverMenuItemClipboard from 'components/popover/menu-item-clipboard';
 import { getPost } from 'state/posts/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
+import { infoNotice } from 'state/notices/actions';
 
-function PostActionsEllipsisMenuCopyLink( { onCopyLinkClick, copyLink, translate } ) {
+function PostActionsEllipsisMenuCopyLink( { onCopyLinkClick, copyLink, infoNotice, translate } ) {
+	const onCopy = () => {
+		onCopyLinkClick();
+		infoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } );
+	};
 	return (
-		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopyLinkClick }>
+		<PopoverMenuItemClipboard text={ copyLink } onCopy={ onCopy }>
 			{ translate( 'Copy Link' ) }
 		</PopoverMenuItemClipboard>
 	);
@@ -41,7 +46,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 	};
 };
 
-const mapDispatchToProps = { bumpStat, recordTracksEvent };
+const mapDispatchToProps = { bumpStat, infoNotice, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpCopyLinkStat = bumpStatGenerator( stateProps.type, 'copyLink', dispatchProps.bumpStat );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -41,7 +41,7 @@ function PostActionsEllipsisMenuDuplicate( {
 	return (
 		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="clipboard">
 			<QueryJetpackModules siteId={ siteId } />
-			{ translate( 'Copy Post', { context: 'verb' } ) }
+			{ translate( 'Copy Post' ) }
 		</PopoverMenuItem>
 	);
 }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -41,7 +41,7 @@ function PostActionsEllipsisMenuDuplicate( {
 	return (
 		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="clipboard">
 			<QueryJetpackModules siteId={ siteId } />
-			{ translate( 'Copy', { context: 'verb' } ) }
+			{ translate( 'Copy Post', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);
 }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -20,6 +20,7 @@ import PostActionsEllipsisMenuTrash from './trash';
 import PostActionsEllipsisMenuView from './view';
 import PostActionsEllipsisMenuRestore from './restore';
 import PostActionsEllipsisMenuDuplicate from './duplicate';
+import PostActionsEllipsisMenuCopyLink from './copy-link';
 
 /**
  * Style dependencies
@@ -39,6 +40,7 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 			<PostActionsEllipsisMenuShare key="share" />,
 			<PostActionsEllipsisMenuRestore key="restore" />,
 			<PostActionsEllipsisMenuDuplicate key="duplicate" />,
+			<PostActionsEllipsisMenuCopyLink key="copyLink" />,
 			<PostActionsEllipsisMenuTrash key="trash" />
 		);
 	}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
@@ -12,3 +12,8 @@
 		margin-right: -16px;
 	}
 }
+
+.ellipsis-menu__menu .button .gridicon {
+	top: inherit;
+	margin-top: inherit;
+}


### PR DESCRIPTION
This PR adds a "Copy Link" menu item to the ellipsis menus of both the post and page list views, allowing the user to easily copy the content's permalink to their clipboard.

<img width="1447" alt="Screen Shot 2019-10-25 at 1 56 29 PM" src="https://user-images.githubusercontent.com/349751/67604054-6c0fa900-f72f-11e9-916c-212a02f9f680.png">

fixes #36826 