### PR TITLE
Revert swap domain step and site title step A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,13 +124,4 @@ export default {
 		},
 		defaultVariation: 'default',
 	},
-	prefillSiteTitleWithDomainQuery: {
-		datestamp: '20191017',
-		variations: {
-			variant: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { assign, get, includes, indexOf, reject } from 'lodash';
-import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -69,17 +68,6 @@ const flows = generateFlows( {
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 } );
-
-if ( flows.onboarding && 'variant' === abtest( 'prefillSiteTitleWithDomainQuery' ) ) {
-	flows.onboarding.steps = [
-		'user',
-		'site-type',
-		'site-topic-with-preview',
-		'domains-with-preview',
-		'site-title-with-preview',
-		'plans',
-	];
-}
 
 function removeUserStepFromFlow( flow ) {
 	if ( ! flow ) {

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -7,8 +7,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get } from 'lodash';
-import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -23,7 +21,6 @@ import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
-import { getSignupProgress } from 'state/signup/progress/selectors';
 
 /**
  * Style dependencies
@@ -44,24 +41,7 @@ class SiteTitleStep extends Component {
 		siteType: PropTypes.string,
 	};
 
-	getDomainFormLastQuery() {
-		return get(
-			find( this.props.signupProgress, { stepName: 'domains-with-preview' } ),
-			[ 'domainForm', 'lastQuery' ],
-			null
-		);
-	}
-
 	componentDidMount() {
-		if (
-			this.props.flowName === 'onboarding' &&
-			'variant' === abtest( 'prefillSiteTitleWithDomainQuery' )
-		) {
-			const domainLastQuery = this.getDomainFormLastQuery();
-			if ( domainLastQuery && ! this.props.siteTitle ) {
-				this.props.setSiteTitle( domainLastQuery );
-			}
-		}
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
 
@@ -135,7 +115,6 @@ class SiteTitleStep extends Component {
 
 export default connect(
 	state => ( {
-		signupProgress: getSignupProgress( state ),
 		siteTitle: getSiteTitle( state ),
 		siteType: getSiteType( state ),
 	} ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert [A/B test that swapped domain step and site title steps](https://github.com/Automattic/wp-calypso/pull/36878) in onboarding and pre-filled the site title with the domain search query terms (`prefillSiteTitleWithDomainQuery`).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site in the onboarding flow, selecting `blog`, `business`, or `professional` — the site title step should come before the domains step, and function as expected (a normal empty text input field, and adding a site title updates the site preview).
