### PR TITLE
Block-Editor: reorder Jetpack and CoBlocks categories

### DIFF
--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -21,6 +21,9 @@ There are two environments the block editor integration supports:
 - `disable-nux-tour.js`: Disable the pop-up tooltip tour that is displayed on first use.
 - `rich-text.js`: Extensions for the Rich Text toolbar with the Calypso buttons missing on Core (i.e. underline, justify).
 - `switch-to-classic.js`: Append a button to the "More tools" menu for switching to the classic editor.
+- `tracking`: Adds analytics around specific user actions for Simple, Jetpack and Atomic sites.
+- `reorder-block-categories`: Moves Jetpack and CoBlocks Block Categories below Core Categories
+- `unregister-experimental-blocks`: Removes some experimental blocks from the Gutenberg Plugin.
 
 ### Calypso utilities
 

--- a/apps/wpcom-block-editor/src/common/index.js
+++ b/apps/wpcom-block-editor/src/common/index.js
@@ -2,8 +2,9 @@
  * Internal dependencies
  */
 import './disable-nux-tour';
+import './reorder-block-categories';
 import './rich-text';
-import './switch-to-classic';
 import './style.scss';
-import './unregister-experimental-blocks';
+import './switch-to-classic';
 import './tracking';
+import './unregister-experimental-blocks';

--- a/apps/wpcom-block-editor/src/common/reorder-block-categories.js
+++ b/apps/wpcom-block-editor/src/common/reorder-block-categories.js
@@ -11,19 +11,17 @@ domReady( function() {
 	//preserve order of other columns, and split matching
 	const { core: coreCategories, custom: unsorted } = getCategories().reduce(
 		( { core, custom }, category ) => {
-			const matchIndex = categorySlugs.indexOf( category.slug );
-			if ( matchIndex === -1 ) {
-				return {
-					core: [ ...core, category ],
-					custom,
-				};
-			}
-			if ( matchIndex > -1 ) {
+			const isCustomCategory = categorySlugs.includes( category.slug );
+			if ( isCustomCategory ) {
 				return {
 					core,
 					custom: [ ...custom, category ],
 				};
 			}
+			return {
+				core: [ ...core, category ],
+				custom,
+			};
 		},
 		{ custom: [], core: [] }
 	);

--- a/apps/wpcom-block-editor/src/common/reorder-block-categories.js
+++ b/apps/wpcom-block-editor/src/common/reorder-block-categories.js
@@ -1,0 +1,43 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { getCategories, setCategories } from '@wordpress/blocks';
+import domReady from '@wordpress/dom-ready';
+
+const categorySlugs = [ 'jetpack', 'coblocks', 'coblocks-galleries' ];
+
+domReady( function() {
+	//preserve order of other columns, and split matching
+	const { core: coreCategories, custom: unsorted } = getCategories().reduce(
+		( { core, custom }, category ) => {
+			const matchIndex = categorySlugs.indexOf( category.slug );
+			if ( matchIndex === -1 ) {
+				return {
+					core: [ ...core, category ],
+					custom,
+				};
+			}
+			if ( matchIndex > -1 ) {
+				return {
+					core,
+					custom: [ ...custom, category ],
+				};
+			}
+		},
+		{ custom: [], core: [] }
+	);
+	//sort once following order of categorySlugs
+	const customCategories = unsorted.sort( ( { slug }, { slug: slugB } ) => {
+		const index = categorySlugs.indexOf( slug );
+		const indexB = categorySlugs.indexOf( slugB );
+		if ( index === indexB ) {
+			return 0;
+		}
+		if ( index < indexB ) {
+			return -1;
+		}
+		return 1;
+	} );
+	setCategories( [ ...coreCategories, ...customCategories ] );
+} );

--- a/apps/wpcom-block-editor/src/common/reorder-block-categories.js
+++ b/apps/wpcom-block-editor/src/common/reorder-block-categories.js
@@ -7,35 +7,41 @@ import domReady from '@wordpress/dom-ready';
 
 const categorySlugs = [ 'jetpack', 'coblocks', 'coblocks-galleries' ];
 
-domReady( function() {
-	//preserve order of other columns, and split matching
-	const { core: coreCategories, custom: unsorted } = getCategories().reduce(
-		( { core, custom }, category ) => {
-			const isCustomCategory = categorySlugs.includes( category.slug );
-			if ( isCustomCategory ) {
+// Very fragile checks, we'll replace with proper common bundle splitting in https://github.com/Automattic/wp-calypso/issues/34476
+const isSimpleSite = !! window.wpcomGutenberg.pluginVersion;
+const isAtomicSite = window._currentSiteType === 'atomic';
+
+if ( isAtomicSite || isSimpleSite ) {
+	domReady( function() {
+		//preserve order of other columns, and split matching
+		const { core: coreCategories, custom: unsorted } = getCategories().reduce(
+			( { core, custom }, category ) => {
+				const isCustomCategory = categorySlugs.includes( category.slug );
+				if ( isCustomCategory ) {
+					return {
+						core,
+						custom: [ ...custom, category ],
+					};
+				}
 				return {
-					core,
-					custom: [ ...custom, category ],
+					core: [ ...core, category ],
+					custom,
 				};
+			},
+			{ custom: [], core: [] }
+		);
+		//sort once following order of categorySlugs
+		const customCategories = unsorted.sort( ( { slug }, { slug: slugB } ) => {
+			const index = categorySlugs.indexOf( slug );
+			const indexB = categorySlugs.indexOf( slugB );
+			if ( index === indexB ) {
+				return 0;
 			}
-			return {
-				core: [ ...core, category ],
-				custom,
-			};
-		},
-		{ custom: [], core: [] }
-	);
-	//sort once following order of categorySlugs
-	const customCategories = unsorted.sort( ( { slug }, { slug: slugB } ) => {
-		const index = categorySlugs.indexOf( slug );
-		const indexB = categorySlugs.indexOf( slugB );
-		if ( index === indexB ) {
-			return 0;
-		}
-		if ( index < indexB ) {
-			return -1;
-		}
-		return 1;
+			if ( index < indexB ) {
+				return -1;
+			}
+			return 1;
+		} );
+		setCategories( [ ...coreCategories, ...customCategories ] );
 	} );
-	setCategories( [ ...coreCategories, ...customCategories ] );
-} );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of https://github.com/Automattic/wp-calypso/issues/35876 this moves Jetpack and CoBlocks categories below other categories.

Note that the `core/blocks` store uses the array order of whatever we dispatched via `setCategories`, so doing things like changing a block's category slug name or translated title currently do not affect ordering.

| Before  | After |
| ------------- | ------------- |
| <img width="457" alt="63965105-504c9700-ca4d-11e9-89a7-e9754c3d4db7" src="https://user-images.githubusercontent.com/1270189/67536131-880d3f00-f68a-11e9-9631-8ceeb5791a54.png"> | <img width="539" alt="Screen Shot 2019-10-24 at 6 12 00 PM" src="https://user-images.githubusercontent.com/1270189/67536143-922f3d80-f68a-11e9-9659-5eafa405f7d4.png">|
  
<img width="762" alt="Screen Shot 2019-10-24 at 6 11 52 PM" src="https://user-images.githubusercontent.com/1270189/67536148-978c8800-f68a-11e9-930f-3ae8088abfe2.png">

### Questions / Notes

* Open question for @apeatling  and @simison, would we like this to affect all site types or just Atomic and Simple, excluding self-hosted Jetpack sites? 
* If folks have a different category ordering in mind let me know.
* Is `domReady` a decent event for waiting for all blocks/columns registration to settle? If there's something more appropriate, I can update.

#### Testing instructions

* Apply D34488-code
* Sandbox widgets.wp.com
* Open the Block Editor from wp-admin or WordPress.com/block-editor
* Verify that the new category order matches as expected in an Atomic and Simple Site
* Verify that no reordering happens for Jetpack (standalone) sites

