### PR TITLE
FSE: Update calypso-build to latest 4.2.1

### DIFF
--- a/apps/full-site-editing/package-lock.json
+++ b/apps/full-site-editing/package-lock.json
@@ -930,6 +930,15 @@
 				"@babel/plugin-transform-typescript": "^7.6.0"
 			}
 		},
+		"@babel/runtime": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+			"dev": true,
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
 		"@babel/template": {
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
@@ -979,6 +988,45 @@
 				"minimist": "^1.2.0"
 			}
 		},
+		"@hapi/address": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+			"integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
+			"dev": true
+		},
+		"@hapi/bourne": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+			"dev": true
+		},
+		"@hapi/hoek": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
+			"integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA==",
+			"dev": true
+		},
+		"@hapi/joi": {
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+			"integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/address": "2.x.x",
+				"@hapi/bourne": "1.x.x",
+				"@hapi/hoek": "8.x.x",
+				"@hapi/topo": "3.x.x"
+			}
+		},
+		"@hapi/topo": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+			"integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^8.3.0"
+			}
+		},
 		"@jest/console": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -988,6 +1036,42 @@
 				"@jest/source-map": "^24.9.0",
 				"chalk": "^2.0.1",
 				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/reporters": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.9.0",
+				"jest-config": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.9.0",
+				"jest-resolve-dependencies": "^24.9.0",
+				"jest-runner": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
+				"jest-watcher": "^24.9.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"slash": "^2.0.0",
+				"strip-ansi": "^5.0.0"
 			}
 		},
 		"@jest/environment": {
@@ -1011,6 +1095,43 @@
 				"@jest/types": "^24.9.0",
 				"jest-message-util": "^24.9.0",
 				"jest-mock": "^24.9.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"istanbul-reports": "^2.2.6",
+				"jest-haste-map": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-worker": "^24.6.0",
+				"node-notifier": "^5.4.2",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/source-map": {
@@ -1098,6 +1219,22 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"dev": true,
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+			"dev": true
+		},
 		"@romainberger/css-diff": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@romainberger/css-diff/-/css-diff-1.0.3.tgz",
@@ -1179,6 +1316,81 @@
 				}
 			}
 		},
+		"@sheerun/mutationobserver-shim": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+			"integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+			"dev": true
+		},
+		"@testing-library/dom": {
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.8.1.tgz",
+			"integrity": "sha512-b+Q4wryafqsSTFBV14cc5xqhN/OVB9oMeUQvZwy1kVx+kdqs4zQAcyvCsFkdcqx7NxibWpUN/fBIUaqyAEhitw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@sheerun/mutationobserver-shim": "^0.3.2",
+				"@types/testing-library__dom": "^6.0.0",
+				"aria-query": "3.0.0",
+				"pretty-format": "^24.9.0",
+				"wait-for-expect": "^3.0.0"
+			}
+		},
+		"@testing-library/jest-dom": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.1.2.tgz",
+			"integrity": "sha512-fNf2rCfu0dBD4DmpzqR2ibsaFlFojrWI/EuU8LLqv73CzFIMvT2RMq88p5JVRe4DfeNj0mu0MQ5FTG4mQ0qFaA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.5.1",
+				"chalk": "^2.4.1",
+				"css": "^2.2.3",
+				"css.escape": "^1.5.1",
+				"jest-diff": "^24.0.0",
+				"jest-matcher-utils": "^24.0.0",
+				"lodash": "^4.17.11",
+				"pretty-format": "^24.0.0",
+				"redent": "^3.0.0"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				},
+				"redent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+					"dev": true,
+					"requires": {
+						"indent-string": "^4.0.0",
+						"strip-indent": "^3.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				}
+			}
+		},
+		"@testing-library/react": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.3.0.tgz",
+			"integrity": "sha512-FTPCwmLo0tLtP50Au2uGz4/N1BcJTnBx4StDVHZ47zPMEj1/+J2rk/RTj8SLoHRKWCtcmhN4wRmudOXQNP29/w==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.6.0",
+				"@testing-library/dom": "^6.3.0",
+				"@types/testing-library__react": "^9.1.0"
+			}
+		},
 		"@types/babel__core": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -1220,6 +1432,23 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
+		},
+		"@types/glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
+			"requires": {
+				"@types/events": "*",
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1245,10 +1474,28 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
+		"@types/json-schema": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+			"dev": true
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
 		"@types/node": {
 			"version": "12.11.7",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
 			"integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+			"dev": true
+		},
+		"@types/prop-types": {
+			"version": "15.7.3",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
 			"dev": true
 		},
 		"@types/q": {
@@ -1257,11 +1504,76 @@
 			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
 			"dev": true
 		},
+		"@types/react": {
+			"version": "16.9.11",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.11.tgz",
+			"integrity": "sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==",
+			"dev": true,
+			"requires": {
+				"@types/prop-types": "*",
+				"csstype": "^2.2.0"
+			}
+		},
+		"@types/react-dom": {
+			"version": "16.9.3",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.3.tgz",
+			"integrity": "sha512-FUuZKXPr9qlzUT9lhuzrZgLjH63TvNn28Ch3MvKG4B+F52zQtO8DtE0Opbncy3xaucNZM2WIPfuNTgkbKx5Brg==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*"
+			}
+		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
+		},
+		"@types/testing-library__dom": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.5.3.tgz",
+			"integrity": "sha512-E/LSnbzo25gCLy/YOHKY9KJ+rfI8hy5cfbScyZqVuFw9CUMn1faWEDnxMcVHgjAbWtTStfllB8TwNKCx8bAKeA==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^24.3.0"
+			}
+		},
+		"@types/testing-library__react": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.2.tgz",
+			"integrity": "sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==",
+			"dev": true,
+			"requires": {
+				"@types/react-dom": "*",
+				"@types/testing-library__dom": "*"
+			}
+		},
+		"@types/unist": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+			"dev": true
+		},
+		"@types/vfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*",
+				"@types/vfile-message": "*"
+			}
+		},
+		"@types/vfile-message": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*"
+			}
 		},
 		"@types/yargs": {
 			"version": "13.0.3",
@@ -1277,6 +1589,35 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
 			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
 			"dev": true
+		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+			"dev": true,
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "1.13.0",
+				"eslint-scope": "^4.0.0"
+			}
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+			"dev": true,
+			"requires": {
+				"lodash.unescape": "4.0.1",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"dev": true
+				}
+			}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
@@ -1460,6 +1801,25 @@
 			"integrity": "sha512-b45c4x1+OvQm1f6egrBruO8eVF4bRVRZ8ojM1ttDcMi+K/qXfun3J6O8xXpSnA5eeNCZaJL3DhIk/aoNBbpwzw==",
 			"dev": true
 		},
+		"@wordpress/babel-preset-default": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.6.2.tgz",
+			"integrity": "sha512-UCR35dagwrlWLYFWqEOG8ZrCUYQl1dHcvnMgiW+MvAnAZwiGV041M0ApbiyKQOUvM6Q2RnRzAsSl+vgdeO9y5w==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.4.5",
+				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+				"@babel/plugin-transform-react-jsx": "^7.3.0",
+				"@babel/plugin-transform-runtime": "^7.4.4",
+				"@babel/preset-env": "^7.4.5",
+				"@babel/runtime": "^7.4.5",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^2.3.0",
+				"@wordpress/browserslist-config": "^2.6.0",
+				"@wordpress/element": "^2.8.2",
+				"core-js": "^3.1.4"
+			}
+		},
 		"@wordpress/browserslist-config": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.6.0.tgz",
@@ -1475,6 +1835,248 @@
 				"json2php": "^0.0.4",
 				"webpack": "^4.8.3",
 				"webpack-sources": "^1.3.0"
+			}
+		},
+		"@wordpress/element": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.8.2.tgz",
+			"integrity": "sha512-pwy2qvbkNIoB+XTwtvsAKP/pmCoqFq3vyH9uakNIVHJF/DzOwwLS3y5I5hHTuNYmmgFuGALQVZlUVVkujRpWfg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/escape-html": "^1.5.1",
+				"lodash": "^4.17.15",
+				"react": "^16.9.0",
+				"react-dom": "^16.9.0"
+			}
+		},
+		"@wordpress/escape-html": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.1.tgz",
+			"integrity": "sha512-C4chmaS4US5+SDQKcYuqU+MZJa41o7Wq7IwDsqIQfnrqTEhjk5JBFQm2M0slWOti9hry9CAGlmorp5XvE/eiyg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			}
+		},
+		"@wordpress/eslint-plugin": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
+			"integrity": "sha512-i/eNTWll3OH7rFukG2pNZXlOl0xihnuxg/2maEEMGzLS8dA8TEwyzCUXCqKycpOLR9sqODhdWFjeQBAPIjpZHg==",
+			"dev": true,
+			"requires": {
+				"babel-eslint": "^10.0.2",
+				"eslint-plugin-jest": "^22.15.1",
+				"eslint-plugin-jsdoc": "^15.8.0",
+				"eslint-plugin-jsx-a11y": "^6.2.3",
+				"eslint-plugin-react": "^7.14.3",
+				"eslint-plugin-react-hooks": "^1.6.1",
+				"globals": "^12.0.0",
+				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "12.1.1",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-12.1.1.tgz",
+					"integrity": "sha512-i4wvLF+QFfPq/gNA1S8dL4Z2f2Cb62ZvxDhj38fZIProAfyUidDmUQILIg1jc5iwqJr4PVJSUB5usYvFxSzg+A==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
+				}
+			}
+		},
+		"@wordpress/jest-console": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.3.1.tgz",
+			"integrity": "sha512-3lDSBHq6sgH3LWoAAqDnt9CzT2iJ80ezHciVKfOwbfpR7dPxUXVD4fUau/xdqdzfICJXvCUgN5oTih9DtS29AQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"jest-matcher-utils": "^24.7.0",
+				"lodash": "^4.17.15"
+			}
+		},
+		"@wordpress/jest-preset-default": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-5.1.1.tgz",
+			"integrity": "sha512-QQHXjM03A39XRfZb9lhFVw960yjrj3Yr3BFuJczPMk8hWCM0hqW+yYyMLfMny+yW2VJ6WizVFzoS6L/RH97+LA==",
+			"dev": true,
+			"requires": {
+				"@wordpress/jest-console": "^3.3.1",
+				"babel-jest": "^24.7.1",
+				"enzyme": "^3.9.0",
+				"enzyme-adapter-react-16": "^1.10.0",
+				"enzyme-to-json": "^3.3.5"
+			}
+		},
+		"@wordpress/npm-package-json-lint-config": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.1.0.tgz",
+			"integrity": "sha512-NSwcK7GtlmW5O5ZMG7elRKBa9sPws17Sadjlztig6ShOuhlLFeHYk99tUenpmJ/PYOZex4fSJ5e9mqjPyKunjw==",
+			"dev": true
+		},
+		"@wordpress/scripts": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-5.1.0.tgz",
+			"integrity": "sha512-S5fu9MIYLhkfLFkRWgBB1bSCKiPByEBDFxP+d7jzwNAZGZhHTTbAFvYEtEGQTXkEMCXW0p2oF233Sc6wY/tmjQ==",
+			"dev": true,
+			"requires": {
+				"@wordpress/babel-preset-default": "^4.6.2",
+				"@wordpress/dependency-extraction-webpack-plugin": "^2.0.0",
+				"@wordpress/eslint-plugin": "^3.1.0",
+				"@wordpress/jest-preset-default": "^5.1.1",
+				"@wordpress/npm-package-json-lint-config": "^2.1.0",
+				"babel-jest": "^24.7.1",
+				"babel-loader": "^8.0.5",
+				"chalk": "^2.4.2",
+				"check-node-version": "^3.1.1",
+				"command-exists": "^1.2.8",
+				"cross-spawn": "^5.1.0",
+				"decompress-zip": "^0.2.2",
+				"eslint": "^6.1.0",
+				"jest": "^24.7.1",
+				"jest-puppeteer": "^4.3.0",
+				"js-yaml": "^3.13.1",
+				"lodash": "^4.17.15",
+				"minimist": "^1.2.0",
+				"npm-package-json-lint": "^3.6.0",
+				"puppeteer": "^1.19.0",
+				"read-pkg-up": "^1.0.1",
+				"request": "^2.88.0",
+				"resolve-bin": "^0.4.0",
+				"source-map-loader": "^0.2.4",
+				"sprintf-js": "^1.1.1",
+				"stylelint": "^9.10.1",
+				"stylelint-config-wordpress": "^13.1.0",
+				"thread-loader": "^2.1.2",
+				"webpack": "^4.41.0",
+				"webpack-bundle-analyzer": "^3.3.2",
+				"webpack-cli": "^3.1.2",
+				"webpack-livereload-plugin": "^2.2.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
 			}
 		},
 		"@xtuc/ieee754": {
@@ -1501,6 +2103,16 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"accepts": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+			"dev": true,
+			"requires": {
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
+			}
+		},
 		"acorn": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
@@ -1517,11 +2129,26 @@
 				"acorn-walk": "^6.0.1"
 			}
 		},
+		"acorn-jsx": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+			"dev": true
+		},
 		"acorn-walk": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
+		},
+		"agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
 		},
 		"airbnb-prop-types": {
 			"version": "2.15.0",
@@ -1575,6 +2202,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -1638,6 +2271,16 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"aria-query": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"dev": true,
+			"requires": {
+				"ast-types-flow": "0.0.7",
+				"commander": "^2.11.0"
+			}
+		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -1679,6 +2322,22 @@
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
 			"dev": true
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+			"dev": true
+		},
+		"array-includes": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.7.0"
+			}
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -1793,6 +2452,18 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
+		"ast-types-flow": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
+		},
 		"async": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
@@ -1858,6 +2529,29 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
+		},
+		"axobject-query": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+			"integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+			"dev": true,
+			"requires": {
+				"ast-types-flow": "0.0.7"
+			}
+		},
+		"babel-eslint": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+			"integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"eslint-visitor-keys": "^1.0.0",
+				"resolve": "^1.12.0"
+			}
 		},
 		"babel-jest": {
 			"version": "24.9.0",
@@ -1925,6 +2619,12 @@
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
 				"babel-plugin-jest-hoist": "^24.9.0"
 			}
+		},
+		"bail": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -2002,11 +2702,33 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bfj": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
+			"integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.5.5",
+				"check-types": "^8.0.3",
+				"hoopy": "^0.1.4",
+				"tryer": "^1.0.1"
+			}
+		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
+		},
+		"binary": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"dev": true,
+			"requires": {
+				"buffers": "~0.1.1",
+				"chainsaw": "~0.1.0"
+			}
 		},
 		"binary-extensions": {
 			"version": "1.13.1",
@@ -2034,6 +2756,83 @@
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
 			"dev": true
+		},
+		"body": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+			"integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+			"dev": true,
+			"requires": {
+				"continuable-cache": "^0.3.1",
+				"error": "^7.0.0",
+				"raw-body": "~1.1.0",
+				"safe-json-parse": "~1.0.1"
+			},
+			"dependencies": {
+				"bytes": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+					"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+					"dev": true
+				},
+				"raw-body": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+					"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+					"dev": true,
+					"requires": {
+						"bytes": "1",
+						"string_decoder": "0.10"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"body-parser": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+			"dev": true,
+			"requires": {
+				"bytes": "3.1.0",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
+				"on-finished": "~2.3.0",
+				"qs": "6.7.0",
+				"raw-body": "2.4.0",
+				"type-is": "~1.6.17"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+					"dev": true
+				}
+			}
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -2223,10 +3022,22 @@
 			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
 			"dev": true
 		},
+		"buffers": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+			"dev": true
+		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+			"dev": true
+		},
+		"bytes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 			"dev": true
 		},
 		"cacache": {
@@ -2268,6 +3079,12 @@
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
 			}
+		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
 		},
 		"caller-callsite": {
 			"version": "2.0.0",
@@ -2358,6 +3175,21 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
+		"ccount": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
+			"dev": true
+		},
+		"chainsaw": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"dev": true,
+			"requires": {
+				"traverse": ">=0.3.0 <0.4"
+			}
+		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2368,6 +3200,57 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
+		},
+		"character-entities": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
+			"dev": true
+		},
+		"character-entities-html4": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+			"integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
+			"dev": true
+		},
+		"character-entities-legacy": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
+			"dev": true
+		},
+		"character-reference-invalid": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
+			"dev": true
+		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
+		},
+		"check-node-version": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.3.0.tgz",
+			"integrity": "sha512-OAtp7prQf+8YYKn2UB/fK1Ppb9OT+apW56atoKYUvucYLPq69VozOY0B295okBwCKymk2cictrS3qsdcZwyfzw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.3.0",
+				"map-values": "^1.0.1",
+				"minimist": "^1.2.0",
+				"object-filter": "^1.0.2",
+				"object.assign": "^4.0.4",
+				"run-parallel": "^1.1.4",
+				"semver": "^5.0.3"
+			}
+		},
+		"check-types": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
+			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.3",
@@ -2463,6 +3346,26 @@
 				}
 			}
 		},
+		"classnames": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
 		"cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -2483,6 +3386,16 @@
 				"is-plain-object": "^2.0.4",
 				"kind-of": "^6.0.2",
 				"shallow-clone": "^3.0.0"
+			}
+		},
+		"clone-regexp": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+			"integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+			"dev": true,
+			"requires": {
+				"is-regexp": "^1.0.0",
+				"is-supported-regexp-flag": "^1.0.0"
 			}
 		},
 		"co": {
@@ -2506,6 +3419,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collapse-white-space": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -2568,10 +3487,22 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"command-exists": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
+			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+			"dev": true
+		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
+		},
+		"comment-parser": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.6.2.tgz",
+			"integrity": "sha512-Wdms0Q8d4vvb2Yk72OwZjwNWtMklbC5Re7lD9cjCP/AG1fhocmc0TrxGBBAXPLy8fZQPrfHGgyygwI0lA7pbzA==",
 			"dev": true
 		},
 		"commondir": {
@@ -2625,6 +3556,27 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
+		"content-disposition": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
+		"continuable-cache": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+			"integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
+			"dev": true
+		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -2633,6 +3585,18 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
+		},
+		"cookie": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+			"dev": true
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+			"dev": true
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -2654,13 +3618,19 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
+		"core-js": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.4.tgz",
+			"integrity": "sha512-BtibooaAmSOptGLRccsuX/dqgPtXwNgqcvYA6kOTTMzonRxZ+pJS4e+6mvVutESfXMeTnK8m3M+aBu3bkJbR+w==",
+			"dev": true
+		},
 		"core-js-compat": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.3.tgz",
-			"integrity": "sha512-GNZkENsx5pMnS7Inwv7ZO/s3B68a9WU5kIjxqrD/tkNR8mtfXJRk8fAKRlbvWZSGPc59/TkiOBDYl5Cb65pTVA==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.4.tgz",
+			"integrity": "sha512-7OK3/LPP8R3Ovasf3GilEOp+o1w0ZKJ75FMou2RDfTwIV69G5RkKCGFnqgBv/ZhR6xo9GCzlfVALyHmydbE7DA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.7.1",
+				"browserslist": "^4.7.2",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -2759,6 +3729,26 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"css": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"source-map": "^0.6.1",
+				"source-map-resolve": "^0.5.2",
+				"urix": "^0.1.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"css-color-names": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -2840,6 +3830,12 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
 			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+			"dev": true
+		},
+		"css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -2967,6 +3963,12 @@
 				"cssom": "0.3.x"
 			}
 		},
+		"csstype": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
+			"integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==",
+			"dev": true
+		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2976,10 +3978,26 @@
 				"array-find-index": "^1.0.1"
 			}
 		},
+		"cwd": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+			"integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
+			"dev": true,
+			"requires": {
+				"find-pkg": "^0.1.2",
+				"fs-exists-sync": "^0.1.0"
+			}
+		},
 		"cyclist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+			"dev": true
+		},
+		"damerau-levenshtein": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+			"integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
 			"dev": true
 		},
 		"dashdash": {
@@ -3036,11 +4054,62 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decamelize-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
+			"requires": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			}
+		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
+		},
+		"decompress-zip": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.2.2.tgz",
+			"integrity": "sha512-v+Na3Ck86Px7s2ix+f77pMQC3GlkxHHN+YyvnkEW7+xX5F39pcDpIV/VFvGYk8MznTFcMoPjL3XNWEJLXWoSPw==",
+			"dev": true,
+			"requires": {
+				"binary": "^0.3.0",
+				"graceful-fs": "^4.1.3",
+				"mkpath": "^0.1.0",
+				"nopt": "^3.0.1",
+				"q": "^1.1.2",
+				"readable-stream": "^1.1.8",
+				"touch": "0.0.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
 		},
 		"deep-equal-ident": {
 			"version": "1.1.1",
@@ -3154,6 +4223,12 @@
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true
 		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -3163,6 +4238,12 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
 			}
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+			"dev": true
 		},
 		"detect-file": {
 			"version": "1.0.0",
@@ -3193,11 +4274,29 @@
 				"randombytes": "^2.0.0"
 			}
 		},
+		"dir-glob": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+			"dev": true,
+			"requires": {
+				"path-type": "^3.0.0"
+			}
+		},
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
 			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
 			"dev": true
+		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2"
+			}
 		},
 		"dom-serializer": {
 			"version": "0.1.1",
@@ -3258,6 +4357,12 @@
 				"is-obj": "^1.0.0"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -3291,6 +4396,18 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
+		},
+		"ejs": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==",
+			"dev": true
 		},
 		"electron-to-chromium": {
 			"version": "1.3.296",
@@ -3329,6 +4446,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
 		},
 		"end-of-stream": {
@@ -3467,6 +4590,15 @@
 				"prr": "~1.0.1"
 			}
 		},
+		"error": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/error/-/error-7.2.0.tgz",
+			"integrity": "sha512-M6t3j3Vt3uDicrViMP5fLq2AeADNrCVFD8Oj4Qt2MHsX0mPYG7D5XdnEfSdRpaHQzjAJ19wu+I1mw9rQYMTAPg==",
+			"dev": true,
+			"requires": {
+				"string-template": "~0.2.1"
+			}
+		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3505,6 +4637,27 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -3533,6 +4686,172 @@
 				}
 			}
 		},
+		"eslint": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+			"integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.10.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^1.4.2",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.1",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^5.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.0.0",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^6.4.1",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.14",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.1",
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
+				"table": "^5.2.3",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				},
+				"eslint-scope": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"import-fresh": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+					"dev": true,
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-jest": {
+			"version": "22.20.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.20.0.tgz",
+			"integrity": "sha512-UwHGXaYprxwd84Wer8H7jZS+5C3LeEaU8VD7NqORY6NmPJrs+9Ugbq3wyjqO3vWtSsDaLar2sqEB8COmOZA4zw==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^1.13.0"
+			}
+		},
+		"eslint-plugin-jsdoc": {
+			"version": "15.12.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.12.1.tgz",
+			"integrity": "sha512-kiE2dB/fxP4PQFVE9yBq1rJ9fooHlH3soZw1tNJoE0GOGmafM7lAxqMZCUceG0Lk8Fl1mxcjLNE8arCzzs4uFg==",
+			"dev": true,
+			"requires": {
+				"comment-parser": "^0.6.2",
+				"debug": "^4.1.1",
+				"jsdoctypeparser": "^5.1.1",
+				"lodash": "^4.17.15",
+				"object.entries-ponyfill": "^1.0.1",
+				"regextras": "^0.6.1"
+			}
+		},
+		"eslint-plugin-jsx-a11y": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+			"integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.5",
+				"aria-query": "^3.0.0",
+				"array-includes": "^3.0.3",
+				"ast-types-flow": "^0.0.7",
+				"axobject-query": "^2.0.2",
+				"damerau-levenshtein": "^1.0.4",
+				"emoji-regex": "^7.0.2",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.2.1"
+			}
+		},
+		"eslint-plugin-react": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
+			"integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"doctrine": "^2.1.0",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.2.1",
+				"object.entries": "^1.1.0",
+				"object.fromentries": "^2.0.0",
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2",
+				"resolve": "^1.12.0"
+			}
+		},
+		"eslint-plugin-react-hooks": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
+			"integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+			"dev": true
+		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -3543,11 +4862,54 @@
 				"estraverse": "^4.1.1"
 			}
 		},
+		"eslint-utils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.1.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"dev": true
+		},
+		"espree": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+					"dev": true
+				}
+			}
+		},
 		"esprima": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
 			"dev": true
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.0.0"
+			}
 		},
 		"esrecurse": {
 			"version": "4.2.1",
@@ -3568,6 +4930,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
 		},
 		"events": {
@@ -3605,6 +4973,15 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			}
+		},
+		"execall": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+			"integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+			"dev": true,
+			"requires": {
+				"clone-regexp": "^1.0.0"
 			}
 		},
 		"exit": {
@@ -3686,6 +5063,73 @@
 				"jest-regex-util": "^24.9.0"
 			}
 		},
+		"expect-puppeteer": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.3.0.tgz",
+			"integrity": "sha512-p8N/KSVPG9PAOJlftK5f1n3JrULJ6Qq1EQ8r/n9xzkX2NmXbK8PcnJnkSAEzEHrMycELKGnlJV7M5nkgm+wEWA==",
+			"dev": true
+		},
+		"express": {
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.7",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
+				"content-type": "~1.0.4",
+				"cookie": "0.4.0",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.1.2",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.1.2",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+					"dev": true
+				}
+			}
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3711,6 +5155,17 @@
 						"is-plain-object": "^2.0.4"
 					}
 				}
+			}
+		},
+		"external-editor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"dev": true,
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -3778,6 +5233,35 @@
 				}
 			}
 		},
+		"extract-zip": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+			"dev": true,
+			"requires": {
+				"concat-stream": "1.6.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1",
+				"yauzl": "2.4.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -3789,6 +5273,20 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
+		},
+		"fast-glob": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+			"integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+			"dev": true,
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.3",
+				"micromatch": "^3.1.10"
+			}
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -3802,6 +5300,15 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"faye-websocket": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+			"dev": true,
+			"requires": {
+				"websocket-driver": ">=0.5.1"
+			}
+		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -3811,11 +5318,38 @@
 				"bser": "^2.0.0"
 			}
 		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"dev": true,
+			"requires": {
+				"pend": "~1.2.0"
+			}
+		},
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
 			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 			"dev": true
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
 		},
 		"file-loader": {
 			"version": "3.0.1",
@@ -3826,6 +5360,12 @@
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^1.0.0"
 			}
+		},
+		"filesize": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+			"dev": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -3850,6 +5390,38 @@
 				}
 			}
 		},
+		"finalhandler": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
+				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"find-cache-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -3859,6 +5431,108 @@
 				"commondir": "^1.0.1",
 				"make-dir": "^2.0.0",
 				"pkg-dir": "^3.0.0"
+			}
+		},
+		"find-file-up": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+			"integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+			"dev": true,
+			"requires": {
+				"fs-exists-sync": "^0.1.0",
+				"resolve-dir": "^0.1.0"
+			},
+			"dependencies": {
+				"expand-tilde": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+					"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+					"dev": true,
+					"requires": {
+						"os-homedir": "^1.0.1"
+					}
+				},
+				"global-modules": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+					"dev": true,
+					"requires": {
+						"global-prefix": "^0.1.4",
+						"is-windows": "^0.2.0"
+					}
+				},
+				"global-prefix": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+					"dev": true,
+					"requires": {
+						"homedir-polyfill": "^1.0.0",
+						"ini": "^1.3.4",
+						"is-windows": "^0.2.0",
+						"which": "^1.2.12"
+					}
+				},
+				"is-windows": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+					"dev": true
+				},
+				"resolve-dir": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+					"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+					"dev": true,
+					"requires": {
+						"expand-tilde": "^1.2.2",
+						"global-modules": "^0.2.3"
+					}
+				}
+			}
+		},
+		"find-parent-dir": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+			"dev": true
+		},
+		"find-pkg": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+			"integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+			"dev": true,
+			"requires": {
+				"find-file-up": "^0.1.2"
+			}
+		},
+		"find-process": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.2.tgz",
+			"integrity": "sha512-O83EVJr4dWvHJ7QpUzANNAMeQVKukRzRqRx4AIzdLYRrQorRdbqDwLPigkd9PYPhJRhmNPAoVjOm9bcwSmcZaw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"commander": "^2.11.0",
+				"debug": "^2.6.8"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
 			}
 		},
 		"find-root": {
@@ -3906,6 +5580,34 @@
 				"resolve-dir": "^1.0.1"
 			}
 		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"dev": true,
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
+		},
+		"flatted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+			"dev": true
+		},
 		"flatten": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -3928,6 +5630,15 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.1"
+			}
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3945,6 +5656,12 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+			"dev": true
+		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -3953,6 +5670,12 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -3963,6 +5686,12 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
 			}
+		},
+		"fs-exists-sync": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+			"dev": true
 		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
@@ -4560,6 +6289,12 @@
 				"is-callable": "^1.1.4"
 			}
 		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
 		"functions-have-names": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.0.tgz",
@@ -4699,6 +6434,12 @@
 				}
 			}
 		},
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+			"dev": true
+		},
 		"global-modules": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -4762,6 +6503,12 @@
 				}
 			}
 		},
+		"globjoin": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+			"dev": true
+		},
 		"globule": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
@@ -4773,11 +6520,64 @@
 				"minimatch": "~3.0.2"
 			}
 		},
+		"gonzales-pe": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
+			"integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "1.1.x"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+					"dev": true
+				}
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
 			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 			"dev": true
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
+		},
+		"gzip-size": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+			"dev": true,
+			"requires": {
+				"duplexer": "^0.1.1",
+				"pify": "^4.0.1"
+			}
+		},
+		"handlebars": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+			"integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -4917,6 +6717,12 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
+		"hoopy": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+			"dev": true
+		},
 		"hosted-git-info": {
 			"version": "2.8.5",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
@@ -4959,6 +6765,12 @@
 				"whatwg-encoding": "^1.0.1"
 			}
 		},
+		"html-tags": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+			"integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+			"dev": true
+		},
 		"htmlparser2": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -4986,6 +6798,33 @@
 				}
 			}
 		},
+		"http-errors": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+			"dev": true,
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				}
+			}
+		},
+		"http-parser-js": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+			"dev": true
+		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5002,6 +6841,27 @@
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
+		},
+		"https-proxy-agent": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+			"integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
@@ -5039,6 +6899,12 @@
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
 		},
+		"ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true
+		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -5066,6 +6932,12 @@
 			"requires": {
 				"resolve-from": "^3.0.0"
 			}
+		},
+		"import-lazy": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+			"integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+			"dev": true
 		},
 		"import-local": {
 			"version": "2.0.0",
@@ -5132,6 +7004,56 @@
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
+		"inquirer": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.12",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.4.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.1.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
+			}
+		},
 		"interpret": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
@@ -5151,6 +7073,18 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
+		},
+		"ipaddr.js": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+			"dev": true
+		},
+		"irregular-plurals": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
+			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
 			"dev": true
 		},
 		"is-absolute-url": {
@@ -5177,6 +7111,28 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
+			}
+		},
+		"is-alphabetical": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
+			"dev": true
+		},
+		"is-alphanumeric": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+			"dev": true
+		},
+		"is-alphanumerical": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+			"dev": true,
+			"requires": {
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -5261,6 +7217,12 @@
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
 		},
+		"is-decimal": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
+			"dev": true
+		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -5327,6 +7289,12 @@
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
+		},
+		"is-hexadecimal": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
+			"dev": true
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -5399,6 +7367,12 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -5407,6 +7381,12 @@
 			"requires": {
 				"has": "^1.0.1"
 			}
+		},
+		"is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+			"dev": true
 		},
 		"is-resolvable": {
 			"version": "1.1.0",
@@ -5430,6 +7410,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
 			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+			"dev": true
+		},
+		"is-supported-regexp-flag": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+			"integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
 			"dev": true
 		},
 		"is-svg": {
@@ -5462,10 +7448,22 @@
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
 			"dev": true
 		},
+		"is-whitespace-character": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+			"dev": true
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-word-character": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
 			"dev": true
 		},
 		"is-wsl": {
@@ -5527,6 +7525,102 @@
 				}
 			}
 		},
+		"istanbul-lib-report": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"rimraf": "^2.6.3",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+			"dev": true,
+			"requires": {
+				"handlebars": "^4.1.2"
+			}
+		},
+		"jest": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+			"dev": true,
+			"requires": {
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.9.0"
+			},
+			"dependencies": {
+				"jest-cli": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^24.9.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-validate": "^24.9.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^13.3.0"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.9.0",
+				"execa": "^1.0.0",
+				"throat": "^4.0.0"
+			}
+		},
 		"jest-config": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
@@ -5550,6 +7644,21 @@
 				"micromatch": "^3.1.10",
 				"pretty-format": "^24.9.0",
 				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-dev-server": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.3.0.tgz",
+			"integrity": "sha512-bC9flKY2G1honQ/UI0gEhb0wFnDhpFr7xidC8Nk+evi7TgnNtfsGIzzF2dcIhF1G9BGF0n/M7CJrMAzwQhyTPA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"cwd": "^0.10.0",
+				"find-process": "^1.4.2",
+				"prompts": "^2.1.0",
+				"spawnd": "^4.0.0",
+				"tree-kill": "^1.2.1",
+				"wait-on": "^3.3.0"
 			}
 		},
 		"jest-diff": {
@@ -5620,6 +7729,18 @@
 				"@jest/types": "^24.9.0",
 				"jest-mock": "^24.9.0",
 				"jest-util": "^24.9.0"
+			}
+		},
+		"jest-environment-puppeteer": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.3.0.tgz",
+			"integrity": "sha512-ZighMsU39bnacn2ylyHb88CB+ldgCfXGD3lS78k4PEo8A8xyt6+2mxmSR62FH3Y7K+W2gPDu5+QM3/LZuq42fQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"cwd": "^0.10.0",
+				"jest-dev-server": "^4.3.0",
+				"merge-deep": "^3.0.2"
 			}
 		},
 		"jest-enzyme": {
@@ -5736,6 +7857,16 @@
 			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
 			"dev": true
 		},
+		"jest-puppeteer": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.3.0.tgz",
+			"integrity": "sha512-WXhaWlbQl01xadZyNmdZntrtIr8uWUmgjPogDih7dOnr3G/xRr3A034SCqdjwV6fE0tqz7c5hwO8oBTyGZPRgA==",
+			"dev": true,
+			"requires": {
+				"expect-puppeteer": "^4.3.0",
+				"jest-environment-puppeteer": "^4.3.0"
+			}
+		},
 		"jest-regex-util": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
@@ -5753,6 +7884,17 @@
 				"chalk": "^2.0.1",
 				"jest-pnp-resolver": "^1.2.1",
 				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.9.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.9.0"
 			}
 		},
 		"jest-runner": {
@@ -5890,6 +8032,21 @@
 				"pretty-format": "^24.9.0"
 			}
 		},
+		"jest-watcher": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
+			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"@types/yargs": "^13.0.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"jest-util": "^24.9.0",
+				"string-length": "^2.0.0"
+			}
+		},
 		"jest-worker": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
@@ -5951,6 +8108,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"jsdoctypeparser": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.1.1.tgz",
+			"integrity": "sha512-APGygIJrT5bbz5lsVt8vyLJC0miEbQf/z9ZBfTr4RYvdia8AhWMRlYgivvwHG5zKD/VW3d6qpChCy64hpQET3A==",
 			"dev": true
 		},
 		"jsdom": {
@@ -6025,6 +8188,12 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -6058,6 +8227,16 @@
 				"verror": "1.10.0"
 			}
 		},
+		"jsx-ast-utils": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+			"integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"object.assign": "^4.1.0"
+			}
+		},
 		"junk": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
@@ -6068,6 +8247,24 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true
+		},
+		"known-css-properties": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.11.0.tgz",
+			"integrity": "sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==",
+			"dev": true
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
 			"dev": true
 		},
 		"lcid": {
@@ -6100,6 +8297,12 @@
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
 			}
+		},
+		"livereload-js": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
+			"integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
+			"dev": true
 		},
 		"load-json-file": {
 			"version": "4.0.0",
@@ -6253,10 +8456,31 @@
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+			"dev": true
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1"
+			}
+		},
+		"longest-streak": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
+			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -6333,6 +8557,12 @@
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 			"dev": true
 		},
+		"map-values": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
+			"integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -6341,6 +8571,24 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
+		},
+		"markdown-escapes": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
+			"dev": true
+		},
+		"markdown-table": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+			"dev": true
+		},
+		"mathml-tag-names": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+			"integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
+			"dev": true
 		},
 		"maximatch": {
 			"version": "0.1.0",
@@ -6365,10 +8613,25 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
+		"mdast-util-compact": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+			"integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
+			"dev": true,
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
 		"mdn-data": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
 			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+			"dev": true
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
 		"mem": {
@@ -6500,10 +8763,92 @@
 				}
 			}
 		},
+		"merge-deep": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+			"integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"clone-deep": "^0.2.4",
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"clone-deep": {
+					"version": "0.2.4",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+					"dev": true,
+					"requires": {
+						"for-own": "^0.1.3",
+						"is-plain-object": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"lazy-cache": "^1.0.3",
+						"shallow-clone": "^0.1.2"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"shallow-clone": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+					"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.1",
+						"kind-of": "^2.0.1",
+						"lazy-cache": "^0.2.3",
+						"mixin-object": "^2.0.1"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.0.2"
+							}
+						},
+						"lazy-cache": {
+							"version": "0.2.7",
+							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
+		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
+		"merge2": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+			"dev": true
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
 			"dev": true
 		},
 		"micromatch": {
@@ -6537,6 +8882,12 @@
 				"brorand": "^1.0.1"
 			}
 		},
+		"mime": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+			"dev": true
+		},
 		"mime-db": {
 			"version": "1.40.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -6556,6 +8907,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
+		"min-indent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+			"integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
 			"dev": true
 		},
 		"mini-css-extract-plugin-with-rtl": {
@@ -6596,6 +8953,16 @@
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
+		"minimist-options": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
+			}
+		},
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -6635,6 +9002,24 @@
 				}
 			}
 		},
+		"mixin-object": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+			"dev": true,
+			"requires": {
+				"for-in": "^0.1.3",
+				"is-extendable": "^0.1.1"
+			},
+			"dependencies": {
+				"for-in": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+					"dev": true
+				}
+			}
+		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -6651,6 +9036,12 @@
 					"dev": true
 				}
 			}
+		},
+		"mkpath": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+			"integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
+			"dev": true
 		},
 		"moo": {
 			"version": "0.4.3",
@@ -6676,6 +9067,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
 		"nan": {
@@ -6721,6 +9118,12 @@
 				"randexp": "0.4.6",
 				"semver": "^5.4.1"
 			}
+		},
+		"negotiator": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+			"dev": true
 		},
 		"neo-async": {
 			"version": "2.6.1",
@@ -6812,6 +9215,19 @@
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
 			"dev": true
+		},
+		"node-notifier": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+			"dev": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
+			}
 		},
 		"node-releases": {
 			"version": "1.1.39",
@@ -6956,6 +9372,12 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
 			"dev": true
 		},
+		"normalize-selector": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
+			"dev": true
+		},
 		"normalize-url": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -6966,6 +9388,174 @@
 				"prepend-http": "^1.0.0",
 				"query-string": "^4.1.0",
 				"sort-keys": "^1.0.0"
+			}
+		},
+		"npm-package-json-lint": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.7.0.tgz",
+			"integrity": "sha512-eWi1pZ/ZhPHAOMLC1+njBJj81yCu2Ek4VxhwpPHABvSVHS0dkaL6aKhSj/TX8Rtm/0rIg3edgMLt3kSRtWkFaA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.10.0",
+				"chalk": "^2.4.2",
+				"glob": "^7.1.4",
+				"ignore": "^5.1.2",
+				"is-path-inside": "^2.1.0",
+				"is-plain-obj": "^1.1.0",
+				"is-resolvable": "^1.1.0",
+				"log-symbols": "^2.2.0",
+				"meow": "^5.0.0",
+				"plur": "^3.1.1",
+				"semver": "^5.6.0",
+				"strip-json-comments": "^2.0.1",
+				"validator": "^10.11.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"is-path-inside": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+					"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+					"dev": true,
+					"requires": {
+						"path-is-inside": "^1.0.2"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
+				},
+				"meow": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+					"dev": true,
+					"requires": {
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0",
+						"yargs-parser": "^10.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"redent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
+				},
+				"trim-newlines": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
+				},
+				"yargs-parser": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -7059,6 +9649,12 @@
 				}
 			}
 		},
+		"object-filter": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+			"integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
+			"dev": true
+		},
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -7110,6 +9706,12 @@
 				"has": "^1.0.3"
 			}
 		},
+		"object.entries-ponyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+			"integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+			"dev": true
+		},
 		"object.fromentries": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
@@ -7153,6 +9755,15 @@
 				"has": "^1.0.3"
 			}
 		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7160,6 +9771,53 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
+				}
+			}
+		},
+		"opener": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"dev": true
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"dev": true
+				}
 			}
 		},
 		"optionator": {
@@ -7219,6 +9877,15 @@
 			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
 			"dev": true
 		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -7249,6 +9916,12 @@
 				"p-limit": "^2.0.0"
 			}
 		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
+		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -7272,6 +9945,15 @@
 				"readable-stream": "^2.1.5"
 			}
 		},
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
+			}
+		},
 		"parse-asn1": {
 			"version": "5.1.5",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -7284,6 +9966,20 @@
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
+			}
+		},
+		"parse-entities": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+			"dev": true,
+			"requires": {
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"parse-json": {
@@ -7310,6 +10006,12 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -7359,6 +10061,12 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+			"dev": true
+		},
 		"path-type": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -7388,6 +10096,12 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+			"dev": true
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -7434,11 +10148,42 @@
 				"find-up": "^3.0.0"
 			}
 		},
+		"plur": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
+			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
+			"dev": true,
+			"requires": {
+				"irregular-plurals": "^2.0.0"
+			}
+		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
 			"dev": true
+		},
+		"portfinder": {
+			"version": "1.0.25",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+			"integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+			"dev": true,
+			"requires": {
+				"async": "^2.6.2",
+				"debug": "^3.1.1",
+				"mkdirp": "^0.5.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -7596,6 +10341,33 @@
 				"postcss": "^7.0.0"
 			}
 		},
+		"postcss-html": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+			"integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "^3.10.0"
+			}
+		},
+		"postcss-jsx": {
+			"version": "0.36.3",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.3.tgz",
+			"integrity": "sha512-yV8Ndo6KzU8eho5mCn7LoLUGPkXrRXRjhMpX4AaYJ9wLJPv099xbtpbRQ8FrPnzVxb/cuMebbPR7LweSt+hTfA==",
+			"dev": true,
+			"requires": {
+				"@babel/core": ">=7.2.2"
+			}
+		},
+		"postcss-less": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.14"
+			}
+		},
 		"postcss-load-config": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
@@ -7617,6 +10389,22 @@
 				"postcss-load-config": "^2.0.0",
 				"schema-utils": "^1.0.0"
 			}
+		},
+		"postcss-markdown": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
+			"integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
+			"dev": true,
+			"requires": {
+				"remark": "^10.0.1",
+				"unist-util-find-all-after": "^1.0.2"
+			}
+		},
+		"postcss-media-query-parser": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+			"dev": true
 		},
 		"postcss-merge-longhand": {
 			"version": "4.0.11",
@@ -8018,6 +10806,52 @@
 				}
 			}
 		},
+		"postcss-reporter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+			"integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"lodash": "^4.17.11",
+				"log-symbols": "^2.2.0",
+				"postcss": "^7.0.7"
+			}
+		},
+		"postcss-resolve-nested-selector": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+			"integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+			"dev": true
+		},
+		"postcss-safe-parser": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
+			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
+		"postcss-sass": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
+			"integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+			"dev": true,
+			"requires": {
+				"gonzales-pe": "^4.2.3",
+				"postcss": "^7.0.1"
+			}
+		},
+		"postcss-scss": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
+			"integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
 		"postcss-selector-parser": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
@@ -8048,6 +10882,12 @@
 					"dev": true
 				}
 			}
+		},
+		"postcss-syntax": {
+			"version": "0.36.2",
+			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+			"dev": true
 		},
 		"postcss-unique-selectors": {
 			"version": "4.0.1",
@@ -8119,6 +10959,12 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
+		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -8133,6 +10979,16 @@
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 			"dev": true
+		},
+		"prompts": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
+			"integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.3"
+			}
 		},
 		"prop-types": {
 			"version": "15.7.2",
@@ -8155,6 +11011,22 @@
 				"object.assign": "^4.1.0",
 				"reflect.ownkeys": "^0.2.0"
 			}
+		},
+		"proxy-addr": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+			"dev": true,
+			"requires": {
+				"forwarded": "~0.1.2",
+				"ipaddr.js": "1.9.0"
+			}
+		},
+		"proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
 		},
 		"prr": {
 			"version": "1.0.1",
@@ -8227,6 +11099,33 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"puppeteer": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+			"integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"extract-zip": "^1.6.6",
+				"https-proxy-agent": "^2.2.1",
+				"mime": "^2.0.3",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^2.6.1",
+				"ws": "^6.1.0"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -8259,6 +11158,12 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
+		},
+		"quick-lru": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
 			"dev": true
 		},
 		"raf": {
@@ -8303,6 +11208,47 @@
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
+			}
+		},
+		"range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"dev": true
+		},
+		"raw-body": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+			"dev": true,
+			"requires": {
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			}
+		},
+		"react": {
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.11.0.tgz",
+			"integrity": "sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			}
+		},
+		"react-dom": {
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
+			"integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.17.0"
 			}
 		},
 		"react-is": {
@@ -8442,6 +11388,12 @@
 				"regenerate": "^1.4.0"
 			}
 		},
+		"regenerator-runtime": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+			"dev": true
+		},
 		"regenerator-transform": {
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
@@ -8461,6 +11413,12 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+			"dev": true
+		},
 		"regexpu-core": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
@@ -8474,6 +11432,12 @@
 				"unicode-match-property-ecmascript": "^1.0.4",
 				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
+		},
+		"regextras": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
+			"integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA==",
+			"dev": true
 		},
 		"regjsgen": {
 			"version": "0.5.1",
@@ -8496,6 +11460,62 @@
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
 					"dev": true
 				}
+			}
+		},
+		"remark": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+			"integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
+			"dev": true,
+			"requires": {
+				"remark-parse": "^6.0.0",
+				"remark-stringify": "^6.0.0",
+				"unified": "^7.0.0"
+			}
+		},
+		"remark-parse": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+			"integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+			"dev": true,
+			"requires": {
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^1.1.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"trim": "0.0.1",
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^1.0.0",
+				"vfile-location": "^2.0.0",
+				"xtend": "^4.0.1"
+			}
+		},
+		"remark-stringify": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+			"integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
+			"dev": true,
+			"requires": {
+				"ccount": "^1.0.0",
+				"is-alphanumeric": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"longest-streak": "^2.0.1",
+				"markdown-escapes": "^1.0.0",
+				"markdown-table": "^1.1.0",
+				"mdast-util-compact": "^1.0.0",
+				"parse-entities": "^1.0.2",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"stringify-entities": "^1.0.1",
+				"unherit": "^1.0.4",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -8524,6 +11544,12 @@
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
+		},
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.0",
@@ -8603,6 +11629,12 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
+		"requireindex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -8610,6 +11642,15 @@
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-bin": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.0.tgz",
+			"integrity": "sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk=",
+			"dev": true,
+			"requires": {
+				"find-parent-dir": "~0.3.0"
 			}
 		},
 		"resolve-cwd": {
@@ -8655,6 +11696,16 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
 		},
 		"ret": {
 			"version": "0.1.15",
@@ -8741,6 +11792,21 @@
 				}
 			}
 		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "^2.1.0"
+			}
+		},
+		"run-parallel": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"dev": true
+		},
 		"run-queue": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -8750,10 +11816,31 @@
 				"aproba": "^1.1.1"
 			}
 		},
+		"rx": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+			"dev": true
+		},
+		"rxjs": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safe-json-parse": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+			"integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
 			"dev": true
 		},
 		"safe-regex": {
@@ -9081,11 +12168,75 @@
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
 		},
+		"send": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
+					}
+				},
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
 		"serialize-javascript": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
 			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
 			"dev": true
+		},
+		"serve-static": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+			"dev": true,
+			"requires": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -9122,6 +12273,12 @@
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
 			"dev": true
 		},
+		"setprototypeof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
+		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -9156,6 +12313,12 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9179,11 +12342,28 @@
 				}
 			}
 		},
+		"sisteransi": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
+			"integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
+			"dev": true
+		},
 		"slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
 			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 			"dev": true
+		},
+		"slice-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"astral-regex": "^1.0.0",
+				"is-fullwidth-code-point": "^2.0.0"
+			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -9328,6 +12508,16 @@
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
+		"source-map-loader": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+			"integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+			"dev": true,
+			"requires": {
+				"async": "^2.5.0",
+				"loader-utils": "^1.1.0"
+			}
+		},
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
@@ -9365,6 +12555,18 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
+		"spawnd": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.0.0.tgz",
+			"integrity": "sha512-ql3qhJnhAkvXpaqKBWOqou1rUTSQhFRaZkyOT+MTFB4xY3X+brgw6LTWV2wHuE9A6YPhrNe1cbg7S+jAYnbC0Q==",
+			"dev": true,
+			"requires": {
+				"exit": "^0.1.2",
+				"signal-exit": "^3.0.2",
+				"tree-kill": "^1.2.1",
+				"wait-port": "^0.2.2"
+			}
+		},
 		"spdx-correct": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -9395,6 +12597,12 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"dev": true
+		},
+		"specificity": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
 			"dev": true
 		},
 		"split-string": {
@@ -9450,6 +12658,12 @@
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
+		"state-toggle": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
+			"dev": true
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -9470,6 +12684,12 @@
 					}
 				}
 			}
+		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
 		},
 		"stdout-stream": {
 			"version": "1.4.1",
@@ -9531,6 +12751,39 @@
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
 		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string-template": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+			"dev": true
+		},
 		"string-width": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -9582,6 +12835,18 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"stringify-entities": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+			"dev": true,
+			"requires": {
+				"character-entities-html4": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
 		"strip-ansi": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -9618,6 +12883,12 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
+		"style-search": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+			"dev": true
+		},
 		"stylehacks": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -9642,6 +12913,315 @@
 				}
 			}
 		},
+		"stylelint": {
+			"version": "9.10.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.10.1.tgz",
+			"integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
+			"dev": true,
+			"requires": {
+				"autoprefixer": "^9.0.0",
+				"balanced-match": "^1.0.0",
+				"chalk": "^2.4.1",
+				"cosmiconfig": "^5.0.0",
+				"debug": "^4.0.0",
+				"execall": "^1.0.0",
+				"file-entry-cache": "^4.0.0",
+				"get-stdin": "^6.0.0",
+				"global-modules": "^2.0.0",
+				"globby": "^9.0.0",
+				"globjoin": "^0.1.4",
+				"html-tags": "^2.0.0",
+				"ignore": "^5.0.4",
+				"import-lazy": "^3.1.0",
+				"imurmurhash": "^0.1.4",
+				"known-css-properties": "^0.11.0",
+				"leven": "^2.1.0",
+				"lodash": "^4.17.4",
+				"log-symbols": "^2.0.0",
+				"mathml-tag-names": "^2.0.1",
+				"meow": "^5.0.0",
+				"micromatch": "^3.1.10",
+				"normalize-selector": "^0.2.0",
+				"pify": "^4.0.0",
+				"postcss": "^7.0.13",
+				"postcss-html": "^0.36.0",
+				"postcss-jsx": "^0.36.0",
+				"postcss-less": "^3.1.0",
+				"postcss-markdown": "^0.36.0",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-reporter": "^6.0.0",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-safe-parser": "^4.0.0",
+				"postcss-sass": "^0.3.5",
+				"postcss-scss": "^2.0.0",
+				"postcss-selector-parser": "^3.1.0",
+				"postcss-syntax": "^0.36.2",
+				"postcss-value-parser": "^3.3.0",
+				"resolve-from": "^4.0.0",
+				"signal-exit": "^3.0.2",
+				"slash": "^2.0.0",
+				"specificity": "^0.4.1",
+				"string-width": "^3.0.0",
+				"style-search": "^0.1.0",
+				"sugarss": "^2.0.0",
+				"svg-tags": "^1.0.0",
+				"table": "^5.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
+					}
+				},
+				"file-entry-cache": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
+					"integrity": "sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"get-stdin": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+					"dev": true
+				},
+				"globby": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+					"dev": true,
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"array-union": "^1.0.2",
+						"dir-glob": "^2.2.2",
+						"fast-glob": "^2.2.6",
+						"glob": "^7.1.3",
+						"ignore": "^4.0.3",
+						"pify": "^4.0.1",
+						"slash": "^2.0.0"
+					},
+					"dependencies": {
+						"ignore": {
+							"version": "4.0.6",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+							"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+							"dev": true
+						}
+					}
+				},
+				"ignore": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
+				},
+				"meow": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+					"dev": true,
+					"requires": {
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0",
+						"yargs-parser": "^10.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"redent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
+				},
+				"trim-newlines": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
+				},
+				"yargs-parser": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"stylelint-config-recommended": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
+			"integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
+			"dev": true
+		},
+		"stylelint-config-recommended-scss": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.3.0.tgz",
+			"integrity": "sha512-BvuuLYwoet8JutOP7K1a8YaiENN+0HQn390eDi0SWe1h7Uhx6O3GUQ6Ubgie9b/AmHX4Btmp+ZzVGbzriFTBcA==",
+			"dev": true,
+			"requires": {
+				"stylelint-config-recommended": "^2.2.0"
+			}
+		},
+		"stylelint-config-wordpress": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-13.1.0.tgz",
+			"integrity": "sha512-dpKj2/d3/XjDVoOvQzd54GoM8Rj5zldluOZKkVhBCc4JYMc6r1VYL5hpcgIjqy/i2Hyqg4Rh7zTafE/2AWq//w==",
+			"dev": true,
+			"requires": {
+				"stylelint-config-recommended": "^2.1.0",
+				"stylelint-config-recommended-scss": "^3.2.0",
+				"stylelint-scss": "^3.3.0"
+			}
+		},
+		"stylelint-scss": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.12.0.tgz",
+			"integrity": "sha512-RvZqmCnILJ0etFBjSGTXQKOspYjF+jjtFdUGoqjuis2YILy/3LCtgSdBP2I+LUOfRT+eJFCrb8g+j3ZND4FaNA==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.15",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-selector-parser": "^6.0.2",
+				"postcss-value-parser": "^4.0.2"
+			}
+		},
+		"sugarss": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -9650,6 +13230,12 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
+		},
+		"svg-tags": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+			"dev": true
 		},
 		"svgo": {
 			"version": "1.3.0",
@@ -9701,6 +13287,18 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"table": {
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
+			}
 		},
 		"tapable": {
 			"version": "1.1.3",
@@ -9775,6 +13373,12 @@
 				"require-main-filename": "^2.0.0"
 			}
 		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
 		"thread-loader": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
@@ -9790,6 +13394,12 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
 		"through2": {
@@ -9816,6 +13426,40 @@
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
+		},
+		"tiny-lr": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+			"integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
+			"dev": true,
+			"requires": {
+				"body": "^5.1.0",
+				"debug": "^3.1.0",
+				"faye-websocket": "~0.10.0",
+				"livereload-js": "^2.3.0",
+				"object-assign": "^4.1.0",
+				"qs": "^6.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -9877,6 +13521,32 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
+		},
+		"touch": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+			"integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+			"dev": true,
+			"requires": {
+				"nopt": "~1.0.10"
+			},
+			"dependencies": {
+				"nopt": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+					"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+					"dev": true,
+					"requires": {
+						"abbrev": "1"
+					}
+				}
+			}
+		},
 		"tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -9896,10 +13566,40 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"traverse": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+			"dev": true
+		},
+		"tree-kill": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+			"dev": true
+		},
+		"trim": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+			"dev": true
+		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+			"dev": true
+		},
+		"trim-trailing-lines": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
+			"dev": true
+		},
+		"trough": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
 			"dev": true
 		},
 		"true-case-path": {
@@ -9910,6 +13610,12 @@
 			"requires": {
 				"glob": "^7.1.2"
 			}
+		},
+		"tryer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.10.0",
@@ -9947,6 +13653,22 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
+		"type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true
+		},
+		"type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"dev": true,
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			}
+		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -9958,6 +13680,36 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
 			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
 			"dev": true
+		},
+		"uglify-js": {
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
+			"integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.20.3",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"unherit": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
+			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -9986,6 +13738,22 @@
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
 			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
 			"dev": true
+		},
+		"unified": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"@types/vfile": "^3.0.0",
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^3.0.0",
+				"x-is-string": "^0.1.0"
+			}
 		},
 		"union-value": {
 			"version": "1.0.1",
@@ -10028,6 +13796,60 @@
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
+		},
+		"unist-util-find-all-after": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+			"integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
+			"dev": true,
+			"requires": {
+				"unist-util-is": "^3.0.0"
+			}
+		},
+		"unist-util-is": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+			"dev": true
+		},
+		"unist-util-remove-position": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
+			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
+			"dev": true,
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+			"dev": true
+		},
+		"unist-util-visit": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+			"dev": true,
+			"requires": {
+				"unist-util-visit-parents": "^2.0.0"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+			"dev": true,
+			"requires": {
+				"unist-util-is": "^3.0.0"
+			}
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
 		},
 		"unquote": {
 			"version": "1.1.1",
@@ -10153,6 +13975,12 @@
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
+		},
 		"uuid": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
@@ -10175,6 +14003,18 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
+		"validator": {
+			"version": "10.11.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+			"integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+			"dev": true
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+			"dev": true
+		},
 		"vendors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
@@ -10192,6 +14032,41 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
+		"vfile": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+			"dev": true,
+			"requires": {
+				"is-buffer": "^2.0.0",
+				"replace-ext": "1.0.0",
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"dev": true
+				}
+			}
+		},
+		"vfile-location": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+			"integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
+			"dev": true
+		},
+		"vfile-message": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"dev": true,
+			"requires": {
+				"unist-util-stringify-position": "^1.1.1"
+			}
+		},
 		"vm-browserify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
@@ -10205,6 +14080,52 @@
 			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"wait-for-expect": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.0.tgz",
+			"integrity": "sha512-9LyJL+MugZdcQn5V9PBSEC4d2UPTy1xX2U9wTc6LvG/18qeeYqdE/CgmAQJxc/Vcjs+VzH+wiyIXxz05F3nrpQ==",
+			"dev": true
+		},
+		"wait-on": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
+			"integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/joi": "^15.0.3",
+				"core-js": "^2.6.5",
+				"minimist": "^1.2.0",
+				"request": "^2.88.0",
+				"rx": "^4.1.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.10",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+					"dev": true
+				}
+			}
+		},
+		"wait-port": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.6.tgz",
+			"integrity": "sha512-nXE5Yp0Zs1obhFVc0Da7WVJc3y0LxoCq3j4mtV0NdI5P/ZvRdKp5yhuojvMOcOxSwpQL1hGbOgMNQ+4wpRpwCA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"commander": "^3.0.2",
+				"debug": "^4.1.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+					"dev": true
+				}
 			}
 		},
 		"walker": {
@@ -10262,6 +14183,38 @@
 				"terser-webpack-plugin": "^1.4.1",
 				"watchpack": "^1.6.0",
 				"webpack-sources": "^1.4.1"
+			}
+		},
+		"webpack-bundle-analyzer": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.0.tgz",
+			"integrity": "sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.7",
+				"acorn-walk": "^6.1.1",
+				"bfj": "^6.1.1",
+				"chalk": "^2.4.1",
+				"commander": "^2.18.0",
+				"ejs": "^2.6.1",
+				"express": "^4.16.3",
+				"filesize": "^3.6.1",
+				"gzip-size": "^5.0.0",
+				"lodash": "^4.17.15",
+				"mkdirp": "^0.5.1",
+				"opener": "^1.5.1",
+				"ws": "^6.0.0"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
 			}
 		},
 		"webpack-cli": {
@@ -10356,6 +14309,16 @@
 			"integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
 			"dev": true
 		},
+		"webpack-livereload-plugin": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.2.0.tgz",
+			"integrity": "sha512-sx9xA5mHoNOUgLQI0PmXT3KV9ecsVmUaTgr+fsoL69qAOHw/7VzkL1+ZMDQ8n0dPbWounswK6cBRSgMod7Nhgg==",
+			"dev": true,
+			"requires": {
+				"portfinder": "^1.0.17",
+				"tiny-lr": "^1.1.1"
+			}
+		},
 		"webpack-rtl-plugin": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/webpack-rtl-plugin/-/webpack-rtl-plugin-1.8.2.tgz",
@@ -10386,6 +14349,23 @@
 					"dev": true
 				}
 			}
+		},
+		"websocket-driver": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+			"integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+			"dev": true,
+			"requires": {
+				"http-parser-js": ">=0.4.0 <0.4.11",
+				"safe-buffer": ">=5.1.0",
+				"websocket-extensions": ">=0.1.1"
+			}
+		},
+		"websocket-extensions": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
@@ -10496,6 +14476,15 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
+		"write": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
+		},
 		"write-file-atomic": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
@@ -10515,6 +14504,12 @@
 			"requires": {
 				"async-limiter": "~1.0.0"
 			}
+		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
@@ -10566,6 +14561,15 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
+			}
+		},
+		"yauzl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+			"dev": true,
+			"requires": {
+				"fd-slicer": "~1.0.1"
 			}
 		}
 	}

--- a/apps/full-site-editing/package-lock.json
+++ b/apps/full-site-editing/package-lock.json
@@ -5,48 +5,49 @@
 	"requires": true,
 	"dependencies": {
 		"@automattic/calypso-build": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@automattic/calypso-build/-/calypso-build-4.1.0.tgz",
-			"integrity": "sha512-AL67ISScHydco7UeWfeVlFZ+3CX1FLD1dxHKUdhj9oG/jRYFYFcqGEbZlD7tgsojwxxaZ9FeTIgwKRRWq0YBsA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@automattic/calypso-build/-/calypso-build-4.2.1.tgz",
+			"integrity": "sha512-60GuWk//+wKGuODUKiFFiawD1kGtSrlx+1AiJFWpJpgyrhPk0W2i0+czxbJ2edKw3VY8YQvt6HIg1v/jAQ8dQw==",
 			"dev": true,
 			"requires": {
-				"@automattic/calypso-color-schemes": "^2.0.2",
-				"@babel/core": "7.5.5",
+				"@automattic/calypso-color-schemes": "^2.1.0",
+				"@babel/core": "7.6.4",
 				"@babel/plugin-proposal-class-properties": "7.5.5",
 				"@babel/plugin-syntax-dynamic-import": "7.2.0",
 				"@babel/plugin-transform-react-jsx": "7.3.0",
-				"@babel/plugin-transform-runtime": "7.5.5",
-				"@babel/preset-env": "7.5.5",
-				"@babel/preset-react": "7.0.0",
-				"@babel/preset-typescript": "7.3.3",
+				"@babel/plugin-transform-runtime": "7.6.2",
+				"@babel/preset-env": "7.6.3",
+				"@babel/preset-react": "7.6.3",
+				"@babel/preset-typescript": "7.6.0",
 				"@wordpress/babel-plugin-import-jsx-pragma": "2.3.0",
-				"@wordpress/browserslist-config": "2.3.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "1.1.0",
-				"autoprefixer": "9.4.4",
-				"babel-jest": "^24.9.0",
-				"babel-loader": "8.0.5",
-				"browserslist": "4.6.6",
+				"@wordpress/browserslist-config": "2.6.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "2.0.0",
+				"autoprefixer": "9.7.0",
+				"babel-jest": "24.9.0",
+				"babel-loader": "8.0.6",
+				"browserslist": "4.7.2",
 				"caniuse-api": "3.0.0",
 				"css-loader": "2.1.1",
 				"duplicate-package-checker-webpack-plugin": "3.0.0",
 				"enzyme": "3.10.0",
-				"enzyme-adapter-react-16": "1.14.0",
-				"enzyme-to-json": "3.4.0",
+				"enzyme-adapter-react-16": "1.15.1",
+				"enzyme-to-json": "3.4.3",
 				"file-loader": "3.0.1",
 				"jest-config": "24.9.0",
+				"jest-enzyme": "7.1.1",
 				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
-				"node-sass": "4.11.0",
-				"postcss-custom-properties": "8.0.9",
+				"node-sass": "4.13.0",
+				"postcss-custom-properties": "8.0.11",
 				"postcss-loader": "3.0.0",
 				"recursive-copy": "2.0.10",
-				"sass-loader": "7.1.0",
-				"terser-webpack-plugin": "1.2.3",
-				"thread-loader": "2.1.2",
-				"typescript": "3.4.3",
-				"webpack": "4.29.6",
-				"webpack-cli": "3.3.0",
+				"sass-loader": "7.3.1",
+				"terser-webpack-plugin": "1.4.1",
+				"thread-loader": "2.1.3",
+				"typescript": "3.6.4",
+				"webpack": "4.41.2",
+				"webpack-cli": "3.3.9",
 				"webpack-filter-warnings-plugin": "1.2.1",
-				"webpack-rtl-plugin": "1.8.0"
+				"webpack-rtl-plugin": "1.8.2"
 			}
 		},
 		"@automattic/calypso-color-schemes": {
@@ -65,18 +66,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+			"integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/generator": "^7.6.4",
+				"@babel/helpers": "^7.6.2",
+				"@babel/parser": "^7.6.4",
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.3",
+				"@babel/types": "^7.6.3",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -768,9 +769,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
-			"integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+			"integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -849,9 +850,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
-			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+			"integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -859,9 +860,9 @@
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
@@ -870,11 +871,11 @@
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
 				"@babel/plugin-transform-async-to-generator": "^7.5.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.5.5",
+				"@babel/plugin-transform-block-scoping": "^7.6.3",
 				"@babel/plugin-transform-classes": "^7.5.5",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.5.0",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/plugin-transform-destructuring": "^7.6.0",
+				"@babel/plugin-transform-dotall-regex": "^7.6.2",
 				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
 				"@babel/plugin-transform-for-of": "^7.4.4",
@@ -882,10 +883,10 @@
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.6.0",
 				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
 				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
@@ -893,12 +894,12 @@
 				"@babel/plugin-transform-regenerator": "^7.4.5",
 				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.6.2",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.5.5",
+				"@babel/plugin-transform-unicode-regex": "^7.6.2",
+				"@babel/types": "^7.6.3",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -907,9 +908,9 @@
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
-			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.6.3.tgz",
+			"integrity": "sha512-07yQhmkZmRAfwREYIQgW0HEwMY9GBJVuPY4Q12UC72AbfaawuupVWa8zQs2tlL+yun45Nv/1KreII/0PLfEsgA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -920,22 +921,13 @@
 			}
 		},
 		"@babel/preset-typescript": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
-			"integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.6.0.tgz",
+			"integrity": "sha512-4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-typescript": "^7.3.2"
-			}
-		},
-		"@babel/runtime": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
-			"dev": true,
-			"requires": {
-				"regenerator-runtime": "^0.13.2"
+				"@babel/plugin-transform-typescript": "^7.6.0"
 			}
 		},
 		"@babel/template": {
@@ -987,45 +979,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@hapi/address": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
-			"integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
-			"dev": true
-		},
-		"@hapi/bourne": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
-			"dev": true
-		},
-		"@hapi/hoek": {
-			"version": "8.3.1",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.1.tgz",
-			"integrity": "sha512-75ocgnI7HG/I01iGA3/rs0y6PXydUA/kxhFZM0HoT8NLSTnt/J8Gq03iKl4a4B/2A3iMG0ctXtxr5Hg9SGr1gw==",
-			"dev": true
-		},
-		"@hapi/joi": {
-			"version": "15.1.1",
-			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-			"integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/address": "2.x.x",
-				"@hapi/bourne": "1.x.x",
-				"@hapi/hoek": "8.x.x",
-				"@hapi/topo": "3.x.x"
-			}
-		},
-		"@hapi/topo": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-			"integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "^8.3.0"
-			}
-		},
 		"@jest/console": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -1035,42 +988,6 @@
 				"@jest/source-map": "^24.9.0",
 				"chalk": "^2.0.1",
 				"slash": "^2.0.0"
-			}
-		},
-		"@jest/core": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
-			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.9.0",
-				"jest-config": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-resolve-dependencies": "^24.9.0",
-				"jest-runner": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"jest-watcher": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"p-each-series": "^1.0.0",
-				"realpath-native": "^1.1.0",
-				"rimraf": "^2.5.4",
-				"slash": "^2.0.0",
-				"strip-ansi": "^5.0.0"
 			}
 		},
 		"@jest/environment": {
@@ -1094,43 +1011,6 @@
 				"@jest/types": "^24.9.0",
 				"jest-message-util": "^24.9.0",
 				"jest-mock": "^24.9.0"
-			}
-		},
-		"@jest/reporters": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
-			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
-			"dev": true,
-			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"glob": "^7.1.2",
-				"istanbul-lib-coverage": "^2.0.2",
-				"istanbul-lib-instrument": "^3.0.1",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.2.6",
-				"jest-haste-map": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.4.2",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.0",
-				"string-length": "^2.0.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/source-map": {
@@ -1218,22 +1098,6 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
-		"@mrmlnc/readdir-enhanced": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-			"dev": true,
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"glob-to-regexp": "^0.3.0"
-			}
-		},
-		"@nodelib/fs.stat": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
-			"dev": true
-		},
 		"@romainberger/css-diff": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@romainberger/css-diff/-/css-diff-1.0.3.tgz",
@@ -1315,81 +1179,6 @@
 				}
 			}
 		},
-		"@sheerun/mutationobserver-shim": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
-			"integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
-			"dev": true
-		},
-		"@testing-library/dom": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.8.1.tgz",
-			"integrity": "sha512-b+Q4wryafqsSTFBV14cc5xqhN/OVB9oMeUQvZwy1kVx+kdqs4zQAcyvCsFkdcqx7NxibWpUN/fBIUaqyAEhitw==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.6.2",
-				"@sheerun/mutationobserver-shim": "^0.3.2",
-				"@types/testing-library__dom": "^6.0.0",
-				"aria-query": "3.0.0",
-				"pretty-format": "^24.9.0",
-				"wait-for-expect": "^3.0.0"
-			}
-		},
-		"@testing-library/jest-dom": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.1.2.tgz",
-			"integrity": "sha512-fNf2rCfu0dBD4DmpzqR2ibsaFlFojrWI/EuU8LLqv73CzFIMvT2RMq88p5JVRe4DfeNj0mu0MQ5FTG4mQ0qFaA==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.5.1",
-				"chalk": "^2.4.1",
-				"css": "^2.2.3",
-				"css.escape": "^1.5.1",
-				"jest-diff": "^24.0.0",
-				"jest-matcher-utils": "^24.0.0",
-				"lodash": "^4.17.11",
-				"pretty-format": "^24.0.0",
-				"redent": "^3.0.0"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-					"dev": true
-				},
-				"redent": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-					"dev": true,
-					"requires": {
-						"indent-string": "^4.0.0",
-						"strip-indent": "^3.0.0"
-					}
-				},
-				"strip-indent": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-					"dev": true,
-					"requires": {
-						"min-indent": "^1.0.0"
-					}
-				}
-			}
-		},
-		"@testing-library/react": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.3.0.tgz",
-			"integrity": "sha512-FTPCwmLo0tLtP50Au2uGz4/N1BcJTnBx4StDVHZ47zPMEj1/+J2rk/RTj8SLoHRKWCtcmhN4wRmudOXQNP29/w==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.6.0",
-				"@testing-library/dom": "^6.3.0",
-				"@types/testing-library__react": "^9.1.0"
-			}
-		},
 		"@types/babel__core": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -1431,23 +1220,6 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
-		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-			"dev": true,
-			"requires": {
-				"@types/events": "*",
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1473,28 +1245,10 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"@types/json-schema": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
-			"dev": true
-		},
-		"@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-			"dev": true
-		},
 		"@types/node": {
-			"version": "12.7.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-			"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
-			"dev": true
-		},
-		"@types/prop-types": {
-			"version": "15.7.3",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+			"version": "12.11.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
+			"integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
 			"dev": true
 		},
 		"@types/q": {
@@ -1503,76 +1257,11 @@
 			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
 			"dev": true
 		},
-		"@types/react": {
-			"version": "16.9.6",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.6.tgz",
-			"integrity": "sha512-ulPWlBFO0DQiObqxEm3t4icozuakPy5O81g6QyHv+Nyo1UPL+QVq2rmq1e4J8oHY7jl0HEtMAHNwNIzv6FRuTQ==",
-			"dev": true,
-			"requires": {
-				"@types/prop-types": "*",
-				"csstype": "^2.2.0"
-			}
-		},
-		"@types/react-dom": {
-			"version": "16.9.2",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.2.tgz",
-			"integrity": "sha512-hgPbBoI1aTSTvZwo8HYw35UaTldW6n2ETLvHAcfcg1FaOuBV3olmyCe5eMpx2WybWMBPv0MdU2t5GOcQhP+3zA==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*"
-			}
-		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
-		},
-		"@types/testing-library__dom": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.5.3.tgz",
-			"integrity": "sha512-E/LSnbzo25gCLy/YOHKY9KJ+rfI8hy5cfbScyZqVuFw9CUMn1faWEDnxMcVHgjAbWtTStfllB8TwNKCx8bAKeA==",
-			"dev": true,
-			"requires": {
-				"pretty-format": "^24.3.0"
-			}
-		},
-		"@types/testing-library__react": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.2.tgz",
-			"integrity": "sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==",
-			"dev": true,
-			"requires": {
-				"@types/react-dom": "*",
-				"@types/testing-library__dom": "*"
-			}
-		},
-		"@types/unist": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-			"dev": true
-		},
-		"@types/vfile": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
-			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"@types/unist": "*",
-				"@types/vfile-message": "*"
-			}
-		},
-		"@types/vfile-message": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
-			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"@types/unist": "*"
-			}
 		},
 		"@types/yargs": {
 			"version": "13.0.3",
@@ -1588,35 +1277,6 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
 			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
 			"dev": true
-		},
-		"@typescript-eslint/experimental-utils": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
-			"dev": true,
-			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "1.13.0",
-				"eslint-scope": "^4.0.0"
-			}
-		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
-			"dev": true,
-			"requires": {
-				"lodash.unescape": "4.0.1",
-				"semver": "5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true
-				}
-			}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
@@ -1800,390 +1460,21 @@
 			"integrity": "sha512-b45c4x1+OvQm1f6egrBruO8eVF4bRVRZ8ojM1ttDcMi+K/qXfun3J6O8xXpSnA5eeNCZaJL3DhIk/aoNBbpwzw==",
 			"dev": true
 		},
-		"@wordpress/babel-preset-default": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.6.2.tgz",
-			"integrity": "sha512-UCR35dagwrlWLYFWqEOG8ZrCUYQl1dHcvnMgiW+MvAnAZwiGV041M0ApbiyKQOUvM6Q2RnRzAsSl+vgdeO9y5w==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.4.5",
-				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
-				"@babel/plugin-transform-react-jsx": "^7.3.0",
-				"@babel/plugin-transform-runtime": "^7.4.4",
-				"@babel/preset-env": "^7.4.5",
-				"@babel/runtime": "^7.4.5",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^2.3.0",
-				"@wordpress/browserslist-config": "^2.6.0",
-				"@wordpress/element": "^2.8.2",
-				"core-js": "^3.1.4"
-			},
-			"dependencies": {
-				"@wordpress/browserslist-config": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.6.0.tgz",
-					"integrity": "sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA==",
-					"dev": true
-				}
-			}
-		},
 		"@wordpress/browserslist-config": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.3.0.tgz",
-			"integrity": "sha512-bNOahe6ntNF3pRvCaeh2tGgnpPxe35U6UBfvRjDcOk3sIRvN1S7XlG0rlGZOOD+vJU93VLDM8AUj4uL6VPqPgQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.6.0.tgz",
+			"integrity": "sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA==",
 			"dev": true
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.1.0.tgz",
-			"integrity": "sha512-tCyxy7hLzDdCHQ1xGPiMlE7fBp/pCuEum89gqzoiz2HQJld6F7BTNMo3XfTzxFO0SHh/C64yOZgBB8FvH+warQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.0.0.tgz",
+			"integrity": "sha512-RJSbpnLBndYu02jrzbk0MTUi4uoOiEHXYSe9s8YM/40yJnUm6k1PvrytDG6VxFbjFARCCOzKgU70L+/xeC4pLQ==",
 			"dev": true,
 			"requires": {
+				"json2php": "^0.0.4",
 				"webpack": "^4.8.3",
 				"webpack-sources": "^1.3.0"
-			}
-		},
-		"@wordpress/element": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.8.2.tgz",
-			"integrity": "sha512-pwy2qvbkNIoB+XTwtvsAKP/pmCoqFq3vyH9uakNIVHJF/DzOwwLS3y5I5hHTuNYmmgFuGALQVZlUVVkujRpWfg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/escape-html": "^1.5.1",
-				"lodash": "^4.17.15",
-				"react": "^16.9.0",
-				"react-dom": "^16.9.0"
-			}
-		},
-		"@wordpress/escape-html": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.1.tgz",
-			"integrity": "sha512-C4chmaS4US5+SDQKcYuqU+MZJa41o7Wq7IwDsqIQfnrqTEhjk5JBFQm2M0slWOti9hry9CAGlmorp5XvE/eiyg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4"
-			}
-		},
-		"@wordpress/eslint-plugin": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
-			"integrity": "sha512-i/eNTWll3OH7rFukG2pNZXlOl0xihnuxg/2maEEMGzLS8dA8TEwyzCUXCqKycpOLR9sqODhdWFjeQBAPIjpZHg==",
-			"dev": true,
-			"requires": {
-				"babel-eslint": "^10.0.2",
-				"eslint-plugin-jest": "^22.15.1",
-				"eslint-plugin-jsdoc": "^15.8.0",
-				"eslint-plugin-jsx-a11y": "^6.2.3",
-				"eslint-plugin-react": "^7.14.3",
-				"eslint-plugin-react-hooks": "^1.6.1",
-				"globals": "^12.0.0",
-				"requireindex": "^1.2.0"
-			},
-			"dependencies": {
-				"globals": {
-					"version": "12.1.1",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.1.1.tgz",
-					"integrity": "sha512-i4wvLF+QFfPq/gNA1S8dL4Z2f2Cb62ZvxDhj38fZIProAfyUidDmUQILIg1jc5iwqJr4PVJSUB5usYvFxSzg+A==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				}
-			}
-		},
-		"@wordpress/jest-console": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.3.1.tgz",
-			"integrity": "sha512-3lDSBHq6sgH3LWoAAqDnt9CzT2iJ80ezHciVKfOwbfpR7dPxUXVD4fUau/xdqdzfICJXvCUgN5oTih9DtS29AQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"jest-matcher-utils": "^24.7.0",
-				"lodash": "^4.17.15"
-			}
-		},
-		"@wordpress/jest-preset-default": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-5.1.1.tgz",
-			"integrity": "sha512-QQHXjM03A39XRfZb9lhFVw960yjrj3Yr3BFuJczPMk8hWCM0hqW+yYyMLfMny+yW2VJ6WizVFzoS6L/RH97+LA==",
-			"dev": true,
-			"requires": {
-				"@wordpress/jest-console": "^3.3.1",
-				"babel-jest": "^24.7.1",
-				"enzyme": "^3.9.0",
-				"enzyme-adapter-react-16": "^1.10.0",
-				"enzyme-to-json": "^3.3.5"
-			}
-		},
-		"@wordpress/npm-package-json-lint-config": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.1.0.tgz",
-			"integrity": "sha512-NSwcK7GtlmW5O5ZMG7elRKBa9sPws17Sadjlztig6ShOuhlLFeHYk99tUenpmJ/PYOZex4fSJ5e9mqjPyKunjw==",
-			"dev": true
-		},
-		"@wordpress/scripts": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-5.1.0.tgz",
-			"integrity": "sha512-S5fu9MIYLhkfLFkRWgBB1bSCKiPByEBDFxP+d7jzwNAZGZhHTTbAFvYEtEGQTXkEMCXW0p2oF233Sc6wY/tmjQ==",
-			"dev": true,
-			"requires": {
-				"@wordpress/babel-preset-default": "^4.6.2",
-				"@wordpress/dependency-extraction-webpack-plugin": "^2.0.0",
-				"@wordpress/eslint-plugin": "^3.1.0",
-				"@wordpress/jest-preset-default": "^5.1.1",
-				"@wordpress/npm-package-json-lint-config": "^2.1.0",
-				"babel-jest": "^24.7.1",
-				"babel-loader": "^8.0.5",
-				"chalk": "^2.4.2",
-				"check-node-version": "^3.1.1",
-				"command-exists": "^1.2.8",
-				"cross-spawn": "^5.1.0",
-				"decompress-zip": "^0.2.2",
-				"eslint": "^6.1.0",
-				"jest": "^24.7.1",
-				"jest-puppeteer": "^4.3.0",
-				"js-yaml": "^3.13.1",
-				"lodash": "^4.17.15",
-				"minimist": "^1.2.0",
-				"npm-package-json-lint": "^3.6.0",
-				"puppeteer": "^1.19.0",
-				"read-pkg-up": "^1.0.1",
-				"request": "^2.88.0",
-				"resolve-bin": "^0.4.0",
-				"source-map-loader": "^0.2.4",
-				"sprintf-js": "^1.1.1",
-				"stylelint": "^9.10.1",
-				"stylelint-config-wordpress": "^13.1.0",
-				"thread-loader": "^2.1.2",
-				"webpack": "^4.41.0",
-				"webpack-bundle-analyzer": "^3.3.2",
-				"webpack-cli": "^3.1.2",
-				"webpack-livereload-plugin": "^2.2.0"
-			},
-			"dependencies": {
-				"@wordpress/dependency-extraction-webpack-plugin": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.0.0.tgz",
-					"integrity": "sha512-RJSbpnLBndYu02jrzbk0MTUi4uoOiEHXYSe9s8YM/40yJnUm6k1PvrytDG6VxFbjFARCCOzKgU70L+/xeC4pLQ==",
-					"dev": true,
-					"requires": {
-						"json2php": "^0.0.4",
-						"webpack": "^4.8.3",
-						"webpack-sources": "^1.3.0"
-					}
-				},
-				"cacache": {
-					"version": "12.0.3",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-					"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
-					"dev": true,
-					"requires": {
-						"bluebird": "^3.5.5",
-						"chownr": "^1.1.1",
-						"figgy-pudding": "^3.5.1",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.1.15",
-						"infer-owner": "^1.0.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.3",
-						"ssri": "^6.0.1",
-						"unique-filename": "^1.1.1",
-						"y18n": "^4.0.0"
-					}
-				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "4.1.5",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-							"dev": true,
-							"requires": {
-								"pseudomap": "^1.0.2",
-								"yallist": "^2.1.2"
-							}
-						}
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"sprintf-js": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-					"dev": true
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"terser": {
-					"version": "4.3.9",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
-					"integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
-					"dev": true,
-					"requires": {
-						"commander": "^2.20.0",
-						"source-map": "~0.6.1",
-						"source-map-support": "~0.5.12"
-					}
-				},
-				"terser-webpack-plugin": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-					"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
-					"dev": true,
-					"requires": {
-						"cacache": "^12.0.2",
-						"find-cache-dir": "^2.1.0",
-						"is-wsl": "^1.1.0",
-						"schema-utils": "^1.0.0",
-						"serialize-javascript": "^1.7.0",
-						"source-map": "^0.6.1",
-						"terser": "^4.1.2",
-						"webpack-sources": "^1.4.0",
-						"worker-farm": "^1.7.0"
-					}
-				},
-				"webpack": {
-					"version": "4.41.2",
-					"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-					"integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.8.5",
-						"@webassemblyjs/helper-module-context": "1.8.5",
-						"@webassemblyjs/wasm-edit": "1.8.5",
-						"@webassemblyjs/wasm-parser": "1.8.5",
-						"acorn": "^6.2.1",
-						"ajv": "^6.10.2",
-						"ajv-keywords": "^3.4.1",
-						"chrome-trace-event": "^1.0.2",
-						"enhanced-resolve": "^4.1.0",
-						"eslint-scope": "^4.0.3",
-						"json-parse-better-errors": "^1.0.2",
-						"loader-runner": "^2.4.0",
-						"loader-utils": "^1.2.3",
-						"memory-fs": "^0.4.1",
-						"micromatch": "^3.1.10",
-						"mkdirp": "^0.5.1",
-						"neo-async": "^2.6.1",
-						"node-libs-browser": "^2.2.1",
-						"schema-utils": "^1.0.0",
-						"tapable": "^1.1.3",
-						"terser-webpack-plugin": "^1.4.1",
-						"watchpack": "^1.6.0",
-						"webpack-sources": "^1.4.1"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-					"dev": true
-				}
 			}
 		},
 		"@xtuc/ieee754": {
@@ -2207,28 +1498,13 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"dev": true,
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"acorn": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
 			"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
-			"dev": true
-		},
-		"acorn-dynamic-import": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -2241,26 +1517,11 @@
 				"acorn-walk": "^6.0.1"
 			}
 		},
-		"acorn-jsx": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
-			"dev": true
-		},
 		"acorn-walk": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
-		},
-		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-			"dev": true,
-			"requires": {
-				"es6-promisify": "^5.0.0"
-			}
 		},
 		"airbnb-prop-types": {
 			"version": "2.15.0",
@@ -2314,12 +1575,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
-		},
-		"ansi-escapes": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -2383,16 +1638,6 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
-		"aria-query": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-			"dev": true,
-			"requires": {
-				"ast-types-flow": "0.0.7",
-				"commander": "^2.11.0"
-			}
-		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2434,22 +1679,6 @@
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
 			"dev": true
-		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-			"dev": true
-		},
-		"array-includes": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
-			}
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -2564,18 +1793,6 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
-		"ast-types-flow": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
-			"dev": true
-		},
-		"astral-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-			"dev": true
-		},
 		"async": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
@@ -2616,17 +1833,18 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "9.4.4",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
-			"integrity": "sha512-7tpjBadJyHKf+gOJEmKhZIksWxdZCSrnKbbTJNsw+/zX9+f//DLELRQPWjjjVoDbbWlCuNRkN7RfmZwDVgWMLw==",
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.0.tgz",
+			"integrity": "sha512-j2IRvaCfrUxIiZun9ba4mhJ2omhw4OY88/yVzLO+lHhGBumAAK72PgM6gkbSN8iregPOn1ZlxGkmZh2CQ7X4AQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.3.7",
-				"caniuse-lite": "^1.0.30000926",
+				"browserslist": "^4.7.2",
+				"caniuse-lite": "^1.0.30001004",
+				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.7",
-				"postcss-value-parser": "^3.3.1"
+				"postcss": "^7.0.19",
+				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"aws-sign2": {
@@ -2640,29 +1858,6 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
-		},
-		"axobject-query": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
-			"integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
-			"dev": true,
-			"requires": {
-				"ast-types-flow": "0.0.7"
-			}
-		},
-		"babel-eslint": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
-			"integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@babel/types": "^7.0.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			}
 		},
 		"babel-jest": {
 			"version": "24.9.0",
@@ -2680,15 +1875,15 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
-			"integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+			"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "^2.0.0",
 				"loader-utils": "^1.0.2",
 				"mkdirp": "^0.5.1",
-				"util.promisify": "^1.0.0"
+				"pify": "^4.0.1"
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
@@ -2731,16 +1926,11 @@
 				"babel-plugin-jest-hoist": "^24.9.0"
 			}
 		},
-		"bail": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
-			"dev": true
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -2812,33 +2002,11 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bfj": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
-			"integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.5.5",
-				"check-types": "^8.0.3",
-				"hoopy": "^0.1.4",
-				"tryer": "^1.0.1"
-			}
-		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
-		},
-		"binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-			"dev": true,
-			"requires": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			}
 		},
 		"binary-extensions": {
 			"version": "1.13.1",
@@ -2867,83 +2035,6 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
 			"dev": true
 		},
-		"body": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
-			"integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
-			"dev": true,
-			"requires": {
-				"continuable-cache": "^0.3.1",
-				"error": "^7.0.0",
-				"raw-body": "~1.1.0",
-				"safe-json-parse": "~1.0.1"
-			},
-			"dependencies": {
-				"bytes": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-					"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
-					"dev": true
-				},
-				"raw-body": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-					"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-					"dev": true,
-					"requires": {
-						"bytes": "1",
-						"string_decoder": "0.10"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
-		"body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"dev": true,
-			"requires": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				}
-			}
-		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2954,6 +2045,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3089,20 +2181,20 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
+			"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000984",
-				"electron-to-chromium": "^1.3.191",
-				"node-releases": "^1.1.25"
+				"caniuse-lite": "^1.0.30001004",
+				"electron-to-chromium": "^1.3.295",
+				"node-releases": "^1.1.38"
 			}
 		},
 		"bser": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-			"integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
 			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
@@ -3131,28 +2223,16 @@
 			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
 			"dev": true
 		},
-		"buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
-			"dev": true
-		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true
 		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-			"dev": true
-		},
 		"cacache": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
-			"integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+			"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.5",
@@ -3160,6 +2240,7 @@
 				"figgy-pudding": "^3.5.1",
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.1.15",
+				"infer-owner": "^1.0.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
@@ -3187,12 +2268,6 @@
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
 			}
-		},
-		"call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-			"dev": true
 		},
 		"caller-callsite": {
 			"version": "2.0.0",
@@ -3263,9 +2338,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000999",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
-			"integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
+			"version": "1.0.30001004",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001004.tgz",
+			"integrity": "sha512-3nfOR4O8Wa2RWoYfJkMtwRVOsK96TQ+eq57wd0iKaEWl8dwG4hKZ/g0MVBfCvysFvMLi9fQGR/DvozMdkEPl3g==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -3283,21 +2358,6 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
-		"ccount": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
-			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
-			"dev": true
-		},
-		"chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-			"dev": true,
-			"requires": {
-				"traverse": ">=0.3.0 <0.4"
-			}
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3308,57 +2368,6 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
-		},
-		"character-entities": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
-			"dev": true
-		},
-		"character-entities-html4": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
-			"integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
-			"dev": true
-		},
-		"character-entities-legacy": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
-			"dev": true
-		},
-		"character-reference-invalid": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
-			"dev": true
-		},
-		"chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
-		},
-		"check-node-version": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.3.0.tgz",
-			"integrity": "sha512-OAtp7prQf+8YYKn2UB/fK1Ppb9OT+apW56atoKYUvucYLPq69VozOY0B295okBwCKymk2cictrS3qsdcZwyfzw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.3.0",
-				"map-values": "^1.0.1",
-				"minimist": "^1.2.0",
-				"object-filter": "^1.0.2",
-				"object.assign": "^4.0.4",
-				"run-parallel": "^1.1.4",
-				"semver": "^5.0.3"
-			}
-		},
-		"check-types": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
-			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
-			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.3",
@@ -3397,7 +2406,8 @@
 		"chownr": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -3424,6 +2434,12 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"circular-json-es6": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/circular-json-es6/-/circular-json-es6-2.0.2.tgz",
+			"integrity": "sha512-ODYONMMNb3p658Zv+Pp+/XPa5s6q7afhz3Tzyvo+VRh9WIrJ64J76ZC4GQxnlye/NesTn09jvOiuE8+xxfpwhQ==",
+			"dev": true
+		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3447,26 +2463,6 @@
 				}
 			}
 		},
-		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-		},
-		"cli-cursor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
-			"requires": {
-				"restore-cursor": "^2.0.0"
-			}
-		},
-		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
-		},
 		"cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -3479,25 +2475,14 @@
 			}
 		},
 		"clone-deep": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
-			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
 			"dev": true,
 			"requires": {
-				"for-own": "^1.0.0",
 				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.0",
-				"shallow-clone": "^1.0.0"
-			}
-		},
-		"clone-regexp": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-			"integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
-			"dev": true,
-			"requires": {
-				"is-regexp": "^1.0.0",
-				"is-supported-regexp-flag": "^1.0.0"
+				"kind-of": "^6.0.2",
+				"shallow-clone": "^3.0.0"
 			}
 		},
 		"co": {
@@ -3520,12 +2505,7 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
-		"collapse-white-space": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
-			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
 		},
 		"collection-visit": {
@@ -3588,22 +2568,10 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
-		"command-exists": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
-			"dev": true
-		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
-		},
-		"comment-parser": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.6.2.tgz",
-			"integrity": "sha512-Wdms0Q8d4vvb2Yk72OwZjwNWtMklbC5Re7lD9cjCP/AG1fhocmc0TrxGBBAXPLy8fZQPrfHGgyygwI0lA7pbzA==",
 			"dev": true
 		},
 		"commondir": {
@@ -3621,7 +2589,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -3656,27 +2625,6 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
-		},
-		"continuable-cache": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
-			"integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
-			"dev": true
-		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -3685,18 +2633,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
-		},
-		"cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-			"dev": true
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -3718,33 +2654,16 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.2.tgz",
-			"integrity": "sha512-S1FfZpeBchkhyoY76YAdFzKS4zz9aOK7EeFaNA2aJlyXyA+sgqz6xdxmLPGXEAf0nF44MVN1kSjrA9Kt3ATDQg==",
-			"dev": true
-		},
 		"core-js-compat": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.2.tgz",
-			"integrity": "sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.3.tgz",
+			"integrity": "sha512-GNZkENsx5pMnS7Inwv7ZO/s3B68a9WU5kIjxqrD/tkNR8mtfXJRk8fAKRlbvWZSGPc59/TkiOBDYl5Cb65pTVA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.7.0",
+				"browserslist": "^4.7.1",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.7.0",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-					"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000989",
-						"electron-to-chromium": "^1.3.247",
-						"node-releases": "^1.1.29"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3840,26 +2759,6 @@
 				"randomfill": "^1.0.3"
 			}
 		},
-		"css": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.5.2",
-				"urix": "^0.1.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
 		"css-color-names": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -3893,6 +2792,14 @@
 				"postcss-modules-values": "^2.0.0",
 				"postcss-value-parser": "^3.3.0",
 				"schema-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"css-select": {
@@ -3933,12 +2840,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
 			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-			"dev": true
-		},
-		"css.escape": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -4066,12 +2967,6 @@
 				"cssom": "0.3.x"
 			}
 		},
-		"csstype": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-			"integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==",
-			"dev": true
-		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -4081,26 +2976,10 @@
 				"array-find-index": "^1.0.1"
 			}
 		},
-		"cwd": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
-			"integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
-			"dev": true,
-			"requires": {
-				"find-pkg": "^0.1.2",
-				"fs-exists-sync": "^0.1.0"
-			}
-		},
 		"cyclist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
-			"dev": true
-		},
-		"damerau-levenshtein": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
-			"integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
 			"dev": true
 		},
 		"dashdash": {
@@ -4124,9 +3003,9 @@
 			},
 			"dependencies": {
 				"whatwg-url": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 					"dev": true,
 					"requires": {
 						"lodash.sortby": "^4.7.0",
@@ -4157,69 +3036,32 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
-			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			}
-		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"decompress-zip": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.2.2.tgz",
-			"integrity": "sha512-v+Na3Ck86Px7s2ix+f77pMQC3GlkxHHN+YyvnkEW7+xX5F39pcDpIV/VFvGYk8MznTFcMoPjL3XNWEJLXWoSPw==",
+		"deep-equal-ident": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz",
+			"integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
 			"dev": true,
 			"requires": {
-				"binary": "^0.3.0",
-				"graceful-fs": "^4.1.3",
-				"mkpath": "^0.1.0",
-				"nopt": "^3.0.1",
-				"q": "^1.1.2",
-				"readable-stream": "^1.1.8",
-				"touch": "0.0.3"
+				"lodash.isequal": "^3.0"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+				"lodash.isequal": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
+					"integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
+						"lodash._baseisequal": "^3.0.0",
+						"lodash._bindcallback": "^3.0.0"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
 				}
 			}
-		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true,
-			"optional": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -4312,12 +3154,6 @@
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
-		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -4328,24 +3164,11 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
-		},
 		"detect-file": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true,
-			"optional": true
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -4370,29 +3193,11 @@
 				"randombytes": "^2.0.0"
 			}
 		},
-		"dir-glob": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-			"dev": true,
-			"requires": {
-				"path-type": "^3.0.0"
-			}
-		},
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
 			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
 			"dev": true
-		},
-		"doctrine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"dev": true,
-			"requires": {
-				"esutils": "^2.0.2"
-			}
 		},
 		"dom-serializer": {
 			"version": "0.1.1",
@@ -4453,12 +3258,6 @@
 				"is-obj": "^1.0.0"
 			}
 		},
-		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
-		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -4493,22 +3292,10 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
-		},
-		"ejs": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
-			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==",
-			"dev": true
-		},
 		"electron-to-chromium": {
-			"version": "1.3.282",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
-			"integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
+			"version": "1.3.296",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz",
+			"integrity": "sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ==",
 			"dev": true
 		},
 		"elliptic": {
@@ -4542,12 +3329,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
 		},
 		"end-of-stream": {
@@ -4618,17 +3399,18 @@
 			}
 		},
 		"enzyme-adapter-react-16": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
-			"integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.1.tgz",
+			"integrity": "sha512-yMPxrP3vjJP+4wL/qqfkT6JAIctcwKF+zXO6utlGPgUJT2l4tzrdjMDWGd/Pp1BjHBcljhN24OzNEGRteibJhA==",
 			"dev": true,
 			"requires": {
-				"enzyme-adapter-utils": "^1.12.0",
+				"enzyme-adapter-utils": "^1.12.1",
+				"enzyme-shallow-equal": "^1.0.0",
 				"has": "^1.0.3",
 				"object.assign": "^4.1.0",
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.2",
-				"react-is": "^16.8.6",
+				"react-is": "^16.10.2",
 				"react-test-renderer": "^16.0.0-0",
 				"semver": "^5.7.0"
 			}
@@ -4647,13 +3429,33 @@
 				"semver": "^5.7.0"
 			}
 		},
-		"enzyme-to-json": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.4.0.tgz",
-			"integrity": "sha512-gbu8P8PMAtb+qtKuGVRdZIYxWHC03q1dGS3EKRmUzmTDIracu3o6cQ0d4xI2YWojbelbxjYOsmqM5EgAL0WgIA==",
+		"enzyme-matchers": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-7.1.1.tgz",
+			"integrity": "sha512-fw/FxwpEg6n1KYpEHnhA44iFduYHDUVVePXSMmf883q/JDMXb+sIU55maSw2oFWqt9zd7rcGqmSV8sHQO5pReg==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.12"
+				"circular-json-es6": "^2.0.1",
+				"deep-equal-ident": "^1.1.1"
+			}
+		},
+		"enzyme-shallow-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.0.tgz",
+			"integrity": "sha512-VUf+q5o1EIv2ZaloNQQtWCJM9gpeux6vudGVH6vLmfPXFLRuxl5+Aq3U260wof9nn0b0i+P5OEUXm1vnxkRpXQ==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3",
+				"object-is": "^1.0.1"
+			}
+		},
+		"enzyme-to-json": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.4.3.tgz",
+			"integrity": "sha512-jqNEZlHqLdz7OTpXSzzghArSS3vigj67IU/fWkPyl1c0TCj9P5s6Ze0kRkYZWNEoCqCR79xlQbigYlMx5erh8A==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.15"
 			}
 		},
 		"errno": {
@@ -4663,15 +3465,6 @@
 			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
-			}
-		},
-		"error": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/error/-/error-7.2.0.tgz",
-			"integrity": "sha512-M6t3j3Vt3uDicrViMP5fLq2AeADNrCVFD8Oj4Qt2MHsX0mPYG7D5XdnEfSdRpaHQzjAJ19wu+I1mw9rQYMTAPg==",
-			"dev": true,
-			"requires": {
-				"string-template": "~0.2.1"
 			}
 		},
 		"error-ex": {
@@ -4684,9 +3477,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
@@ -4711,27 +3504,6 @@
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
 			}
-		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-			"dev": true
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dev": true,
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -4761,172 +3533,6 @@
 				}
 			}
 		},
-		"eslint": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
-			"integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.10.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
-				"debug": "^4.0.1",
-				"doctrine": "^3.0.0",
-				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.4.2",
-				"eslint-visitor-keys": "^1.1.0",
-				"espree": "^6.1.1",
-				"esquery": "^1.0.1",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^5.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
-				"globals": "^11.7.0",
-				"ignore": "^4.0.6",
-				"import-fresh": "^3.0.0",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.4.1",
-				"is-glob": "^4.0.0",
-				"js-yaml": "^3.13.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.14",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"progress": "^2.0.0",
-				"regexpp": "^2.0.1",
-				"semver": "^6.1.2",
-				"strip-ansi": "^5.2.0",
-				"strip-json-comments": "^3.0.1",
-				"table": "^5.2.3",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
-			},
-			"dependencies": {
-				"doctrine": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2"
-					}
-				},
-				"eslint-scope": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"glob-parent": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"import-fresh": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-					"dev": true
-				}
-			}
-		},
-		"eslint-plugin-jest": {
-			"version": "22.19.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.19.0.tgz",
-			"integrity": "sha512-4zUc3rh36ds0SXdl2LywT4YWA3zRe8sfLhz8bPp8qQPIKvynTTkNGwmSCMpl5d9QiZE2JxSinGF+WD8yU+O0Lg==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/experimental-utils": "^1.13.0"
-			}
-		},
-		"eslint-plugin-jsdoc": {
-			"version": "15.11.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.11.1.tgz",
-			"integrity": "sha512-eozHqOjiYvtCKxYEZsblWlFIUnshXYfj6s3pa3VJ+I+ZFDzY0wwpSMkDyaM0tzNgqLvMAlJBSFlI5RrjhJ9TDg==",
-			"dev": true,
-			"requires": {
-				"comment-parser": "^0.6.2",
-				"debug": "^4.1.1",
-				"jsdoctypeparser": "^5.1.1",
-				"lodash": "^4.17.15",
-				"object.entries-ponyfill": "^1.0.1",
-				"regextras": "^0.6.1"
-			}
-		},
-		"eslint-plugin-jsx-a11y": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
-			"integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.5",
-				"aria-query": "^3.0.0",
-				"array-includes": "^3.0.3",
-				"ast-types-flow": "^0.0.7",
-				"axobject-query": "^2.0.2",
-				"damerau-levenshtein": "^1.0.4",
-				"emoji-regex": "^7.0.2",
-				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.2.1"
-			}
-		},
-		"eslint-plugin-react": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
-			"integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
-			"dev": true,
-			"requires": {
-				"array-includes": "^3.0.3",
-				"doctrine": "^2.1.0",
-				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.2.1",
-				"object.entries": "^1.1.0",
-				"object.fromentries": "^2.0.0",
-				"object.values": "^1.1.0",
-				"prop-types": "^15.7.2",
-				"resolve": "^1.12.0"
-			}
-		},
-		"eslint-plugin-react-hooks": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-			"integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
-			"dev": true
-		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -4937,54 +3543,11 @@
 				"estraverse": "^4.1.1"
 			}
 		},
-		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
-			"dev": true,
-			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
-			}
-		},
-		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-			"dev": true
-		},
-		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
-			"dev": true,
-			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
-					"dev": true
-				}
-			}
-		},
 		"esprima": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
 			"dev": true
-		},
-		"esquery": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-			"dev": true,
-			"requires": {
-				"estraverse": "^4.0.0"
-			}
 		},
 		"esrecurse": {
 			"version": "4.2.1",
@@ -5005,12 +3568,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
 		},
 		"events": {
@@ -5048,15 +3605,6 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
-			}
-		},
-		"execall": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-			"integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
-			"dev": true,
-			"requires": {
-				"clone-regexp": "^1.0.0"
 			}
 		},
 		"exit": {
@@ -5138,73 +3686,6 @@
 				"jest-regex-util": "^24.9.0"
 			}
 		},
-		"expect-puppeteer": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.3.0.tgz",
-			"integrity": "sha512-p8N/KSVPG9PAOJlftK5f1n3JrULJ6Qq1EQ8r/n9xzkX2NmXbK8PcnJnkSAEzEHrMycELKGnlJV7M5nkgm+wEWA==",
-			"dev": true
-		},
-		"express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				}
-			}
-		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5230,17 +3711,6 @@
 						"is-plain-object": "^2.0.4"
 					}
 				}
-			}
-		},
-		"external-editor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
-			"requires": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -5308,35 +3778,6 @@
 				}
 			}
 		},
-		"extract-zip": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-			"dev": true,
-			"requires": {
-				"concat-stream": "1.6.2",
-				"debug": "2.6.9",
-				"mkdirp": "0.5.1",
-				"yauzl": "2.4.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -5348,20 +3789,6 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
-		},
-		"fast-glob": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
-			"integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
-			"dev": true,
-			"requires": {
-				"@mrmlnc/readdir-enhanced": "^2.2.1",
-				"@nodelib/fs.stat": "^1.1.2",
-				"glob-parent": "^3.1.0",
-				"is-glob": "^4.0.0",
-				"merge2": "^1.2.3",
-				"micromatch": "^3.1.10"
-			}
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -5375,15 +3802,6 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"faye-websocket": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-			"dev": true,
-			"requires": {
-				"websocket-driver": ">=0.5.1"
-			}
-		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -5393,38 +3811,11 @@
 				"bser": "^2.0.0"
 			}
 		},
-		"fd-slicer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-			"dev": true,
-			"requires": {
-				"pend": "~1.2.0"
-			}
-		},
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
 			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 			"dev": true
-		},
-		"figures": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.5"
-			}
-		},
-		"file-entry-cache": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-			"dev": true,
-			"requires": {
-				"flat-cache": "^2.0.1"
-			}
 		},
 		"file-loader": {
 			"version": "3.0.1",
@@ -5435,12 +3826,6 @@
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^1.0.0"
 			}
-		},
-		"filesize": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-			"dev": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -5465,38 +3850,6 @@
 				}
 			}
 		},
-		"finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
 		"find-cache-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -5506,108 +3859,6 @@
 				"commondir": "^1.0.1",
 				"make-dir": "^2.0.0",
 				"pkg-dir": "^3.0.0"
-			}
-		},
-		"find-file-up": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
-			"integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
-			"dev": true,
-			"requires": {
-				"fs-exists-sync": "^0.1.0",
-				"resolve-dir": "^0.1.0"
-			},
-			"dependencies": {
-				"expand-tilde": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-					"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.1"
-					}
-				},
-				"global-modules": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^0.1.4",
-						"is-windows": "^0.2.0"
-					}
-				},
-				"global-prefix": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.0",
-						"ini": "^1.3.4",
-						"is-windows": "^0.2.0",
-						"which": "^1.2.12"
-					}
-				},
-				"is-windows": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-					"dev": true
-				},
-				"resolve-dir": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-					"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^1.2.2",
-						"global-modules": "^0.2.3"
-					}
-				}
-			}
-		},
-		"find-parent-dir": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-			"dev": true
-		},
-		"find-pkg": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
-			"integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
-			"dev": true,
-			"requires": {
-				"find-file-up": "^0.1.2"
-			}
-		},
-		"find-process": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.2.tgz",
-			"integrity": "sha512-O83EVJr4dWvHJ7QpUzANNAMeQVKukRzRqRx4AIzdLYRrQorRdbqDwLPigkd9PYPhJRhmNPAoVjOm9bcwSmcZaw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1",
-				"commander": "^2.11.0",
-				"debug": "^2.6.8"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
 			}
 		},
 		"find-root": {
@@ -5644,55 +3895,16 @@
 			}
 		},
 		"findup-sync": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-			"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
 			"dev": true,
 			"requires": {
 				"detect-file": "^1.0.0",
-				"is-glob": "^3.1.0",
+				"is-glob": "^4.0.0",
 				"micromatch": "^3.0.4",
 				"resolve-dir": "^1.0.1"
-			},
-			"dependencies": {
-				"is-glob": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.0"
-					}
-				}
 			}
-		},
-		"flat-cache": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-			"dev": true,
-			"requires": {
-				"flatted": "^2.0.0",
-				"rimraf": "2.6.3",
-				"write": "1.0.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
-		},
-		"flatted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
-			"dev": true
 		},
 		"flatten": {
 			"version": "1.0.2",
@@ -5716,15 +3928,6 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
-		"for-own": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-			"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-			"dev": true,
-			"requires": {
-				"for-in": "^1.0.1"
-			}
-		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -5742,12 +3945,6 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-			"dev": true
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -5756,12 +3953,6 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -5772,12 +3963,6 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
 			}
-		},
-		"fs-exists-sync": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-			"dev": true
 		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
@@ -5794,7 +3979,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.2.9",
@@ -5807,73 +3993,504 @@
 				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"chownr": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"debug": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"deep-extend": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"iconv-lite": {
+					"version": "0.4.24",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"minipass": {
+					"version": "2.3.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
 				},
 				"ms": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"needle": {
+					"version": "2.3.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "^4.1.0",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.12.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.1",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.2.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
+					}
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"abbrev": "1",
 						"osenv": "^0.1.4"
 					}
 				},
+				"npm-bundled": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
 				"rimraf": {
 					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
 				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
 				"semver": {
 					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
 						"strip-ansi": "^3.0.0"
 					}
 				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
 				"tar": {
 					"version": "4.4.8",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
 					"requires": {
 						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
@@ -5883,6 +4500,33 @@
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wide-align": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "^1.0.2 || 2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -5916,16 +4560,10 @@
 				"is-callable": "^1.1.4"
 			}
 		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"dev": true
-		},
 		"functions-have-names": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.1.1.tgz",
-			"integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.0.tgz",
+			"integrity": "sha512-zKXyzksTeaCSw5wIX79iCA40YAa6CJMJgNg9wdkU/ERBrIdPSimPICYiLp65lRbSBqtiHql/HZfS2DyI/AH6tQ==",
 			"dev": true
 		},
 		"gauge": {
@@ -6027,9 +4665,10 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -6060,21 +4699,26 @@
 				}
 			}
 		},
-		"glob-to-regexp": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-			"dev": true
-		},
 		"global-modules": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
+				"global-prefix": "^3.0.0"
+			},
+			"dependencies": {
+				"global-prefix": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+					"dev": true,
+					"requires": {
+						"ini": "^1.3.5",
+						"kind-of": "^6.0.2",
+						"which": "^1.3.1"
+					}
+				}
 			}
 		},
 		"global-prefix": {
@@ -6118,12 +4762,6 @@
 				}
 			}
 		},
-		"globjoin": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
-			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
-			"dev": true
-		},
 		"globule": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
@@ -6135,64 +4773,11 @@
 				"minimatch": "~3.0.2"
 			}
 		},
-		"gonzales-pe": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
-			"integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "1.1.x"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
-					"dev": true
-				}
-			}
-		},
 		"graceful-fs": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 			"dev": true
-		},
-		"growly": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
-		},
-		"gzip-size": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
-			"dev": true,
-			"requires": {
-				"duplexer": "^0.1.1",
-				"pify": "^4.0.1"
-			}
-		},
-		"handlebars": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-			"integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
-			"dev": true,
-			"requires": {
-				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -6332,12 +4917,6 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
-		"hoopy": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-			"dev": true
-		},
 		"hosted-git-info": {
 			"version": "2.8.5",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
@@ -6380,12 +4959,6 @@
 				"whatwg-encoding": "^1.0.1"
 			}
 		},
-		"html-tags": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
-			"integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
-			"dev": true
-		},
 		"htmlparser2": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -6413,33 +4986,6 @@
 				}
 			}
 		},
-		"http-errors": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
-				}
-			}
-		},
-		"http-parser-js": {
-			"version": "0.4.10",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
-			"dev": true
-		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -6456,27 +5002,6 @@
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
-		},
-		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
-			"dev": true,
-			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
@@ -6514,22 +5039,6 @@
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
 		},
-		"ignore": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"dev": true
-		},
-		"ignore-walk": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"minimatch": "^3.0.4"
-			}
-		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -6557,12 +5066,6 @@
 			"requires": {
 				"resolve-from": "^3.0.0"
 			}
-		},
-		"import-lazy": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-			"integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
-			"dev": true
 		},
 		"import-local": {
 			"version": "2.0.0",
@@ -6611,6 +5114,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6619,63 +5123,14 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
-		},
-		"inquirer": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^3.2.0",
-				"chalk": "^2.4.2",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^3.0.3",
-				"figures": "^2.0.0",
-				"lodash": "^4.17.12",
-				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rxjs": "^6.4.0",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^5.1.0",
-				"through": "^2.3.6"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				}
-			}
 		},
 		"interpret": {
 			"version": "1.2.0",
@@ -6696,18 +5151,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
-		},
-		"ipaddr.js": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
-			"dev": true
-		},
-		"irregular-plurals": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
 			"dev": true
 		},
 		"is-absolute-url": {
@@ -6734,28 +5177,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"is-alphabetical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
-			"dev": true
-		},
-		"is-alphanumeric": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
-			"dev": true
-		},
-		"is-alphanumerical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
-			"dev": true,
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -6840,12 +5261,6 @@
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
 		},
-		"is-decimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
-			"dev": true
-		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -6912,12 +5327,6 @@
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
-		},
-		"is-hexadecimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
-			"dev": true
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -6990,12 +5399,6 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
-		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -7004,12 +5407,6 @@
 			"requires": {
 				"has": "^1.0.1"
 			}
-		},
-		"is-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-			"dev": true
 		},
 		"is-resolvable": {
 			"version": "1.1.0",
@@ -7033,12 +5430,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
 			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
-		},
-		"is-supported-regexp-flag": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-			"integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
 			"dev": true
 		},
 		"is-svg": {
@@ -7071,22 +5462,10 @@
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
 			"dev": true
 		},
-		"is-whitespace-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
-			"dev": true
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
-		},
-		"is-word-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
 			"dev": true
 		},
 		"is-wsl": {
@@ -7148,102 +5527,6 @@
 				}
 			}
 		},
-		"istanbul-lib-report": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-			"dev": true,
-			"requires": {
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"supports-color": "^6.1.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"istanbul-lib-source-maps": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"rimraf": "^2.6.3",
-				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"istanbul-reports": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
-			"dev": true,
-			"requires": {
-				"handlebars": "^4.1.2"
-			}
-		},
-		"jest": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
-			"dev": true,
-			"requires": {
-				"import-local": "^2.0.0",
-				"jest-cli": "^24.9.0"
-			},
-			"dependencies": {
-				"jest-cli": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
-					"dev": true,
-					"requires": {
-						"@jest/core": "^24.9.0",
-						"@jest/test-result": "^24.9.0",
-						"@jest/types": "^24.9.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"import-local": "^2.0.0",
-						"is-ci": "^2.0.0",
-						"jest-config": "^24.9.0",
-						"jest-util": "^24.9.0",
-						"jest-validate": "^24.9.0",
-						"prompts": "^2.0.1",
-						"realpath-native": "^1.1.0",
-						"yargs": "^13.3.0"
-					}
-				}
-			}
-		},
-		"jest-changed-files": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
-			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^24.9.0",
-				"execa": "^1.0.0",
-				"throat": "^4.0.0"
-			}
-		},
 		"jest-config": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
@@ -7267,21 +5550,6 @@
 				"micromatch": "^3.1.10",
 				"pretty-format": "^24.9.0",
 				"realpath-native": "^1.1.0"
-			}
-		},
-		"jest-dev-server": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.3.0.tgz",
-			"integrity": "sha512-bC9flKY2G1honQ/UI0gEhb0wFnDhpFr7xidC8Nk+evi7TgnNtfsGIzzF2dcIhF1G9BGF0n/M7CJrMAzwQhyTPA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2",
-				"cwd": "^0.10.0",
-				"find-process": "^1.4.2",
-				"prompts": "^2.1.0",
-				"spawnd": "^4.0.0",
-				"tree-kill": "^1.2.1",
-				"wait-on": "^3.3.0"
 			}
 		},
 		"jest-diff": {
@@ -7318,6 +5586,15 @@
 				"pretty-format": "^24.9.0"
 			}
 		},
+		"jest-environment-enzyme": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-enzyme/-/jest-environment-enzyme-7.1.1.tgz",
+			"integrity": "sha512-k+QJkK0iRtjWbNfKdtj1QQIs12JbbvPmHW30cSbDoIgOFO7Bd1lLo6qOabM+PdhPCeLWQ1D1ZoTrHPauXdYpzA==",
+			"dev": true,
+			"requires": {
+				"jest-environment-jsdom": "^24.0.0"
+			}
+		},
 		"jest-environment-jsdom": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
@@ -7345,16 +5622,15 @@
 				"jest-util": "^24.9.0"
 			}
 		},
-		"jest-environment-puppeteer": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.3.0.tgz",
-			"integrity": "sha512-ZighMsU39bnacn2ylyHb88CB+ldgCfXGD3lS78k4PEo8A8xyt6+2mxmSR62FH3Y7K+W2gPDu5+QM3/LZuq42fQ==",
+		"jest-enzyme": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/jest-enzyme/-/jest-enzyme-7.1.1.tgz",
+			"integrity": "sha512-ujMi/2OF16rsjsS2ozdZCukfRZGC/Sb3MoJjINXITTvZM6lTL14lDliJr1kYIlUZVrphw0fmZkTNVTP7DnJ+Xw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.2",
-				"cwd": "^0.10.0",
-				"jest-dev-server": "^4.3.0",
-				"merge-deep": "^3.0.2"
+				"enzyme-matchers": "^7.1.1",
+				"enzyme-to-json": "^3.3.0",
+				"jest-environment-enzyme": "^7.1.1"
 			}
 		},
 		"jest-get-type": {
@@ -7460,16 +5736,6 @@
 			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
 			"dev": true
 		},
-		"jest-puppeteer": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.3.0.tgz",
-			"integrity": "sha512-WXhaWlbQl01xadZyNmdZntrtIr8uWUmgjPogDih7dOnr3G/xRr3A034SCqdjwV6fE0tqz7c5hwO8oBTyGZPRgA==",
-			"dev": true,
-			"requires": {
-				"expect-puppeteer": "^4.3.0",
-				"jest-environment-puppeteer": "^4.3.0"
-			}
-		},
 		"jest-regex-util": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
@@ -7487,17 +5753,6 @@
 				"chalk": "^2.0.1",
 				"jest-pnp-resolver": "^1.2.1",
 				"realpath-native": "^1.1.0"
-			}
-		},
-		"jest-resolve-dependencies": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
-			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.9.0"
 			}
 		},
 		"jest-runner": {
@@ -7635,21 +5890,6 @@
 				"pretty-format": "^24.9.0"
 			}
 		},
-		"jest-watcher": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
-			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
-			"dev": true,
-			"requires": {
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/yargs": "^13.0.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"jest-util": "^24.9.0",
-				"string-length": "^2.0.0"
-			}
-		},
 		"jest-worker": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
@@ -7711,12 +5951,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
-		"jsdoctypeparser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.1.1.tgz",
-			"integrity": "sha512-APGygIJrT5bbz5lsVt8vyLJC0miEbQf/z9ZBfTr4RYvdia8AhWMRlYgivvwHG5zKD/VW3d6qpChCy64hpQET3A==",
 			"dev": true
 		},
 		"jsdom": {
@@ -7791,12 +6025,6 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify-without-jsonify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-			"dev": true
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -7830,16 +6058,6 @@
 				"verror": "1.10.0"
 			}
 		},
-		"jsx-ast-utils": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-			"integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
-			"dev": true,
-			"requires": {
-				"array-includes": "^3.0.3",
-				"object.assign": "^4.1.0"
-			}
-		},
 		"junk": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
@@ -7850,24 +6068,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-			"dev": true
-		},
-		"kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true
-		},
-		"known-css-properties": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.11.0.tgz",
-			"integrity": "sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==",
-			"dev": true
-		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
 			"dev": true
 		},
 		"lcid": {
@@ -7900,12 +6100,6 @@
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
 			}
-		},
-		"livereload-js": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
-			"integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
-			"dev": true
 		},
 		"load-json-file": {
 			"version": "4.0.0",
@@ -7971,16 +6165,27 @@
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 			"dev": true
 		},
-		"lodash.assign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+		"lodash._baseisequal": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+			"dev": true,
+			"requires": {
+				"lodash.isarray": "^3.0.0",
+				"lodash.istypedarray": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
+		"lodash._bindcallback": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
 			"dev": true
 		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
 			"dev": true
 		},
 		"lodash.escape": {
@@ -7995,11 +6200,40 @@
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
 			"dev": true
+		},
+		"lodash.istypedarray": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+			"integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
+			}
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -8013,49 +6247,16 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-			"dev": true
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
-		"lodash.tail": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
-			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
-			"dev": true
-		},
-		"lodash.unescape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-			"dev": true
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-			"dev": true
-		},
-		"log-symbols": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1"
-			}
-		},
-		"longest-streak": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
-			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -8132,12 +6333,6 @@
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 			"dev": true
 		},
-		"map-values": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
-			"integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
-			"dev": true
-		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -8146,24 +6341,6 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
-		},
-		"markdown-escapes": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
-			"dev": true
-		},
-		"markdown-table": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
-			"dev": true
-		},
-		"mathml-tag-names": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
-			"integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
-			"dev": true
 		},
 		"maximatch": {
 			"version": "0.1.0",
@@ -8188,25 +6365,10 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
-		"mdast-util-compact": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
-			"integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit": "^1.1.0"
-			}
-		},
 		"mdn-data": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
 			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
-			"dev": true
-		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
 		"mem": {
@@ -8338,101 +6500,10 @@
 				}
 			}
 		},
-		"merge-deep": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
-			"integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
-			"dev": true,
-			"requires": {
-				"arr-union": "^3.1.0",
-				"clone-deep": "^0.2.4",
-				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"clone-deep": {
-					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
-					"dev": true,
-					"requires": {
-						"for-own": "^0.1.3",
-						"is-plain-object": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"lazy-cache": "^1.0.3",
-						"shallow-clone": "^0.1.2"
-					}
-				},
-				"for-own": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"shallow-clone": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-					"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.1",
-						"kind-of": "^2.0.1",
-						"lazy-cache": "^0.2.3",
-						"mixin-object": "^2.0.1"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.0.2"
-							}
-						},
-						"lazy-cache": {
-							"version": "0.2.7",
-							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-							"dev": true
-						}
-					}
-				}
-			}
-		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
-		},
-		"merge2": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
-			"dev": true
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
 			"dev": true
 		},
 		"micromatch": {
@@ -8466,12 +6537,6 @@
 				"brorand": "^1.0.1"
 			}
 		},
-		"mime": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-			"dev": true
-		},
 		"mime-db": {
 			"version": "1.40.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -8491,12 +6556,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
-		},
-		"min-indent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-			"integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
 			"dev": true
 		},
 		"mini-css-extract-plugin-with-rtl": {
@@ -8526,6 +6585,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -8535,16 +6595,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
-		},
-		"minimist-options": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
-			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0"
-			}
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -8585,28 +6635,11 @@
 				}
 			}
 		},
-		"mixin-object": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
-			},
-			"dependencies": {
-				"for-in": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-					"dev": true
-				}
-			}
-		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -8614,15 +6647,10 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
 				}
 			}
-		},
-		"mkpath": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-			"integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
-			"dev": true
 		},
 		"moo": {
 			"version": "0.4.3",
@@ -8648,12 +6676,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"mute-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
 		"nan": {
@@ -8699,24 +6721,6 @@
 				"randexp": "0.4.6",
 				"semver": "^5.4.1"
 			}
-		},
-		"needle": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-			"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"debug": "^4.1.0",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			}
-		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-			"dev": true
 		},
 		"neo-async": {
 			"version": "2.6.1",
@@ -8809,40 +6813,10 @@
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
 			"dev": true
 		},
-		"node-notifier": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-			"dev": true,
-			"requires": {
-				"growly": "^1.3.0",
-				"is-wsl": "^1.1.0",
-				"semver": "^5.5.0",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
-			}
-		},
-		"node-pre-gyp": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-			"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"needle": "^2.2.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0"
-			}
-		},
 		"node-releases": {
-			"version": "1.1.35",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
-			"integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
+			"version": "1.1.39",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
+			"integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.3.0"
@@ -8857,9 +6831,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-			"integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+			"integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -8869,12 +6843,10 @@
 				"get-stdin": "^4.0.1",
 				"glob": "^7.0.3",
 				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
+				"lodash": "^4.17.15",
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
-				"nan": "^2.10.0",
+				"nan": "^2.13.2",
 				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
 				"request": "^2.88.0",
@@ -8984,12 +6956,6 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
 			"dev": true
 		},
-		"normalize-selector": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
-			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
-			"dev": true
-		},
 		"normalize-url": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -9000,192 +6966,6 @@
 				"prepend-http": "^1.0.0",
 				"query-string": "^4.1.0",
 				"sort-keys": "^1.0.0"
-			}
-		},
-		"npm-bundled": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
-			"dev": true,
-			"optional": true
-		},
-		"npm-package-json-lint": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-3.7.0.tgz",
-			"integrity": "sha512-eWi1pZ/ZhPHAOMLC1+njBJj81yCu2Ek4VxhwpPHABvSVHS0dkaL6aKhSj/TX8Rtm/0rIg3edgMLt3kSRtWkFaA==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.10.0",
-				"chalk": "^2.4.2",
-				"glob": "^7.1.4",
-				"ignore": "^5.1.2",
-				"is-path-inside": "^2.1.0",
-				"is-plain-obj": "^1.1.0",
-				"is-resolvable": "^1.1.0",
-				"log-symbols": "^2.2.0",
-				"meow": "^5.0.0",
-				"plur": "^3.1.1",
-				"semver": "^5.6.0",
-				"strip-json-comments": "^2.0.1",
-				"validator": "^10.11.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0",
-						"map-obj": "^2.0.0",
-						"quick-lru": "^1.0.0"
-					}
-				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-					"dev": true
-				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				},
-				"is-path-inside": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-					"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-					"dev": true,
-					"requires": {
-						"path-is-inside": "^1.0.2"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
-				},
-				"meow": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0",
-						"yargs-parser": "^10.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"redent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^3.0.0",
-						"strip-indent": "^2.0.0"
-					}
-				},
-				"strip-indent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
-				},
-				"trim-newlines": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
-				}
-			}
-		},
-		"npm-packlist": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-			"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"ignore-walk": "^3.0.1",
-				"npm-bundled": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -9227,7 +7007,8 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwsapi": {
 			"version": "2.1.4",
@@ -9277,12 +7058,6 @@
 					}
 				}
 			}
-		},
-		"object-filter": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
-			"integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
-			"dev": true
 		},
 		"object-inspect": {
 			"version": "1.6.0",
@@ -9335,12 +7110,6 @@
 				"has": "^1.0.3"
 			}
 		},
-		"object.entries-ponyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
-			"integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
-			"dev": true
-		},
 		"object.fromentries": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
@@ -9384,68 +7153,13 @@
 				"has": "^1.0.3"
 			}
 		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
-			}
-		},
-		"onetime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
-			"requires": {
-				"mimic-fn": "^1.0.0"
-			},
-			"dependencies": {
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"dev": true
-				}
-			}
-		},
-		"opener": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
-			"dev": true
-		},
-		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
-			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.10",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-					"dev": true
-				},
-				"wordwrap": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
-				}
 			}
 		},
 		"optionator": {
@@ -9471,7 +7185,8 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "1.4.0",
@@ -9485,12 +7200,14 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -9501,15 +7218,6 @@
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
 			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
 			"dev": true
-		},
-		"p-each-series": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-			"dev": true,
-			"requires": {
-				"p-reduce": "^1.0.0"
-			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -9541,12 +7249,6 @@
 				"p-limit": "^2.0.0"
 			}
 		},
-		"p-reduce": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-			"dev": true
-		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -9570,15 +7272,6 @@
 				"readable-stream": "^2.1.5"
 			}
 		},
-		"parent-module": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
-			"requires": {
-				"callsites": "^3.0.0"
-			}
-		},
 		"parse-asn1": {
 			"version": "5.1.5",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -9591,20 +7284,6 @@
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
-			}
-		},
-		"parse-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-			"dev": true,
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"parse-json": {
@@ -9631,12 +7310,6 @@
 			"requires": {
 				"@types/node": "*"
 			}
-		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -9665,7 +7338,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -9683,12 +7357,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
-		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"path-type": {
@@ -9720,12 +7388,6 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
-		},
-		"pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-			"dev": true
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -9772,42 +7434,11 @@
 				"find-up": "^3.0.0"
 			}
 		},
-		"plur": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
-			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
-			"dev": true,
-			"requires": {
-				"irregular-plurals": "^2.0.0"
-			}
-		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
 			"dev": true
-		},
-		"portfinder": {
-			"version": "1.0.25",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-			"integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.2",
-				"debug": "^3.1.1",
-				"mkdirp": "^0.5.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -9816,9 +7447,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
-			"integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+			"version": "7.0.20",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+			"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -9871,6 +7502,12 @@
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
+				},
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
 				}
 			}
 		},
@@ -9885,6 +7522,14 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-convert-values": {
@@ -9895,16 +7540,24 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "8.0.9",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz",
-			"integrity": "sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==",
+			"version": "8.0.11",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+			"integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.5",
-				"postcss-values-parser": "^2.0.0"
+				"postcss": "^7.0.17",
+				"postcss-values-parser": "^2.0.1"
 			}
 		},
 		"postcss-discard-comments": {
@@ -9943,33 +7596,6 @@
 				"postcss": "^7.0.0"
 			}
 		},
-		"postcss-html": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
-			"integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
-			"dev": true,
-			"requires": {
-				"htmlparser2": "^3.10.0"
-			}
-		},
-		"postcss-jsx": {
-			"version": "0.36.3",
-			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.3.tgz",
-			"integrity": "sha512-yV8Ndo6KzU8eho5mCn7LoLUGPkXrRXRjhMpX4AaYJ9wLJPv099xbtpbRQ8FrPnzVxb/cuMebbPR7LweSt+hTfA==",
-			"dev": true,
-			"requires": {
-				"@babel/core": ">=7.2.2"
-			}
-		},
-		"postcss-less": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
-			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.14"
-			}
-		},
 		"postcss-load-config": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
@@ -9992,22 +7618,6 @@
 				"schema-utils": "^1.0.0"
 			}
 		},
-		"postcss-markdown": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
-			"integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
-			"dev": true,
-			"requires": {
-				"remark": "^10.0.1",
-				"unist-util-find-all-after": "^1.0.2"
-			}
-		},
-		"postcss-media-query-parser": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
-			"dev": true
-		},
 		"postcss-merge-longhand": {
 			"version": "4.0.11",
 			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
@@ -10018,6 +7628,14 @@
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"stylehacks": "^4.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-merge-rules": {
@@ -10055,6 +7673,14 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-minify-gradients": {
@@ -10067,6 +7693,14 @@
 				"is-color-stop": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-minify-params": {
@@ -10081,6 +7715,14 @@
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"uniqs": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-minify-selectors": {
@@ -10126,6 +7768,14 @@
 				"postcss": "^7.0.6",
 				"postcss-selector-parser": "^6.0.0",
 				"postcss-value-parser": "^3.3.1"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-modules-scope": {
@@ -10166,6 +7816,14 @@
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-normalize-positions": {
@@ -10178,6 +7836,14 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-normalize-repeat-style": {
@@ -10190,6 +7856,14 @@
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-normalize-string": {
@@ -10201,6 +7875,14 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-normalize-timing-functions": {
@@ -10212,6 +7894,14 @@
 				"cssnano-util-get-match": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-normalize-unicode": {
@@ -10223,6 +7913,14 @@
 				"browserslist": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-normalize-url": {
@@ -10242,6 +7940,12 @@
 					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
 					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
 					"dev": true
+				},
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
 				}
 			}
 		},
@@ -10253,6 +7957,14 @@
 			"requires": {
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-ordered-values": {
@@ -10264,6 +7976,14 @@
 				"cssnano-util-get-arguments": "^4.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-reduce-initial": {
@@ -10288,52 +8008,14 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			}
-		},
-		"postcss-reporter": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
-			"integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"lodash": "^4.17.11",
-				"log-symbols": "^2.2.0",
-				"postcss": "^7.0.7"
-			}
-		},
-		"postcss-resolve-nested-selector": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-			"integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
-			"dev": true
-		},
-		"postcss-safe-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
-			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.0"
-			}
-		},
-		"postcss-sass": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
-			"integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
-			"dev": true,
-			"requires": {
-				"gonzales-pe": "^4.2.3",
-				"postcss": "^7.0.1"
-			}
-		},
-		"postcss-scss": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
-			"integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-selector-parser": {
@@ -10357,13 +8039,15 @@
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"svgo": "^1.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
-		},
-		"postcss-syntax": {
-			"version": "0.36.2",
-			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-			"dev": true
 		},
 		"postcss-unique-selectors": {
 			"version": "4.0.1",
@@ -10377,9 +8061,9 @@
 			}
 		},
 		"postcss-value-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+			"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 			"dev": true
 		},
 		"postcss-values-parser": {
@@ -10435,12 +8119,6 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
-		"progress": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
-		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -10455,16 +8133,6 @@
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 			"dev": true
-		},
-		"prompts": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
-			"integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
-			"dev": true,
-			"requires": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.3"
-			}
 		},
 		"prop-types": {
 			"version": "15.7.2",
@@ -10487,22 +8155,6 @@
 				"object.assign": "^4.1.0",
 				"reflect.ownkeys": "^0.2.0"
 			}
-		},
-		"proxy-addr": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-			"dev": true,
-			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.0"
-			}
-		},
-		"proxy-from-env": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
-			"dev": true
 		},
 		"prr": {
 			"version": "1.0.1",
@@ -10575,33 +8227,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"puppeteer": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
-			"integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.0",
-				"extract-zip": "^1.6.6",
-				"https-proxy-agent": "^2.2.1",
-				"mime": "^2.0.3",
-				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^2.6.1",
-				"ws": "^6.1.0"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-					"dev": true,
-					"requires": {
-						"async-limiter": "~1.0.0"
-					}
-				}
-			}
-		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -10634,12 +8259,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
-		},
-		"quick-lru": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
 			"dev": true
 		},
 		"raf": {
@@ -10686,76 +8305,22 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true
-		},
-		"raw-body": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-			"dev": true,
-			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			}
-		},
-		"react": {
-			"version": "16.10.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.10.2.tgz",
-			"integrity": "sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
-			}
-		},
-		"react-dom": {
-			"version": "16.10.2",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.10.2.tgz",
-			"integrity": "sha512-kWGDcH3ItJK4+6Pl9DZB16BXYAZyrYQItU4OMy0jAkv5aNqc+mAKb4TpFtAteI6TJZu+9ZlNhaeNQSVQDHJzkw==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.16.2"
-			}
-		},
 		"react-is": {
-			"version": "16.10.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-			"integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==",
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+			"integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==",
 			"dev": true
 		},
 		"react-test-renderer": {
-			"version": "16.10.2",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.10.2.tgz",
-			"integrity": "sha512-k9Qzyev6cTIcIfrhgrFlYQAFxh5EEDO6ALNqYqmKsWVA7Q/rUMTay5nD3nthi6COmYsd4ghVYyi8U86aoeMqYQ==",
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.11.0.tgz",
+			"integrity": "sha512-nh9gDl8R4ut+ZNNb2EeKO5VMvTKxwzurbSMuGBoKtjpjbg8JK/u3eVPVNi1h1Ue+eYK9oSzJjb+K3lzLxyA4ag==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"react-is": "^16.8.6",
-				"scheduler": "^0.16.2"
+				"scheduler": "^0.17.0"
 			}
 		},
 		"read-pkg": {
@@ -10877,12 +8442,6 @@
 				"regenerate": "^1.4.0"
 			}
 		},
-		"regenerator-runtime": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-			"dev": true
-		},
 		"regenerator-transform": {
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
@@ -10902,12 +8461,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexpp": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-			"dev": true
-		},
 		"regexpu-core": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
@@ -10922,16 +8475,10 @@
 				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
 		},
-		"regextras": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
-			"integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA==",
-			"dev": true
-		},
 		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
 			"dev": true
 		},
 		"regjsparser": {
@@ -10949,62 +8496,6 @@
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
 					"dev": true
 				}
-			}
-		},
-		"remark": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
-			"integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
-			"dev": true,
-			"requires": {
-				"remark-parse": "^6.0.0",
-				"remark-stringify": "^6.0.0",
-				"unified": "^7.0.0"
-			}
-		},
-		"remark-parse": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-			"integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
-			"dev": true,
-			"requires": {
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^1.1.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^1.0.0",
-				"vfile-location": "^2.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-stringify": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
-			"integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
-			"dev": true,
-			"requires": {
-				"ccount": "^1.0.0",
-				"is-alphanumeric": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"longest-streak": "^2.0.1",
-				"markdown-escapes": "^1.0.0",
-				"markdown-table": "^1.1.0",
-				"mdast-util-compact": "^1.0.0",
-				"parse-entities": "^1.0.2",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"stringify-entities": "^1.0.1",
-				"unherit": "^1.0.4",
-				"xtend": "^4.0.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -11033,12 +8524,6 @@
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-			"dev": true
 		},
 		"request": {
 			"version": "2.88.0",
@@ -11118,12 +8603,6 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
-		"requireindex": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-			"dev": true
-		},
 		"resolve": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -11131,15 +8610,6 @@
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
-			}
-		},
-		"resolve-bin": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.0.tgz",
-			"integrity": "sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk=",
-			"dev": true,
-			"requires": {
-				"find-parent-dir": "~0.3.0"
 			}
 		},
 		"resolve-cwd": {
@@ -11159,6 +8629,19 @@
 			"requires": {
 				"expand-tilde": "^2.0.0",
 				"global-modules": "^1.0.0"
+			},
+			"dependencies": {
+				"global-modules": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+					"dev": true,
+					"requires": {
+						"global-prefix": "^1.0.1",
+						"is-windows": "^1.0.1",
+						"resolve-dir": "^1.0.0"
+					}
+				}
 			}
 		},
 		"resolve-from": {
@@ -11172,16 +8655,6 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
-		},
-		"restore-cursor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
-			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
-			}
 		},
 		"ret": {
 			"version": "0.1.15",
@@ -11268,21 +8741,6 @@
 				}
 			}
 		},
-		"run-async": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
-		},
-		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-			"dev": true
-		},
 		"run-queue": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -11292,30 +8750,10 @@
 				"aproba": "^1.1.1"
 			}
 		},
-		"rx": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-			"dev": true
-		},
-		"rxjs": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.9.0"
-			}
-		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"safe-json-parse": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
-			"integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
 		"safe-regex": {
@@ -11569,23 +9007,22 @@
 			}
 		},
 		"sass-loader": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
-			"integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.3.1.tgz",
+			"integrity": "sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "^2.0.1",
+				"clone-deep": "^4.0.1",
 				"loader-utils": "^1.0.1",
-				"lodash.tail": "^4.1.1",
 				"neo-async": "^2.5.0",
-				"pify": "^3.0.0",
-				"semver": "^5.5.0"
+				"pify": "^4.0.1",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -11597,9 +9034,9 @@
 			"dev": true
 		},
 		"scheduler": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.16.2.tgz",
-			"integrity": "sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+			"integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
@@ -11644,75 +9081,11 @@
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
 		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
-				"mime": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				}
-			}
-		},
 		"serialize-javascript": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
 			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
 			"dev": true
-		},
-		"serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"dev": true,
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
-			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -11749,12 +9122,6 @@
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
 			"dev": true
 		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-			"dev": true
-		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -11766,22 +9133,12 @@
 			}
 		},
 		"shallow-clone": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
 			"dev": true,
 			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^5.0.0",
-				"mixin-object": "^2.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
-				}
+				"kind-of": "^6.0.2"
 			}
 		},
 		"shebang-command": {
@@ -11797,12 +9154,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
-		},
-		"shellwords": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -11828,28 +9179,11 @@
 				}
 			}
 		},
-		"sisteransi": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
-			"integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
-			"dev": true
-		},
 		"slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
 			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 			"dev": true
-		},
-		"slice-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.0",
-				"astral-regex": "^1.0.0",
-				"is-fullwidth-code-point": "^2.0.0"
-			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -11994,16 +9328,6 @@
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
-		"source-map-loader": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
-			"integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.5.0",
-				"loader-utils": "^1.1.0"
-			}
-		},
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
@@ -12041,18 +9365,6 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
-		"spawnd": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.0.0.tgz",
-			"integrity": "sha512-ql3qhJnhAkvXpaqKBWOqou1rUTSQhFRaZkyOT+MTFB4xY3X+brgw6LTWV2wHuE9A6YPhrNe1cbg7S+jAYnbC0Q==",
-			"dev": true,
-			"requires": {
-				"exit": "^0.1.2",
-				"signal-exit": "^3.0.2",
-				"tree-kill": "^1.2.1",
-				"wait-port": "^0.2.2"
-			}
-		},
 		"spdx-correct": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -12083,12 +9395,6 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-			"dev": true
-		},
-		"specificity": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
-			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
 			"dev": true
 		},
 		"split-string": {
@@ -12144,12 +9450,6 @@
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
-		"state-toggle": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
-			"dev": true
-		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -12170,12 +9470,6 @@
 					}
 				}
 			}
-		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true
 		},
 		"stdout-stream": {
 			"version": "1.4.1",
@@ -12237,39 +9531,6 @@
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
 		},
-		"string-length": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-			"dev": true,
-			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
-		"string-template": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-			"dev": true
-		},
 		"string-width": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -12321,18 +9582,6 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"stringify-entities": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-			"dev": true,
-			"requires": {
-				"character-entities-html4": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -12369,12 +9618,6 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
-		"style-search": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
-			"dev": true
-		},
 		"stylehacks": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -12399,337 +9642,6 @@
 				}
 			}
 		},
-		"stylelint": {
-			"version": "9.10.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.10.1.tgz",
-			"integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
-			"dev": true,
-			"requires": {
-				"autoprefixer": "^9.0.0",
-				"balanced-match": "^1.0.0",
-				"chalk": "^2.4.1",
-				"cosmiconfig": "^5.0.0",
-				"debug": "^4.0.0",
-				"execall": "^1.0.0",
-				"file-entry-cache": "^4.0.0",
-				"get-stdin": "^6.0.0",
-				"global-modules": "^2.0.0",
-				"globby": "^9.0.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^2.0.0",
-				"ignore": "^5.0.4",
-				"import-lazy": "^3.1.0",
-				"imurmurhash": "^0.1.4",
-				"known-css-properties": "^0.11.0",
-				"leven": "^2.1.0",
-				"lodash": "^4.17.4",
-				"log-symbols": "^2.0.0",
-				"mathml-tag-names": "^2.0.1",
-				"meow": "^5.0.0",
-				"micromatch": "^3.1.10",
-				"normalize-selector": "^0.2.0",
-				"pify": "^4.0.0",
-				"postcss": "^7.0.13",
-				"postcss-html": "^0.36.0",
-				"postcss-jsx": "^0.36.0",
-				"postcss-less": "^3.1.0",
-				"postcss-markdown": "^0.36.0",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-reporter": "^6.0.0",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^4.0.0",
-				"postcss-sass": "^0.3.5",
-				"postcss-scss": "^2.0.0",
-				"postcss-selector-parser": "^3.1.0",
-				"postcss-syntax": "^0.36.2",
-				"postcss-value-parser": "^3.3.0",
-				"resolve-from": "^4.0.0",
-				"signal-exit": "^3.0.2",
-				"slash": "^2.0.0",
-				"specificity": "^0.4.1",
-				"string-width": "^3.0.0",
-				"style-search": "^0.1.0",
-				"sugarss": "^2.0.0",
-				"svg-tags": "^1.0.0",
-				"table": "^5.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0",
-						"map-obj": "^2.0.0",
-						"quick-lru": "^1.0.0"
-					}
-				},
-				"file-entry-cache": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
-					"integrity": "sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==",
-					"dev": true,
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				},
-				"global-modules": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-					"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^3.0.0"
-					}
-				},
-				"global-prefix": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-					"dev": true,
-					"requires": {
-						"ini": "^1.3.5",
-						"kind-of": "^6.0.2",
-						"which": "^1.3.1"
-					}
-				},
-				"globby": {
-					"version": "9.2.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
-					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
-					"dev": true,
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^1.0.2",
-						"dir-glob": "^2.2.2",
-						"fast-glob": "^2.2.6",
-						"glob": "^7.1.3",
-						"ignore": "^4.0.3",
-						"pify": "^4.0.1",
-						"slash": "^2.0.0"
-					},
-					"dependencies": {
-						"ignore": {
-							"version": "4.0.6",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-							"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-							"dev": true
-						}
-					}
-				},
-				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-					"dev": true
-				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				},
-				"leven": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
-				},
-				"meow": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0",
-						"yargs-parser": "^10.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				},
-				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
-					"dev": true,
-					"requires": {
-						"dot-prop": "^4.1.1",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"redent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^3.0.0",
-						"strip-indent": "^2.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
-				},
-				"strip-indent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
-				},
-				"trim-newlines": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
-				}
-			}
-		},
-		"stylelint-config-recommended": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
-			"integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
-			"dev": true
-		},
-		"stylelint-config-recommended-scss": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.3.0.tgz",
-			"integrity": "sha512-BvuuLYwoet8JutOP7K1a8YaiENN+0HQn390eDi0SWe1h7Uhx6O3GUQ6Ubgie9b/AmHX4Btmp+ZzVGbzriFTBcA==",
-			"dev": true,
-			"requires": {
-				"stylelint-config-recommended": "^2.2.0"
-			}
-		},
-		"stylelint-config-wordpress": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-13.1.0.tgz",
-			"integrity": "sha512-dpKj2/d3/XjDVoOvQzd54GoM8Rj5zldluOZKkVhBCc4JYMc6r1VYL5hpcgIjqy/i2Hyqg4Rh7zTafE/2AWq//w==",
-			"dev": true,
-			"requires": {
-				"stylelint-config-recommended": "^2.1.0",
-				"stylelint-config-recommended-scss": "^3.2.0",
-				"stylelint-scss": "^3.3.0"
-			}
-		},
-		"stylelint-scss": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.11.1.tgz",
-			"integrity": "sha512-0FZNSfy5X2Or4VRA3Abwfrw1NHrI6jHT8ji9xSwP8Re2Kno0i90qbHwm8ohPO0kRB1RP9x1vCYBh4Tij+SZjIg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.15",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.2",
-				"postcss-value-parser": "^4.0.2"
-			},
-			"dependencies": {
-				"postcss-value-parser": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
-					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
-					"dev": true
-				}
-			}
-		},
-		"sugarss": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
-			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.2"
-			}
-		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -12738,12 +9650,6 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
-		},
-		"svg-tags": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
-			"dev": true
 		},
 		"svgo": {
 			"version": "1.3.0",
@@ -12796,18 +9702,6 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
-		"table": {
-			"version": "5.4.6",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.10.2",
-				"lodash": "^4.17.14",
-				"slice-ansi": "^2.1.0",
-				"string-width": "^3.0.0"
-			}
-		},
 		"tapable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -12826,14 +9720,14 @@
 			}
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
+			"integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.19.0",
+				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.10"
+				"source-map-support": "~0.5.12"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12845,19 +9739,20 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
-			"integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+			"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
 			"dev": true,
 			"requires": {
-				"cacache": "^11.0.2",
-				"find-cache-dir": "^2.0.0",
+				"cacache": "^12.0.2",
+				"find-cache-dir": "^2.1.0",
+				"is-wsl": "^1.1.0",
 				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^1.4.0",
+				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.16.1",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
+				"terser": "^4.1.2",
+				"webpack-sources": "^1.4.0",
+				"worker-farm": "^1.7.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12880,16 +9775,10 @@
 				"require-main-filename": "^2.0.0"
 			}
 		},
-		"text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
-		},
 		"thread-loader": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.2.tgz",
-			"integrity": "sha512-7xpuc9Ifg6WU+QYw/8uUqNdRwMD+N5gjwHKMqETrs96Qn+7BHwECpt2Brzr4HFlf4IAkZsayNhmGdbkBsTJ//w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
+			"integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
 			"dev": true,
 			"requires": {
 				"loader-runner": "^2.3.1",
@@ -12901,12 +9790,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-			"dev": true
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
 		"through2": {
@@ -12933,40 +9816,6 @@
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
-		},
-		"tiny-lr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
-			"integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
-			"dev": true,
-			"requires": {
-				"body": "^5.1.0",
-				"debug": "^3.1.0",
-				"faye-websocket": "~0.10.0",
-				"livereload-js": "^2.3.0",
-				"object-assign": "^4.1.0",
-				"qs": "^6.4.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
-		"tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
-			"requires": {
-				"os-tmpdir": "~1.0.2"
-			}
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -13028,32 +9877,6 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-			"dev": true
-		},
-		"touch": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-			"integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
-			"dev": true,
-			"requires": {
-				"nopt": "~1.0.10"
-			},
-			"dependencies": {
-				"nopt": {
-					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-					"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-					"dev": true,
-					"requires": {
-						"abbrev": "1"
-					}
-				}
-			}
-		},
 		"tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -13073,40 +9896,10 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-			"dev": true
-		},
-		"tree-kill": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
-			"dev": true
-		},
-		"trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-			"dev": true
-		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true
-		},
-		"trim-trailing-lines": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
-			"dev": true
-		},
-		"trough": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
 			"dev": true
 		},
 		"true-case-path": {
@@ -13117,12 +9910,6 @@
 			"requires": {
 				"glob": "^7.1.2"
 			}
-		},
-		"tryer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
-			"dev": true
 		},
 		"tslib": {
 			"version": "1.10.0",
@@ -13160,22 +9947,6 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-			"dev": true
-		},
-		"type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"dev": true,
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			}
-		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -13183,47 +9954,10 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-			"integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
 			"dev": true
-		},
-		"uglify-js": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
-			"integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"commander": "2.20.0",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"dev": true,
-					"optional": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"unherit": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
-			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"xtend": "^4.0.1"
-			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -13252,22 +9986,6 @@
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
 			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
 			"dev": true
-		},
-		"unified": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
-			"dev": true,
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"@types/vfile": "^3.0.0",
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-plain-obj": "^1.1.0",
-				"trough": "^1.0.0",
-				"vfile": "^3.0.0",
-				"x-is-string": "^0.1.0"
-			}
 		},
 		"union-value": {
 			"version": "1.0.1",
@@ -13310,60 +10028,6 @@
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
-		},
-		"unist-util-find-all-after": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
-			"integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
-			"dev": true,
-			"requires": {
-				"unist-util-is": "^3.0.0"
-			}
-		},
-		"unist-util-is": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-			"dev": true
-		},
-		"unist-util-remove-position": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
-			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit": "^1.1.0"
-			}
-		},
-		"unist-util-stringify-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
-			"dev": true
-		},
-		"unist-util-visit": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit-parents": "^2.0.0"
-			}
-		},
-		"unist-util-visit-parents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-			"dev": true,
-			"requires": {
-				"unist-util-is": "^3.0.0"
-			}
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
 		},
 		"unquote": {
 			"version": "1.1.1",
@@ -13489,12 +10153,6 @@
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
-		},
 		"uuid": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
@@ -13502,9 +10160,9 @@
 			"dev": true
 		},
 		"v8-compile-cache": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -13516,18 +10174,6 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"validator": {
-			"version": "10.11.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-			"integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
-			"dev": true
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"dev": true
 		},
 		"vendors": {
 			"version": "1.0.3",
@@ -13546,41 +10192,6 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
-		"vfile": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^2.0.0",
-				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^1.0.0",
-				"vfile-message": "^1.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-					"dev": true
-				}
-			}
-		},
-		"vfile-location": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
-			"integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
-			"dev": true
-		},
-		"vfile-message": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-			"dev": true,
-			"requires": {
-				"unist-util-stringify-position": "^1.1.1"
-			}
-		},
 		"vm-browserify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
@@ -13594,52 +10205,6 @@
 			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
-			}
-		},
-		"wait-for-expect": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.0.tgz",
-			"integrity": "sha512-9LyJL+MugZdcQn5V9PBSEC4d2UPTy1xX2U9wTc6LvG/18qeeYqdE/CgmAQJxc/Vcjs+VzH+wiyIXxz05F3nrpQ==",
-			"dev": true
-		},
-		"wait-on": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
-			"integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/joi": "^15.0.3",
-				"core-js": "^2.6.5",
-				"minimist": "^1.2.0",
-				"request": "^2.88.0",
-				"rx": "^4.1.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
-					"dev": true
-				}
-			}
-		},
-		"wait-port": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.6.tgz",
-			"integrity": "sha512-nXE5Yp0Zs1obhFVc0Da7WVJc3y0LxoCq3j4mtV0NdI5P/ZvRdKp5yhuojvMOcOxSwpQL1hGbOgMNQ+4wpRpwCA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2",
-				"commander": "^3.0.2",
-				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-					"dev": true
-				}
 			}
 		},
 		"walker": {
@@ -13669,110 +10234,65 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.29.6",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.6.tgz",
-			"integrity": "sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==",
+			"version": "4.41.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
+			"integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-module-context": "1.8.5",
 				"@webassemblyjs/wasm-edit": "1.8.5",
 				"@webassemblyjs/wasm-parser": "1.8.5",
-				"acorn": "^6.0.5",
-				"acorn-dynamic-import": "^4.0.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^1.0.0",
+				"acorn": "^6.2.1",
+				"ajv": "^6.10.2",
+				"ajv-keywords": "^3.4.1",
+				"chrome-trace-event": "^1.0.2",
 				"enhanced-resolve": "^4.1.0",
-				"eslint-scope": "^4.0.0",
+				"eslint-scope": "^4.0.3",
 				"json-parse-better-errors": "^1.0.2",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"micromatch": "^3.1.8",
-				"mkdirp": "~0.5.0",
-				"neo-async": "^2.5.0",
-				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^1.0.0",
-				"tapable": "^1.1.0",
-				"terser-webpack-plugin": "^1.1.0",
-				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.3.0"
-			}
-		},
-		"webpack-bundle-analyzer": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.5.2.tgz",
-			"integrity": "sha512-g9spCNe25QYUVqHRDkwG414GTok2m7pTTP0wr6l0J50Z3YLS04+BGodTqqoVBL7QfU/U/9p/oiI5XFOyfZ7S/A==",
-			"dev": true,
-			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-walk": "^6.1.1",
-				"bfj": "^6.1.1",
-				"chalk": "^2.4.1",
-				"commander": "^2.18.0",
-				"ejs": "^2.6.1",
-				"express": "^4.16.3",
-				"filesize": "^3.6.1",
-				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.15",
+				"loader-runner": "^2.4.0",
+				"loader-utils": "^1.2.3",
+				"memory-fs": "^0.4.1",
+				"micromatch": "^3.1.10",
 				"mkdirp": "^0.5.1",
-				"opener": "^1.5.1",
-				"ws": "^6.0.0"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-					"dev": true,
-					"requires": {
-						"async-limiter": "~1.0.0"
-					}
-				}
+				"neo-async": "^2.6.1",
+				"node-libs-browser": "^2.2.1",
+				"schema-utils": "^1.0.0",
+				"tapable": "^1.1.3",
+				"terser-webpack-plugin": "^1.4.1",
+				"watchpack": "^1.6.0",
+				"webpack-sources": "^1.4.1"
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.0.tgz",
-			"integrity": "sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.9.tgz",
+			"integrity": "sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
-				"cross-spawn": "^6.0.5",
-				"enhanced-resolve": "^4.1.0",
-				"findup-sync": "^2.0.0",
-				"global-modules": "^1.0.0",
-				"import-local": "^2.0.0",
-				"interpret": "^1.1.0",
-				"loader-utils": "^1.1.0",
-				"supports-color": "^5.5.0",
-				"v8-compile-cache": "^2.0.2",
-				"yargs": "^12.0.5"
+				"chalk": "2.4.2",
+				"cross-spawn": "6.0.5",
+				"enhanced-resolve": "4.1.0",
+				"findup-sync": "3.0.0",
+				"global-modules": "2.0.0",
+				"import-local": "2.0.0",
+				"interpret": "1.2.0",
+				"loader-utils": "1.2.3",
+				"supports-color": "6.1.0",
+				"v8-compile-cache": "2.0.3",
+				"yargs": "13.2.4"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"cliui": {
+				"enhanced-resolve": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+					"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.4.0",
+						"tapable": "^1.0.0"
 					}
-				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
 				},
 				"invert-kv": {
 					"version": "2.0.0",
@@ -13800,106 +10320,32 @@
 						"mem": "^4.0.0"
 					}
 				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-							"dev": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						}
+						"has-flag": "^3.0.0"
 					}
 				},
 				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"version": "13.2.4",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
+						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"os-locale": "^3.1.0",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
+						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.0"
 					}
 				}
 			}
@@ -13910,20 +10356,10 @@
 			"integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
 			"dev": true
 		},
-		"webpack-livereload-plugin": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.2.0.tgz",
-			"integrity": "sha512-sx9xA5mHoNOUgLQI0PmXT3KV9ecsVmUaTgr+fsoL69qAOHw/7VzkL1+ZMDQ8n0dPbWounswK6cBRSgMod7Nhgg==",
-			"dev": true,
-			"requires": {
-				"portfinder": "^1.0.17",
-				"tiny-lr": "^1.1.1"
-			}
-		},
 		"webpack-rtl-plugin": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-rtl-plugin/-/webpack-rtl-plugin-1.8.0.tgz",
-			"integrity": "sha512-m6WfqfJ73YgetQN8eKwdoLIwnHkQGO9GKgmB7LPMYfODFKqk3SrsjXRLQ+0HprWcH6xoDN61tagZD1+E5US2CA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/webpack-rtl-plugin/-/webpack-rtl-plugin-1.8.2.tgz",
+			"integrity": "sha512-qQq6zfdolXeNf1L/C8BDZ4eA8k5NgVAHIBr7SCqz9Pi0BQkxCk4o6qSV7q5HTVvmhY33cJfKQQYTqvvPxBNdzw==",
 			"dev": true,
 			"requires": {
 				"@romainberger/css-diff": "^1.0.3",
@@ -13950,23 +10386,6 @@
 					"dev": true
 				}
 			}
-		},
-		"websocket-driver": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
-			"integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
-			"dev": true,
-			"requires": {
-				"http-parser-js": ">=0.4.0 <0.4.11",
-				"safe-buffer": ">=5.1.0",
-				"websocket-extensions": ">=0.1.1"
-			}
-		},
-		"websocket-extensions": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
@@ -14074,16 +10493,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"write": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-			"dev": true,
-			"requires": {
-				"mkdirp": "^0.5.1"
-			}
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "2.4.1",
@@ -14104,12 +10515,6 @@
 			"requires": {
 				"async-limiter": "~1.0.0"
 			}
-		},
-		"x-is-string": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
-			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
@@ -14132,7 +10537,8 @@
 		"yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
 		},
 		"yargs": {
 			"version": "13.3.0",
@@ -14160,15 +10566,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			}
-		},
-		"yauzl": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-			"dev": true,
-			"requires": {
-				"fd-slicer": "~1.0.1"
 			}
 		}
 	}

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -38,7 +38,7 @@
 		"classnames": "2.2.6"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^4.1.0",
+		"@automattic/calypso-build": "^4.2.1",
 		"@testing-library/jest-dom": "^4.1.0",
 		"@testing-library/react": "^9.1.3",
 		"@wordpress/jest-preset-default": "5.1.1",


### PR DESCRIPTION
Update FSE calypso-build to latest version. Required for #37031.

## Testing
- Make sure the FSE build and output continues to work as expected.