### PR TITLE
Calypso build: Prep 4.2.1

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 4.3.0
+# 4.2.1
+
+- Fix a bad file: dependency in the published package.
+
+# 4.2.0
+
 - Update a number of dependencies
   - @babel/core@7.6.4
   - @babel/preset-env@7.6.3
@@ -15,8 +20,6 @@
   - webpack@4.41.2
   - webpack-cli@3.3.9
   - webpack-rtl-plugin@1.8.2
-
-# 4.2.0
 - Support CommonJS/ESM compilation by adding a `modules` option (and `MODULES` env variable) to the `babel/default` preset.
 - Add `jest-enzyme` assertion library to `jest-preset.js`.
 

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",


### PR DESCRIPTION
4.2.0 contains a [bad file: reference in the published package](https://unpkg.com/browse/@automattic/calypso-build@4.2.0/package.json). Fix it by publishing 4.2.1

Also updates CHANGELOG to reflect 4.2.0 changes correctly (4.3.0 was never published).