### PR TITLE
Calypso Build: Remove calypso-color-schemes dep (alternate lyrics)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,6 @@
 			"version": "file:packages/calypso-build",
 			"dev": true,
 			"requires": {
-				"@automattic/calypso-color-schemes": "file:packages/calypso-color-schemes",
 				"@babel/core": "7.6.4",
 				"@babel/plugin-proposal-class-properties": "7.5.5",
 				"@babel/plugin-syntax-dynamic-import": "7.2.0",
@@ -3021,9 +3020,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "12.11.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
-			"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
+			"version": "12.11.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
+			"integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -4705,16 +4704,10 @@
 				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001004",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001004.tgz",
-					"integrity": "sha512-3nfOR4O8Wa2RWoYfJkMtwRVOsK96TQ+eq57wd0iKaEWl8dwG4hKZ/g0MVBfCvysFvMLi9fQGR/DvozMdkEPl3g==",
-					"dev": true
-				},
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -5332,13 +5325,6 @@
 				"caniuse-lite": "^1.0.30001004",
 				"electron-to-chromium": "^1.3.295",
 				"node-releases": "^1.1.38"
-			},
-			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001004",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001004.tgz",
-					"integrity": "sha512-3nfOR4O8Wa2RWoYfJkMtwRVOsK96TQ+eq57wd0iKaEWl8dwG4hKZ/g0MVBfCvysFvMLi9fQGR/DvozMdkEPl3g=="
-				}
 			}
 		},
 		"browserslist-useragent": {
@@ -7461,9 +7447,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -7514,9 +7500,9 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -7633,9 +7619,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -7699,9 +7685,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -7748,9 +7734,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -8569,9 +8555,9 @@
 			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.295",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.295.tgz",
-			"integrity": "sha512-KxlGE9GcZTv7xGwYJGMEABHJq2JuTMNF7jD8NwHk6sBY226mW+Dyp9kZmA2Od9tKHMCS7ltPnqFg+zq3jTWN7Q=="
+			"version": "1.3.296",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz",
+			"integrity": "sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ=="
 		},
 		"elliptic": {
 			"version": "6.5.1",
@@ -11655,9 +11641,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -14133,9 +14119,9 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-			"integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+			"integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.0.3",
@@ -15658,9 +15644,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.38",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.38.tgz",
-			"integrity": "sha512-/5NZAaOyTj134Oy5Cp/J8mso8OD/D9CSuL+6TOXXsTKO8yjc5e4up75SRPCganCjwFKMj2jbp5tR0dViVdox7g==",
+			"version": "1.1.39",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
+			"integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
 			"requires": {
 				"semver": "^6.3.0"
 			},
@@ -17412,9 +17398,9 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17600,9 +17586,9 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
@@ -17666,9 +17652,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17704,9 +17690,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17742,9 +17728,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17779,9 +17765,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17816,9 +17802,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17853,9 +17839,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17890,9 +17876,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17945,9 +17931,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -17994,9 +17980,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18050,9 +18036,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18092,9 +18078,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18141,9 +18127,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18181,9 +18167,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18223,9 +18209,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18263,9 +18249,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18311,9 +18297,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18350,9 +18336,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18388,9 +18374,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18426,9 +18412,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18463,9 +18449,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18502,9 +18488,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18542,9 +18528,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18582,9 +18568,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18621,9 +18607,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18660,9 +18646,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18699,9 +18685,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18739,9 +18725,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18777,9 +18763,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18816,9 +18802,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18856,9 +18842,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18896,9 +18882,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -18935,9 +18921,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
@@ -18975,9 +18961,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -19013,9 +18999,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -19049,9 +19035,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
@@ -19097,9 +19083,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -19142,9 +19128,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -22388,9 +22374,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -22561,9 +22547,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -22648,9 +22634,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "7.0.19",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.19.tgz",
-					"integrity": "sha512-0InetJoW1WQMoiJ3E5oF1m37ZAJX0d0XLgR50bVXCC4cF8HCYRpT6hH2nNYHVCV7QAx1hWj81/2CRT0elHAy5g==",
+					"version": "7.0.20",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+					"integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 5.0.0
 
 - Remove `@automattic/calypso-color-schemes` dependency
-  - See the [example in the README](./README.md#advanced-usage-use-own-postcss-config] for instructions on how to continue to use color definitions from that file in your project.
+  - See the [example in the README](./README.md#advanced-usage-use-own-postcss-config) for instructions on how to continue to use color definitions from that file in your project.
 - Remove `calypso-color-schemes` Sass Prelude.
   - Remove the `calypso-color-schemes` colors prelude from the default webpack config.
     This was useful when the colors were defined as SCSS variables, but now when they are

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -8,7 +8,7 @@
     defined as CSS variables included in the CSS output, the prelude no longer makes sense.
 - Use Consumer's `postcss.config.js`, if present.
 - Remove `preserveCssCustomProperties` option from SASS preset; default to `true`.
-- Add `postCssConfigContext` and `postCssConfigPath` options to SASS preset to expose the corresponding PostCSS options.
+- Add `postCssConfig` options to SASS preset to enable customization of PostCSS options.
 
 # 4.2.1
 

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 5.0.0
 
 - Remove `@automattic/calypso-color-schemes` dependency
-  - See the example given at `https://github.com/Automattic/wp-calypso/blob/master/packages/calypso-build/README.md#advanced-usage-use-own-postcss-config` for instructions on how to continue to use color definitions from that file in your project.
+  - See the [example in the README](./README.md#advanced-usage-use-own-postcss-config] for instructions on how to continue to use color definitions from that file in your project.
 - Remove `calypso-color-schemes` Sass Prelude.
   - Remove the `calypso-color-schemes` colors prelude from the default webpack config.
     This was useful when the colors were defined as SCSS variables, but now when they are

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -7,7 +7,8 @@
     This was useful when the colors were defined as SCSS variables, but now when they are
     defined as CSS variables included in the CSS output, the prelude no longer makes sense.
 - Use Consumer's `postcss.config.js`, if present.
-- Remove `preserveCssCustomProperties` option; default to `true`.
+- Remove `preserveCssCustomProperties` option from SASS preset; default to `true`.
+- Add `postCssConfigContext` and `postCssConfigPath` options to SASS preset to expose the corresponding PostCSS options.
 
 # 4.2.1
 

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 5.0.0
+
+- Remove `@automattic/calypso-color-schemes` dependency
+  - See the example given at `https://github.com/Automattic/wp-calypso/blob/master/packages/calypso-build/README.md#advanced-usage-use-own-postcss-config` for instructions on how to continue
+    to use color definitions from that file in your project.
+- Remove `calypso-color-schemes` Sass Prelude.
+  - Remove the `calypso-color-schemes` colors prelude from the default webpack config.
+    This was useful when the colors were defined as SCSS variables, but now when they are
+    defined as CSS variables included in the CSS output, the prelude no longer makes sense.
+- Use Consumer's `postcss.config.js`, if present.
+- Remove `preserveCssCustomProperties` option.
+
 # 4.2.1
 
 - Fix a bad file: dependency in the published package.

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,14 +1,13 @@
 # 5.0.0
 
 - Remove `@automattic/calypso-color-schemes` dependency
-  - See the example given at `https://github.com/Automattic/wp-calypso/blob/master/packages/calypso-build/README.md#advanced-usage-use-own-postcss-config` for instructions on how to continue
-    to use color definitions from that file in your project.
+  - See the example given at `https://github.com/Automattic/wp-calypso/blob/master/packages/calypso-build/README.md#advanced-usage-use-own-postcss-config` for instructions on how to continue to use color definitions from that file in your project.
 - Remove `calypso-color-schemes` Sass Prelude.
   - Remove the `calypso-color-schemes` colors prelude from the default webpack config.
     This was useful when the colors were defined as SCSS variables, but now when they are
     defined as CSS variables included in the CSS output, the prelude no longer makes sense.
 - Use Consumer's `postcss.config.js`, if present.
-- Remove `preserveCssCustomProperties` option.
+- Remove `preserveCssCustomProperties` option; default to `true`.
 
 # 4.2.1
 

--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -123,12 +123,28 @@ module.exports = {
 The `default` preset has a `modules` option that specifies whether we want to transpile ESM `import` and `export` statements. Most common values are `false`, which keeps these statements intact and results in ES modules as output, and `'commonjs'`, which transpiles the module to the CommonJS format. See the [@babel/preset-env documentation](https://babeljs.io/docs/en/babel-preset-env#modules) for more details.
 
 ```js
-presets: [
-	[ '@automattic/calypso-build/babel/default', { modules: 'commonjs' } ]
-]
+presets: [ [ '@automattic/calypso-build/babel/default', { modules: 'commonjs' } ] ];
 ```
 
 Another way to set the `modules` option is to set the `MODULES` environment variable to `'esm'` (maps to `false`) or any other valid value. That's convenient for running Babel from command line, where specifying options for presets (`--presets=...`) is not supported.
+
+## Advanced Usage: Use own PostCSS Config
+
+You can also customize how PostCSS transforms your project's style files by adding a `postcss.config.js` to it.
+
+For example, the following `postcss.config.js` will use color definitions from `@automattic/calypso-color-schemes` by setting CSS variables, and add 'polyfills' for browsers like IE11:
+
+```js
+module.exports = () => ( {
+	plugins: {
+		'postcss-custom-properties': {
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+			preserve: true,
+		},
+		autoprefixer: {},
+	},
+} );
+```
 
 ## Jest
 
@@ -137,5 +153,5 @@ Use the provided Jest configuration via a preset. In your `jest.config.js` set t
 ```js
 module.exports = {
 	preset: '@automattic/calypso-build',
-}
+};
 ```

--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -139,7 +139,6 @@ module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
 			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
-			preserve: true,
 		},
 		autoprefixer: {},
 	},

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -34,7 +34,6 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
-		"@automattic/calypso-color-schemes": "file:../calypso-color-schemes",
 		"@babel/core": "7.6.4",
 		"@babel/plugin-proposal-class-properties": "7.5.5",
 		"@babel/plugin-syntax-dynamic-import": "7.2.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "4.2.1",
+	"version": "5.0.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",

--- a/packages/calypso-build/postcss.config.js
+++ b/packages/calypso-build/postcss.config.js
@@ -1,8 +1,7 @@
-module.exports = ( { options: { preserveCssCustomProperties = true } } ) => ( {
+module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
-			preserve: preserveCssCustomProperties,
+			preserve: false,
 		},
 		autoprefixer: {},
 	},

--- a/packages/calypso-build/postcss.config.js
+++ b/packages/calypso-build/postcss.config.js
@@ -1,8 +1,6 @@
 module.exports = () => ( {
 	plugins: {
-		'postcss-custom-properties': {
-			preserve: false,
-		},
+		'postcss-custom-properties': {},
 		autoprefixer: {},
 	},
 } );

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -106,10 +106,7 @@ function getWebpackConfig(
 					presets,
 					workerCount,
 				} ),
-				SassConfig.loader( {
-					preserveCssCustomProperties: false,
-					prelude: '@import "~@automattic/calypso-color-schemes/src/shared/colors";',
-				} ),
+				SassConfig.loader(),
 				FileConfig.loader(),
 			],
 		},

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -112,7 +112,7 @@ function getWebpackConfig(
 					presets,
 					workerCount,
 				} ),
-				SassConfig.loader( { postCssConfigPath } ),
+				SassConfig.loader( { postCssConfig: { path: postCssConfigPath } } ),
 				FileConfig.loader(),
 			],
 		},

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -71,6 +71,12 @@ function getWebpackConfig(
 		babelConfig = undefined;
 	}
 
+	let postCssConfigPath = process.cwd();
+	if ( ! fs.existsSync( path.join( postCssConfigPath, 'postcss.config.js' ) ) ) {
+		// Default to this package's PostCSS config
+		postCssConfigPath = __dirname;
+	}
+
 	const webpackConfig = {
 		bail: ! isDevelopment,
 		entry,
@@ -106,7 +112,7 @@ function getWebpackConfig(
 					presets,
 					workerCount,
 				} ),
-				SassConfig.loader(),
+				SassConfig.loader( { postCssConfigPath } ),
 				FileConfig.loader(),
 			],
 		},

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -74,7 +74,7 @@ function getWebpackConfig(
 	let postCssConfigPath = process.cwd();
 	if ( ! fs.existsSync( path.join( postCssConfigPath, 'postcss.config.js' ) ) ) {
 		// Default to this package's PostCSS config
-		postCssConfigPath = __dirname;
+		postCssConfigPath = undefined;
 	}
 
 	const webpackConfig = {

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -4,7 +4,6 @@
 const FilterWarningsPlugin = require( 'webpack-filter-warnings-plugin' );
 const MiniCssExtractPluginWithRTL = require( 'mini-css-extract-plugin-with-rtl' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
-const path = require( 'path' );
 
 /**
  * Return a webpack loader object containing our styling (Sass -> CSS) stack.
@@ -13,10 +12,16 @@ const path = require( 'path' );
  * @param  {boolean}   _.preserveCssCustomProperties  whether Custom Properties and properties using them should be preserved in their original form
  * @param  {string[]}  _.includePaths                 Sass files lookup paths
  * @param  {string}    _.prelude                      String to prepend to each Sass file
+ * @param  {string}    _.postCssConfigPath            Path to PostCSS config file
  *
  * @return {Object}                                   webpack loader object
  */
-module.exports.loader = ( { preserveCssCustomProperties, includePaths, prelude } ) => ( {
+module.exports.loader = ( {
+	preserveCssCustomProperties,
+	includePaths,
+	prelude,
+	postCssConfigPath,
+} ) => ( {
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPluginWithRTL.loader,
@@ -33,7 +38,7 @@ module.exports.loader = ( { preserveCssCustomProperties, includePaths, prelude }
 					ctx: {
 						preserveCssCustomProperties,
 					},
-					path: path.join( __dirname, '..' ),
+					path: postCssConfigPath,
 				},
 			},
 		},

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -11,11 +11,17 @@ const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
  * @param  {Object}    _                              Options
  * @param  {string[]}  _.includePaths                 Sass files lookup paths
  * @param  {string}    _.prelude                      String to prepend to each Sass file
+ * @param  {Object}    _.postCssConfigContext         PostCSS context
  * @param  {string}    _.postCssConfigPath            Path to PostCSS config file
  *
  * @return {Object}                                   webpack loader object
  */
-module.exports.loader = ( { includePaths, prelude, postCssConfigPath } ) => ( {
+module.exports.loader = ( {
+	includePaths,
+	prelude,
+	postCssConfigContext,
+	postCssConfigPath,
+} ) => ( {
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPluginWithRTL.loader,
@@ -29,6 +35,7 @@ module.exports.loader = ( { includePaths, prelude, postCssConfigPath } ) => ( {
 			loader: require.resolve( 'postcss-loader' ),
 			options: {
 				config: {
+					context: postCssConfigContext,
 					path: postCssConfigPath,
 				},
 			},

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -11,17 +11,11 @@ const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
  * @param  {Object}    _                              Options
  * @param  {string[]}  _.includePaths                 Sass files lookup paths
  * @param  {string}    _.prelude                      String to prepend to each Sass file
- * @param  {Object}    _.postCssConfigContext         PostCSS context
- * @param  {string}    _.postCssConfigPath            Path to PostCSS config file
+ * @param  {Object}    _.postCssConfig                PostCSS config
  *
  * @return {Object}                                   webpack loader object
  */
-module.exports.loader = ( {
-	includePaths,
-	prelude,
-	postCssConfigContext,
-	postCssConfigPath,
-} ) => ( {
+module.exports.loader = ( { includePaths, prelude, postCssConfig = {} } ) => ( {
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPluginWithRTL.loader,
@@ -34,10 +28,7 @@ module.exports.loader = ( {
 		{
 			loader: require.resolve( 'postcss-loader' ),
 			options: {
-				config: {
-					context: postCssConfigContext,
-					path: postCssConfigPath,
-				},
+				config: postCssConfig,
 			},
 		},
 		{

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -9,19 +9,13 @@ const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
  * Return a webpack loader object containing our styling (Sass -> CSS) stack.
  *
  * @param  {Object}    _                              Options
- * @param  {boolean}   _.preserveCssCustomProperties  whether Custom Properties and properties using them should be preserved in their original form
  * @param  {string[]}  _.includePaths                 Sass files lookup paths
  * @param  {string}    _.prelude                      String to prepend to each Sass file
  * @param  {string}    _.postCssConfigPath            Path to PostCSS config file
  *
  * @return {Object}                                   webpack loader object
  */
-module.exports.loader = ( {
-	preserveCssCustomProperties,
-	includePaths,
-	prelude,
-	postCssConfigPath,
-} ) => ( {
+module.exports.loader = ( { includePaths, prelude, postCssConfigPath } ) => ( {
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPluginWithRTL.loader,
@@ -35,9 +29,6 @@ module.exports.loader = ( {
 			loader: require.resolve( 'postcss-loader' ),
 			options: {
 				config: {
-					ctx: {
-						preserveCssCustomProperties,
-					},
 					path: postCssConfigPath,
 				},
 			},

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,9 @@
+module.exports = () => ( {
+	plugins: {
+		'postcss-custom-properties': {
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+			preserve: true,
+		},
+		autoprefixer: {},
+	},
+} );

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,6 @@ module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
 			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
-			preserve: true,
 		},
 		autoprefixer: {},
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -237,7 +237,6 @@ const webpackConfig = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				preserveCssCustomProperties: true,
 				includePaths: [ path.join( __dirname, 'client' ) ],
 				prelude: `@import '${ path.join(
 					__dirname,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Alternative to @jsnajdr's #36471, implementing ideas from https://github.com/Automattic/wp-calypso/pull/36471#issuecomment-545991575 (and below).

The basic idea for this PR is to have `calypso-build` pick up a project's own `postcss.config.js` (if there is one, much like we already do for Webpack and Babel). This allows us to drop the `calypso-color-schemes` dependency from the default configuration, but add it back e.g. to Calypso-the-app (without having to resort to Webpack config/"preset"-level configs).

From the Changelog:

```
- Remove `@automattic/calypso-color-schemes` dependency
  - See the example given at `https://github.com/Automattic/wp-calypso/blob/master/packages/calypso-build/README.md#advanced-usage-use-own-postcss-config` for instructions on how to continue
    to use color definitions from that file in your project.
- Remove `calypso-color-schemes` Sass Prelude.
  - Remove the `calypso-color-schemes` colors prelude from the default webpack config.
    This was useful when the colors were defined as SCSS variables, but now when they are
    defined as CSS variables included in the CSS output, the prelude no longer makes sense.
- Use Consumer's `postcss.config.js`, if present.
- Remove `preserveCssCustomProperties` option.
```

#### Testing instructions

- Verify that Calypso still builds, runs, and looks the same.
- For bonus points, `npm link` a different project (e.g. Jetpack) to this branch's `calypso-build`, and verify that it also still builds/runs/looks the same. You might have to include a custom `postcss.config.js`, as described in the updated README.

Fixes #36466.
