### PR TITLE
Composite-checkout: Make private

### DIFF
--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -37,5 +37,6 @@
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",
 		"styled-components": "4.4.0"
-	}
+	},
+	"private": true
 }


### PR DESCRIPTION
Allow `lerna` to be used for publish without publishing this package.

When it is ready, `private` can be removed and the package published.

Required for https://github.com/Automattic/wp-calypso/pull/37059