### PR TITLE
Use an empty object as a default product price matrix to prevent errors

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -64,4 +64,18 @@ The following props can be passed to the Product Selector block:
 * `productPriceMatrix`: ( object ) Matrix of product price relationships. Each key is a product slug, and each value is an object with the following structure:
 	* `relatedProduct`: ( string ) Slug of the related product.
 	* `ratio`: ( number ) Ratio between original plan and related plan. Example: for a `yearly` to `monthly` plan, this should be `12`.
+
+	Example:
+	```
+	productPriceMatrix: {
+		jetpack_backup_daily: {
+			relatedProduct: jetpack_backup_daily_monthly,
+			ratio: 12,
+		},
+		jetpack_backup_realtime: {
+			relatedProduct: jetpack_backup_realtime_monthly,
+			ratio: 12,
+		},
+	}
+	```
 * `siteId`: ( number ) ID of the site we're retrieving purchases for. Used to fetch information about the associated purchases of the selected products.

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -14,10 +14,10 @@ const products = [
 	{
 		title: 'Jetpack Backup',
 		description: (
-			<Fragment>
+			<p>
 				Automatic scanning and one-click fixes keep your site one step ahead of security threats.{' '}
 				<a href="https://jetpack.com/">More info</a>
-			</Fragment>
+			</p>
 		),
 		id: 'jetpack_backup',
 		options: {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -276,6 +276,10 @@ ProductSelector.propTypes = {
 	moment: PropTypes.func.isRequired,
 };
 
+ProductSelector.defaultProps = {
+	productPriceMatrix: {},
+};
+
 const connectComponent = connect( ( state, { products, siteId } ) => {
 	const selectedSiteId = siteId || getSelectedSiteId( state );
 	const productSlugs = extractProductSlugs( products );

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -197,7 +197,6 @@ export class ProductSelector extends Component {
 
 		return map( products, product => {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
-			const productObject = storeProducts[ selectedProductSlug ];
 			const stateKey = this.getStateKey( product.id, intervalType );
 			const purchase = this.getPurchaseByProduct( product );
 

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -155,7 +155,7 @@ export default class AppComponents extends React.Component {
 					<PlanStorage readmeFilePath="plan-storage" />
 					<PostSchedule />
 					<PostSelector />
-					<ProductSelector />
+					<ProductSelector readmeFilePath="product-selector" />
 					<Site readmeFilePath="site" />
 					<SitePlaceholder />
 					<SitesDropdown />


### PR DESCRIPTION
The product selector example is not rendered in devdocs. The reason is that we're not checking for a `productPriceMatrix` existence. This PR addresses this issue.

Some minor problems in the readme/example/devdocs are resolved here as well.

#### Changes proposed in this Pull Request

* Use an empty object as a default product price matrix to prevent errors
* Add `productPriceMatrix` example in the readme file
* Add product selector readme file reference to devdocs
* Add missing paragraph tag in the product selector example
* Remove unused `productBlock` reference in the `renderProducts` method

#### Testing instructions

* Checkout this branch
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector
* Confirm that a product selector is rendered for any selected site
* Confirm that the block readme is displayed below the example in devdocs 

Fixes n/a
