### PR TITLE
Layout CSS: move `a` CSS reset to main style

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -252,6 +252,10 @@ th {
 }
 
 /* Links */
+a {
+	text-decoration: none;
+}
+
 a,
 a:visited {
 	color: var( --color-link );

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -28,11 +28,6 @@
 	box-sizing: border-box;
 	overflow: hidden;
 
-	// I guess we dont want links to look like links.
-	a {
-		text-decoration: none;
-	}
-
 	// Various screens dont use a sidebar.
 	.has-no-sidebar & {
 		padding-left: 32px;
@@ -151,11 +146,11 @@
 	.site__title {
 		color: var( --color-sidebar-text );
 	}
-	
+
 	.site__domain {
 		color: var( --color-sidebar-text-alternative );
 	}
-	
+
 	.site__title::after,
 	.site__domain::after {
 		@include long-content-fade( $color: var( --color-sidebar-background-rgb ) );
@@ -165,14 +160,14 @@
 		&.is-large .site-selector__sites {
 			border-color: var( --color-sidebar-border );
 		}
-		
+
 		&__sites {
 			background: var( --color-sidebar-background );
 		}
-	
+
 		&__add-new-site {
 			border-color: var( --color-sidebar-border );
-		
+
 			.button {
 				color: var( --color-sidebar-text-alternative );
 				&:hover {
@@ -180,30 +175,30 @@
 				}
 			}
 		}
-		
+
 		&__recent {
 			border-color: var( --color-sidebar-border );
 		}
-		
+
 		&__no-results {
 			color: var( --color-sidebar-text-alternative );
 		}
-		
+
 		&__hidden-sites-message,
 		&__manage-hidden-sites {
 			color: var( --color-sidebar-text );
 		}
-		
+
 		.all-sites {
 			border-color: var( --color-sidebar-border );
 		}
 	}
-	
+
 	.all-sites .count {
 		color: var( --color-sidebar-text );
 		border-color: var( --color-sidebar-text );
 	}
-	
+
 	.app-promo .app-promo__link {
 		box-shadow: 0 0 0 1px var( --color-sidebar-border ),
 			0 1px 2px var( --color-sidebar-border );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves `a` reset to `_main.scss` stylesheet from layout, because that's where more generic type selectors styles like this belong.

Came up when refactoring stylesheets: https://github.com/Automattic/wp-calypso/pull/37020

@jsnajdr noted (https://github.com/Automattic/wp-calypso/pull/37020#discussion_r338917176):

> The only thing outside `.layout__content` is the Masterbar and things inside it, notably Notifications. Notifications have their own `.wpnc__main a { text-decoration: none }` style, so they shouldn't get hurt by this change. I think it's good and safe move.

#### Testing instructions

- Do all the links stay as they should in the header?
