### PR TITLE
Gutenboarding: Connect to store

### DIFF
--- a/client/gutenboarding/components/header/index.tsx
+++ b/client/gutenboarding/components/header/index.tsx
@@ -5,13 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { Button, IconButton } from '@wordpress/components';
 import React from 'react';
 import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import { useOnboardingState } from '../../store';
 import './style.scss';
-import { STORE_KEY } from '../../store';
 
 interface Props {
 	isEditorSidebarOpened: boolean;
@@ -19,7 +18,7 @@ interface Props {
 }
 
 export function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
-	const siteType = useSelect( select => select( STORE_KEY ).getSiteType() );
+	const { siteTitle, siteType } = useOnboardingState();
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -27,9 +26,19 @@ export function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props )
 			className="gutenboarding__header"
 			role="region"
 			aria-label={ __( 'Top bar' ) }
-			tabIndex="-1"
+			tabIndex={ -1 }
 		>
-			<div>You have a: { siteType }!</div>
+			<div>
+				<p>
+					You have a: { siteType }!
+					{ siteTitle && (
+						<>
+							<br />
+							It's called <em>{ siteTitle }</em>!
+						</>
+					) }
+				</p>
+			</div>
 			<div
 				aria-label={ __( 'Document tools' ) }
 				aria-orientation="horizontal"

--- a/client/gutenboarding/components/header/index.tsx
+++ b/client/gutenboarding/components/header/index.tsx
@@ -5,11 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { Button, IconButton } from '@wordpress/components';
 import React from 'react';
 import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import { STORE_KEY } from '../../store';
 
 interface Props {
 	isEditorSidebarOpened: boolean;
@@ -17,6 +19,8 @@ interface Props {
 }
 
 export function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
+	const siteType = useSelect( select => select( STORE_KEY ).getSiteType() );
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div
@@ -25,6 +29,7 @@ export function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props )
 			aria-label={ __( 'Top bar' ) }
 			tabIndex="-1"
 		>
+			<div>You have a: { siteType }!</div>
 			<div
 				aria-label={ __( 'Document tools' ) }
 				aria-orientation="horizontal"

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -4,28 +4,30 @@
 import { sprintf, __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
 import { BlockEditProps } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
-import { Attributes, SiteType } from '.';
+import { SiteType } from '.';
+import { STORE_KEY } from '../store';
 
-export default function OnboardingEdit( {
-	attributes: { siteType },
-	setAttributes,
-}: BlockEditProps< Attributes > ) {
-	if ( ! siteType ) {
+export default function OnboardingEdit() {
+	const siteType = useSelect( select => select( STORE_KEY ).getSiteType() );
+	const { setSiteType } = useDispatch( STORE_KEY );
+
+	if ( true || ! siteType ) {
 		return (
 			<>
 				<h1>{ __( "Let's set up your website -- it takes only a moment" ) }</h1>
 				{ __( 'I want to create a website ' ) }
 				<SelectControl< SiteType >
-					onChange={ v => setAttributes( { siteType: v } ) }
+					onChange={ setSiteType }
 					options={ [
-						{ label: __( 'with a blog.' ), value: 'blog' },
-						{ label: __( 'for a store.' ), value: 'store' },
-						{ label: __( 'to write a story.' ), value: 'story' },
+						{ label: __( 'with a blog.' ), value: SiteType.BLOG },
+						{ label: __( 'for a store.' ), value: SiteType.STORE },
+						{ label: __( 'to write a story.' ), value: SiteType.STORY },
 					] }
 					value={ siteType || SiteType.BLOG }
 				/>

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -1,38 +1,39 @@
 /**
  * External dependencies
  */
-import { sprintf, __ } from '@wordpress/i18n';
-import { SelectControl } from '@wordpress/components';
-import { BlockEditProps } from '@wordpress/blocks';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { TextControl, SelectControl } from '@wordpress/components';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
-import { SiteType } from '.';
-import { STORE_KEY } from '../store';
+import { SiteType } from '../store/types';
+import { useOnboardingDispatch, useOnboardingState } from '../store';
 
 export default function OnboardingEdit() {
-	const siteType = useSelect( select => select( STORE_KEY ).getSiteType() );
-	const { setSiteType } = useDispatch( STORE_KEY );
+	const { siteTitle, siteType } = useOnboardingState();
+	const { setSiteType, setSiteTitle } = useOnboardingDispatch();
 
-	if ( true || ! siteType ) {
-		return (
-			<>
-				<h1>{ __( "Let's set up your website -- it takes only a moment" ) }</h1>
-				{ __( 'I want to create a website ' ) }
-				<SelectControl< SiteType >
-					onChange={ setSiteType }
-					options={ [
-						{ label: __( 'with a blog.' ), value: SiteType.BLOG },
-						{ label: __( 'for a store.' ), value: SiteType.STORE },
-						{ label: __( 'to write a story.' ), value: SiteType.STORY },
-					] }
-					value={ siteType || SiteType.BLOG }
-				/>
-			</>
-		);
-	}
-	return <div>{ sprintf( __( 'Cool, you have a %s' ), siteType ) }</div>;
+	return (
+		<>
+			<p>{ __( "Let's set up your website -- it takes only a moment" ) }</p>
+			{ __( 'I want to create a website ' ) }
+			<SelectControl< SiteType >
+				onChange={ setSiteType }
+				options={ [
+					{ label: __( 'with a blog.' ), value: SiteType.BLOG },
+					{ label: __( 'for a store.' ), value: SiteType.STORE },
+					{ label: __( 'to write a story.' ), value: SiteType.STORY },
+				] }
+				value={ siteType }
+			/>
+			{ ( siteType || siteTitle ) && (
+				<>
+					<p>{ __( "It's called" ) }</p>
+					<TextControl onChange={ setSiteTitle } value={ siteTitle } />
+				</>
+			) }
+		</>
+	);
 }

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -11,19 +11,13 @@ import edit from './edit';
 
 export const name = 'automattic/onboarding';
 
-export enum SiteType {
-	BLOG = 'blog',
-	STORE = 'store',
-	STORY = 'story',
-}
-
 export interface Attributes {
 	align: 'full';
 }
 
 export const settings: BlockConfiguration< Attributes > = {
 	title: __( 'Onboarding' ),
-	category: 'layout', // TODO
+	category: 'layout', // @TODO
 	description: __( 'Onboarding wizard block' ),
 	attributes: {
 		align: {

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -19,10 +19,6 @@ export enum SiteType {
 
 export interface Attributes {
 	align: 'full';
-	siteTitle: string;
-	siteType?: SiteType;
-	theme: string;
-	vertical: string;
 }
 
 export const settings: BlockConfiguration< Attributes > = {
@@ -33,18 +29,6 @@ export const settings: BlockConfiguration< Attributes > = {
 		align: {
 			type: 'string',
 			default: 'full',
-		},
-		siteTitle: {
-			type: 'string',
-		},
-		siteType: {
-			type: 'string',
-		},
-		theme: {
-			type: 'string',
-		},
-		vertical: {
-			type: 'string',
 		},
 	},
 	supports: {

--- a/client/gutenboarding/store/action-types.ts
+++ b/client/gutenboarding/store/action-types.ts
@@ -1,7 +1,0 @@
-// With a _real_ TypeScript compiler, we could use const enums.
-/* const */ enum ActionTypes {
-	SET_SITE_TYPE,
-	SET_STEP,
-}
-
-export default ActionTypes;

--- a/client/gutenboarding/store/action-types.ts
+++ b/client/gutenboarding/store/action-types.ts
@@ -1,6 +1,7 @@
 // With a _real_ TypeScript compiler, we could use const enums.
 /* const */ enum ActionTypes {
 	SET_SITE_TYPE,
+	SET_STEP,
 }
 
 export default ActionTypes;

--- a/client/gutenboarding/store/actions.ts
+++ b/client/gutenboarding/store/actions.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ActionType, SiteType } from '.';
+import { ActionType, SiteType } from './types';
 
 export const setSiteType = ( siteType: SiteType ) => ( {
 	type: ActionType.SET_SITE_TYPE,

--- a/client/gutenboarding/store/actions.ts
+++ b/client/gutenboarding/store/actions.ts
@@ -1,17 +1,14 @@
 /**
- * External dependencies
- */
-import { Action, ActionCreator } from 'redux';
-
-/**
  * Internal dependencies
  */
-import ActionTypes from './action-types';
+import { ActionType, SiteType } from '.';
 
-export interface SetSiteTypeAction extends Action< ActionTypes.SET_SITE_TYPE > {
-	siteType: string;
-}
-export const setSiteType: ActionCreator< SetSiteTypeAction > = ( siteType: string ) => ( {
-	type: ActionTypes.SET_SITE_TYPE,
+export const setSiteType = ( siteType: SiteType ) => ( {
+	type: ActionType.SET_SITE_TYPE,
 	siteType,
+} );
+
+export const setSiteTitle = ( siteTitle: string ) => ( {
+	type: ActionType.SET_SITE_TITLE,
+	siteTitle,
 } );

--- a/client/gutenboarding/store/index.ts
+++ b/client/gutenboarding/store/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerStore } from '@wordpress/data';
+import { registerStore, useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,11 +12,19 @@ import * as selectors from './selectors';
 
 export const STORE_KEY = 'automattic/onboard';
 
-const store = registerStore< State >( STORE_KEY, {
+registerStore< State >( STORE_KEY, {
 	reducer,
 	actions,
 	selectors,
 	// persist: [],
 } );
 
-export default store;
+export function useOnboardingState(): State {
+	return useSelect( select => select( STORE_KEY ).getState() );
+}
+
+export function useOnboardingDispatch() {
+	return useDispatch( STORE_KEY ) as {
+		[ D in keyof typeof actions ]: ( ...args: Parameters< typeof actions[ D ] > ) => void;
+	};
+}

--- a/client/gutenboarding/store/index.ts
+++ b/client/gutenboarding/store/index.ts
@@ -10,7 +10,9 @@ import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 
-const store = registerStore< State >( 'automattic/onboard', {
+export const STORE_KEY = 'automattic/onboard';
+
+const store = registerStore< State >( STORE_KEY, {
 	reducer,
 	actions,
 	selectors,

--- a/client/gutenboarding/store/reducer.ts
+++ b/client/gutenboarding/store/reducer.ts
@@ -7,21 +7,32 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import ActionTypes from './action-types';
-import { SetSiteTypeAction } from './actions';
+import { ActionType, SiteType } from './types';
+import * as Actions from './actions';
 
-const siteType: Reducer< null | SetSiteTypeAction[ 'siteType' ], SetSiteTypeAction > = (
-	state = null,
+const siteType: Reducer< SiteType, ReturnType< typeof Actions[ 'setSiteType' ] > > = (
+	state = SiteType.BLOG,
 	action
 ) => {
 	switch ( action.type ) {
-		case ActionTypes.SET_SITE_TYPE:
+		case ActionType.SET_SITE_TYPE:
 			return action.siteType;
 	}
 	return state;
 };
 
-const reducer = combineReducers( { siteType } );
+const siteTitle: Reducer< string, ReturnType< typeof Actions[ 'setSiteTitle' ] > > = (
+	state = '',
+	action
+) => {
+	switch ( action.type ) {
+		case ActionType.SET_SITE_TITLE:
+			return action.siteTitle;
+	}
+	return state;
+};
+
+const reducer = combineReducers( { siteType, siteTitle } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/client/gutenboarding/store/types.ts
+++ b/client/gutenboarding/store/types.ts
@@ -1,0 +1,12 @@
+// With a _real_ TypeScript compiler, we could use const enums.
+/* const */ enum ActionType {
+	SET_SITE_TITLE,
+	SET_SITE_TYPE,
+}
+export { ActionType };
+
+export enum SiteType {
+	BLOG = 'blog',
+	STORE = 'store',
+	STORY = 'story',
+}


### PR DESCRIPTION
- Reworks the store a bit to reduce boilerplate.
- Adds a couple of specific hooks which provide better typings
- Connects the inputs to the store and displays them in the header.

## Testing
- Hit [/gutenboarding](https://calypso.live/gutenboarding?branch=update/connect-onboarding-store) and play with the inputs 🎉 