### PR TITLE
Gutenboarding: don't translate

### DIFF
--- a/client/gutenboarding/components/header/index.tsx
+++ b/client/gutenboarding/components/header/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { NO__ } from '../../devtools';
 import { Button, IconButton } from '@wordpress/components';
 import React from 'react';
 import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';
@@ -25,7 +25,7 @@ export function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props )
 		<div
 			className="gutenboarding__header"
 			role="region"
-			aria-label={ __( 'Top bar' ) }
+			aria-label={ NO__( 'Top bar' ) }
 			tabIndex={ -1 }
 		>
 			<div>
@@ -40,18 +40,18 @@ export function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props )
 				</p>
 			</div>
 			<div
-				aria-label={ __( 'Document tools' ) }
+				aria-label={ NO__( 'Document tools' ) }
 				aria-orientation="horizontal"
 				className="gutenboarding__header-toolbar"
 				role="toolbar"
 			></div>
 			<div className="gutenboarding__header-actions">
 				<Button isPrimary isLarge>
-					{ __( 'Continue' ) }
+					{ NO__( 'Continue' ) }
 				</Button>
 				<IconButton
 					icon="admin-generic"
-					label={ 'Site Block Settings' }
+					label={ NO__( 'Site block settings' ) }
 					onClick={ toggleGeneralSidebar }
 					isToggled={ isEditorSidebarOpened }
 					aria-expanded={ isEditorSidebarOpened }

--- a/client/gutenboarding/components/header/index.tsx
+++ b/client/gutenboarding/components/header/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { NO__ } from '../../devtools';
+import { __ as NO__ } from '@wordpress/i18n';
 import { Button, IconButton } from '@wordpress/components';
 import React from 'react';
 import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';

--- a/client/gutenboarding/components/settings-sidebar/index.js
+++ b/client/gutenboarding/components/settings-sidebar/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { NO__ } from '../../devtools';
+import { __ as NO__ } from '@wordpress/i18n';
 import React from 'react';
 import { BlockInspector } from '@wordpress/block-editor';
 import { Panel, PanelBody } from '@wordpress/components';

--- a/client/gutenboarding/components/settings-sidebar/index.js
+++ b/client/gutenboarding/components/settings-sidebar/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { NO__ } from '../../devtools';
 import React from 'react';
 import { BlockInspector } from '@wordpress/block-editor';
 import { Panel, PanelBody } from '@wordpress/components';
@@ -15,7 +16,7 @@ import Sidebar from '../sidebar';
 export default function SettingsSidebar( { isActive } ) {
 	return (
 		<Sidebar
-			label="SiteBlock Settings"
+			label={ NO__( 'Site block settings' ) }
 			className="gutenboarding__settings-sidebar"
 			isActive={ isActive }
 		>

--- a/client/gutenboarding/devtools.ts
+++ b/client/gutenboarding/devtools.ts
@@ -25,15 +25,4 @@ export const wpDataDebugMiddleware: PageJS.Callback = ( context, next ) => {
  *
  * This is to avoid sending strings for translation tool too early.
  */
-
-export const NO__ = ( value: string ) => value;
-
-export const NO_n = ( single: string, plural: string, number: number ) =>
-	number > 1 ? plural : single;
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const NO_nx = ( single: string, plural: string, number: number, context: string ) =>
-	NO_n( single, plural, number );
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const NO_x = ( value: string, context: string ) => value;
+export { __ as NO__, _n as NO_n, _nx as NO_nx, _x as NO_x, sprintf } from '@wordpress/i18n';

--- a/client/gutenboarding/devtools.ts
+++ b/client/gutenboarding/devtools.ts
@@ -18,11 +18,3 @@ export const wpDataDebugMiddleware: PageJS.Callback = ( context, next ) => {
 	}
 	next();
 };
-
-/**
- * Functions to use instead of `__()` etc from `@wordpress/i18n`.
- * https://developer.wordpress.org/block-editor/packages/packages-i18n/
- *
- * This is to avoid sending strings for translation tool too early.
- */
-export { __ as NO__, _n as NO_n, _nx as NO_nx, _x as NO_x, sprintf } from '@wordpress/i18n';

--- a/client/gutenboarding/devtools.ts
+++ b/client/gutenboarding/devtools.ts
@@ -18,3 +18,22 @@ export const wpDataDebugMiddleware: PageJS.Callback = ( context, next ) => {
 	}
 	next();
 };
+
+/**
+ * Functions to use instead of `__()` etc from `@wordpress/i18n`.
+ * https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ *
+ * This is to avoid sending strings for translation tool too early.
+ */
+
+export const NO__ = ( value: string ) => value;
+
+export const NO_n = ( single: string, plural: string, number: number ) =>
+	number > 1 ? plural : single;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const NO_nx = ( single: string, plural: string, number: number, context: string ) =>
+	NO_n( single, plural, number );
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const NO_x = ( value: string, context: string ) => value;

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { NO__ } from '../devtools';
 import { TextControl, SelectControl } from '@wordpress/components';
 import React from 'react';
 
@@ -17,20 +17,20 @@ export default function OnboardingEdit() {
 
 	return (
 		<>
-			<p>{ __( "Let's set up your website -- it takes only a moment" ) }</p>
-			{ __( 'I want to create a website ' ) }
+			<p>{ NO__( "Let's set up your website -- it takes only a moment" ) }</p>
+			{ NO__( 'I want to create a website ' ) }
 			<SelectControl< SiteType >
 				onChange={ setSiteType }
 				options={ [
-					{ label: __( 'with a blog.' ), value: SiteType.BLOG },
-					{ label: __( 'for a store.' ), value: SiteType.STORE },
-					{ label: __( 'to write a story.' ), value: SiteType.STORY },
+					{ label: NO__( 'with a blog.' ), value: SiteType.BLOG },
+					{ label: NO__( 'for a store.' ), value: SiteType.STORE },
+					{ label: NO__( 'to write a story.' ), value: SiteType.STORY },
 				] }
 				value={ siteType }
 			/>
 			{ ( siteType || siteTitle ) && (
 				<>
-					<p>{ __( "It's called" ) }</p>
+					<p>{ NO__( "It's called" ) }</p>
 					<TextControl onChange={ setSiteTitle } value={ siteTitle } />
 				</>
 			) }

--- a/client/gutenboarding/onboarding-block/edit.tsx
+++ b/client/gutenboarding/onboarding-block/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { NO__ } from '../devtools';
+import { __ as NO__ } from '@wordpress/i18n';
 import { TextControl, SelectControl } from '@wordpress/components';
 import React from 'react';
 

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { NO__ } from '../devtools';
+import { __ as NO__ } from '@wordpress/i18n';
 import { BlockConfiguration } from '@wordpress/blocks';
 
 /**

--- a/client/gutenboarding/onboarding-block/index.ts
+++ b/client/gutenboarding/onboarding-block/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { NO__ } from '../devtools';
 import { BlockConfiguration } from '@wordpress/blocks';
 
 /**
@@ -16,9 +16,9 @@ export interface Attributes {
 }
 
 export const settings: BlockConfiguration< Attributes > = {
-	title: __( 'Onboarding' ),
+	title: NO__( 'Onboarding' ),
 	category: 'layout', // @TODO
-	description: __( 'Onboarding wizard block' ),
+	description: NO__( 'Onboarding wizard block' ),
 	attributes: {
 		align: {
 			type: 'string',


### PR DESCRIPTION
Avoid sending strings for the translation tool in gutenboarding section by re-exporting `@wordpress/i18n` translation function with `NO` prefix: `__( 'Hello, world!' )` -> `NO__( 'Hello, world!' )`.

#### Testing instructions

* Builds and works as expected (visit [`/gutenboarding`](https://calypso.live/gutenboarding?branch=update/gutenboarding-dont-translate) and look for "translated" strings).
* Strings should not be present in parsed translations.