### PR TITLE
Add format method to lib/url.

### DIFF
--- a/client/lib/url/format.ts
+++ b/client/lib/url/format.ts
@@ -13,7 +13,7 @@ const BASE_URL = 'http://__domain__.invalid/';
 
 /**
  * Format a URL as a particular type.
- * Does not support formatting path-relative URLs.
+ * Does not support formatting invalid or path-relative URLs.
  *
  * @param url The URL to format.
  * @param urlType The URL type into which to format. If not provided, defaults to the same type as
@@ -21,7 +21,10 @@ const BASE_URL = 'http://__domain__.invalid/';
  *
  * @returns The formatted URL.
  */
-export default function format( url: URLString | URL | Falsy, urlType?: URL_TYPE ): URLString {
+export default function format(
+	url: URLString | URL | Falsy,
+	urlType?: Exclude< URL_TYPE, URL_TYPE.INVALID | URL_TYPE.PATH_RELATIVE >
+): URLString {
 	let parsed: URL;
 	let originalType: URL_TYPE;
 
@@ -47,7 +50,7 @@ export default function format( url: URLString | URL | Falsy, urlType?: URL_TYPE
 		urlType = originalType;
 	}
 
-	switch ( urlType ) {
+	switch ( urlType as URL_TYPE ) {
 		case URL_TYPE.PATH_RELATIVE:
 			throw new Error( 'Cannot format into path-relative URLs.' );
 

--- a/client/lib/url/format.ts
+++ b/client/lib/url/format.ts
@@ -9,7 +9,7 @@ import { Falsy } from 'utility-types';
  */
 import { determineUrlType, URL_TYPE } from './url-type';
 
-const BASE_URL = `http://__domain__.invalid/`;
+const BASE_URL = 'http://__domain__.invalid/';
 
 /**
  * Format a URL as a particular type.

--- a/client/lib/url/format.ts
+++ b/client/lib/url/format.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { URL as URLString } from 'types';
-import { Falsey } from 'utility-types';
+import { Falsy } from 'utility-types';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ const BASE_URL = `http://__domain__.invalid/`;
  *
  * @returns The formatted URL.
  */
-export default function format( url: URLString | URL | Falsey, urlType?: URL_TYPE ): URLString {
+export default function format( url: URLString | URL | Falsy, urlType?: URL_TYPE ): URLString {
 	let parsed: URL;
 	let originalType: URL_TYPE;
 

--- a/client/lib/url/format.ts
+++ b/client/lib/url/format.ts
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { URL as URLString } from 'types';
+import { Falsey } from 'utility-types';
+
+/**
+ * Internal dependencies
+ */
+import { determineUrlType, URL_TYPE } from './url-type';
+
+const BASE_URL = `http://__domain__.invalid/`;
+
+/**
+ * Format a URL as a particular type.
+ * Does not support formatting path-relative URLs.
+ *
+ * @param url The URL to format.
+ * @param urlType The URL type into which to format. If not provided, defaults to the same type as
+ *                `url`, which effectively results in the URL being normalized.
+ *
+ * @returns The formatted URL.
+ */
+export default function format( url: URLString | URL | Falsey, urlType?: URL_TYPE ): URLString {
+	let parsed: URL;
+	let originalType: URL_TYPE;
+
+	if ( url instanceof URL ) {
+		// The native URL object can only represent absolute URLs.
+		parsed = url;
+		originalType = URL_TYPE.ABSOLUTE;
+	} else {
+		originalType = determineUrlType( url );
+
+		if ( originalType === URL_TYPE.INVALID ) {
+			throw new Error( 'Cannot format an invalid URL.' );
+		}
+
+		if ( originalType === URL_TYPE.PATH_RELATIVE ) {
+			throw new Error( 'Cannot format path-relative URLs.' );
+		}
+
+		parsed = new URL( url as URLString, BASE_URL );
+	}
+
+	if ( urlType === undefined ) {
+		urlType = originalType;
+	}
+
+	switch ( urlType ) {
+		case URL_TYPE.PATH_RELATIVE:
+			throw new Error( 'Cannot format into path-relative URLs.' );
+
+		case URL_TYPE.PATH_ABSOLUTE:
+			return parsed.href.replace( parsed.origin, '' );
+
+		case URL_TYPE.SCHEME_RELATIVE:
+			if ( originalType === URL_TYPE.PATH_ABSOLUTE ) {
+				throw new Error( 'Cannot format a path-absolute URL as a scheme-relative URL.' );
+			}
+			return parsed.href.replace( parsed.protocol, '' );
+
+		case URL_TYPE.ABSOLUTE:
+			if ( originalType !== URL_TYPE.ABSOLUTE ) {
+				throw new Error( 'Cannot format a partial URL as an absolute URL.' );
+			}
+			return parsed.href;
+
+		default:
+			throw new Error( `Cannot format as \`${ urlType }\` URL type.` );
+	}
+}

--- a/client/lib/url/format.ts
+++ b/client/lib/url/format.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { URL as URLString } from 'types';
-import { Falsy } from 'utility-types';
 
 /**
  * Internal dependencies
@@ -22,11 +21,15 @@ const BASE_URL = 'http://__domain__.invalid/';
  * @returns The formatted URL.
  */
 export default function format(
-	url: URLString | URL | Falsy,
+	url: URLString | URL,
 	urlType?: Exclude< URL_TYPE, URL_TYPE.INVALID | URL_TYPE.PATH_RELATIVE >
 ): URLString {
 	let parsed: URL;
 	let originalType: URL_TYPE;
+
+	if ( ! ( url instanceof URL ) && typeof url !== 'string' ) {
+		throw new Error( '`url` should be a string or URL instance' );
+	}
 
 	if ( url instanceof URL ) {
 		// The native URL object can only represent absolute URLs.

--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -22,6 +22,7 @@ export { default as isOutsideCalypso } from './is-outside-calypso';
 export { default as isHttps } from './is-https';
 export { addSchemeIfMissing, setUrlScheme } from './scheme-utils';
 export { decodeURIIfValid, decodeURIComponentIfValid } from './decode-utils';
+export { default as format } from './format';
 
 /**
  * Removes given params from a url.

--- a/client/lib/url/test/format.js
+++ b/client/lib/url/test/format.js
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import format from '../format';
+
+describe( 'getUrlType', () => {
+	test( 'should format absolute URLs as absolute URLs', () => {
+		expect( format( 'http://example.com/', 'ABSOLUTE' ) ).toBe( 'http://example.com/' );
+		expect( format( 'http://example.com:8080/', 'ABSOLUTE' ) ).toBe( 'http://example.com:8080/' );
+		expect( format( 'http://www.example.com', 'ABSOLUTE' ) ).toBe( 'http://www.example.com/' );
+		expect( format( 'http://example.com/foo?b=a#z', 'ABSOLUTE' ) ).toBe(
+			'http://example.com/foo?b=a#z'
+		);
+		expect( format( 'http://example.com/foo/bar/../baz', 'ABSOLUTE' ) ).toBe(
+			'http://example.com/foo/baz'
+		);
+		// Normalization examples from https://url.spec.whatwg.org/#urls
+		expect( format( 'https:example.org', 'ABSOLUTE' ) ).toBe( 'https://example.org/' );
+		expect( format( 'https://////example.com///', 'ABSOLUTE' ) ).toBe( 'https://example.com///' );
+		expect( format( 'https://example.com/././foo', 'ABSOLUTE' ) ).toBe( 'https://example.com/foo' );
+		expect( format( 'file:///C|/demo', 'ABSOLUTE' ) ).toBe( 'file:///C:/demo' );
+		expect( format( 'file://loc%61lhost/', 'ABSOLUTE' ) ).toBe( 'file:///' );
+		expect( format( 'https://user:password@example.org/', 'ABSOLUTE' ) ).toBe(
+			'https://user:password@example.org/'
+		);
+		expect( format( 'https://example.org/foo bar', 'ABSOLUTE' ) ).toBe(
+			'https://example.org/foo%20bar'
+		);
+		expect( format( 'https://EXAMPLE.com/../x', 'ABSOLUTE' ) ).toBe( 'https://example.com/x' );
+	} );
+
+	test( 'should format absolute URLs as scheme-relative URLs', () => {
+		expect( format( 'http://example.com/', 'SCHEME_RELATIVE' ) ).toBe( '//example.com/' );
+		expect( format( 'http://example.com:8080/', 'SCHEME_RELATIVE' ) ).toBe( '//example.com:8080/' );
+		expect( format( 'http://www.example.com', 'SCHEME_RELATIVE' ) ).toBe( '//www.example.com/' );
+		expect( format( 'http://example.com/foo?b=a#z', 'SCHEME_RELATIVE' ) ).toBe(
+			'//example.com/foo?b=a#z'
+		);
+		expect( format( 'http://example.com/foo/bar/../baz', 'SCHEME_RELATIVE' ) ).toBe(
+			'//example.com/foo/baz'
+		);
+	} );
+
+	test( 'should format scheme-relative URLs as scheme-relative URLs', () => {
+		expect( format( '//example.com/', 'SCHEME_RELATIVE' ) ).toBe( '//example.com/' );
+		expect( format( '//example.com:8080/', 'SCHEME_RELATIVE' ) ).toBe( '//example.com:8080/' );
+		expect( format( '//www.example.com', 'SCHEME_RELATIVE' ) ).toBe( '//www.example.com/' );
+		expect( format( '//example.com/foo?b=a#z', 'SCHEME_RELATIVE' ) ).toBe(
+			'//example.com/foo?b=a#z'
+		);
+		expect( format( '//example.com/foo/bar/../baz', 'SCHEME_RELATIVE' ) ).toBe(
+			'//example.com/foo/baz'
+		);
+	} );
+
+	test( 'should format absolute URLs as path-absolute URLs', () => {
+		expect( format( 'http://example.com/', 'PATH_ABSOLUTE' ) ).toBe( '/' );
+		expect( format( 'http://example.com:8080/', 'PATH_ABSOLUTE' ) ).toBe( '/' );
+		expect( format( 'http://www.example.com', 'PATH_ABSOLUTE' ) ).toBe( '/' );
+		expect( format( 'http://example.com/foo?b=a#z', 'PATH_ABSOLUTE' ) ).toBe( '/foo?b=a#z' );
+	} );
+
+	test( 'should format scheme-relative URLs as path-absolute URLs', () => {
+		expect( format( '//example.com/', 'PATH_ABSOLUTE' ) ).toBe( '/' );
+		expect( format( '//example.com:8080/', 'PATH_ABSOLUTE' ) ).toBe( '/' );
+		expect( format( '//www.example.com', 'PATH_ABSOLUTE' ) ).toBe( '/' );
+		expect( format( '//example.com/foo?b=a#z', 'PATH_ABSOLUTE' ) ).toBe( '/foo?b=a#z' );
+		expect( format( '//example.com/foo/bar/../baz', 'PATH_ABSOLUTE' ) ).toBe( '/foo/baz' );
+	} );
+
+	test( 'should format path-absolute URLs as path-absolute URLs', () => {
+		expect( format( '/', 'PATH_ABSOLUTE' ) ).toBe( '/' );
+		expect( format( '/foo?b=a#z', 'PATH_ABSOLUTE' ) ).toBe( '/foo?b=a#z' );
+		expect( format( '/foo/bar/../baz', 'PATH_ABSOLUTE' ) ).toBe( '/foo/baz' );
+	} );
+
+	test( 'should format a URL into its own type when a format is not specified', () => {
+		expect( format( 'http://example.com/foo' ) ).toBe( 'http://example.com/foo' );
+		expect( format( '//example.com/foo' ) ).toBe( '//example.com/foo' );
+		expect( format( '/foo' ) ).toBe( '/foo' );
+	} );
+
+	test( 'should throw if passed an invalid URL', () => {
+		expect( () => format( null, 'PATH_ABSOLUTE' ) ).toThrow();
+		expect( () => format( '///', 'PATH_ABSOLUTE' ) ).toThrow();
+	} );
+
+	test( 'should throw if passed an invalid url type into which to format', () => {
+		expect( () => format( 'http://example.com/', 'INVALID' ) ).toThrow();
+		expect( () => format( 'http://example.com/', 'NONEXISTENT' ) ).toThrow();
+	} );
+
+	test( 'should throw if attempting to format a URL as a path-relative URL', () => {
+		expect( () => format( 'http://example.com/', 'PATH_RELATIVE' ) ).toThrow();
+		expect( () => format( 'foo', 'PATH_RELATIVE' ) ).toThrow();
+	} );
+
+	test( 'should throw if passed a path-absolute URL to format as scheme-relative', () => {
+		expect( () => format( '/', 'SCHEME_RELATIVE' ) ).toThrow();
+	} );
+
+	test( 'should throw if passed a path-relative URL to format as scheme-relative', () => {
+		expect( () => format( 'foo', 'SCHEME_RELATIVE' ) ).toThrow();
+	} );
+
+	test( 'should throw if passed a path-absolute URL to format as absolute', () => {
+		expect( () => format( '/', 'ABSOLUTE' ) ).toThrow();
+	} );
+
+	test( 'should throw if passed a pathrelative URL to format as absolute', () => {
+		expect( () => format( 'foo', 'ABSOLUTE' ) ).toThrow();
+	} );
+
+	test( 'should throw if passed a scheme-relative URL to format as absolute', () => {
+		expect( () => format( '//example.com/', 'ABSOLUTE' ) ).toThrow();
+	} );
+} );


### PR DESCRIPTION
This method allows for formatting a URL into other types, like turning an absolute URL into a scheme-relative one. While formatting, it will also normalize the URL.

It will not format a lesser type into a more complete type, as it's not possible to do so without adding extra information.

It does not handle path-relative URLs.

This is the second of two PRs that together will unblock #36995.

Please feel free to add any other reviewers that may want to look at this.

#### Changes proposed in this Pull Request

* Add `format` method to `lib/url`.
* Add unit tests for new `format` method.

#### Testing instructions

* Ensure the included unit tests pass
* Ensure the set of unit tests appears reasonably complete
