### PR TITLE
Add Gutenboarding entrypoint

### DIFF
--- a/client/assets/stylesheets/style-bare.scss
+++ b/client/assets/stylesheets/style-bare.scss
@@ -1,0 +1,8 @@
+// External Dependencies
+@import 'vendor';
+
+// Color Schemes
+@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+
+// Shared
+@import 'shared/reset'; // css reset before the rest of the styles are defined

--- a/client/landing/gutenbearding/index.js
+++ b/client/landing/gutenbearding/index.js
@@ -1,0 +1,33 @@
+/**
+ * Global polyfills
+ */
+import 'boot/polyfills';
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import user from 'lib/user';
+import { Gutenboard } from 'gutenboarding/gutenboard';
+
+/**
+ * Style dependencies
+ */
+import 'assets/stylesheets/style-bare.scss';
+import 'components/environment-badge/style.scss';
+
+const gutenbeard = () => {
+	ReactDom.render( <Gutenboard />, document.getElementById( 'wpcom' ) );
+};
+
+window.AppBoot = async () => {
+	await user().initialize();
+	page( '/gutenbearding', gutenbeard );
+	page.start();
+};

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -799,6 +799,17 @@ module.exports = function() {
 	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
 	loginRouter( serverRouter( app, setUpRoute, null ) );
 
+	// Set up Gutenbearding routing.
+	handleSectionPath(
+		{
+			name: 'gutenbearding',
+			module: 'gutenbearding',
+			enableLoggedOut: true,
+		},
+		'/gutenbearding',
+		'entry-gutenbearding'
+	);
+
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers
 	app.post(
 		'/cspreport',

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -239,7 +239,7 @@ function setupLoggedInContext( req, res, next ) {
 	next();
 }
 
-function getDefaultContext( request ) {
+function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	let initialServerState = {};
 	let lang = config( 'i18n_default_locale_slug' );
 	const bodyClasses = [];
@@ -294,7 +294,7 @@ function getDefaultContext( request ) {
 		isWCComConnect,
 		badge: false,
 		lang,
-		entrypoint: getFilesForEntrypoint( target, 'entry-main' ),
+		entrypoint: getFilesForEntrypoint( target, entrypoint ),
 		manifest: getAssets( target ).manifests.manifest,
 		faviconURL: config( 'favicon_url' ),
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
@@ -554,7 +554,6 @@ function setUpCSP( req, res, next ) {
 }
 
 function setUpRoute( req, res, next ) {
-	req.context = getDefaultContext( req );
 	setUpCSP( req, res, () =>
 		req.context.isLoggedIn
 			? setUpLoggedInRoute( req, res, next )
@@ -737,7 +736,7 @@ module.exports = function() {
 
 	// Landing pages for domains-related emails
 	app.get( '/domain-services/:action', function( req, res ) {
-		const ctx = getDefaultContext( req );
+		const ctx = getDefaultContext( req, 'entry-domains-landing' );
 		attachBuildTimestamp( ctx );
 		attachHead( ctx );
 		attachI18n( ctx );
@@ -748,22 +747,18 @@ module.exports = function() {
 			query: get( req, 'query', {} ),
 		};
 
-		const target = getBuildTargetFromRequest( req );
-
-		const pageHtml = renderJsx( 'domains-landing', {
-			...ctx,
-			entrypoint: getFilesForEntrypoint( target, 'entry-domains-landing' ),
-		} );
+		const pageHtml = renderJsx( 'domains-landing', ctx );
 		res.send( pageHtml );
 	} );
 
-	function handleSectionPath( section, sectionPath, isEntrypoint = false ) {
+	function handleSectionPath( section, sectionPath, entrypoint ) {
 		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get( pathRegex, function( req, res, next ) {
-			req.context = Object.assign( {}, req.context, { sectionName: section.name } );
+			req.context = getDefaultContext( req, entrypoint );
+			req.context.sectionName = section.name;
 
-			if ( ! isEntrypoint && config.isEnabled( 'code-splitting' ) ) {
+			if ( ! entrypoint && config.isEnabled( 'code-splitting' ) ) {
 				req.context.chunkFiles = getFilesForChunk( section.name, req );
 			} else {
 				req.context.chunkFiles = EMPTY_ASSETS;
@@ -800,20 +795,9 @@ module.exports = function() {
 			}
 		} );
 
-	function loginRouteSetup( req, res, next ) {
-		req.context = getDefaultContext( req );
-		const target = getBuildTargetFromRequest( req );
-		req.context.entrypoint = getFilesForEntrypoint( target, 'entry-login' );
-		setUpCSP( req, res, () =>
-			req.context.isLoggedIn
-				? setUpLoggedInRoute( req, res, next )
-				: setUpLoggedOutRoute( req, res, next )
-		);
-	}
-
 	// Set up login routing.
-	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', true );
-	loginRouter( serverRouter( app, loginRouteSetup, null ) );
+	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
+	loginRouter( serverRouter( app, setUpRoute, null ) );
 
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers
 	app.post(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,6 +187,7 @@ const webpackConfig = {
 		'entry-main': [ path.join( __dirname, 'client', 'boot', 'app' ) ],
 		'entry-domains-landing': [ path.join( __dirname, 'client', 'landing', 'domains' ) ],
 		'entry-login': [ path.join( __dirname, 'client', 'landing', 'login' ) ],
+		'entry-gutenbearding': [ path.join( __dirname, 'client', 'landing', 'gutenbearding' ) ],
 	},
 	mode: isDevelopment ? 'development' : 'production',
 	devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),


### PR DESCRIPTION
Experiment to add a Guteboarding entrypoint.

First commit is a preparatory refactoring of the rather chaotic server-side code that creates Express.js route handlers for entrypoints and sections and sends along the right JS and CSS webpack chunks. I'll land this as a separate PR.

Second commit adds a `style-bare.scss` stylesheet with just the CSS resets and color schemes, without Calypso-opinionated styles.

Third commit adds the actual entrypoint. To not conflict with the existing `/gutenboarding` section, I call it `/gutenbearding` 🧔🏻. It renders the same `<Gutenboard />` component. There is no Redux at all in this entrypoint, it just bootstraps the user (so that `user.get()` returns the logged-in user) and then renders a React component. It also doesn't use the Calypso `<Layout>` component. Renders directly into the `wpcom` div.

One thing that doesn't work is the loading placeholder that server sends and browser displays while JS is loading. It's unstyled, because its styles are part of the Calypso-opinionated `main` stylesheet.

