### PR TITLE
Product selector use displayJetpackPlans

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -430,8 +430,9 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { intervalType, isAtomicSite, isInSignup, isJetpack } = this.props;
-		if ( ( ! isInSignup && ! isJetpack ) || isAtomicSite ) {
+		const { intervalType, displayJetpackPlans } = this.props;
+
+		if ( ! displayJetpackPlans ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Lets rely on the `displayJetpackPlans` prompt to determine when the products should show up or not. 

#### Testing instructions
* Go to http://calypso.localhost:3000/jetpack/connect/store 
Notice that the product shows up here. 

* Go to http://calypso.localhost:3000/start/plans
Notice that the products are not there. 

* Go to http://calypso.localhost:3000/plans
Notice that the products are there. 

Fixes Products showing up in the /start/plans page
