### PR TITLE
Add support for different descriptions based on purchased product option

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -56,19 +56,19 @@ The following props can be passed to the Product Selector block:
 	Each key is a product slug, and the value is the corresponding copy. Example:
 		```
 		optionDescriptions: {
-			jetpack_backup_daily: __( 'Looking for more? Get unlimited real-time backup archives' ),
-			jetpack_backup_daily_monthly: __( 'Looking for more? Get unlimited real-time backup archives' ),
-			jetpack_backup_realtime: __( 'Your changes are saved as you edit and you have unlimited backup archives' ),
-			jetpack_backup_realtime_monthly: __( 'Your changes are saved as you edit and you have unlimited backup archives' ),
+			jetpack_backup_daily: translate( 'Looking for more? Get unlimited real-time backup archives' ),
+			jetpack_backup_daily_monthly: translate( 'Looking for more? Get unlimited real-time backup archives' ),
+			jetpack_backup_realtime: translate( 'Your changes are saved as you edit and you have unlimited backup archives' ),
+			jetpack_backup_realtime_monthly: translate( 'Your changes are saved as you edit and you have unlimited backup archives' ),
 		}
 		```
 	* `optionNames`: ( object ) Optional names of the product options. Each key is a product slug, and the value is the corresponding title. Example:
 		```
 		optionsNames: {
-			jetpack_backup_daily: __( 'Daily Backups' ),
-			jetpack_backup_daily_monthly: __( 'Daily Backups' ),
-			jetpack_backup_realtime: __( 'Real-Time Backups' ),
-			jetpack_backup_realtime_monthly: __( 'Real-Time Backups' ),
+			jetpack_backup_daily: 'Daily Backups',
+			jetpack_backup_daily_monthly: 'Daily Backups',
+			jetpack_backup_realtime: 'Real-Time Backups',
+			jetpack_backup_realtime_monthly: 'Real-Time Backups',
 		}
 		```
 	* `optionsLabel`: ( string ) Title of the product options section.

--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -51,22 +51,24 @@ The following props can be passed to the Product Selector block:
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
 		}
 		```
-	* `optionDescriptions`: ( object ) Optional descriptions of the product options. Each key is a product slug, and the value is the corresponding copy. Example:
+	* `optionDescriptions`: ( object ) Optional descriptions for the product options.
+	They replace a default `description` in case a given option (represented by the object's key) has been purchased.
+	Each key is a product slug, and the value is the corresponding copy. Example:
 		```
 		optionDescriptions: {
-			jetpack_backup_daily: 'Looking for more? With Real-time backups, we save as you edit and you’ll get unlimited backup archives',
-			jetpack_backup_daily_monthly: 'Looking for more? With Real-time backups, we save as you edit and you’ll get unlimited backup archives',
-			jetpack_backup_realtime: 'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives',
-			jetpack_backup_realtime_monthly: 'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives',
+			jetpack_backup_daily: __( 'Looking for more? Get unlimited real-time backup archives' ),
+			jetpack_backup_daily_monthly: __( 'Looking for more? Get unlimited real-time backup archives' ),
+			jetpack_backup_realtime: __( 'Your changes are saved as you edit and you have unlimited backup archives' ),
+			jetpack_backup_realtime_monthly: __( 'Your changes are saved as you edit and you have unlimited backup archives' ),
 		}
 		```
 	* `optionNames`: ( object ) Optional names of the product options. Each key is a product slug, and the value is the corresponding title. Example:
 		```
 		optionsNames: {
-			jetpack_backup_daily: 'Daily Backups',
-			jetpack_backup_daily_monthly: 'Daily Backups',
-			jetpack_backup_realtime: 'Real-Time Backups',
-			jetpack_backup_realtime_monthly: 'Real-Time Backups',
+			jetpack_backup_daily: __( 'Daily Backups' ),
+			jetpack_backup_daily_monthly: __( 'Daily Backups' ),
+			jetpack_backup_realtime: __( 'Real-Time Backups' ),
+			jetpack_backup_realtime_monthly: __( 'Real-Time Backups' ),
 		}
 		```
 	* `optionsLabel`: ( string ) Title of the product options section.

--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -51,6 +51,15 @@ The following props can be passed to the Product Selector block:
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
 		}
 		```
+	* `optionDescriptions`: ( object ) Optional descriptions of the product options. Each key is a product slug, and the value is the corresponding copy. Example:
+		```
+		optionDescriptions: {
+			jetpack_backup_daily: 'Looking for more? With Real-time backups, we save as you edit and you’ll get unlimited backup archives',
+			jetpack_backup_daily_monthly: 'Looking for more? With Real-time backups, we save as you edit and you’ll get unlimited backup archives',
+			jetpack_backup_realtime: 'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives',
+			jetpack_backup_realtime_monthly: 'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives',
+		}
+		```
 	* `optionNames`: ( object ) Optional names of the product options. Each key is a product slug, and the value is the corresponding title. Example:
 		```
 		optionsNames: {

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -16,39 +16,13 @@ const products = [
 		description: (
 			<p>
 				Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{' '}
-				<a href="https://jetpack.com/">Which one do I need?</a>
+				<a href="https://jetpack.com/upgrade/backup/">Which one do I need?</a>
 			</p>
 		),
 		id: 'jetpack_backup',
 		options: {
 			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
-		},
-		optionDescriptions: {
-			jetpack_backup_daily: (
-				<p>
-					<strong>Looking for more?</strong> With Real-time backups, we save as you edit and you’ll
-					get unlimited backup archives
-				</p>
-			),
-			jetpack_backup_daily_monthly: (
-				<p>
-					<strong>Looking for more?</strong> With Real-time backups, we save as you edit and you’ll
-					get unlimited backup archives
-				</p>
-			),
-			jetpack_backup_realtime: (
-				<p>
-					Always-on backups ensure you never lose your site. Your changes are saved as you edit and
-					you have unlimited backup archives
-				</p>
-			),
-			jetpack_backup_realtime_monthly: (
-				<p>
-					Always-on backups ensure you never lose your site. Your changes are saved as you edit and
-					you have unlimited backup archives
-				</p>
-			),
 		},
 		optionNames: {
 			jetpack_backup_daily: 'Daily Backups',

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -15,14 +15,40 @@ const products = [
 		title: 'Jetpack Backup',
 		description: (
 			<p>
-				Automatic scanning and one-click fixes keep your site one step ahead of security threats.{' '}
-				<a href="https://jetpack.com/">More info</a>
+				Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{' '}
+				<a href="https://jetpack.com/">Which one do I need?</a>
 			</p>
 		),
 		id: 'jetpack_backup',
 		options: {
 			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
 			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
+		},
+		optionDescriptions: {
+			jetpack_backup_daily: (
+				<p>
+					<strong>Looking for more?</strong> With Real-time backups, we save as you edit and you’ll
+					get unlimited backup archives
+				</p>
+			),
+			jetpack_backup_daily_monthly: (
+				<p>
+					<strong>Looking for more?</strong> With Real-time backups, we save as you edit and you’ll
+					get unlimited backup archives
+				</p>
+			),
+			jetpack_backup_realtime: (
+				<p>
+					Always-on backups ensure you never lose your site. Your changes are saved as you edit and
+					you have unlimited backup archives
+				</p>
+			),
+			jetpack_backup_realtime_monthly: (
+				<p>
+					Always-on backups ensure you never lose your site. Your changes are saved as you edit and
+					you have unlimited backup archives
+				</p>
+			),
 		},
 		optionNames: {
 			jetpack_backup_daily: 'Daily Backups',

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -85,7 +85,7 @@ export class ProductSelector extends Component {
 		const { description, optionDescriptions } = product;
 		const purchase = this.getPurchaseByProduct( product );
 
-		if ( ! purchase || ! optionDescriptions ) {
+		if ( ! purchase || ! optionDescriptions || ! optionDescriptions[ purchase.productSlug ] ) {
 			return description;
 		}
 

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -81,6 +81,17 @@ export class ProductSelector extends Component {
 		} );
 	}
 
+	getDescriptionByProduct( product ) {
+		const { description, optionDescriptions } = product;
+		const purchase = this.getPurchaseByProduct( product );
+
+		if ( ! purchase || ! optionDescriptions ) {
+			return description;
+		}
+
+		return optionDescriptions[ purchase.productSlug ];
+	}
+
 	getProductName( product, productSlug ) {
 		if ( product.optionNames && product.optionNames[ productSlug ] ) {
 			return product.optionNames[ productSlug ];
@@ -207,7 +218,7 @@ export class ProductSelector extends Component {
 					billingTimeFrame={ this.getBillingTimeFrameLabel() }
 					fullPrice={ this.getProductOptionFullPrice( selectedProductSlug ) }
 					discountedPrice={ this.getProductOptionDiscountedPrice( selectedProductSlug ) }
-					description={ product.description }
+					description={ this.getDescriptionByProduct( product ) }
 					currencyCode={ currencyCode }
 					purchase={ purchase }
 					subtitle={ this.getSubtitleByProduct( product ) }
@@ -253,6 +264,7 @@ ProductSelector.propTypes = {
 			id: PropTypes.string,
 			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 			options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
+			optionDescriptions: PropTypes.objectOf( [ PropTypes.string, PropTypes.element ] ),
 			optionsLabel: PropTypes.string,
 		} )
 	).isRequired,

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
@@ -24,6 +29,33 @@ export const JETPACK_BACKUP_PRODUCT_NAMES = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 'Daily Backups',
 	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 'Real-Time Backups',
 	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 'Real-Time Backups',
+};
+
+// @TODO: Translate those strings once we have confirmed the copy.
+export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = (
+	<p>
+		Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{' '}
+		<a href="https://jetpack.com/">Which one do I need?</a>
+	</p>
+);
+export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = (
+	<p>
+		<strong>Looking for more?</strong> With Real-time backups, we save as you edit and you’ll get
+		unlimited backup archives
+	</p>
+);
+export const PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION = (
+	<p>
+		Always-on backups ensure you never lose your site. Your changes are saved as you edit and you
+		have unlimited backup archives
+	</p>
+);
+
+export const JETPACK_BACKUP_PRODUCT_DESCRIPTIONS = {
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION,
+	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION,
 };
 
 export const JETPACK_PRODUCT_PRICE_MATRIX = {

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -35,19 +35,19 @@ export const JETPACK_BACKUP_PRODUCT_NAMES = {
 export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = (
 	<p>
 		Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{' '}
-		<a href="https://jetpack.com/">Which one do I need?</a>
+		<a href="https://jetpack.com/upgrade/backup/">Which one do I need?</a>
 	</p>
 );
 export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = (
 	<p>
 		<strong>Looking for more?</strong> With Real-time backups, we save as you edit and you’ll get
-		unlimited backup archives
+		unlimited backup archives.
 	</p>
 );
 export const PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION = (
 	<p>
 		Always-on backups ensure you never lose your site. Your changes are saved as you edit and you
-		have unlimited backup archives
+		have unlimited backup archives.
 	</p>
 );
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -28,11 +28,13 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 import {
+	JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
 	JETPACK_BACKUP_PRODUCT_NAMES,
 	JETPACK_BACKUP_PRODUCTS_MONTHLY,
 	JETPACK_BACKUP_PRODUCTS_YEARLY,
 	JETPACK_PRODUCT_PRICE_MATRIX,
 	PRODUCT_JETPACK_BACKUP,
+	PRODUCT_JETPACK_BACKUP_DESCRIPTION,
 } from 'lib/products-values/constants';
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
@@ -78,16 +80,14 @@ import './style.scss';
 const jetpackProducts = [
 	{
 		title: 'Jetpack Backup',
-		description: (
-			<p>
-				Automatic scanning and one-click fixes keep your site one step ahead of security threats.{' '}
-				<a href="https://jetpack.com/">More info</a>
-			</p>
-		),
+		description: PRODUCT_JETPACK_BACKUP_DESCRIPTION,
 		id: PRODUCT_JETPACK_BACKUP,
 		options: {
 			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
 			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
+		},
+		optionDescriptions: {
+			...JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
 		},
 		optionNames: {
 			...JETPACK_BACKUP_PRODUCT_NAMES,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for different descriptions based on purchased product option

Before purchase:
![Screenshot 2019-10-25 at 17 52 40](https://user-images.githubusercontent.com/478735/67585737-7b531e80-f750-11e9-9712-7a5ebe08165c.png)

With Daily option:
<img width="541" alt="Screenshot 2019-10-25 at 17 53 00" src="https://user-images.githubusercontent.com/478735/67585753-8312c300-f750-11e9-8d95-4752791652a9.png">

With Real-Time option:
![Screenshot 2019-10-25 at 17 54 01](https://user-images.githubusercontent.com/478735/67585768-88700d80-f750-11e9-8da8-e8380a7e72a9.png)

#### Testing instructions

* Checkout this branch
* Go to http://calypso.localhost:3000/plans
* Select a site that has no Backup product purchased
* Confirm that the description matches the Figma designs
* Purchase the Daily option and return to Plans page - confirm that the description matches the Figma designs
* Remove the subscription and purchase Real-Time option. On Plans page confirm that the description matches the Figma designs

Fixes n/a