### PR TITLE
Fixing styles on the Crowdsignal signup/in page.

### DIFF
--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -18,8 +18,9 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup.is-crowdsignal {
 	// Crowdsignal color palette
-	--color-link: #384869;
-	--color-text: #384869;
+	--color-link: #001d2d;
+	--color-text: #001d2d;
+	--color-link-hover: #4ccee4;
 
 	.formatted-header {
 		color: var( --color-text );
@@ -49,10 +50,11 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal {
 	// Crowdsignal color palette
-	--color-accent: #fb5457;
-	--color-crowdsignal: #384869;
-	--color-link: #384869;
-	--color-text: #384869;
+	--color-accent: #bd4682;
+	--color-accent-dark: #8d2259;
+	--color-crowdsignal: #001D2D;
+	--color-link: #001d2d;
+	--color-text: #001d2d;
 
 	color: var( --color-text );
 	font-family: 'Muli', $sans;
@@ -63,6 +65,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		box-sizing: border-box;
 		font-family: 'Muli', $sans;
 		padding: 12px 20px;
+
+		&.is-primary {
+			border: 1px solid var( --color-accent-dark );
+		}
 	}
 }
 
@@ -103,6 +109,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		font-weight: normal;
 		letter-spacing: 0.5px;
 		width: 100%;
+		// !important is necessary to get the shadows to match on all buttons
+		box-shadow: 0 2px 3px 0 var( --color-neutral-10 ) !important;
 	}
 
 	.card {
@@ -124,6 +132,18 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 	.signup-form__social {
 		padding: 0;
+
+		p {
+			color: var( --color-text );
+		}
+
+		a {
+			color: var( --color-link );
+
+			&:hover {
+				color: var( --color-link-hover );
+			}
+		}
 	}
 }
 
@@ -189,7 +209,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	background-color: var( --color-crowdsignal );
 	color: var( --color-text-inverted );
 	text-align: center;
-	margin-bottom: 0;
+	margin: 20px 0 0;
 
 	@include breakpoint( '>660px' ) {
 		display: none;
@@ -255,7 +275,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	padding: 0;
 
 	&:hover {
-		color: var( --color-text );
+		color: var( --color-link-hover );
 	}
 
 	.signup-form__crowdsignal-back-button-wrapper.is-first-step & {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -89,10 +89,10 @@
 
 .crowdsignal {
 	// Crowdsignal color palette
-	--color-accent: #fb5457;
-	--color-crowdsignal: #384869;
-	--color-link: #384869;
-	--color-text: #384869;
+	--color-accent: #bd4682;
+	--color-crowdsignal: #001d2d;
+	--color-link: #001d2d;
+	--color-text: #001d2d;
 
 	background: #f2f2f2;
 	color: var( --color-text );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the styles on the Crowdsignal signup page to use new colors and fix some display issues caused by the addition of the "Sign in with Apple" feature.

I changed the following:

- Changed values of some color variables.
- Added border to `primary` buttons.
- Enforced a shadow on all of the buttons on the form (Had to use an `!important` to accomplish this 😢)
- Fixed the white text that showed when in the mobile view.

Before:
<img width="1159" alt="Screen Shot 2019-10-25 at 11 25 57 AM" src="https://user-images.githubusercontent.com/789137/67592114-1d0c4880-f71c-11e9-9be0-b51df2b50ead.png">
<img width="465" alt="Screen Shot 2019-10-25 at 11 26 07 AM" src="https://user-images.githubusercontent.com/789137/67592115-1d0c4880-f71c-11e9-9bca-025196b753cf.png">

After:
<img width="1179" alt="Screen Shot 2019-10-25 at 11 20 20 AM" src="https://user-images.githubusercontent.com/789137/67592128-285f7400-f71c-11e9-9815-fbb0e9524f0a.png">
<img width="445" alt="Screen Shot 2019-10-25 at 11 20 06 AM" src="https://user-images.githubusercontent.com/789137/67592129-285f7400-f71c-11e9-866c-104b9abbdca2.png">


#### Testing instructions

Visit [this link](https://hash-a7b138e976d89ef6ae171e1a8f2b1ba7d523e3ed.calypso.live/start/crowdsignal/oauth2-name?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D5b545e09c751f6e6a85f894b7e72f7dadc4caa11844feaf457fd7d01b0d5cc07%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dsignup%2526action%253Drequest_access_token%26wpcom_connect%3D1%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login&oauth2_client_id=978) and verify the buttons have the new Crowdsignal coloring, and that the signup form still works!
