### PR TITLE
WP Migration: Add tools/migration menu

### DIFF
--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -3,13 +3,19 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal Dependencies
  */
 import SectionMigrate from 'my-sites/migrate/section-migrate';
+import { isEnabled } from 'config';
 
 export function migrateSite( context, next ) {
-	context.primary = <SectionMigrate />;
-	next();
+	if ( isEnabled( 'tools/migrate' ) ) {
+		context.primary = <SectionMigrate />;
+		return next();
+	}
+
+	page.redirect( '/' );
 }

--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -1,0 +1,15 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import SectionMigrate from 'my-sites/migrate/section-migrate';
+
+export function migrateSite( context, next ) {
+	context.primary = <SectionMigrate />;
+	next();
+}

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -1,0 +1,26 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { migrateSite } from 'my-sites/migrate/controller';
+import { makeLayout, render as clientRender } from 'controller';
+import { navigation, redirectWithoutSite, sites, siteSelection } from 'my-sites/controller';
+
+export default function() {
+	page( '/migrate', siteSelection, navigation, sites, makeLayout, clientRender );
+
+	page(
+		'/migrate/:site_id',
+		siteSelection,
+		navigation,
+		redirectWithoutSite( '/migrate' ),
+		migrateSite,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -24,7 +24,7 @@ import './section-migrate.scss';
 
 class SectionMigrate extends Component {
 	state = {
-		sourceSite: null,
+		sourceSiteId: null,
 	};
 
 	jetpackSiteFilter = sourceSite => {

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
@@ -20,6 +21,16 @@ import SiteSelector from 'components/site-selector';
 import './section-migrate.scss';
 
 class SectionMigrate extends Component {
+	state = {
+		sourceSite: null,
+	};
+
+	setSourceSite = site => {
+		this.setState( {
+			sourceSite: site,
+		} );
+	};
+
 	jetpackSiteFilter( site ) {
 		return site.jetpack;
 	}
@@ -39,7 +50,15 @@ class SectionMigrate extends Component {
 					subHeaderText={ subHeaderText }
 				/>
 				<CompactCard className="migrate__card">
-					<SiteSelector filter={ this.jetpackSiteFilter } />
+					<SiteSelector
+						className="migrate__source-site"
+						selected={ this.state.sourceSite }
+						onSiteSelect={ this.setSourceSite }
+						filter={ this.jetpackSiteFilter }
+					/>
+					<Button primary disabled={ ! this.state.sourceSite }>
+						{ translate( 'Migrate' ) }
+					</Button>
 				</CompactCard>
 			</Main>
 		);

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSelector from 'components/site-selector';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Style dependencies
@@ -25,15 +27,17 @@ class SectionMigrate extends Component {
 		sourceSite: null,
 	};
 
-	setSourceSite = site => {
-		this.setState( {
-			sourceSite: site,
-		} );
+	jetpackSiteFilter = sourceSite => {
+		const { siteId } = this.props;
+
+		return sourceSite.jetpack && sourceSite.ID !== siteId;
 	};
 
-	jetpackSiteFilter( site ) {
-		return site.jetpack;
-	}
+	setSourceSiteId = sourceSiteId => {
+		this.setState( {
+			sourceSiteId,
+		} );
+	};
 
 	render() {
 		const { translate } = this.props;
@@ -52,11 +56,11 @@ class SectionMigrate extends Component {
 				<CompactCard className="migrate__card">
 					<SiteSelector
 						className="migrate__source-site"
-						selected={ this.state.sourceSite }
-						onSiteSelect={ this.setSourceSite }
+						selected={ this.state.sourceSiteId }
+						onSiteSelect={ this.setSourceSiteId }
 						filter={ this.jetpackSiteFilter }
 					/>
-					<Button primary disabled={ ! this.state.sourceSite }>
+					<Button primary disabled={ ! this.state.sourceSiteId }>
 						{ translate( 'Migrate' ) }
 					</Button>
 				</CompactCard>
@@ -65,4 +69,6 @@ class SectionMigrate extends Component {
 	}
 }
 
-export default localize( SectionMigrate );
+export default connect( state => ( {
+	siteId: getSelectedSiteId( state ),
+} ) )( localize( SectionMigrate ) );

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import SiteSelector from 'components/site-selector';
+
+/**
+ * Style dependencies
+ */
+import './section-migrate.scss';
+
+class SectionMigrate extends Component {
+	jetpackSiteFilter( site ) {
+		return site.jetpack;
+	}
+
+	render() {
+		const { translate } = this.props;
+		const headerText = translate( 'Migrate' );
+		const subHeaderText = translate( 'Migrate your WordPress site to WordPress.com' );
+
+		return (
+			<Main>
+				<DocumentHead title={ translate( 'Migrate' ) } />
+				<SidebarNavigation />
+				<FormattedHeader
+					className="migrate__section-header"
+					headerText={ headerText }
+					subHeaderText={ subHeaderText }
+				/>
+				<CompactCard className="migrate__card">
+					<SiteSelector filter={ this.jetpackSiteFilter } />
+				</CompactCard>
+			</Main>
+		);
+	}
+}
+
+export default localize( SectionMigrate );

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -1,3 +1,9 @@
 .migrate__card {
 	min-height: 400px;
 }
+
+.migrate__source-site {
+	max-height: 400px;
+	overflow: scroll;
+	margin-bottom: 16px;
+}

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -3,7 +3,5 @@
 }
 
 .migrate__source-site {
-	max-height: 400px;
-	overflow: scroll;
 	margin-bottom: 16px;
 }

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -1,0 +1,3 @@
+.migrate__card {
+	min-height: 400px;
+}

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -232,6 +232,30 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	trackMigrateClick = () => {
+		this.trackMenuItemClick( 'migrate' );
+		this.onNavigate();
+	};
+
+	migrate() {
+		const { path, siteSuffix, translate } = this.props;
+
+		if ( ! isEnabled( 'tools/migrate' ) ) {
+			return null;
+		}
+
+		return (
+			<SidebarItem
+				label={ translate( 'Migrate' ) }
+				selected={ itemLinkMatches( '/migrate', path ) }
+				link={ `/migrate${ siteSuffix }` }
+				onNavigate={ this.trackMigrateClick }
+				tipTarget="migrate"
+				expandSection={ this.expandToolsSection }
+			/>
+		);
+	}
+
 	trackCustomizeClick = () => {
 		this.trackMenuItemClick( 'customize' );
 		this.onNavigate();
@@ -705,6 +729,7 @@ export class MySitesSidebar extends Component {
 						materialIcon="build"
 					>
 						{ this.tools() }
+						{ this.migrate() }
 						{ this.marketing() }
 						{ this.earn() }
 						{ this.activity() }

--- a/client/sections.js
+++ b/client/sections.js
@@ -435,6 +435,13 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'migrate',
+		paths: [ '/migrate' ],
+		module: 'my-sites/migrate',
+		secondary: true,
+		group: 'sites',
+	},
+	{
 		name: 'devdocs',
 		paths: [ '/devdocs' ],
 		module: 'devdocs',

--- a/config/development.json
+++ b/config/development.json
@@ -155,6 +155,7 @@
 		"signup/wpcc": true,
 		"memberships": true,
 		"support-user": true,
+		"tools/migrate": true,
 		"try/preconnect": true,
 		"try/preload": true,
 		"try/single-cdn": true,


### PR DESCRIPTION
This change is behind a feature-flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Adds a feature-flag (`tools/migrate`)
* Adds "Migrate" under the "Tools" menu in the sidebar
* Adds `/migrate` route
* Adds new page (`SectionMigrate`) at new route
* Adds `SiteSelector` for selection of Jetpack sites on new page

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this pull request and run Calypso locally, or view it on calypso.live with the flag `tools/migrate`.
* Viewing `calypso.localhost:3000/migrate/`, you should see a `SiteSelector` component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another `SiteSelector` component, listing all the Jetpack sites your account has access to. The Tools section in the sidebar should show the new Migrate option.

