### PR TITLE
Site Selector: Fix Private Badge Colours

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -42,10 +42,6 @@
 	&.is-selected {
 		background-color: var( --color-sidebar-menu-selected-background );
 
-		.site__badge {
-			color: var( --color-sidebar-menu-selected-text );
-		}
-
 		.site__title,
 		.site__domain {
 			color: var( --color-sidebar-menu-selected-text );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the pill that appears for private sites in some schemes (notably Classic Blue and Sunset) on hover

**Before:**

![ezgif-6-2ccb0af51c35](https://user-images.githubusercontent.com/43215253/67622433-00523c80-f812-11e9-9171-770d4894eedb.gif)

**After:**

![ezgif-6-3a6e4e67dd0b](https://user-images.githubusercontent.com/43215253/67622441-0fd18580-f812-11e9-954c-ecef2540ac68.gif)

#### Testing instructions

* Visit `/me` and scroll to the Primary Site dropdown on an account with multiple sites
* Hover over a private site (Note: I couldn't actually get the hover shade in the original issue to appear, you might need to manually add the `is-selected` class to `.site`)
* Verify the colours are visible

cc @carinapilar & @sixhours - if I recall correctly, you were involved with this design

Fixes #37024
