### PR TITLE
composite-checkout-wpcom: Checkout component specialized to WPCOM

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -779,7 +779,7 @@ Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
 Undocumented.prototype.getCart = function( cartKey, fn ) {
 	debug( 'GET: /me/shopping-cart/:cart-key' );
 
-	this._sendRequest(
+	return this._sendRequest(
 		{
 			path: '/me/shopping-cart/' + cartKey,
 			method: 'GET',
@@ -798,7 +798,7 @@ Undocumented.prototype.getCart = function( cartKey, fn ) {
 Undocumented.prototype.setCart = function( cartKey, data, fn ) {
 	debug( 'POST: /me/shopping-cart/:cart-key', data );
 
-	this._sendRequest(
+	return this._sendRequest(
 		{
 			path: '/me/shopping-cart/' + cartKey,
 			method: 'POST',

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -52,7 +52,7 @@ export function checkout( context, next ) {
 
 	context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
 
-	if ( config.isEnabled( 'composite-checkout' ) ) {
+	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
 		context.primary = <CompositeCheckoutContainer />;
 		next();
 		return;

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,
+		"composite-checkout-wpcom": false,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,7 +328,6 @@
 		},
 		"@automattic/composite-checkout": {
 			"version": "file:packages/composite-checkout",
-			"dev": true,
 			"requires": {
 				"@emotion/core": "10.0.22",
 				"@emotion/styled": "10.0.23",
@@ -345,7 +344,30 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",
 					"integrity": "sha512-4UlzOLNdbJsZr4JwbTdJjxhedAfalDDtfEYLHEBo0MKG0KgSLRAeIJup0/6NSpKtBLK4ieOMAwvyln9ICOSilQ==",
-					"dev": true,
+					"requires": {
+						"prop-types": "15.7.2"
+					}
+				}
+			}
+		},
+		"@automattic/composite-checkout-wpcom": {
+			"version": "file:packages/composite-checkout-wpcom",
+			"requires": {
+				"@automattic/composite-checkout": "^1.0.0",
+				"@emotion/core": "10.0.22",
+				"@emotion/styled": "10.0.23",
+				"@wordpress/data": "^4.9.2",
+				"emotion-theming": "10.0.19",
+				"i18n-calypso": "^4.0.0",
+				"prop-types": "^15.7.2",
+				"react": "^16.8.6",
+				"react-stripe-elements": "^5.1.0"
+			},
+			"dependencies": {
+				"react-stripe-elements": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",
+					"integrity": "sha512-4UlzOLNdbJsZr4JwbTdJjxhedAfalDDtfEYLHEBo0MKG0KgSLRAeIJup0/6NSpKtBLK4ieOMAwvyln9ICOSilQ==",
 					"requires": {
 						"prop-types": "15.7.2"
 					}
@@ -25340,6 +25362,16 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
 			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
 		},
+		"source-map-loader": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+			"integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+			"dev": true,
+			"requires": {
+				"async": "^2.5.0",
+				"loader-utils": "^1.1.0"
+			}
+		},
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
@@ -27223,6 +27255,96 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+		},
+		"ts-loader": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
+			"integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.3.0",
+				"enhanced-resolve": "^4.0.0",
+				"loader-utils": "^1.0.2",
+				"micromatch": "^4.0.0",
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
+			}
 		},
 		"tslib": {
 			"version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"@automattic/color-studio": "2.2.0",
 		"@automattic/components": "file:./packages/components",
 		"@automattic/composite-checkout": "file:./packages/composite-checkout",
+		"@automattic/composite-checkout-wpcom": "file:./packages/composite-checkout-wpcom",
 		"@automattic/format-currency": "file:./packages/format-currency",
 		"@automattic/load-script": "file:./packages/load-script",
 		"@automattic/material-design-icons": "file:./packages/material-design-icons",
@@ -294,7 +295,8 @@
 		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",
 		"whybundled": "whybundled stats.json",
-		"composite-checkout-demo": "webpack-dev-server --config ./packages/composite-checkout/webpack.config.demo.js --mode development"
+		"composite-checkout-demo": "webpack-dev-server --config ./packages/composite-checkout/webpack.config.demo.js --mode development",
+		"composite-checkout-wpcom-demo": "webpack-dev-server --config ./packages/composite-checkout-wpcom/webpack.config.demo.js --mode development"
 	},
 	"devDependencies": {
 		"@automattic/babel-plugin-i18n-calypso": "file:./packages/babel-plugin-i18n-calypso",
@@ -376,11 +378,13 @@
 		"sinon": "7.4.2",
 		"sinon-chai": "3.3.0",
 		"socket.io": "2.3.0",
+		"source-map-loader": "0.2.4",
 		"stackframe": "1.1.0",
 		"stacktrace-gps": "3.0.3",
 		"stylelint": "9.10.1",
 		"supertest": "3.4.2",
 		"svgstore-cli": "1.3.1",
+		"ts-loader": "6.2.1",
 		"typescript": "3.7.2",
 		"webpack": "4.41.2",
 		"webpack-cli": "3.3.10",

--- a/packages/composite-checkout-wpcom/.gitignore
+++ b/packages/composite-checkout-wpcom/.gitignore
@@ -1,0 +1,2 @@
+/* TypeScript generated files */
+*.d.ts

--- a/packages/composite-checkout-wpcom/README.md
+++ b/packages/composite-checkout-wpcom/README.md
@@ -1,0 +1,4 @@
+composite-checkout-wpcom
+========================
+
+

--- a/packages/composite-checkout-wpcom/demo/index.html
+++ b/packages/composite-checkout-wpcom/demo/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Checkout Sample</title>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<style>
+		body {
+			margin: 0;
+			padding: 0;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+			-webkit-font-smoothing: antialiased;
+			-moz-osx-font-smoothing: grayscale;
+			background: #F3F4F5;
+		}
+	</style>
+</head>
+
+<body>
+	<div id="root"></div>
+	<noscript>
+		You need to enable JavaScript to run this app.
+	</noscript>
+	<script src="../dist/bundle-wpcom.js"></script>
+</body>
+
+</html>

--- a/packages/composite-checkout-wpcom/demo/index.jsx
+++ b/packages/composite-checkout-wpcom/demo/index.jsx
@@ -1,18 +1,21 @@
+require( '@babel/polyfill' );
+
 /**
  * External dependencies
  */
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { createRegistry, createPayPalMethod } from '@automattic/composite-checkout';
-import {
-	WPCOMCheckout,
-	makeShoppingCartHook,
-	mockPayPalExpressRequest,
-} from '@automattic/composite-checkout-wpcom';
 
 /**
  * Internal dependencies
  */
-import wp from 'lib/wp';
+import {
+	WPCOMCheckout,
+	makeShoppingCartHook,
+	mockCartEndpoint,
+	mockPayPalExpressRequest,
+} from '../src/index';
 
 const initialCart = {
 	coupon: '',
@@ -29,14 +32,14 @@ const initialCart = {
 				registrar: 'KS_RAM',
 			},
 			free_trial: false,
-			meta: 'asdkfjalsdkjfalsdjkflaksdjflkajsdfffd.com',
+			meta: 'foo.cash',
 			product_id: 106,
 			volume: 1,
 		},
 		{
 			extra: {
 				context: 'signup',
-				domain_to_bundle: 'asdkfjalsdkjfalsdjkflaksdjflkajsdfffd.com',
+				domain_to_bundle: 'foo.cash',
 			},
 			free_trial: false,
 			meta: '',
@@ -54,14 +57,9 @@ const initialCart = {
 const registry = createRegistry();
 const { registerStore } = registry;
 
-const wpcom = wp.undocumented();
+const useShoppingCart = makeShoppingCartHook( mockCartEndpoint, initialCart );
 
-const useShoppingCart = makeShoppingCartHook(
-	( cartKey, cartParam ) => wpcom.setCart( cartKey, cartParam ),
-	initialCart
-);
-
-export default function CompositeCheckoutContainer() {
+function App() {
 	return (
 		<WPCOMCheckout
 			useShoppingCart={ useShoppingCart }
@@ -75,3 +73,5 @@ export default function CompositeCheckoutContainer() {
 		/>
 	);
 }
+
+ReactDOM.render( <App />, document.getElementById( 'root' ) );

--- a/packages/composite-checkout-wpcom/jest.config.js
+++ b/packages/composite-checkout-wpcom/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rootDir: __dirname,
+	testMatch: [ '**/test/**/*.[jt]s?(x)' ],
+	modulePathIgnorePatterns: [ 'enzyme-adapter.js' ],
+};

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -9,7 +9,8 @@
 	"scripts": {
 		"clean": "npx rimraf dist types",
 		"prepublish": "npm run clean",
-		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json"
+		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
+		"typecheck": "tsc --project ./tsconfig.json --noEmit"
 	},
 	"files": [
 		"dist",

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@automattic/composite-checkout-wpcom",
+	"version": "1.0.0",
+	"description": "A checkout component for WordPress.com",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"types": "types/types.d.ts",
+	"sideEffects": false,
+	"scripts": {
+		"clean": "npx rimraf dist types",
+		"prepublish": "npm run clean",
+		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json"
+	},
+	"files": [
+		"dist",
+		"src",
+		"types"
+	],
+	"keywords": [
+		"checkout",
+		"payments",
+		"automattic"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/composite-checkout-wpcom"
+	},
+	"author": "Automattic Inc.",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/composite-checkout-wpcom#readme",
+	"dependencies": {
+		"@automattic/composite-checkout": "^1.0.0",
+		"@emotion/core": "10.0.22",
+		"@emotion/styled": "10.0.23",
+		"@wordpress/data": "^4.9.2",
+		"emotion-theming": "10.0.19",
+		"i18n-calypso": "^4.0.0",
+		"prop-types": "^15.7.2",
+		"react": "^16.8.6",
+		"react-stripe-elements": "^5.1.0"
+	},
+	"private": true
+}

--- a/packages/composite-checkout-wpcom/src/components/checkout.jsx
+++ b/packages/composite-checkout-wpcom/src/components/checkout.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Checkout, CheckoutProvider, WPCheckoutOrderSummary } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import { OrderReview } from './order-review';
+
+// These are used only for non-redirect payment methods
+// TODO: write this
+const onSuccess = () => alert( 'Payment succeeded!' );
+const onFailure = error => alert( 'There was a problem with your payment' + error );
+
+// These are used only for redirect payment methods
+const successRedirectUrl = window.location.href;
+const failureRedirectUrl = window.location.href;
+
+// Called when the store is changed.
+const handleCheckoutEvent = select => () => {
+	// TODO: write this
+	alert( `handleCheckoutEvent: ${ select }` );
+};
+
+// This is the parent component which would be included on a host page
+export function WPCOMCheckout( { useShoppingCart, availablePaymentMethods, registry } ) {
+	const { itemsWithTax, total, deleteItem, changePlanLength } = useShoppingCart();
+
+	const { select, subscribe } = registry;
+
+	useEffect( () => {
+		return subscribe( handleCheckoutEvent( select ) );
+	}, [ select, subscribe ] );
+
+	const ReviewContent = () => (
+		<OrderReview
+			items={ itemsWithTax }
+			total={ total }
+			onDeleteItem={ deleteItem }
+			onChangePlanLength={ changePlanLength }
+		/>
+	);
+
+	return (
+		<CheckoutProvider
+			locale={ 'en-us' }
+			items={ itemsWithTax }
+			total={ total }
+			onSuccess={ onSuccess }
+			onFailure={ onFailure }
+			successRedirectUrl={ successRedirectUrl }
+			failureRedirectUrl={ failureRedirectUrl }
+			paymentMethods={ availablePaymentMethods }
+			registry={ registry }
+		>
+			<Checkout OrderSummary={ WPCheckoutOrderSummary } ReviewContent={ ReviewContent } />
+		</CheckoutProvider>
+	);
+}
+
+WPCOMCheckout.propTypes = {
+	availablePaymentMethods: PropTypes.arrayOf( PropTypes.object ).isRequired,
+	useShoppingCart: PropTypes.func.isRequired,
+	registry: PropTypes.object.isRequired,
+};

--- a/packages/composite-checkout-wpcom/src/components/items.jsx
+++ b/packages/composite-checkout-wpcom/src/components/items.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { renderDisplayValueMarkdown } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+
+export function PlanItem( { item, onDeleteItem, onChangePlanLength } ) {
+	const translate = useTranslate();
+	const changePlanLength = planLength => onChangePlanLength( item, planLength );
+	const deleteItem = () => onDeleteItem( item );
+	const itemSpanId = `checkout-line-item-${ item.wpcom_meta.uuid }`;
+	return (
+		<React.Fragment>
+			<div>
+				<span>
+					<div id={ itemSpanId }>{ item.label }</div>
+					{ item.subLabel && <div>{ item.subLabel }</div> }
+				</span>
+				<span aria-labelledby={ itemSpanId }>
+					{ renderDisplayValueMarkdown( item.amount.displayValue ) }
+				</span>
+				<button onClick={ deleteItem }>{ translate( 'Delete' ) }</button>
+			</div>
+			<PlanLengthSelector onChange={ changePlanLength } />
+		</React.Fragment>
+	);
+}
+
+export function DomainItem( { item, onDeleteItem } ) {
+	const translate = useTranslate();
+	const deleteItem = () => onDeleteItem( item );
+	const itemSpanId = `checkout-line-item-${ item.wpcom_meta.uuid }`;
+	return (
+		<div>
+			<span>
+				<div id={ itemSpanId }>{ item.label }</div>
+				{ item.subLabel && <div>{ item.subLabel }</div> }
+			</span>
+			<span aria-labelledby={ itemSpanId }>
+				{ renderDisplayValueMarkdown( item.amount.displayValue ) }
+			</span>
+			<button onClick={ deleteItem }>{ translate( 'Delete' ) }</button>
+		</div>
+	);
+}
+
+export function TaxItem( { item } ) {
+	const taxSpanId = 'checkout-tax-line-item';
+	return (
+		<div>
+			<span>
+				<div id={ taxSpanId }>{ item.label }</div>
+				{ item.subLabel && <div>{ item.subLabel }</div> }
+			</span>
+			<span aria-labelledby={ taxSpanId }>
+				{ renderDisplayValueMarkdown( item.amount.displayValue ) }
+			</span>
+		</div>
+	);
+}
+
+function PlanLengthSelector() {
+	return <span>TODO</span>;
+}

--- a/packages/composite-checkout-wpcom/src/components/order-review.jsx
+++ b/packages/composite-checkout-wpcom/src/components/order-review.jsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { OrderReviewLineItems, OrderReviewTotal } from '@automattic/composite-checkout';
+
+import { PlanItem, DomainItem, TaxItem } from './items';
+
+export function OrderReview( { items, total, onDeleteItem, onChangePlanLength } ) {
+	return (
+		<React.Fragment>
+			{ partitionItems( items ).map( group => {
+				return (
+					<OrderReviewGroup
+						key={ group.groupLabel }
+						groupItems={ group.groupItems }
+						onDeleteItem={ onDeleteItem }
+						onChangePlanLength={ onChangePlanLength }
+					/>
+				);
+			} ) }
+			<OrderReviewTotal total={ total } className={ 'order-review__total' } />
+		</React.Fragment>
+	);
+}
+
+export function OrderReviewCollapsed( { useShoppingCart } ) {
+	const { items, total } = useShoppingCart();
+	const planItems = items.filter( item => item.type === 'plan' );
+	const domainItems = items.filter( item => item.type === 'domain' );
+	const miscItems = items.filter( item => ! [ 'plan', 'domain', 'tax' ].includes( item.type ) );
+
+	return (
+		<React.Fragment>
+			<OrderReviewLineItems collapsed items={ planItems } />
+			<OrderReviewLineItems collapsed items={ miscItems } />
+			<OrderReviewLineItems collapsed items={ domainItems } />
+			<OrderReviewTotal collapsed total={ total } />
+		</React.Fragment>
+	);
+}
+
+/**
+ * Arrange cart items into groups. Any logic concerning
+ * how cart items are ordered and grouped in the checkout
+ * belongs here.
+ *
+ * @param {[{object}]} items Array of cart items
+ * @returns {[object]} Nested array of item groups, in order
+ *   [ { groupLabel: string
+ *     , groupItems:
+ *       [ { label: string
+ *         , sublabel: string
+ *         , type: string
+ *         , amount:
+ *           { value: int
+ *           , currency: string
+ *           , displayValue: string
+ *           }
+ *         , wpcom_meta:
+ *           { uuid: int
+ *           , plan_length: string
+ *           , group_slug: string
+ *           }
+ *         }
+ *       ]
+ *     }
+ *   ]
+ */
+function partitionItems( items ) {
+	return [ { groupLabel: 'all', groupItems: items } ];
+}
+
+function OrderReviewGroup( { groupItems, onDeleteItem, onChangePlanLength } ) {
+	return groupItems.map( convertItemToComponent( onDeleteItem, onChangePlanLength ) );
+}
+
+/**
+ * Return a function which converts a single cart item
+ * into a component.
+ *
+ * @param {Function} onDeleteItem Delete callback
+ * @param {Function} onChangePlanLength Plan length change callback
+ * @returns {Function} Item component
+ */
+function convertItemToComponent( onDeleteItem, onChangePlanLength ) {
+	return item => {
+		switch ( item.type ) {
+			case 'tax':
+				return <TaxItem key={ item.label } item={ item } />;
+
+			case 'personal-bundle':
+			case 'premium-bundle':
+				return (
+					<PlanItem
+						key={ item.wpcom_meta.uuid }
+						item={ item }
+						onDeleteItem={ onDeleteItem }
+						onChangePlanLength={ onChangePlanLength }
+					/>
+				);
+
+			case 'domain':
+				return (
+					<DomainItem key={ item.wpcom_meta.uuid } item={ item } onDeleteItem={ onDeleteItem } />
+				);
+		}
+	};
+}

--- a/packages/composite-checkout-wpcom/src/components/upsell.jsx
+++ b/packages/composite-checkout-wpcom/src/components/upsell.jsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export function UpSellCoupon( { onClick } ) {
+	return (
+		<div>
+			<h4>Exclusive offer</h4>
+			<p>Buy a quick start session and get 50% off.</p>
+			<button onClick={ onClick }>Add to cart</button>
+		</div>
+	);
+}

--- a/packages/composite-checkout-wpcom/src/hooks/cart-manager.js
+++ b/packages/composite-checkout-wpcom/src/hooks/cart-manager.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { translateWpcomCartToCheckoutCart } from '../lib/translate-cart';
+
+/**
+ * Custom hook for managing state in the WPCOM checkout component.
+ *
+ * We need to allow users to make some simple changes to their
+ * shopping cart during checkout; things like deleting items,
+ * changing plan lengths, and removing domains. The rules around
+ * how these changes can be made is complex and already implemented
+ * on the backend via the shopping cart endpoint. So rather than
+ * duplicate that logic here we let the server do it for us.
+ *
+ * The flow goes like this:
+ *     1. The host page renders checkout as a component with
+ *       this custom hook as a prop, after 'instantiating' it
+ *       with a REST callback wrapper and the initial cart data.
+ *     2. This hook maintains a copy of the request parameter
+ *       and updates it in response to edit events in checkout.
+ *     3. When the request parameter changes, we fetch an updated
+ *       cart from the server and translate it into the format
+ *       required by the checkout component. This data is otherwise
+ *       not changed.
+ *
+ * @param {function()} callWpcomShoppingCartEndpoint
+ *     An asynchronous wrapper around the wpcom shopping cart
+ *     endpoint. We pass this in to make testing easier.
+ * @param {object} initialRequest
+ *     Initial request parameter as expected by the cart endpoint
+ *     on the backend, passed in from the host page.
+ *     @see WPCOM_JSON_API_Me_Shopping_Cart_Endpoint
+ * @returns {function()} Custom React hook
+ *     To be passed as a prop to the WPCOMCheckout component.
+ */
+export function makeShoppingCartHook( callWpcomShoppingCartEndpoint, initialRequest ) {
+	return () => {
+		// Stored shopping cart endpoint request parameter.
+		// We manipulate this directly and pass it back to
+		// the endpoint on update events.
+		const [ requestParam, setRequestParam ] = useState( initialRequest );
+
+		// Stored representation of the cart for checkout.
+		// The default value is needed because we populate
+		// the cart with an async call to the endpoint via
+		// translateWpcomCartToCheckoutCart().
+		const [ cart, setCart ] = useState( {
+			items: [],
+			tax: {
+				id: 'tax-line-item',
+				label: 'Tax',
+				type: 'tax',
+				amount: { value: 0, currency: '', displayValue: '' },
+			},
+			total: { value: 0, currency: '', displayValue: '' },
+			allowedPaymentMethods: [],
+		} );
+
+		// Asynchronously get and translate the cart when
+		// requestParam changes.
+		useEffect( () => {
+			const fetchAndUpdate = async () => {
+				await callWpcomShoppingCartEndpoint( 'key', requestParam ).then( response => {
+					setCart( translateWpcomCartToCheckoutCart( response ) );
+				} );
+			};
+			fetchAndUpdate();
+		}, [ requestParam ] );
+
+		const addItem = item => {
+			alert( 'addItem: ' + item );
+			setRequestParam( requestParam );
+		};
+
+		const deleteItem = itemToDelete => {
+			const filteredProducts = requestParam.products.filter( ( item, index ) => {
+				return index !== itemToDelete.wpcom_meta.uuid;
+			} );
+			setRequestParam( { ...requestParam, products: filteredProducts } );
+		};
+
+		const changePlanLength = ( planItem, planLength ) => {
+			// TODO
+			alert( 'changePlanLength: ' + planLength + planItem );
+			setRequestParam( requestParam );
+		};
+
+		const updatePricesForAddress = address => {
+			// TODO
+			alert( 'updatePricesForAddress: ' + address );
+			setRequestParam( requestParam );
+		};
+
+		return {
+			items: cart.items,
+			itemsWithTax: [ ...cart.items, cart.tax ],
+			total: { label: 'Total', amount: cart.total },
+			addItem,
+			deleteItem,
+			changePlanLength,
+			updatePricesForAddress,
+		};
+	};
+}

--- a/packages/composite-checkout-wpcom/src/index.js
+++ b/packages/composite-checkout-wpcom/src/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { WPCOMCheckout } from './components/checkout';
+import { makeShoppingCartHook } from './hooks/cart-manager';
+import { mockCartEndpoint } from './mock/cart-endpoint';
+import { mockPayPalExpressRequest } from './mock/paypal-payment-method';
+
+// Re-export the public API
+export { WPCOMCheckout, makeShoppingCartHook, mockCartEndpoint, mockPayPalExpressRequest };

--- a/packages/composite-checkout-wpcom/src/lib/edit-cart.js
+++ b/packages/composite-checkout-wpcom/src/lib/edit-cart.js
@@ -1,0 +1,12 @@
+export function replacePlanWithDifferentLength() {}
+
+export function adjustItemPricesForCountry() {}
+
+// replace this once https://github.com/Automattic/wp-calypso/pull/36758 is merged
+export function formatValueForCurrency( currency, value ) {
+	if ( currency !== 'USD' ) {
+		throw new Error( 'Non-USD currency is not yet supported' );
+	}
+
+	return `${ value / 100 } ${ currency }`;
+}

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -1,0 +1,100 @@
+/**
+ * Internal dependencies
+ */
+import {
+	ServerCart,
+	ServerCartItem,
+	WPCOMCart,
+	WPCOMCartItem,
+	CheckoutCartItem,
+	CheckoutCartItemAmount,
+	readWPCOMPaymentMethodClass,
+	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+} from '../types';
+
+/**
+ * Translate a cart object as returned by the WPCOM cart endpoint to
+ * the format required by the composite checkout component.
+ *
+ * @param serverCart Cart object returned by the WPCOM cart endpoint
+ * @returns Cart object suitable for passing to the checkout component
+ */
+export function translateWpcomCartToCheckoutCart( serverCart: ServerCart ): WPCOMCart {
+	const {
+		products,
+		total_tax_integer,
+		total_tax_display,
+		total_cost_integer,
+		total_cost_display,
+		currency,
+		allowed_payment_methods,
+	} = serverCart;
+
+	const taxLineItem: CheckoutCartItem = {
+		id: 'tax-line-item',
+		label: 'Tax',
+		type: 'tax', // TODO: does this need to be localized, e.g. tax-us?
+		amount: {
+			currency: currency,
+			value: total_tax_integer,
+			displayValue: total_tax_display,
+		},
+	};
+
+	const totalItem: CheckoutCartItemAmount = {
+		currency: currency,
+		value: total_cost_integer,
+		displayValue: total_cost_display,
+	};
+
+	return {
+		items: products.map( translateWpcomCartItemToCheckoutCartItem ),
+		tax: taxLineItem,
+		total: totalItem,
+		allowedPaymentMethods: allowed_payment_methods
+			.map( readWPCOMPaymentMethodClass )
+			.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
+			.filter( Boolean ),
+	};
+}
+
+/**
+ * Convert a backend cart item to a checkout cart item
+ *
+ * @param serverCartItem Cart item object as provided by the backend
+ * @param index Index into an array of products; used as a uuid
+ * @returns Cart item suitable for passing to the checkout component,
+ *     with extra WPCOM specific data attached
+ */
+function translateWpcomCartItemToCheckoutCartItem(
+	serverCartItem: ServerCartItem,
+	index: number
+): WPCOMCartItem {
+	const {
+		product_name,
+		product_slug,
+		currency,
+		item_subtotal_integer,
+		item_subtotal_display,
+		is_domain_registration,
+		meta,
+	} = serverCartItem;
+
+	// Sublabel is the domain name for registrations
+	const sublabel = is_domain_registration ? meta : undefined;
+
+	return {
+		id: String( index ),
+		label: product_name,
+		sublabel: sublabel,
+		type: product_slug,
+		amount: {
+			currency: currency,
+			value: item_subtotal_integer,
+			displayValue: item_subtotal_display,
+		},
+		wpcom_meta: {
+			uuid: String( index ),
+		},
+	};
+}

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.js
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.js
@@ -1,0 +1,70 @@
+require( '@babel/polyfill' );
+
+/**
+ * A fake WPCOM shopping cart endpoint.
+ *
+ * @param {string} cartKey ID string of the cart, used by the backend
+ * @param {object} products Product object as accepted by the cart endpoint
+ * @returns {{products, currency: *, allowed_payment_methods: [string,string,string,string], total_tax_display: string, total_tax_integer, total_cost_display: string, total_cost_integer}}
+ *   Fake response from the cart endpoint
+ */
+export async function mockCartEndpoint( cartKey, {
+	products: requestProducts,
+	currency: requestCurrency,
+	// TODO: coupon: requestCoupon,
+} ) {
+	const products = requestProducts.map( convertRequestProductToResponseProduct( requestCurrency ) );
+
+	const taxInteger = products.reduce( ( accum, current ) => {
+		return accum + current.item_tax;
+	}, 0 );
+
+	const totalInteger = products.reduce( ( accum, current ) => {
+		return accum + current.item_subtotal_integer;
+	}, taxInteger );
+
+	return {
+		products: products,
+		currency: requestCurrency,
+		allowed_payment_methods: [
+			'WPCOM_Billing_Stripe_Payment_Method',
+			'WPCOM_Billing_Ebanx',
+			'WPCOM_Billing_Web_Payment',
+		],
+		total_tax_display: 'R$5',
+		total_tax_integer: taxInteger,
+		total_cost_display: 'R$149',
+		total_cost_integer: totalInteger,
+	};
+}
+
+function convertRequestProductToResponseProduct( currency ) {
+	return product => {
+		const { product_id } = product;
+
+		switch ( product_id ) {
+			case 1009: // WPCOM Personal Bundle
+				return {
+					product_id: 1009,
+					product_name: 'WordPress.com Personal',
+					product_slug: 'personal-bundle',
+					currency: currency,
+					is_domain_registration: false,
+					item_subtotal_integer: 14400,
+					item_subtotal_display: 'R$144',
+					item_tax: 0,
+				};
+		}
+
+		return {
+			product_id: product_id,
+			product_name: 'UNKNOWN',
+			product_slug: 'unknown',
+			currency: currency,
+			is_domain_registration: false,
+			item_subtotal_integer: 0,
+			item_subtotal_display: '$0',
+			item_tax: 0,
+		};
+	};
+}

--- a/packages/composite-checkout-wpcom/src/mock/paypal-payment-method.js
+++ b/packages/composite-checkout-wpcom/src/mock/paypal-payment-method.js
@@ -1,0 +1,3 @@
+export function mockPayPalExpressRequest() {
+	return {};
+}

--- a/packages/composite-checkout-wpcom/src/types.ts
+++ b/packages/composite-checkout-wpcom/src/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { CheckoutPaymentMethodSlug } from './types/checkout-payment-method-slug';
+import {
+	WPCOMPaymentMethodClass,
+	readWPCOMPaymentMethodClass,
+	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+} from './types/wpcom-payment-method-class';
+import { ServerCart, ServerCartItem } from './types/server-cart';
+import {
+	WPCOMCart,
+	WPCOMCartItem,
+	CheckoutCartItem,
+	CheckoutCartItemAmount,
+} from './types/checkout-cart';
+
+export {
+	CheckoutPaymentMethodSlug,
+	WPCOMPaymentMethodClass,
+	readWPCOMPaymentMethodClass,
+	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+	ServerCart,
+	ServerCartItem,
+	WPCOMCart,
+	WPCOMCartItem,
+	CheckoutCartItem,
+	CheckoutCartItemAmount,
+};

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { CheckoutPaymentMethodSlug } from './checkout-payment-method-slug';
+
+/**
+ * Amount object as used by composite-checkout. If that
+ * package used TS this would belong there.
+ */
+export interface CheckoutCartItemAmount {
+	currency: string;
+	value: number;
+	displayValue: string;
+}
+
+/**
+ * Cart item object as used by composite-checkout. If that
+ * package used TS this would belong there.
+ */
+export interface CheckoutCartItem {
+	id: string;
+	label: string;
+	sublabel?: string;
+	type: string;
+	amount: CheckoutCartItemAmount;
+}
+
+/**
+ * Cart item with WPCOM specific info added.
+ */
+export type WPCOMCartItem = CheckoutCartItem & {
+	wpcom_meta: { uuid: string; plan_length?: string };
+};
+
+export interface WPCOMCart {
+	items: WPCOMCartItem[];
+	tax: CheckoutCartItem;
+	total: CheckoutCartItemAmount;
+	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
+}

--- a/packages/composite-checkout-wpcom/src/types/checkout-payment-method-slug.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-payment-method-slug.ts
@@ -1,0 +1,21 @@
+/**
+ * Payment method slugs as expected by composite-checkout.
+ * If the composite-checkout package used typescript, this
+ * would belong there.
+ */
+export type CheckoutPaymentMethodSlug =
+	| 'alipay'
+	| 'apple-pay'
+	| 'bancontact'
+	| 'card'
+	| 'ebanx'
+	| 'brazil-tef'
+	| 'eps'
+	| 'giropay'
+	| 'ideal'
+	| 'p24'
+	| 'paypal'
+	| 'paypal-direct'
+	| 'sofort'
+	| 'stripe-three-d-secure'
+	| 'wechat';

--- a/packages/composite-checkout-wpcom/src/types/server-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/server-cart.ts
@@ -1,0 +1,26 @@
+/**
+ * Cart object as returned by the WPCOM cart endpoint.
+ * Rather- just enough of it to get what we need for checkout.
+ */
+export interface ServerCart {
+	products: ServerCartItem[];
+	total_tax_integer: number;
+	total_tax_display: string;
+	total_cost_integer: number;
+	total_cost_display: string;
+	currency: string;
+	allowed_payment_methods: string[];
+}
+
+/**
+ * Cart item object as returned by the backend
+ */
+export interface ServerCartItem {
+	product_name: string;
+	product_slug: string;
+	currency: string;
+	item_subtotal_integer: number;
+	item_subtotal_display: string;
+	is_domain_registration: boolean;
+	meta: string;
+}

--- a/packages/composite-checkout-wpcom/src/types/wpcom-payment-method-class.ts
+++ b/packages/composite-checkout-wpcom/src/types/wpcom-payment-method-class.ts
@@ -1,0 +1,166 @@
+/**
+ * Internal dependencies
+ */
+import { CheckoutPaymentMethodSlug } from './checkout-payment-method-slug';
+
+/**
+ * Payment method slugs as returned by the WPCOM backend.
+ * These need to be translated to the values expected by
+ * composite-checkout.
+ *
+ * Defining these as interfaces allows WPCOMPaymentMethodClass
+ * to be treated as a discriminated union so the compiler
+ * can do exhaustiveness checking. For example, in a switch
+ * block such as
+ *
+ *     // method : WPCOMPaymentMethodClass
+ *     switch ( method.name ) {
+ *       case ...
+ *     }
+ *
+ * the typescript compiler will raise an error if we forget to
+ * handle all the cases.
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
+ */
+export type WPCOMPaymentMethodClass =
+	| WPCOMBillingEbanx
+	| WPCOMBillingEbanxRedirectBrazilTef
+	| WPCOMBillingPayPalDirect
+	| WPCOMBillingPayPalExpress
+	| WPCOMBillingStripePaymentMethod
+	| WPCOMBillingStripeSourceAlipay
+	| WPCOMBillingStripeSourceBancontact
+	| WPCOMBillingStripeSourceEps
+	| WPCOMBillingStripeSourceGiropay
+	| WPCOMBillingStripeSourceIdeal
+	| WPCOMBillingStripeSourceP24
+	| WPCOMBillingStripeSourceSofort
+	| WPCOMBillingStripeSourceThreeDSecure
+	| WPCOMBillingStripeSourceWechat
+	| WPCOMBillingWebPayment;
+
+export interface WPCOMBillingEbanx {
+	name: 'WPCOM_Billing_Ebanx';
+}
+export interface WPCOMBillingEbanxRedirectBrazilTef {
+	name: 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef';
+}
+export interface WPCOMBillingPayPalDirect {
+	name: 'WPCOM_Billing_PayPal_Direct';
+}
+export interface WPCOMBillingPayPalExpress {
+	name: 'WPCOM_Billing_PayPal_Express';
+}
+export interface WPCOMBillingStripePaymentMethod {
+	name: 'WPCOM_Billing_Stripe_Payment_Method';
+}
+export interface WPCOMBillingStripeSourceAlipay {
+	name: 'WPCOM_Billing_Stripe_Source_Alipay';
+}
+export interface WPCOMBillingStripeSourceBancontact {
+	name: 'WPCOM_Billing_Stripe_Source_Bancontact';
+}
+export interface WPCOMBillingStripeSourceEps {
+	name: 'WPCOM_Billing_Stripe_Source_Eps';
+}
+export interface WPCOMBillingStripeSourceGiropay {
+	name: 'WPCOM_Billing_Stripe_Source_Giropay';
+}
+export interface WPCOMBillingStripeSourceIdeal {
+	name: 'WPCOM_Billing_Stripe_Source_Ideal';
+}
+export interface WPCOMBillingStripeSourceP24 {
+	name: 'WPCOM_Billing_Stripe_Source_P24';
+}
+export interface WPCOMBillingStripeSourceSofort {
+	name: 'WPCOM_Billing_Stripe_Source_Sofort';
+}
+export interface WPCOMBillingStripeSourceThreeDSecure {
+	name: 'WPCOM_Billing_Stripe_Source_Three_D_Secure';
+}
+export interface WPCOMBillingStripeSourceWechat {
+	name: 'WPCOM_Billing_Stripe_Source_Wechat';
+}
+export interface WPCOMBillingWebPayment {
+	name: 'WPCOM_Billing_Web_Payment';
+}
+
+/**
+ * Convert a payment method class name from a string to a
+ * typed value. This function is extensionally equivalent to
+ *
+ *     ( slug ) => { name: slug }
+ *
+ * However the explicit switch is necessary for inferring the
+ * correct type.
+ *
+ * @param slug Name of one of the payment method classes on WPCOM
+ *
+ * @returns Typed payment method slug
+ */
+export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodClass {
+	switch ( slug ) {
+		case 'WPCOM_Billing_Ebanx':
+		case 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef':
+		case 'WPCOM_Billing_PayPal_Direct':
+		case 'WPCOM_Billing_PayPal_Express':
+		case 'WPCOM_Billing_Stripe_Payment_Method':
+		case 'WPCOM_Billing_Stripe_Source_Alipay':
+		case 'WPCOM_Billing_Stripe_Source_Bancontact':
+		case 'WPCOM_Billing_Stripe_Source_Eps':
+		case 'WPCOM_Billing_Stripe_Source_Giropay':
+		case 'WPCOM_Billing_Stripe_Source_Ideal':
+		case 'WPCOM_Billing_Stripe_Source_P24':
+		case 'WPCOM_Billing_Stripe_Source_Sofort':
+		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':
+		case 'WPCOM_Billing_Stripe_Source_Wechat':
+		case 'WPCOM_Billing_Web_Payment':
+			return { name: slug };
+	}
+
+	throw new Error( `Unrecognized payment method class name: "${ slug }"` );
+}
+
+/**
+ * Convert a WPCOM payment method class name to a checkout payment method slug
+ *
+ * @param paymentMethod WPCOM payment method class name
+ * @returns Payment method slug accepted by the checkout component
+ */
+export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
+	paymentMethod: WPCOMPaymentMethodClass
+): CheckoutPaymentMethodSlug {
+	switch ( paymentMethod.name ) {
+		case 'WPCOM_Billing_Ebanx':
+			return 'ebanx';
+		case 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef':
+			return 'brazil-tef';
+		case 'WPCOM_Billing_PayPal_Direct':
+			return 'paypal-direct';
+		case 'WPCOM_Billing_PayPal_Express':
+			return 'paypal';
+		case 'WPCOM_Billing_Stripe_Payment_Method':
+			return 'card';
+		case 'WPCOM_Billing_Stripe_Source_Alipay':
+			return 'alipay';
+		case 'WPCOM_Billing_Stripe_Source_Bancontact':
+			return 'bancontact';
+		case 'WPCOM_Billing_Stripe_Source_Eps':
+			return 'eps';
+		case 'WPCOM_Billing_Stripe_Source_Giropay':
+			return 'giropay';
+		case 'WPCOM_Billing_Stripe_Source_Ideal':
+			return 'ideal';
+		case 'WPCOM_Billing_Stripe_Source_P24':
+			return 'p24';
+		case 'WPCOM_Billing_Stripe_Source_Sofort':
+			return 'sofort';
+		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':
+			return 'stripe-three-d-secure';
+		case 'WPCOM_Billing_Stripe_Source_Wechat':
+			return 'wechat';
+		case 'WPCOM_Billing_Web_Payment':
+			return 'apple-pay';
+	}
+}

--- a/packages/composite-checkout-wpcom/test/enzyme-adapter.js
+++ b/packages/composite-checkout-wpcom/test/enzyme-adapter.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { configure, shallow, mount, render } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure( { adapter: new Adapter() } );
+export { shallow, mount, render };

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -1,0 +1,318 @@
+/**
+ * Internal dependencies
+ */
+import { translateWpcomCartToCheckoutCart } from '../src/lib/translate-cart';
+
+describe( 'translateWpcomCartToCheckoutCart', function() {
+	describe( 'Cart with one plan only (BRL)', function() {
+		const serverResponse = {
+			blog_id: 123,
+			products: [
+				{
+					product_id: 1009,
+					product_name: 'WordPress.com Personal',
+					product_name_en: 'WordPress.com Personal',
+					product_slug: 'personal-bundle',
+					product_cost: 144,
+					meta: '',
+					cost: 144,
+					currency: 'BRL',
+					volume: 1,
+					free_trial: false,
+					orig_cost: null,
+					cost_before_coupon: 144,
+					extra: {
+						context: 'signup',
+						domain_to_bundle: 'foo.cash',
+					},
+					bill_period: 365,
+					is_domain_registration: false,
+					time_added_to_cart: 1572551402,
+					is_bundled: false,
+					item_subtotal: 144,
+					item_subtotal_integer: 14400,
+					item_subtotal_display: 'R$144',
+					item_tax: 0,
+					item_total: 144,
+					subscription_id: 0,
+				},
+			],
+			tax: [],
+			sub_total: '144',
+			sub_total_display: 'R$144',
+			sub_total_integer: 14400,
+			total_tax: '5',
+			total_tax_display: 'R$5',
+			total_tax_integer: 500,
+			total_cost: 149,
+			total_cost_display: 'R$149',
+			total_cost_integer: 14900,
+			currency: 'BRL',
+			allowed_payment_methods: [
+				'WPCOM_Billing_Stripe_Payment_Method',
+				'WPCOM_Billing_Ebanx',
+				'WPCOM_Billing_Web_Payment',
+			],
+		};
+
+		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+
+		it( 'has a total property', function() {
+			expect( clientCart.total ).toBeDefined();
+		} );
+		it( 'has the expected total value', function() {
+			expect( clientCart.total.value ).toBe( 14900 );
+		} );
+		it( 'has the expected currency', function() {
+			expect( clientCart.total.currency ).toBe( 'BRL' );
+		} );
+		it( 'has the expected total display value', function() {
+			expect( clientCart.total.displayValue ).toBe( 'R$149' );
+		} );
+		it( 'has an array of items', function() {
+			expect( clientCart.items ).toBeDefined();
+		} );
+		it( 'has the expected number of line items', function() {
+			expect( clientCart.items.length ).toBe( 1 );
+		} );
+		it( 'has an array of allowed payment methods', function() {
+			expect( clientCart.allowedPaymentMethods ).toBeDefined();
+		} );
+
+		describe( 'first cart item (plan)', function() {
+			it( 'has an id', function() {
+				expect( clientCart.items[ 0 ].id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.items[ 0 ].type ).toBe( 'personal-bundle' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'BRL' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.items[ 0 ].amount.value ).toBe( 14400 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.items[ 0 ].amount.displayValue ).toBe( 'R$144' );
+			} );
+		} );
+
+		describe( 'taxes', function() {
+			it( 'has an id', function() {
+				expect( clientCart.tax.id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.tax.label ).toBe( 'Tax' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.tax.type ).toBe( 'tax' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.tax.amount.currency ).toBe( 'BRL' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.tax.amount.value ).toBe( 500 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.tax.amount.displayValue ).toBe( 'R$5' );
+			} );
+		} );
+
+		describe( 'allowed payment methods', function() {
+			it( 'contains the expected slugs', function() {
+				expect( clientCart.allowedPaymentMethods ).toStrictEqual( [
+					'card',
+					'ebanx',
+					'apple-pay',
+				] );
+			} );
+		} );
+	} );
+
+	describe( 'Cart with one plan and one bundled domain (BRL)', function() {
+		const serverResponse = {
+			blog_id: 123,
+			products: [
+				{
+					product_id: 1009,
+					product_name: 'WordPress.com Personal',
+					product_name_en: 'WordPress.com Personal',
+					product_slug: 'personal-bundle',
+					product_cost: 144,
+					meta: '',
+					cost: 144,
+					currency: 'BRL',
+					volume: 1,
+					free_trial: false,
+					orig_cost: null,
+					cost_before_coupon: 144,
+					extra: {
+						context: 'signup',
+						domain_to_bundle: 'foo.cash',
+					},
+					bill_period: 365,
+					is_domain_registration: false,
+					time_added_to_cart: 1572551402,
+					is_bundled: false,
+					item_subtotal: 144,
+					item_subtotal_integer: 14400,
+					item_subtotal_display: 'R$144',
+					item_tax: 0,
+					item_total: 144,
+					subscription_id: 0,
+				},
+				{
+					product_id: 106,
+					product_name: '.cash Domain Registration',
+					product_name_en: '.cash Domain Registration',
+					product_slug: 'dotcash_domain',
+					product_cost: 88,
+					meta: 'foo.cash',
+					cost: 0,
+					currency: 'BRL',
+					volume: 1,
+					free_trial: false,
+					orig_cost: 0,
+					cost_before_coupon: 88,
+					extra: {
+						privacy: true,
+						context: 'signup',
+						registrar: 'KS_RAM',
+						domain_registration_agreement_url:
+							'https://wordpress.com/automattic-domain-name-registration-agreement/',
+						privacy_available: true,
+					},
+					bill_period: 365,
+					is_domain_registration: true,
+					time_added_to_cart: 1572551402,
+					is_bundled: true,
+					item_subtotal: 0,
+					item_subtotal_integer: 0,
+					item_subtotal_display: 'R$0',
+					item_tax: 0,
+					item_total: 0,
+					subscription_id: 0,
+				},
+			],
+			tax: [],
+			sub_total: '144',
+			sub_total_display: 'R$144',
+			sub_total_integer: 14400,
+			total_tax: '5',
+			total_tax_display: 'R$5',
+			total_tax_integer: 500,
+			total_cost: 149,
+			total_cost_display: 'R$149',
+			total_cost_integer: 14900,
+			currency: 'BRL',
+			allowed_payment_methods: [
+				'WPCOM_Billing_Stripe_Payment_Method',
+				'WPCOM_Billing_Ebanx',
+				'WPCOM_Billing_Web_Payment',
+			],
+		};
+
+		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+
+		it( 'has a total property', function() {
+			expect( clientCart.total ).toBeDefined();
+		} );
+		it( 'has the expected total value', function() {
+			expect( clientCart.total.value ).toBe( 14900 );
+		} );
+		it( 'has the expected currency', function() {
+			expect( clientCart.total.currency ).toBe( 'BRL' );
+		} );
+		it( 'has the expected total display value', function() {
+			expect( clientCart.total.displayValue ).toBe( 'R$149' );
+		} );
+		it( 'has a list of items', function() {
+			expect( clientCart.items ).toBeDefined();
+		} );
+		it( 'has the expected number of line items', function() {
+			expect( clientCart.items.length ).toBe( 2 );
+		} );
+		it( 'has an array of allowed payment methods', function() {
+			expect( clientCart.allowedPaymentMethods ).toBeDefined();
+		} );
+
+		describe( 'first cart item (plan)', function() {
+			it( 'has an id', function() {
+				expect( clientCart.items[ 0 ].id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.items[ 0 ].type ).toBe( 'personal-bundle' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'BRL' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.items[ 0 ].amount.value ).toBe( 14400 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.items[ 0 ].amount.displayValue ).toBe( 'R$144' );
+			} );
+		} );
+
+		describe( 'second cart item (domain)', function() {
+			it( 'has an id', function() {
+				expect( clientCart.items[ 1 ].id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.items[ 1 ].label ).toBe( '.cash Domain Registration' );
+			} );
+			it( 'has the expected sublabel (the domain name)', function() {
+				expect( clientCart.items[ 1 ].sublabel ).toBe( 'foo.cash' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.items[ 1 ].type ).toBe( 'dotcash_domain' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.items[ 1 ].amount.currency ).toBe( 'BRL' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.items[ 1 ].amount.value ).toBe( 0 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.items[ 1 ].amount.displayValue ).toBe( 'R$0' );
+			} );
+		} );
+
+		describe( 'taxes', function() {
+			it( 'has an id', function() {
+				expect( clientCart.tax.id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.tax.label ).toBe( 'Tax' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.tax.type ).toBe( 'tax' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.tax.amount.currency ).toBe( 'BRL' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.tax.amount.value ).toBe( 500 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.tax.amount.displayValue ).toBe( 'R$5' );
+			} );
+		} );
+
+		describe( 'allowed payment methods', function() {
+			it( 'contains the expected slugs', function() {
+				expect( clientCart.allowedPaymentMethods ).toStrictEqual( [
+					'card',
+					'ebanx',
+					'apple-pay',
+				] );
+			} );
+		} );
+	} );
+} );

--- a/packages/composite-checkout-wpcom/test/wpcom-checkout.js
+++ b/packages/composite-checkout-wpcom/test/wpcom-checkout.js
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { createRegistry, createPayPalMethod } from '@automattic/composite-checkout';
+
+/**
+ * Internal dependencies
+ */
+import {
+	WPCOMCheckout,
+	makeShoppingCartHook,
+	mockCartEndpoint,
+	mockPayPalExpressRequest,
+} from '../src/index';
+
+let container = null;
+
+beforeEach( () => {
+	// setup a DOM element as a render target
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	// cleanup on exiting
+	unmountComponentAtNode( container );
+	container.remove();
+	container = null;
+} );
+
+test( 'When we enter checkout, the line items and total are rendered', async () => {
+	const initialCart = {
+		coupon: '',
+		currency: 'BRL',
+		is_coupon_applied: false,
+		products: [
+			{
+				extra: {
+					context: 'signup',
+					domain_registration_agreement_url:
+						'https://wordpress.com/automattic-domain-name-registration-agreement/',
+					privacy: true,
+					privacy_available: true,
+					registrar: 'KS_RAM',
+				},
+				free_trial: false,
+				meta: 'foo.cash',
+				product_id: 106,
+				volume: 1,
+			},
+			{
+				extra: {
+					context: 'signup',
+					domain_to_bundle: 'foo.cash',
+				},
+				free_trial: false,
+				meta: '',
+				product_id: 1009,
+				volume: 1,
+			},
+		],
+		tax: {
+			display_taxes: false,
+			location: {},
+		},
+		temporary: false,
+	};
+
+	const registry = createRegistry();
+	const { registerStore } = registry;
+
+	// Using a mocked server responses
+	const useShoppingCart = makeShoppingCartHook( mockCartEndpoint, initialCart );
+
+	const MyCheckout = () => (
+		<WPCOMCheckout
+			useShoppingCart={ useShoppingCart }
+			availablePaymentMethods={ [
+				createPayPalMethod( {
+					registerStore: registerStore,
+					makePayPalExpressRequest: mockPayPalExpressRequest,
+				} ),
+			] }
+			registry={ registry }
+		/>
+	);
+
+	let renderResult;
+
+	await act( async () => {
+		renderResult = render( <MyCheckout />, container );
+	} );
+
+	// Product line items show the correct price
+	renderResult
+		.getAllByLabelText( 'WordPress.com Personal' )
+		.map( element => expect( element ).toHaveTextContent( 'R$144' ) );
+
+	// Tax line items show the expected amount
+	renderResult
+		.getAllByLabelText( 'Tax' )
+		.map( element => expect( element ).toHaveTextContent( 'R$5' ) );
+
+	// All elements labeled 'Total' show the expected price
+	renderResult
+		.getAllByLabelText( 'Total' )
+		.map( element => expect( element ).toHaveTextContent( 'R$149' ) );
+} );

--- a/packages/composite-checkout-wpcom/tsconfig-cjs.json
+++ b/packages/composite-checkout-wpcom/tsconfig-cjs.json
@@ -1,19 +1,9 @@
 {
+	"extends": "./tsconfig",
 	"compilerOptions": {
-		"target": "es5",
 		"module": "commonjs",
-		"outDir": "./dist/cjs",
-
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noImplicitReturns": true,
-		"noFallthroughCasesInSwitch": true,
-		"strictNullChecks": true,
-
-		"moduleResolution": "node",
-		"esModuleInterop": true
-	},
-	"include": [ "src/**/*" ],
-	"exclude": [ "**/test/**/*", "**/docs/**/*" ]
+		"declaration": false,
+		"declarationDir": null,
+		"outDir": "./dist/cjs"
+	}
 }

--- a/packages/composite-checkout-wpcom/tsconfig-cjs.json
+++ b/packages/composite-checkout-wpcom/tsconfig-cjs.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"target": "es5",
+		"module": "commonjs",
+		"outDir": "./dist/cjs",
+
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"strictNullChecks": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true
+	},
+	"include": [ "src/**/*" ],
+	"exclude": [ "**/test/**/*", "**/docs/**/*" ]
+}

--- a/packages/composite-checkout-wpcom/tsconfig.json
+++ b/packages/composite-checkout-wpcom/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"jsx": "react",
+		"target": "es5",
+		"module": "es2015",
+		"declaration": true,
+		"declarationDir": "types",
+		"outDir": "./dist/esm",
+
+		"strict": true,
+		"noImplicitAny": false,
+
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"strictNullChecks": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true
+	},
+	"include": [ "src/**/*" ],
+	"exclude": [ "**/test/**/*", "**/docs/**/*" ]
+}

--- a/packages/composite-checkout-wpcom/tsconfig.json
+++ b/packages/composite-checkout-wpcom/tsconfig.json
@@ -3,7 +3,7 @@
 		"allowJs": true,
 		"jsx": "react",
 		"target": "es5",
-		"module": "es2015",
+		"module": "esnext",
 		"declaration": true,
 		"declarationDir": "types",
 		"outDir": "./dist/esm",

--- a/packages/composite-checkout-wpcom/webpack.config.demo.js
+++ b/packages/composite-checkout-wpcom/webpack.config.demo.js
@@ -1,0 +1,44 @@
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+
+module.exports = {
+	entry: './packages/composite-checkout-wpcom/demo/index.jsx',
+	mode: 'development',
+	module: {
+		rules: [
+			{
+				test: /\.(ts|tsx)$/,
+				exclude: /node_modules/,
+				loader: 'ts-loader',
+			},
+			{
+				test: /\.jsx$/,
+				exclude: /(node_modules|bower_components)/,
+				loader: 'babel-loader',
+				options: { presets: [ '@babel/env' ] },
+			},
+			{
+				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
+				loader: 'source-map-loader',
+			},
+			{
+				test: /\.css$/,
+				use: [ 'style-loader', 'css-loader' ],
+			},
+		],
+	},
+	resolve: { extensions: [ '*', '.js', '.jsx', '.ts', '.tsx' ] },
+	output: {
+		path: path.resolve( __dirname, '/dist/' ),
+		publicPath: '/dist/',
+		filename: 'bundle-wpcom.js',
+	},
+	devServer: {
+		contentBase: path.join( __dirname, '/demo/' ),
+		port: 3001,
+		publicPath: 'http://localhost:3001/dist/',
+		hotOnly: true,
+	},
+	plugins: [ new webpack.HotModuleReplacementPlugin() ],
+};

--- a/packages/composite-checkout-wpcom/webpack.config.js
+++ b/packages/composite-checkout-wpcom/webpack.config.js
@@ -1,0 +1,36 @@
+const path = require( 'path' );
+
+module.exports = {
+	entry: './src/public-api.js',
+	mode: 'development',
+	module: {
+		rules: [
+			{
+				test: /\.(ts|tsx)$/,
+				exclude: /node_modules/,
+				loader: 'ts-loader',
+			},
+			{
+				test: /\.jsx$/,
+				exclude: /(node_modules|bower_components)/,
+				loader: 'babel-loader',
+				options: { presets: [ '@babel/env' ] },
+			},
+			{
+				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
+				loader: 'source-map-loader',
+			},
+			{
+				test: /\.css$/,
+				use: [ 'style-loader', 'css-loader' ],
+			},
+		],
+	},
+	resolve: { extensions: [ '*', '.js', '.jsx', '.ts', '.tsx' ] },
+	output: {
+		path: path.resolve( __dirname, 'dist/' ),
+		publicPath: '/dist/',
+		filename: 'bundle.js',
+	},
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add cart management component for WPCOM

#### Testing instructions

Run tests: `npm install && npm run test-packages composite-checkout-wpcom`

Run live standalone demo: `npm run composite-checkout-wpcom-demo`

Enable in calypso: `ENABLE_FEATURES=composite-checkout-wpcom npm start`

Typecheck: `cd packages/composite-checkout-wpcom/ && tsc; cd ../..`