### PR TITLE
Concierge banner: Record tracks event for banner click in /me/purchases

### DIFF
--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import ActionCard from 'components/action-card';
-import { recordTracksEvent } from 'state/analytics/actions';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
 class ConciergeBanner extends Component {
@@ -33,7 +32,7 @@ class ConciergeBanner extends Component {
 					buttonHref="/me/concierge"
 					buttonTarget={ null }
 					buttonOnClick={ () => {
-						recordTracksEvent( 'calypso_purchases_concierge_banner_click', {
+						this.props.recordTracksEvent( 'calypso_purchases_concierge_banner_click', {
 							referer: '/me/purchases',
 						} );
 					} }

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -50,7 +50,9 @@ class PurchasesList extends Component {
 		if ( this.props.hasLoadedUserPurchasesFromServer && this.props.purchases.length ) {
 			content = (
 				<div>
-					{ this.props.isBusinessPlanUser && <ConciergeBanner /> }
+					{ this.props.isBusinessPlanUser && (
+						<ConciergeBanner recordTracksEvent={ this.props.recordTracksEvent } />
+					) }
 
 					{ getPurchasesBySite( this.props.purchases, this.props.sites ).map( site => (
 						<PurchasesSite


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For Business plan users, we show a concierge banner on the `/me/purchases` page:

<img width="731" alt="Screenshot 2019-10-28 at 10 50 14 AM" src="https://user-images.githubusercontent.com/1269602/67653738-bf246e80-f970-11e9-963c-e40b7d8d3cbb.png">


* Clicking the "Schedule Now" button on the banner is expected to fire a Tracks event but due to an existing bug the Tracks event does not fire.

* This PR fixes the issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an account with a Business plan.
* In your browser console, type this:
```
localStorage.setItem('debug', 'calypso:analytics:tracks');
```
This will show all the Tracks events fired in your browser console.

* Go to /me/purchases page
* Click the "Schedule Now" button. Verify that you see the Tracks event fired in the browser console:

<img width="892" alt="Screenshot 2019-10-28 at 10 46 44 AM" src="https://user-images.githubusercontent.com/1269602/67653815-293d1380-f971-11e9-9ea4-274ac0fce07f.png">


Fixes #37062
