### PR TITLE
Store: Remove createReducer from shipping-zone-method-settings

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { withoutPersistence } from 'state/utils';
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST,
 	WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS,
@@ -8,7 +9,7 @@ import {
 import { LOADING } from 'woocommerce/state/constants';
 import { WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED } from 'woocommerce/state/action-types';
 
-export default function( state = {}, action ) {
+export default withoutPersistence( function( state = {}, action ) {
 	switch ( action.type ) {
 		case WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST:
 			return {
@@ -30,4 +31,4 @@ export default function( state = {}, action ) {
 	}
 
 	return state;
-}
+} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
@@ -26,7 +26,7 @@ export default withoutPersistence( function( state = {}, action ) {
 		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED:
 			return {
 				...state,
-				instanceId: action.data.id,
+				[ action.data.id ]: true,
 			};
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
@@ -1,10 +1,6 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST,
 	WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS,
@@ -12,32 +8,26 @@ import {
 import { LOADING } from 'woocommerce/state/constants';
 import { WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED } from 'woocommerce/state/action-types';
 
-const reducers = {};
+export default function( state = {}, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST:
+			return {
+				...state,
+				[ action.instanceId ]: LOADING,
+			};
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST ] = (
-	state,
-	{ instanceId }
-) => {
-	return {
-		...state,
-		[ instanceId ]: LOADING,
-	};
-};
+		case WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS:
+			return {
+				...state,
+				[ action.instanceId ]: true,
+			};
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS ] = (
-	state,
-	{ instanceId }
-) => {
-	return {
-		...state,
-		[ instanceId ]: true,
-	};
-};
+		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED:
+			return {
+				...state,
+				[ action.data.id ]: true,
+			};
+	}
 
-reducers[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED ] = ( state, { data } ) => {
-	return reducers[ WOOCOMMERCE_SERVICES_SHIPPING_ZONE_METHOD_SETTINGS_REQUEST_SUCCESS ]( state, {
-		instanceId: data.id,
-	} );
-};
-
-export default createReducer( {}, reducers );
+	return state;
+}

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-zone-method-settings/reducer.js
@@ -26,7 +26,7 @@ export default withoutPersistence( function( state = {}, action ) {
 		case WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED:
 			return {
 				...state,
-				[ action.data.id ]: true,
+				instanceId: action.data.id,
 			};
 	}
 


### PR DESCRIPTION
Remove createReducer from shipping-zone-method-settings

Extracted from #36678 ~and corrected~.

This should be _functionally equivalent_ and result in _no behavioral changes_ to the application.

#### Testing instructions

I'm unfamiliar with this part of the code base and unable to provide instructions for manual testing.