### PR TITLE
Plans: Remove unused isAtomicSite

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -62,7 +62,6 @@ import ProductSelector from 'blocks/product-selector';
 import FormattedHeader from 'components/formatted-header';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import { getDiscountByName } from 'lib/discounts';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import { getSiteOption, getSitePlan, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
@@ -552,7 +551,6 @@ export default connect(
 			plansWithScroll: ! props.displayJetpackPlans && props.plansWithScroll,
 			customerType,
 			domains: getDecoratedSiteDomains( state, siteId ),
-			isAtomicSite: isSiteAtomic( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack: isJetpackSite( state, siteId ),
 			siteId,


### PR DESCRIPTION
We introduced this in #37019 but after a recent change it's no longer necessary.

#### Changes proposed in this Pull Request

* Remove an unused prop from `PlansFeaturesMain`

#### Testing instructions

* Checkout this branch. 
* Go to `http://calypso.localhost:3000/plans/:site` where `:site` is a Jetpack site.
* Verify it still works well.