### PR TITLE
Run ncp through npx.

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
 		"build-devdocs:index": "cross-env-shell NODE_PATH=$NODE_PATH:server:client:. npm run -s build-devdocs:index:_env",
 		"build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index",
 		"build-docker": "node bin/build-docker.js",
-		"build-static": "ncp static public",
+		"build-static": "npx ncp static public",
 		"prebuild-server": "mkdirp build",
 		"build-server": "cross-env-shell BROWSERSLIST_ENV=server NODE_PATH=$NODE_PATH:server:client:. webpack --display errors-only --config webpack.config.node.js",
 		"build-client": "npm run build-client-evergreen",


### PR DESCRIPTION
Run `ncp` through `npx`, instead of directly.

This should help avoid `sh: ncp: command not found` errors.

#### Changes proposed in this Pull Request

* Run `ncp` through `npx`, instead of directly.

#### Testing instructions

Ensure the build continues working as normally.
