### PR TITLE
Address design feedback on the single product price size in Jetpack Connect flow

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1159,6 +1159,10 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 		color: var( --color-neutral-70 );
 		font-style: normal;
 		vertical-align: baseline;
+
+		@include breakpoint( '>660px' ) {
+			font-weight: 600;
+		}
 	}
 
 	.plan-price.is-original,
@@ -1166,28 +1170,15 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 		color: var( --color-neutral-light );
 	}
 
-	.product-card__header {
-		.plan-price,
-		.plan-price *,
-		.product-card__billing-timeframe {
-			font-size: 16px;
-			font-weight: 500;
-			line-height: 20px;
-
-			@include breakpoint( '>660px' ) {
-				font-size: 20px;
-				font-weight: 600;
-			}
-		}
+	.product-card__billing-timeframe {
+		font-size: 14px;
 	}
 
-	.product-card__option {
-		.plan-price.is-discounted,
-		.plan-price.is-discounted *,
-		.product-card__billing-timeframe {
-			@include breakpoint( '>660px' ) {
-				font-weight: 600;
-			}
+	.product-card__header {
+		.plan-price,
+		.plan-price * {
+			font-size: 16px;
+			line-height: 21px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the price size in the single product card header in Jetpack Connect flow

![Screenshot 2019-10-28 at 13 40 08](https://user-images.githubusercontent.com/478735/67679058-809aae00-f988-11e9-927b-29734126c4a4.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Confirm the price size in the single product card header matches the design and feedback provided in the design review p7rcWF-19m-p2

Fixes n/a
