### PR TITLE
Calypso Build: Fix PostCSS config path default

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.1
+
+- Fix PostCSS config path default.
+
 # 5.0.0
 
 - Remove `@automattic/calypso-color-schemes` dependency

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -74,7 +74,7 @@ function getWebpackConfig(
 	let postCssConfigPath = process.cwd();
 	if ( ! fs.existsSync( path.join( postCssConfigPath, 'postcss.config.js' ) ) ) {
 		// Default to this package's PostCSS config
-		postCssConfigPath = undefined;
+		postCssConfigPath = __dirname;
 	}
 
 	const webpackConfig = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Calypso Build: Fix PostCSS config path default

Turns out the `undefined` fallback doesn't work so well after all: See https://github.com/Automattic/jetpack/pull/13854 which currently fails to find a PostCSS config.

I tried various other fixes (setting different levels of config options to `undefined` or empty object), but none seemed to work. The fix I ended up was the only reliable way I could find.

#### Testing instructions

Verify that Calypso still builds and runs.

Most importantly, test this in a different repo that uses `calypso-build`. In the following, we'll be using Jetpack.

- Follow instructions in https://github.com/Automattic/jetpack/pull/13854. Verify that it fails with errors complaining that it can't find a PostCSS config. 
- Then, apply this PR's change to your checked-out Jetpack's `node_modules/@automattic/calypso-build/webpack.config.js`.
- Run `yarn build-extensions` again. 