### PR TITLE
Fixed bug with Customer Home support illustration stretching on desktop

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -372,8 +372,6 @@ class Home extends Component {
 							<img
 								src="/calypso/images/customer-home/happiness.png"
 								alt={ translate( 'Support' ) }
-								height="119"
-								width="137"
 							/>
 							<VerticalNav className="customer-home__card-links">
 								<VerticalNavItem

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -128,6 +128,8 @@
 
 		img {
 			margin: 0 7%;
+			height: 119px;
+			width: 137px;
 		}
 
 		.vertical-nav {


### PR DESCRIPTION
## Description

@rachelmcr brought to my attention that the support illustration within Customer Home was being stretched vertically within the Desktop app.

**Before**
![](https://d1czrtm2mp3lak.cloudfront.net/items/3N3X2G2U3V063M3b0A37/Image%202019-10-28%20at%208.52.18%20AM.png)

**After**
![](https://d1czrtm2mp3lak.cloudfront.net/items/3Q2L000J432v0O1A0k0B/Image%202019-10-28%20at%208.51.37%20AM.png)

Fixes https://github.com/Automattic/wp-desktop/issues/689
