### PR TITLE
SFTP: Retrieve actual credentials

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -78,7 +78,11 @@ const SFTPCard = ( { translate, username, password, siteId, loading, disabled } 
 			</div>
 			<div className="sftp-card__body">
 				<CardHeading>{ translate( 'SFTP Information' ) }</CardHeading>
-				{ ! disabled && ! loading ? (
+				{ disabled || username || loading ? (
+					<p>
+						{ translate( "Access and edit your website's files directly using an FTP client." ) }
+					</p>
+				) : (
 					<>
 						<p>
 							{ translate(
@@ -89,10 +93,6 @@ const SFTPCard = ( { translate, username, password, siteId, loading, disabled } 
 							{ translate( 'Enable SFTP' ) }
 						</Button>
 					</>
-				) : (
-					<p>
-						{ translate( "Access and edit your website's files directly using an FTP client." ) }
-					</p>
 				) }
 			</div>
 			{ ( username || disabled ) && (
@@ -141,14 +141,23 @@ const SFTPCard = ( { translate, username, password, siteId, loading, disabled } 
 	);
 };
 
-export default connect( state => {
+export default connect( ( state, { disabled } ) => {
 	const siteId = getSelectedSiteId( state );
-	const sftpDetails = requestAtomicSFTPDetails( siteId );
+	let username = null;
+	let password = null;
+	let loading = null;
+
+	if ( ! disabled ) {
+		const sftpDetails = requestAtomicSFTPDetails( siteId );
+		username = get( sftpDetails, 'data.username' );
+		password = get( sftpDetails, 'data.password' );
+		loading = sftpDetails.state === 'pending';
+	}
 
 	return {
 		siteId,
-		username: get( sftpDetails, 'data.username' ),
-		password: get( sftpDetails, 'data.password' ),
-		loading: sftpDetails.state === 'pending',
+		username,
+		password,
+		loading,
 	};
 } )( localize( SFTPCard ) );

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -19,57 +19,23 @@ import Button from 'components/button';
 import ClipboardButton from 'components/forms/clipboard-button';
 import Spinner from 'components/spinner';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	requestAtomicSFTPDetails,
+	resetAtomicSFTPUserPassword,
+	createAtomicSFTPUser,
+} from 'state/data-getters';
 
-// @TODO derive API request details from props when API is merged & remove component state for dummy data
-const SFTPCard = ( { translate, siteId, disabled } ) => {
+const SFTPCard = ( { translate, username, password, errorCode, siteId, loading, disabled } ) => {
 	// State for clipboard copy button for both username and password data
 	const [ isCopied, setIsCopied ] = useState( false );
 	const usernameIsCopied = isCopied === 'username';
 	const passwordIsCopied = isCopied === 'password';
 
-	// Begin dummy API data/methods
-	const [ dummyApiRequest, setDummyApiRequest ] = useState( {
-		status: 'error',
-		error: {
-			status: 404,
-		},
-	} );
-
-	const username = get( dummyApiRequest, 'data.username', null );
-	const password = get( dummyApiRequest, 'data.password', null );
-	const loading = dummyApiRequest.status === 'pending';
-	const noSftpUser = dummyApiRequest.error.status === 404;
-
-	const createAtomicSFTPUser = () => {
-		setDummyApiRequest( {
-			status: 'success',
-			data: {
-				username: 'test_user_testsite.wordpress.com_1234',
-			},
-			error: {
-				status: 0,
-			},
-		} );
-	};
-
-	const resetAtomicSFTPUserPassword = () => {
-		setDummyApiRequest( {
-			status: 'success',
-			data: {
-				username: 'test_user_testsite.wordpress.com_1234',
-				password: 'a.reset.p.a.s.s.word',
-			},
-			error: {
-				status: 0,
-			},
-		} );
-	};
-	// End of dummy API data/methods
-
 	const sftpData = {
 		[ translate( 'URL' ) ]: 'sftp1.wordpress.com',
 		[ translate( 'Port' ) ]: 22,
 	};
+	const noSftpUser = errorCode === 404;
 
 	const renderPasswordCell = () => {
 		if ( disabled ) {
@@ -171,15 +137,21 @@ const SFTPCard = ( { translate, siteId, disabled } ) => {
 					</tbody>
 				</table>
 			) }
-			{ loading && ! noSftpUser && <Spinner /> }
+			{ loading && <Spinner /> }
 		</Card>
 	);
 };
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
+	const sftpDetails = requestAtomicSFTPDetails( siteId );
+	const username = get( sftpDetails, 'data.username', null );
 
 	return {
 		siteId,
+		username,
+		password: get( sftpDetails, 'data.password' ),
+		errorCode: get( sftpDetails, 'error.status' ),
+		loading: get( sftpDetails, 'state' ) === 'pending',
 	};
 } )( localize( SFTPCard ) );

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -25,7 +25,7 @@ import {
 	createAtomicSFTPUser,
 } from 'state/data-getters';
 
-const SFTPCard = ( { translate, username, password, errorCode, siteId, loading, disabled } ) => {
+const SFTPCard = ( { translate, username, password, noSftpUser, siteId, loading, disabled } ) => {
 	// State for clipboard copy button for both username and password data
 	const [ isCopied, setIsCopied ] = useState( false );
 	const usernameIsCopied = isCopied === 'username';
@@ -35,7 +35,6 @@ const SFTPCard = ( { translate, username, password, errorCode, siteId, loading, 
 		[ translate( 'URL' ) ]: 'sftp1.wordpress.com',
 		[ translate( 'Port' ) ]: 22,
 	};
-	const noSftpUser = errorCode === 404;
 
 	const renderPasswordCell = () => {
 		if ( disabled ) {
@@ -145,13 +144,12 @@ const SFTPCard = ( { translate, username, password, errorCode, siteId, loading, 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const sftpDetails = requestAtomicSFTPDetails( siteId );
-	const username = get( sftpDetails, 'data.username', null );
 
 	return {
 		siteId,
-		username,
+		username: get( sftpDetails, 'data.username' ),
 		password: get( sftpDetails, 'data.password' ),
-		errorCode: get( sftpDetails, 'error.status' ),
-		loading: get( sftpDetails, 'state' ) === 'pending',
+		noSftpUser: get( sftpDetails, 'error.status' ) === 404,
+		loading: get( sftpDetails, 'status' ) === 'pending',
 	};
 } )( localize( SFTPCard ) );

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -25,7 +25,7 @@ import {
 	createAtomicSFTPUser,
 } from 'state/data-getters';
 
-const SFTPCard = ( { translate, username, password, noSftpUser, siteId, loading, disabled } ) => {
+const SFTPCard = ( { translate, username, password, siteId, loading, disabled } ) => {
 	// State for clipboard copy button for both username and password data
 	const [ isCopied, setIsCopied ] = useState( false );
 	const usernameIsCopied = isCopied === 'username';
@@ -78,7 +78,7 @@ const SFTPCard = ( { translate, username, password, noSftpUser, siteId, loading,
 			</div>
 			<div className="sftp-card__body">
 				<CardHeading>{ translate( 'SFTP Information' ) }</CardHeading>
-				{ ! disabled && noSftpUser ? (
+				{ ! disabled && ! loading ? (
 					<>
 						<p>
 							{ translate(
@@ -149,7 +149,6 @@ export default connect( state => {
 		siteId,
 		username: get( sftpDetails, 'data.username' ),
 		password: get( sftpDetails, 'data.password' ),
-		noSftpUser: get( sftpDetails, 'error.status' ) === 404,
-		loading: get( sftpDetails, 'status' ) === 'pending',
+		loading: sftpDetails.state === 'pending',
 	};
 } )( localize( SFTPCard ) );

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -223,7 +223,9 @@ export const requestAtomicSFTPDetails = siteId =>
 		),
 		{
 			freshness: 5 * 60 * 1000,
-			fromApi: () => ( { username } ) => [ [ `atomic-hosting-data-${ siteId }`, { username } ] ],
+			fromApi: () => ( { username } ) => [
+				[ `atomic-hosting-data-${ siteId }`, username ? { username } : {} ],
+			],
 		}
 	);
 

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -241,7 +241,7 @@ export const resetAtomicSFTPUserPassword = siteId =>
 		),
 		{
 			fromApi: () => ( { username, password } ) => {
-				return [ `atomic-hosting-data-${ siteId }`, { username, password } ];
+				return [ [ `atomic-hosting-data-${ siteId }`, { username, password } ] ];
 			},
 			freshness: 0,
 		}
@@ -261,7 +261,7 @@ export const createAtomicSFTPUser = siteId =>
 		),
 		{
 			fromApi: () => ( { username, password } ) => {
-				return [ `atomic-hosting-data-${ siteId }`, { username, password } ];
+				return [ [ `atomic-hosting-data-${ siteId }`, { username, password } ] ];
 			},
 			freshness: 0,
 		}

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -223,9 +223,7 @@ export const requestAtomicSFTPDetails = siteId =>
 		),
 		{
 			freshness: 5 * 60 * 1000,
-			fromApi: () => ( { username } ) => {
-				return [ `atomic-hosting-data-${ siteId }`, { username } ];
-			},
+			fromApi: () => ( { username } ) => [ [ `atomic-hosting-data-${ siteId }`, { username } ] ],
 		}
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reverts the dummy data added in #36860 and pulls the actual SFTP credentials from the endpoint implemented in D34243-code.

#### Testing instructions

- Apply D34660-code and sandbox the API.
- Go to `http://calypso.localhost:3000/hosting/your.atomic.site`.
- If you didn't create a SFTP user yet, click on the "Enable SFTP" button.
- Make sure you the SFTP card displays your user. If you created a user in the step above, you should see the password as well.
- Try resetting the password using the "Reset password" button.
- Make sure the new password is displayed.
- Switch to a Business site that has not been transfered yet.
- Confirm the SFTP card is disabled (it displays a placeholder) and there is banner directing you to activate the features (clicking on the button does nothing at the moment).

fixes #36284