### PR TITLE
SectionHeader: Move mobile chevron next to the heading text

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -73,8 +73,7 @@
 }
 
 .section-nav__mobile-header-text {
-	margin-right: 4px;
-	flex: auto;
+	margin-right: 8px;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `SectionHeader` turns `NavItem` children into a drop-down menu on narrow screens. The chevron that indicates this is a drop-down is located to the far right of the component. When there is extra functionality on the right side of the SectionHeader (ie. a search icon on the People screen, or the cart on the Plans/Domains screens) it becomes unclear what the chevron is attached to.
* This PR moves the chevron directly to the right of the heading title, making the relationship between it and the heading clearer.

**Before**

<img width="328" alt="Screen Shot 2019-10-28 at 4 13 52 PM" src="https://user-images.githubusercontent.com/2124984/67714698-d37f6000-f99e-11e9-8b4b-ecf9b7c0c69b.png">
<img width="329" alt="Screen Shot 2019-10-28 at 4 14 00 PM" src="https://user-images.githubusercontent.com/2124984/67714699-d37f6000-f99e-11e9-9028-b282698b6101.png">
<img width="328" alt="Screen Shot 2019-10-28 at 4 14 10 PM" src="https://user-images.githubusercontent.com/2124984/67714700-d37f6000-f99e-11e9-9869-7fdd8bf14b53.png">

**After**

<img width="324" alt="Screen Shot 2019-10-28 at 4 14 32 PM" src="https://user-images.githubusercontent.com/2124984/67714713-d8441400-f99e-11e9-87ab-53a90183c5b1.png">
<img width="325" alt="Screen Shot 2019-10-28 at 4 14 44 PM" src="https://user-images.githubusercontent.com/2124984/67714714-d8441400-f99e-11e9-8ed7-323eca518de5.png">
<img width="327" alt="Screen Shot 2019-10-28 at 4 14 54 PM" src="https://user-images.githubusercontent.com/2124984/67714717-d8dcaa80-f99e-11e9-8e88-29738c1d8967.png">

#### Testing instructions

* Switch to this PR using a mobile device or small screen.
* This component is used in a number of places, so it's good to test this across multiple areas of Calypso. Stats, People, Domains, Plans, Site Settings, /me, etc.
* Does the drop-down menu function? Does it look visually correct?

Fixes #36739
