### PR TITLE
Jetpack onboarding: update Anti-spam feature name in Jetpack checklist

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -200,9 +200,9 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 					{ isPaidPlan && productInstallStatus && (
 						<Task
 							id="jetpack_akismet"
-							title={ translate( "We're automatically turning on spam filtering." ) }
+							title={ translate( "We're automatically turning on Anti-spam." ) }
 							completedButtonText={ translate( 'View spam stats' ) }
-							completedTitle={ translate( "We've automatically turned on spam filtering." ) }
+							completedTitle={ translate( "We've automatically turned on Anti-spam." ) }
 							completed={ akismetFinished }
 							href={ `//${ siteSlug.replace(
 								'::',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Replace "Spam Filtering" with "Anti-spam" in Jetpack Onboarding checklist. Fixes #37121 

ref: p1HpG7-7Ro (feature naming alignment)

<img width="1323" alt="Screen Shot 2019-10-28 at 1 37 39 PM" src="https://user-images.githubusercontent.com/204742/67722855-ed6d7280-f99f-11e9-83fe-a02f88485bb4.png">


#### Testing instructions
* Check out this branch
* Purchase any level paid Jetpack Plan on a test site
* Go to `http://calypso.localhost:3000/plans/my-plan/SITE_URL` and see that the "We've automatically turned on spam filtering." wording has changed to "We've automatically turned on Anti-spam." as in the above screenshot.
