### PR TITLE
FSE: fix Template Part name in Block Navigator

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -17,12 +17,14 @@ import './site-logo';
 if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
 	registerBlockType( 'a8c/template', {
 		title: __( 'Template Part' ),
+		__experimentalDisplayName: 'label',
 		description: __( 'Display a Template Part.' ),
 		icon: 'layout',
 		category: 'layout',
 		attributes: {
 			templateId: { type: 'number' },
 			className: { type: 'string' },
+			label: { type: 'string' },
 		},
 		supports: {
 			anchor: false,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -161,9 +161,9 @@ class WP_Template {
 			return null;
 		}
 
-		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"label\":\"Header\",\"className\":\"site-header site-branding\"} /-->" .
+		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"label\":\"" . __( 'Header', 'full-site-editing' ) . '","className":"site-header site-branding"} /-->' .
 				'<!-- wp:a8c/post-content /-->' .
-				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"label\":\"Footer\",\"className\":\"site-footer\"} /-->";
+				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"label\":\"" . __( 'Footer', 'full-site-editing' ) . '","className":"site-footer"} /-->';
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -161,9 +161,9 @@ class WP_Template {
 			return null;
 		}
 
-		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"className\":\"site-header site-branding\"} /-->" .
+		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"label\":\"Header\",\"className\":\"site-header site-branding\"} /-->" .
 				'<!-- wp:a8c/post-content /-->' .
-				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"className\":\"site-footer\"} /-->";
+				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"label\":\"Footer\",\"className\":\"site-footer\"} /-->";
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* added __experimentalDisplayName and label attribute for header and footer

Before - 
![Screen Shot 2019-10-28 at 6 34 54 PM](https://user-images.githubusercontent.com/28742426/67723213-b86a1b80-f9b1-11e9-86a6-83874b210686.png)

After - 
![Screen Shot 2019-10-28 at 6 34 10 PM](https://user-images.githubusercontent.com/28742426/67723221-bd2ecf80-f9b1-11e9-99ed-86d1162a4c60.png)


#### Testing instructions

Testing with local Gutenberg environment with latest Master branch.
1. Run this PR
2. edit a Page
3. verify that "Header" and "Footer" are titles in the Block Navigation component.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes #36508 
