### PR TITLE
Jetpack Settings: update Jetpack Anti-spam security settings card title

### DIFF
--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -79,7 +79,7 @@ class SiteSettingsFormSecurity extends Component {
 							isSaving={ isSavingSettings }
 							onButtonClick={ handleSubmitForm }
 							showButton
-							title={ translate( 'Jetpack Anti-spam' ) }
+							title={ translate( 'Anti-spam' ) }
 						/>
 						<SpamFilteringSettings
 							dirtyFields={ dirtyFields }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Remove "Jetpack" from Anti-spam card title in Calypso Jetpack Security settings. Fixes #37120 

ref: p1HpG7-7Ro (feature naming alignment)

<img width="1312" alt="Screen Shot 2019-10-28 at 1 37 23 PM" src="https://user-images.githubusercontent.com/204742/67723703-64a40600-f9a2-11e9-99de-edf211b46564.png">

#### Testing instructions
* Check out this branch
* Purchase any level paid Jetpack Plan on a test site
* Go to `http://calypso.localhost:3000/settings/security/SITE_URL` and see that the Anti-spam card title has been updated as in the above screenshot (word "Jetpack" removed).
