### PR TITLE
Wpcom Checklist: Add missing translate call

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -127,10 +127,10 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	handleTaskDismiss = taskId => () => {
-		const { siteId } = this.props;
+		const { siteId, translate } = this.props;
 
 		if ( taskId ) {
-			this.props.successNotice( 'You completed a task!', { duration: 5000 } );
+			this.props.successNotice( translate( 'You completed a task!' ), { duration: 5000 } );
 			this.props.requestSiteChecklistTaskUpdate( siteId, taskId );
 			this.trackTaskDismiss( taskId );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a missing `translate()` call.

#### Testing instructions

Skip a step in a site's checklist ( https://wordpress.com/home/$site ). You can use the community translator to check whether the string is translatable:

before:
![Liste_de_contrôle_du_site_‹_Site_Title_—_WordPress_com](https://user-images.githubusercontent.com/5952255/67730865-10e8f980-fa42-11e9-8b8c-8a0aaaebdeef.jpg)

After:

![Liste_de_contrôle_du_site_‹_Site_Title_—_WordPress_com_and_Slack___i18n-chatter___A8C_and_Wpcom_Checklist__Add_missing_translate_call_by_deBhal_·_Pull_Request__37132_·_Automattic_wp-calypso](https://user-images.githubusercontent.com/5952255/67731132-e9466100-fa42-11e9-800f-86fe9f04faca.jpg)
