### PR TITLE
Enable concierge upsell for wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,6 +143,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,
+		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Post checkout Concierge upsell offer page does not show in `wpcalypso` environment. This makes testing that offer page impossible when using the calypso.live links.
* This PR enables the post signup concierge upsell offer for `wpcalypso` environment



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live URL from [here](https://github.com/Automattic/wp-calypso/pull/37135#issuecomment-547289785) to go through the signup flow
* Purchase a Personal plan
* Verify that you can see the concierge upsell offer.


