### PR TITLE
Server: Refactor entrypoint handling in server handler

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -755,8 +755,10 @@ module.exports = function() {
 		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get( pathRegex, function( req, res, next ) {
-			req.context = getDefaultContext( req, entrypoint );
-			req.context.sectionName = section.name;
+			req.context = {
+				...getDefaultContext( req, entrypoint ),
+				sectionName: section.name,
+			};
 
 			if ( ! entrypoint && config.isEnabled( 'code-splitting' ) ) {
 				req.context.chunkFiles = getFilesForChunk( section.name, req );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -239,7 +239,7 @@ function setupLoggedInContext( req, res, next ) {
 	next();
 }
 
-function getDefaultContext( request ) {
+function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	let initialServerState = {};
 	let lang = config( 'i18n_default_locale_slug' );
 	const bodyClasses = [];
@@ -294,7 +294,7 @@ function getDefaultContext( request ) {
 		isWCComConnect,
 		badge: false,
 		lang,
-		entrypoint: getFilesForEntrypoint( target, 'entry-main' ),
+		entrypoint: getFilesForEntrypoint( target, entrypoint ),
 		manifest: getAssets( target ).manifests.manifest,
 		faviconURL: config( 'favicon_url' ),
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
@@ -554,7 +554,6 @@ function setUpCSP( req, res, next ) {
 }
 
 function setUpRoute( req, res, next ) {
-	req.context = getDefaultContext( req );
 	setUpCSP( req, res, () =>
 		req.context.isLoggedIn
 			? setUpLoggedInRoute( req, res, next )
@@ -737,7 +736,7 @@ module.exports = function() {
 
 	// Landing pages for domains-related emails
 	app.get( '/domain-services/:action', function( req, res ) {
-		const ctx = getDefaultContext( req );
+		const ctx = getDefaultContext( req, 'entry-domains-landing' );
 		attachBuildTimestamp( ctx );
 		attachHead( ctx );
 		attachI18n( ctx );
@@ -748,22 +747,18 @@ module.exports = function() {
 			query: get( req, 'query', {} ),
 		};
 
-		const target = getBuildTargetFromRequest( req );
-
-		const pageHtml = renderJsx( 'domains-landing', {
-			...ctx,
-			entrypoint: getFilesForEntrypoint( target, 'entry-domains-landing' ),
-		} );
+		const pageHtml = renderJsx( 'domains-landing', ctx );
 		res.send( pageHtml );
 	} );
 
-	function handleSectionPath( section, sectionPath, isEntrypoint = false ) {
+	function handleSectionPath( section, sectionPath, entrypoint ) {
 		const pathRegex = pathToRegExp( sectionPath );
 
 		app.get( pathRegex, function( req, res, next ) {
-			req.context = Object.assign( {}, req.context, { sectionName: section.name } );
+			req.context = getDefaultContext( req, entrypoint );
+			req.context.sectionName = section.name;
 
-			if ( ! isEntrypoint && config.isEnabled( 'code-splitting' ) ) {
+			if ( ! entrypoint && config.isEnabled( 'code-splitting' ) ) {
 				req.context.chunkFiles = getFilesForChunk( section.name, req );
 			} else {
 				req.context.chunkFiles = EMPTY_ASSETS;
@@ -800,20 +795,9 @@ module.exports = function() {
 			}
 		} );
 
-	function loginRouteSetup( req, res, next ) {
-		req.context = getDefaultContext( req );
-		const target = getBuildTargetFromRequest( req );
-		req.context.entrypoint = getFilesForEntrypoint( target, 'entry-login' );
-		setUpCSP( req, res, () =>
-			req.context.isLoggedIn
-				? setUpLoggedInRoute( req, res, next )
-				: setUpLoggedOutRoute( req, res, next )
-		);
-	}
-
 	// Set up login routing.
-	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', true );
-	loginRouter( serverRouter( app, loginRouteSetup, null ) );
+	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
+	loginRouter( serverRouter( app, setUpRoute, null ) );
 
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers
 	app.post(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor entrypoint handling in server handler

Branched from @jsnajdr's #37071 (thanks Jarda!)

> [...] preparatory refactoring of the rather chaotic server-side code that creates Express.js route handlers for entrypoints and sections and sends along the right JS and CSS webpack chunks.

#### Testing instructions

- Verify that the app still builds and runs
- In an incognito window, try accessing `http://calypso.localhost:3000/log-in/link/use/es`. You should see a warning in Spanish ("El enlace de acceso ha caducado o no es válido") :grimacing: (Compare to current production)
- In an incognito window, try accessing `http://calypso.localhost:3000/domain-services/unknown-action`. You should see a warning saying "Uh oh. Page not found. If you've arrived here after clicking a link from a WordPress.com email, please contact support.". (Again, compare to production.)

The lint error that CircleCI complains about is about the 'restricted' `superagent` import. Ignore.