### PR TITLE
Add formatted header to plans grid if Jetpack Backup is enabled

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -152,6 +152,14 @@ export class PlansFeaturesMain extends Component {
 				) }
 				data-e2e-plans={ displayJetpackPlans ? 'jetpack' : 'wpcom' }
 			>
+				{ /* @todo: Add translations in FormattedHeader once the final copy is provided. */ }
+				{ isEnabled( 'plans/jetpack-backup' ) && (
+					<FormattedHeader
+						headerText="Plans"
+						subHeaderText="Get everything your site needs, in one package — so you can focus on your business."
+						compactOnMobile
+					/>
+				) }
 				<PlanFeatures
 					basePlansPath={ basePlansPath }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -153,7 +153,7 @@ export class PlansFeaturesMain extends Component {
 				data-e2e-plans={ displayJetpackPlans ? 'jetpack' : 'wpcom' }
 			>
 				{ /* @todo: Add translations in FormattedHeader once the final copy is provided. */ }
-				{ isEnabled( 'plans/jetpack-backup' ) && (
+				{ isEnabled( 'plans/jetpack-backup' ) && displayJetpackPlans && (
 					<FormattedHeader
 						headerText="Plans"
 						subHeaderText="Get everything your site needs, in one package — so you can focus on your business."


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add formatted header to plans grid if Jetpack Backup is enabled

![Screenshot 2019-10-29 at 12 31 23](https://user-images.githubusercontent.com/478735/67763472-0fbacb00-fa48-11e9-8daa-6e97dfbc1407.png)

![Screenshot 2019-10-29 at 12 31 09](https://user-images.githubusercontent.com/478735/67763476-121d2500-fa48-11e9-899b-bb363d2b5ade.png)

#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/plans/, select a Jetpack site and confirm that there's a "Plans" header along with an intro text between Jetpack Backup and plans grid.
* Go to http://calypso.localhost:3000/plans/, select a non-Jetpack site (.com, pressable etc.) and confirm there is **no header and intro text** between Jetpack Backup and plans grid.
* Go to http://calypso.localhost:3000/jetpack/connect/store and confirm that there's a "Plans" header along with an intro text between Jetpack Backup and plans grid.

Fixes n/a