### PR TITLE
Update Crowdsignal OAuth pages styling

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -264,12 +264,9 @@ class Login extends Component {
 			}
 
 			if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
-				headerText = translate( 'Howdy!{{br/}}Log in to %(clientTitle)s:', {
+				headerText = translate( 'Sign in to %(clientTitle)s', {
 					args: {
 						clientTitle: oauth2Client.title,
-					},
-					components: {
-						br: <br />,
 					},
 				} );
 			}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -573,28 +573,6 @@ export class LoginForm extends Component {
 						</p>
 					) }
 
-					{ config.isEnabled( 'signup/social' ) && isCrowdsignalOAuth2Client( oauth2Client ) && (
-						<p className="login__form-terms login__form-terms-bottom">
-							{ preventWidows(
-								this.props.translate(
-									'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
-									{
-										components: {
-											tosLink: (
-												<a
-													href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								),
-								5
-							) }
-						</p>
-					) }
-
 					<div className="login__form-action">
 						<FormsButton primary disabled={ isFormDisabled }>
 							{ this.isPasswordView() || this.isFullView()

--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -132,20 +132,24 @@ class CrowdsignalSignupForm extends Component {
 									>
 										{ translate( 'Create a WordPress.com Account' ) }
 									</FormButton>
+
+									<p className="signup-form__crowdsignal-learn-more">
+										{ translate( 'Why WordPress.com? {{a}}Learn more.{{/a}}', {
+											components: {
+												a: (
+													<a
+														href="https://crowdsignal.com/2012/12/03/crowdsignal-wordpress-account/"
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
+											},
+										} ) }
+									</p>
 								</LoggedOutFormFooter>
 							</LoggedOutForm>
 						</div>
 					</div>
-				</div>
-
-				<div className="signup-form__crowdsignal-tos">
-					<span>
-						{ translate( 'By creating an account, you agree to our {{a}}Terms of Service{{/a}}.', {
-							components: {
-								a: <a href="https://wordpress.com/tos" target="_blank" rel="noopener noreferrer" />,
-							},
-						} ) }
-					</span>
 				</div>
 
 				<div className={ backButtonWrapperClass }>

--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -134,7 +134,7 @@ class CrowdsignalSignupForm extends Component {
 									</FormButton>
 
 									<p className="signup-form__crowdsignal-learn-more">
-										{ translate( 'Why WordPress.com? {{a}}Learn more.{{/a}}', {
+										{ translate( 'Why WordPress.com? {{a}}Learn more{{/a}}.', {
 											components: {
 												a: (
 													<a

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -59,7 +59,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 
 	@include breakpoint( '>660px' ) {
-		background-color: var( --color-white );
+		background-color: var( --color-surface );
 	    box-shadow: 0 2px 3px 0 var( --color-neutral-10 );
 		display: block;
 		margin: 0 auto;

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -16,59 +16,27 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.signup.is-crowdsignal {
-	// Crowdsignal color palette
-	--color-link: #001d2d;
-	--color-text: #001d2d;
-	--color-link-hover: #4ccee4;
-
-	.formatted-header {
-		color: var( --color-text );
-
-		font-family: 'Muli', $sans;
-		margin-bottom: 20px;
-	}
-
-	.formatted-header__title {
-		font-size: 32px;
-		font-weight: 600;
-		margin-bottom: 10px;
-	}
-
-	.formatted-header__subtitle {
-		font-size: 15px;
-
-		a {
-			font-weight: 600;
-		}
-
-		@include breakpoint( '<660px' ) {
-			margin: 40px 0;
-		}
-	}
+.signup.is-crowdsignal .formatted-header {
+	margin-bottom: 20px;
 }
 
-.signup-form__crowdsignal {
-	// Crowdsignal color palette
-	--color-accent: #bd4682;
-	--color-accent-dark: #8d2259;
-	--color-crowdsignal: #001d2d;
-	--color-link: #001d2d;
-	--color-text: #001d2d;
+.signup.is-crowdsignal .formatted-header__title {
+	font-family: 'Recoleta', serif;
+	font-size: 32px;
+	font-weight: bold;
+	margin-bottom: 10px;
+}
 
-	color: var( --color-text );
-	font-family: 'Muli', $sans;
+.signup.is-crowdsignal .formatted-header__subtitle {
+	color: var( --color-text-subtle );
+	font-size: 15px;
 
-	.button {
-		border: 0;
-		border-radius: 0;
-		box-sizing: border-box;
-		font-family: 'Muli', $sans;
-		padding: 12px 20px;
+	a {
+		font-weight: bold;
+	}
 
-		&.is-primary {
-			border: 1px solid var( --color-accent-dark );
-		}
+	@include breakpoint( '<660px' ) {
+		margin: 40px 0;
 	}
 }
 
@@ -91,7 +59,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 
 	@include breakpoint( '>660px' ) {
-		background-color: var( --color-surface );
+		background-color: var( --color-white );
 	    box-shadow: 0 2px 3px 0 var( --color-neutral-10 );
 		display: block;
 		margin: 0 auto;
@@ -105,12 +73,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 
 	.button {
-		display: block;
-		font-weight: normal;
-		letter-spacing: 0.5px;
 		width: 100%;
-		// !important is necessary to get the shadows to match on all buttons
-		box-shadow: 0 2px 3px 0 var( --color-neutral-10 ) !important;
 	}
 
 	.card {
@@ -147,15 +110,23 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.signup-form__crowdsignal-social {
+.button.is-primary.signup-form__crowdsignal-submit {
+	background: var( --color-primary );
+	border-color: var( --color-primary-dark );
+}
+
+.signup-form__crowdsignal-wpcom .wordpress-logo {
+	margin: 0 15px 0 0;
+}
+
+.crowdsignal .signup-form__social {
 	.button {
+		display: none;
 		margin-bottom: 40px;
 		text-align: left;
 
-		.wordpress-logo {
-			margin: 0 15px 0 0;
-			height: 22px;
-			width: 22px;
+		&:first-child {
+			display: block;
 		}
 
 		@include breakpoint( '<660px' ) {
@@ -163,12 +134,12 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		}
 	}
 
-	.social-buttons__button {
-		border: 1px solid #cecfd1;
-	}
-
 	.social-buttons__service-name {
 		margin-left: 15px;
+	}
+
+	.signup-form__social-buttons-tos {
+		display: none;
 	}
 }
 
@@ -191,6 +162,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 }
 
 .signup-form__crowdsignal-card-subheader {
+	color: var( --color-text-subtle );
 	display: none;
 	margin: 0 auto;
 	padding: 20px 0 50px;
@@ -203,10 +175,12 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .button.signup-form__crowdsignal-wpcom {
 	display: flex;
+	margin-bottom: 40px;
 }
 
 .button.signup-form__crowdsignal-show-form {
-	background-color: var( --color-crowdsignal );
+	background-color: var( --color-primary );
+	border-color: var( --color-primary-dark );
 	color: var( --color-text-inverted );
 	text-align: center;
 	margin: 20px 0 0;
@@ -218,6 +192,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal-learn-more {
 	font-size: 12px;
+	margin-bottom: -10px;
 	margin-top: 20px;
 	text-align: center;
 
@@ -268,11 +243,12 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	width: 100%;
 }
 
-.signup-form__crowdsignal-back-button {
+.crowdsignal .signup-form__crowdsignal-back-button {
 	border: 0;
-	color: var( --color-text );
+	color: var( --color-text-subtle );
 	display: none;
 	padding: 0;
+	text-decoration: none;
 
 	&:hover {
 		color: var( --color-link-hover );
@@ -288,7 +264,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 }
 
 .button.signup-form__crowdsignal-prev-button {
-	color: var( --color-text );
 	display: inline-block;
 
 	.signup-form__crowdsignal-back-button-wrapper.is-first-step & {
@@ -302,7 +277,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal-tos {
 	text-align: center;
-	color: var( --color-neutral-50 );
+	color: var( --color-text-subtle );
 	margin-top: 20px;
 	padding: 0 20px;
 
@@ -314,10 +289,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 .signup-form__crowdsignal-footer {
 	background-color: var( --color-crowdsignal );
 	box-sizing: border-box;
-	color: var( --color-neutral-0 );
+	color: var( --color-text-inverted );
 	display: flex;
 	flex-direction: row;
-	fill: var( --color-neutral-0 );
+	fill: var( --color-text-inverted );
 	height: 58px;
 	padding: 20px 40px;
 	position: absolute;

--- a/client/layout/masterbar/crowdsignal.jsx
+++ b/client/layout/masterbar/crowdsignal.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { filter, map, tap } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/layout/masterbar/crowdsignal.jsx
+++ b/client/layout/masterbar/crowdsignal.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { filter, tap } from 'lodash';
+import { filter, map, tap } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,22 +17,18 @@ import './crowdsignal.scss';
 
 class CrowdsignalOauthMasterbar extends Component {
 	componentDidMount() {
-		// Crowdsignal's OAuth2 pages should load and use the 'Muli' font to match the marketing page
+		// Crowdsignal's OAuth2 pages should load and use the 'Recoleta' font to match the style of the app
 		// By loading it here we're not affecting any other pages inside Calypso that don't need the font
-		const crowdsignalGoogleFontsLink = 'https://fonts.googleapis.com/css?family=Muli:400,600';
-		const crowdsignalFonts = filter(
-			Array.from( document.head.childNodes ),
-			node => node.nodeName.toLowerCase() === 'link' && node.href === crowdsignalGoogleFontsLink
-		);
 
-		if ( crowdsignalFonts.length === 0 ) {
-			document.head.appendChild(
-				tap( document.createElement( 'link' ), link => {
-					link.type = 'text/css';
-					link.rel = 'stylesheet';
-					link.href = crowdsignalGoogleFontsLink;
-				} )
-			);
+		const crowdsignalFonts = [
+			new FontFace( 'Recoleta', 'url(https://s1.wp.com/i/fonts/recoleta/400.woff2)' ),
+			new FontFace( 'Recoleta', 'url(https://s1.wp.com/i/fonts/recoleta/700.woff2)', { weight: 700} ),
+		];
+
+		if ( ! document.fonts.check( '12px Recoleta' ) ) {
+			map( crowdsignalFonts, ( font ) => {
+				font.load().then( ( loadedFont ) => document.fonts.add( loadedFont ) );
+			} );
 		}
 	}
 

--- a/client/layout/masterbar/crowdsignal.scss
+++ b/client/layout/masterbar/crowdsignal.scss
@@ -1,21 +1,37 @@
+.crowdsignal {
+	// Crowdsignal color palette
+
+	--color-crowdsignal: var( --studio-wordpress-blue-90 );
+
+	--color-primary: var( --studio-wordpress-blue-90 );
+	--color-primary-dark: var( --studio-wordpress-blue-100 );
+	--color-accent: var( --studio-pink-50 );
+	--color-accent-dark: var( --studio-pink-70 );
+
+	--color-border: var( --studio-gray-5 );
+	--color-surface: var( --studio-white );
+
+	--color-text: var( --studio-gray-100 );
+	--color-text-subtle: var( --studio-gray-50 );
+	--color-text-inverted: var( --studio-white );
+	--color-link: inherit;
+}
+
 .masterbar.masterbar__crowdsignal {
-	background-color: #fff;
+	background-color: var( --color-crowdsignal );
 	border: 0;
 	box-sizing: border-box;
-	font-family: 'Muli', $sans;
-	height: 90px;
-	padding: 20px;
+	color: var( --color-text-inverted );
+	height: 64px;
+	padding: 8px 20px;
 	position: absolute;
 		left: 0;
 		right: 0;
 		top: 0;
 
 	@include breakpoint( '>480px' ) {
-		padding: 20px 35px;
-	}
-
-	@include breakpoint( '>660px' ) {
-		padding: 20px 60px;
+		height: 88px;
+		padding: 20px 25px;
 	}
 }
 
@@ -45,7 +61,6 @@
 }
 
 .masterbar__crowdsignal-text {
-	color: #969ca1;
 	display: flex;
 	flex-direction: column;
 	font-size: 10px;
@@ -76,5 +91,5 @@
 }
 
 .masterbar__crowdsignal-wordpress-logo {
-	fill: #3d4145;
+	fill: var( --color-text-inverted );
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -133,7 +133,7 @@
 			padding-bottom: 145px;
 		}
 
-		.card {
+		.card:not(.gdpr-banner) {
 			background: none;
 			box-shadow: none;
 			border: 0;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -88,15 +88,42 @@
 }
 
 .crowdsignal {
-	// Crowdsignal color palette
-	--color-accent: #bd4682;
-	--color-crowdsignal: #001d2d;
-	--color-link: #001d2d;
-	--color-text: #001d2d;
+	background: var( --color-surface );
+	color: var( --studio-gray-100 );
 
-	background: #f2f2f2;
-	color: var( --color-text );
-	font-family: 'Muli', $sans;
+	@include breakpoint( '>660px' ) {
+		background: var( --studio-gray-0 );
+	}
+
+	a, a:visited {
+		color: inherit;
+	}
+
+	.button {
+		background-color: var( --studio-gray-0 );
+		border-radius: 5px;
+		border-width: 1px 1px 2px;
+		box-shadow: none;
+		box-sizing: border-box;
+		font-size: 14px;
+		font-weight: 500;
+		height: 45px;
+		line-height: normal;
+		padding: 13px 40px 12px;
+
+		&.is-borderless {
+			background-color: transparent;
+		}
+
+		&.is-primary {
+			background-color: var( --color-accent );
+			border-color: var( --color-accent-dark );
+		}
+	}
+
+	.card {
+		--color-link-hover: #4ccee4;
+	}
 
 	&.is-section-login {
 		padding-bottom: 100px;
@@ -104,16 +131,6 @@
 		@include breakpoint( '>660px' ) {
 			min-height: calc( 100% - 145px );
 			padding-bottom: 145px;
-		}
-
-		.button {
-			border: 0;
-			border-radius: 0;
-			box-sizing: border-box;
-			font-family: 'Muli', $sans;
-			font-weight: normal;
-			letter-spacing: 0.5px;
-			padding: 12px 20px;
 		}
 
 		.card {
@@ -155,13 +172,37 @@
 			position: relative;
 		}
 
+		.login__social-buttons {
+			.button {
+				display: none;
+				margin-bottom: 40px;
+				text-align: left;
+
+				&:first-child {
+					display: block;
+				}
+
+				@include breakpoint( '<660px' ) {
+					margin-bottom: 20px;
+				}
+			}
+
+			.social-buttons__service-name {
+				margin-left: 15px;
+			}
+
+			.login__social-tos {
+				display: none;
+			}
+		}
+
 		.login form {
 			box-sizing: border-box;
 			display: block;
 
 			@include breakpoint( '>660px' ) {
 				background-color: var( --color-surface );
-				box-shadow: 0 2px 3px 0 var( --color-neutral-10 );
+				box-shadow: 0 2px 3px 0 var(--color-neutral-10);
 				margin: 0 auto;
 				padding: 35px 55px 20px;
 				width: 550px;
@@ -184,10 +225,12 @@
 		}
 
 		.login__form-header {
+			font-family: 'Recoleta', serif;
 			font-size: 25px;
 			color: var( --color-text );
 			font-weight: 600;
 			margin-bottom: 80px;
+			margin-top: 0;
 
 			@include breakpoint( '>480px' ) {
 				font-size: 32px;
@@ -215,7 +258,6 @@
 			display: none;
 
 			@include breakpoint( '>660px' ) {
-				color: var( --color-text );
 				display: block;
 				font-size: 20px;
 				font-weight: 600;
@@ -225,30 +267,16 @@
 		}
 
 		.login__form-terms {
-			color: var( --color-text );
 			margin: 0;
 			position: absolute;
 			left: 0;
 			right: 0;
-			top: 84px;
+			top: 60px;
 			text-align: center;
 
-			@include breakpoint( '>480px' ) {
-				top: 106px;
-			}
-
 			@include breakpoint( '>660px' ) {
-				display: none;
-			}
-
-			&.login__form-terms-bottom {
-				display: none;
-
-				@include breakpoint( '>660px' ) {
-					display: block;
-					position: initial;
-					margin-bottom: 30px;
-				}
+				position: static;
+				margin-bottom: 30px;
 			}
 
 			a {
@@ -312,15 +340,6 @@
 			margin: 0 0 24px;
 		}
 
-		.social-buttons__button {
-			border: 1px solid #cecfd1;
-			border-radius: 0;
-
-			&:last-of-type {
-				margin-bottom: 40px;
-			}
-		}
-
 		.translator-invite {
 			display: none;
 		}
@@ -328,10 +347,10 @@
 		.wp-login__crowdsignal-footer {
 			background-color: var( --color-crowdsignal );
 			box-sizing: border-box;
-			color: var( --color-neutral-0 );
+			color: var( --color-text-inverted );
 			display: flex;
 			flex-direction: row;
-			fill: var( --color-neutral-0 );
+			fill: var( --color-text-inverted );
 			height: 58px;
 			padding: 20px 40px;
 			position: absolute;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -112,12 +112,12 @@ export class UserStep extends Component {
 				} );
 			} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 				subHeaderText = translate(
-					'Crowdsignal now uses WordPress.com Accounts.{{br/}}{{a}}Learn more about the benefits{{/a}}',
+					'By creating an account via any of the options below, {{br/}}you agree to our {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
 							a: (
 								<a
-									href="https://crowdsignal.com/2012/12/03/crowdsignal-wordpress-account/"
+									href="https://wordpress.com/tos/"
 									target="_blank"
 									rel="noopener noreferrer"
 								/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates Crowdsignal's sign up and login pages according to pabtAt-vM-p2.

I also moved the previously scattered Crowdsignal color palette definitions into `client/layout/masterbar/crowdsignal.scss` as the custom masterbar is a common denominator for all pages where it should apply.

Note: the logo is part of the settings so we need to update these or the image itself separately to match Crowdsignal.com.

How it looks now:

![crowdsignal-login-desktop](https://user-images.githubusercontent.com/8056203/67765258-fe73bd80-fa4b-11e9-8589-f41b89c5fb87.png)
![crowdsignal-login-mobile](https://user-images.githubusercontent.com/8056203/67765606-d3d63480-fa4c-11e9-94e8-f74af01b0c4b.png)
![crowdsignal-signup-desktop](https://user-images.githubusercontent.com/8056203/67765260-ff0c5400-fa4b-11e9-83a0-d6072dbbec6b.png)
![crowdsignal-signup-mobile](https://user-images.githubusercontent.com/8056203/67765262-ff0c5400-fa4b-11e9-93a9-753ed5625c4d.png)

#### Testing instructions

