### PR TITLE
Add `overrides` option to `transpile`.

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Add `overrides` option to `transpile`, to be used in `babel-loader`.
+  This allows for providing e.g. extra plugin configuration, beyond what's in the `configFile`.
+
 # 5.0.1
 
 - Fix PostCSS config path default.

--- a/packages/calypso-build/webpack/transpile.js
+++ b/packages/calypso-build/webpack/transpile.js
@@ -19,6 +19,7 @@ module.exports.loader = ( {
 	exclude,
 	include,
 	presets,
+	overrides,
 } ) => ( {
 	test: /\.[jt]sx?$/,
 	include,
@@ -38,6 +39,7 @@ module.exports.loader = ( {
 				cacheDirectory,
 				cacheIdentifier,
 				presets,
+				overrides,
 			},
 		},
 	],


### PR DESCRIPTION
This allows for providing e.g. extra plugin configuration, beyond what's in the `configFile`.

This will be useful for a `babel` plugin I'm writing; the `webpack` configuration file is aware of the current environment, whereas the `babel` configuration file is not. With `overrides`, I can instance the plugin with the correct options in the `webpack` configuration file, while keeping all the existing options that are defined in the `babel` configuration file.

#### Changes proposed in this Pull Request

* Add `overrides` option to `transpile`.

#### Testing instructions

No testing instructions. This is a new option that gets directly forwarded to `babel-loader`, so everything should continue working normally, as it's not yet being used.
