### PR TITLE
Plans: Set ProductSelector to loading state when purchases are fetching

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -20,7 +20,7 @@ import { extractProductSlugs, filterByProductSlugs } from './utils';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
+import { getSitePurchases, isFetchingSitePurchases } from 'state/purchases/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 
@@ -206,9 +206,15 @@ export class ProductSelector extends Component {
 	}
 
 	renderProducts() {
-		const { currencyCode, intervalType, products, storeProducts } = this.props;
+		const {
+			currencyCode,
+			fetchingSitePurchases,
+			intervalType,
+			products,
+			storeProducts,
+		} = this.props;
 
-		if ( isEmpty( storeProducts ) ) {
+		if ( isEmpty( storeProducts ) || fetchingSitePurchases ) {
 			return map( products, product => {
 				return (
 					<ProductCard
@@ -291,6 +297,7 @@ ProductSelector.propTypes = {
 
 	// Connected props
 	currencyCode: PropTypes.string,
+	fetchingSitePurchases: PropTypes.bool,
 	productSlugs: PropTypes.arrayOf( PropTypes.string ),
 	purchases: PropTypes.array,
 	selectedSiteId: PropTypes.number,
@@ -314,6 +321,7 @@ const connectComponent = connect( ( state, { products, siteId } ) => {
 
 	return {
 		currencyCode: getCurrentUserCurrencyCode( state ),
+		fetchingSitePurchases: isFetchingSitePurchases( state ),
 		productSlugs,
 		purchases: getSitePurchases( state, selectedSiteId ),
 		selectedSiteId,


### PR DESCRIPTION
Currently, if purchases aren't loaded, we display options available for purchase, even if the product has been purchased. This is because the purchases can take longer to load. So this PR alters the `ProductSelector` block to display a loading state while the site purchases are being fetched.

#### Changes proposed in this Pull Request

* Plans: Set ProductSelector to loading state when purchases are fetching

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site.
* Verify that while site purchases are loading, you see the products in a placeholder/loading state.
* Verify this works well both in monthly and yearly billing interval.
* Verify this works well when a product has been purchased from the selected billing interval.
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector and pick a Jetpack site.
* Verify that while site purchases are loading, you see the products in a placeholder/loading state.
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify it doesn't show placeholder/loading state because there's no selected site in that page.
