### PR TITLE
Blocks: Fix option-related PropTypes in ProductSelector

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -279,7 +279,15 @@ ProductSelector.propTypes = {
 			id: PropTypes.string,
 			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 			options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
-			optionDescriptions: PropTypes.objectOf( [ PropTypes.string, PropTypes.element ] ),
+			optionDescriptions: PropTypes.objectOf(
+				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
+			),
+			optionDisplayNames: PropTypes.objectOf(
+				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
+			),
+			optionShortNames: PropTypes.objectOf(
+				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
+			),
 			optionsLabel: PropTypes.string,
 		} )
 	).isRequired,


### PR DESCRIPTION
Currently, when accessing the Plans page for a Jetpack site on wpcalypso or dev environment, we can see this React warning:

![](https://cldup.com/t1yNvEPAfp.png)

This PR fixes it by resolving the existing problems in the `ProductSelector` propTypes definition.

#### Changes proposed in this Pull Request

* Fix propTypes inside ProductSelector

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site.
* Verify the prop warning is gone and the block functions properly.
