### PR TITLE
Split multiple modules in `lib/url`

### DIFF
--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { format as formatUrl, parse as parseUrl } from 'url';
-import { has, isString, omit, startsWith } from 'lodash';
+import { has, isString, omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { URL, Scheme } from 'types';
+import { URL } from 'types';
 import { Falsy } from 'utility-types';
 
 /**
@@ -18,46 +18,9 @@ export { withoutHttp, urlToSlug, urlToDomainAndPath } from './http-utils';
 export { default as isExternal } from './is-external';
 export { default as resemblesUrl } from './resembles-url';
 export { URL_TYPE, determineUrlType } from './url-type';
-
-/**
- * Check if a URL is located outside of Calypso.
- * Note that the check this function implements is incomplete --
- * it only returns false for absolute URLs, so it misses
- * relative URLs, or pure query strings, or hashbangs.
- *
- * @param  url URL to check
- * @return     true if the given URL is located outside of Calypso
- */
-export function isOutsideCalypso( url: URL ): boolean {
-	return !! url && ( startsWith( url, '//' ) || ! startsWith( url, '/' ) );
-}
-
-export function isHttps( url: URL ): boolean {
-	return !! url && startsWith( url, 'https://' );
-}
-
-const schemeRegex = /^\w+:\/\//;
-
-export function addSchemeIfMissing( url: URL, scheme: Scheme ): URL {
-	if ( false === schemeRegex.test( url ) ) {
-		return scheme + '://' + url;
-	}
-	return url;
-}
-
-export function setUrlScheme( url: URL, scheme: Scheme ) {
-	const schemeWithSlashes = scheme + '://';
-	if ( startsWith( url, schemeWithSlashes ) ) {
-		return url;
-	}
-
-	const newUrl = addSchemeIfMissing( url, scheme );
-	if ( newUrl !== url ) {
-		return newUrl;
-	}
-
-	return url.replace( schemeRegex, schemeWithSlashes );
-}
+export { default as isOutsideCalypso } from './is-outside-calypso';
+export { default as isHttps } from './is-https';
+export { addSchemeIfMissing, setUrlScheme } from './scheme-utils';
 
 /**
  * Removes given params from a url.

--- a/client/lib/url/is-https.ts
+++ b/client/lib/url/is-https.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { URL as URLString } from 'types';
+
+export default function isHttps( url: URLString ): boolean {
+	return !! url && url.startsWith( 'https://' );
+}

--- a/client/lib/url/is-outside-calypso.ts
+++ b/client/lib/url/is-outside-calypso.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { URL as URLString } from 'types';
+
+/**
+ * Check if a URL is located outside of Calypso.
+ * Note that the check this function implements is incomplete --
+ * it only returns false for absolute URLs, so it misses
+ * relative URLs, or pure query strings, or hashbangs.
+ *
+ * @param  url URL to check
+ * @return     true if the given URL is located outside of Calypso
+ */
+export default function isOutsideCalypso( url: URLString ): boolean {
+	return !! url && ( url.startsWith( '//' ) || ! url.startsWith( '/' ) );
+}

--- a/client/lib/url/scheme-utils.ts
+++ b/client/lib/url/scheme-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { URL as URLString, Scheme } from 'types';
+
+const schemeRegex = /^\w+:\/\//;
+
+export function addSchemeIfMissing( url: URLString, scheme: Scheme ): URLString {
+	if ( false === schemeRegex.test( url ) ) {
+		return scheme + '://' + url;
+	}
+	return url;
+}
+
+export function setUrlScheme( url: URLString, scheme: Scheme ) {
+	const schemeWithSlashes = scheme + '://';
+	if ( url && url.startsWith( schemeWithSlashes ) ) {
+		return url;
+	}
+
+	const newUrl = addSchemeIfMissing( url, scheme );
+	if ( newUrl !== url ) {
+		return newUrl;
+	}
+
+	return url.replace( schemeRegex, schemeWithSlashes );
+}

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -10,56 +10,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { addSchemeIfMissing, setUrlScheme, omitUrlParams } from '../';
-
-describe( 'addSchemeIfMissing()', () => {
-	test( 'should add scheme if missing', () => {
-		const source = 'example.com/path';
-		const expected = 'https://example.com/path';
-
-		const actual = addSchemeIfMissing( source, 'https' );
-
-		expect( actual ).to.equal( expected );
-	} );
-
-	test( 'should skip if scheme exists', () => {
-		const source = 'https://example.com/path';
-		const expected = 'https://example.com/path';
-
-		const actual = addSchemeIfMissing( source, 'https' );
-
-		expect( actual ).to.equal( expected );
-	} );
-} );
-
-describe( 'setUrlScheme()', () => {
-	test( 'should skip if scheme already set', () => {
-		const source = 'http://example.com/path';
-		const expected = 'http://example.com/path';
-
-		const actual = setUrlScheme( source, 'http' );
-
-		expect( actual ).to.equal( expected );
-	} );
-
-	test( 'should add scheme if missing', () => {
-		const source = 'example.com/path';
-		const expected = 'http://example.com/path';
-
-		const actual = setUrlScheme( source, 'http' );
-
-		expect( actual ).to.equal( expected );
-	} );
-
-	test( 'should replace scheme if different', () => {
-		const source = 'https://example.com/path';
-		const expected = 'http://example.com/path';
-
-		const actual = setUrlScheme( source, 'http' );
-
-		expect( actual ).to.equal( expected );
-	} );
-} );
+import { omitUrlParams } from '../';
 
 describe( 'omitUrlParams()', () => {
 	describe( 'when no URL is supplied', () => {

--- a/client/lib/url/test/scheme-utils.js
+++ b/client/lib/url/test/scheme-utils.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { addSchemeIfMissing, setUrlScheme } from '../scheme-utils';
+
+describe( 'addSchemeIfMissing()', () => {
+	test( 'should add scheme if missing', () => {
+		const source = 'example.com/path';
+		const expected = 'https://example.com/path';
+
+		const actual = addSchemeIfMissing( source, 'https' );
+
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should skip if scheme exists', () => {
+		const source = 'https://example.com/path';
+		const expected = 'https://example.com/path';
+
+		const actual = addSchemeIfMissing( source, 'https' );
+
+		expect( actual ).toBe( expected );
+	} );
+} );
+
+describe( 'setUrlScheme()', () => {
+	test( 'should skip if scheme already set', () => {
+		const source = 'http://example.com/path';
+		const expected = 'http://example.com/path';
+
+		const actual = setUrlScheme( source, 'http' );
+
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should add scheme if missing', () => {
+		const source = 'example.com/path';
+		const expected = 'http://example.com/path';
+
+		const actual = setUrlScheme( source, 'http' );
+
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should replace scheme if different', () => {
+		const source = 'https://example.com/path';
+		const expected = 'http://example.com/path';
+
+		const actual = setUrlScheme( source, 'http' );
+
+		expect( actual ).toBe( expected );
+	} );
+} );


### PR DESCRIPTION
This is one of several PRs aiming at splitting up `lib/url` into several files for tree-shaking, replacing usage of the browserified node `url` module with native functionality, and generally improving it.

This PR focuses on a few small modules, which I'm splitting out. There are no code changes, other than dropping some trivial `lodash` usage.

This PR was split out from #36531, which got too big.

#### Changes proposed in this Pull Request

* Split out several modules in `lib/url`. Reimplement using native functionality, dropping `lodash`.
* Split out corresponding tests into their own files too. Drop `chai` and use `jest` expectations exclusively.

#### Testing instructions

The unit tests should be enough in ensuring that there are no undesirable behaviour changes.