### PR TITLE
Plans: Move Jetpack Products to product constants

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -90,3 +90,26 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = {
 		ratio: 12,
 	},
 };
+
+// @TODO: Translate those strings once we have confirmed the copy.
+export const JETPACK_PRODUCTS = [
+	{
+		title: 'Jetpack Backup',
+		description: PRODUCT_JETPACK_BACKUP_DESCRIPTION,
+		id: PRODUCT_JETPACK_BACKUP,
+		options: {
+			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
+			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
+		},
+		optionShortNames: {
+			...JETPACK_BACKUP_PRODUCT_SHORT_NAMES,
+		},
+		optionDisplayNames: {
+			...JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES,
+		},
+		optionDescriptions: {
+			...JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
+		},
+		optionsLabel: 'Backup options',
+	},
+];

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -27,16 +27,7 @@ import {
 	GROUP_WPCOM,
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
-import {
-	JETPACK_BACKUP_PRODUCT_SHORT_NAMES,
-	JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES,
-	JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
-	JETPACK_BACKUP_PRODUCTS_MONTHLY,
-	JETPACK_BACKUP_PRODUCTS_YEARLY,
-	JETPACK_PRODUCT_PRICE_MATRIX,
-	PRODUCT_JETPACK_BACKUP,
-	PRODUCT_JETPACK_BACKUP_DESCRIPTION,
-} from 'lib/products-values/constants';
+import { JETPACK_PRODUCT_PRICE_MATRIX, JETPACK_PRODUCTS } from 'lib/products-values/constants';
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
 import WpcomFAQ from './wpcom-faq';
@@ -76,29 +67,6 @@ import { getSiteTypePropertyValue } from 'lib/signup/site-type';
  * Style dependencies
  */
 import './style.scss';
-
-// @todo: Add translations to `jetpackProducts` once the final copy is provided.
-const jetpackProducts = [
-	{
-		title: 'Jetpack Backup',
-		description: PRODUCT_JETPACK_BACKUP_DESCRIPTION,
-		id: PRODUCT_JETPACK_BACKUP,
-		options: {
-			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
-			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
-		},
-		optionShortNames: {
-			...JETPACK_BACKUP_PRODUCT_SHORT_NAMES,
-		},
-		optionDisplayNames: {
-			...JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES,
-		},
-		optionDescriptions: {
-			...JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
-		},
-		optionsLabel: 'Backup options',
-	},
-];
 
 export class PlansFeaturesMain extends Component {
 	componentDidUpdate( prevProps ) {
@@ -442,7 +410,7 @@ export class PlansFeaturesMain extends Component {
 					compactOnMobile
 				/>
 				<ProductSelector
-					products={ jetpackProducts }
+					products={ JETPACK_PRODUCTS }
 					intervalType={ intervalType }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }
 				/>


### PR DESCRIPTION
Currently, the Jetpack Products are defined in the plans page, but that definition makes more sense where the products are defined. This PR is moving it there.

#### Changes proposed in this Pull Request

* Move the Jetpack Products definition to the product constants.

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site.
* Verify the single product plans section still works well.
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector and pick a Jetpack site.
* Verify the single product plans section still works well.
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify the single product plans section still works well.
