### PR TITLE
Domains: Fix Primary Domain chip colors to use correct vars

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -21,8 +21,8 @@
 	.domain__primary-flag {
 		vertical-align: middle;
 		margin-left: 8px;
-		background: var( --sidebar-menu-hover-background );
-		color: var( --sidebar-menu-hover-color );
+		background-color: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-menu-hover-text );
 		border-radius: 12px;
 		display: inline-block;
 		padding: 2px 10px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Primary Domain flag in the domains management section was using the old color variables. This PR updates the flag to use the correct variables, which fixes the visual display.

**Before**

<img width="847" alt="Screen Shot 2019-10-29 at 11 08 38 AM" src="https://user-images.githubusercontent.com/2124984/67780688-d6309280-fa3c-11e9-94a7-016007104169.png">


**After**
 
<img width="844" alt="Screen Shot 2019-10-29 at 11 11 42 AM" src="https://user-images.githubusercontent.com/2124984/67780729-e6e10880-fa3c-11e9-8326-d663326b06f0.png">


#### Testing instructions

* Switch to this PR and navigate to `/domains`
* The primary domain should have a flag or chip underneath with the above colors.