### PR TITLE
Plans: Add Jetpack Backup products as features to Jetpack plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1,4 +1,10 @@
-/** @format */
+/**
+ * Internal dependencies
+ */
+import {
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+} from 'lib/products-values/constants';
 
 // plans constants
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
@@ -150,6 +156,8 @@ export const FEATURE_UNLIMITED_PRODUCTS_SERVICES = 'unlimited-products-service';
 export const FEATURE_ECOMMERCE_MARKETING = 'ecommerce-marketing';
 export const FEATURE_PREMIUM_CUSTOMIZABE_THEMES = 'premium-customizable-themes';
 export const FEATURE_ALL_BUSINESS_FEATURES = 'all-business-features';
+export const FEATURE_JETPACK_BACKUP_DAILY = PRODUCT_JETPACK_BACKUP_DAILY;
+export const FEATURE_JETPACK_BACKUP_REALTIME = PRODUCT_JETPACK_BACKUP_REALTIME;
 
 // Meta grouping constants
 export const GROUP_WPCOM = 'GROUP_WPCOM';

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -721,6 +721,7 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY ],
 	},
 
 	[ constants.PLAN_JETPACK_PREMIUM_MONTHLY ]: {
@@ -779,6 +780,7 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
+		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY ],
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL ]: {
@@ -820,6 +822,7 @@ export const PLANS_LIST = {
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY ],
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL_MONTHLY ]: {
@@ -860,6 +863,7 @@ export const PLANS_LIST = {
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
+		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY ],
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS ]: {
@@ -920,6 +924,7 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_REALTIME ],
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS_MONTHLY ]: {
@@ -979,6 +984,7 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
+		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_REALTIME ],
 	},
 };
 


### PR DESCRIPTION
As part of the work being done in the Single Product Plans project, we need to know if the current plan of the user contains a Jetpack Backup product as a feature. To be able to know that, we need a mapping between the Jetpack products and the Jetpack plans. There is already functionality that allows us to create the mapping: plan features.

This PR takes advantage of the plan features, and defines the Jetpack Backup products as plan features. Then, it registers those features in each corresponding plan, as follows:

* Jetpack Free gets nothing 😉 
* Jetpack Personal (yearly/monthly) gets a daily backup feature.
* Jetpack Premium (yearly/monthly) gets a daily backup feature.
* Jetpack Professional (Business) (yearly/monthly) gets a real-time backup feature.

These follow the current pricing model as seen in https://jetpack.com/pricing/

The idea is to be able to later use the `hasFeature()` selector for a site, and be able to tell if that site has a particular Jetpack Backups feature or not. Based on that, we might (or might not) show an upsell button in the `ProductSelector` (respectively, `ProductCard`).

This starts an alternative approach to #37067 in terms of implementing upsells.

#### Changes proposed in this Pull Request

* Plans: Define Jetpack Backup products as plan features
* Plans: Add Jetpack Backup features to Jetpack plans

#### Testing instructions

* Note: This is not easy to test without making code changes locally. Thanks in advance for testing 😉 
* Checkout this branch.
* In `my-sites/plans-features-main/index.js`, import these:

```
import { FEATURE_JETPACK_BACKUP_DAILY } from 'lib/plans/constants';
import { hasFeature } from 'state/sites/plans/selectors';
```
* Then, in the `mapStateToProps`, make sure you have `siteId` that comes from the `getSelectedSiteId` selector, and add:

```
hasJetpackBackupDaily: hasFeature( state, siteId, FEATURE_JETPACK_BACKUP_DAILY ),
```
* Add a `console.log( this.props.hasJetpackBackupDaily )` in your `render()` method.
* Pick a Jetpack site that has a free plan.
* Verify that it logs `false`.
* Pick a Jetpack site that has a Premium or Personal plan.
* Verify that it logs `true`.
* Pick a Jetpack site that has a Professional plan.
* Verify that it logs `false` (makes sense as this site has the realtime feature).