### PR TITLE
Remove i18n-calypso moment from my-sites.

### DIFF
--- a/client/my-sites/activity/controller.jsx
+++ b/client/my-sites/activity/controller.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import moment from 'moment';
 import page from 'page';
 import { isEqual } from 'lodash';
 
@@ -56,9 +55,6 @@ function queryFilterToStats( filter ) {
 export function activity( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	const startDate = moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
-		? context.query.startDate
-		: undefined;
 
 	const filter = siteId && getActivityLogFilter( state, siteId );
 	const queryFilter = queryToFilterState( context.query );
@@ -71,7 +67,7 @@ export function activity( context, next ) {
 	}
 
 	recordTrack( 'calypso_activitylog_view', queryFilterToStats( queryFilter ) );
-	context.primary = <ActivityLog siteId={ siteId } context={ context } startDate={ startDate } />;
+	context.primary = <ActivityLog siteId={ siteId } context={ context } />;
 
 	next();
 }

--- a/client/my-sites/activity/controller.jsx
+++ b/client/my-sites/activity/controller.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import moment from 'moment';
 import page from 'page';
 import { isEqual } from 'lodash';
 
@@ -56,7 +56,7 @@ function queryFilterToStats( filter ) {
 export function activity( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	const startDate = i18n.moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
+	const startDate = moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
 		? context.query.startDate
 		: undefined;
 

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/terms-and-conditions.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/terms-and-conditions.jsx
@@ -1,98 +1,101 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { localize, moment } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import ExternalLink from 'components/external-link';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 /*
  * Constants
  */
 const expirationDate = '2020-06-30';
 
-const googleTermsAndConditions = ( { translate } ) => (
-	<div>
-		<h3>{ translate( 'Terms and conditions for this offer:' ) }</h3>
-		<p>
-			{ translate(
-				'In the below terms, “Google Ads” may mean Google Ads or AdWords Express, as appropriate.'
-			) }
-		</p>
-		<ol>
-			<li className="google-voucher__terms-and-conditions">
+export default function GoogleTermsAndConditions() {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	return (
+		<div>
+			<h3>{ translate( 'Terms and conditions for this offer:' ) }</h3>
+			<p>
 				{ translate(
-					'Offer available to customers with a billing address in the United States only. ' +
-						'One promotional code per advertiser.'
+					'In the below terms, “Google Ads” may mean Google Ads or AdWords Express, as appropriate.'
 				) }
-			</li>
+			</p>
+			<ol>
+				<li className="google-voucher__terms-and-conditions">
+					{ translate(
+						'Offer available to customers with a billing address in the United States only. ' +
+							'One promotional code per advertiser.'
+					) }
+				</li>
 
-			<li className="google-voucher__terms-and-conditions">
-				{ translate(
-					'To activate this offer: Enter the promotional code in your account before %(expirationDate)s. ' +
-						'In order to participate in this offer, ' +
-						'you must enter the code within 14 days of your first ad impression being served from your first Google Ads account.',
-					{
-						args: {
-							expirationDate: moment( expirationDate ).format( 'LL' ),
-						},
-					}
-				) }
-			</li>
+				<li className="google-voucher__terms-and-conditions">
+					{ translate(
+						'To activate this offer: Enter the promotional code in your account before %(expirationDate)s. ' +
+							'In order to participate in this offer, ' +
+							'you must enter the code within 14 days of your first ad impression being served from your first Google Ads account.',
+						{
+							args: {
+								expirationDate: moment( expirationDate ).format( 'LL' ),
+							},
+						}
+					) }
+				</li>
 
-			<li className="google-voucher__terms-and-conditions">
-				{ translate(
-					'To earn the credit: After entering the code, your advertising campaigns must accrue costs of at least $25, ' +
-						'excluding any taxes, within 30 days. Making a payment of $25 is not sufficient. ' +
-						'The tracking of advertising costs towards $25 begins after you’ve entered the code.'
-				) }
-			</li>
+				<li className="google-voucher__terms-and-conditions">
+					{ translate(
+						'To earn the credit: After entering the code, your advertising campaigns must accrue costs of at least $25, ' +
+							'excluding any taxes, within 30 days. Making a payment of $25 is not sufficient. ' +
+							'The tracking of advertising costs towards $25 begins after you’ve entered the code.'
+					) }
+				</li>
 
-			<li className="google-voucher__terms-and-conditions">
-				{ translate(
-					'Once 2 and 3 are completed, the credit will typically be applied within 5 days to the Billing Summary of your account.'
-				) }
-			</li>
+				<li className="google-voucher__terms-and-conditions">
+					{ translate(
+						'Once 2 and 3 are completed, the credit will typically be applied within 5 days to the Billing Summary of your account.'
+					) }
+				</li>
 
-			<li className="google-voucher__terms-and-conditions">
-				{ translate(
-					'Credits apply to future advertising costs only. ' +
-						'Credits cannot be applied to costs accrued before the code was entered.'
-				) }
-			</li>
+				<li className="google-voucher__terms-and-conditions">
+					{ translate(
+						'Credits apply to future advertising costs only. ' +
+							'Credits cannot be applied to costs accrued before the code was entered.'
+					) }
+				</li>
 
-			<li className="google-voucher__terms-and-conditions">
-				{ translate(
-					'You won’t receive a notification once your credit is used up and any additional advertising costs ' +
-						'will be charged to your form of payment. ' +
-						'If you don’t want to continue advertising, you can pause or delete your campaigns at any time.'
-				) }
-			</li>
+				<li className="google-voucher__terms-and-conditions">
+					{ translate(
+						'You won’t receive a notification once your credit is used up and any additional advertising costs ' +
+							'will be charged to your form of payment. ' +
+							'If you don’t want to continue advertising, you can pause or delete your campaigns at any time.'
+					) }
+				</li>
 
-			<li className="google-voucher__terms-and-conditions">
-				{ translate(
-					'Your account must be successfully billed by Google Ads ' +
-						'and remain in good standing in order to qualify for the promotional credit.'
-				) }
-			</li>
+				<li className="google-voucher__terms-and-conditions">
+					{ translate(
+						'Your account must be successfully billed by Google Ads ' +
+							'and remain in good standing in order to qualify for the promotional credit.'
+					) }
+				</li>
 
-			<li className="google-voucher__terms-and-conditions">
-				{ translate( 'Full terms and conditions can be found here ' ) }
-				<ExternalLink
-					href="https://www.google.com/ads/coupons/terms.html"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					https://www.google.com/ads/coupons/terms.html
-				</ExternalLink>
-				.
-			</li>
-		</ol>
-	</div>
-);
-
-export default localize( googleTermsAndConditions );
+				<li className="google-voucher__terms-and-conditions">
+					{ translate( 'Full terms and conditions can be found here ' ) }
+					<ExternalLink
+						href="https://www.google.com/ads/coupons/terms.html"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						https://www.google.com/ads/coupons/terms.html
+					</ExternalLink>
+					.
+				</li>
+			</ol>
+		</div>
+	);
+}

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -1,34 +1,34 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { CALYPSO_CONTACT } from 'lib/url/support';
+import StatsNavigation from 'blocks/stats-navigation';
 import DocumentHead from 'components/data/document-head';
-import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
-import GoogleMyBusinessLocation from 'my-sites/google-my-business/location';
-import GoogleMyBusinessStatsChart from 'my-sites/google-my-business/stats/chart';
 import Gridicon from 'components/gridicon';
+import { withLocalizedMoment } from 'components/localized-moment';
 import Main from 'components/main';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QueryKeyringServices from 'components/data/query-keyring-services';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import { CALYPSO_CONTACT } from 'lib/url/support';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import StatsNavigation from 'blocks/stats-navigation';
+import GoogleMyBusinessLocation from 'my-sites/google-my-business/location';
+import GoogleMyBusinessStatsChart from 'my-sites/google-my-business/stats/chart';
 import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
 import { withEnhancers } from 'state/utils';
 
 /**
@@ -83,7 +83,7 @@ class GoogleMyBusinessStats extends Component {
 					count: viewCount,
 					args: {
 						value: viewCount,
-						monday: moment( date ).format( 'LL' ),
+						monday: this.props.moment( date ).format( 'LL' ),
 					},
 				}
 			);
@@ -93,7 +93,7 @@ class GoogleMyBusinessStats extends Component {
 			count: viewCount,
 			args: {
 				value: viewCount,
-				day: moment( date ).format( 'LL' ),
+				day: this.props.moment( date ).format( 'LL' ),
 			},
 		} );
 	};
@@ -108,7 +108,7 @@ class GoogleMyBusinessStats extends Component {
 					count: actionCount,
 					args: {
 						value: actionCount,
-						monday: moment( date ).format( 'LL' ),
+						monday: this.props.moment( date ).format( 'LL' ),
 					},
 				}
 			);
@@ -118,7 +118,7 @@ class GoogleMyBusinessStats extends Component {
 			count: actionCount,
 			args: {
 				value: actionCount,
-				day: moment( date ).format( 'LL' ),
+				day: this.props.moment( date ).format( 'LL' ),
 			},
 		} );
 	};
@@ -284,4 +284,4 @@ export default connect(
 	{
 		recordTracksEvent: withEnhancers( recordTracksEvent, enhanceWithSiteType ),
 	}
-)( localize( GoogleMyBusinessStats ) );
+)( localize( withLocalizedMoment( GoogleMyBusinessStats ) ) );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { moment, withRtl } from 'i18n-calypso';
+import { withRtl } from 'i18n-calypso';
 import { clone, filter, findIndex, min, noop } from 'lodash';
 import ReactDom from 'react-dom';
 import React from 'react';
@@ -17,8 +16,9 @@ import { getMimePrefix } from 'lib/media/utils';
 import ListItem from './list-item';
 import ListNoResults from './list-no-results';
 import ListNoContent from './list-no-content';
-import SortedGrid from 'components/sorted-grid';
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
+import SortedGrid from 'components/sorted-grid';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { getPreference } from 'state/preferences/selectors';
 
 export class MediaLibraryList extends React.Component {
@@ -151,14 +151,14 @@ export class MediaLibraryList extends React.Component {
 		const currentDate = new Date();
 
 		if ( itemDate.getFullYear() === currentDate.getFullYear() ) {
-			return moment( date ).format( 'MMM D' );
+			return this.props.moment( date ).format( 'MMM D' );
 		}
 
-		return moment( date ).format( 'MMM D, YYYY' );
+		return this.props.moment( date ).format( 'MMM D, YYYY' );
 	};
 
 	getItemGroup = item =>
-		min( [ item.date.slice( 0, 10 ), moment( new Date() ).format( 'YYYY-MM-DD' ) ] );
+		min( [ item.date.slice( 0, 10 ), this.props.moment( new Date() ).format( 'YYYY-MM-DD' ) ] );
 
 	renderItem = item => {
 		const index = findIndex( this.props.media, { ID: item.ID } );
@@ -263,4 +263,4 @@ export class MediaLibraryList extends React.Component {
 
 export default connect( state => ( {
 	mediaScale: getPreference( state, 'mediaScale' ),
-} ) )( withRtl( MediaLibraryList ) );
+} ) )( withRtl( withLocalizedMoment( MediaLibraryList ) ) );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { toArray } from 'lodash';
 import React from 'react';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -68,6 +69,7 @@ describe( 'MediaLibraryList item selection', () => {
 						site={ { ID: DUMMY_SITE_ID } }
 						media={ fixtures.media }
 						mediaScale={ 0.24 }
+						moment={ moment }
 					/>
 				</MediaLibrarySelectedData>
 			);
@@ -155,6 +157,7 @@ describe( 'MediaLibraryList item selection', () => {
 						site={ { ID: DUMMY_SITE_ID } }
 						media={ fixtures.media }
 						mediaScale={ 0.24 }
+						moment={ moment }
 						single
 					/>
 				</MediaLibrarySelectedData>
@@ -195,6 +198,7 @@ describe( 'MediaLibraryList item selection', () => {
 					site={ { ID: DUMMY_SITE_ID } }
 					media={ media }
 					mediaScale={ 0.24 }
+					moment={ moment }
 					source={ source }
 					single
 				/>

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { get, isEmpty } from 'lodash';
@@ -14,6 +13,7 @@ import { get, isEmpty } from 'lodash';
  */
 import { Button, Card } from '@automattic/components';
 import ExternalLink from 'components/external-link';
+import { withLocalizedMoment } from 'components/localized-moment';
 import Version from 'components/version';
 import PluginRatings from 'my-sites/plugins/plugin-ratings/';
 import { getExtensionSettingsPath } from 'my-sites/plugins/utils';
@@ -102,7 +102,7 @@ class PluginInformation extends React.Component {
 
 	renderLastUpdated = () => {
 		if ( this.props.plugin && this.props.plugin.last_updated ) {
-			const dateFromNow = i18n.moment
+			const dateFromNow = this.props.moment
 				.utc( this.props.plugin.last_updated, 'YYYY-MM-DD hh:mma' )
 				.fromNow();
 			const syncIcon = this.props.hasUpdate ? <Gridicon icon="sync" size={ 18 } /> : null;
@@ -142,6 +142,7 @@ class PluginInformation extends React.Component {
 			versionView = (
 				<div className="plugin-information__version-limit">
 					{ this.props.translate(
+						// eslint-disable-next-line wpcalypso/i18n-no-collapsible-whitespace
 						'{{wpIcon/}}  Compatible with %(minVersion)s to {{span}} %(maxVersion)s {{versionCheck/}}{{/span}}',
 						{
 							args: { minVersion: limits.minVersion, maxVersion: limits.maxVersion },
@@ -207,7 +208,7 @@ class PluginInformation extends React.Component {
 			adminUrl += 'admin.php?page=vaultpress'; // adminUrl has a trailing slash
 		}
 
-		return adminUrl ? { [ i18n.translate( 'WP Admin' ) ]: adminUrl } : null;
+		return adminUrl ? { [ this.props.translate( 'WP Admin' ) ]: adminUrl } : null;
 	};
 
 	renderPlaceholder = () => {
@@ -318,4 +319,4 @@ class PluginInformation extends React.Component {
 	}
 }
 
-export default localize( PluginInformation );
+export default localize( withLocalizedMoment( PluginInformation ) );

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { flowRight as compose, isEqual, uniqBy } from 'lodash';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,6 +17,7 @@ import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import Count from 'components/count';
 import Notice from 'components/notice';
+import { withLocalizedMoment } from 'components/localized-moment';
 import PluginNotices from 'lib/plugins/notices';
 import { errorNotice } from 'state/notices/actions';
 
@@ -100,7 +100,7 @@ class PluginItem extends Component {
 	}
 
 	ago( date ) {
-		return moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
+		return this.props.moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
 	}
 
 	doing() {
@@ -378,4 +378,8 @@ class PluginItem extends Component {
 	}
 }
 
-export default compose( connect( null, { errorNotice } ), localize )( PluginItem );
+export default compose(
+	connect( null, { errorNotice } ),
+	localize,
+	withLocalizedMoment
+)( PluginItem );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -7,7 +7,8 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, includes, some } from 'lodash';
 import Gridicon from 'components/gridicon';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { pick } from 'lodash';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,6 +16,7 @@ import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isRequestingSiteStatsForQuery,
@@ -57,7 +57,7 @@ class StatsAllTime extends Component {
 		let bestDay;
 
 		if ( viewsBestDay && ! isLoading ) {
-			bestDay = moment( viewsBestDay ).format( 'LL' );
+			bestDay = this.props.moment( viewsBestDay ).format( 'LL' );
 		}
 
 		const classes = {
@@ -126,4 +126,4 @@ export default connect( state => {
 		siteId,
 		...allTimeStats,
 	};
-} )( localize( StatsAllTime ) );
+} )( localize( withLocalizedMoment( StatsAllTime ) ) );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
 import { find, pick, get } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -51,7 +52,7 @@ function rangeOfPeriod( period, date ) {
 
 function getNumPeriodAgo( momentSiteZone, date, period ) {
 	const endOfCurrentPeriod = momentSiteZone.endOf( period );
-	const durationAgo = i18n.moment.duration( endOfCurrentPeriod.diff( date ) );
+	const durationAgo = moment.duration( endOfCurrentPeriod.diff( date ) );
 	let numPeriodAgo;
 
 	switch ( period ) {
@@ -129,7 +130,7 @@ function getSiteFilters( siteId ) {
 
 function getMomentSiteZone( state, siteId ) {
 	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
-	return i18n.moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
+	return moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
 }
 
 export default {
@@ -244,11 +245,10 @@ export default {
 		}
 
 		const momentSiteZone = getMomentSiteZone( state, siteId );
-		const isValidStartDate =
-			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
+		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 
 		const date = isValidStartDate
-			? i18n.moment( queryOptions.startDate ).locale( 'en' )
+			? moment( queryOptions.startDate ).locale( 'en' )
 			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
 
 		const parsedPeriod = isValidStartDate
@@ -306,7 +306,7 @@ export default {
 			'searchterms',
 			'annualstats',
 		];
-		let momentSiteZone = i18n.moment();
+		let momentSiteZone = moment();
 
 		const site = getSite( context.store.getState(), siteId );
 		siteId = site ? site.ID || 0 : 0;
@@ -329,12 +329,11 @@ export default {
 
 		const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
 		if ( Number.isFinite( gmtOffset ) ) {
-			momentSiteZone = i18n.moment().utcOffset( gmtOffset );
+			momentSiteZone = moment().utcOffset( gmtOffset );
 		}
-		const isValidStartDate =
-			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
+		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 		const date = isValidStartDate
-			? i18n.moment( queryOptions.startDate ).locale( 'en' )
+			? moment( queryOptions.startDate ).locale( 'en' )
 			: momentSiteZone.endOf( activeFilter.period ).locale( 'en' );
 		const period = rangeOfPeriod( activeFilter.period, date );
 
@@ -432,11 +431,10 @@ export default {
 		}
 
 		const momentSiteZone = getMomentSiteZone( state, siteId );
-		const isValidStartDate =
-			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
+		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 
 		const date = isValidStartDate
-			? i18n.moment( queryOptions.startDate ).locale( 'en' )
+			? moment( queryOptions.startDate ).locale( 'en' )
 			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
 
 		const parsedPeriod = isValidStartDate

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { flowRight, find, get } from 'lodash';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

It switches `my-sites` to vanilla `moment` or `components/localized-moment`, depending on what's needed in each case.

Note: If I added you and you feel you're not the right person to review these changes, I apologise for that; please feel free to ignore or remove yourself. I just went with the default GitHub suggestions since I had no idea who to add 🤷‍♂

Please feel free to add whomever you feel should be included in the reviewers list.

#### Changes proposed in this Pull Request

* Replace `i18n-calypso` `moment` with vanilla `moment` or `components/localized-moment`, depending on what's needed in each case.
* Minor drive-by fixes (linting, import cleanups, etc.)

#### Testing instructions

These changes are mostly mechanical, so I wouldn't expect for there to be a great need for testing. The likeliest scenario for an error is that I assumed that a file does not make use of localized moment when in fact it does; I've noted the files where I've made that assumption if you want to double-check the code or the running behaviour.
