### PR TITLE
composite-checkout: Fix test for new dispatcher

### DIFF
--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -11,6 +11,7 @@ import '@testing-library/jest-dom/extend-expect';
 import Checkout from '../../src/components/checkout';
 
 test( 'When we enter checkout, the line items and total are rendered', () => {
+	const noop = () => {};
 	const { container } = render(
 		<Checkout
 			locale="en-us"
@@ -42,6 +43,8 @@ test( 'When we enter checkout, the line items and total are rendered', () => {
 			} }
 			successRedirectUrl="#"
 			failureRedirectUrl="#"
+			paymentData={ {} }
+			dispatchPaymentAction={ noop }
 		/>
 	);
 


### PR DESCRIPTION
Fixes a regression caused by #37134 which failed to add some new props to a test of the `Checkout` component.