### PR TITLE
Domains: Reduce right margin on Domains SectionHeader button to add a domain.

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -312,10 +312,10 @@ export class List extends React.Component {
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}
 		return (
-			<div>
+			<>
 				{ this.changePrimaryButton() }
 				{ this.addDomainButton() }
-			</div>
+			</>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -111,3 +111,11 @@ input[type='radio'].domain-management-list-item__radio {
 		margin-right: 15px;
 	}
 }
+
+.section-header__actions .button.domain-management-list__add-a-domain {
+	margin-right: 4px;
+
+	@include breakpoint( '>480px' ) {
+		margin-right: 0;
+	}
+}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -111,11 +111,3 @@ input[type='radio'].domain-management-list-item__radio {
 		margin-right: 15px;
 	}
 }
-
-.section-header__actions .button.domain-management-list__add-a-domain {
-	margin-right: 4px;
-
-	@include breakpoint( '>480px' ) {
-		margin-right: 0;
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Domain button had too much right-hand margin, which made it look out of place, particularly on mobile screens. This PR removes the buttons' wrapping div in favor of a React Fragment so the component's native CSS is applied correctly.

**Before**

<img width="326" alt="Screen Shot 2019-10-29 at 3 35 15 PM" src="https://user-images.githubusercontent.com/2124984/67802578-cc6d5600-fa61-11e9-9cd2-903a67f8ef8b.png">
<img width="1055" alt="Screen Shot 2019-10-29 at 3 34 58 PM" src="https://user-images.githubusercontent.com/2124984/67802576-cc6d5600-fa61-11e9-83f5-b691e87fcb9b.png">

**After**

<img width="320" alt="Screen Shot 2019-10-29 at 3 32 02 PM" src="https://user-images.githubusercontent.com/2124984/67802485-9fb93e80-fa61-11e9-9454-ee16ae91289a.png">
<img width="1080" alt="Screen Shot 2019-10-29 at 3 32 18 PM" src="https://user-images.githubusercontent.com/2124984/67802486-9fb93e80-fa61-11e9-879d-2959d8fd0fb7.png">


#### Testing instructions

* Switch to this PR and go to `/domains`
* Check the right margin on the Add Domain button. It should look approximately the same as the left-hand margin for the SectionHeader title.