### PR TITLE
Notice: Reduce bottom margin for mobile devices

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -11,13 +11,17 @@
 	display: flex;
 	position: relative;
 	width: 100%;
-	margin-bottom: 24px;
+	margin-bottom: 12px;
 	box-sizing: border-box;
 	animation: appear 0.3s ease-in-out;
 	background: var( --color-neutral-80 );
 	color: var( --color-text-inverted );
 	border-radius: 3px;
 	line-height: 1.5;
+
+	@include breakpoint( '>660px' ) {
+		margin-bottom: 24px;
+	}
 
 	// Success!
 	&.is-success {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Notices have a default bottom margin of 24px, but this is excessive on mobile devices, particularly when you have multiple notices stacked. This PR reduces the bottom margin to 12px on screens < 660px wide to save on vertical space.

**Before**

<img width="328" alt="Screen Shot 2019-10-29 at 3 47 54 PM" src="https://user-images.githubusercontent.com/2124984/67803470-7dc0bb80-fa63-11e9-8582-1874f9a9412d.png">

**After**

<img width="329" alt="Screen Shot 2019-10-29 at 3 43 35 PM" src="https://user-images.githubusercontent.com/2124984/67803441-6550a100-fa63-11e9-8853-6436f723cf85.png">

#### Testing instructions

* Switch to this PR and look at notices across Calypso. 
* Check on both large screens and mobile devices. Look for visual errors or stress cases.
