### PR TITLE
Domains: Consider removing domain URL from HeaderCake title

### DIFF
--- a/client/my-sites/domains/domain-management/components/header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/header/index.jsx
@@ -18,13 +18,12 @@ import DocumentHead from 'components/data/document-head';
 import './style.scss';
 
 export default function DomainManagementHeader( props ) {
-	const { onClick, backHref, selectedDomainName, children } = props;
+	const { onClick, backHref, children } = props;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<HeaderCake className="domain-management-header" onClick={ onClick } backHref={ backHref }>
 			<div className="domain-management-header__children">
-				{ selectedDomainName && <span>{ selectedDomainName }: </span> }
 				<span className="domain-management-header__title">{ children }</span>
 			</div>
 			<DocumentHead title={ children } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is part of a Fixing the Flows project to audit Calypso screens and optimize them for mobile web, finding quick wins.
* The domain URL is almost always repeated elsewhere in the page contents, and the longer domain name obscures the more important section title on mobile devices and small screens.
* Alternatively, we could use CSS to hide the domain name for mobile devices and small screens, but I think we could lose it altogether without harming usability. Thoughts?

**Before**

<img width="327" alt="Screen Shot 2019-10-29 at 4 00 19 PM" src="https://user-images.githubusercontent.com/2124984/67804710-e90b8d00-fa65-11e9-8c11-9b1f4d229de7.png">
<img width="745" alt="Screen Shot 2019-10-29 at 3 59 51 PM" src="https://user-images.githubusercontent.com/2124984/67804709-e872f680-fa65-11e9-8cef-718acda5234b.png">

**After**

<img width="326" alt="Screen Shot 2019-10-29 at 4 00 34 PM" src="https://user-images.githubusercontent.com/2124984/67804712-e90b8d00-fa65-11e9-9edf-4c954e8f034c.png">
<img width="727" alt="Screen Shot 2019-10-29 at 4 00 43 PM" src="https://user-images.githubusercontent.com/2124984/67804713-e90b8d00-fa65-11e9-9675-7d406e4d9abf.png">

#### Testing instructions

* Switch to this PR and navigate to `/domains`
* Check out multiple domains/site URLs in this section, and their corresponding settings. Does the content make sense without the domain URL in the header title?
