### PR TITLE
Domains: Remove unnecessary bottom margin on site redirects paragraph

### DIFF
--- a/client/my-sites/domains/domain-management/site-redirect/style.scss
+++ b/client/my-sites/domains/domain-management/site-redirect/style.scss
@@ -12,6 +12,7 @@
 .site-redirect__explanation {
 	display: block;
 	margin-top: 5px;
+	margin-bottom: 0;
 	font-size: 13px;
 	font-style: italic;
 	color: var( --color-text-subtle );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes bottom margin from paragraph with explanatory text on Site Redirect settings screen.

**Before**

<img width="735" alt="Screen Shot 2019-10-29 at 4 26 33 PM" src="https://user-images.githubusercontent.com/2124984/67806571-85835e80-fa69-11e9-82c8-cc1ce8c078ee.png">
<img width="325" alt="Screen Shot 2019-10-29 at 4 27 36 PM" src="https://user-images.githubusercontent.com/2124984/67806575-85835e80-fa69-11e9-8ec0-28f9f936aaae.png">


**After**

<img width="732" alt="Screen Shot 2019-10-29 at 4 26 51 PM" src="https://user-images.githubusercontent.com/2124984/67806572-85835e80-fa69-11e9-98a6-9e0db1d07119.png">
<img width="324" alt="Screen Shot 2019-10-29 at 4 27 21 PM" src="https://user-images.githubusercontent.com/2124984/67806574-85835e80-fa69-11e9-8242-6c3de4b5dc91.png">

#### Testing instructions

* Switch to this PR, navigate to `/domains`. 
* Select a domain/site URL with a Site Redirect. Check out the spacing underneath the text input and before the buttons.