### PR TITLE
Domains: Ensure form label wraps/targets the field its intended for

### DIFF
--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -127,18 +127,20 @@ class SiteRedirect extends React.Component {
 					<Card className={ classes }>
 						<form>
 							<FormFieldset>
-								<FormLabel>{ translate( 'Redirect To' ) }</FormLabel>
+								<FormLabel>
+									{ translate( 'Redirect To' ) }
 
-								<FormTextInputWithAffixes
-									disabled={ isFetching || isUpdating }
-									name="destination"
-									noWrap
-									onChange={ this.handleChange }
-									onFocus={ this.handleFocus }
-									prefix="http://"
-									type="text"
-									value={ this.state.redirectUrl }
-								/>
+									<FormTextInputWithAffixes
+										disabled={ isFetching || isUpdating }
+										name="destination"
+										noWrap
+										onChange={ this.handleChange }
+										onFocus={ this.handleFocus }
+										prefix="http://"
+										type="text"
+										value={ this.state.redirectUrl }
+									/>
+								</FormLabel>
 
 								<p className="site-redirect__explanation">
 									{ translate( 'All domains on this site will redirect here.' ) }

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -127,20 +127,19 @@ class SiteRedirect extends React.Component {
 					<Card className={ classes }>
 						<form>
 							<FormFieldset>
-								<FormLabel>
-									{ translate( 'Redirect To' ) }
+								<FormLabel htmlFor="site-redirect__input">{ translate( 'Redirect To' ) }</FormLabel>
 
-									<FormTextInputWithAffixes
-										disabled={ isFetching || isUpdating }
-										name="destination"
-										noWrap
-										onChange={ this.handleChange }
-										onFocus={ this.handleFocus }
-										prefix="http://"
-										type="text"
-										value={ this.state.redirectUrl }
-									/>
-								</FormLabel>
+								<FormTextInputWithAffixes
+									disabled={ isFetching || isUpdating }
+									name="destination"
+									noWrap
+									onChange={ this.handleChange }
+									onFocus={ this.handleFocus }
+									prefix="http://"
+									type="text"
+									value={ this.state.redirectUrl }
+									id="site-redirect__input"
+								/>
 
 								<p className="site-redirect__explanation">
 									{ translate( 'All domains on this site will redirect here.' ) }

--- a/client/my-sites/domains/domain-management/site-redirect/style.scss
+++ b/client/my-sites/domains/domain-management/site-redirect/style.scss
@@ -3,14 +3,6 @@
 		margin-bottom: 10px;
 	}
 
-	.form-text-input-with-affixes {
-		margin-top: 5px;
-	}
-
-	.form-text-input-with-affixes__prefix {
-		font-weight: normal;
-	}
-
 	&.fetching input[type='text'] {
 		animation: pulse-light 0.8s ease-in-out infinite;
 		background: var( --color-neutral-10 );

--- a/client/my-sites/domains/domain-management/site-redirect/style.scss
+++ b/client/my-sites/domains/domain-management/site-redirect/style.scss
@@ -3,6 +3,14 @@
 		margin-bottom: 10px;
 	}
 
+	.form-text-input-with-affixes {
+		margin-top: 5px;
+	}
+
+	.form-text-input-with-affixes__prefix {
+		font-weight: normal;
+	}
+
 	&.fetching input[type='text'] {
 		animation: pulse-light 0.8s ease-in-out infinite;
 		background: var( --color-neutral-10 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Site Redirect settings page has a text input with a form label, but the label was not attached to the text input. This PR adds an ID to the text input and ensures the label targets that ID.
* Visually there should be no changes, but when you click on the label text, it should put focus on the text input.

**Video**

https://cloudup.com/cLY1kp07r4R

#### Testing instructions

* Switch to this PR, navigate to `/domains`
* Click on a domain URL that is a Site Redirect
* Click on the label "Redirect to"
* Focus should switch to the text input below.