### PR TITLE
FSE: conditionally load `WP_Template` in the customizer

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -216,6 +216,11 @@ function enqueue_coblocks_gallery_scripts() {
 		return;
 	}
 
+	// this happens in the Customizer because we try very hard not to load things and we get a fatal
+	// https://github.com/Automattic/wp-calypso/issues/36680
+	if ( ! class_exists( '\A8C\FSE\WP_Template' ) ) {
+		require_once( __DIR__ . '/full-site-editing/templates/class-wp-template.php' );
+	}
 	$template = new WP_Template();
 	$header   = $template->get_template_content( 'header' );
 	$footer   = $template->get_template_content( 'footer' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -216,7 +216,7 @@ function enqueue_coblocks_gallery_scripts() {
 		return;
 	}
 
-	// this happens in the Customizer because we try very hard not to load things and we get a fatal
+	// This happens in the Customizer because we try very hard not to load things and we get a fatal
 	// https://github.com/Automattic/wp-calypso/issues/36680
 	if ( ! class_exists( '\A8C\FSE\WP_Template' ) ) {
 		require_once( __DIR__ . '/full-site-editing/templates/class-wp-template.php' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* prevent fatals in the Customizer for FSE sites when previewing an FSE theme

#### Testing instructions

1. sandbox a site with FSE active
2. switch to an unsupported theme (currently not Maywood)
3. Click "Try and Customize" for Maywood
4. Notice that the preview pane is blank (there's a fatal error)
5. Apply this diff to your sandbox
6. Repeat step 3, the Customizer preview should work

BEFORE
<img width="1273" alt="image" src="https://user-images.githubusercontent.com/195089/67810305-5ae4d600-fa68-11e9-9660-869268da9d60.png">

AFTER
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/195089/67810251-3ab51700-fa68-11e9-86e8-610ed1837216.png">


Fixes #36680
