### PR TITLE
Revert vertical-suggested themes AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,10 +99,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	verticalSuggestedThemes: {
-		datestamp: '20191031',
+		datestamp: '20191101',
 		variations: {
-			control: 90,
-			test: 10,
+			control: 100,
+			test: 0,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
A pre-approved PR to revert the vertical-suggested themes AB test. Just in case.

#### Changes proposed in this Pull Request

* Reverts #37133 by re-assigning all users to the control group.

Please review and then stick in the Blocked column.
