### PR TITLE
Atomic: Eligibility check, hide support URL if none

### DIFF
--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
@@ -16,36 +15,40 @@ import Card from 'components/card';
 import ExternalLink from 'components/external-link';
 import SectionHeader from 'components/section-header';
 
-export const WarningList = ( { translate, warnings } ) => (
-	<div>
-		<SectionHeader
-			label={ translate(
-				"By proceeding you'll lose %d feature:",
-				"By proceeding you'll lose these %d features:",
-				{
-					count: warnings.length,
-					args: warnings.length,
-				}
-			) }
-		/>
-		<Card className="eligibility-warnings__warning-list">
-			{ map( warnings, ( { name, description, supportUrl }, index ) => (
-				<div className="eligibility-warnings__warning" key={ index }>
-					<Gridicon icon="cross-small" size={ 24 } />
-					<div className="eligibility-warnings__message">
-						<span className="eligibility-warnings__message-title">{ name }</span>
-						:&nbsp;
-						<span className="eligibility-warnings__message-description">{ description }</span>
+export const WarningList = ( { translate, warnings } ) => {
+	return (
+		<div>
+			<SectionHeader
+				label={ translate(
+					"By proceeding you'll lose %d feature:",
+					"By proceeding you'll lose these %d features:",
+					{
+						count: warnings.length,
+						args: warnings.length,
+					}
+				) }
+			/>
+			<Card className="eligibility-warnings__warning-list">
+				{ map( warnings, ( { name, description, supportUrl }, index ) => (
+					<div className="eligibility-warnings__warning" key={ index }>
+						<Gridicon icon="cross-small" size={ 24 } />
+						<div className="eligibility-warnings__message">
+							<span className="eligibility-warnings__message-title">{ name }</span>
+							:&nbsp;
+							<span className="eligibility-warnings__message-description">{ description }</span>
+						</div>
+						{ supportUrl && (
+							<div className="eligibility-warnings__action">
+								<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+									<Gridicon icon="help-outline" size={ 24 } />
+								</ExternalLink>
+							</div>
+						) }
 					</div>
-					<div className="eligibility-warnings__action">
-						<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-							<Gridicon icon="help-outline" size={ 24 } />
-						</ExternalLink>
-					</div>
-				</div>
-			) ) }
-		</Card>
-	</div>
-);
+				) ) }
+			</Card>
+		</div>
+	);
+};
 
 export default localize( WarningList );

--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -15,40 +15,38 @@ import Card from 'components/card';
 import ExternalLink from 'components/external-link';
 import SectionHeader from 'components/section-header';
 
-export const WarningList = ( { translate, warnings } ) => {
-	return (
-		<div>
-			<SectionHeader
-				label={ translate(
-					"By proceeding you'll lose %d feature:",
-					"By proceeding you'll lose these %d features:",
-					{
-						count: warnings.length,
-						args: warnings.length,
-					}
-				) }
-			/>
-			<Card className="eligibility-warnings__warning-list">
-				{ map( warnings, ( { name, description, supportUrl }, index ) => (
-					<div className="eligibility-warnings__warning" key={ index }>
-						<Gridicon icon="cross-small" size={ 24 } />
-						<div className="eligibility-warnings__message">
-							<span className="eligibility-warnings__message-title">{ name }</span>
-							:&nbsp;
-							<span className="eligibility-warnings__message-description">{ description }</span>
-						</div>
-						{ supportUrl && (
-							<div className="eligibility-warnings__action">
-								<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-									<Gridicon icon="help-outline" size={ 24 } />
-								</ExternalLink>
-							</div>
-						) }
+export const WarningList = ( { translate, warnings } ) => (
+	<div>
+		<SectionHeader
+			label={ translate(
+				"By proceeding you'll lose %d feature:",
+				"By proceeding you'll lose these %d features:",
+				{
+					count: warnings.length,
+					args: warnings.length,
+				}
+			) }
+		/>
+		<Card className="eligibility-warnings__warning-list">
+			{ map( warnings, ( { name, description, supportUrl }, index ) => (
+				<div className="eligibility-warnings__warning" key={ index }>
+					<Gridicon icon="cross-small" size={ 24 } />
+					<div className="eligibility-warnings__message">
+						<span className="eligibility-warnings__message-title">{ name }</span>
+						:&nbsp;
+						<span className="eligibility-warnings__message-description">{ description }</span>
 					</div>
-				) ) }
-			</Card>
-		</div>
-	);
-};
+					{ supportUrl && (
+						<div className="eligibility-warnings__action">
+							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+								<Gridicon icon="help-outline" size={ 24 } />
+							</ExternalLink>
+						</div>
+					) }
+				</div>
+			) ) }
+		</Card>
+	</div>
+);
 
 export default localize( WarningList );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

No point in showing the support URL icon if there is no support URL.

#### Testing instructions

Depends on D34720-code.

- Buy a business plan on a new site
- Try going Atomic with wp.com domain
- See warning, but no support link