### PR TITLE
Hosting Panel: Add a feature flag for existing Phase 2 development work

### DIFF
--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -12,15 +12,20 @@ import { get } from 'lodash';
  * Internal Dependencies
  */
 import Hosting from './main';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isBusinessPlan } from 'lib/plans';
-import { getSelectedSite } from 'state/ui/selectors';
 
-export function redirectIfNotBusiness( context, next ) {
+export function handleHostingPanelRedirect( context, next ) {
 	const { store } = context;
 	const state = store.getState();
+	const isAtomic = isSiteAutomatedTransfer( state, getSelectedSiteId( state ) );
 	const isBusinessSite = isBusinessPlan( get( getSelectedSite( state ), 'plan.product_slug' ) );
 
-	if ( config.isEnabled( 'hosting' ) && isBusinessSite ) {
+	if (
+		config.isEnabled( 'hosting' ) &&
+		( isAtomic || ( config.isEnabled( 'hosting/non-atomic-support' ) && isBusinessSite ) )
+	) {
 		next();
 		return;
 	}

--- a/client/my-sites/hosting/index.js
+++ b/client/my-sites/hosting/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { redirectIfNotBusiness, layout } from './controller';
+import { handleHostingPanelRedirect, layout } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
@@ -17,7 +17,7 @@ export default function() {
 		'/hosting/:site_id',
 		siteSelection,
 		navigation,
-		redirectIfNotBusiness,
+		handleHostingPanelRedirect,
 		layout,
 		makeLayout,
 		clientRender

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -53,6 +54,9 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		isDisabled: ! isSiteAutomatedTransfer( state, siteId ),
+		// We should never hit this case for the development flag, as it is handled on the redirect, but just as an extra layer...
+		isDisabled:
+			config.isEnabled( 'hosting/non-atomic-support' ) &&
+			! isSiteAutomatedTransfer( state, siteId ),
 	};
 } )( localize( Hosting ) );

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -6,7 +6,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -54,9 +53,6 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		// We should never hit this case for the development flag, as it is handled on the redirect, but just as an extra layer...
-		isDisabled:
-			config.isEnabled( 'hosting/non-atomic-support' ) &&
-			! isSiteAutomatedTransfer( state, siteId ),
+		isDisabled: ! isSiteAutomatedTransfer( state, siteId ),
 	};
 } )( localize( Hosting ) );

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -498,9 +498,13 @@ export class MySitesSidebar extends Component {
 	};
 
 	hosting() {
-		const { translate, path, site, siteSuffix } = this.props;
+		const { translate, isAtomicSite, path, site, siteSuffix } = this.props;
 
-		if ( ! site || ! isBusiness( site.plan ) || ! isEnabled( 'hosting' ) ) {
+		const invalidSiteType = isEnabled( 'hosting/non-atomic-support' )
+			? ! isBusiness( site.plan )
+			: ! isAtomicSite;
+
+		if ( ! site || invalidSiteType || ! isEnabled( 'hosting' ) ) {
 			return null;
 		}
 

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -36,6 +36,7 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": false,
+		"hosting/non-atomic-support": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/personalPlan": true,

--- a/config/development.json
+++ b/config/development.json
@@ -62,6 +62,7 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": true,
+		"hosting/non-atomic-support": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,6 +39,7 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": false,
+		"hosting/non-atomic-support": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,

--- a/config/production.json
+++ b/config/production.json
@@ -38,6 +38,7 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": false,
+		"hosting/non-atomic-support": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": false,
 		"jetpack/concierge-sessions": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,6 +40,7 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": false,
+		"hosting/non-atomic-support": false,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,

--- a/config/test.json
+++ b/config/test.json
@@ -39,6 +39,7 @@
 		"google-my-business": false,
 		"help": true,
 		"hosting": false,
+		"hosting/non-atomic-support": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/site-questions": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -49,6 +49,7 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": false,
+		"hosting/non-atomic-support": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,


### PR DESCRIPTION
### Summary

This PR ensures that existing Phase 2 development work for the hosting panel is encapsulated behind a new feature flag called `'hosting/non-atomic-support'`. Without that flag enabled, existing work to expose the hosting panel to non-Atomic business sites is not available.

### Testing

td;lr testing - should not be able to access the hosting panel for non-atomic sites on a business plan when the `'hosting/non-atomic-support'` feature flag is disabled. Everything else should function as before, noting that the development work for handling non-atomic business sites is encapsulated behind that feature flag.

Longform:

* Spin up a local Calypso dev instance with this branch applied.

**With `'hosting/non-atomic-support'` feature flag disabled:**
* Select an Atomic site.
    * Ensure that 'PHP & MySQL'  link shows up under the collapsible 'Manage' section in the sidebar.
    * Click on the  'PHP & MySQL' menu item, ensure that it navigates to the Hosting panel (`/hosting/{site}`).
    * Ensure that there is no banner above the cards and that the cards are not disabled.
* Select a non-Atomic site on a Business plan in Calypso.
    * Ensure that the 'PHP & MySQL' menu item does not show up in the sidebar.
    * Ensure that navigating directly to the hosting panel - eg, `calypso.localhost:3000/hosting/your.site` - redirects to the Calypso homepage.
* Select a non-Atomic site in Calypso.
    * Ensure that the 'PHP & MySQL' menu item does not show up in the sidebar.

**With `'hosting/non-atomic-support'` feature flag enabled:**
* Select a non-Atomic site on a Business plan in Calypso.
    * Ensure that 'PHP & MySQL'  link shows up under the collapsible 'Manage' section in the sidebar.
    * Click on the  'PHP & MySQL' menu item, ensure that it navigates to the Hosting panel (`/hosting/{site}`).
    * Notice that both cards are disabled and a banner is displayed, directing you to activate the Hosting panel features.
* Select an Atomic site.
    * Ensure that the Hosting Panel functions the same for Atomic sites as when the feature flag is disabled.
* Select a non-Atomic site.
    * Ensure that the Hosting Panel functions the same for non-Atomic sites as when the feature flag is disabled.

Fixes #36484