### PR TITLE
Add backup_in_progress and last_good_backup fields to the Rewind state API

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -151,6 +151,8 @@ export const active = stateSchema( 'active', {
 				threats: { type: threat },
 			},
 		},
+		last_backup_when: { type: 'string' },
+		backup_in_progress: { type: 'boolean' },
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},
 	required: [ 'state', 'last_updated' ],

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -151,7 +151,7 @@ export const active = stateSchema( 'active', {
 				threats: { type: threat },
 			},
 		},
-		last_backup_when: { type: 'string' },
+		last_good_backup: { type: 'string' },
 		backup_in_progress: { type: 'boolean' },
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},


### PR DESCRIPTION
We've added 2 new fields to the Rewind state API, backup_in_progress and last_good_backup. 
This PR changes the schema to support the new fields. 
See D34701-code. 
Feel free to add more changes needed in order to fully support this.

#### Changes proposed in this Pull Request
* Change rewind/schema.js, add the fields.

#### Testing instructions
* Deploy D34701-code.
* Open Calypso. Go to Site Settings -> Security tab. A hit to the Rewind status API should be made. No error should happen.