### PR TITLE
Add reCAPTCHA v3 to user step on load, and submit token with n…

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -95,6 +95,7 @@ class SignupForm extends Component {
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
+		recaptchaClientId: PropTypes.number,
 		save: PropTypes.func,
 		signupDependencies: PropTypes.object,
 		step: PropTypes.object,
@@ -947,6 +948,7 @@ class SignupForm extends Component {
 						renderTerms={ this.termsOfServiceLink }
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }
+						recaptchaClientId={ this.props.recaptchaClientId }
 					/>
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -82,6 +82,7 @@ class SignupForm extends Component {
 		className: PropTypes.string,
 		disableEmailExplanation: PropTypes.string,
 		disableEmailInput: PropTypes.bool,
+		disableSubmitButton: PropTypes.bool,
 		disabled: PropTypes.bool,
 		displayNameInput: PropTypes.bool,
 		displayUsernameInput: PropTypes.bool,
@@ -818,7 +819,9 @@ class SignupForm extends Component {
 				{ this.termsOfServiceLink() }
 				<FormButton
 					className="signup-form__submit"
-					disabled={ this.state.submitting || this.props.disabled }
+					disabled={
+						this.state.submitting || this.props.disabled || this.props.disableSubmitButton
+					}
 				>
 					{ this.props.submitButtonText }
 				</FormButton>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -951,6 +951,7 @@ class SignupForm extends Component {
 						renderTerms={ this.termsOfServiceLink }
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }
+						disableSubmitButton={ this.props.disableSubmitButton }
 						recaptchaClientId={ this.props.recaptchaClientId }
 					/>
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -104,6 +104,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		showRecaptchaToS: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -115,6 +116,7 @@ class SignupForm extends Component {
 		displayUsernameInput: true,
 		flowName: '',
 		isSocialSignupEnabled: false,
+		showRecaptchaToS: false,
 	};
 
 	state = {
@@ -830,26 +832,47 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
-		const { flowName, translate } = this.props;
+		const { flowName, showRecaptchaToS, translate } = this.props;
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
 			? this.getLoginLink()
 			: localizeUrl( config( 'login_url' ), this.props.locale );
 
 		return (
-			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ flowName === 'onboarding'
-						? translate( 'Log in to create a site for your existing account.' )
-						: translate( 'Already have a WordPress.com account?' ) }
-				</LoggedOutFormLinkItem>
-				{ this.props.oauth2Client && (
-					<LoggedOutFormBackLink
-						oauth2Client={ this.props.oauth2Client }
-						recordClick={ this.recordBackLinkClick }
-					/>
+			<>
+				<LoggedOutFormLinks>
+					<LoggedOutFormLinkItem href={ logInUrl }>
+						{ flowName === 'onboarding'
+							? translate( 'Log in to create a site for your existing account.' )
+							: translate( 'Already have a WordPress.com account?' ) }
+					</LoggedOutFormLinkItem>
+					{ this.props.oauth2Client && (
+						<LoggedOutFormBackLink
+							oauth2Client={ this.props.oauth2Client }
+							recordClick={ this.recordBackLinkClick }
+						/>
+					) }
+				</LoggedOutFormLinks>
+				{ showRecaptchaToS && (
+					<div className="signup-form__recaptcha-tos">
+						<LoggedOutFormLinks>
+							<p>
+								{ translate(
+									'This site is protected by reCAPTCHA and the Google {{a1}}Privacy Policy{{/a1}} and {{a2}}Terms of Service{{/a2}} apply.',
+									{
+										components: {
+											a1: <a href="https://policies.google.com/privacy" />,
+											a2: <a href="https://policies.google.com/terms" />,
+										},
+										comment:
+											'English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed',
+									}
+								) }
+							</p>
+						</LoggedOutFormLinks>
+					</div>
 				) }
-			</LoggedOutFormLinks>
+			</>
 		);
 	}
 
@@ -941,7 +964,11 @@ class SignupForm extends Component {
 				: localizeUrl( config( 'login_url' ), this.props.locale );
 
 			return (
-				<div className={ classNames( 'signup-form', this.props.className ) }>
+				<div
+					className={ classNames( 'signup-form', this.props.className, {
+						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+					} ) }
+				>
 					{ this.getNotice() }
 					<PasswordlessSignupForm
 						step={ this.props.step }
@@ -968,7 +995,11 @@ class SignupForm extends Component {
 		}
 
 		return (
-			<div className={ classNames( 'signup-form', this.props.className ) }>
+			<div
+				className={ classNames( 'signup-form', this.props.className, {
+					'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+				} ) }
+			>
 				{ this.getNotice() }
 
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -216,7 +216,12 @@ class PasswordlessSignupForm extends Component {
 					type="submit"
 					primary
 					busy={ isSubmitting }
-					disabled={ isSubmitting || ! isEmailAddressValid || !! this.props.disabled }
+					disabled={
+						isSubmitting ||
+						! isEmailAddressValid ||
+						!! this.props.disabled ||
+						!! this.props.disableSubmitButton
+					}
 				>
 					{ submitButtonText }
 				</Button>

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -77,7 +77,7 @@ class PasswordlessSignupForm extends Component {
 			form,
 		} );
 
-		recordGoogleRecaptchaAction( this.props.recaptchaClientId, 'calypso/submitForm' ).then(
+		recordGoogleRecaptchaAction( this.props.recaptchaClientId, 'calypso/signup/formSubmit' ).then(
 			recaptchaToken => {
 				wpcom
 					.undocumented()

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -79,7 +79,7 @@ class PasswordlessSignupForm extends Component {
 		} );
 
 		const recaptchaPromise =
-			'show' === abtest( 'userStepRecaptcha' )
+			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
 				? recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' )
 				: Promise.resolve();
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -79,7 +79,13 @@ class PasswordlessSignupForm extends Component {
 		wpcom
 			.undocumented()
 			.createUserAccountFromEmailAddress(
-				{ email: typeof this.state.email === 'string' ? this.state.email.trim() : '' },
+				{
+					email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+					'g-recaptcha-response':
+						this.props.step && this.props.step.recaptchaToken
+							? this.props.step.recaptchaToken
+							: undefined,
+				},
 				null
 			)
 			.then( response => this.createUserAccountFromEmailAddressCallback( null, response ) )

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -78,34 +78,24 @@ class PasswordlessSignupForm extends Component {
 			form,
 		} );
 
-		if ( 'show' === abtest( 'userStepRecaptcha' ) ) {
-			recordGoogleRecaptchaAction( this.props.recaptchaClientId, 'calypso/signup/formSubmit' ).then(
-				recaptchaToken => {
-					wpcom
-						.undocumented()
-						.createUserAccountFromEmailAddress(
-							{
-								email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
-								'g-recaptcha-response': recaptchaToken,
-							},
-							null
-						)
-						.then( response => this.createUserAccountFromEmailAddressCallback( null, response ) )
-						.catch( err => this.createUserAccountFromEmailAddressCallback( err ) );
-				}
-			);
-		} else {
+		const recaptchaPromise =
+			'show' === abtest( 'userStepRecaptcha' )
+				? recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' )
+				: Promise.resolve();
+
+		recaptchaPromise.then( recaptchaToken => {
 			wpcom
 				.undocumented()
 				.createUserAccountFromEmailAddress(
 					{
 						email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+						'g-recaptcha-response': recaptchaToken || undefined,
 					},
 					null
 				)
 				.then( response => this.createUserAccountFromEmailAddressCallback( null, response ) )
 				.catch( err => this.createUserAccountFromEmailAddressCallback( err ) );
-		}
+		} );
 	};
 
 	createUserAccountFromEmailAddressCallback = ( error, response ) => {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -72,3 +72,43 @@
 		min-height: auto;
 	}
 }
+
+.signup-form__recaptcha-tos {
+	display: none;
+	padding: 20px 10px 10px;
+	font-size: 13px;
+	color: var( --studio-blue-5 );
+	text-align: center;
+
+	p {
+		margin: 0;
+		padding-top: 9px;
+	}
+
+	a {
+		color: var( --studio-blue-5 );
+		text-decoration: underline;
+	}
+}
+
+// Replace recaptcha badge with ToS text and space
+// everything out a little more.
+@media ( max-width: 660px ) {
+	.signup-form__recaptcha-tos {
+		display: block;
+	}
+
+	.grecaptcha-badge {
+		visibility: hidden;
+	}
+
+	.signup-form.is-showing-recaptcha-tos {
+		.signup-form__social {
+			padding-bottom: 28px;
+		}
+
+		.logged-out-form__links::before {
+			margin-bottom: 16px;
+		}
+	}
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -125,4 +125,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	userStepRecaptcha: {
+		datestamp: '20191111',
+		variations: {
+			show: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1859,11 +1859,11 @@ async function initGoogleRecaptcha() {
  * @returns {String|null} a reCAPTCHA token or null if the function fails
  */
 export async function recordGoogleRecaptchaAction( action ) {
-	if ( ! ( await initGoogleRecaptcha() ) ) {
+	if ( ! isGoogleRecaptchaEnabled || ! TRACKING_IDS.wpcomGoogleRecaptchaSiteKey ) {
 		return null;
 	}
 
-	if ( ! isGoogleRecaptchaEnabled || ! TRACKING_IDS.wpcomGoogleRecaptchaSiteKey ) {
+	if ( ! ( await initGoogleRecaptcha() ) ) {
 		return null;
 	}
 

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1840,7 +1840,7 @@ async function initGoogleRecaptcha() {
 	// Use loadScript directly instead of the loadTrackingScripts function, to ensure that the
 	// reCAPTCHA script is only loaded when needed.
 	try {
-		const src = GOOGLE_RECAPTCHA_SCRIPT_URL + TRACKING_IDS.wpcomGoogleRecaptchaSiteKey;
+		const src = GOOGLE_RECAPTCHA_SCRIPT_URL + 'explicit';
 		await loadScript( src );
 		debug( 'initGoogleRecaptcha: [Loaded]', src );
 	} catch ( error ) {
@@ -1870,6 +1870,12 @@ export async function recordGoogleRecaptchaAction( action ) {
 	await new Promise( resolve => window.grecaptcha.ready( resolve ) );
 
 	try {
+		// Render to an explicit DOM id 'g-recaptcha' that should already be on the page.
+		window.grecaptcha.render( 'g-recaptcha', {
+			sitekey: TRACKING_IDS.wpcomGoogleRecaptchaSiteKey,
+			size: 'invisible',
+		} );
+
 		const token = await window.grecaptcha.execute( TRACKING_IDS.wpcomGoogleRecaptchaSiteKey, {
 			action,
 		} );

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1871,12 +1871,12 @@ export async function recordGoogleRecaptchaAction( action ) {
 
 	try {
 		// Render to an explicit DOM id 'g-recaptcha' that should already be on the page.
-		window.grecaptcha.render( 'g-recaptcha', {
+		const clientId = await window.grecaptcha.render( 'g-recaptcha', {
 			sitekey: TRACKING_IDS.wpcomGoogleRecaptchaSiteKey,
 			size: 'invisible',
 		} );
 
-		const token = await window.grecaptcha.execute( TRACKING_IDS.wpcomGoogleRecaptchaSiteKey, {
+		const token = await window.grecaptcha.execute( clientId, {
 			action,
 		} );
 

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -309,10 +309,6 @@ function getTrackingScriptsToLoad() {
 		scripts.push( GOOGLE_GTAG_SCRIPT_URL + enabledGtags[ 0 ] );
 	}
 
-	if ( isGoogleRecaptchaEnabled && TRACKING_IDS.wpcomGoogleRecaptchaSiteKey ) {
-		scripts.push( GOOGLE_RECAPTCHA_SCRIPT_URL + TRACKING_IDS.wpcomGoogleRecaptchaSiteKey );
-	}
-
 	if ( isBingEnabled ) {
 		scripts.push( BING_TRACKING_SCRIPT_URL );
 	}
@@ -1851,12 +1847,21 @@ function initGoogleRecaptcha( callback ) {
  *
  * @param {Function} callback - a callback function to call with a reCAPTCHA token
  *
- * @returns {String} a reCaptcha token
+ * @returns {String} a reCAPTCHA token
  */
-export function recordGoogleRecaptchaCalypso( callback ) {
-	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
-		loadTrackingScripts( recordGoogleRecaptchaCalypso.bind( null, callback ) );
-		return;
+export async function recordGoogleRecaptchaCalypso( callback ) {
+	if ( ! window.grecaptcha ) {
+		const src = GOOGLE_RECAPTCHA_SCRIPT_URL + TRACKING_IDS.wpcomGoogleRecaptchaSiteKey;
+
+		// Use loadScript directly instead of the loadTrackingScripts function, to ensure that the
+		// reCAPTCHA script is only loaded when needed.
+		try {
+			await loadScript( src );
+		} catch ( error ) {
+			debug( 'recordGoogleRecaptchaCalypso: [Load Error] the script failed to load: ', error );
+			return;
+		}
+		debug( 'recordGoogleRecaptchaCalypso: [Loaded]', src );
 	}
 
 	// init Google reCAPTCHA

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -30,6 +30,7 @@ const debug = debugFactory( 'calypso:analytics:ad-tracking' );
 // Enable/disable ad-tracking
 // These should not be put in the json config as they must not differ across environments
 const isGoogleAnalyticsEnabled = true;
+const isGoogleRecaptchaEnabled = true;
 const isFloodlightEnabled = true;
 const isFacebookEnabled = true;
 const isBingEnabled = true;
@@ -58,6 +59,7 @@ let lastRetargetTime = 0;
  */
 const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevents.js',
 	GOOGLE_GTAG_SCRIPT_URL = 'https://www.googletagmanager.com/gtag/js?id=',
+	GOOGLE_RECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js?render=',
 	BING_TRACKING_SCRIPT_URL = 'https://bat.bing.com/bat.js',
 	CRITEO_TRACKING_SCRIPT_URL = 'https://static.criteo.net/js/ld/ld.js',
 	YAHOO_GEMINI_CONVERSION_PIXEL_URL =
@@ -107,6 +109,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		wpcomGoogleAdsGtagSignup: 'AW-946162814/5-NnCKy3xZQBEP6YlcMD', // "All Calypso Signups (WordPress.com)"
 		wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 		wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
+		wpcomGoogleRecaptchaSiteKey: config( 'google_recaptcha_site_key' ),
 		pinterestInit: '2613194105266',
 	},
 	// This name is something we created to store a session id for DCM Floodlight session tracking
@@ -304,6 +307,10 @@ function getTrackingScriptsToLoad() {
 	].filter( id => false !== id );
 	if ( enabledGtags.length > 0 ) {
 		scripts.push( GOOGLE_GTAG_SCRIPT_URL + enabledGtags[ 0 ] );
+	}
+
+	if ( isGoogleRecaptchaEnabled && TRACKING_IDS.wpcomGoogleRecaptchaSiteKey ) {
+		scripts.push( GOOGLE_RECAPTCHA_SCRIPT_URL + TRACKING_IDS.wpcomGoogleRecaptchaSiteKey );
 	}
 
 	if ( isBingEnabled ) {
@@ -1821,4 +1828,39 @@ function initFacebook() {
 	// See: <https://developers.facebook.com/docs/facebook-pixel/api-reference#automatic-configuration>
 	window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookJetpackInit );
 	window.fbq( 'init', TRACKING_IDS.facebookJetpackInit, advancedMatching );
+}
+
+/**
+ * Initializes Google reCAPTCHA
+ *
+ * @param {Function} callback - a callback function to call with a reCAPTCHA token
+ */
+function initGoogleRecaptcha( callback ) {
+	window.grecaptcha.ready( () => {
+		window.grecaptcha
+			.execute( TRACKING_IDS.wpcomGoogleRecaptchaSiteKey, { action: 'calypso' } )
+			.then( function( token ) {
+				debug( 'initGoogleRecaptcha', token );
+				callback( token );
+			} );
+	} );
+}
+
+/**
+ * Loads Google reCAPTCHA script and records calypso action
+ *
+ * @param {Function} callback - a callback function to call with a reCAPTCHA token
+ *
+ * @returns {String} a reCaptcha token
+ */
+export function recordGoogleRecaptchaCalypso( callback ) {
+	if ( TRACKING_STATE_VALUES.LOADED !== trackingState ) {
+		loadTrackingScripts( recordGoogleRecaptchaCalypso.bind( null, callback ) );
+		return;
+	}
+
+	// init Google reCAPTCHA
+	if ( isGoogleRecaptchaEnabled && TRACKING_IDS.wpcomGoogleRecaptchaSiteKey ) {
+		return initGoogleRecaptcha( callback );
+	}
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -370,7 +370,7 @@ export function launchSiteApi( callback, dependencies ) {
 export function createAccount(
 	callback,
 	dependencies,
-	{ userData, flowName, queryArgs, service, access_token, id_token, oauth2Signup },
+	{ userData, flowName, queryArgs, service, access_token, id_token, oauth2Signup, recaptchaToken },
 	reduxStore
 ) {
 	const state = reduxStore.getState();
@@ -437,7 +437,8 @@ export function createAccount(
 							// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
 							oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
 					  }
-					: null
+					: null,
+				recaptchaToken ? { 'g-recaptcha-response': recaptchaToken } : null
 			),
 			( error, response ) => {
 				const errors =

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -76,7 +76,7 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		initGoogleRecaptcha( 'g-recaptcha', 'calypso/pageload' ).then( this.saveRecaptchaToken );
+		initGoogleRecaptcha( 'g-recaptcha', 'calypso/signup/pageLoad' ).then( this.saveRecaptchaToken );
 
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
@@ -201,7 +201,7 @@ export class UserStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
 
-		recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/submitForm' ).then(
+		recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' ).then(
 			token => {
 				this.submit( {
 					userData,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -49,6 +49,7 @@ export class UserStep extends Component {
 		submitting: false,
 		subHeaderText: '',
 		recaptchaClientId: null,
+		isLoadingRecaptcha: true,
 	};
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -119,13 +120,7 @@ export class UserStep extends Component {
 					'By creating an account via any of the options below, {{br/}}you agree to our {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
-							a: (
-								<a
-									href="https://wordpress.com/tos/"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
+							a: <a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
 							br: <br />,
 						},
 					}
@@ -155,7 +150,11 @@ export class UserStep extends Component {
 	}
 
 	saveRecaptchaToken = ( { token, clientId } ) => {
-		this.setState( { recaptchaClientId: clientId } );
+		this.setState( {
+			isLoadingRecaptcha: false,
+			recaptchaClientId: clientId,
+		} );
+
 		this.props.saveSignupStep( {
 			stepName: this.props.stepName,
 			recaptchaToken: typeof token === 'string' ? token : undefined,
@@ -353,6 +352,7 @@ export class UserStep extends Component {
 					{ ...omit( this.props, [ 'translate' ] ) }
 					redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 					disabled={ this.userCreationStarted() }
+					disableSubmitButton={ this.state.isLoadingRecaptcha }
 					submitting={ this.userCreationStarted() }
 					save={ this.save }
 					submitForm={ this.submitForm }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -23,6 +23,7 @@ import { getSuggestedUsername } from 'state/signup/optional-dependencies/selecto
 import { recordTracksEvent } from 'state/analytics/actions';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { WPCC } from 'lib/url/support';
+import { recordGoogleRecaptchaCalypso } from 'lib/analytics/ad-tracking';
 import config from 'config';
 import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
@@ -74,7 +75,12 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		const token = recordGoogleRecaptchaCalypso( this.saveRecaptchaToken );
+
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			recaptchaToken: typeof token === 'string' ? token : undefined,
+		} );
 	}
 
 	setSubHeaderText( props ) {
@@ -150,6 +156,13 @@ export class UserStep extends Component {
 		this.setState( { subHeaderText } );
 	}
 
+	saveRecaptchaToken = token => {
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			recaptchaToken: typeof token === 'string' ? token : undefined,
+		} );
+	};
+
 	save = form => {
 		this.props.saveSignupStep( {
 			stepName: this.props.stepName,
@@ -193,6 +206,10 @@ export class UserStep extends Component {
 			userData,
 			form: formWithoutPassword,
 			queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
+			recaptchaToken:
+				this.props.step && this.props.step.recaptchaToken
+					? this.props.step.recaptchaToken
+					: undefined,
 		} );
 	};
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -50,7 +50,10 @@ export class UserStep extends Component {
 		submitting: false,
 		subHeaderText: '',
 		recaptchaClientId: null,
-		isLoadingRecaptcha: 'show' === abtest( 'userStepRecaptcha' ) ? true : false,
+		isLoadingRecaptcha:
+			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
+				? true
+				: false,
 	};
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -78,7 +81,7 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		if ( 'show' === abtest( 'userStepRecaptcha' ) ) {
+		if ( 'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' ) ) {
 			initGoogleRecaptcha( 'g-recaptcha', 'calypso/signup/pageLoad' ).then(
 				this.saveRecaptchaToken
 			);
@@ -206,7 +209,7 @@ export class UserStep extends Component {
 		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
 
 		const recaptchaPromise =
-			'show' === abtest( 'userStepRecaptcha' )
+			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
 				? recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' )
 				: Promise.resolve();
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -374,6 +374,9 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
+					showRecaptchaToS={
+						'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
+					}
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -205,24 +205,19 @@ export class UserStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
 
-		if ( 'show' === abtest( 'userStepRecaptcha' ) ) {
-			recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' ).then(
-				token => {
-					this.submit( {
-						userData,
-						form: formWithoutPassword,
-						queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
-						recaptchaToken: token,
-					} );
-				}
-			);
-		} else {
+		const recaptchaPromise =
+			'show' === abtest( 'userStepRecaptcha' )
+				? recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' )
+				: Promise.resolve();
+
+		recaptchaPromise.then( token => {
 			this.submit( {
 				userData,
 				form: formWithoutPassword,
 				queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
+				recaptchaToken: token || undefined,
 			} );
-		}
+		} );
 	};
 
 	/**

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -23,7 +23,7 @@ import { getSuggestedUsername } from 'state/signup/optional-dependencies/selecto
 import { recordTracksEvent } from 'state/analytics/actions';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { WPCC } from 'lib/url/support';
-import { recordGoogleRecaptchaCalypso } from 'lib/analytics/ad-tracking';
+import { recordGoogleRecaptchaAction } from 'lib/analytics/ad-tracking';
 import config from 'config';
 import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
@@ -75,12 +75,9 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		const token = recordGoogleRecaptchaCalypso( this.saveRecaptchaToken );
+		recordGoogleRecaptchaAction( 'calypso' ).then( this.saveRecaptchaToken );
 
-		this.props.saveSignupStep( {
-			stepName: this.props.stepName,
-			recaptchaToken: typeof token === 'string' ? token : undefined,
-		} );
+		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
 
 	setSubHeaderText( props ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -345,20 +345,23 @@ export class UserStep extends Component {
 		}
 
 		return (
-			<SignupForm
-				{ ...omit( this.props, [ 'translate' ] ) }
-				redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
-				disabled={ this.userCreationStarted() }
-				submitting={ this.userCreationStarted() }
-				save={ this.save }
-				submitForm={ this.submitForm }
-				submitButtonText={ this.submitButtonText() }
-				suggestedUsername={ this.props.suggestedUsername }
-				handleSocialResponse={ this.handleSocialResponse }
-				isSocialSignupEnabled={ isSocialSignupEnabled }
-				socialService={ socialService }
-				socialServiceResponse={ socialServiceResponse }
-			/>
+			<>
+				<SignupForm
+					{ ...omit( this.props, [ 'translate' ] ) }
+					redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
+					disabled={ this.userCreationStarted() }
+					submitting={ this.userCreationStarted() }
+					save={ this.save }
+					submitForm={ this.submitForm }
+					submitButtonText={ this.submitButtonText() }
+					suggestedUsername={ this.props.suggestedUsername }
+					handleSocialResponse={ this.handleSocialResponse }
+					isSocialSignupEnabled={ isSocialSignupEnabled }
+					socialService={ socialService }
+					socialServiceResponse={ socialServiceResponse }
+				/>
+				<div id="g-recaptcha"></div>
+			</>
 		);
 	}
 

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -19,7 +19,9 @@ import { noop } from 'lodash';
 import { UserStep as User } from '../';
 
 jest.mock( 'blocks/signup-form', () => require( 'components/empty-component' ) );
-jest.mock( 'lib/abtest', () => () => {} );
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
 jest.mock( 'signup/step-wrapper', () => require( 'components/empty-component' ) );
 jest.mock( 'signup/utils', () => ( {
 	getFlowSteps: flow => {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -18,6 +18,7 @@
 	"facebook_api_key": false,
 	"features": {},
 	"google_analytics_key": false,
+	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -130,5 +130,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "desktop",
 	"google_analytics_key": "UA-10673494-10",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true
 }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -130,6 +130,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "desktop",
 	"google_analytics_key": "UA-10673494-10",
-	"google_recaptcha_site_key": "",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/development.json
+++ b/config/development.json
@@ -18,7 +18,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/development.json
+++ b/config/development.json
@@ -18,6 +18,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -124,5 +124,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
 	"google_analytics_key": "UA-10673494-20",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -124,6 +124,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
 	"google_analytics_key": "UA-10673494-20",
-	"google_recaptcha_site_key": "",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -157,6 +157,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
 	"google_analytics_key": "UA-10673494-10",
-	"google_recaptcha_site_key": "",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -157,5 +157,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
 	"google_analytics_key": "UA-10673494-10",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -157,6 +157,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "",
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "stage",

--- a/config/stage.json
+++ b/config/stage.json
@@ -157,7 +157,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "stage",

--- a/config/test.json
+++ b/config/test.json
@@ -16,7 +16,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/test.json
+++ b/config/test.json
@@ -16,6 +16,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/test.json
+++ b/config/test.json
@@ -16,7 +16,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,5 +177,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,6 +177,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
 	"google_analytics_key": "UA-10673494-15",
-	"google_recaptcha_site_key": "",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1777,11 +1777,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
 			async function() {
 				const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
-				await jetpackAddNewSitePage.createNewWordPressDotComSite();
-				return await jetpackAddNewSitePage.overrideABTestInLocalStorage(
+				await jetpackAddNewSitePage.overrideABTestInLocalStorage(
 					'passwordlessSignup',
 					'passwordless'
 				);
+				return await jetpackAddNewSitePage.createNewWordPressDotComSite();
 			}
 		);
 


### PR DESCRIPTION
Adds reCAPTCHA v3 to the user step in signup.

More reading: https://developers.google.com/recaptcha/docs/v3

When the user step mounts, it calls a function `initGoogleRecaptcha` that loads the reCAPTCHA script and when the user submits the form it calls `recordGoogleRecaptchaAction` to record and action that we will verify with the backend.

Firing the action when the button is clicked slows down form submission. Rationale is Google can only verify an action that's occured in the last 2 minutes, and the user could sit on the user step for a long time. So the action is recorded right as the user is ready to leave.

#### Changes proposed in this Pull Request

* Load recaptcha when user step mounts
* Send `calypso/signup/pageLoad` action when step mounts
* Send `calypso/signup/formSubmit` action when submitting the user step
* Sends the token from the above action to the new user API as the `g-recaptcha-response` param
* Recaptcha UI removed when leaving the user step.
* Doesn't do any of this when in the test environment because the recaptcha key is excluded from `test.json`
* Place A/B test behaviour behind a 50/50 A/B test `userStepRecaptcha`

We never verify the page load action with the backend so technically not needed. Maybe it helps train the AI? 🤷‍♂ 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D34725-code
* Go to http://calypso.localhost:3000/start
* From the bug icon in the bottom right, select the `show` variant of the `userStepRecaptcha` A/B test
* You should see the reCAPTCHA notice in the bottom right
* Open up the Network tab in DevTools and create a new user account
* Take a look at the network request for the API call to create a new user `/users/new` and you should see the `g-recaptcha-response` prop with the reCAPTCHA token in it.
* Go to recaptcha console p1573160951123500-slack-CJEQFAAJU and you should see events there (unfortunately I can't see any way to filter the actions)
* Look for track event (instructions in D34725-code)
* Do it again for the passwordless user step
* Test normal account creation and passwordless account creation in the `control` group of the `userStepRecaptcha` A/B test to ensure there are regressions.