### PR TITLE
Onboarding block styling

### DIFF
--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -20,16 +20,7 @@
 	@include break-small {
 		position: fixed;
 		padding: $grid-size;
-		// Needed at wp-admin but not in Calypso
-		// top: $admin-bar-height-big;
 	}
-
-	// Needed at wp-admin but not in Calypso
-	/*
-	@include break-medium() {
-		top: $admin-bar-height;
-	}
-	*/
 }
 
 .gutenboarding__header-actions {

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -32,7 +32,7 @@ registerBlockType( name, settings );
 const onboardingBlock = createBlock( name, {} );
 
 export function Gutenboard() {
-	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( true );
+	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );
 
 	function toggleGeneralSidebar() {
 		updateIsEditorSidebarOpened( ! isEditorSidebarOpened );
@@ -40,7 +40,7 @@ export function Gutenboard() {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="gutenboarding block-editor__container">
+		<div className="block-editor__container">
 			<SlotFillProvider>
 				<DropZoneProvider>
 					<div

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -2,40 +2,56 @@
  * External dependencies
  */
 import { __ as NO__ } from '@wordpress/i18n';
-import { TextControl, SelectControl } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-
-import React from 'react';
+import React, { useCallback } from 'react';
 
 /**
  * Internal dependencies
  */
 import { SiteType } from '../store/types';
 import { STORE_KEY } from '../store';
+import './style.scss';
 
 export default function OnboardingEdit() {
 	const { siteTitle, siteType } = useSelect( select => select( STORE_KEY ).getState() );
 	const { setSiteType, setSiteTitle } = useDispatch( STORE_KEY );
-
-	return (
-		<>
-			<p>{ NO__( "Let's set up your website -- it takes only a moment" ) }</p>
-			{ NO__( 'I want to create a website ' ) }
-			<SelectControl< SiteType >
-				onChange={ setSiteType }
-				options={ [
-					{ label: NO__( 'with a blog.' ), value: SiteType.BLOG },
-					{ label: NO__( 'for a store.' ), value: SiteType.STORE },
-					{ label: NO__( 'to write a story.' ), value: SiteType.STORY },
-				] }
-				value={ siteType }
-			/>
-			{ ( siteType || siteTitle ) && (
-				<>
-					<p>{ NO__( "It's called" ) }</p>
-					<TextControl onChange={ setSiteTitle } value={ siteTitle } />
-				</>
-			) }
-		</>
+	const handleTitleChange = useCallback(
+		( e: React.ChangeEvent< HTMLInputElement > ) => setSiteTitle( e.target.value ),
+		[ setSiteTitle ]
 	);
+
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<div className="onboarding__questions">
+			<h2 className="onboarding__questions-heading">
+				{ NO__( "Let's set up your website – it takes only a moment." ) }
+			</h2>
+
+			<label className="onboarding__question">
+				<span>{ NO__( 'I want to create a website ' ) }</span>
+				<SelectControl< SiteType >
+					onChange={ setSiteType }
+					options={ [
+						{ label: NO__( 'with a blog.' ), value: SiteType.BLOG },
+						{ label: NO__( 'for a store.' ), value: SiteType.STORE },
+						{ label: NO__( 'to write a story.' ), value: SiteType.STORY },
+					] }
+					value={ siteType }
+					className="onboarding__question-input"
+				/>
+			</label>
+			{ ( siteType || siteTitle ) && (
+				<label className="onboarding__question">
+					<span>{ NO__( "It's called" ) }</span>
+					<input
+						className="onboarding__question-input"
+						onChange={ handleTitleChange }
+						value={ siteTitle }
+					/>
+				</label>
+			) }
+		</div>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -1,0 +1,32 @@
+@import 'assets/stylesheets/gutenberg-base-styles/style';
+
+.onboarding__questions-heading {
+	font-size: 1.5em;
+	line-height: 2em;
+	margin-bottom: 10px;
+}
+
+.onboarding__question {
+	display: flex;
+	font-size: 2em;
+	line-height: 2.1em;
+	margin-bottom: 10px;
+}
+
+.onboarding__question-input {
+	border: 0;
+	border-bottom: 3px solid $light-gray-500;
+	display: inline-block;
+	font-size: inherit;
+	line-height: inherit;
+	margin: 0 0.5em;
+	padding: 0;
+	&:hover {
+		border-color: $blue-medium-highlight;
+	}
+	&:active,
+	&:focus {
+		outline: 0; // @TODO: needs a11y considerations
+		border-color: $blue-medium-focus;
+	}
+}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -13,15 +13,6 @@ $admin-sidebar-width-collapsed: 0;
 @import '~@wordpress/block-editor/src/style.scss';
 @import '~@wordpress/format-library/src/style.scss';
 
-// These are default block editor styles in case the theme doesn't provide them.
 .wp-block {
-	max-width: $content-width;
-
-	&[data-align='wide'] {
-		max-width: 1100px;
-	}
-
-	&[data-align='full'] {
-		max-width: none;
-	}
+	max-width: 1100px; // Overrides default $content-width
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/87168/67957210-f0659e80-fbfd-11e9-92e5-5fa6c4ef5783.png)


#### Changes proposed in this Pull Request

* Adds styles to onboarding block
* Keep sidebar hidden by default

#### Testing instructions

- Open `/gutenboarding`
- Lookin' good?
- The sidebar was hidden when you open the page? You can still toggle it visible from the cog icon?
