### PR TITLE
i18n: Don't extract translatable strings from FSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
 		"test-server": "jest -c=test/server/jest.config.js",
 		"test-server:coverage": "npm run -s test-server -- --coverage",
 		"test-server:watch": "npm run -s test-server -- --watch",
-		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**'",
+		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!apps/full-site-editing/**' '!**/node_modules/**'",
 		"typecheck": "tsc --noEmit",
 		"update-deps": "npx rimraf npm-shrinkwrap.json && npm run -s distclean && npm i && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
 		"validate-fallback-es5": "npx eslint --env=es5 --no-eslintrc --no-ignore ./public/fallback/*.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Exclude the path `apps/full-site-editing` from `npm run translate` since the plugin is translated at https://translate.wordpress.org/projects/wp-plugins/full-site-editing/

#### Testing instructions

* `npm run translate` should no longer include strings with a location that starts with `apps/full-site-editing/`