### PR TITLE
Update copy related to Jetpack Backup product and add i18n support

### DIFF
--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -15,6 +15,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -21,6 +21,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**
@@ -67,11 +68,11 @@ describe( 'UpgradeToPremiumNudgePure basic tests', () => {
 	} );
 
 	test( 'hide when user cannot upgrade', () => {
-		const props = {
+		const localProps = {
 			translate: x => x,
 			canUserUpgrade: false,
 		};
-		const comp = shallow( <UpgradeToPremiumNudgePure { ...props } /> );
+		const comp = shallow( <UpgradeToPremiumNudgePure { ...localProps } /> );
 		expect( comp.find( 'Banner' ).length ).toBe( 0 );
 	} );
 } );

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -29,6 +29,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -18,6 +18,8 @@ import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-spec
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 jest.mock( 'lib/checkout/processor-specific', () => {

--- a/client/components/plans/plan-icon/test/test.jsx
+++ b/client/components/plans/plan-icon/test/test.jsx
@@ -14,6 +14,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/components/seo/preview-upgrade-nudge/test/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/test/index.jsx
@@ -22,6 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
+import { translate } from 'i18n-calypso';
 
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
@@ -25,19 +26,27 @@ export const JETPACK_BACKUP_PRODUCTS = [
 
 // @TODO: Translate those strings once we have confirmed the copy.
 export const JETPACK_BACKUP_PRODUCT_SHORT_NAMES = {
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 'Daily Backups',
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 'Daily Backups',
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 'Real-Time Backups',
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 'Real-Time Backups',
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate( 'Daily Backups' ),
+	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'Daily Backups' ),
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'Real-Time Backups' ),
+	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
 };
 export const JETPACK_BACKUP_PRODUCT_DAILY_DISPLAY_NAME = (
 	<Fragment>
-		Jetpack Backup <em>Daily</em>
+		{ translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
+			components: {
+				em: <em />,
+			},
+		} ) }
 	</Fragment>
 );
 export const JETPACK_BACKUP_PRODUCT_REALTIME_DISPLAY_NAME = (
 	<Fragment>
-		Jetpack Backup <em>Real-Time</em>
+		{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+			components: {
+				em: <em />,
+			},
+		} ) }
 	</Fragment>
 );
 export const JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES = {
@@ -47,23 +56,35 @@ export const JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES = {
 	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: JETPACK_BACKUP_PRODUCT_REALTIME_DISPLAY_NAME,
 };
 
-// @TODO: Translate those strings once we have confirmed the copy.
 export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = (
 	<p>
-		Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{' '}
-		<a href="https://jetpack.com/upgrade/backup/">Which one do I need?</a>
+		{ translate(
+			'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
+			{
+				components: {
+					a: <a href="https://jetpack.com/upgrade/backup/" />,
+				},
+			}
+		) }
 	</p>
 );
 export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = (
 	<p>
-		<strong>Looking for more?</strong> With Real-time backups, we save as you edit and you’ll get
-		unlimited backup archives.
+		{ translate(
+			'{{strong}}Looking for more?{{/strong}} With Real-time backups, we save as you edit and you’ll get unlimited backup archives.',
+			{
+				components: {
+					strong: <strong />,
+				},
+			}
+		) }
 	</p>
 );
 export const PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION = (
 	<p>
-		Always-on backups ensure you never lose your site. Your changes are saved as you edit and you
-		have unlimited backup archives.
+		{ translate(
+			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+		) }
 	</p>
 );
 
@@ -85,10 +106,9 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = {
 	},
 };
 
-// @TODO: Translate those strings once we have confirmed the copy.
 export const JETPACK_PRODUCTS = [
 	{
-		title: 'Jetpack Backup',
+		title: translate( 'Jetpack Backup' ),
 		description: PRODUCT_JETPACK_BACKUP_DESCRIPTION,
 		id: PRODUCT_JETPACK_BACKUP,
 		options: {
@@ -104,6 +124,6 @@ export const JETPACK_PRODUCTS = [
 		optionDescriptions: {
 			...JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
 		},
-		optionsLabel: 'Backup options',
+		optionsLabel: translate( 'Backup Options' ),
 	},
 ];

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -24,7 +24,6 @@ export const JETPACK_BACKUP_PRODUCTS = [
 	...JETPACK_BACKUP_PRODUCTS_MONTHLY,
 ];
 
-// @TODO: Translate those strings once we have confirmed the copy.
 export const JETPACK_BACKUP_PRODUCT_SHORT_NAMES = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate( 'Daily Backups' ),
 	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'Daily Backups' ),

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
@@ -20,6 +20,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -21,6 +21,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -103,6 +103,7 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			siteType,
 			plansWithScroll,
+			translate,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -120,11 +121,12 @@ export class PlansFeaturesMain extends Component {
 				) }
 				data-e2e-plans={ displayJetpackPlans ? 'jetpack' : 'wpcom' }
 			>
-				{ /* @todo: Add translations in FormattedHeader once the final copy is provided. */ }
 				{ isEnabled( 'plans/jetpack-backup' ) && displayJetpackPlans && (
 					<FormattedHeader
-						headerText="Plans"
-						subHeaderText="Get everything your site needs, in one package — so you can focus on your business."
+						headerText={ translate( 'Plans' ) }
+						subHeaderText={ translate(
+							'Get everything your site needs, in one package — so you can focus on your business.'
+						) }
 						compactOnMobile
 					/>
 				) }
@@ -395,18 +397,17 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { intervalType, displayJetpackPlans } = this.props;
+		const { intervalType, displayJetpackPlans, translate } = this.props;
 
 		if ( ! displayJetpackPlans ) {
 			return null;
 		}
 
-		// @todo: Add translations in FormattedHeader once the final copy is provided.
 		return (
 			<div className="plans-features-main__group is-narrow">
 				<FormattedHeader
-					headerText="Single Products"
-					subHeaderText="Just looking for backups? We’ve got you covered."
+					headerText={ translate( 'Single Products' ) }
+					subHeaderText={ translate( 'Just looking for backups? We’ve got you covered.' ) }
 					compactOnMobile
 				/>
 				<ProductSelector

--- a/client/my-sites/plans/current-plan/test/header.jsx
+++ b/client/my-sites/plans/current-plan/test/header.jsx
@@ -24,6 +24,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -39,6 +39,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -29,6 +29,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -18,6 +18,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -22,6 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**


### PR DESCRIPTION
This PR adds i18 support to new, Jetpack Backup-related strings.

#### Changes proposed in this Pull Request

* Update copy related to Jetpack Backup product
* Add `translate` functions to Jetpack Backup strings
* Add missing methods to `i18n-calypso` mocks in tests

#### Testing instructions

* Check out this branch.
* Go to http://calypso.localhost:3000/plans and confirm all labels and descriptions are in place (no regression).
* Test on sites that already have Jetpack Backup products to confirm there's no regression there as well. 

Fixes n/a
