### PR TITLE
Atomic Hosting: Change path to /hosting-admin

### DIFF
--- a/client/my-sites/hosting/index.js
+++ b/client/my-sites/hosting/index.js
@@ -12,9 +12,9 @@ import { handleHostingPanelRedirect, layout } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/sftp-mysql', siteSelection, sites, makeLayout, clientRender );
+	page( '/wp-hosting', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/sftp-mysql/:site_id',
+		'/wp-hosting/:site_id',
 		siteSelection,
 		navigation,
 		handleHostingPanelRedirect,

--- a/client/my-sites/hosting/index.js
+++ b/client/my-sites/hosting/index.js
@@ -12,9 +12,9 @@ import { handleHostingPanelRedirect, layout } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/hosting', siteSelection, sites, makeLayout, clientRender );
+	page( '/sftp-mysql', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/hosting/:site_id',
+		'/sftp-mysql/:site_id',
 		siteSelection,
 		navigation,
 		handleHostingPanelRedirect,

--- a/client/my-sites/hosting/index.js
+++ b/client/my-sites/hosting/index.js
@@ -12,9 +12,9 @@ import { handleHostingPanelRedirect, layout } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/wp-hosting', siteSelection, sites, makeLayout, clientRender );
+	page( '/hosting-admin', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/wp-hosting/:site_id',
+		'/hosting-admin/:site_id',
 		siteSelection,
 		navigation,
 		handleHostingPanelRedirect,

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -511,8 +511,8 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ translate( 'SFTP & MySQL' ) }
-				selected={ itemLinkMatches( '/wp-hosting', path ) }
-				link={ `/wp-hosting${ siteSuffix }` }
+				selected={ itemLinkMatches( '/hosting-admin', path ) }
+				link={ `/hosting-admin${ siteSuffix }` }
 				onNavigate={ this.trackHostingClick }
 				preloadSectionName="hosting"
 				expandSection={ this.expandManageSection }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -511,7 +511,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ translate( 'SFTP & MySQL' ) }
-				selected={ itemLinkMatches( '/hosting', path ) }
+				selected={ itemLinkMatches( '/sftp-mysql', path ) }
 				link={ `/hosting${ siteSuffix }` }
 				onNavigate={ this.trackHostingClick }
 				preloadSectionName="hosting"

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -512,7 +512,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label={ translate( 'SFTP & MySQL' ) }
 				selected={ itemLinkMatches( '/sftp-mysql', path ) }
-				link={ `/hosting${ siteSuffix }` }
+				link={ `/sftp-mysql${ siteSuffix }` }
 				onNavigate={ this.trackHostingClick }
 				preloadSectionName="hosting"
 				expandSection={ this.expandManageSection }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -511,8 +511,8 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ translate( 'SFTP & MySQL' ) }
-				selected={ itemLinkMatches( '/sftp-mysql', path ) }
-				link={ `/sftp-mysql${ siteSuffix }` }
+				selected={ itemLinkMatches( '/wp-hosting', path ) }
+				link={ `/wp-hosting${ siteSuffix }` }
 				onNavigate={ this.trackHostingClick }
 				preloadSectionName="hosting"
 				expandSection={ this.expandManageSection }

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -93,6 +93,9 @@ class Sites extends Component {
 			case 'home':
 				path = translate( 'My Home' );
 				break;
+			case 'sftp-mysql':
+				path = translate( 'SFTP & MySQL' );
+				break;
 		}
 
 		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -93,7 +93,7 @@ class Sites extends Component {
 			case 'home':
 				path = translate( 'My Home' );
 				break;
-			case 'wp-hosting':
+			case 'hosting-admin':
 				path = translate( 'SFTP & MySQL' );
 				break;
 		}

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -93,7 +93,7 @@ class Sites extends Component {
 			case 'home':
 				path = translate( 'My Home' );
 				break;
-			case 'sftp-mysql':
+			case 'wp-hosting':
 				path = translate( 'SFTP & MySQL' );
 				break;
 		}

--- a/client/sections.js
+++ b/client/sections.js
@@ -464,7 +464,7 @@ const sections = [
 	},
 	{
 		name: 'hosting',
-		paths: [ '/wp-hosting' ],
+		paths: [ '/hosting-admin' ],
 		module: 'my-sites/hosting',
 		secondary: true,
 		group: 'sites',

--- a/client/sections.js
+++ b/client/sections.js
@@ -464,7 +464,7 @@ const sections = [
 	},
 	{
 		name: 'hosting',
-		paths: [ '/sftp-mysql' ],
+		paths: [ '/wp-hosting' ],
 		module: 'my-sites/hosting',
 		secondary: true,
 		group: 'sites',

--- a/client/sections.js
+++ b/client/sections.js
@@ -464,7 +464,7 @@ const sections = [
 	},
 	{
 		name: 'hosting',
-		paths: [ '/hosting' ],
+		paths: [ '/sftp-mysql' ],
 		module: 'my-sites/hosting',
 		secondary: true,
 		group: 'sites',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the path used for the Atomic Hosting Dashboard to `/wp-hosting`.

We cannot use the `/hosting` path because https://wordpress.com/hosting is currently being used as a landing page.

#### Testing instructions

* If using a local install, be sure to do a fresh start so that the new routes can take effect (`npm start`).
* Switch to an Atomic site.
* Select "Manage > SFTP & MySQL" in the sidebar.
* Make sure it redirects to `/wp-hosting/:site`.
* Make sure the "Manage > SFTP & MySQL" sidebar item is marked as active.
* Go to `/wp-hosting`.
* Confirm the URL works and displays a site selector.
* Select an Atomic site.
* Verify the URL changes to `/wp-hosting/:site`.
