### PR TITLE
Plans: Open Jetpack Backup links in new window

### DIFF
--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -16,7 +16,9 @@ const products = [
 		description: (
 			<p>
 				Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{' '}
-				<a href="https://jetpack.com/upgrade/backup/">Which one do I need?</a>
+				<a href="https://jetpack.com/upgrade/backup/" target="_blank" rel="noopener noreferrer">
+					Which one do I need?
+				</a>
 			</p>
 		),
 		id: 'jetpack_backup',

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -61,7 +61,13 @@ export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = (
 			'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
 			{
 				components: {
-					a: <a href="https://jetpack.com/upgrade/backup/" />,
+					a: (
+						<a
+							href="https://jetpack.com/upgrade/backup/"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
 				},
 			}
 		) }


### PR DESCRIPTION
Currently, the links inside Jetpack Backup product descriptions open in the same window. Since they are external links, they should open in a new window. This is what this PR does.

#### Changes proposed in this Pull Request

* Plans: Open Jetpack Backup links in new window

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site without any Jetpack backups product.
* Click on the external link inside the Jetpack Backup product card description.
* Verify it opens in a new window.
