### PR TITLE
CoBlocks: Correct example image URLs.

### DIFF
--- a/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
+++ b/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
@@ -58,8 +58,8 @@ function getCoBlocksLogosExampleImages( settings, name ) {
 			attributes: {
 				...settings.attributes,
 				images: [
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[0]' ), width: 420 },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[1]' ), width: 340 },
+					{ url: get( 'wpcomGutenberg', 'coblocksLogosImages[0]' ), width: 420 },
+					{ url: get( 'wpcomGutenberg', 'coblocksLogosImages[1]' ), width: 340 },
 				],
 			},
 		},

--- a/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
+++ b/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
@@ -8,10 +8,14 @@ const blocksToFilter = [ 'coblocks/masonry-gallery', 'coblocks/gallery-stacked',
 const isSimpleSite = !! window.wpcomGutenberg.pluginVersion;
 
 function updateUrl( url, version ) {
-	const updatedPath = new URL( url ).pathname.replace(
-		/coblocks\/dist/,
-		`coblocks/${ version }/dist`
-	);
+	let updatedPath;
+
+	try {
+		updatedPath = new URL( url ).pathname.replace( /coblocks\/dist/, `coblocks/${ version }/dist` );
+	} catch ( e ) {
+		return false;
+	}
+
 	return `https://s0.wp.com${ updatedPath }`;
 }
 

--- a/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
+++ b/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { get } from 'lodash';
+
+function getCoBlocksMasonryExampleImages( settings, name ) {
+	if ( 'coblocks/gallery-masonry' !== name ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		example: {
+			attributes: {
+				...settings.attributes,
+				images: [
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[0]' ) },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[1]' ) },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[2]' ) },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[3]' ) },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[4]' ) },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[5]' ) },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[6]' ) },
+				],
+			},
+		},
+	};
+}
+
+function getCoBlocksStackedExampleImages( settings, name ) {
+	if ( 'coblocks/gallery-stacked' !== name ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		example: {
+			attributes: {
+				...settings.attributes,
+				images: [
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[5]' ) },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[1]' ) },
+				],
+			},
+		},
+	};
+}
+
+function getCoBlocksLogosExampleImages( settings, name ) {
+	if ( 'coblocks/logos' !== name ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		example: {
+			attributes: {
+				...settings.attributes,
+				images: [
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[0]' ), width: 420 },
+					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[1]' ), width: 340 },
+				],
+			},
+		},
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'coblocks/gallery-masonry',
+	getCoBlocksMasonryExampleImages
+);
+
+addFilter(
+	'blocks.registerBlockType',
+	'coblocks/gallery-stacked',
+	getCoBlocksStackedExampleImages
+);
+
+addFilter( 'blocks.registerBlockType', 'coblocks/logos', getCoBlocksLogosExampleImages );

--- a/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
+++ b/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
@@ -66,16 +66,17 @@ function getCoBlocksLogosExampleImages( settings, name ) {
 	};
 }
 
-addFilter(
-	'blocks.registerBlockType',
-	'coblocks/gallery-masonry',
-	getCoBlocksMasonryExampleImages
-);
-
-addFilter(
-	'blocks.registerBlockType',
-	'coblocks/gallery-stacked',
-	getCoBlocksStackedExampleImages
-);
-
-addFilter( 'blocks.registerBlockType', 'coblocks/logos', getCoBlocksLogosExampleImages );
+const isSimpleSite = !! window.wpcomGutenberg.pluginVersion;
+if ( isSimpleSite ) {
+	addFilter(
+		'blocks.registerBlockType',
+		'coblocks/gallery-masonry',
+		getCoBlocksMasonryExampleImages
+	);
+	addFilter(
+		'blocks.registerBlockType',
+		'coblocks/gallery-stacked',
+		getCoBlocksStackedExampleImages
+	);
+	addFilter( 'blocks.registerBlockType', 'coblocks/logos', getCoBlocksLogosExampleImages );
+}

--- a/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
+++ b/apps/wpcom-block-editor/src/common/coblocks-preview-images.js
@@ -4,79 +4,46 @@
 import { addFilter } from '@wordpress/hooks';
 import { get } from 'lodash';
 
-function getCoBlocksMasonryExampleImages( settings, name ) {
-	if ( 'coblocks/gallery-masonry' !== name ) {
-		return settings;
-	}
-
-	return {
-		...settings,
-		example: {
-			attributes: {
-				...settings.attributes,
-				images: [
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[0]' ) },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[1]' ) },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[2]' ) },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[3]' ) },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[4]' ) },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[5]' ) },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[6]' ) },
-				],
-			},
-		},
-	};
-}
-
-function getCoBlocksStackedExampleImages( settings, name ) {
-	if ( 'coblocks/gallery-stacked' !== name ) {
-		return settings;
-	}
-
-	return {
-		...settings,
-		example: {
-			attributes: {
-				...settings.attributes,
-				images: [
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[5]' ) },
-					{ url: get( 'wpcomGutenberg', 'coblocksGalleryImages[1]' ) },
-				],
-			},
-		},
-	};
-}
-
-function getCoBlocksLogosExampleImages( settings, name ) {
-	if ( 'coblocks/logos' !== name ) {
-		return settings;
-	}
-
-	return {
-		...settings,
-		example: {
-			attributes: {
-				...settings.attributes,
-				images: [
-					{ url: get( 'wpcomGutenberg', 'coblocksLogosImages[0]' ), width: 420 },
-					{ url: get( 'wpcomGutenberg', 'coblocksLogosImages[1]' ), width: 340 },
-				],
-			},
-		},
-	};
-}
-
+const blocksToFilter = [ 'coblocks/masonry-gallery', 'coblocks/gallery-stacked', 'coblocks/logos' ];
 const isSimpleSite = !! window.wpcomGutenberg.pluginVersion;
+
+function updateUrl( url, version ) {
+	const updatedPath = new URL( url ).pathname.replace(
+		/coblocks\/dist/,
+		`coblocks/${ version }/dist`
+	);
+	return `https://s0.wp.com${ updatedPath }`;
+}
+
+function getCoBlocksExampleImages( settings, name ) {
+	if (
+		! blocksToFilter.includes( name ) ||
+		! get( 'window', 'wpcomGutenberg', 'coblocksVersion' )
+	) {
+		return settings;
+	}
+
+	const images = settings.example.attributes.images.map( image => {
+		return {
+			...image,
+			url: image.url ? updateUrl( image.url, window.wpcomGutenberg.coblocksVersion ) : false,
+		};
+	} );
+
+	return {
+		...settings,
+		example: {
+			...settings.example,
+			attributes: {
+				...settings.example.attributes,
+				images,
+			},
+		},
+	};
+}
+
 if ( isSimpleSite ) {
-	addFilter(
-		'blocks.registerBlockType',
-		'coblocks/gallery-masonry',
-		getCoBlocksMasonryExampleImages
-	);
-	addFilter(
-		'blocks.registerBlockType',
-		'coblocks/gallery-stacked',
-		getCoBlocksStackedExampleImages
-	);
-	addFilter( 'blocks.registerBlockType', 'coblocks/logos', getCoBlocksLogosExampleImages );
+	addFilter( 'blocks.registerBlockType', 'coblocks/gallery-masonry', getCoBlocksExampleImages );
+	addFilter( 'blocks.registerBlockType', 'coblocks/gallery-stacked', getCoBlocksExampleImages );
+	addFilter( 'blocks.registerBlockType', 'coblocks/logos', getCoBlocksExampleImages );
 }

--- a/apps/wpcom-block-editor/src/common/index.js
+++ b/apps/wpcom-block-editor/src/common/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './coblocks-preview-images';
 import './disable-nux-tour';
 import './reorder-block-categories';
 import './rich-text';


### PR DESCRIPTION
This PR filters certain CoBlocks settings to correct example image URLs.

#### Testing instructions

1. Sandbox the API and `widgets.wp.com`.
2. Build the `wpcom-block-editor` app from this branch, and transfer to your sandbox.
3. Bust the cache by entering a dummy value for `$__autogen_cache_buster_wpcom_block_editor`.
4. Start a new post in the block editor for a sandboxed test site.
5. Click the inserter in the top control bar, and hover over each of the three affected blocks: Masonry, Stacked, and Logos.
6. Ensure example images load properly in the preview to the right.

Fixes #37096 
