### PR TITLE
Vertical-suggested themes: Only assign business users to `vert…

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,7 +99,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	verticalSuggestedThemes: {
-		datestamp: '20191029',
+		datestamp: '20191031',
 		variations: {
 			control: 90,
 			test: 10,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -170,6 +170,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	if (
 		flowToCheck === 'onboarding' &&
+		siteSegment === 1 &&
 		newSiteParams.options.theme !== defaultSiteTypeTheme &&
 		abtest( 'verticalSuggestedThemes' ) === 'test'
 	) {

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -24,7 +24,9 @@ import { abtest } from 'lib/abtest';
 // case don't send a site_type param to the API.
 export const requestVerticals = action => {
 	const verticalSuggestedThemeTest =
-		action.flowName === 'onboarding' && abtest( 'verticalSuggestedThemes' ) === 'test';
+		action.flowName === 'onboarding' &&
+		action.siteTypeId === 1 &&
+		abtest( 'verticalSuggestedThemes' ) === 'test';
 
 	return http(
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only assign users to `verticalSuggestedThemes` test if they've choosen the business segment
* Change test date to restart test

Discussion: p1572473959010500-slack-CJEQFAAJU

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Incognito window
* `/start` and create a **blog**, go the whole way through the signup process
* Run this in the console:
  ```
  Object.keys(JSON.parse(localStorage.getItem('ABTests'))).find(t => t.match('verticalSuggestedThemes'))
  ```
* Should return `undefined`
* Same user, `/start` and create a **business**, go the whole way through the signup process
* Run the same thing in the console
* Should return `'test'` or `'control'`