### PR TITLE
Check for isPasswordlessSignupForm before the abtest check in flow controller

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -308,8 +308,8 @@ export default class SignupFlowController {
 		*/
 		if (
 			'onboarding' === this._flowName &&
-			'passwordless' === abtest( 'passwordlessSignup' ) &&
-			get( step, 'isPasswordlessSignupForm' )
+			get( step, 'isPasswordlessSignupForm' ) &&
+			'passwordless' === abtest( 'passwordlessSignup' )
 		) {
 			this._processingSteps.delete( step.stepName );
 			analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/pull/37171

This small PR swaps the order of the check for the `isPasswordlessSignupForm` property in the step, and the passwordlessSignup A/B test in the flow controller, to ensure that at this stage, non-passwordless users aren't accidentally assigned a test group.

#### Changes proposed in this Pull Request

* In the flow controller, put the check for the `isPasswordlessSignupForm` step property before the call to `abtest` to ensure that non-passwordless users aren't assigned a group here.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the same instructions as for #36519 to test out passwordless — you can set yourself to be in the test variant by setting the local storage value `localStorage.setItem( 'ABTests', '{"passwordlessSignup_20191029":"passwordless"}' );`
* Starting from http://calypso.localhost:3000/jetpack/new/ — Ensure that a passwordless signup (where you are in the `passwordless` variant of the `passwordlessSignup` A/B test) and site creation works.
* In the control group of this A/B test, ensure that account creation and sign up still works.
