### PR TITLE
composite-checkout: Rename some hooks

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -2,11 +2,11 @@
 
 A set of React components, custom Hooks, and helper functions that together can be used to create a purchase and checkout flow.
 
-## 💰 Installation
+## Installation
 
 `npm install composite-checkout styled-components`
 
-## 💰 Usage
+## Description
 
 This package provides a context provider, `CheckoutProvider`, and a default component, `Checkout`, which creates a checkout form.
 
@@ -16,20 +16,13 @@ The form has three steps:
 2. Billing details
 3. Review order
 
-The steps can be customized using various props. `Checkout` is actually just a wrapper for other components and functions exported by this package, though, so if these customizations aren't sufficient, it's possible to build a custom form. The only real requirement is that the form be a child of `CheckoutProvider`.
+The steps can be customized using various props.
+
+For more detailed customization, it's possible to build a custom form using the other components exported by this package.
 
 ### Select payment method
 
-The payment methods displayed in the first step are chosen from an optional array called `availablePaymentMethods`, which in turn is selected from the following options:
-
-- 'web-payment'
-- 'apple-pay'
-- 'card'
-- 'paypal'
-- 'ebanx'
-- 'ideal'
-
-The actual payment method options displayed on the form are chosen automatically by the component based on the environment, locale, and possibly other factors, but they will include only methods in the `availablePaymentMethods` array.
+The payment method options displayed on the form are chosen automatically by the component based on the environment, locale, and possibly other factors, but they will include only methods listed in the optional `availablePaymentMethods` array. If the array is not set, no appropriate payment methods will be excluded.
 
 ![payment method step](https://raw.githubusercontent.com/Automattic/wp-calypso/add/wp-checkout-component/packages/composite-checkout/doc-assets/payment-method-step.png 'Payment Method Step')
 
@@ -37,25 +30,19 @@ Any previously stored payment methods (eg: saved credit cards) will be fetched a
 
 The content of the second and third step vary based on the payment method chosen in the first step. For example, the second step may only request a postal code if the payment method is 'apple-pay', but it may request the full address for the 'card' method.
 
-Inside the component, this is a `CheckoutStep` wrapping a `CheckoutPaymentMethods` component.
-
 ### Billing details
 
 This step contains various form fields to collect billing contact information from the customer.
 
-The billing information may be automatically filled based on data retrieved from the server. If the billing address is set or changed during this step, the updated address will be used for the checkout. However, as a side effect, an event handler passed to `CheckoutProvider` as the `eventHandler` prop will allow the parent component can take any necessary actions like updating the line items and total.
+The billing information may be automatically filled based on data retrieved from the server. If the billing address is set or changed during this step, the updated address will be used for the checkout. However, as a side effect, an event handler passed to `CheckoutProvider` as the `eventHandler` prop will allow the parent component to take any necessary actions like updating the line items and total.
 
 ![billing details step](https://raw.githubusercontent.com/Automattic/wp-calypso/add/wp-checkout-component/packages/composite-checkout/doc-asset/billing-step.png 'Billing Details Step')
 
 Any other component can request the information from these form fields by using the `usePaymentData` React Hook.
 
-Inside the component, this is a `CheckoutStep` wrapping whatever `BillingContactComponent` is provided by the payment method.
-
 ### Review order
 
 The third step presents a simple list of line items and a total, followed by a purchase button.
-
-Inside the component, this is a `CheckoutStep` wrapping a `CheckoutReviewOrder` component.
 
 ![review order step](https://raw.githubusercontent.com/Automattic/wp-calypso/add/wp-checkout-component/packages/composite-checkout/doc-asset/review-step.png 'Review Order Step')
 
@@ -77,7 +64,7 @@ If the payment method succeeds, the `onSuccess` prop will be called instead. It'
 
 Some payment methods may require a redirect to an external site. If that occurs, the `failureRedirectUrl` and `successRedirectUrl` props on `Checkout` will be used instead of the `onFailure` and `onSuccess` callbacks. All four props are required.
 
-## 💰 Examples
+## Examples
 
 ### Example 1
 
@@ -399,7 +386,7 @@ function UpSellCoupon( { onClick } ) {
 }
 ```
 
-## 💰 Styles and Themes
+## Styles and Themes
 
 Each component will be styled using [styled-components](https://www.styled-components.com/) (included in this package as a [peer dependency](https://nodejs.org/en/blog/npm/peer-dependencies/)) and many of the styles will be editable by passing a `theme` object to the `CheckoutProvider`.
 
@@ -407,7 +394,7 @@ For style customization beyond what is available in the theme, each component wi
 
 When using the individual API components, you can also pass a `className` prop, which will be applied to that component in addition to the classNames from BEM and styled-components.
 
-## 💰 Payment Methods
+## Payment Methods
 
 A payment method, in the context of this package, consists of the following pieces:
 
@@ -436,7 +423,7 @@ Each payment method is registered by calling `registerPaymentMethod()` and passi
 
 Within the components, the Hook `usePaymentMethod()` will return an object of the above form with the key of the currently selected payment method or null if none is selected. To retrieve all the payment methods and their properties, the function `getPaymentMethods()` will return an array that contains them all.
 
-## 💰 Advanced API
+## API
 
 While the `Checkout` component takes care of most everything, there are many situations where its appearance and behavior will be customized. In these cases it's appropriate to use the underlying building blocks of this package.
 
@@ -573,7 +560,7 @@ A React Hook that will return a two element array. It can be used to store and s
 
 A React Hook that will return a two element array. The first element is a string representing the currently selected payment method (or null if none is selected). The second element is a function that will replace the currently selected payment method.
 
-## 💰 FAQ
+## FAQ
 
 ### How do I use Credits and Coupons?
 
@@ -591,6 +578,6 @@ The primary properties used in a line item by default are `id` (which must be un
 
 To maintain the integrity of the line item schema, adding custom fields is discouraged, but allowed. If you need specific custom data as part of a line item so that it can be used in another part of the form, it's recommended to pass the line item object through a helper function to collect the extra data rather than serializing it into the line item itself. This will make that data collection more testable. However, if the data collection process is expensive or slow, and caching isn't an option, it may make sense to preload the data into the line items.
 
-## 💰 Development
+## Development
 
 In the root of the monorepo, run `npm run composite-checkout-demo` which will start a local webserver that will display the component.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -47,7 +47,7 @@ The billing information may be automatically filled based on data retrieved from
 
 ![billing details step](https://raw.githubusercontent.com/Automattic/wp-calypso/add/wp-checkout-component/packages/composite-checkout/doc-asset/billing-step.png 'Billing Details Step')
 
-Any other component can request the information from these form fields by using the `usePaymentMethodData` React Hook.
+Any other component can request the information from these form fields by using the `usePaymentData` React Hook.
 
 Inside the component, this is a `CheckoutStep` wrapping whatever `BillingContactComponent` is provided by the payment method.
 
@@ -67,7 +67,7 @@ There are several other optional props aside from `ReviewContent` which allow cu
 
 ![component slots](https://raw.githubusercontent.com/Automattic/wp-calypso/add/wp-checkout-component/packages/composite-checkout/doc-asset/checkout-slots.png 'Highlighted component slots')
 
-Any component within `Checkout` can use the custom React Hook `useCheckoutLineItems`, which returns a two element array where the first element is the current array of line items (matching the `items` prop on `Checkout`), the second element is the current total (matching the `total` prop).
+Any component within `Checkout` can use the custom React Hook `useLineItems`, which returns a two element array where the first element is the current array of line items (matching the `items` prop on `Checkout`), the second element is the current total (matching the `total` prop).
 
 ### Submitting the form
 
@@ -159,7 +159,7 @@ The following bigger example demonstrates a checkout page using many of the opti
 import React, { useState } from 'react';
 import {
 	Checkout,
-	useCheckoutLineItems,
+	useLineItems,
 	OrderReviewLineItems,
 	OrderReviewSection,
 	OrderReviewTotal,
@@ -320,7 +320,7 @@ function useShoppingCart() {
 }
 
 function OrderReview( { onDeleteItem, onChangePlanLength } ) {
-	const [ items, total ] = useCheckoutLineItems();
+	const [ items, total ] = useLineItems();
 	const planItems = items.filter( item => item.type === 'plan' );
 	const domainItems = items.filter( item => item.type === 'domain' );
 	const taxItems = items.filter( item => item.type === 'tax' );
@@ -553,7 +553,7 @@ Takes one argument, a displayValue string, and returns the displayValue with som
 
 A React Hook that will return a two element array where the first element is the `onSuccess` handler and the second is the `onFailure` handler as passed to `Checkout`.
 
-### useCheckoutLineItems()
+### useLineItems()
 
 A React Hook that will return a two element array where the first element is the current array of line items (matching the `items` prop on `Checkout`), and the second element is the current total (matching the `total` prop).
 
@@ -565,7 +565,7 @@ A React Hook that will return a two element array where the first element is the
 
 A React Hook that will return an object containing all the information about the currently selected payment method (or null if none is selected). The most relevant property is probably `id`, which is a string identifying whatever payment method was entered in the payment method step.
 
-### usePaymentMethodData()
+### usePaymentData()
 
 A React Hook that will return a two element array. It can be used to store and share data entered into the payment forms. The first element is an object representing the current state. The second element is a "dispatch" function which can be used to update the state (with an implicit merge) or trigger an event for side effects. The dispatch function should be passed an object with two properties: `type` and `payload` following the [flux-standard-action](https://github.com/redux-utilities/flux-standard-action) pattern.
 

--- a/packages/composite-checkout/src/components/billing-fields.js
+++ b/packages/composite-checkout/src/components/billing-fields.js
@@ -9,13 +9,13 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { useLocalize } from '../lib/localize';
-import { useCheckoutLineItems, usePaymentMethodData } from '../public-api';
+import { useLineItems, usePaymentData } from '../public-api';
 import GridRow from './grid-row';
 import Field from './field';
 
 export default function BillingFields( { summary, isActive, isComplete } ) {
-	const [ items ] = useCheckoutLineItems();
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ items ] = useLineItems();
+	const [ paymentData, dispatch ] = usePaymentData();
 	const { isDomainContactSame = true } = paymentData;
 
 	if ( summary && isComplete ) {
@@ -171,7 +171,7 @@ const DomainRegistrationCheckbox = styled.input`
 
 function AddressFields( { fieldType } ) {
 	const localize = useLocalize();
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ paymentData, dispatch ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updatePaymentData = ( key, value ) =>
 		dispatch( { type: 'PAYMENT_DATA_UPDATE', payload: { [ key ]: value } } );
@@ -248,7 +248,7 @@ function isStateorProvince() {
 
 function PhoneNumberField( { fieldType } ) {
 	const localize = useLocalize();
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ paymentData, dispatch ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updatePaymentData = ( key, value ) =>
 		dispatch( { type: 'PAYMENT_DATA_UPDATE', payload: { [ key ]: value } } );
@@ -277,7 +277,7 @@ PhoneNumberField.propTypes = {
 function VatIdField() {
 	const localize = useLocalize();
 	const fieldType = 'billing';
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ paymentData, dispatch ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updatePaymentData = ( key, value ) =>
 		dispatch( { type: 'PAYMENT_DATA_UPDATE', payload: { [ key ]: value } } );
@@ -299,7 +299,7 @@ function VatIdField() {
 
 function TaxFields( { fieldType } ) {
 	const localize = useLocalize();
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ paymentData, dispatch ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updatePaymentData = ( key, value ) =>
 		dispatch( { type: 'PAYMENT_DATA_UPDATE', payload: { [ key ]: value } } );
@@ -396,7 +396,7 @@ const DomainContactFieldsDescription = styled.p`
 
 function BillingFormSummary() {
 	const localize = useLocalize();
-	const [ paymentData ] = usePaymentMethodData();
+	const [ paymentData ] = usePaymentData();
 	const { billing = {}, domains = {}, isDomainContactSame = true } = paymentData;
 
 	//Check if paymentData is empty

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -77,7 +77,7 @@ CheckoutProvider.propTypes = {
 	failureRedirectUrl: PropTypes.string.isRequired,
 };
 
-export const useCheckoutLineItems = () => {
+export const useLineItems = () => {
 	const { total, items } = useContext( CheckoutContext );
 	return [ items, total ];
 };

--- a/packages/composite-checkout/src/components/checkout-review-order.js
+++ b/packages/composite-checkout/src/components/checkout-review-order.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import joinClasses from '../lib/join-classes';
-import { useCheckoutLineItems, renderDisplayValueMarkdown } from '../public-api';
+import { useLineItems, renderDisplayValueMarkdown } from '../public-api';
 import {
 	OrderReviewLineItems,
 	OrderReviewTotal,
@@ -16,7 +16,7 @@ import {
 } from './order-review-line-items';
 
 export default function CheckoutReviewOrder( { summary, className } ) {
-	const [ items, total ] = useCheckoutLineItems();
+	const [ items, total ] = useLineItems();
 	if ( summary ) {
 		return (
 			<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -12,7 +12,7 @@ import joinClasses from '../lib/join-classes';
 import { useLocalize } from '../lib/localize';
 import CheckoutStep from './checkout-step';
 import CheckoutPaymentMethods from './checkout-payment-methods';
-import { usePaymentMethodData, usePaymentMethod, usePaymentMethodId } from '../lib/payment-methods';
+import { usePaymentData, usePaymentMethod, usePaymentMethodId } from '../lib/payment-methods';
 import CheckoutNextStepButton from './checkout-next-step-button';
 import CheckoutReviewOrder from './checkout-review-order';
 import CheckoutSubmitButton from './checkout-submit-button';
@@ -26,7 +26,7 @@ export default function Checkout( {
 } ) {
 	const localize = useLocalize();
 	const [ stepNumber, setStepNumber ] = useState( 1 );
-	const [ , dispatchPaymentAction ] = usePaymentMethodData();
+	const [ , dispatchPaymentAction ] = usePaymentData();
 	const changeStep = useCallback(
 		nextStep => {
 			setStepNumber( prevStep => {
@@ -178,7 +178,7 @@ PaymentMethodsStep.propTypes = {
 
 function BillingDetailsStep( { isActive, isComplete, setStepNumber } ) {
 	const localize = useLocalize();
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ paymentData, dispatch ] = usePaymentData();
 	const paymentMethod = usePaymentMethod();
 	if ( ! paymentMethod ) {
 		throw new Error( 'Cannot render Billing details without a payment method' );

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -15,9 +15,9 @@ import { useLocalize } from '../lib/localize';
 import { useStripe, createStripePaymentMethod, confirmStripePaymentIntent } from '../lib/stripe';
 import {
 	useCheckoutHandlers,
-	useCheckoutLineItems,
+	useLineItems,
 	useCheckoutRedirects,
-	usePaymentMethodData,
+	usePaymentData,
 	renderDisplayValueMarkdown,
 } from '../public-api';
 import { VisaLogo, AmexLogo, MastercardLogo } from './payment-logos';
@@ -316,8 +316,8 @@ function LockIcon( { className } ) {
 
 export function StripePayButton() {
 	const localize = useLocalize();
-	const [ items, total ] = useCheckoutLineItems();
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ items, total ] = useLineItems();
+	const [ paymentData, dispatch ] = usePaymentData();
 	const { onSuccess, onFailure } = useCheckoutHandlers();
 	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
 	const { stripe, stripeConfiguration } = useStripe();

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -9,7 +9,7 @@ import styled from 'styled-components';
  */
 import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
-import { useCheckoutLineItems, renderDisplayValueMarkdown } from '../../public-api';
+import { useLineItems, renderDisplayValueMarkdown } from '../../public-api';
 
 export function CreditCardLabel() {
 	const localize = useLocalize();
@@ -23,7 +23,7 @@ export function CreditCardLabel() {
 
 export function CreditCardSubmitButton() {
 	const localize = useLocalize();
-	const [ , total ] = useCheckoutLineItems();
+	const [ , total ] = useLineItems();
 	// TODO: we need to use a placeholder for the value so the localization string can be generic
 	const buttonString = localize(
 		`Pay ${ renderDisplayValueMarkdown( total.amount.displayValue ) }`

--- a/packages/composite-checkout/src/lib/payment-methods/index.js
+++ b/packages/composite-checkout/src/lib/payment-methods/index.js
@@ -59,7 +59,7 @@ export function usePaymentMethod() {
 	return paymentMethod;
 }
 
-export function usePaymentMethodData() {
+export function usePaymentData() {
 	const { paymentData, dispatchPaymentAction } = useContext( CheckoutContext );
 	return [ paymentData, dispatchPaymentAction ];
 }

--- a/packages/composite-checkout/src/lib/stripe.js
+++ b/packages/composite-checkout/src/lib/stripe.js
@@ -7,7 +7,7 @@ import { injectStripe, StripeProvider, Elements } from 'react-stripe-elements';
 /**
  * Internal dependencies
  */
-import { usePaymentMethodData } from '../public-api';
+import { usePaymentData } from '../public-api';
 
 const StripeContext = createContext();
 
@@ -221,7 +221,7 @@ function loadScriptAsync( url ) {
  */
 function useStripeConfiguration( requestArgs ) {
 	const [ currentAttempt, setAttempt ] = useState( 1 );
-	const [ paymentData, dispatch ] = usePaymentMethodData();
+	const [ paymentData, dispatch ] = usePaymentData();
 	useEffect( () => {
 		dispatch( { type: 'STRIPE_CONFIGURATION_FETCH', payload: requestArgs || {} } );
 	}, [ requestArgs, currentAttempt, dispatch ] );

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -3,7 +3,7 @@
  */
 import {
 	CheckoutProvider,
-	useCheckoutLineItems,
+	useLineItems,
 	useCheckoutHandlers,
 	useCheckoutRedirects,
 } from './components/checkout-provider';
@@ -16,7 +16,7 @@ import {
 } from './components/order-review-line-items';
 import Checkout from './components/checkout';
 import { renderDisplayValueMarkdown } from './lib/render';
-import { usePaymentMethod, usePaymentMethodData, usePaymentMethodId } from './lib/payment-methods';
+import { usePaymentMethod, usePaymentData, usePaymentMethodId } from './lib/payment-methods';
 
 // Re-export the public API
 export {
@@ -29,9 +29,9 @@ export {
 	OrderReviewTotal,
 	renderDisplayValueMarkdown,
 	useCheckoutHandlers,
-	useCheckoutLineItems,
+	useLineItems,
 	useCheckoutRedirects,
 	usePaymentMethod,
-	usePaymentMethodData,
+	usePaymentData,
 	usePaymentMethodId,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Rename `useCheckoutLineItems` to `useLineItems` (because what other line items could there be) and `usePaymentMethodData` to `usePaymentData` (because the `paymentData` object is no longer tied to the payment methods).

Requires #37232

#### Testing instructions

Make sure tests pass and that loading the demo works as expected.

