### PR TITLE
Revert signupWithBasicSite A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,15 +89,6 @@ export default {
 		defaultVariation: 'notSkippable',
 		allowExistingUsers: true,
 	},
-	signupWithBasicSite: {
-		datestamp: '20190930',
-		variations: {
-			variant: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	verticalSuggestedThemes: {
 		datestamp: '20191031',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -120,13 +120,6 @@ export function generateFlows( {
 			lastModified: '2019-06-20',
 		},
 
-		'get-started': {
-			steps: [ 'user', 'site-type', 'domains', 'plans' ],
-			destination: getSignupDestination,
-			description: 'A blank slate flow used with the `signupEscapeHatch` AB test',
-			lastModified: '2019-09-23',
-		},
-
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -36,10 +36,6 @@ class SiteType extends Component {
 		this.submitStep( 'import' );
 	};
 
-	// This function is to support the A/B test `signupWithBasicSite`
-	// by using a flow that does not include intermediary steps before 'domain'
-	handleBasicSiteButtonClick = () => this.submitStep( 'business', 'get-started' );
-
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import Button from 'components/button';
@@ -18,11 +17,9 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
-	'get-started': 'get-started',
 	'online-store': 'ecommerce-onboarding',
 };
 
@@ -43,15 +40,11 @@ class SiteType extends Component {
 	// by using a flow that does not include intermediary steps before 'domain'
 	handleBasicSiteButtonClick = () => this.submitStep( 'business', 'get-started' );
 
-	submitStep = ( siteTypeValue, flowName ) => {
+	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 
-		if ( flowName ) {
-			this.props.goToNextStep( flowName );
-			return;
-		}
-
 		// Modify the flowname if the site type matches an override.
+		let flowName;
 		if ( 'import-onboarding' === this.props.flowName ) {
 			flowName = siteTypeToFlowname[ siteTypeValue ] || 'onboarding';
 		} else {
@@ -75,20 +68,6 @@ class SiteType extends Component {
 		);
 	}
 
-	renderStartWithBasicSiteButton() {
-		if ( 'variant' !== abtest( 'signupWithBasicSite' ) ) {
-			return null;
-		}
-
-		return (
-			<div className="site-type__basic-site">
-				<Button borderless onClick={ this.handleBasicSiteButtonClick }>
-					{ this.props.translate( 'Skip setup and start with a basic website.' ) }
-				</Button>
-			</div>
-		);
-	}
-
 	renderStepContent() {
 		const { siteType } = this.props;
 
@@ -99,7 +78,6 @@ class SiteType extends Component {
 					submitForm={ this.submitStep }
 					siteType={ siteType }
 				/>
-				{ this.renderStartWithBasicSiteButton() }
 				{ this.renderImportButton() }
 			</Fragment>
 		);
@@ -142,5 +120,5 @@ export default connect(
 		siteType: getSiteType( state ) || 'blog',
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
-	{ recordTracksEvent, saveSignupStep, submitSiteType, setSiteVertical }
+	{ recordTracksEvent, saveSignupStep, submitSiteType }
 )( localize( SiteType ) );

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -85,7 +85,6 @@
 	}
 }
 
-.site-type__basic-site,
 .site-type__import-button {
 	text-align: center;
 	margin-top: 20px;


### PR DESCRIPTION
p8Eqe3-PR-p2#comment-2584

#### Changes proposed in this Pull Request

* Revert signupWithBasicSite A/B test (https://github.com/Automattic/wp-calypso/pull/36221)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.localhost:3000/start and log in
* At the site type step you *shouldn't* see a link to `Skip setup and start with a basic website.`
* In the list of A/B tests available, you shouldn't see `signupWithBasicSite`
* Creating a site with any of the existing segments should still work (e.g. create a site with the blog segment)
