### PR TITLE
Jetpack Backup: Cleanup all <p>s from descriptions

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -283,10 +283,10 @@ ProductSelector.propTypes = {
 		PropTypes.shape( {
 			title: PropTypes.string,
 			id: PropTypes.string,
-			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
 			options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
 			optionDescriptions: PropTypes.objectOf(
-				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
+				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] )
 			),
 			optionDisplayNames: PropTypes.objectOf(
 				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -66,7 +66,7 @@ const ProductCard = ( {
 						</a>
 					</p>
 				) }
-				{ description }
+				{ description && <p>{ description }</p> }
 			</div>
 			{ children }
 		</Card>

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -76,7 +76,7 @@ const ProductCard = ( {
 ProductCard.propTypes = {
 	billingTimeFrame: PropTypes.string,
 	currencyCode: PropTypes.string,
-	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
 	discountedPrice: PropTypes.oneOfType( [
 		PropTypes.number,
 		PropTypes.arrayOf( PropTypes.number ),

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -55,42 +55,30 @@ export const JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES = {
 	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: JETPACK_BACKUP_PRODUCT_REALTIME_DISPLAY_NAME,
 };
 
-export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = (
-	<p>
-		{ translate(
-			'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
-			{
-				components: {
-					a: (
-						<a
-							href="https://jetpack.com/upgrade/backup/"
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		) }
-	</p>
+export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = translate(
+	'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
+	{
+		components: {
+			a: (
+				<a
+					href="https://jetpack.com/upgrade/backup/"
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		},
+	}
 );
-export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = (
-	<p>
-		{ translate(
-			'{{strong}}Looking for more?{{/strong}} With Real-time backups, we save as you edit and you’ll get unlimited backup archives.',
-			{
-				components: {
-					strong: <strong />,
-				},
-			}
-		) }
-	</p>
+export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = translate(
+	'{{strong}}Looking for more?{{/strong}} With Real-time backups, we save as you edit and you’ll get unlimited backup archives.',
+	{
+		components: {
+			strong: <strong />,
+		},
+	}
 );
-export const PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION = (
-	<p>
-		{ translate(
-			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-		) }
-	</p>
+export const PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION = translate(
+	'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
 );
 
 export const JETPACK_BACKUP_PRODUCT_DESCRIPTIONS = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove all the unnecessary p tags from the Jetpack Backup product descriptions.

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site. 
* Test all the cases when you have purchased a Jetpack backup product and haven't purchased one.
* Verify descriptions all look the same as they did before (you can compare to wpcalypso).