### PR TITLE
[reCaptcha v3]: Hide reCAPTCHA badge on phone and show our own…

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -856,17 +856,19 @@ class SignupForm extends Component {
 				{ showReCaptchaToS && (
 					<div className="signup-form__recaptcha-tos">
 						<LoggedOutFormLinks>
-							{ translate(
-								'This site is protected by reCAPTCHA and the Google {{a1}}Privacy Policy{{/a1}} and {{a2}}Terms of Service{{/a2}} apply.',
-								{
-									components: {
-										a1: <a href="https://policies.google.com/privacy" />,
-										a2: <a href="https://policies.google.com/terms" />,
-									},
-									comment:
-										'English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed',
-								}
-							) }
+							<p>
+								{ translate(
+									'This site is protected by reCAPTCHA and the Google {{a1}}Privacy Policy{{/a1}} and {{a2}}Terms of Service{{/a2}} apply.',
+									{
+										components: {
+											a1: <a href="https://policies.google.com/privacy" />,
+											a2: <a href="https://policies.google.com/terms" />,
+										},
+										comment:
+											'English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed',
+									}
+								) }
+							</p>
 						</LoggedOutFormLinks>
 					</div>
 				) }
@@ -962,7 +964,11 @@ class SignupForm extends Component {
 				: localizeUrl( config( 'login_url' ), this.props.locale );
 
 			return (
-				<div className={ classNames( 'signup-form', this.props.className ) }>
+				<div
+					className={ classNames( 'signup-form', this.props.className, {
+						'is-showing-recaptcha-tos': this.props.showReCaptchaToS,
+					} ) }
+				>
 					{ this.getNotice() }
 					<PasswordlessSignupForm
 						step={ this.props.step }
@@ -989,7 +995,11 @@ class SignupForm extends Component {
 		}
 
 		return (
-			<div className={ classNames( 'signup-form', this.props.className ) }>
+			<div
+				className={ classNames( 'signup-form', this.props.className, {
+					'is-showing-recaptcha-tos': this.props.showReCaptchaToS,
+				} ) }
+			>
 				{ this.getNotice() }
 
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -104,6 +104,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		showReCaptchaToS: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -115,6 +116,7 @@ class SignupForm extends Component {
 		displayUsernameInput: true,
 		flowName: '',
 		isSocialSignupEnabled: false,
+		showReCaptchaToS: false,
 	};
 
 	state = {
@@ -830,26 +832,45 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
-		const { flowName, translate } = this.props;
+		const { flowName, showReCaptchaToS, translate } = this.props;
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
 			? this.getLoginLink()
 			: localizeUrl( config( 'login_url' ), this.props.locale );
 
 		return (
-			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ flowName === 'onboarding'
-						? translate( 'Log in to create a site for your existing account.' )
-						: translate( 'Already have a WordPress.com account?' ) }
-				</LoggedOutFormLinkItem>
-				{ this.props.oauth2Client && (
-					<LoggedOutFormBackLink
-						oauth2Client={ this.props.oauth2Client }
-						recordClick={ this.recordBackLinkClick }
-					/>
+			<>
+				<LoggedOutFormLinks>
+					<LoggedOutFormLinkItem href={ logInUrl }>
+						{ flowName === 'onboarding'
+							? translate( 'Log in to create a site for your existing account.' )
+							: translate( 'Already have a WordPress.com account?' ) }
+					</LoggedOutFormLinkItem>
+					{ this.props.oauth2Client && (
+						<LoggedOutFormBackLink
+							oauth2Client={ this.props.oauth2Client }
+							recordClick={ this.recordBackLinkClick }
+						/>
+					) }
+				</LoggedOutFormLinks>
+				{ showReCaptchaToS && (
+					<div className="signup-form__recaptcha-tos">
+						<LoggedOutFormLinks>
+							{ translate(
+								'This site is protected by reCAPTCHA and the Google {{a1}}Privacy Policy{{/a1}} and {{a2}}Terms of Service{{/a2}} apply.',
+								{
+									components: {
+										a1: <a href="https://policies.google.com/privacy" />,
+										a2: <a href="https://policies.google.com/terms" />,
+									},
+									comment:
+										'English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed',
+								}
+							) }
+						</LoggedOutFormLinks>
+					</div>
 				) }
-			</LoggedOutFormLinks>
+			</>
 		);
 	}
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -104,7 +104,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
-		showReCaptchaToS: PropTypes.bool,
+		showRecaptchaToS: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -116,7 +116,7 @@ class SignupForm extends Component {
 		displayUsernameInput: true,
 		flowName: '',
 		isSocialSignupEnabled: false,
-		showReCaptchaToS: false,
+		showRecaptchaToS: false,
 	};
 
 	state = {
@@ -832,7 +832,7 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
-		const { flowName, showReCaptchaToS, translate } = this.props;
+		const { flowName, showRecaptchaToS, translate } = this.props;
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
 			? this.getLoginLink()
@@ -853,7 +853,7 @@ class SignupForm extends Component {
 						/>
 					) }
 				</LoggedOutFormLinks>
-				{ showReCaptchaToS && (
+				{ showRecaptchaToS && (
 					<div className="signup-form__recaptcha-tos">
 						<LoggedOutFormLinks>
 							<p>
@@ -966,7 +966,7 @@ class SignupForm extends Component {
 			return (
 				<div
 					className={ classNames( 'signup-form', this.props.className, {
-						'is-showing-recaptcha-tos': this.props.showReCaptchaToS,
+						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
 					} ) }
 				>
 					{ this.getNotice() }
@@ -997,7 +997,7 @@ class SignupForm extends Component {
 		return (
 			<div
 				className={ classNames( 'signup-form', this.props.className, {
-					'is-showing-recaptcha-tos': this.props.showReCaptchaToS,
+					'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
 				} ) }
 			>
 				{ this.getNotice() }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -77,8 +77,7 @@
 	display: none;
 	padding: 20px 10px 10px;
 	font-size: 13px;
-	//  Opacity choosen to stay within WCAG contrast guidelines
-	color: rgba( var( --color-text-inverted-rgb ), 0.74 );
+	color: var( --studio-blue-5 );
 	text-align: center;
 
 	p {
@@ -87,7 +86,7 @@
 	}
 
 	a {
-		color: rgba( var( --color-text-inverted-rgb ), 0.74 );
+		color: var( --studio-blue-5 );
 		text-decoration: underline;
 	}
 }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -72,3 +72,26 @@
 		min-height: auto;
 	}
 }
+
+.signup-form__recaptcha-tos {
+	display: none;
+	padding: 40px 10px 10px;
+	font-size: 13px;
+	color: var( --color-text-inverted );
+	text-align: center;
+
+	a {
+		color: var( --color-text-inverted );
+		text-decoration: underline;
+	}
+}
+
+@media ( max-width: 660px ) {
+	.signup-form__recaptcha-tos {
+		display: block;
+	}
+
+	.grecaptcha-badge {
+		visibility: hidden;
+	}
+}

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -75,17 +75,25 @@
 
 .signup-form__recaptcha-tos {
 	display: none;
-	padding: 40px 10px 10px;
+	padding: 20px 10px 10px;
 	font-size: 13px;
-	color: var( --color-text-inverted );
+	//  Opacity choosen to stay within WCAG contrast guidelines
+	color: rgba( var( --color-text-inverted-rgb ), 0.74 );
 	text-align: center;
 
+	p {
+		margin: 0;
+		padding-top: 9px;
+	}
+
 	a {
-		color: var( --color-text-inverted );
+		color: rgba( var( --color-text-inverted-rgb ), 0.74 );
 		text-decoration: underline;
 	}
 }
 
+// Replace recaptcha badge with ToS text and space
+// everything out a little more.
 @media ( max-width: 660px ) {
 	.signup-form__recaptcha-tos {
 		display: block;
@@ -93,5 +101,15 @@
 
 	.grecaptcha-badge {
 		visibility: hidden;
+	}
+
+	.signup-form.is-showing-recaptcha-tos {
+		.signup-form__social {
+			padding-bottom: 28px;
+		}
+
+		.logged-out-form__links::before {
+			margin-bottom: 16px;
+		}
 	}
 }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -374,6 +374,7 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
+					showReCaptchaToS={ true }
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -374,7 +374,7 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					showReCaptchaToS={
+					showRecaptchaToS={
 						'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
 					}
 				/>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -374,7 +374,9 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					showReCaptchaToS={ true }
+					showReCaptchaToS={
+						'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
+					}
 				/>
 				<div id="g-recaptcha"></div>
 			</>


### PR DESCRIPTION
Trying out just leaving the badge where it is on desktop. The signup is already very wordy and at least the badge is tucked out of the way. However on small screens the floating badge gets in the way so that's when we show our own message.

[The specific wording comes from Google.](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed)

Hiding the badge at 660px wide because that's when the login buttons jump to the bigger size.

Epic: Automattic/zelda-private#239

#### Changes proposed in this Pull Request

##### Desktop

Passwordless | With Password
-------------|-----
<img width="1108" alt="passwordless desktop" src="https://user-images.githubusercontent.com/1500769/67930919-af818000-fc25-11e9-9065-d0614f9414fc.png"> | <img width="1108" alt="password desktop" src="https://user-images.githubusercontent.com/1500769/67930929-b8725180-fc25-11e9-921c-e28f714ee68b.png">

##### Phone

Passwordless | With Password
-------------|-----
<img width="389" alt="passwordless phone" src="https://user-images.githubusercontent.com/1500769/67930973-d2ac2f80-fc25-11e9-8e7f-931f865a7e17.png"> | <img width="389" alt="password phone" src="https://user-images.githubusercontent.com/1500769/67930986-d770e380-fc25-11e9-82ce-5e6bac489b14.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow setup steps in #37170
* Resize browser to observe.
