### PR TITLE
Jetpack Connect: update wording for connection title

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -295,7 +295,7 @@ class Login extends Component {
 				</p>
 			);
 		} else if ( isJetpack ) {
-			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack' );
+			headerText = translate( 'Log in or create a WordPress.com account to set up Jetpack' );
 			preHeader = (
 				<div className="login__jetpack-logo">
 					<AsyncLoad


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the wording that appears when connecting Jetpack through the Connect in Place flow.

![image](https://user-images.githubusercontent.com/426388/67936083-643a8380-fbcb-11e9-8d4f-f6bc60718691.png)


#### Testing instructions

* Start from a new, unconnected Jetpack site. 
* Add the following constant to your site's wp-config.php file:
`define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
* Start connecting and verify wording as above.

As suggested here:
p8oabR-qb-p2#comment-3478
