### PR TITLE
Store Transactions: move payment creator functions to separate module

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -551,33 +551,3 @@ export async function getStripeConfiguration( requestArgs ) {
 export function hasDomainDetails( transaction ) {
 	return ! isEmpty( transaction.domainDetails );
 }
-
-export function newCardPayment( newCardDetails ) {
-	return {
-		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
-		newCardDetails: newCardDetails || {},
-	};
-}
-
-export function newStripeCardPayment( newCardDetails ) {
-	return {
-		paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
-		newCardDetails: newCardDetails || {},
-	};
-}
-
-export function storedCardPayment( storedCard ) {
-	return {
-		paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
-		storedCard: storedCard,
-	};
-}
-
-export function webPayment( newCardDetails ) {
-	return {
-		paymentMethod: 'WPCOM_Billing_Web_Payment',
-		newCardDetails: newCardDetails || {},
-	};
-}
-
-export const fullCreditsPayment = { paymentMethod: 'WPCOM_Billing_WPCOM' };

--- a/client/lib/transaction/payments.js
+++ b/client/lib/transaction/payments.js
@@ -1,0 +1,33 @@
+export function newCardPayment( newCardDetails ) {
+	return {
+		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
+		newCardDetails: newCardDetails || {},
+	};
+}
+
+export function newStripeCardPayment( newCardDetails ) {
+	return {
+		paymentMethod: 'WPCOM_Billing_Stripe_Payment_Method',
+		newCardDetails: newCardDetails || {},
+	};
+}
+
+export function storedCardPayment( storedCard ) {
+	return {
+		paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
+		storedCard,
+	};
+}
+
+export function webPayment( newCardDetails ) {
+	return {
+		paymentMethod: 'WPCOM_Billing_Web_Payment',
+		newCardDetails: newCardDetails || {},
+	};
+}
+
+export function fullCreditsPayment() {
+	return {
+		paymentMethod: 'WPCOM_Billing_WPCOM',
+	};
+}

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -12,7 +12,7 @@ import { find, defer } from 'lodash';
 import analytics from 'lib/analytics';
 import CreditCard from 'components/credit-card';
 import NewCardForm from './new-card-form';
-import { newCardPayment, newStripeCardPayment, storedCardPayment } from 'lib/store-transactions';
+import { newCardPayment, newStripeCardPayment, storedCardPayment } from 'lib/transaction/payments';
 import { setPayment } from 'lib/transaction/actions';
 import { withStripeProps } from 'lib/stripe';
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -22,14 +22,14 @@ import StripeElementsPaymentBox from './stripe-elements-payment-box';
 import WechatPaymentBox from './wechat-payment-box';
 import RedirectPaymentBox from './redirect-payment-box';
 import WebPaymentBox from './web-payment-box';
+import { submit } from 'lib/store-transactions';
+import analytics from 'lib/analytics';
+import { setPayment, setTransactionStep } from 'lib/transaction/actions';
 import {
 	fullCreditsPayment,
 	newStripeCardPayment,
 	storedCardPayment,
-	submit,
-} from 'lib/store-transactions';
-import analytics from 'lib/analytics';
-import { setPayment, setTransactionStep } from 'lib/transaction/actions';
+} from 'lib/transaction/payments';
 import { saveSiteSettings } from 'state/site-settings/actions';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import isPrivateSite from 'state/selectors/is-private-site';
@@ -105,7 +105,7 @@ export class SecurePaymentForm extends Component {
 				// FIXME: The endpoint doesn't currently support transactions with no
 				//   payment info, so for now we rely on the credits payment method for
 				//   free carts.
-				newPayment = fullCreditsPayment;
+				newPayment = fullCreditsPayment();
 				break;
 
 			case 'credit-card':

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -26,7 +26,7 @@ import {
 	WEB_PAYMENT_BASIC_CARD_METHOD,
 	WEB_PAYMENT_APPLE_PAY_METHOD,
 } from 'lib/web-payment';
-import { webPayment } from 'lib/store-transactions';
+import { webPayment } from 'lib/transaction/payments';
 import { setPayment, setStripeObject } from 'lib/transaction/actions';
 import { setTaxCountryCode, setTaxPostalCode } from 'lib/cart/actions';
 import CartToggle from './cart-toggle';


### PR DESCRIPTION
Let's not include the whole `lib/store-transactions` flow machinery into code that just wants to create a payment type object (pure data) and dispatch the Transaction Store setter action.

`lib/transaction/payments` is a better home for these payment creator functions.
