### PR TITLE
Store Transactions: move hasDomainDetails to Transaction Store

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -547,7 +547,3 @@ export async function getStripeConfiguration( requestArgs ) {
 	debug( 'Stripe configuration', config );
 	return config;
 }
-
-export function hasDomainDetails( transaction ) {
-	return ! isEmpty( transaction.domainDetails );
-}

--- a/client/lib/transaction/selectors.js
+++ b/client/lib/transaction/selectors.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+export function hasDomainDetails( transaction ) {
+	return ! isEmpty( transaction.domainDetails );
+}

--- a/client/lib/transaction/store.js
+++ b/client/lib/transaction/store.js
@@ -19,12 +19,12 @@ import {
 	TRANSACTION_STEP_SET,
 	TRANSACTION_STRIPE_SET,
 } from './action-types';
+import { hasDomainDetails } from './selectors';
 import { hasDomainRegistration } from 'lib/cart-values/cart-items';
 import CartStore from 'lib/cart/store';
 import Emitter from 'lib/mixins/emitter';
 import Dispatcher from 'dispatcher';
 import { BEFORE_SUBMIT } from 'lib/store-transactions/step-types';
-import { hasDomainDetails } from 'lib/store-transactions';
 
 let _transaction = createInitialTransaction();
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -46,7 +46,7 @@ import { clearPurchases } from 'state/purchases/actions';
 import DomainDetailsForm from './domain-details-form';
 import { fetchReceiptCompleted } from 'state/receipts/actions';
 import { getExitCheckoutUrl } from 'lib/checkout';
-import { hasDomainDetails } from 'lib/store-transactions';
+import { hasDomainDetails } from 'lib/transaction/selectors';
 import notices from 'notices';
 import { managePurchase } from 'me/purchases/paths';
 import SubscriptionLengthPicker from 'blocks/subscription-length-picker';
@@ -844,8 +844,7 @@ export class Checkout extends React.Component {
 	}
 
 	needsDomainDetails() {
-		const cart = this.props.cart;
-		const transaction = this.props.transaction;
+		const { cart, transaction } = this.props;
 
 		if ( cart && hasOnlyRenewalItems( cart ) ) {
 			return false;

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -29,9 +29,6 @@ jest.mock( 'lib/analytics', () => ( {
 jest.mock( 'lib/analytics/ad-tracking', () => ( {
 	recordViewCheckout: jest.fn(),
 } ) );
-jest.mock( 'lib/store-transactions', () => ( {
-	hasDomainDetails: jest.fn(),
-} ) );
 jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
 } ) );


### PR DESCRIPTION
Don't include the whole `TransactionFlow` machinery to modules that just need to retrieve (select) info from the Transaction Store. `hasDomainDetails` is basically a selector that belongs to `lib/transaction`. And it will become a standard selector when Transaction Store is Reduxified.
