### PR TITLE
Atomic Hosting: Rename PHPMyAdmin to phpMyAdmin

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -34,7 +34,7 @@ const Hosting = ( { translate, isDisabled } ) => {
 			{ isDisabled && (
 				<Banner
 					title={ translate(
-						'Please active SFTP and PHPMyAdmin access to begin using these features.'
+						'Please active SFTP and phpMyAdmin access to begin using these features.'
 					) }
 					icon="info"
 					callToAction={ translate( 'Activate' ) }

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -57,7 +57,7 @@ const PhpMyAdminCard = ( { translate, siteId, token, loading, disabled } ) => {
 				<CardHeading>{ translate( 'Database Access' ) }</CardHeading>
 				<p>
 					{ translate(
-						'Manage your databases with PHPMyAdmin and run a wide range of operations with MySQL.'
+						'Manage your databases with phpMyAdmin and run a wide range of operations with MySQL.'
 					) }
 				</p>
 				<Button
@@ -65,7 +65,7 @@ const PhpMyAdminCard = ( { translate, siteId, token, loading, disabled } ) => {
 					busy={ ! disabled && loading }
 					disabled={ disabled }
 				>
-					<span>{ translate( 'Open PHPMyAdmin' ) }</span>
+					<span>{ translate( 'Open phpMyAdmin' ) }</span>
 					<MaterialIcon icon="launch" size={ 16 } />
 				</Button>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Rename all `PHPMyAdmin` instances to `phpMyAdmin` which is the [official name](https://www.phpmyadmin.net/).

#### Testing instructions

* Switch to an Atomic Site.
* Go to "Manage > SFTP & MySQL".
* Make sure all references to phpMyAdmin are read as `phpMyAdmin` and not `PHPMyAdmin`.
* Switch to a non-Atomic Business Site.
* Go to "Manage > SFTP & MySQL".
* Make sure all references to phpMyAdmin are read as `phpMyAdmin` and not `PHPMyAdmin`.
