### PR TITLE
Marketing: Auto Expand Mailchimp when Setting up Form

### DIFF
--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -363,6 +363,13 @@ export class SharingService extends Component {
 				this.setState( { isSelectingAccount: true } );
 			}
 		}
+
+		/**
+		 * Scroll to the bottom if connecting Mailchimp.
+		 */
+		if ( this.props.queryArgs && 'mailchimp' in this.props.queryArgs ) {
+			window.scrollTo( 0, 9999 );
+		}
 	}
 
 	/**
@@ -465,7 +472,6 @@ export class SharingService extends Component {
 			( this.state.justConnected ||
 				( this.props.queryArgs && 'mailchimp' in this.props.queryArgs ) )
 		) {
-			window.scrollTo( 0, 9999 );
 			return true;
 		}
 

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -365,10 +365,15 @@ export class SharingService extends Component {
 		}
 
 		/**
-		 * Scroll to the bottom if connecting Mailchimp.
+		 * Scroll directly to the Mailchimp setting if connecting Mailchimp.
 		 */
-		if ( this.props.queryArgs && 'mailchimp' in this.props.queryArgs ) {
-			window.scrollTo( 0, 9999 );
+		if (
+			this.isMailchimpService() &&
+			this.props.queryArgs &&
+			'mailchimp' in this.props.queryArgs
+		) {
+			const mailchimpSetting = document.getElementById( 'mailchimp' );
+			mailchimpSetting.scrollIntoView( { behavior: 'smooth' } );
 		}
 	}
 
@@ -508,7 +513,7 @@ export class SharingService extends Component {
 		const accounts = this.state.isSelectingAccount ? this.props.availableExternalAccounts : [];
 
 		const header = (
-			<div>
+			<div id={ this.props.service.ID }>
 				{ ! this.isMailchimpService( connectionStatus ) && this.renderLogo() }
 				{ this.isMailchimpService( connectionStatus ) && renderMailchimpLogo() }
 

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -37,6 +37,7 @@ import {
 } from 'state/sharing/publicize/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 import ServiceAction from './service-action';
@@ -459,7 +460,12 @@ export class SharingService extends Component {
 	}
 
 	shouldBeExpanded( status ) {
-		if ( this.isMailchimpService() && this.state.justConnected ) {
+		if (
+			this.isMailchimpService() &&
+			( this.state.justConnected ||
+				( this.props.queryArgs && 'mailchimp' in this.props.queryArgs ) )
+		) {
+			window.scrollTo( 0, 9999 );
 			return true;
 		}
 
@@ -490,6 +496,8 @@ export class SharingService extends Component {
 		const connectionStatus = this.getConnectionStatus( this.props.service.ID );
 		const classNames = classnames( 'sharing-service', this.props.service.ID, connectionStatus, {
 			'is-open': this.state.isOpen,
+			'is-highlighted':
+				this.isMailchimpService() && this.props.queryArgs && 'mailchimp' in this.props.queryArgs,
 		} );
 		const accounts = this.state.isSelectingAccount ? this.props.availableExternalAccounts : [];
 
@@ -616,6 +624,7 @@ export function connectFor( sharingService, mapStateToProps, mapDispatchToProps 
 				keyringConnections: getKeyringConnectionsByName( state, service.ID ),
 				removableConnections: getRemovableConnections( state, service.ID ),
 				path: getCurrentRouteParameterized( state, siteId ),
+				queryArgs: getCurrentQueryArguments( state ),
 				service,
 				siteId,
 				siteUserConnections: getSiteUserConnectionsForService( state, siteId, userId, service.ID ),

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -172,6 +172,10 @@
 		position: relative;
 		overflow: hidden;
 		background: var( --color-surface );
+		
+		&.is-highlighted {
+			border: 2px solid var( --color-primary );
+		}
 
 		&.not-connected .sharing-service-examples {
 			display: block;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Auto expands and highlights the Mailchimp service when the user has previously clicked to set up the form

<img width="1199" alt="Screenshot 2019-10-31 at 12 31 26" src="https://user-images.githubusercontent.com/43215253/67947104-c3ec5b00-fbda-11e9-98b1-c6008867e59c.png">

**Requires** Automattic/jetpack#13908

#### Testing instructions

* Apply Automattic/jetpack#13908
* On an account without Mailchimp set up, go to the Gutenberg editor and use the Mailchimp Block
* Click the "Set up Mailchimp" button
* Verify you're directed to the Marketing page, and that the box is expanded and highlighted

Fixes #37208
