### PR TITLE
Block picker search term tracking: turn terms lowercase before tracking

### DIFF
--- a/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 /**
  * External dependencies
  */
@@ -9,7 +11,7 @@ import { debounce } from 'lodash';
 import tracksRecordEvent from './track-record-event';
 
 const trackSearchTerm = ( event, target ) => {
-	const search_term = target.value;
+	const search_term = ( target.value || '' ).trim().toLowerCase();
 
 	if ( search_term.length < 3 ) {
 		return;


### PR DESCRIPTION
Ensure Tracking block picker search terms is lowercased and trimmed.

So these all should track as same value:
`Shop`
`SHOP`
`shop ` ← with space at the end

#### Changes proposed in this Pull Request

* Ensures tracked search terms are trimmed and lowercased.

#### Testing instructions

Follow instructions from https://github.com/Automattic/wp-calypso/pull/34655

Ensure that `search_term` is sent to tracks always in lowercase.