### PR TITLE
Gutenboarding: hide block UI via CSS

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -63,7 +63,7 @@ export function Gutenboard() {
 								>
 									<WritingFlow>
 										<ObserveTyping>
-											<BlockList />
+											<BlockList className="gutenboarding-block-list" />
 										</ObserveTyping>
 									</WritingFlow>
 								</div>

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -29,9 +29,10 @@ $admin-sidebar-width-collapsed: 0;
 /**
  * Hide the block UI with CSS overrides
  *
- * Ideally this would be done via JS:
- * https://github.com/WordPress/gutenberg/issues/7469
- * https://github.com/WordPress/gutenberg/pull/18173
+ * @TODO: Remove this once Gutenberg gets support for hiding block UI.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/7469
+ * @see https://github.com/WordPress/gutenberg/pull/18173
  */
 .block-editor-block-list__layout {
 	.wp-block {

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -25,3 +25,40 @@ $admin-sidebar-width-collapsed: 0;
 		max-width: none;
 	}
 }
+
+/**
+ * Hide the block UI with CSS overrides
+ *
+ * Ideally this would be done via JS:
+ * https://github.com/WordPress/gutenberg/issues/7469
+ * https://github.com/WordPress/gutenberg/pull/18173
+ */
+.block-editor-block-list__layout {
+	.wp-block {
+		&.is-selected {
+			.block-editor-block-contextual-toolbar {
+				display: none;
+			}
+		}
+
+		&.block-editor-block-list__block {
+			// Need to get super specific to override the core css selectors:
+			&,
+			&.has-child-selected,
+			&.is-navigate-mode,
+			&.is-hovered {
+				> .block-editor-block-list__block-edit {
+					&::before {
+						transition: none;
+						border: none;
+						outline: none;
+						box-shadow: none;
+					}
+					> .block-editor-block-list__breadcrumb {
+						display: none;
+					}
+				}
+			}
+		}
+	}
+}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -34,7 +34,7 @@ $admin-sidebar-width-collapsed: 0;
  * @see https://github.com/WordPress/gutenberg/issues/7469
  * @see https://github.com/WordPress/gutenberg/pull/18173
  */
-.block-editor-block-list__layout {
+.gutenboarding-block-list {
 	.wp-block {
 		&.is-selected {
 			.block-editor-block-contextual-toolbar {


### PR DESCRIPTION
Hide block UI with CSS overrides.

Not great, but it seems like there isn't a core provided mechanism just yet (https://github.com/WordPress/gutenberg/issues/7469).

Once https://github.com/WordPress/gutenberg/pull/18173 lands and is available via NPM, we can hide UI via JS with props in `BlockList`.

I grabbed [the override from FSE]( https://github.com/Automattic/wp-calypso/blob/3950f26d017694657ea94d58615447a5af4f0355/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss#L60-L89) — this could very well be a sass mixin or function that is shared between FSE and Gutenboarding, but I didn't feel like doing that because we can have core provided mechanism soonish.

#### Changes proposed in this Pull Request

*

#### Testing instructions

- Check `/gutenboarding`


 **Before**
<img width="900" alt="Screenshot 2019-10-31 at 16 57 45" src="https://user-images.githubusercontent.com/87168/67958336-b6959780-fbff-11e9-8bb6-92044bf9348c.png">


**After**
<img width="893" alt="Screenshot 2019-10-31 at 16 57 26" src="https://user-images.githubusercontent.com/87168/67958331-b4cbd400-fbff-11e9-90a1-77aa489f11ca.png">
