### PR TITLE
Add incremental:true to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"strict": true,
 		// Disallow features that require cross-file information for emit.
 		"isolatedModules": true,
+		"incremental": true,
 		// Import non-ES modules as default imports.
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
Enable incremental typescript builds. I'd hope this would improve the tsserver time to start up.

We need more memory to handle this, like the following:

https://github.com/Automattic/wp-calypso/blob/6b2ad819b5a98321300b226db818bffbda7dbc54/package.json#L285

I don't know whether `tsserver` uses or produces incremental build files.

## Testing
- `npm run typecheck` - This runs out of memory and fails 😞 