### PR TITLE
lib/route: Declare no side effects for tree-shaking

### DIFF
--- a/client/lib/route/package.json
+++ b/client/lib/route/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}


### PR DESCRIPTION
Declares no sideEffects from the lib/route module.

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

There is one sideEffect-ful module, but it is not imported anywhere. It's removed in #37224 

## Testing
- Verify no code violating side effects is present in lib/route (best to review #37224 or wait until it's landed)
- e2e passes