### PR TITLE
composite-checkout: Run stripe.handleCardPayment for auth

### DIFF
--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -57,7 +57,7 @@ function handleCheckoutEvent( { type, payload }, dispatch, next ) {
 				.catch( error => dispatch( { type: 'STRIPE_TRANSACTION_ERROR', payload: error } ) );
 			return;
 		case 'STRIPE_TRANSACTION_BEGIN':
-			sendStripeTransaction( payload )
+			sendStripeTransaction( formatDataForStripeTransaction( payload ) )
 				.then( async response => {
 					dispatch( { type: 'STRIPE_TRANSACTION_RESPONSE', payload: response } );
 				} )
@@ -112,6 +112,97 @@ function formatValueForCurrency( currency, value ) {
 	}
 	const floatValue = value / 100;
 	return '$' + floatValue.toString();
+}
+
+function formatDataForStripeTransaction( {
+	items,
+	total,
+	country,
+	postalCode,
+	subdivisionCode,
+	paymentData,
+	stripePaymentMethod,
+	stripeConfiguration,
+	successUrl,
+	cancelUrl,
+} ) {
+	const siteId = ''; // TODO: get site id
+	const couponId = null; // TODO: get couponId
+	const payment = {
+		payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+		payment_key: stripePaymentMethod.id,
+		payment_partner: stripeConfiguration.processor_id,
+		name,
+		zip: postalCode,
+		country,
+		successUrl,
+		cancelUrl,
+	};
+	return {
+		cart: createCartFromLineItems( {
+			siteId,
+			couponId,
+			items,
+			total,
+			country,
+			postalCode,
+			subdivisionCode,
+		} ),
+		domain_details: getDomainDetailsFromPaymentData( paymentData ),
+		payment,
+	};
+}
+
+function createCartFromLineItems( {
+	siteId,
+	couponId,
+	items,
+	country,
+	postalCode,
+	subdivisionCode,
+} ) {
+	// TODO: use cart manager to create cart object needed for this transaction
+	const currency = items.reduce( ( value, item ) => value || item.amount.currency );
+	return {
+		blog_id: siteId,
+		coupon: couponId || '',
+		currency: currency || '',
+		temporary: false,
+		extra: [],
+		products: items.map( item => ( {
+			product_id: item.id,
+			meta: '', // TODO: get this for domains, etc
+			cost: item.amount.value, // TODO: how to convert this from 3500 to 35?
+			currency: item.amount.currency,
+			volume: 1,
+		} ) ),
+		tax: {
+			location: {
+				country_code: country,
+				postal_code: postalCode,
+				subdivision_code: subdivisionCode,
+			},
+		},
+	};
+}
+
+function getDomainDetailsFromPaymentData( paymentData ) {
+	const { billing = {}, domains = {}, isDomainContactSame = true } = paymentData;
+	return {
+		first_name: isDomainContactSame ? billing.name : domains.name || billing.name || '',
+		last_name: isDomainContactSame ? billing.name : domains.name || billing.name || '', // TODO: how do we split up first/last name?
+		address_1: isDomainContactSame ? billing.address : domains.address || billing.address || '',
+		city: isDomainContactSame ? billing.city : domains.city || billing.city || '',
+		state: isDomainContactSame
+			? billing.state || billing.province
+			: domains.state || domains.province || billing.state || billing.province || '',
+		postal_code: isDomainContactSame
+			? billing.postalCode || billing.zipCode
+			: domains.postalCode || domains.zipCode || billing.postalCode || billing.zipCode || '',
+		country_code: isDomainContactSame ? billing.country : domains.country || billing.country || '',
+		email: isDomainContactSame ? billing.email : domains.email || billing.email || '', // TODO: we need to get email address
+		phone: isDomainContactSame ? '' : domains.phoneNumber || '',
+	};
 }
 
 ReactDOM.render( <MyCheckout />, document.getElementById( 'root' ) );

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -129,7 +129,10 @@ function paymentStateHandler( { type, payload }, dispatch, setPaymentData ) {
 			dispatch( { type: 'PAYMENT_DATA_UPDATE', payload: { stripeTransactionStatus: 'complete' } } );
 			return;
 		case 'STRIPE_TRANSACTION_AUTH':
-			dispatch( { type: 'PAYMENT_DATA_UPDATE', payload: { stripeTransactionStatus: 'auth' } } );
+			dispatch( {
+				type: 'PAYMENT_DATA_UPDATE',
+				payload: { stripeTransactionStatus: 'auth', stripeTransactionAuthData: payload },
+			} );
 			return;
 		case 'STRIPE_TRANSACTION_REDIRECT':
 			dispatch( { type: 'PAYMENT_DATA_UPDATE', payload: { stripeTransactionStatus: 'redirect' } } );

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -412,32 +412,19 @@ async function submitStripePayment( {
 
 	try {
 		const stripePaymentMethod = await createStripePaymentMethod( stripe, paymentDetailsForStripe );
-		const payment = {
-			payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
-			payment_key: stripePaymentMethod.id,
-			payment_partner: stripeConfiguration.processor_id,
-			name,
-			zip: postalCode,
+		const dataForTransaction = {
+			items,
+			total,
 			country,
+			postalCode,
+			subdivisionCode,
+			paymentData,
+			stripePaymentMethod,
+			stripeConfiguration,
 			successUrl,
 			cancelUrl,
 		};
-		const siteId = ''; // TODO: get site id
-		const couponId = null; // TODO: get couponId
-		const transaction = {
-			cart: createCartFromLineItems( {
-				siteId,
-				couponId,
-				items,
-				total,
-				country,
-				postalCode,
-				subdivisionCode,
-			} ),
-			domain_details: getDomainDetailsFromPaymentData( paymentData ),
-			payment,
-		};
-		dispatch( { type: 'STRIPE_TRANSACTION_BEGIN', payload: transaction } );
+		dispatch( { type: 'STRIPE_TRANSACTION_BEGIN', payload: dataForTransaction } );
 	} catch ( error ) {
 		onFailure( error );
 		return;
@@ -453,56 +440,4 @@ async function showStripeModalAuth( { stripeConfiguration, response } ) {
 	if ( authenticationResponse ) {
 		// TODO: what do we do here?
 	}
-}
-
-function createCartFromLineItems( {
-	siteId,
-	couponId,
-	items,
-	country,
-	postalCode,
-	subdivisionCode,
-} ) {
-	// TODO: use cart manager to create cart object needed for this transaction
-	const currency = items.reduce( ( value, item ) => value || item.amount.currency );
-	return {
-		blog_id: siteId,
-		coupon: couponId || '',
-		currency: currency || '',
-		temporary: false,
-		extra: [],
-		products: items.map( item => ( {
-			product_id: item.id,
-			meta: '', // TODO: get this for domains, etc
-			cost: item.amount.value, // TODO: how to convert this from 3500 to 35?
-			currency: item.amount.currency,
-			volume: 1,
-		} ) ),
-		tax: {
-			location: {
-				country_code: country,
-				postal_code: postalCode,
-				subdivision_code: subdivisionCode,
-			},
-		},
-	};
-}
-
-function getDomainDetailsFromPaymentData( paymentData ) {
-	const { billing = {}, domains = {}, isDomainContactSame = true } = paymentData;
-	return {
-		first_name: isDomainContactSame ? billing.name : domains.name || billing.name || '',
-		last_name: isDomainContactSame ? billing.name : domains.name || billing.name || '', // TODO: how do we split up first/last name?
-		address_1: isDomainContactSame ? billing.address : domains.address || billing.address || '',
-		city: isDomainContactSame ? billing.city : domains.city || billing.city || '',
-		state: isDomainContactSame
-			? billing.state || billing.province
-			: domains.state || domains.province || billing.state || billing.province || '',
-		postal_code: isDomainContactSame
-			? billing.postalCode || billing.zipCode
-			: domains.postalCode || domains.zipCode || billing.postalCode || billing.zipCode || '',
-		country_code: isDomainContactSame ? billing.country : domains.country || billing.country || '',
-		email: isDomainContactSame ? billing.email : domains.email || billing.email || '', // TODO: we need to get email address
-		phone: isDomainContactSame ? '' : domains.phoneNumber || '',
-	};
 }

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -331,6 +331,9 @@ export function StripePayButton() {
 		if ( paymentData.stripeTransactionStatus === 'complete' ) {
 			onSuccess();
 		}
+		if ( paymentData.stripeTransactionStatus === 'redirect' ) {
+			// TODO: notify user that we are going to redirect
+		}
 		if ( paymentData.stripeTransactionStatus === 'auth' ) {
 			showStripeModalAuth( {
 				stripeConfiguration,


### PR DESCRIPTION
When the transaction call replies with an auth request (eg: 3DS), this will display the confirmation dialog that's required.

We can't really test this until we have the transactions endpoint wired up, but it would be good to have this be a placeholder.