### PR TITLE
Add TODO comment for removing hacky CSS

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -57,7 +57,14 @@
 	}
 }
 
-/* Hide the content slot block UI */
+/**
+ * Hide the content slot block UI
+ *
+ * @TODO: Remove this once Gutenberg gets support for hiding block UI.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/7469
+ * @see https://github.com/WordPress/gutenberg/pull/18173
+ */
 .block-editor-block-list__layout {
 	.post-content__block {
 		&.is-selected {


### PR DESCRIPTION
@simison was looking at this code but didn't know that we had temporarily done this because Gutenberg doesn't support it yet. With this new info, now folks know the context around our changes.