### PR TITLE
Extend wait times for calypso.live

### DIFF
--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -3,8 +3,8 @@
 sha=$CIRCLE_SHA1
 
 COUNT=0
-RESETCOUNT=120 # 5sec retry = Reset the branch after 5 minutes
-MAXCOUNT=240  # 5sec retry = Cancel after 10 minutes
+RESETCOUNT=240 # 5sec retry = Reset the branch after 20 minutes
+MAXCOUNT=480  # 5sec retry = Cancel after 40 minutes
 SITEWAITCOUNT=30 # 5sec retry = Stop waiting after 2.5 minutes
 
 STATUS=$(curl https://hash-$sha.calypso.live/status 2>/dev/null)

--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -4,7 +4,7 @@ sha=$CIRCLE_SHA1
 
 COUNT=0
 RESETCOUNT=240 # 5sec retry = Reset the branch after 20 minutes
-MAXCOUNT=480  # 5sec retry = Cancel after 40 minutes
+MAXCOUNT=360  # 5sec retry = Cancel after 30 minutes
 SITEWAITCOUNT=30 # 5sec retry = Stop waiting after 2.5 minutes
 
 STATUS=$(curl https://hash-$sha.calypso.live/status 2>/dev/null)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This changes the amount of time that we wait for calypso.live to come back up.  We have been resetting very often, so this should give the build adequate time to complete before we reset it.

#### Testing instructions
* This is just a config change. Make sure the wait for calypso.live task completes in build