### PR TITLE
Duplicate Submissions of Downgrades are Possible

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -267,8 +267,13 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	downgradeClick = () => {
-		this.props.downgradeClick();
-		this.recordEvent( 'calypso_purchases_downgrade_form_submit' );
+		if ( ! this.state.isSubmitting ) {
+			this.props.downgradeClick();
+			this.recordEvent( 'calypso_purchases_downgrade_form_submit' );
+			this.setState( {
+				isSubmitting: true,
+			} );
+		}
 	};
 
 	renderQuestionOne = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A user managed to submit the downgrade form twice.

#### Testing instructions

1. With the store sandbox enabled, buy a Premium plan
2. Go to Manage Purchases, click Cancel
3. In the Marketing survey, select that the plan was too expensive
4. Click Downgrade twice
5. Make sure the button became disabled after the first click and nothing happened after the second click

![cancel-donwgrade-9](https://user-images.githubusercontent.com/82778/68044806-bd480b80-fce0-11e9-815d-709c4eaef99f.gif)


Fixes #
