### PR TITLE
Add autofill markers plus new domain fields

### DIFF
--- a/packages/composite-checkout/src/components/billing-fields.js
+++ b/packages/composite-checkout/src/components/billing-fields.js
@@ -180,56 +180,86 @@ function AddressFields( { fieldType } ) {
 
 	return (
 		<React.Fragment>
+			<FieldRow gap="4%" columnWidths="48% 48%">
+				<Field
+					id={ fieldType + '-first-name' }
+					type="text"
+					label={ localize( 'First name' ) }
+					value={ currentLocationData.firstName || '' }
+					onChange={ value => {
+						updateLocationData( 'firstName', value );
+					} }
+					autoComplete="given-name"
+				/>
+
+				<Field
+					id={ fieldType + '-last-name' }
+					type="text"
+					label={ localize( 'Last name' ) }
+					value={ currentLocationData.lastName || '' }
+					onChange={ value => {
+						updateLocationData( 'lastName', value );
+					} }
+					autoComplete="family-name"
+				/>
+			</FieldRow>
+
 			<FormField
-				id={ fieldType + '-name' }
-				type="Text"
-				label={ localize( 'Name' ) }
-				value={ currentLocationData.name || '' }
+				id={ fieldType + '-email-address' }
+				type="email"
+				label={ localize( 'Email address' ) }
+				placeholder={ localize( 'name@example.com' ) }
+				value={ currentLocationData.email || '' }
 				onChange={ value => {
-					updateLocationData( 'name', value );
+					updateLocationData( 'email', value );
 				} }
+				autoComplete="email"
 			/>
 
 			<FormField
 				id={ fieldType + '-address' }
-				type="Text"
+				type="text"
 				label={ localize( 'Address' ) }
 				value={ currentLocationData.address || '' }
 				onChange={ value => {
 					updateLocationData( 'address', value );
 				} }
+				autoComplete={ fieldType + ' street-address' }
 			/>
 
 			<FieldRow gap="4%" columnWidths="48% 48%">
 				<Field
 					id={ fieldType + '-city' }
-					type="Text"
+					type="text"
 					label={ localize( 'City' ) }
 					value={ currentLocationData.city || '' }
 					onChange={ value => {
 						updateLocationData( 'city', value );
 					} }
+					autoComplete={ fieldType + ' address-level2' }
 				/>
 
 				{ isStateorProvince() === 'state' ? (
 					<Field
 						id={ fieldType + '-state' }
-						type="Text"
+						type="text"
 						label={ localize( 'State' ) }
 						value={ currentLocationData.state || '' }
 						onChange={ value => {
 							updateLocationData( 'state', value );
 						} }
+						autoComplete={ fieldType + ' address-level1' }
 					/>
 				) : (
 					<Field
 						id={ fieldType + '-province' }
-						type="Text"
+						type="text"
 						label={ localize( 'Province' ) }
 						value={ currentLocationData.province || '' }
 						onChange={ value => {
 							updateLocationData( 'province', value );
 						} }
+						autoComplete={ fieldType + ' address-level1' }
 					/>
 				) }
 			</FieldRow>
@@ -266,6 +296,7 @@ function PhoneNumberField( { fieldType } ) {
 			onChange={ value => {
 				updateLocationData( 'phoneNumber', value );
 			} }
+			autoComplete="tel"
 		/>
 	);
 }
@@ -312,33 +343,36 @@ function TaxFields( { fieldType } ) {
 				{ isZipOrPostal() === 'zip' ? (
 					<Field
 						id={ fieldType + '-zip-code' }
-						type="Text"
+						type="text"
 						label={ localize( 'Zip code' ) }
 						value={ currentLocationData.zipCode || '' }
 						onChange={ value => {
 							updateLocationData( 'zipCode', value );
 						} }
+						autoComplete={ fieldType + ' postal-code' }
 					/>
 				) : (
 					<Field
 						id={ fieldType + '-postal-code' }
-						type="Text"
+						type="text"
 						label={ localize( 'Postal code' ) }
 						value={ currentLocationData.postalCode || '' }
 						onChange={ value => {
 							updateLocationData( 'postalCode', value );
 						} }
+						autoComplete={ fieldType + ' postal-code' }
 					/>
 				) }
 
 				<Field
 					id={ fieldType + '-country' }
-					type="Text"
+					type="text"
 					label={ localize( 'Country' ) }
 					value={ currentLocationData.country || '' }
 					onChange={ value => {
 						updateLocationData( 'country', value );
 					} }
+					autoComplete={ fieldType + ' country' }
 				/>
 			</FieldRow>
 		</React.Fragment>
@@ -410,7 +444,10 @@ function BillingFormSummary() {
 		<GridRow gap="4%" columnWidths="48% 48%">
 			<div>
 				<BillingSummaryDetails>
-					<BillingSummaryLine>{ billing.name || '' } </BillingSummaryLine>
+					<BillingSummaryLine>
+						{ billing.firstName || '' } { billing.lastName || '' }
+					</BillingSummaryLine>
+					<BillingSummarySpacerLine>{ billing.email || '' }</BillingSummarySpacerLine>
 					<BillingSummaryLine>{ billing.address || '' } </BillingSummaryLine>
 					<BillingSummaryLine>
 						{ billing.city && billing.city + ', ' } { billing.state || billing.province || '' }
@@ -435,7 +472,8 @@ function BillingFormSummary() {
 			{ domains && ! isDomainContactSame && (
 				<div>
 					<BillingSummaryDetails>
-						<BillingSummaryLine>{ domains.name }</BillingSummaryLine>
+						<BillingSummaryLine>{ domains.firstName + ' ' + domains.lastName }</BillingSummaryLine>
+						<BillingSummarySpacerLine>{ domains.email }</BillingSummarySpacerLine>
 						<BillingSummaryLine>{ domains.address }</BillingSummaryLine>
 						<BillingSummaryLine>
 							{ domains.city && domains.city + ', ' } { domains.state || domains.province }
@@ -467,4 +505,8 @@ const BillingSummaryLine = styled.li`
 	margin: 0;
 	padding: 0;
 	list-style: none;
+`;
+
+const BillingSummarySpacerLine = styled( BillingSummaryLine )`
+	margin-bottom: 8px;
 `;

--- a/packages/composite-checkout/src/components/credit-card-fields.js
+++ b/packages/composite-checkout/src/components/credit-card-fields.js
@@ -23,6 +23,7 @@ export default function CreditCardFields() {
 				placeholder="1234 1234 1234 1234"
 				icon={ <LockIcon /> }
 				isIconVisible={ true }
+				autoComplete="cc-number"
 			/>
 			<FieldRow gap="4%" columnWidths="48% 48%">
 				<Field
@@ -30,6 +31,7 @@ export default function CreditCardFields() {
 					type="Number"
 					label={ localize( 'Expiry Date' ) }
 					placeholder="MM / YY"
+					autoComplete="cc-exp"
 				/>
 				<GridRow gap="4%" columnWidths="67% 29%">
 					<Field
@@ -37,6 +39,7 @@ export default function CreditCardFields() {
 						type="Number"
 						label={ localize( 'Security Code' ) }
 						placeholder="111"
+						autoComplete="cc-csc"
 					/>
 					<CVVImage />
 				</GridRow>
@@ -47,6 +50,7 @@ export default function CreditCardFields() {
 				type="Text"
 				label={ localize( 'Cardholder name' ) }
 				description={ localize( 'Enter your name as it’s written on the card' ) }
+				autoComplete="cc-name"
 			/>
 		</CreditCardFieldsWrapper>
 	);

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -25,6 +25,7 @@ export default function Field( {
 	tabIndex,
 	description,
 	errorMessage,
+	autoComplete,
 } ) {
 	const fieldOnChange = event => {
 		if ( onChange ) {
@@ -52,6 +53,7 @@ export default function Field( {
 					placeholder={ placeholder }
 					tabIndex={ tabIndex }
 					isError={ isError }
+					autoComplete={ autoComplete }
 				/>
 				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
 			</InputWrapper>
@@ -79,6 +81,7 @@ Field.propTypes = {
 	tabIndex: PropTypes.string,
 	description: PropTypes.string,
 	errorMessage: PropTypes.string,
+	autoComplete: PropTypes.string,
 };
 
 const Label = styled.label`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

![image](https://user-images.githubusercontent.com/6981253/68048735-96c1aa80-fcb7-11e9-93b3-84127b59ccc9.png)


This PR adds new first + last name and email fields to the billing details screen. It also adds autofill markers so that our firms can be filled out easier. 

#### Testing instructions
* Follow these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Try autofill the billing form


