### PR TITLE
composite-checkout: throw when using hooks outside CheckoutProvider

### DIFF
--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -78,11 +78,10 @@ CheckoutProvider.propTypes = {
 };
 
 export const useLineItems = () => {
-	const context = useContext( CheckoutContext );
-	if ( ! context ) {
+	const { items, total } = useContext( CheckoutContext );
+	if ( ! items || ! total ) {
 		throw new Error( 'useLineItems can only be used inside a CheckoutProvider' );
 	}
-	const { total, items } = context;
 	return [ items, total ];
 };
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -79,16 +79,25 @@ CheckoutProvider.propTypes = {
 
 export const useLineItems = () => {
 	const { total, items } = useContext( CheckoutContext );
+	if ( ! total || ! items ) {
+		throw new Error( 'useLineItems can only be used inside a CheckoutProvider' );
+	}
 	return [ items, total ];
 };
 
 export const useCheckoutHandlers = () => {
 	const { onSuccess, onFailure } = useContext( CheckoutContext );
+	if ( ! onSuccess || ! onFailure ) {
+		throw new Error( 'useCheckoutHandlers can only be used inside a CheckoutProvider' );
+	}
 	return { onSuccess, onFailure };
 };
 
 export const useCheckoutRedirects = () => {
 	const { successRedirectUrl, failureRedirectUrl } = useContext( CheckoutContext );
+	if ( ! successRedirectUrl || ! failureRedirectUrl ) {
+		throw new Error( 'useCheckoutRedirects can only be used inside a CheckoutProvider' );
+	}
 	return { successRedirectUrl, failureRedirectUrl };
 };
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -78,10 +78,11 @@ CheckoutProvider.propTypes = {
 };
 
 export const useLineItems = () => {
-	const { total, items } = useContext( CheckoutContext );
-	if ( ! total || ! items ) {
+	const context = useContext( CheckoutContext );
+	if ( ! context ) {
 		throw new Error( 'useLineItems can only be used inside a CheckoutProvider' );
 	}
+	const { total, items } = context;
 	return [ items, total ];
 };
 

--- a/packages/composite-checkout/src/lib/localize.js
+++ b/packages/composite-checkout/src/lib/localize.js
@@ -19,5 +19,8 @@ export default function localizeFactory( locale ) {
 
 export function useLocalize() {
 	const { localize } = useContext( CheckoutContext );
+	if ( ! localize ) {
+		throw new Error( 'useLocalize can only be used inside a CheckoutProvider' );
+	}
 	return localize;
 }

--- a/packages/composite-checkout/src/lib/payment-methods/index.js
+++ b/packages/composite-checkout/src/lib/payment-methods/index.js
@@ -44,11 +44,17 @@ export function getPaymentMethods() {
 
 export function usePaymentMethodId() {
 	const { paymentMethodId, setPaymentMethodId } = useContext( CheckoutContext );
+	if ( ! setPaymentMethodId ) {
+		throw new Error( 'usePaymentMethodId can only be used inside a CheckoutProvider' );
+	}
 	return [ paymentMethodId, setPaymentMethodId ];
 }
 
 export function usePaymentMethod() {
-	const { paymentMethodId } = useContext( CheckoutContext );
+	const { paymentMethodId, setPaymentMethodId } = useContext( CheckoutContext );
+	if ( ! setPaymentMethodId ) {
+		throw new Error( 'usePaymentMethodId can only be used inside a CheckoutProvider' );
+	}
 	if ( ! paymentMethodId ) {
 		return null;
 	}
@@ -61,6 +67,9 @@ export function usePaymentMethod() {
 
 export function usePaymentData() {
 	const { paymentData, dispatchPaymentAction } = useContext( CheckoutContext );
+	if ( ! paymentData ) {
+		throw new Error( 'usePaymentData can only be used inside a CheckoutProvider' );
+	}
 	return [ paymentData, dispatchPaymentAction ];
 }
 

--- a/packages/composite-checkout/src/lib/payment-methods/index.js
+++ b/packages/composite-checkout/src/lib/payment-methods/index.js
@@ -67,7 +67,7 @@ export function usePaymentMethod() {
 
 export function usePaymentData() {
 	const { paymentData, dispatchPaymentAction } = useContext( CheckoutContext );
-	if ( ! paymentData ) {
+	if ( ! dispatchPaymentAction ) {
 		throw new Error( 'usePaymentData can only be used inside a CheckoutProvider' );
 	}
 	return [ paymentData, dispatchPaymentAction ];

--- a/packages/composite-checkout/test/components/checkout-provider.js
+++ b/packages/composite-checkout/test/components/checkout-provider.js
@@ -39,6 +39,43 @@ describe( 'useLineItems', function() {
 		expect( () => render( <ThingWithHook /> ) ).toThrow( /CheckoutProvider/ );
 	} );
 
+	it( 'does not throw if there are no items', function() {
+		const ThingWithHook = () => {
+			const [ items, total ] = useLineItems();
+			return (
+				<div>
+					{ items.map( item => (
+						<span data-testid={ item.id } key={ item.id }>
+							{ item.label }
+						</span>
+					) ) }
+					<span data-testid="total" key={ total.id }>
+						{ total.label }
+					</span>
+				</div>
+			);
+		};
+		const renderThing = () =>
+			render(
+				<CheckoutProvider
+					locale={ 'US' }
+					total={ {
+						id: 'total',
+						label: 'total',
+						amount: { value: 40, currency: 'USD', displayValue: '40' },
+					} }
+					items={ [] }
+					onSuccess={ () => {} }
+					onFailure={ () => {} }
+					successRedirectUrl={ '#' }
+					failureRedirectUrl={ '#' }
+				>
+					<ThingWithHook />
+				</CheckoutProvider>
+			);
+		expect( renderThing ).not.toThrow( /CheckoutProvider/ );
+	} );
+
 	it( 'returns the items list', function() {
 		const ThingWithHook = () => {
 			const [ items, total ] = useLineItems();

--- a/packages/composite-checkout/test/components/checkout-provider.js
+++ b/packages/composite-checkout/test/components/checkout-provider.js
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import { CheckoutProvider, useLineItems } from '../../src/components/checkout-provider';
+
+// React writes to console.error when a component throws before re-throwing
+// but we don't want to see that here so we mock console.error.
+/* eslint-disable no-console */
+const original = console.error;
+
+describe( 'useLineItems', function() {
+	beforeEach( () => {
+		console.error = jest.fn();
+	} );
+
+	afterEach( () => {
+		console.error = original;
+	} );
+
+	it( 'throws if outside of a CheckoutProvider', function() {
+		const ThingWithHook = () => {
+			const [ items, total ] = useLineItems();
+			return (
+				<div>
+					{ items.map( item => (
+						<span key={ item.id }>{ item.label }</span>
+					) ) }
+					<span key={ total.id }>{ total.label }</span>
+				</div>
+			);
+		};
+		expect( () => render( <ThingWithHook /> ) ).toThrow( /CheckoutProvider/ );
+	} );
+
+	it( 'returns the items list', function() {
+		const ThingWithHook = () => {
+			const [ items, total ] = useLineItems();
+			return (
+				<div>
+					{ items.map( item => (
+						<span data-testid={ item.id } key={ item.id }>
+							{ item.label }
+						</span>
+					) ) }
+					<span data-testid="total" key={ total.id }>
+						{ total.label }
+					</span>
+				</div>
+			);
+		};
+		const { getByTestId } = render(
+			<CheckoutProvider
+				locale={ 'US' }
+				total={ {
+					id: 'total',
+					label: 'total',
+					amount: { value: 40, currency: 'USD', displayValue: '40' },
+				} }
+				items={ [
+					{
+						id: 'one',
+						label: 'thing1',
+						amount: { value: 20, currency: 'USD', displayValue: '20' },
+					},
+					{
+						id: 'two',
+						label: 'thing2',
+						amount: { value: 20, currency: 'USD', displayValue: '20' },
+					},
+				] }
+				onSuccess={ () => {} }
+				onFailure={ () => {} }
+				successRedirectUrl={ '#' }
+				failureRedirectUrl={ '#' }
+			>
+				<ThingWithHook />
+			</CheckoutProvider>
+		);
+		expect( getByTestId( 'one' ) ).toHaveTextContent( 'thing1' );
+		expect( getByTestId( 'two' ) ).toHaveTextContent( 'thing2' );
+	} );
+
+	it( 'returns the total', function() {
+		const ThingWithHook = () => {
+			const [ items, total ] = useLineItems();
+			return (
+				<div>
+					{ items.map( item => (
+						<span data-testid={ item.id } key={ item.id }>
+							{ item.label }
+						</span>
+					) ) }
+					<span data-testid="total" key={ total.id }>
+						{ total.label }
+					</span>
+				</div>
+			);
+		};
+		const { getByTestId } = render(
+			<CheckoutProvider
+				locale={ 'US' }
+				total={ {
+					id: 'total',
+					label: 'total',
+					amount: { value: 40, currency: 'USD', displayValue: '40' },
+				} }
+				items={ [
+					{
+						id: 'one',
+						label: 'thing1',
+						amount: { value: 20, currency: 'USD', displayValue: '20' },
+					},
+					{
+						id: 'two',
+						label: 'thing2',
+						amount: { value: 20, currency: 'USD', displayValue: '20' },
+					},
+				] }
+				onSuccess={ () => {} }
+				onFailure={ () => {} }
+				successRedirectUrl={ '#' }
+				failureRedirectUrl={ '#' }
+			>
+				<ThingWithHook />
+			</CheckoutProvider>
+		);
+		expect( getByTestId( 'total' ) ).toHaveTextContent( 'total' );
+	} );
+} );
+/* eslint-enable no-console */

--- a/packages/composite-checkout/test/lib/localize.js
+++ b/packages/composite-checkout/test/lib/localize.js
@@ -3,18 +3,20 @@
  */
 import React from 'react';
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 
 /**
  * Internal dependencies
  */
+import { CheckoutProvider } from '../../src/components/checkout-provider';
 import { useLocalize } from '../../src/lib/localize';
 
-describe( 'useLocalize', function() {
-	// React writes to console.error when a component throws before re-throwing
-	// but we don't want to see that here so we mock console.error.
-	/* eslint-disable no-console */
-	const original = console.error;
+// React writes to console.error when a component throws before re-throwing
+// but we don't want to see that here so we mock console.error.
+/* eslint-disable no-console */
+const original = console.error;
 
+describe( 'useLocalize', function() {
 	beforeEach( () => {
 		console.error = jest.fn();
 	} );
@@ -22,7 +24,6 @@ describe( 'useLocalize', function() {
 	afterEach( () => {
 		console.error = original;
 	} );
-	/* eslint-enable no-console */
 
 	it( 'throws if outside of a CheckoutProvider', function() {
 		const ThingWithLocalize = () => {
@@ -31,4 +32,26 @@ describe( 'useLocalize', function() {
 		};
 		expect( () => render( <ThingWithLocalize /> ) ).toThrow( /CheckoutProvider/ );
 	} );
+
+	it( 'returns a function that returns a string', function() {
+		const ThingWithLocalize = () => {
+			const localize = useLocalize();
+			return <span data-testid="text">{ localize( 'hello' ) }</span>;
+		};
+		const { getByTestId } = render(
+			<CheckoutProvider
+				locale={ 'US' }
+				total={ { label: 'total', amount: { value: 10, currency: 'USD', displayValue: '10' } } }
+				items={ [ { label: 'total', amount: { value: 10, currency: 'USD', displayValue: '10' } } ] }
+				onSuccess={ () => {} }
+				onFailure={ () => {} }
+				successRedirectUrl={ '#' }
+				failureRedirectUrl={ '#' }
+			>
+				<ThingWithLocalize />
+			</CheckoutProvider>
+		);
+		expect( getByTestId( 'text' ) ).toHaveTextContent( 'hello' );
+	} );
 } );
+/* eslint-enable no-console */

--- a/packages/composite-checkout/test/lib/localize.js
+++ b/packages/composite-checkout/test/lib/localize.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalize } from '../../src/lib/localize';
+
+describe( 'useLocalize', function() {
+	// React writes to console.error when a component throws before re-throwing
+	// but we don't want to see that here so we mock console.error.
+	/* eslint-disable no-console */
+	const original = console.error;
+
+	beforeEach( () => {
+		console.error = jest.fn();
+	} );
+
+	afterEach( () => {
+		console.error = original;
+	} );
+	/* eslint-enable no-console */
+
+	it( 'throws if outside of a CheckoutProvider', function() {
+		const ThingWithLocalize = () => {
+			const localize = useLocalize();
+			return <span>{ localize( 'hello' ) }</span>;
+		};
+		expect( () => render( <ThingWithLocalize /> ) ).toThrow( /CheckoutProvider/ );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds errors that are thrown when trying to use the custom hooks that require `CheckoutProvider` if that provider is not available. It should make it easier to solve bugs where that occurs.

#### Testing instructions

Unit tests are included.

#### To do

- [x] Unit test for `useLineItems` failure
- [x] Unit test for `useLineItems` success
- [ ] Unit test for `useCheckoutHandlers` failure
- [ ] Unit test for `useCheckoutHandlers` success
- [ ] Unit test for `useCheckoutRedirects` failure
- [ ] Unit test for `useCheckoutRedirects` success
- [x] Unit test for `useLocalize` failure
- [x] Unit test for `useLocalize` success
- [ ] Unit test for `usePaymentMethodId` failure
- [ ] Unit test for `usePaymentMethodId` success
- [ ] Unit test for `usePaymentData` failure
- [ ] Unit test for `usePaymentData` success