### PR TITLE
Refactor site options and add new HOC

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -29,7 +29,7 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import useSiteOptions from '../useSiteOptions';
+import { useSiteOptions } from '../../lib';
 
 function SiteDescriptionEdit( {
 	attributes,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -29,39 +29,26 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { useSiteOptions } from '../../lib';
+import { withSiteOptions } from '../../lib';
 
 function SiteDescriptionEdit( {
 	attributes,
 	backgroundColor,
 	className,
-	createErrorNotice,
 	fontSize,
 	insertDefaultBlock,
-	isSelected,
 	setAttributes,
 	setBackgroundColor,
 	setFontSize,
 	setTextColor,
-	shouldUpdateSiteOption,
+	siteDescription,
 	textColor,
 } ) {
 	const { customFontSize, textAlign } = attributes;
 
 	const actualFontSize = customFontSize || fontSize.size;
 
-	const inititalDescription = __( 'Site description loading…' );
-
-	const { siteOptions, handleChange } = useSiteOptions(
-		'description',
-		inititalDescription,
-		createErrorNotice,
-		isSelected,
-		shouldUpdateSiteOption,
-		setAttributes
-	);
-
-	const { option } = siteOptions;
+	const { value, updateValue } = siteDescription;
 
 	return (
 		<Fragment>
@@ -114,7 +101,7 @@ function SiteDescriptionEdit( {
 					[ fontSize.class ]: ! customFontSize && fontSize.class,
 				} ) }
 				identifier="content"
-				onChange={ value => handleChange( value ) }
+				onChange={ updateValue }
 				onReplace={ insertDefaultBlock }
 				onSplit={ noop }
 				placeholder={ __( 'Add a Site Description' ) }
@@ -124,7 +111,7 @@ function SiteDescriptionEdit( {
 					fontSize: actualFontSize ? actualFontSize + 'px' : undefined,
 				} }
 				tagName="p"
-				value={ option }
+				value={ value }
 			/>
 		</Fragment>
 	);
@@ -134,9 +121,6 @@ export default compose( [
 	withColors( 'backgroundColor', { textColor: 'color' } ),
 	withFontSizes( 'fontSize' ),
 	withSelect( ( select, { clientId } ) => {
-		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
-			'core/editor'
-		);
 		const { getBlockIndex, getBlockRootClientId, getTemplateLock } = select( 'core/block-editor' );
 		const rootClientId = getBlockRootClientId( clientId );
 
@@ -144,14 +128,13 @@ export default compose( [
 			blockIndex: getBlockIndex( clientId, rootClientId ),
 			isLocked: !! getTemplateLock( rootClientId ),
 			rootClientId,
-			shouldUpdateSiteOption:
-				( ( isSavingPost() && isCurrentPostPublished() ) || isPublishingPost() ) &&
-				! isAutosavingPost(),
 		};
 	} ),
 	withDispatch( ( dispatch, { blockIndex, rootClientId } ) => ( {
-		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
 		insertDefaultBlock: () =>
 			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
 	} ) ),
+	withSiteOptions( {
+		siteDescription: { optionName: 'description', defaultValue: __( 'Site description loading…' ) },
+	} ),
 ] )( SiteDescriptionEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -28,37 +28,24 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { useSiteOptions } from '../../lib';
+import { withSiteOptions } from '../../lib';
 
 function SiteTitleEdit( {
 	attributes,
 	className,
-	createErrorNotice,
 	fontSize,
 	insertDefaultBlock,
-	isSelected,
 	setAttributes,
 	setFontSize,
 	setTextColor,
-	shouldUpdateSiteOption,
+	siteTitle,
 	textColor,
 } ) {
 	const { customFontSize, textAlign } = attributes;
 
 	const actualFontSize = customFontSize || fontSize.size;
 
-	const inititalTitle = __( 'Site title loading…' );
-
-	const { siteOptions, handleChange } = useSiteOptions(
-		'title',
-		inititalTitle,
-		createErrorNotice,
-		isSelected,
-		shouldUpdateSiteOption,
-		setAttributes
-	);
-
-	const { option } = siteOptions;
+	const { value, updateValue } = siteTitle;
 
 	return (
 		<Fragment>
@@ -96,7 +83,7 @@ function SiteTitleEdit( {
 					[ fontSize.class ]: ! customFontSize && fontSize.class,
 				} ) }
 				identifier="content"
-				onChange={ value => handleChange( value ) }
+				onChange={ updateValue }
 				onReplace={ insertDefaultBlock }
 				onSplit={ noop }
 				placeholder={ __( 'Add a Site Title' ) }
@@ -105,7 +92,7 @@ function SiteTitleEdit( {
 					fontSize: actualFontSize ? actualFontSize + 'px' : undefined,
 				} }
 				tagName="h1"
-				value={ option }
+				value={ value }
 			/>
 		</Fragment>
 	);
@@ -115,9 +102,6 @@ export default compose( [
 	withColors( { textColor: 'color' } ),
 	withFontSizes( 'fontSize' ),
 	withSelect( ( select, { clientId } ) => {
-		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
-			'core/editor'
-		);
 		const { getBlockIndex, getBlockRootClientId, getTemplateLock } = select( 'core/block-editor' );
 		const rootClientId = getBlockRootClientId( clientId );
 
@@ -125,14 +109,13 @@ export default compose( [
 			blockIndex: getBlockIndex( clientId, rootClientId ),
 			isLocked: !! getTemplateLock( rootClientId ),
 			rootClientId,
-			shouldUpdateSiteOption:
-				( ( isSavingPost() && isCurrentPostPublished() ) || isPublishingPost() ) &&
-				! isAutosavingPost(),
 		};
 	} ),
 	withDispatch( ( dispatch, { blockIndex, rootClientId } ) => ( {
-		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
 		insertDefaultBlock: () =>
 			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
 	} ) ),
+	withSiteOptions( {
+		siteTitle: { optionName: 'title', defaultValue: __( 'Site title loading…' ) },
+	} ),
 ] )( SiteTitleEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -28,7 +28,7 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import useSiteOptions from '../useSiteOptions';
+import { useSiteOptions } from '../../lib';
 
 function SiteTitleEdit( {
 	attributes,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/index.js
@@ -1,0 +1,1 @@
+export * from './site-options';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/index.js
@@ -1,1 +1,2 @@
 export * from './use-site-options';
+export * from './with-site-options';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/index.js
@@ -1,0 +1,1 @@
+export * from './use-site-options';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/use-previous.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/use-previous.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 /**
  * External dependencies
  */
@@ -11,7 +13,7 @@ import { useEffect, useRef } from '@wordpress/element';
  * @param  {any}  value state or prop value for which previous value is required
  * @return {any}  previous value of requested state or prop value
  */
-export default function usePrevious( value ) {
+export function usePrevious( value ) {
 	const ref = useRef();
 
 	useEffect( () => {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/use-site-options.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/use-site-options.js
@@ -62,7 +62,15 @@ export function useSiteOptions(
 
 	function updateSiteOption() {
 		const { option, previousOption } = siteOptions;
-		const optionUnchanged = option && option.trim() === previousOption.trim();
+
+		/**
+		 * 1. Both `previousOption` and `option` are falsey.
+		 * OR
+		 * 2. Both `previousOption` and `option` are the same value after trim.
+		 */
+		const optionUnchanged =
+			( ! previousOption && ! option ) ||
+			( option && previousOption && option.trim() === previousOption.trim() );
 		const optionIsEmpty = ! option || option.trim().length === 0;
 
 		// Reset to initial value if user de-selects the block with an empty value.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/use-site-options.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/use-site-options.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 /**
  * External dependencies
  */
@@ -9,9 +11,9 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
-import usePrevious from './usePrevious';
+import { usePrevious } from './use-previous';
 
-export default function useSiteOptions(
+export function useSiteOptions(
 	siteOption,
 	inititalOption,
 	createErrorNotice,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/with-site-options.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/with-site-options.js
@@ -34,8 +34,12 @@ import { useSiteOptions } from './use-site-options';
  *
  * @return {Component} The higher order component.
  *
+ * In the following example, withSiteOptions is called with an object mapping a
+ * name for the option to some information about it. In particular, optionName
+ * needs to match the name of the option in WordPress, and defaultValue is used
+ * while the option is loading from the API.
+ *
  * @example
- * ```js
  * function Component( { mySiteOption } ) {
  *   const { value, updateValue } = mySiteOption;
  *   // `updateValue( 'foo' )` the component will re-render if called.
@@ -47,11 +51,6 @@ import { useSiteOptions } from './use-site-options';
  *     mySiteOption: { optionName: 'title', defaultValue: __( 'Site title loading…' ) },
  * 	} ),
  * ] )( Component );
- * ```
- * In the above example, we call withSiteOptions with an object mapping our name
- * for the option to some information about it. In particular, optionName needs
- * to match the name of the option in WordPress, and defaultValue is used while
- * the option is loading from the API.
  *
  */
 export const withSiteOptions = options =>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/with-site-options.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/with-site-options.js
@@ -1,0 +1,100 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useSiteOptions } from './use-site-options';
+
+/**
+ * Higher Order Component used to inject site options.
+ *
+ * The option value is requested from the WordPress API. Note that arbitrary
+ * options can only be retrieved if they have been registered as site settings.
+ *
+ * Updates are persisted to the database as they change.
+ *
+ * In the component, every specified `optionName` will be a prop which maps to
+ * an object with the keys `value`, `updateValue`, and `loaded`. `value`
+ * contains the actual value of the WordPress option, and `updateValue` can be
+ * used to update the option. `updateValue` will re-render the component with
+ * the new `value`.
+ *
+ * @param {Object} options An object of site options to retrieve. Keys should be
+ *                         option names you wish to have locally. They can be
+ *                         named whatever makes sense in the context of your
+ *                         component. Any key's value should be another object
+ *                         whih contains `optionName`, the actual name of the
+ *                         WordPress option to fetch, and `defaultValue`, the
+ *                         value to use while the option is fetching.
+ *
+ * @return {Component} The higher order component.
+ *
+ * @example
+ * ```js
+ * function Component( { mySiteOption } ) {
+ *   const { value, updateValue } = mySiteOption;
+ *   // `updateValue( 'foo' )` the component will re-render if called.
+ *   return <span>{ value }</span>;
+ * }
+ *
+ * export default compose( [
+ *   withSiteOptions( {
+ *     mySiteOption: { optionName: 'title', defaultValue: __( 'Site title loading…' ) },
+ * 	} ),
+ * ] )( Component );
+ * ```
+ * In the above example, we call withSiteOptions with an object mapping our name
+ * for the option to some information about it. In particular, optionName needs
+ * to match the name of the option in WordPress, and defaultValue is used while
+ * the option is loading from the API.
+ *
+ */
+export const withSiteOptions = options =>
+	createHigherOrderComponent(
+		WrappedComponent =>
+			pure( ownProps => {
+				const shouldUpdateSiteOption = useSelect( select => {
+					const {
+						isSavingPost,
+						isPublishingPost,
+						isAutosavingPost,
+						isCurrentPostPublished,
+					} = select( 'core/editor' );
+					return (
+						( ( isSavingPost() && isCurrentPostPublished() ) || isPublishingPost() ) &&
+						! isAutosavingPost()
+					);
+				} );
+
+				const createErrorNotice = useDispatch(
+					dispatch => dispatch( 'core/notices' ).createErrorNotice
+				);
+
+				const { isSelected, setAttributes } = ownProps;
+				const allOptions = Object.keys( options ).reduce( ( accumulator, name ) => {
+					const { optionName, defaultValue } = options[ name ];
+					const { siteOptions, handleChange } = useSiteOptions(
+						optionName,
+						defaultValue,
+						createErrorNotice,
+						isSelected,
+						shouldUpdateSiteOption,
+						setAttributes
+					);
+					accumulator[ name ] = {
+						value: siteOptions.option,
+						updateValue: handleChange,
+						loaded: siteOptions.loaded,
+					};
+					return accumulator;
+				}, {} );
+
+				return <WrappedComponent { ...ownProps } { ...allOptions } />;
+			} ),
+		'withSiteOptions'
+	);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/with-site-options.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/lib/site-options/with-site-options.js
@@ -16,7 +16,7 @@ import { useSiteOptions } from './use-site-options';
  * The option value is requested from the WordPress API. Note that arbitrary
  * options can only be retrieved if they have been registered as site settings.
  *
- * Updates are persisted to the database as they change.
+ * Updates are persisted to the database when the post is saved.
  *
  * In the component, every specified `optionName` will be a prop which maps to
  * an object with the keys `value`, `updateValue`, and `loaded`. `value`


### PR DESCRIPTION
_Originally implemented in #37012 but moved here for clarity_

The goal of this is to reduce duplicate code everywhere we use `useSiteOptions`. As I discovered when implementing site credit block, there is a lot of extra wrapper stuff just used for this! I think it makes sense to roll that into an HOC to improve reusability.

#### Changes proposed in this Pull Request

* Move useSiteOptions into new `lib` folder
* Add new HOC to make using site options easier
* Fix bug in site options where a null value in `previousOption` would crash things.
* Use new HOC for site title and description.

#### Testing instructions
1. Pull changes to your local testing environment.
2. Edit the site title/description and make sure changes and updates work as expected. (Really smoke test this hard to make sure everything is working correctly.)