### PR TITLE
Add Floodlight/Google Ads Signup Start events

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -26,7 +26,7 @@ import {
 	retarget as retargetAdTrackers,
 	recordAliasInFloodlight,
 	recordSignupCompletionInFloodlight,
-	recordSignupStartInFloodlight,
+	recordSignupStart,
 	recordRegistration,
 	recordSignup,
 	recordAddToCart,
@@ -354,7 +354,7 @@ const analytics = {
 		// Google Analytics
 		analytics.ga.recordEvent( 'Signup', 'calypso_signup_start' );
 		// Marketing
-		recordSignupStartInFloodlight();
+		recordSignupStart( { flow } );
 	},
 
 	recordRegistration: function( { flow } ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Based on https://github.com/Automattic/wp-calypso/pull/37263
  * Adds Floodlight/Google Ads Signup Start events

## Testing instructions

### In an incognito window, open:
https://hash-5ff001421a4b3978adf2d5ff620bd7cb5735f9ef.calypso.live/start

In DevTools console, run the following, then refresh the page:

```
document.cookie = 'flags=gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
document.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
localStorage.setItem( 'debug', 'calypso:*' );
```

### Confirm new pixels are firing on this page:

- Filter Network tab by `baDICKzQiq4BEP6YlcMD` and confirm 3 requests.
- Filter Network tab by `landi00` and confirm 3 requests.
- ...
- Filter Network tab by `pre-p0` and confirm 3 requests.
- Filter Network tab `calypso_signup_start` and confirm 3 requests.

---

### Log in and open:
https://hash-5ff001421a4b3978adf2d5ff620bd7cb5735f9ef.calypso.live/start

The new pixels should NOT fire when logged-in.

- Filter Network tab by `baDICKzQiq4BEP6YlcMD` and confirm **0 requests**.
- Filter Network tab by `landi00` and confirm **0 requests**.
- ...
- Filter Network tab by `pre-p0` and confirm 3 requests.
- Filter Network tab `calypso_signup_start` and confirm 3 requests.

**TBD:** Should this be if not logged-in **OR** `site_count=0`?
What if someone is already logged-in, but has no sites. Don't we want to track signup start?
**UPDATE:** To be considered in a follow-up.

---

### Test other flows:

### In an incognito window, open:
https://hash-5ff001421a4b3978adf2d5ff620bd7cb5735f9ef.calypso.live/start/crowdsignal
https://hash-5ff001421a4b3978adf2d5ff620bd7cb5735f9ef.calypso.live/start/account

The new pixels should NOT fire in these flows.

- Filter Network tab by `baDICKzQiq4BEP6YlcMD` and confirm **0 requests**.
- Filter Network tab by `landi00` and confirm **0 requests**.
- ...
- Filter Network tab by `pre-p0` and confirm 3 requests.
- Filter Network tab `calypso_signup_start` and confirm 3 requests.
