### PR TITLE
Plans: Use ExternalLink for Jetpack Backup external links

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -4,6 +4,11 @@
 import React, { Fragment } from 'react';
 import { translate } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
@@ -59,13 +64,7 @@ export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = translate(
 	'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
 	{
 		components: {
-			a: (
-				<a
-					href="https://jetpack.com/upgrade/backup/"
-					target="_blank"
-					rel="noopener noreferrer"
-				/>
-			),
+			a: <ExternalLink href="https://jetpack.com/upgrade/backup/" icon />,
 		},
 	}
 );


### PR DESCRIPTION
When looking at the designs I noticed that we should actually be using the external link icon here. I checked that after conveniently being nudged by @simison about it in another PR 😉 

#### Changes proposed in this Pull Request

* Plans: Use ExternalLink for Jetpack Backup external links

#### Preview

Before:
![](https://cldup.com/JQFkzR4FK0.png)

After:
![](https://cldup.com/ozxr3hEMtl.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site.
* Verify you can see the icon after the link text.
* Verify clicking it still opens the link in a new window.
* Verify it has the `rel=" noopener noreferrer"` attribute as well.
