### PR TITLE
Atomic: Update blocked plugins from October 2019

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -357,7 +357,6 @@ export class PluginMeta extends Component {
 			'wp-monero-miner-using-coin-hive',
 			'wp-optimize-by-xtraffic',
 			'wpematico',
-			'yellow-pencil-visual-theme-customizer',
 			'yuzo-related-post',
 			'zapp-proxy-server',
 		];

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -296,7 +296,6 @@ export class PluginMeta extends Component {
 			'another-wordpress-classifieds-plugin',
 			'broken-link-checker',
 			'leads',
-			'mycred',
 			'native-ads-adnow',
 			'ol_scrapes',
 			'page-visit-counter',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -356,7 +356,6 @@ export class PluginMeta extends Component {
 			'wp-monero-miner-pro',
 			'wp-monero-miner-using-coin-hive',
 			'wp-optimize-by-xtraffic',
-			'wp-phpmyadmin-extension',
 			'wpematico',
 			'yellow-pencil-visual-theme-customizer',
 			'yuzo-related-post',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -358,6 +358,7 @@ export class PluginMeta extends Component {
 			'wp-optimize-by-xtraffic',
 			'wp-phpmyadmin-extension',
 			'wpematico',
+			'yellow-pencil-visual-theme-customizer',
 			'yuzo-related-post',
 			'zapp-proxy-server',
 		];

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -342,7 +342,6 @@ export class PluginMeta extends Component {
 			'fast-velocity-minify',
 			'nginx-helper',
 			'p3',
-			'popup-builder',
 			'porn-embed',
 			'propellerads-official',
 			'speed-contact-bar',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update list of blocked plugins from October 2019
- A few plugins are removed from the blocks as they updated by the devs
- Details: p9F6qB-48E-p2

Removed from the list:

- mycred
- popup-builder
- wp-phpmyadmin-extension
- yellow-pencil-visual-theme-customizer