### PR TITLE
Plans Page: update devdoc so that no longer P tag is used in description

### DIFF
--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -14,12 +14,12 @@ const products = [
 	{
 		title: 'Jetpack Backup',
 		description: (
-			<p>
+			<Fragment>
 				Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{' '}
 				<a href="https://jetpack.com/upgrade/backup/" target="_blank" rel="noopener noreferrer">
 					Which one do I need?
 				</a>
-			</p>
+			</Fragment>
 		),
 		id: 'jetpack_backup',
 		options: {

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -19,7 +19,7 @@ See p1HpG7-7ET-p2 for more details.
 ### How to use the `<ProductCard />`
 
 ```jsx
-import React from 'react';
+import React, { Fragment } from 'react';
 import ProductCard from 'components/product-card';
 
 export default class extends React.Component {
@@ -27,13 +27,13 @@ export default class extends React.Component {
 		return (
 			<ProductCard
 				title="Jetpack Scan"
-				billingTimeFrame={ 'per year' }
+				billingTimeFrame="per year"
 				fullPrice={ 25 }
 				description={
-					<p>
+					<Fragment>
 						Automatic scanning and one-click fixes keep your site one step ahead of security
 						threats. <a href="/plans">More info</a>
-					</p>
+					</Fragment>
 				}
 			/>
 		);
@@ -54,7 +54,7 @@ The following props can be passed to the Product Card component:
 
 * `billingTimeFrame`: ( string ) Billing time frame label
 * `currencyCode`: ( string ) Currency code
-* `description`: ( string | element ) Product description. It can be a string or a React element (e.g. `<Fragment>`)
+* `description`: ( string | element | node ) Product description. It can be a string, a node or a React element (e.g. `<Fragment>`)
 * `discountedPrice`: ( number | array ) Discounted price of the product. If an array of 2 numbers is passed, it will be
  displayed as a price range
 * `fullPrice`: ( number | array ) Full price of a product. If an array of 2 numbers is passed, it will be displayed as
@@ -87,15 +87,10 @@ export default class extends React.Component {
 		return (
 			<ProductCard
 				title="Jetpack Backup"
-				billingTimeFrame={ 'per month' }
+				billingTimeFrame="per month"
 				fullPrice={ [ 16, 25 ] }
 				discountedPrice={ [ 12, 16 ] }
-				description={
-					<p>
-						Always-on backups ensure you never lose your site. Choose from real-time or daily
-						backups. <a href="/plans">Which one do I need?</a>
-					</p>
-				}
+				description="Always-on backups ensure you never lose your site. Choose from real-time or daily backups."
 			>
 				<ProductCardOptions
 					optionsLabel="Backup options:"
@@ -160,18 +155,9 @@ export default class extends React.Component {
 	render() {
 		return (
 			<ProductCard
-				title={
-					<Fragment>
-						Jetpack Backup <strong>Daily</strong>
-					</Fragment>
-				}
+				title="Jetpack Backup Daily"
 				subtitle="Purchased 2019-09-13"
-				description={
-					<p>
-						<strong>Looking for more?</strong> With Real-time backups:, we save as you edit and
-						you’ll get unlimited backup archives
-					</p>
-				}
+				description="Looking for more? With Real-time backups we save as you edit and you’ll get unlimited backup archives"
 			>
 				<ProductCardAction
 					intro="Get Real-Time Backups $16 /year"

--- a/client/components/product-card/docs/example.jsx
+++ b/client/components/product-card/docs/example.jsx
@@ -41,10 +41,10 @@ function ProductCardExample() {
 				billingTimeFrame={ isPlaceholder ? null : 'per year' }
 				fullPrice={ isPlaceholder ? null : 25 }
 				description={
-					<p>
+					<Fragment>
 						Automatic scanning and one-click fixes keep your site one step ahead of security
 						threats. <a href="/plans">More info</a>
-					</p>
+					</Fragment>
 				}
 			/>
 
@@ -56,10 +56,10 @@ function ProductCardExample() {
 				fullPrice={ isPlaceholder ? null : [ 16, 25 ] }
 				discountedPrice={ isPlaceholder ? null : [ 12, 16 ] }
 				description={
-					<p>
+					<Fragment>
 						Always-on backups ensure you never lose your site. Choose from real-time or daily
 						backups. <a href="/plans">Which one do I need?</a>
-					</p>
+					</Fragment>
 				}
 			>
 				<ProductCardOptions
@@ -93,10 +93,10 @@ function ProductCardExample() {
 				}
 				subtitle="Purchased 2019-09-13"
 				description={
-					<p>
+					<Fragment>
 						<strong>Looking for more?</strong> With Real-time backups:, we save as you edit and
 						you’ll get unlimited backup archives
-					</p>
+					</Fragment>
 				}
 				isPlaceholder={ isPlaceholder }
 				purchase={ purchase }
@@ -119,12 +119,7 @@ function ProductCardExample() {
 						Included in your <a href="/my-plan">Personal Plan</a>
 					</Fragment>
 				}
-				description={
-					<p>
-						Always-on backups ensure you never lose your site. Your changes are saved as you edit
-						and you have unlimited backup archives
-					</p>
-				}
+				description="Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives"
 				isPlaceholder={ isPlaceholder }
 				purchase={ purchase }
 			>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update example and readme files for `<ProductSelector />` and `<ProductCard />` so that no longer a P tag is used in the `description` prop ([see this comment](https://github.com/Automattic/wp-calypso/pull/37203#issuecomment-549324318)).

#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/devdocs/blocks/product-selector and confirm that no error about nesting P tags is reported in the dev tools console. 
* Go to http://calypso.localhost:3000/devdocs/design/product-card and confirm that  no error about nesting P tags is reported in the dev tools console. 

Fixes n/a
