### PR TITLE
Fix rounded border overflow in Safari

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -169,6 +169,7 @@ body.is-fullscreen-mode {
 		overflow: hidden;
 		background-color: #fff;
 		position: relative;
+		transform: translate3d( 0, 0, 0 ); // Fix for Safari rounded border overflow (1/2).
 
 		.template-selector-item__template-title {
 			width: 100%;
@@ -224,6 +225,7 @@ body.is-fullscreen-mode {
 		position: relative;
 		pointer-events: none;
 		opacity: 1;
+		transform: translate3d( 0, 0, 0 ); // Fix for Safari rounded border overflow (2/2).
 
 		@media screen and ( max-width: 659px ) {
 			padding-top: 120%;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -169,7 +169,7 @@ body.is-fullscreen-mode {
 		overflow: hidden;
 		background-color: #fff;
 		position: relative;
-		transform: translate3d( 0, 0, 0 ); // Fix for Safari rounded border overflow (1/2).
+		transform: translateZ( 0 ); // Fix for Safari rounded border overflow (1/2).
 
 		.template-selector-item__template-title {
 			width: 100%;
@@ -225,7 +225,7 @@ body.is-fullscreen-mode {
 		position: relative;
 		pointer-events: none;
 		opacity: 1;
-		transform: translate3d( 0, 0, 0 ); // Fix for Safari rounded border overflow (2/2).
+		transform: translateZ( 0 ); // Fix for Safari rounded border overflow (2/2).
 
 		@media screen and ( max-width: 659px ) {
 			padding-top: 120%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For the starter page templates (thumbnails) previews use the `translate3d(0, 0, 0)` trick to help Safari render rounded borders better.

#### Testing instructions

- Check out this branch
- Make sure Full Site Editing & Gutenberg plugins are active
- Open Safari & go to `/wp-admin/post-new.php?post_type=page`
- Look at the template preview thumbnail borders - they shouldn't have overflown or thinner corners.

**Before:**

![image](https://user-images.githubusercontent.com/1451471/68125714-76415c80-ff12-11e9-8374-c207aa1549ad.png)

**After:**

![Screenshot 2019-11-04 14 51 37](https://user-images.githubusercontent.com/1451471/68125785-a688fb00-ff12-11e9-8751-8dea510ac88c.png)

Fixes #36395
