### PR TITLE
Fix script not waiting for correct branch

### DIFF
--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-sha=$CIRCLE_SHA1
+if [ "" == "$sha" ]; then
+  echo "sha envvar not set";
+  exit;
+fi
+
+if [ "$sha" != "$calypsoSha" ]; then
+    echo "Using calypsoSha envvar"
+    sha=$calypsoSha
+fi
 
 COUNT=0
 RESETCOUNT=240 # 5sec retry = Reset the branch after 20 minutes


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The wait script in Calypso was missing some changes that had been made in wrapper repo. Updating it so that it works as the main script for both repos

#### Testing instructions

* Ensure that the wait for calypso.live steps work for full suites and canary tests. Make sure that the hash it is waiting for is correct.
