### PR TITLE
e2e-Fix wait script and Add FAIL status support

### DIFF
--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -2,7 +2,7 @@
 
 if [ "" == "$sha" ]; then
   echo "sha envvar not set";
-  exit;
+  sha=$CIRCLE_SHA1
 fi
 
 if [ "$sha" != "$calypsoSha" ]; then

--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -5,7 +5,7 @@ if [ "" == "$sha" ]; then
   sha=$CIRCLE_SHA1
 fi
 
-if [ "$sha" != "$calypsoSha" ]; then
+if [[ "$calypsoSha" != "" ] && ["$sha" != "$calypsoSha" ]]; then
     echo "Using calypsoSha envvar"
     sha=$calypsoSha
 fi

--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -5,7 +5,7 @@ if [ "" == "$sha" ]; then
   sha=$CIRCLE_SHA1
 fi
 
-if [[ "$calypsoSha" != "" ] && ["$sha" != "$calypsoSha" ]]; then
+if [[ "$calypsoSha" != "" ]] && [[ "$sha" != "$calypsoSha" ]]; then
     echo "Using calypsoSha envvar"
     sha=$calypsoSha
 fi

--- a/test/e2e/scripts/wait-for-running-branch.sh
+++ b/test/e2e/scripts/wait-for-running-branch.sh
@@ -11,9 +11,11 @@ if [[ "$calypsoSha" != "" ]] && [[ "$sha" != "$calypsoSha" ]]; then
 fi
 
 COUNT=0
+RESETATTEMPTS=0
 RESETCOUNT=240 # 5sec retry = Reset the branch after 20 minutes
 MAXCOUNT=360  # 5sec retry = Cancel after 30 minutes
 SITEWAITCOUNT=30 # 5sec retry = Stop waiting after 2.5 minutes
+MAXRESETATTEMPTS=1 # Limit reset attempts to one
 
 STATUS=$(curl https://hash-$sha.calypso.live/status 2>/dev/null)
 
@@ -32,6 +34,14 @@ until $(echo $STATUS | grep -wqe "Ready\|NeedsPriming" ); do
   elif [ $COUNT == $RESETCOUNT ]; then
     echo "Reached reset timeout, attempting to reset the branch"
     curl https://hash-$sha.calypso.live/?reset=true >/dev/null 2>&1
+  elif [[ "$STATUS" == "FAIL" ]] && [[ $RESETATTEMPTS < $MAXRESETATTEMPTS ]]; then
+    echo "Build Failed, attempting to reset the branch"
+    curl https://hash-$sha.calypso.live/?reset=true >/dev/null 2>&1
+    ((RESETATTEMPTS++))
+    sleep 20
+  elif [[ "$STATUS" == "FAIL" ]] && [[ $RESETATTEMPTS == $MAXRESETATTEMPTS ]]; then
+    echo "Build Failed, and has already been reset the maximimum number of times. Failing script."
+    exit 1
   fi
 
   # If it's still showing NotBuilt, then curl the branch directly rather than the status endpoint


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The wait script changes weren't working on calypso for canaries. They were passing though so that caused a false comfort.
* A FAIL status was added to dserve. I added a function to reset the build once when a FAIL status is received. If another FAIL status is received, the build will fail.

#### Testing instructions
* Ensure calypso wait works and passes in CI
* Ensure full suite wait works and passes in CI
* Locally (from test/e2e directory), try this command to ensure the script fails when a FAIL status is received twice
`CIRCLE_SHA1=bb45c300778f816f304cf73b6e9a8058abb94e20 ./scripts/wait-for-running-branch.sh`

