### PR TITLE
Make template preview area use system fonts

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 /* eslint-disable import/no-extraneous-dependencies */
 import { isEmpty, isArray, debounce } from 'lodash';
 /* eslint-enable import/no-extraneous-dependencies */
@@ -24,7 +23,6 @@ import BlockPreview from './block-preview';
 const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	const THRESHOLD_RESIZE = 300;
 
-	const previewElClasses = classnames( 'template-selector-preview', 'editor-styles-wrapper' );
 	const [ visibility, setVisibility ] = useState( 'hidden' );
 	const ref = useRef( null );
 
@@ -106,7 +104,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 	if ( isEmpty( blocks ) || ! isArray( blocks ) ) {
 		return (
-			<div className={ previewElClasses }>
+			<div className="template-selector-preview">
 				<div className="template-selector-preview__placeholder">
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
@@ -116,7 +114,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		<div className={ previewElClasses }>
+		<div className="template-selector-preview">
 			<Disabled>
 				<div ref={ ref } className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper" style={ { visibility } }>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview-test.js.snap
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview-test.js.snap
@@ -3,7 +3,7 @@
 exports[`TemplateSelectorPreview Basic rendering renders the preview when blocks are provided 1`] = `
 <div>
   <div
-    class="template-selector-preview editor-styles-wrapper"
+    class="template-selector-preview"
   >
     <div
       class="components-disabled"

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -412,11 +412,14 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 
 .template-selector-preview__placeholder {
 	position: absolute;
-	top: 50%;
+	top: 24%;
 	left: 50%;
 	transform: translateX( -50% );
 	width: 80%;
 	text-align: center;
+	font-size: 15px;
+	font-weight: 400;
+	color: var( --color-text-subtle );
 
 	@media screen and ( min-width: 1441px ) {
 		left: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removed the `editor-styles-wrapper` class from the Template Selector Preview to make it use system fonts instead of theme ones. This only affects the `Blank` template!

**Before**

![](https://cld.wthms.co/7HcbFa+)
![](https://cld.wthms.co/h36eCh+)
![](https://cld.wthms.co/g2noqh+)

**After**

![](https://cld.wthms.co/OuPc4P+)
![](https://cld.wthms.co/wlzqxu+)
![](https://cld.wthms.co/WWUrhX+)

#### Testing instructions

- Make sure you have Full Site Editing and Gutenberg plugins activated
- Go to `/wp-admin/post-new.php?post_type=page`
- Select the `Blank` theme preview
- You should see the `Select a page template to preview.` text inside the preview rendered with a system font (inherited from doc's `body`)

Fixes #37219
