### PR TITLE
Fix `isExternal` for falsy values.

### DIFF
--- a/client/lib/url/is-external.ts
+++ b/client/lib/url/is-external.ts
@@ -17,7 +17,7 @@ const BASE_URL = `http://${ BASE_HOSTNAME }`;
 export default function isExternal( url: URLString ): boolean {
 	// While TypeScript should ensure that `url` really is a string, this method
 	// is still used in a lot of JavaScript contexts, without type checks.
-	if ( ! url ) {
+	if ( ! url && url !== '' ) {
 		return true;
 	}
 

--- a/client/lib/url/is-external.ts
+++ b/client/lib/url/is-external.ts
@@ -17,7 +17,7 @@ const BASE_URL = `http://${ BASE_HOSTNAME }`;
 export default function isExternal( url: URLString ): boolean {
 	// While TypeScript should ensure that `url` really is a string, this method
 	// is still used in a lot of JavaScript contexts, without type checks.
-	if ( ! url && url !== '' ) {
+	if ( ! url ) {
 		return true;
 	}
 
@@ -34,7 +34,13 @@ export default function isExternal( url: URLString ): boolean {
 		url = '//' + url;
 	}
 
-	const { hostname, pathname } = new URL( url, BASE_URL );
+	let parsedUrl;
+	try {
+		parsedUrl = new URL( url, BASE_URL );
+	} catch {
+		return false;
+	}
+	const { hostname, pathname } = parsedUrl;
 
 	// Did we parse a relative URL?
 	if ( hostname === BASE_HOSTNAME ) {

--- a/client/lib/url/is-external.ts
+++ b/client/lib/url/is-external.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import config from 'config';
-import { URL as TypedURL } from 'types';
+import { URL as URLString } from 'types';
 
 /**
  * Internal dependencies
@@ -11,10 +11,16 @@ import { isLegacyRoute } from 'lib/route/legacy-routes';
 
 // Base URL used for URL parsing. The WHATWG URL API doesn't support relative
 // URLs, so we always need to provide a base of some sort.
-const BASE_HOSTNAME = 'base.invalid';
+const BASE_HOSTNAME = '__domain__.invalid';
 const BASE_URL = `http://${ BASE_HOSTNAME }`;
 
-export default function isExternal( url: TypedURL ): boolean {
+export default function isExternal( url: URLString ): boolean {
+	// While TypeScript should ensure that `url` really is a string, this method
+	// is still used in a lot of JavaScript contexts, without type checks.
+	if ( ! url && url !== '' ) {
+		return true;
+	}
+
 	// The url passed in might be of form `en.support.wordpress.com`,
 	// so for this function we'll append double-slashes to fake it.
 	// If it is a relative URL the hostname will be the base hostname.

--- a/client/lib/url/is-external.ts
+++ b/client/lib/url/is-external.ts
@@ -11,7 +11,7 @@ import { isLegacyRoute } from 'lib/route/legacy-routes';
 
 // Base URL used for URL parsing. The WHATWG URL API doesn't support relative
 // URLs, so we always need to provide a base of some sort.
-const BASE_HOSTNAME = '__domain__.invalid';
+const BASE_HOSTNAME = 'base.invalid';
 const BASE_URL = `http://${ BASE_HOSTNAME }`;
 
 export default function isExternal( url: URLString ): boolean {


### PR DESCRIPTION
Add an early return for non-string falsy values (the empty string can be processed normally).

While the typed method doesn't expect falsy values, the nature of JavaScript is that they can be passed in.

#### Changes proposed in this Pull Request

* Handle falsy values correctly in `isExternal`.

#### Testing instructions

The changes should be pretty innocuous, but it may be interesting to consult #100768-z, which this PR should fix. The live branch should make it easy to test the changes.