### PR TITLE
Gutenboarding: Simplify vertical state

### DIFF
--- a/client/landing/gutenboarding/store/actions.ts
+++ b/client/landing/gutenboarding/store/actions.ts
@@ -17,8 +17,7 @@ export const setSiteTitle = ( siteTitle: string ) => ( {
 	siteTitle,
 } );
 
-export const receiveVertical = ( search: string, verticals: Vertical[] ) => ( {
-	type: ActionType.RECEIVE_VERTICAL as const,
-	search,
+export const receiveVerticals = ( verticals: Vertical[] ) => ( {
+	type: ActionType.RECEIVE_VERTICALS as const,
 	verticals,
 } );

--- a/client/landing/gutenboarding/store/reducer.ts
+++ b/client/landing/gutenboarding/store/reducer.ts
@@ -33,21 +33,17 @@ const siteTitle: Reducer< string, ReturnType< typeof Actions[ 'setSiteTitle' ] >
 	return state;
 };
 
-// @TODO Normalize data: searches are lists of ids, ids stored in a map
-const verticalSearches: Reducer<
-	Record< string, Vertical[] >,
-	ReturnType< typeof Actions[ 'receiveVertical' ] >
-> = ( state = {}, action ) => {
-	if ( action.type === ActionType.RECEIVE_VERTICAL ) {
-		return {
-			...state,
-			[ action.search ]: action.verticals,
-		};
+const verticals: Reducer< Vertical[], ReturnType< typeof Actions[ 'receiveVerticals' ] > > = (
+	state = [],
+	action
+) => {
+	if ( action.type === ActionType.RECEIVE_VERTICALS ) {
+		return action.verticals;
 	}
 	return state;
 };
 
-const reducer = combineReducers( { siteType, siteTitle, verticalSearches } );
+const reducer = combineReducers( { siteType, siteTitle, verticals } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/client/landing/gutenboarding/store/resolvers.ts
+++ b/client/landing/gutenboarding/store/resolvers.ts
@@ -1,22 +1,18 @@
 /**
  * External dependencies
  */
-import { addQueryArgs } from '@wordpress/url';
 import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
  */
-import { receiveVertical } from './actions';
-import { TailParameters } from './types';
+import { receiveVerticals } from './actions';
 
-export function* getVertical(
-	search: TailParameters< typeof import('./selectors').getVertical >[ 0 ]
-) {
-	const url = addQueryArgs( 'https://public-api.wordpress.com/wpcom/v2/verticals', { search } );
+export function* getVerticals() {
+	const url = 'https://public-api.wordpress.com/wpcom/v2/verticals';
 
 	// @FIXME use generic fetch?
 	const verticals = yield apiFetch( { url } );
 
-	return receiveVertical( search, verticals );
+	return receiveVerticals( verticals );
 }

--- a/client/landing/gutenboarding/store/selectors.ts
+++ b/client/landing/gutenboarding/store/selectors.ts
@@ -4,4 +4,4 @@
 import { State } from './reducer';
 
 export const getState = ( state: State ) => state;
-export const getVertical = ( state: State, search: string ) => state.verticalSearches[ search ];
+export const getVerticals = ( state: State ) => state.verticals;

--- a/client/landing/gutenboarding/store/types.ts
+++ b/client/landing/gutenboarding/store/types.ts
@@ -1,6 +1,6 @@
 // With a _real_ TypeScript compiler, we could use const enums.
 /* const */ enum ActionType {
-	RECEIVE_VERTICAL = 'RECEIVE_VERTICAL',
+	RECEIVE_VERTICALS = 'RECEIVE_VERTICALS',
 	RESET_SITE_TYPE = 'RESET_SITE_TYPE',
 	SET_SITE_TITLE = 'SET_SITE_TITLE',
 	SET_SITE_TYPE = 'SET_SITE_TYPE',


### PR DESCRIPTION
All verticals are fetched and put into state. Simplify state to reflect this.

Observed in https://github.com/Automattic/wp-calypso/pull/37165#discussion_r341499708

#### Testing instructions

`wp.data.select('automattic/onboard').getVerticals()` lists the verticals once the resolver has completed the fetch.
