### PR TITLE
Domains DNS: promisify the addDns, deleteDns and applyDnsTemplate actions

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -43,11 +43,12 @@ function validateField( { name, value, type, domainName } ) {
 			return includes( [ 'tcp', 'udp', 'tls' ], value );
 		case 'weight':
 		case 'aux':
-		case 'port':
+		case 'port': {
 			const intValue = parseInt( value, 10 );
 			return intValue >= 0 && intValue <= 65535;
+		}
 		case 'service':
-			return value.match( /^[^\s\.]+$/ );
+			return value.match( /^[^\s.]+$/ );
 		default:
 			return true;
 	}
@@ -79,7 +80,7 @@ function isValidData( data, type ) {
 		case 'A':
 			return data.match( /^(\d{1,3}\.){3}\d{1,3}$/ );
 		case 'AAAA':
-			return data.match( /^[a-f0-9\:]+$/i );
+			return data.match( /^[a-f0-9:]+$/i );
 		case 'CNAME':
 		case 'MX':
 			return isValidDomain( data );
@@ -200,10 +201,6 @@ function addMissingWpcomRecords( domain, records ) {
 	return newRecords;
 }
 
-function isBeingProcessed( record ) {
-	return record.isBeingDeleted || record.isBeingAdded;
-}
-
 function isDeletingLastMXRecord( recordToDelete, records ) {
 	const currentMXRecords = filter( records, { type: 'MX' } );
 
@@ -215,6 +212,5 @@ export {
 	getNormalizedData,
 	removeDuplicateWpcomRecords,
 	validateAllFields,
-	isBeingProcessed,
 	isDeletingLastMXRecord,
 };

--- a/client/my-sites/domains/domain-management/dns/dns-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-list.jsx
@@ -66,12 +66,8 @@ class DnsList extends React.Component {
 			return;
 		}
 
-		deleteDnsAction( selectedDomainName, record, error => {
-			if ( error ) {
-				this.props.errorNotice(
-					error.message || translate( 'The DNS record has not been deleted.' )
-				);
-			} else {
+		deleteDnsAction( selectedDomainName, record ).then(
+			() => {
 				const successNoticeId = 'dns-list-success-notice';
 				this.props.successNotice( translate( 'The DNS record has been deleted.' ), {
 					id: successNoticeId,
@@ -83,24 +79,30 @@ class DnsList extends React.Component {
 						this.addDns( record );
 					},
 				} );
+			},
+			error => {
+				this.props.errorNotice(
+					error.message || translate( 'The DNS record has not been deleted.' )
+				);
 			}
-		} );
+		);
 	};
 
 	addDns( record ) {
 		const { translate } = this.props;
 
-		addDnsAction( this.props.selectedDomainName, record, error => {
-			if ( error ) {
-				this.props.errorNotice(
-					error.message || translate( 'The DNS record could not be restored.' )
-				);
-			} else {
+		addDnsAction( this.props.selectedDomainName, record ).then(
+			() => {
 				this.props.successNotice( translate( 'The DNS record has been restored.' ), {
 					duration: 5000,
 				} );
+			},
+			error => {
+				this.props.errorNotice(
+					error.message || translate( 'The DNS record could not be restored.' )
+				);
 			}
-		} );
+		);
 	}
 
 	isDomainConnectRecord( dnsRecord ) {

--- a/client/my-sites/domains/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record.jsx
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { isBeingProcessed } from 'lib/domains/dns';
 import DnsRecordsListItem from '../dns-records/item';
 
 class DnsRecord extends React.Component {
@@ -119,7 +118,7 @@ class DnsRecord extends React.Component {
 
 	render() {
 		const { dnsRecord } = this.props;
-		const disabled = isBeingProcessed( dnsRecord );
+		const disabled = dnsRecord.isBeingDeleted || dnsRecord.isBeingAdded;
 		const isAllowedToBeRemoved = ! dnsRecord.protected_field || 'MX' === dnsRecord.type;
 
 		return (

--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
@@ -43,20 +43,21 @@ class DomainConnectRecord extends React.Component {
 			type: 'TXT',
 		};
 
-		deleteDns( selectedDomainName, record, error => {
-			if ( error ) {
-				this.props.errorNotice(
-					error.message || translate( 'The Domain Connect record could not be disabled.' )
-				);
-			} else {
+		deleteDns( selectedDomainName, record ).then(
+			() => {
 				const successNoticeId = 'domain-connect-disable-success-notice';
 				this.props.successNotice( translate( 'The Domain Connect record has been disabled.' ), {
 					id: successNoticeId,
 					showDismiss: false,
 					duration: 5000,
 				} );
+			},
+			error => {
+				this.props.errorNotice(
+					error.message || translate( 'The Domain Connect record could not be disabled.' )
+				);
 			}
-		} );
+		);
 	};
 
 	enableDomainConnect() {
@@ -69,18 +70,19 @@ class DomainConnectRecord extends React.Component {
 
 		const normalizedData = getNormalizedData( record, this.props.selectedDomainName );
 
-		addDns( this.props.selectedDomainName, normalizedData, error => {
-			if ( error ) {
-				this.props.errorNotice(
-					error.message || translate( 'The Domain Connect record could not be enabled.' )
-				);
-			} else {
+		addDns( this.props.selectedDomainName, normalizedData ).then(
+			() => {
 				this.props.successNotice( translate( 'The Domain Connect record has been enabled.' ), {
 					showDismiss: false,
 					duration: 5000,
 				} );
+			},
+			error => {
+				this.props.errorNotice(
+					error.message || translate( 'The Domain Connect record could not be enabled.' )
+				);
 			}
-		} );
+		);
 	}
 
 	handleToggle = () => {

--- a/client/my-sites/domains/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/domains/domain-management/dns/email-provider.jsx
@@ -45,29 +45,24 @@ class EmailProvider extends Component {
 			variables = template.modifyVariables( variables );
 		}
 
-		applyDnsTemplate(
-			domain,
-			template.dnsTemplateProvider,
-			template.dnsTemplateService,
-			variables,
-			error => {
-				if ( error ) {
+		applyDnsTemplate( domain, template.dnsTemplateProvider, template.dnsTemplateService, variables )
+			.then(
+				() => {
+					this.props.successNotice(
+						translate( "Hooray! We've successfully added DNS records for this service." ),
+						{ duration: 5000 }
+					);
+				},
+				error => {
 					this.props.errorNotice(
 						error.message ||
 							translate( "We weren't able to add DNS records for this service. Please try again." )
 					);
-				} else {
-					this.props.successNotice(
-						translate( "Hooray! We've successfully added DNS records for this service." ),
-						{
-							duration: 5000,
-						}
-					);
 				}
-
+			)
+			.finally( () => {
 				this.setState( { submitting: false } );
-			}
-		);
+			} );
 	};
 
 	render() {


### PR DESCRIPTION
The `addDns`, `deleteDns` and `applyDnsTemplate` Flux actions no longer take a Node-style completion callback as the last argument, but instead return a Promise with the result. That's more Redux friendly, as the action is now similar to a Redux thunk that returns a Promise.

I removed the `isBeingProcessed` helper from `deleteDns`, as that's checked at the UI level (and disabling the delete button) and makes returning a Promise difficult. It would have to be a Promise that never resolves (analogous to the callback that's never called).

One of small safe steps towards Reduxifying the `DnsStore`.

**How to test:**
- verify adding and removing DNS records
- verify enabing and disabling the Domain Connect special record
- verify that applying a DNS template (G Suite, Office 365, Zoho) still works