### PR TITLE
Atomic Hosting: Change page title to SFTP & MySQL

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -28,8 +28,8 @@ import './style.scss';
 const Hosting = ( { translate, isDisabled } ) => {
 	return (
 		<Main className="hosting is-wide-layout">
-			<PageViewTracker path="hosting/:site" title="Hosting" />
-			<DocumentHead title={ translate( 'Hosting' ) } />
+			<PageViewTracker path="hosting-admin/:site" title="SFTP & MySQL" />
+			<DocumentHead title={ translate( 'SFTP & MySQL' ) } />
 			<SidebarNavigation />
 			{ isDisabled && (
 				<Banner

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -28,7 +28,7 @@ import './style.scss';
 const Hosting = ( { translate, isDisabled } ) => {
 	return (
 		<Main className="hosting is-wide-layout">
-			<PageViewTracker path="hosting-admin/:site" title="SFTP & MySQL" />
+			<PageViewTracker path="/hosting-admin/:site" title="SFTP & MySQL" />
 			<DocumentHead title={ translate( 'SFTP & MySQL' ) } />
 			<SidebarNavigation />
 			{ isDisabled && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the page title of the Atomic Hosting Dashboard so it's aligned with the title used in the sidebar.

| Before | After |
|---|---|
| <img width="422" alt="Screen Shot 2019-11-05 at 10 45 06" src="https://user-images.githubusercontent.com/1233880/68197142-04bce900-ffba-11e9-92b5-5509af9762d5.png"> | <img width="421" alt="Screen Shot 2019-11-05 at 10 46 12" src="https://user-images.githubusercontent.com/1233880/68197152-0be3f700-ffba-11e9-9ab8-4431e065507f.png"> |

It also updates the path used in the page view tracker to the new path `/hosting-admin/:site` added in #37183.

<img width="1069" alt="Screen Shot 2019-11-05 at 10 58 40" src="https://user-images.githubusercontent.com/1233880/68197935-69c50e80-ffbb-11e9-9f75-59f88d58b30b.png">


#### Testing instructions

* Create a new business site (only new sites can see the "SFTP & MySQL" section).
* Go to "Manage > SFTP & MySQL".
* Verify the page title (the name that appears in your browser's tab) reads as "SFTP & MySQL".
* Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug and reload the page.
* Verify that the appropriate page view instance is recorded: `/hosting-admin/:site`.
* Using the React devtools, inspect the title prop of the `<PageViewTracker>` component, and verify it's correct.

<img width="555" alt="Screen Shot 2019-11-05 at 11 01 24" src="https://user-images.githubusercontent.com/1233880/68198063-a1cc5180-ffbb-11e9-8b26-c33988a3d875.png">



