### PR TITLE
Add interval discount note to the product selector in Jetpack Connect flow

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -39,6 +39,7 @@ export default class extends React.Component {
 
 The following props can be passed to the Product Selector block:
 
+* `basePlansPath`: ( string ) Plans page base path.
 * `intervalType`: ( string ) Billing interval - `monthly`, `yearly` or `2yearly`.
 * `products`: ( array ) Products to render, each with the following structure:
 	* `title`: ( string ) Product title.

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -173,6 +173,6 @@ export default class extends React.Component {
 
 The following props can be passed to the Product Card Action component:
 
-* `intro`: ( string ) Intro text to be displayed above the action button
+* `intro`: ( string | element | node ) Intro text to be displayed above the action button. It can be a string, a node or a React element (e.g. `<Fragment>`)
 * `label`: ( string ) Action button text
 * `onClick`: ( func ) Action button click event handler

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -19,7 +19,7 @@ const ProductCardAction = ( { intro, label, onClick } ) => (
 );
 
 ProductCardAction.propTypes = {
-	intro: PropTypes.string,
+	intro: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -424,7 +424,7 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { intervalType, translate } = this.props;
+		const { basePlansPath, intervalType, translate } = this.props;
 
 		return (
 			<div className="plans-features-main__group is-narrow">
@@ -436,6 +436,7 @@ export class PlansFeaturesMain extends Component {
 				<ProductSelector
 					products={ JETPACK_PRODUCTS }
 					intervalType={ intervalType }
+					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }
 				/>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add interval discount note to the `<ProductSelector />` block
* Update readme files

Before:
![Screenshot 2019-11-05 at 13 27 57](https://user-images.githubusercontent.com/478735/68207832-1e692b00-ffd0-11e9-994d-c0fd865873b5.png)

After:
![Screenshot 2019-11-05 at 13 26 32](https://user-images.githubusercontent.com/478735/68207805-0d201e80-ffd0-11e9-8624-df56c53491c7.png)


#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/jetpack/connect/store/
* Confirm that there's a 'Save ... over monthly' note above the checkout button if the monthly billing interval is selected
* Confirm that there's a 'Save ... when you buy yearly' note above the checkout button if the yearly billing interval is selected
* Repeat for the other product option and confirm that the math is correct
* Go to http://calypso.localhost:3000/plans/yearly/ and select a Jetpack site that doesn't have the Jetpack Backup product yet
* Confirm there's no additional note above the checkout button

Fixes n/a
