### PR TITLE
Gutenboarding: add `isFilledFormValue` FormValue helper

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { SiteType, EMPTY_FORM_VALUE } from '../store/types';
+import { SiteType, hasValue } from '../store/types';
 import { STORE_KEY } from '../store';
 import './style.scss';
 
@@ -74,7 +74,7 @@ export default function OnboardingEdit() {
 
 			<div className="onboarding-block__question">
 				<span>{ NO__( 'I want to create a website ' ) }</span>
-				{ siteType === EMPTY_FORM_VALUE ? (
+				{ ! hasValue( siteType ) ? (
 					<ul className="onboarding-block__multi-question">
 						{ map( siteTypeOptions, ( label, value ) => (
 							<li key={ value }>
@@ -100,7 +100,7 @@ export default function OnboardingEdit() {
 				) }
 			</div>
 			{ /* FormTokenField sufficient for first round, but not ideal. Simpler component for single autocomplete is needed */ }
-			{ ( siteType !== EMPTY_FORM_VALUE || ! isEmpty( verticalLabel ) ) && (
+			{ ( hasValue( siteType ) || ! isEmpty( verticalLabel ) ) && (
 				<FormTokenField
 					label={ NO__( 'My site is about' ) }
 					maxLength={ 1 }

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { SiteType, hasValue } from '../store/types';
+import { SiteType, isFilledFormValue } from '../store/types';
 import { STORE_KEY } from '../store';
 import './style.scss';
 
@@ -74,7 +74,7 @@ export default function OnboardingEdit() {
 
 			<div className="onboarding-block__question">
 				<span>{ NO__( 'I want to create a website ' ) }</span>
-				{ ! hasValue( siteType ) ? (
+				{ ! isFilledFormValue( siteType ) ? (
 					<ul className="onboarding-block__multi-question">
 						{ map( siteTypeOptions, ( label, value ) => (
 							<li key={ value }>
@@ -99,7 +99,7 @@ export default function OnboardingEdit() {
 				) }
 			</div>
 			{ /* FormTokenField sufficient for first round, but not ideal. Simpler component for single autocomplete is needed */ }
-			{ ( hasValue( siteType ) || ! isEmpty( verticalLabel ) ) && (
+			{ ( isFilledFormValue( siteType ) || ! isEmpty( verticalLabel ) ) && (
 				<FormTokenField
 					label={ NO__( 'My site is about' ) }
 					maxLength={ 1 }

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -80,7 +80,6 @@ export default function OnboardingEdit() {
 							<li key={ value }>
 								<label>
 									<input
-										checked={ siteType === value }
 										name="onboarding_site_type"
 										onChange={ updateSiteType }
 										type="radio"

--- a/client/landing/gutenboarding/store/types.ts
+++ b/client/landing/gutenboarding/store/types.ts
@@ -15,7 +15,7 @@ export enum SiteType {
 
 export const EMPTY_FORM_VALUE = Object.freeze( {} );
 export type FormValue< T > = T | typeof EMPTY_FORM_VALUE;
-export function hasValue< T >( value: FormValue< T > ): value is T {
+export function isFilledFormValue< T >( value: FormValue< T > ): value is T {
 	return value !== EMPTY_FORM_VALUE;
 }
 

--- a/client/landing/gutenboarding/store/types.ts
+++ b/client/landing/gutenboarding/store/types.ts
@@ -13,8 +13,11 @@ export enum SiteType {
 	STORY = 'story',
 }
 
-export const EMPTY_FORM_VALUE = '';
+export const EMPTY_FORM_VALUE = Object.freeze( {} );
 export type FormValue< T > = T | typeof EMPTY_FORM_VALUE;
+export function hasValue< T >( value: FormValue< T > ): value is T {
+	return value !== EMPTY_FORM_VALUE;
+}
 
 export type Vertical = ApiVertical | UserVertical;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a unique, readonly empty object as the "empty" FormValue value
* Add `isFilledFormValue` [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types).

This removes some comparisons with an object that is often not unique `''` and which easily collides with other types. It also improves some encapsulation, not requiring comparison with `EMPTY_FORM_VALUE` constant directly in several files.

#### Testing instructions

* `/gutenboarding` continues to work well, gradually revealing steps as information is added.