### PR TITLE
Add primary color dark var to Jetpack Connect flow to fix focus state

### DIFF
--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -8,6 +8,7 @@
 	// Override global colors with accent variables
 	--color-primary: var( --color-accent-dark );
 	--color-primary-light: var( --color-accent-light );
+	--color-primary-dark: var( --color-accent-dark );
 
 	::selection {
 		color: var( --color-text-inverted );


### PR DESCRIPTION
This addresses one of the issues discovered in #37324

Before:
![Screen Shot on 2019-11-05 at 15-19-27](https://user-images.githubusercontent.com/478735/68215593-ccc89c80-ffdf-11e9-840d-6e9967bdeb8c.png)


After:
![Screen Shot on 2019-11-05 at 15-20-05](https://user-images.githubusercontent.com/478735/68215599-cf2af680-ffdf-11e9-9f1e-76b03a17162b.png)


#### Changes proposed in this Pull Request

* Add primary color dark variation to Jetpack Connect flow in order to fix focus state

#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/jetpack/connect/store/
* Try switching the billing interval and confirm that the button color in the focus/active state matches the Jetpack color scheme (dark green)

Fixes n/a
