### PR TITLE
Update Calypso to use a site specific connections endpoint

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -871,6 +871,25 @@ Undocumented.prototype.metaKeyring = function( fn ) {
 };
 
 /**
+ * Return a list of third-party services that WordPress.com can integrate with for a specific site
+ *
+ * @param {int|string} siteId The site ID or domain
+ * @param {Function} fn The callback function
+ * @return {Promise} A Promise to resolve when complete
+ * @api public
+ */
+Undocumented.prototype.sitesExternalServices = function( siteId, fn ) {
+	debug( '/sites/:site-id:/external-services query' );
+	return this.wpcom.req.get(
+		{
+			path: '/sites/' + siteId + '/external-services/',
+			apiVersion: '1.1',
+		},
+		fn
+	);
+};
+
+/**
  * Return a list of happiness engineers gravatar urls
  *
  * @param {Function} fn The callback function

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -878,12 +878,13 @@ Undocumented.prototype.metaKeyring = function( fn ) {
  * @return {Promise} A Promise to resolve when complete
  * @api public
  */
+
 Undocumented.prototype.sitesExternalServices = function( siteId, fn ) {
 	debug( '/sites/:site-id:/external-services query' );
 	return this.wpcom.req.get(
 		{
 			path: '/sites/' + siteId + '/external-services/',
-			apiVersion: '1.1',
+			apiNamespace: 'wpcom/v2',
 		},
 		fn
 	);

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -883,7 +883,7 @@ Undocumented.prototype.sitesExternalServices = function( siteId, fn ) {
 	debug( '/sites/:site-id:/external-services query' );
 	return this.wpcom.req.get(
 		{
-			path: '/sites/' + siteId + '/external-services/',
+			path: '/sites/' + siteId + '/external-services',
 			apiNamespace: 'wpcom/v2',
 		},
 		fn

--- a/client/state/sharing/services/actions.js
+++ b/client/state/sharing/services/actions.js
@@ -11,6 +11,7 @@ import {
 	KEYRING_SERVICES_REQUEST_FAILURE,
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Triggers a network request for Keyring services.
@@ -18,14 +19,15 @@ import {
  * @return {Function} Action thunk
  */
 export function requestKeyringServices() {
-	return dispatch => {
+	return ( dispatch, getState ) => {
 		dispatch( {
 			type: KEYRING_SERVICES_REQUEST,
 		} );
 
+		const siteId = getSelectedSiteId( getState() );
 		return wpcom
 			.undocumented()
-			.metaKeyring()
+			.sitesExternalServices( siteId )
 			.then( response => {
 				dispatch( {
 					type: KEYRING_SERVICES_RECEIVE,

--- a/client/state/sharing/services/test/actions.js
+++ b/client/state/sharing/services/test/actions.js
@@ -21,14 +21,14 @@ import { useSandbox } from 'test/helpers/use-sinon';
 describe( 'actions', () => {
 	let spy;
 	useSandbox( sandbox => ( spy = sandbox.spy() ) );
-	const getState = () => ( {} );
+	const getState = () => ( { ui: { selectedSiteId: '2916284' } } );
 
 	describe( 'requestKeyringServices()', () => {
 		describe( 'successful requests', () => {
 			useNock( nock => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/meta/external-services/' )
+					.get( '/wpcom/v2/sites/2916284/external-services' )
 					.reply( 200, {
 						services: {
 							facebook: { ID: 'facebook' },
@@ -70,7 +70,7 @@ describe( 'actions', () => {
 			useNock( nock => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/meta/external-services/' )
+					.get( '/wpcom/v2/sites/2916284/external-services' )
 					.reply( 500, {
 						error: 'server_error',
 						message: 'A server error occurred',

--- a/client/state/sharing/services/test/actions.js
+++ b/client/state/sharing/services/test/actions.js
@@ -21,6 +21,7 @@ import { useSandbox } from 'test/helpers/use-sinon';
 describe( 'actions', () => {
 	let spy;
 	useSandbox( sandbox => ( spy = sandbox.spy() ) );
+	const getState = () => ( {} );
 
 	describe( 'requestKeyringServices()', () => {
 		describe( 'successful requests', () => {
@@ -37,7 +38,7 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch fetch action when thunk triggered', () => {
-				requestKeyringServices()( spy );
+				requestKeyringServices()( spy, getState );
 
 				expect( spy ).to.have.been.calledWith( {
 					type: KEYRING_SERVICES_REQUEST,
@@ -45,7 +46,7 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch keyring services receive action when request completes', () => {
-				return requestKeyringServices()( spy ).then( () => {
+				return requestKeyringServices()( spy, getState ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: KEYRING_SERVICES_RECEIVE,
 						services: {
@@ -57,7 +58,7 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch keyring services request success action when request completes', () => {
-				return requestKeyringServices()( spy ).then( () => {
+				return requestKeyringServices()( spy, getState ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: KEYRING_SERVICES_REQUEST_SUCCESS,
 					} );
@@ -77,7 +78,7 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch fetch action when thunk triggered', () => {
-				requestKeyringServices()( spy );
+				requestKeyringServices()( spy, getState );
 
 				expect( spy ).to.have.been.calledWith( {
 					type: KEYRING_SERVICES_REQUEST,
@@ -85,7 +86,7 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch keyring services request fail action when request fails', () => {
-				return requestKeyringServices()( spy ).then( () => {
+				return requestKeyringServices()( spy, getState ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: KEYRING_SERVICES_REQUEST_FAILURE,
 						error: sinon.match( { message: 'A server error occurred' } ),

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -112,7 +112,19 @@
 			"requires": {
 				"prop-types": "^15.7.2",
 				"react": "^16.8.6",
+				"react-stripe-elements": "^5.1.0",
 				"styled-components": "4.4.0"
+			},
+			"dependencies": {
+				"react-stripe-elements": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",
+					"integrity": "sha512-4UlzOLNdbJsZr4JwbTdJjxhedAfalDDtfEYLHEBo0MKG0KgSLRAeIJup0/6NSpKtBLK4ieOMAwvyln9ICOSilQ==",
+					"dev": true,
+					"requires": {
+						"prop-types": "15.7.2"
+					}
+				}
 			}
 		},
 		"@automattic/format-currency": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates /marketing/connections to use a site specific version of the `/meta/external-services` endpoint at `/sites/%s/external-services`.

#### Testing instructions

* Apply the patch D35059
* Check that you can still make connections at /marketing/connections

