### PR TITLE
Checkout-composite: Add initial Modal component

### DIFF
--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -58,7 +58,7 @@ const CallToAction = styled.button`
 		box-shadow: ${ getBoxShadowHover }
 		text-decoration: none;
 		color: ${ props =>
-			props.buttonState === 'default' ? props.theme.color.surface : getTextColor( props ) }
+			props.buttonState === 'default' ? props.theme.colors.surface : getTextColor( props ) }
 		cursor: ${ ( { buttonState } ) =>
 			buttonState && buttonState.includes( 'disabled' ) ? 'not-allowed' : 'pointer' }
 	}
@@ -158,7 +158,7 @@ function getTextColor( { buttonState, theme } ) {
 		case 'disabled':
 			return colors.disabledButtons;
 		default:
-			return colors.highlight;
+			return colors.textColor;
 	}
 }
 
@@ -201,7 +201,7 @@ function getBorderColor( { buttonType, buttonState, theme } ) {
 			}
 			return colors.disabledButtons;
 		default:
-			return colors.highlight;
+			return colors.borderColor;
 	}
 }
 

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -17,19 +17,32 @@ export default function CheckoutModal( {
 	title,
 	copy,
 	primaryAction,
+	closeModal,
 	isVisible,
 	buttonCTA,
+	cancelButtonCTA,
 } ) {
 	const localize = useLocalize();
+	useEffect( () => {
+		if ( isVisible ) {
+			document.body.style = 'overflow: hidden';
+			document.addEventListener(
+				'keydown',
+				key => {
+					handleKeyPress( key, closeModal );
+				},
+				false
+			);
+
+			return;
+		}
+
+		document.body.style = 'overflow: scroll';
+	} );
 
 	if ( ! isVisible ) {
-		//return null;
+		return null;
 	}
-
-	useEffect( () => {
-		document.body.style = 'overflow:hidden';
-		document.addEventListener( 'keydown', handleKeyPress, false );
-	} );
 
 	return (
 		<CheckoutModalWrapper
@@ -37,21 +50,17 @@ export default function CheckoutModal( {
 			onClick={ closeModal }
 		>
 			<CheckoutModalContent className="checkout-modal__content" onClick={ preventClose }>
-				<CheckoutModalTitle className="checkout-modal__title">
-					{ title || 'Modal Title' }
-				</CheckoutModalTitle>
-				<CheckoutModalCopy className="checkout-modal__copy">
-					{ copy || 'Copy goes here' }
-				</CheckoutModalCopy>
+				<CheckoutModalTitle className="checkout-modal__title">{ title }</CheckoutModalTitle>
+				<CheckoutModalCopy className="checkout-modal__copy">{ copy }</CheckoutModalCopy>
 
 				<CheckoutModalActions>
 					<Button buttonState="default" onClick={ closeModal }>
-						Cancel
+						{ cancelButtonCTA || localize( 'Cancel' ) }
 					</Button>
 					<Button
 						buttonState="primary"
 						onClick={ () => {
-							handlePrimaryAction( primaryAction );
+							handlePrimaryAction( primaryAction, closeModal );
 						} }
 					>
 						{ buttonCTA || localize( 'Continue' ) }
@@ -63,12 +72,14 @@ export default function CheckoutModal( {
 }
 
 CheckoutModal.propTypes = {
+	closeModal: PropTypes.func.isRequired,
+	title: PropTypes.string.isRequired,
+	copy: PropTypes.string.isRequired,
+	primaryAction: PropTypes.func.isRequired,
+	isVisible: PropTypes.bool.isRequired,
 	className: PropTypes.string,
-	title: PropTypes.string,
-	copy: PropTypes.string,
-	primaryAction: PropTypes.func,
-	isVisible: PropTypes.bool,
 	buttonCTA: PropTypes.string,
+	cancelButtonCTA: PropTypes.string,
 };
 
 const fadeIn = keyframes`
@@ -142,25 +153,16 @@ const CheckoutModalActions = styled.div`
 	}
 `;
 
-function closeModal() {
-	alert( 'close' );
-
-	//TODO: set isVisible to false
-}
-
-function handlePrimaryAction( primaryAction ) {
-	alert( 'Action' );
-
-	if ( primaryAction ) {
-		primaryAction();
-	}
+function handlePrimaryAction( primaryAction, closeModal ) {
+	primaryAction();
+	closeModal();
 }
 
 function preventClose( event ) {
 	event.stopPropagation();
 }
 
-function handleKeyPress( key ) {
+function handleKeyPress( key, closeModal ) {
 	if ( key.keyCode === 27 ) {
 		closeModal();
 	}

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -23,22 +23,7 @@ export default function CheckoutModal( {
 	cancelButtonCTA,
 } ) {
 	const localize = useLocalize();
-	useEffect( () => {
-		if ( isVisible ) {
-			document.body.style = 'overflow: hidden';
-			document.addEventListener(
-				'keydown',
-				key => {
-					handleKeyPress( key, closeModal );
-				},
-				false
-			);
-
-			return;
-		}
-
-		document.body.style = 'overflow: scroll';
-	} );
+	useModalScreen( isVisible, closeModal );
 
 	if ( ! isVisible ) {
 		return null;
@@ -95,7 +80,7 @@ const fadeIn = keyframes`
 const animateIn = keyframes`
   from {
     opacity: 0;
-    transform: scale(1.08);
+    transform: scale(1.05);
   }
 
   to {
@@ -162,8 +147,22 @@ function preventClose( event ) {
 	event.stopPropagation();
 }
 
-function handleKeyPress( key, closeModal ) {
-	if ( key.keyCode === 27 ) {
-		closeModal();
-	}
+function useModalScreen( isVisible, closeModal ) {
+	useEffect( () => {
+		document.body.style = isVisible ? 'overflow: hidden' : 'overflow: scroll';
+		const keyPressHandler = makeHandleKeyPress( closeModal );
+		if ( isVisible ) {
+			document.addEventListener( 'keydown', keyPressHandler, false );
+		}
+		return () => document.removeEventListener( 'keydown', keyPressHandler, false );
+	}, [ isVisible, closeModal ] );
+}
+
+function makeHandleKeyPress( closeModal ) {
+	const escapeKey = 27;
+	return key => {
+		if ( key.keyCode === escapeKey ) {
+			closeModal();
+		}
+	};
 }

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import styled, { keyframes } from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import joinClasses from '../lib/join-classes';
+import Button from './button';
+import { useLocalize } from '../lib/localize';
+
+export default function CheckoutModal( {
+	className,
+	title,
+	copy,
+	primaryAction,
+	isVisible,
+	buttonCTA,
+} ) {
+	const localize = useLocalize();
+
+	if ( ! isVisible ) {
+		//return null;
+	}
+
+	useEffect( () => {
+		document.body.style = 'overflow:hidden';
+		document.addEventListener( 'keydown', handleKeyPress, false );
+	} );
+
+	return (
+		<CheckoutModalWrapper
+			className={ joinClasses( [ className, 'checkout-modal' ] ) }
+			onClick={ closeModal }
+		>
+			<CheckoutModalContent className="checkout-modal__content" onClick={ preventClose }>
+				<CheckoutModalTitle className="checkout-modal__title">
+					{ title || 'Modal Title' }
+				</CheckoutModalTitle>
+				<CheckoutModalCopy className="checkout-modal__copy">
+					{ copy || 'Copy goes here' }
+				</CheckoutModalCopy>
+
+				<CheckoutModalActions>
+					<Button buttonState="default" onClick={ closeModal }>
+						Cancel
+					</Button>
+					<Button
+						buttonState="primary"
+						onClick={ () => {
+							handlePrimaryAction( primaryAction );
+						} }
+					>
+						{ buttonCTA || localize( 'Continue' ) }
+					</Button>
+				</CheckoutModalActions>
+			</CheckoutModalContent>
+		</CheckoutModalWrapper>
+	);
+}
+
+CheckoutModal.propTypes = {
+	className: PropTypes.string,
+	title: PropTypes.string,
+	copy: PropTypes.string,
+	primaryAction: PropTypes.func,
+	isVisible: PropTypes.bool,
+	buttonCTA: PropTypes.string,
+};
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+`;
+
+const animateIn = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(1.08);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
+const CheckoutModalWrapper = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	background: ${props => props.theme.colors.modalBackground};
+	width: 100%;
+	height: 100vh;
+	z-index: 999;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	animation: ${fadeIn} 0.2s ease-out;
+	animation-fill-mode: backwards;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+`;
+
+const CheckoutModalContent = styled.div`
+	background: ${props => props.theme.colors.surface};
+	display: block;
+	width: 100%;
+	max-width: 300px;
+	padding: 32px;
+	animation: ${animateIn} 0.2s 0.1s ease-out;
+	animation-fill-mode: backwards;
+`;
+
+const CheckoutModalTitle = styled.h1`
+	margin: 0 0 16px;
+	font-weight: ${props => props.theme.weights.normal};
+	font-size: 24px;
+	color: ${props => props.theme.colors.textColor};
+`;
+
+const CheckoutModalCopy = styled.p`
+	margin: 0;
+`;
+
+const CheckoutModalActions = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 24px;
+
+	button:first-child {
+		margin-right: 8px;
+	}
+`;
+
+function closeModal() {
+	alert( 'close' );
+
+	//TODO: set isVisible to false
+}
+
+function handlePrimaryAction( primaryAction ) {
+	alert( 'Action' );
+
+	if ( primaryAction ) {
+		primaryAction();
+	}
+}
+
+function preventClose( event ) {
+	event.stopPropagation();
+}
+
+function handleKeyPress( key ) {
+	if ( key.keyCode === 27 ) {
+		closeModal();
+	}
+}

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -16,7 +16,6 @@ import { usePaymentData, usePaymentMethod, usePaymentMethodId } from '../lib/pay
 import CheckoutNextStepButton from './checkout-next-step-button';
 import CheckoutReviewOrder from './checkout-review-order';
 import CheckoutSubmitButton from './checkout-submit-button';
-import CheckoutModal from './checkout-modal';
 
 export default function Checkout( {
 	availablePaymentMethods,
@@ -43,8 +42,6 @@ export default function Checkout( {
 
 	return (
 		<Container className={ joinClasses( [ className, 'checkout' ] ) }>
-			<CheckoutModal />
-
 			<MainContent>
 				<div>
 					{ CheckoutHeader ? (

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -16,6 +16,7 @@ import { usePaymentData, usePaymentMethod, usePaymentMethodId } from '../lib/pay
 import CheckoutNextStepButton from './checkout-next-step-button';
 import CheckoutReviewOrder from './checkout-review-order';
 import CheckoutSubmitButton from './checkout-submit-button';
+import CheckoutModal from './checkout-modal';
 
 export default function Checkout( {
 	availablePaymentMethods,
@@ -42,6 +43,8 @@ export default function Checkout( {
 
 	return (
 		<Container className={ joinClasses( [ className, 'checkout' ] ) }>
+			<CheckoutModal />
+
 			<MainContent>
 				<div>
 					{ CheckoutHeader ? (

--- a/packages/composite-checkout/src/theme.js
+++ b/packages/composite-checkout/src/theme.js
@@ -27,6 +27,7 @@ const theme = {
 		applePayButtonRollOverColor: swatches.gray80,
 		paypalGold: '#F0C443',
 		paypalGoldHover: '#FFB900',
+		modalBackground: 'rgba( 0,0,0,0.4 )',
 	},
 	breakpoints: {
 		tabletUp: 'min-width: 700px',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the modal component. 

![image](https://user-images.githubusercontent.com/6981253/68227378-92500700-ffc1-11e9-9f22-c212850e8c50.png)

To use the modal you have to setup a state in the component you want to use it in:  
```
const [ isModalVisible, setIsModalVisible ] = useState( false );
```

Then you add the `CheckoutModal` component in the render function:

```
<CheckoutModal 
  isVisible={ isModalVisible }
  closeModal={ () => { setIsModalVisible( false ) } }
  primaryAction={ PRIMARYACTIONGOESHERE } 
  title="Hello world"
  copy="This is the copy that would show here" />		
```

And lastly, you show hide the modal by toggling the state with a button click or page event.

```
setIsModalVisible( ! isModalVisible )
```

#### Testing instructions
- Try add a modal to any component. 
- Then run these steps: https://github.com/Automattic/wp-calypso/pull/37013
