### PR TITLE
Remove i18n-calypso moment from lib/human-date.

### DIFF
--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -1,14 +1,18 @@
 /**
  * External dependencies
  */
-
 import i18n from 'i18n-calypso';
+import moment from 'moment';
 
 const MILLIS_IN_MINUTE = 60 * 1000;
 
-export default function humanDate( dateOrMoment, dateFormat = 'll' ) {
-	const now = i18n.moment();
-	dateOrMoment = i18n.moment( dateOrMoment );
+export default function humanDate(
+	dateOrMoment,
+	dateFormat = 'll',
+	locale = i18n.getLocaleSlug()
+) {
+	const now = moment().locale( locale );
+	dateOrMoment = moment( dateOrMoment ).locale( locale );
 
 	let millisAgo = now.diff( dateOrMoment );
 	if ( millisAgo < 0 ) {

--- a/client/lib/human-date/test/index.js
+++ b/client/lib/human-date/test/index.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import humanDate from '..';
+
+describe( 'humanDate', () => {
+	it( 'should work without a provided format or locale', () => {
+		const now = new Date();
+		expect( humanDate( now ) ).not.toBeFalsy();
+	} );
+
+	it( 'should work without a provided locale', () => {
+		const now = new Date();
+		expect( humanDate( now, 'll' ) ).not.toBeFalsy();
+	} );
+
+	it( 'should return relative strings for recent dates', () => {
+		const aSecondAndHalfAgo = new Date( Date.now() - 1500 );
+		expect( humanDate( aSecondAndHalfAgo, 'll', 'en' ) ).toBe( 'just now' );
+		expect( humanDate( aSecondAndHalfAgo, 'l', 'en' ) ).toBe( 'just now' );
+
+		const aMinuteAndHalfAgo = new Date( Date.now() - 90 * 1000 );
+		expect( humanDate( aMinuteAndHalfAgo, 'll', 'en' ) ).toBe( '2m ago' );
+		expect( humanDate( aMinuteAndHalfAgo, 'l', 'en' ) ).toBe( '2m ago' );
+
+		const anHourAndHalfAgo = new Date( Date.now() - 90 * 60 * 1000 );
+		expect( humanDate( anHourAndHalfAgo, 'll', 'en' ) ).toBe( '1h ago' );
+		expect( humanDate( anHourAndHalfAgo, 'l', 'en' ) ).toBe( '1h ago' );
+
+		const aDayAndHalfAgo = new Date( Date.now() - 36 * 60 * 60 * 1000 );
+		expect( humanDate( aDayAndHalfAgo, 'll', 'en' ) ).toBe( '1d ago' );
+		expect( humanDate( aDayAndHalfAgo, 'l', 'en' ) ).toBe( '1d ago' );
+	} );
+
+	it( 'should return a formatted date for dates older than a week', () => {
+		const thirtyDaysAgo = new Date( '2000-01-01' );
+		expect( humanDate( thirtyDaysAgo, 'll', 'en' ) ).toBe( 'Jan 1, 2000' );
+		expect( humanDate( thirtyDaysAgo, 'l', 'en' ) ).toBe( '1/1/2000' );
+	} );
+} );


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

It switches `lib/human-date` to vanilla `moment` with the current locale slug retrieved from `i18n-calypso`. It also adds some basic tests for the lib.

Please feel free to add whomever you feel should be included in the reviewers list.

#### Changes proposed in this Pull Request

* Replace `i18n-calypso` `moment` with vanilla `moment` (locale set from `i18n-calypso`).
* Add some basic tests for the lib.

#### Testing instructions

There's not a lot of need for testing, as the changes are fairly self-contained, and the new unit tests do a lot of the work.

To ensure that this doesn't break localisation, you can:
- Change your default language, in your profile settings
- Open the `TimeSince` component (which makes use of this library) at `/devdocs/design/time-since`
- Ensure that both the relative and absolute dates are displayed according to your chosen locale
