### PR TITLE
Add: Consistent page headings to improve wayfinding

### DIFF
--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -18,18 +18,12 @@ import { preventWidows } from 'lib/formatting';
  */
 import './style.scss';
 
-function FormattedHeader( {
-	id,
-	headerText,
-	subHeaderText,
-	className,
-	compactOnMobile,
-	leftAlign,
-} ) {
+function FormattedHeader( { id, headerText, subHeaderText, className, compactOnMobile, align } ) {
 	const classes = classNames( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
 		'is-compact-on-mobile': compactOnMobile,
-		'is-left-align': leftAlign,
+		'is-left-align': 'left' === align,
+		'is-right-align': 'right' === align,
 	} );
 
 	return (
@@ -46,6 +40,7 @@ FormattedHeader.propTypes = {
 	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
 	compactOnMobile: PropTypes.bool,
+	align: PropTypes.string,
 };
 
 export default FormattedHeader;

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -18,10 +18,18 @@ import { preventWidows } from 'lib/formatting';
  */
 import './style.scss';
 
-function FormattedHeader( { id, headerText, subHeaderText, className, compactOnMobile } ) {
+function FormattedHeader( {
+	id,
+	headerText,
+	subHeaderText,
+	className,
+	compactOnMobile,
+	leftAlign,
+} ) {
 	const classes = classNames( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
 		'is-compact-on-mobile': compactOnMobile,
+		'is-left-align': leftAlign,
 	} );
 
 	return (

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -9,6 +9,15 @@
 			margin-bottom: 24px;
 		}
 	}
+
+	&.is-left-align {
+		text-align: left;
+		margin: 16px;
+
+		@include breakpoint( '>660px' ) {
+			margin: 0 0 16px;
+		}
+	}
 }
 
 .formatted-header__title {

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -10,13 +10,21 @@
 		}
 	}
 
-	&.is-left-align {
-		text-align: left;
+	&.is-left-align,
+	&.is-right-align {
 		margin: 16px;
 
 		@include breakpoint( '>660px' ) {
 			margin: 0 0 16px;
 		}
+	}
+
+	&.is-left-align {
+		text-align: left;
+	}
+
+	&.is-right-align {
+		text-align: right;
 	}
 }
 
@@ -31,7 +39,8 @@
 		margin: 0 0 5px;
 	}
 
-	.is-left-align & {
+	.is-left-align &,
+	.is-right-align & {
 		margin-top: 0;
 		padding: 0;
 	}
@@ -46,7 +55,8 @@
 		padding: 0;
 	}
 
-	.is-left-align & {
+	.is-left-align &,
+	.is-right-align & {
 		padding: 0;
 	}
 }

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -29,12 +29,13 @@
 }
 
 .formatted-header__title {
-	font-size: 24px;
+	font-size: 20px;
 	margin-top: 24px;
 	padding: 0 10px;
 	line-height: 1.2em;
 
 	@include breakpoint( '>660px' ) {
+		font-size: 24px;
 		padding: 0;
 		margin: 0 0 5px;
 	}

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -22,27 +22,32 @@
 
 .formatted-header__title {
 	font-size: 24px;
-	margin: 0 0 5px;
+	margin-top: 24px;
+	padding: 0 10px;
+	line-height: 1.2em;
 
-	@include breakpoint( '<660px' ) {
-		line-height: 1.2em;
-		padding: 0 10px;
-		margin-top: 24px;
+	@include breakpoint( '>660px' ) {
+		padding: 0;
+		margin: 0 0 5px;
 	}
 
-	@include breakpoint( '<480px' ) {
-		line-height: 1.2em;
-		padding: 0 10px;
+	.is-left-align & {
+		margin-top: 0;
+		padding: 0;
 	}
 }
 
 .formatted-header__subtitle {
 	color: var( --color-neutral-50 );
 	font-size: 14px;
+	padding: 0 20px 24px;
 
-	@include breakpoint( '<480px' ) {
-		margin: 0;
-		padding: 0 20px 24px;
+	@include breakpoint( '>480px' ) {
+		padding: 0;
+	}
+
+	.is-left-align & {
+		padding: 0;
 	}
 }
 

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -26,12 +26,9 @@ function SidebarNavigation( { title, sectionTitle, children, toggleSidebar } ) {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<header className="current-section">
 			<button onClick={ toggleSidebar }>
-				<Gridicon icon="chevron-left" />
+				<Gridicon icon="menu" />
 				{ children }
-				<div>
-					<p className="current-section__group-title">{ sectionTitle }</p>
-					<h1 className="current-section__section-title">{ title }</h1>
-				</div>
+				<h1 className="current-section__site-title">{ sectionTitle }</h1>
 			</button>
 		</header>
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
@@ -39,15 +36,12 @@ function SidebarNavigation( { title, sectionTitle, children, toggleSidebar } ) {
 }
 
 SidebarNavigation.propTypes = {
-	title: TranslatableString,
 	sectionTitle: TranslatableString,
 	toggleSidebar: PropTypes.func.isRequired,
 };
 
 export default connect(
-	state => ( {
-		title: getDocumentHeadTitle( state ),
-	} ),
+	null,
 	{
 		toggleSidebar: () => setLayoutFocus( 'sidebar' ),
 	}

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -12,7 +12,6 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal Dependencies
  */
-import { getDocumentHeadTitle } from 'state/document-head/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import TranslatableString from 'components/translatable/proptype';
 
@@ -21,7 +20,7 @@ import TranslatableString from 'components/translatable/proptype';
  */
 import './style.scss';
 
-function SidebarNavigation( { title, sectionTitle, children, toggleSidebar } ) {
+function SidebarNavigation( { sectionTitle, children, toggleSidebar } ) {
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<header className="current-section">

--- a/client/components/sidebar-navigation/style.scss
+++ b/client/components/sidebar-navigation/style.scss
@@ -24,7 +24,7 @@
 		width: 100%;
 	}
 
-	.gridicon {
+	.gridicons-menu {
 		color: var( --color-neutral-light );
 		margin: 0 8px;
 	}

--- a/client/components/sidebar-navigation/style.scss
+++ b/client/components/sidebar-navigation/style.scss
@@ -12,6 +12,7 @@
 	button {
 		display: flex;
 		justify-content: flex-start;
+		align-items: center;
 		cursor: pointer;
 		padding: 8px 0;
 		color: var( --color-neutral-70 );
@@ -23,15 +24,18 @@
 		width: 100%;
 	}
 
-	.gridicons-chevron-left {
+	.gridicon {
 		color: var( --color-neutral-light );
 		margin: 0 8px;
-		align-self: center;
 	}
+}
 
-	.current-section__group-title {
-		font-size: 10px;
-		color: var( --color-neutral-40 );
-		margin: 2px 0 -3px;
+.layout__page-title {
+	font-size: 24px;
+	font-weight: 300;
+	margin: 16px;
+
+	@include breakpoint( '>660px' ) {
+		margin: 0 0 8px;
 	}
 }

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -38,6 +38,7 @@ import QuerySiteSettings from 'components/data/query-site-settings'; // For site
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import RewindUnavailabilityNotice from './rewind-unavailability-notice';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -408,6 +409,12 @@ class ActivityLog extends Component {
 				) }
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
+
+				<FormattedHeader
+					className="activity-log__page-heading"
+					headerText={ translate( 'Activity' ) }
+					leftAlign
+				/>
 
 				{ siteId && isJetpack && ! isAtomic && <RewindAlerts siteId={ siteId } /> }
 				{ siteId && 'unavailable' === rewindState.state && (

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -413,7 +413,7 @@ class ActivityLog extends Component {
 				<FormattedHeader
 					className="activity-log__page-heading"
 					headerText={ translate( 'Activity' ) }
-					leftAlign
+					align="left"
 				/>
 
 				{ siteId && isJetpack && ! isAtomic && <RewindAlerts siteId={ siteId } /> }

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -104,7 +104,7 @@ export class CommentsManagement extends Component {
 					<FormattedHeader
 						className="comments__page-heading"
 						headerText={ translate( 'Comments' ) }
-						leftAlign
+						align="left"
 					/>
 				) }
 				{ ! showJetpackUpdateScreen && showPermissionError && (

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -20,6 +20,7 @@ import DocumentHead from 'components/data/document-head';
 import CommentList from './comment-list';
 import CommentTree from './comment-tree';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { preventWidows } from 'lib/formatting';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
@@ -87,6 +88,7 @@ export class CommentsManagement extends Component {
 				{ showJetpackUpdateScreen && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 				<PageViewTracker path={ analyticsPath } title="Comments" />
 				<DocumentHead title={ translate( 'Comments' ) } />
+				<SidebarNavigation />
 				{ showJetpackUpdateScreen && (
 					<EmptyContent
 						title={ preventWidows( translate( "Looking to manage this site's comments?" ) ) }
@@ -98,7 +100,13 @@ export class CommentsManagement extends Component {
 						actionCallback={ this.updateJetpackHandler }
 					/>
 				) }
-				{ ! showJetpackUpdateScreen && <SidebarNavigation /> }
+				{ ! showJetpackUpdateScreen && ! showPermissionError && (
+					<FormattedHeader
+						className="comments__page-heading"
+						headerText={ translate( 'Comments' ) }
+						leftAlign
+					/>
+				) }
 				{ ! showJetpackUpdateScreen && showPermissionError && (
 					<EmptyContent
 						title={ preventWidows(

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -174,7 +174,7 @@ export class List extends React.Component {
 				<FormattedHeader
 					className="domain-management__page-heading"
 					headerText={ this.props.translate( 'Domains' ) }
-					leftAlign
+					align="left"
 				/>
 				<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
 				{ this.domainWarnings() }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -50,6 +50,7 @@ import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 import { type } from 'lib/domains/constants';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
 
 /**
  * Style dependencies
@@ -170,6 +171,11 @@ export class List extends React.Component {
 			<Main wideLayout>
 				<DocumentHead title={ headerText } />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="domain-management__page-heading"
+					headerText={ this.props.translate( 'Domains' ) }
+					leftAlign
+				/>
 				<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
 				{ this.domainWarnings() }
 

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -190,7 +190,7 @@ class EarningsMain extends Component {
 				<FormattedHeader
 					className="earn__page-header"
 					headerText={ translate( 'Earn' ) }
-					leftAlign
+					align="left"
 				/>
 				{ this.getHeaderCake() }
 				{ section && this.getSectionNav( section ) }

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -19,6 +19,7 @@ import NavItem from 'components/section-nav/item';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import WordAdsEarnings from 'my-sites/stats/wordads/earnings';
 import AdsSettings from 'my-sites/earn/ads/form-settings';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -186,6 +187,11 @@ class EarningsMain extends Component {
 				/>
 				<DocumentHead title={ layoutTitles[ section ] } />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="earn__page-header"
+					headerText={ translate( 'Earn' ) }
+					leftAlign
+				/>
 				{ this.getHeaderCake() }
 				{ section && this.getSectionNav( section ) }
 				{ component }

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import {
 	getEligibleGSuiteDomain,
 	hasGSuiteSupportedDomain,
@@ -68,6 +69,11 @@ class EmailManagement extends React.Component {
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				<DocumentHead title={ this.props.translate( 'Email' ) } />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="email-management__page-heading"
+					headerText={ this.props.translate( 'Email' ) }
+					align="left"
+				/>
 				{ this.headerOrPlansNavigation() }
 				{ this.content() }
 			</Main>

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -51,7 +51,7 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 					className="exporter__section-header"
 					headerText={ translate( 'Export Your Content' ) }
 					subHeaderText={ translate( 'Your content on WordPress.com is always yours.' ) }
-					leftAlign
+					align="left"
 				/>
 				<ExporterContainer />
 			</Fragment>

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -49,7 +49,7 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 			<Fragment>
 				<FormattedHeader
 					className="exporter__section-header"
-					headerText={ translate( 'Export your content' ) }
+					headerText={ translate( 'Export Your Content' ) }
 					subHeaderText={ translate( 'Your content on WordPress.com is always yours.' ) }
 					leftAlign
 				/>

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -51,6 +51,7 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 					className="exporter__section-header"
 					headerText={ translate( 'Export your content' ) }
 					subHeaderText={ translate( 'Your content on WordPress.com is always yours.' ) }
+					leftAlign
 				/>
 				<ExporterContainer />
 			</Fragment>

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -1,18 +1,3 @@
-.exporter__section-header {
-	&.formatted-header {
-		margin: 0 auto;
-		max-width: 500px;
-	}
-
-	.formatted-header__title {
-		text-transform: capitalize;
-	}
-
-	.formatted-header__subtitle {
-		color: var( --color-neutral-dark );
-	}
-}
-
 .export-card__title,
 .export-media-card__title {
 	font-size: 21px;

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -305,7 +305,7 @@ class SectionImport extends Component {
 				<FormattedHeader
 					className="importer__page-heading"
 					headerText={ translate( 'Import Your Content' ) }
-					leftAlign
+					align="left"
 				/>
 				<EmailVerificationGate allowUnlaunched>
 					{ isJetpack ? <JetpackImporter /> : this.renderImportersList() }

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -14,6 +14,7 @@ import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import DocumentHead from 'components/data/document-head';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import ImporterStore, { getState as getImporterState } from 'lib/importer/store';
 import { Interval, EVERY_FIVE_SECONDS } from 'lib/interval';
 import WordPressImporter from 'my-sites/importer/importer-wordpress';
@@ -299,8 +300,13 @@ class SectionImport extends Component {
 
 		return (
 			<Main>
-				<DocumentHead title={ translate( 'Import' ) } />
+				<DocumentHead title={ translate( 'Import Your Content' ) } />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="importer__page-heading"
+					headerText={ translate( 'Import Your Content' ) }
+					leftAlign
+				/>
 				<EmailVerificationGate allowUnlaunched>
 					{ isJetpack ? <JetpackImporter /> : this.renderImportersList() }
 				</EmailVerificationGate>

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -24,6 +24,7 @@ import NavTabs from 'components/section-nav/tabs';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import UpgradeNudge from 'blocks/upgrade-nudge';
 import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
@@ -87,9 +88,14 @@ export const Sharing = ( {
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="sharing">
-			<DocumentHead title={ translate( 'Sharing' ) } />
+			<DocumentHead title={ translate( 'Marketing and Integrations' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			<SidebarNavigation />
+			<FormattedHeader
+				className="marketing__page-heading"
+				headerText={ translate( 'Marketing and Integrations' ) }
+				leftAlign
+			/>
 			{ filters.length > 0 && (
 				<SectionNav selectedText={ get( selected, 'title', '' ) }>
 					<NavTabs>

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -94,7 +94,7 @@ export const Sharing = ( {
 			<FormattedHeader
 				className="marketing__page-heading"
 				headerText={ translate( 'Marketing and Integrations' ) }
-				leftAlign
+				align="left"
 			/>
 			{ filters.length > 0 && (
 				<SectionNav selectedText={ get( selected, 'title', '' ) }>

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -49,7 +49,7 @@ const SiteSettingsTraffic = ( {
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 	<Main className="settings-traffic site-settings" wideLayout>
 		<PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
-		<DocumentHead title={ translate( 'Site Settings' ) } />
+		<DocumentHead title={ translate( 'Marketing and Integrations' ) } />
 		{ ! isAdmin && (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -4,14 +4,12 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal Dependencies
  */
 import MediaComponent from 'my-sites/media/main';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSiteFragment } from 'lib/route';
 
 export default {
@@ -19,10 +17,6 @@ export default {
 		if ( ! getSiteFragment( context.path ) ) {
 			return page.redirect( '/media' );
 		}
-
-		// Page Title
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
 
 		const mediaId = context.params.mediaId ? parseInt( context.params.mediaId ) : null;
 		// Render

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -373,7 +373,7 @@ class Media extends Component {
 				<FormattedHeader
 					className="media__page-heading"
 					headerText={ translate( 'Media' ) }
-					leftAlign
+					align="left"
 				/>
 				{ this.showDialog() && (
 					<EditorMediaModalDialog

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -11,9 +11,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import MediaLibrary from 'my-sites/media-library';
 import QueryMedia from 'components/data/query-media';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import EditorMediaModalDialog from 'post-editor/media-modal/dialog';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -366,7 +368,13 @@ class Media extends Component {
 			<div ref={ this.containerRef } className="main main-column media" role="main">
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
+				<DocumentHead title={ translate( 'Media' ) } />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="media__page-heading"
+					headerText={ translate( 'Media' ) }
+					leftAlign
+				/>
 				{ this.showDialog() && (
 					<EditorMediaModalDialog
 						isVisible

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -52,6 +52,7 @@ class SectionMigrate extends Component {
 					className="migrate__section-header"
 					headerText={ headerText }
 					subHeaderText={ subHeaderText }
+					leftAlign={ true }
 				/>
 				<CompactCard className="migrate__card">
 					<SiteSelector

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -52,7 +52,7 @@ class SectionMigrate extends Component {
 					className="migrate__section-header"
 					headerText={ headerText }
 					subHeaderText={ subHeaderText }
-					leftAlign={ true }
+					align="left"
 				/>
 				<CompactCard className="migrate__card">
 					<SiteSelector

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -109,7 +109,7 @@ class PagesMain extends React.Component {
 				<FormattedHeader
 					className="pages__page-heading"
 					headerText={ translate( 'Pages' ) }
-					leftAlign
+					align="left"
 				/>
 				<SectionNav selectedText={ filterStrings[ status ] }>
 					<NavTabs label={ translate( 'Status', { context: 'Filter page group label for tabs' } ) }>

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -24,6 +24,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 
 /**
  * Style dependencies
@@ -103,8 +104,13 @@ class PagesMain extends React.Component {
 		return (
 			<Main wideLayout classname="pages">
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
-				<DocumentHead title={ translate( 'Site Pages' ) } />
+				<DocumentHead title={ translate( 'Pages' ) } />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="pages__page-heading"
+					headerText={ translate( 'Pages' ) }
+					leftAlign
+				/>
 				<SectionNav selectedText={ filterStrings[ status ] }>
 					<NavTabs label={ translate( 'Status', { context: 'Filter page group label for tabs' } ) }>
 						{ this.getNavItems( filterStrings, status ) }

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -82,7 +82,7 @@ class People extends React.Component {
 				<FormattedHeader
 					className="people__page-heading"
 					headerText={ translate( 'People' ) }
-					leftAlign
+					align="left"
 				/>
 				<div>
 					{

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -19,6 +19,7 @@ import EmptyContent from 'components/empty-content';
 import PeopleNotices from 'my-sites/people/people-notices';
 import PeopleSectionNav from 'my-sites/people/people-section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -78,6 +79,11 @@ class People extends React.Component {
 					title={ `People > ${ titlecase( filter ) }` }
 				/>
 				<SidebarNavigation />
+				<FormattedHeader
+					className="people__page-heading"
+					headerText={ translate( 'People' ) }
+					leftAlign
+				/>
 				<div>
 					{
 						<PeopleSectionNav

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -16,6 +16,7 @@ import { map } from 'lodash';
 import Main from 'components/main';
 import EmptyContent from 'components/empty-content';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import PeopleListSectionHeader from 'my-sites/people/people-list-section-header';
 import PeopleSectionNav from 'my-sites/people/people-section-nav';
 import PeopleListItem from 'my-sites/people/people-list-item';
@@ -73,7 +74,7 @@ class PeopleInvites extends React.PureComponent {
 	};
 
 	render() {
-		const { site, canViewPeople, isJetpack, isPrivate } = this.props;
+		const { site, canViewPeople, isJetpack, isPrivate, translate } = this.props;
 		const siteId = site && site.ID;
 
 		if ( siteId && ! canViewPeople ) {
@@ -94,6 +95,11 @@ class PeopleInvites extends React.PureComponent {
 				<PageViewTracker path="/people/invites/:site" title="People > Invites" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
+				<FormattedHeader
+					className="people-invites__page-heading"
+					headerText={ translate( 'People' ) }
+					leftAlign
+				/>
 				<PeopleSectionNav
 					filter="invites"
 					site={ site }

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -98,7 +98,7 @@ class PeopleInvites extends React.PureComponent {
 				<FormattedHeader
 					className="people-invites__page-heading"
 					headerText={ translate( 'People' ) }
-					leftAlign
+					align="left"
 				/>
 				<PeopleSectionNav
 					filter="invites"

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -34,6 +34,7 @@ import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import PaidPlanThankYou from './current-plan-thank-you/paid-plan-thank-you';
@@ -128,6 +129,11 @@ class CurrentPlan extends Component {
 			<Main className="current-plan" wideLayout>
 				<SidebarNavigation />
 				<DocumentHead title={ translate( 'My Plan' ) } />
+				<FormattedHeader
+					className="current-plan__page-heading"
+					headerText={ translate( 'Plans' ) }
+					leftAlign
+				/>
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				<QuerySitePurchases siteId={ selectedSiteId } />

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -132,7 +132,7 @@ class CurrentPlan extends Component {
 				<FormattedHeader
 					className="current-plan__page-heading"
 					headerText={ translate( 'Plans' ) }
-					leftAlign
+					align="left"
 				/>
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -21,6 +21,7 @@ import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/plans/navigation';
 import isSiteAutomatedTransferSelector from 'state/selectors/is-site-automated-transfer';
@@ -145,6 +146,11 @@ class Plans extends React.Component {
 					) }
 					{ canAccessPlans && (
 						<div id="plans" className="plans plans__has-sidebar">
+							<FormattedHeader
+								className="plans__page-heading"
+								headerText={ translate( 'Plans' ) }
+								leftAlign
+							/>
 							<CartData>
 								<PlansNavigation path={ this.props.context.path } />
 							</CartData>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -149,7 +149,7 @@ class Plans extends React.Component {
 							<FormattedHeader
 								className="plans__page-heading"
 								headerText={ translate( 'Plans' ) }
-								leftAlign
+								align="left"
 							/>
 							<CartData>
 								<PlansNavigation path={ this.props.context.path } />

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -614,7 +614,7 @@ export class PluginsBrowser extends Component {
 				<FormattedHeader
 					className="plugins-browser__page-heading"
 					headerText={ this.props.translate( 'Plugin Browser' ) }
-					leftAlign
+					align="left"
 				/>
 				{ this.renderUpgradeNudge() }
 				{ this.getPageHeaderView() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import DocumentHead from 'components/data/document-head';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
@@ -610,6 +611,11 @@ export class PluginsBrowser extends Component {
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />
+				<FormattedHeader
+					className="plugins-browser__page-heading"
+					headerText={ this.props.translate( 'Plugin Browser' ) }
+					leftAlign
+				/>
 				{ this.renderUpgradeNudge() }
 				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -8,7 +8,6 @@ import page from 'page';
 import React from 'react';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:my-sites:posts' );
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -18,7 +17,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import Posts from 'my-sites/posts/main';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 
 export default {
 	posts: function( context, next ) {
@@ -54,9 +52,6 @@ export default {
 			page.redirect( context.path.replace( /\/my\b/, '' ) );
 			return;
 		}
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Blog Posts', { textOnly: true } ) ) );
 
 		context.primary = React.createElement( Posts, {
 			context,

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -87,7 +87,7 @@ class PostsMain extends React.Component {
 				<FormattedHeader
 					className="posts__page-heading"
 					headerText={ translate( 'Posts' ) }
-					leftAlign
+					align="left"
 				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />
 				{ siteId && <PostTypeBulkEditBar /> }

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,6 +12,8 @@ import { connect } from 'react-redux';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
 import PostTypeList from 'my-sites/post-type-list';
 import PostTypeBulkEditBar from 'my-sites/post-type-list/bulk-edit-bar';
 import titlecase from 'to-title-case';
@@ -55,7 +58,7 @@ class PostsMain extends React.Component {
 	}
 
 	render() {
-		const { author, category, search, siteId, statusSlug, tag } = this.props;
+		const { author, category, search, siteId, statusSlug, tag, translate } = this.props;
 		const status = mapPostStatus( statusSlug );
 		const query = {
 			author,
@@ -79,7 +82,13 @@ class PostsMain extends React.Component {
 		return (
 			<Main wideLayout className="posts">
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
+				<DocumentHead title={ translate( 'Posts' ) } />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="posts__page-heading"
+					headerText={ translate( 'Posts' ) }
+					leftAlign
+				/>
 				<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />
 				{ siteId && <PostTypeBulkEditBar /> }
 				<PostTypeList
@@ -94,4 +103,4 @@ class PostsMain extends React.Component {
 
 export default connect( state => ( {
 	siteId: getSelectedSiteId( state ),
-} ) )( PostsMain );
+} ) )( localize( PostsMain ) );

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -16,6 +16,7 @@ import Main from 'components/main';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import SiteSettingsNavigation from './navigation';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -32,6 +33,11 @@ const SiteSettingsComponent = ( { siteId, translate } ) => {
 			<QuerySitePurchases siteId={ siteId } />
 			<JetpackDevModeNotice />
 			<SidebarNavigation />
+			<FormattedHeader
+				className="site-settings__page-heading"
+				headerText={ translate( 'Settings' ) }
+				leftAlign
+			/>
 			<SiteSettingsNavigation section={ 'general' } />
 			<GeneralSettings />
 		</Main>

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -36,7 +36,7 @@ const SiteSettingsComponent = ( { siteId, translate } ) => {
 			<FormattedHeader
 				className="site-settings__page-heading"
 				headerText={ translate( 'Settings' ) }
-				leftAlign
+				align="left"
 			/>
 			<SiteSettingsNavigation section={ 'general' } />
 			<GeneralSettings />

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -25,7 +25,7 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 		<FormattedHeader
 			className="settings-discussion__page-heading"
 			headerText={ translate( 'Settings' ) }
-			leftAlign
+			align="left"
 		/>
 		<SiteSettingsNavigation site={ site } section="discussion" />
 		<DiscussionForm />

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -13,6 +13,7 @@ import DocumentHead from 'components/data/document-head';
 import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import { getSelectedSite } from 'state/ui/selectors';
 
@@ -21,6 +22,11 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 		<DocumentHead title={ translate( 'Site Settings' ) } />
 		<JetpackDevModeNotice />
 		<SidebarNavigation />
+		<FormattedHeader
+			className="settings-discussion__page-heading"
+			headerText={ translate( 'Settings' ) }
+			leftAlign
+		/>
 		<SiteSettingsNavigation site={ site } section="discussion" />
 		<DiscussionForm />
 	</Main>

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -22,6 +22,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import Search from 'my-sites/site-settings/search';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SpeedUpYourSite from 'my-sites/site-settings/speed-up-site-settings';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
@@ -50,6 +51,11 @@ class SiteSettingsPerformance extends Component {
 				<DocumentHead title={ translate( 'Site Settings' ) } />
 				<JetpackDevModeNotice />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="settings-performance__page-heading"
+					headerText={ translate( 'Settings' ) }
+					leftAlign
+				/>
 				<SiteSettingsNavigation site={ site } section="performance" />
 
 				{ siteIsJetpack && (

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -54,7 +54,7 @@ class SiteSettingsPerformance extends Component {
 				<FormattedHeader
 					className="settings-performance__page-heading"
 					headerText={ translate( 'Settings' ) }
-					leftAlign
+					align="left"
 				/>
 				<SiteSettingsNavigation site={ site } section="performance" />
 

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -20,6 +20,7 @@ import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import Main from 'components/main';
 import QueryRewindState from 'components/data/query-rewind-state';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -66,6 +67,11 @@ const SiteSettingsSecurity = ( {
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<JetpackDevModeNotice />
 			<SidebarNavigation />
+			<FormattedHeader
+				className="settings-security__page-heading"
+				headerText={ translate( 'Settings' ) }
+				leftAlign
+			/>
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showRewindCredentials && <JetpackCredentials /> }
 			<JetpackMonitor />

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -70,7 +70,7 @@ const SiteSettingsSecurity = ( {
 			<FormattedHeader
 				className="settings-security__page-heading"
 				headerText={ translate( 'Settings' ) }
-				leftAlign
+				align="left"
 			/>
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showRewindCredentials && <JetpackCredentials /> }

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -12,6 +12,7 @@ import DocumentHead from 'components/data/document-head';
 import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import WritingForm from 'my-sites/site-settings/form-writing';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -21,6 +22,11 @@ const SiteSettingsWriting = ( { site, translate } ) => (
 		<DocumentHead title={ translate( 'Site Settings' ) } />
 		<JetpackDevModeNotice />
 		<SidebarNavigation />
+		<FormattedHeader
+			className="settings-writing__page-heading"
+			headerText={ translate( 'Settings' ) }
+			leftAlign
+		/>
 		<SiteSettingsNavigation site={ site } section="writing" />
 		<WritingForm />
 	</Main>

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -25,7 +25,7 @@ const SiteSettingsWriting = ( { site, translate } ) => (
 		<FormattedHeader
 			className="settings-writing__page-heading"
 			headerText={ translate( 'Settings' ) }
-			leftAlign
+			align="left"
 		/>
 		<SiteSettingsNavigation site={ site } section="writing" />
 		<WritingForm />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -160,7 +160,7 @@ class StatsSite extends Component {
 				<FormattedHeader
 					className="stats__section-header"
 					headerText={ translate( 'Stats and Insights' ) }
-					leftAlign
+					align="left"
 				/>
 				<StatsNavigation
 					selectedItem={ 'traffic' }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -150,7 +150,7 @@ class StatsSite extends Component {
 			<Main wideLayout={ true }>
 				<QueryKeyringConnections />
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
-				<DocumentHead title={ translate( 'Traffic Stats' ) } />
+				<DocumentHead title={ translate( 'Stats and Insights' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }
 					title={ `Stats > ${ titlecase( period ) }` }
@@ -159,8 +159,8 @@ class StatsSite extends Component {
 				<SidebarNavigation />
 				<FormattedHeader
 					className="stats__section-header"
-					headerText={ translate( 'Traffic Stats' ) }
-					leftAlign={ true }
+					headerText={ translate( 'Stats and Insights' ) }
+					leftAlign
 				/>
 				<StatsNavigation
 					selectedItem={ 'traffic' }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -16,6 +16,7 @@ import StatsPeriodNavigation from './stats-period-navigation';
 import Main from 'components/main';
 import StatsNavigation from 'blocks/stats-navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import DatePicker from './stats-date-picker';
 import Countries from './stats-countries';
 import ChartTabs from './stats-chart-tabs';
@@ -149,13 +150,18 @@ class StatsSite extends Component {
 			<Main wideLayout={ true }>
 				<QueryKeyringConnections />
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
-				<DocumentHead title={ translate( 'Stats' ) } />
+				<DocumentHead title={ translate( 'Traffic Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }
 					title={ `Stats > ${ titlecase( period ) }` }
 				/>
 				<PrivacyPolicyBanner />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="stats__section-header"
+					headerText={ translate( 'Traffic Stats' ) }
+					leftAlign={ true }
+				/>
 				<StatsNavigation
 					selectedItem={ 'traffic' }
 					interval={ period }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -61,7 +61,7 @@ const StatsInsights = props => {
 			<FormattedHeader
 				className="stats__section-header"
 				headerText={ translate( 'Stats and Insights' ) }
-				leftAlign={ true }
+				align="left"
 			/>
 			<StatsNavigation selectedItem={ 'insights' } siteId={ siteId } slug={ siteSlug } />
 			<div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import DocumentHead from 'components/data/document-head';
 import StatsNavigation from 'blocks/stats-navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import AllTime from 'my-sites/stats/all-time/';
 import Comments from '../stats-comments';
 import Reach from '../stats-reach';
@@ -54,9 +55,14 @@ const StatsInsights = props => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Main wideLayout>
-			<DocumentHead title={ translate( 'Stats' ) } />
+			<DocumentHead title={ translate( 'Traffic Stats' ) } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<SidebarNavigation />
+			<FormattedHeader
+				className="stats__section-header"
+				headerText={ translate( 'Traffic Stats' ) }
+				leftAlign={ true }
+			/>
 			<StatsNavigation selectedItem={ 'insights' } siteId={ siteId } slug={ siteSlug } />
 			<div>
 				<PostingActivity />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -55,12 +55,12 @@ const StatsInsights = props => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Main wideLayout>
-			<DocumentHead title={ translate( 'Traffic Stats' ) } />
+			<DocumentHead title={ translate( 'Stats and Insights' ) } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<SidebarNavigation />
 			<FormattedHeader
 				className="stats__section-header"
-				headerText={ translate( 'Traffic Stats' ) }
+				headerText={ translate( 'Stats and Insights' ) }
 				leftAlign={ true }
 			/>
 			<StatsNavigation selectedItem={ 'insights' } siteId={ siteId } slug={ siteSlug } />

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -22,6 +22,7 @@ import StatsNavigation from 'blocks/stats-navigation';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import DatePicker from '../stats-date-picker';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import WordAdsChartTabs from '../wordads-chart-tabs';
 import titlecase from 'to-title-case';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -139,6 +140,7 @@ class WordAds extends Component {
 			date: endOf.format( 'YYYY-MM-DD' ),
 		};
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main wideLayout={ true }>
 				<DocumentHead title={ translate( 'WordAds Stats' ) } />
@@ -148,6 +150,11 @@ class WordAds extends Component {
 				/>
 				<PrivacyPolicyBanner />
 				<SidebarNavigation />
+				<FormattedHeader
+					className="wordads__section-header"
+					headerText={ translate( 'Stats and Insights' ) }
+					leftAlign
+				/>
 				{ ! canAccessAds && (
 					<EmptyContent
 						illustration="/calypso/images/illustrations/illustration-404.svg"
@@ -211,6 +218,7 @@ class WordAds extends Component {
 				) }
 			</Main>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import Main from 'components/main';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import config from 'config';
 import JetpackReferrerMessage from './jetpack-referrer-message';
@@ -89,6 +90,11 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 	return (
 		<Main className="themes">
 			<SidebarNavigation />
+			<FormattedHeader
+				className="themes__page-heading"
+				headerText={ translate( 'WordPress Themes' ) }
+				leftAlign
+			/>
 			<CurrentTheme siteId={ siteId } />
 			{ ! requestingSitePlans && ! hasUnlimitedPremiumThemes && (
 				<Banner

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -93,7 +93,7 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 			<FormattedHeader
 				className="themes__page-heading"
 				headerText={ translate( 'Themes' ) }
-				leftAlign
+				align="left"
 			/>
 			<CurrentTheme siteId={ siteId } />
 			{ ! requestingSitePlans && ! hasUnlimitedPremiumThemes && (

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -92,7 +92,7 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 			<SidebarNavigation />
 			<FormattedHeader
 				className="themes__page-heading"
-				headerText={ translate( 'WordPress Themes' ) }
+				headerText={ translate( 'Themes' ) }
 				leftAlign
 			/>
 			<CurrentTheme siteId={ siteId } />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -74,7 +74,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 			<SidebarNavigation />
 			<FormattedHeader
 				className="themes__page-heading"
-				headerText={ translate( 'WordPress Themes' ) }
+				headerText={ translate( 'Themes' ) }
 				leftAlign
 			/>
 			<CurrentTheme siteId={ siteId } />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -75,7 +75,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 			<FormattedHeader
 				className="themes__page-heading"
 				headerText={ translate( 'Themes' ) }
-				leftAlign
+				align="left"
 			/>
 			<CurrentTheme siteId={ siteId } />
 			{ bannerLocationBelowSearch ? null : upsellBanner }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import Main from 'components/main';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
 import Banner from 'components/banner';
@@ -71,6 +72,11 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 	return (
 		<Main className="themes">
 			<SidebarNavigation />
+			<FormattedHeader
+				className="themes__page-heading"
+				headerText={ translate( 'WordPress Themes' ) }
+				leftAlign
+			/>
 			<CurrentTheme siteId={ siteId } />
 			{ bannerLocationBelowSearch ? null : upsellBanner }
 

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -42,7 +42,7 @@ function Types( {
 			<FormattedHeader
 				className="types__page-heading"
 				headerText={ get( postType, 'label' ) }
-				leftAlign
+				align="left"
 			/>
 			{ false !== userCanEdit &&
 				false !== postTypeSupported && [

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -16,6 +16,7 @@ import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import PostTypeList from 'my-sites/post-type-list';
 import PostTypeUnsupported from './post-type-unsupported';
@@ -38,6 +39,11 @@ function Types( {
 			<DocumentHead title={ get( postType, 'label' ) } />
 			<PageViewTracker path={ siteId ? '/types/:site' : '/types' } title="Custom Post Type" />
 			<SidebarNavigation />
+			<FormattedHeader
+				className="types__page-heading"
+				headerText={ get( postType, 'label' ) }
+				leftAlign
+			/>
 			{ false !== userCanEdit &&
 				false !== postTypeSupported && [
 					<PostTypeFilter


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds page headings to screens across all of Calypso, using the existing `<FormattedHeader>` component.
* It also refactors the `<SidebarNavigation>` component (the component on mobile viewports that opens the sidebar navigation) to clarify the functionality.

#### Background
There are many overarching issues with the information architecture (IA) of Calypso. Ultimately, these will need to be fixed to provide a great experience to all of our users. When the overall IA is improved it will help reduce the cognitive load of finding your way around.

Until that happens, however, adding a consistent page heading pattern throughout Calypso can help bridge the gap.

Some issues this approach solves:

* **Context.** Adding consistent page headings provides context to users about where they are in relation to the rest of Calypso. Currently the only real context provided is seeing the section highlighted in the sidebar nav. On mobile, the sidebar is hidden, so this context is non-existent.
* **Accessibility.** When using assistive technology like a screen reader, the page does not have a clear title.

More background about design exploration, proposals, and why this specific development approach was chosen can be found at p9Jlb4-12y-p2

#### Screenshots

Mobile Before | Mobile After
------------ | -------------
<img width="374" alt="Screen Shot 2019-11-07 at 11 44 33 AM" src="https://user-images.githubusercontent.com/448298/68408839-0b7f6380-0154-11ea-974d-2587b1f0d690.png"> | <img width="374" alt="Screen Shot 2019-11-07 at 11 44 07 AM" src="https://user-images.githubusercontent.com/448298/68408832-07534600-0154-11ea-9d5a-f843520fe9e1.png">

Desktop Before | Desktop After
---- | ----
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/448298/68409091-80529d80-0154-11ea-8410-86d5071171f6.png"> | <img width="1109" alt="image" src="https://user-images.githubusercontent.com/448298/68409058-72048180-0154-11ea-8aed-473a57ffab6c.png">


#### Testing instructions

* Checkout this branch.
* Go through each section of My Site(s) and check for a consistent page heading component.
* Make sure all sections have a page heading, including sub-sections and filters.
* Try to break it.
* Check mobile viewports to make sure it all still works and looks ok.

#### Known issues
* This only adds the page heading to each page. Issues like copy duplication when list headers match the page heading will be addressed in future PRs.
* Sections in /me are not touched with this PR