### PR TITLE
Build: Add propTypes removal transform

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,6 +154,8 @@ module.exports = {
 		// Allows Chai `expect` expressions. Now that we're on jest, hopefully we can remove this one.
 		'no-unused-expressions': 0,
 
+		'react/forbid-foreign-prop-types': 'error',
+
 		// enforce our classname namespacing rules
 		'wpcalypso/jsx-classname-namespace': [
 			2,

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,9 @@ const babelConfig = {
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
 
 	env: {
+		production: {
+			plugins: [ 'babel-plugin-transform-react-remove-prop-types' ],
+		},
 		build_pot: {
 			plugins: [
 				[

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6597,6 +6597,12 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
 			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
+		"babel-plugin-transform-react-remove-prop-types": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
+			"dev": true
+		},
 		"babel-preset-jest": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -329,6 +329,7 @@
 		"babel-eslint": "10.0.3",
 		"babel-jest": "24.9.0",
 		"babel-plugin-dynamic-import-node": "2.3.0",
+		"babel-plugin-transform-react-remove-prop-types": "0.4.24",
 		"chai": "4.2.0",
 		"chai-enzyme": "1.0.0-beta.1",
 		"check-node-version": "3.3.0",


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/issues/35695 complete, we may be able to strip propTypes from production bundles.

Apply the transform and add an eslint rule to help prevent misuse.

https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types

#### Testing instructions

* Nothing breaks 🤞 
