### PR TITLE
Translator instructions for John Appleseed

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -129,7 +129,9 @@ export function getAllSiteTypes() {
 			theme: 'pub/maywood',
 			designType: 'portfolio',
 			siteTitleLabel: i18n.translate( 'What is your name?' ),
-			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
+			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed', {
+				comment: 'An example of a persons name, use something appropriate for the locale',
+			} ),
 			siteTopicHeader: i18n.translate( 'What type of work do you do?' ),
 			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
 			siteTopicInputPlaceholder: i18n.translate( 'Enter your job title or choose one from below.' ),

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -130,7 +130,7 @@ export function getAllSiteTypes() {
 			designType: 'portfolio',
 			siteTitleLabel: i18n.translate( 'What is your name?' ),
 			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed', {
-				comment: 'An example of a persons name, use something appropriate for the locale',
+				comment: "An example of a person's name, use something appropriate for the locale",
 			} ),
 			siteTopicHeader: i18n.translate( 'What type of work do you do?' ),
 			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),


### PR DESCRIPTION
The site title step for the professional segment looks like this:

<img width="627" alt="Screenshot 2019-11-06 at 11 52 31 AM" src="https://user-images.githubusercontent.com/1500769/68253089-f3dca800-008b-11ea-8206-32b91c505495.png">

Which is a literal translation of "John Appleseed"

Thanks @johnHackworth :)

#### Changes proposed in this Pull Request

* Adds translator instructions for "John Appleseed"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start`
* Choose professional
* Advance to site title step
* The site title step should continue to work, no visible changes. Nothing will change until/unless translators change something.
