### PR TITLE
FSE - Nav Menu to add new page when published.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -91,9 +91,8 @@ export default compose( [
 	withColors( 'backgroundColor', { textColor: 'color' } ),
 	withFontSizes( 'fontSize' ),
 	withSelect( select => {
-		const { isCurrentPostPublished } = select( 'core/editor' );
 		return {
-			isPublished: isCurrentPostPublished(),
+			isPublished: select( 'core/editor' ).isCurrentPostPublished(),
 		};
 	} ),
 ] )( NavigationMenuEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -18,6 +18,7 @@ import {
 	withFontSizes,
 } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ const NavigationMenuEdit = ( {
 	setFontSize,
 	setTextColor,
 	textColor,
+	isPublished,
 } ) => {
 	const { customFontSize, textAlign } = attributes;
 
@@ -76,7 +78,11 @@ const NavigationMenuEdit = ( {
 					/>
 				</PanelColorSettings>
 			</InspectorControls>
-			<ServerSideRender block="a8c/navigation-menu" attributes={ attributes } />
+			<ServerSideRender
+				isPublished={ isPublished }
+				block="a8c/navigation-menu"
+				attributes={ attributes }
+			/>
 		</Fragment>
 	);
 };
@@ -84,4 +90,10 @@ const NavigationMenuEdit = ( {
 export default compose( [
 	withColors( 'backgroundColor', { textColor: 'color' } ),
 	withFontSizes( 'fontSize' ),
+	withSelect( select => {
+		const { isCurrentPostPublished } = select( 'core/editor' );
+		return {
+			isPublished: isCurrentPostPublished(),
+		};
+	} ),
 ] )( NavigationMenuEdit );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Nav Menu updates to include a new page when it is published.

#### Testing instructions

Tested locally and on Sandbox.

1. Run this PR.
2. navigate to add a new page.
3. Select a template.
4. Publish the new page.
5. Verify the new page's name is added to the header's nav menu as an option without the need to refresh the page.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes #36890 
