### PR TITLE
Fix plan bump test errors

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -117,7 +117,7 @@ export default {
 		localeTargets: 'any',
 	},
 	showPlanUpsellConcierge: {
-		datestamp: '20191029',
+		datestamp: '20191106',
 		variations: {
 			variantShowPlanBump: 50,
 			control: 50,

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -441,7 +441,7 @@ export class Checkout extends React.Component {
 		return;
 	}
 
-	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
+	maybeRedirectToConciergeNudge( pendingOrReceiptId, stepResult ) {
 		const { cart, selectedSiteSlug, previousRoute } = this.props;
 
 		// For a user purchasing a qualifying plan, show either a plan upgrade upsell or concierge upsell.
@@ -450,6 +450,8 @@ export class Checkout extends React.Component {
 		// then skip this section so that we do not show further upsells.
 		if (
 			config.isEnabled( 'upsell/concierge-session' ) &&
+			stepResult &&
+			isEmpty( stepResult.failed_purchases ) &&
 			! hasConciergeSession( cart ) &&
 			! hasJetpackPlan( cart ) &&
 			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
@@ -579,7 +581,10 @@ export class Checkout extends React.Component {
 			return redirectPathForGSuiteUpsell;
 		}
 
-		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge( pendingOrReceiptId );
+		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge(
+			pendingOrReceiptId,
+			stepResult
+		);
 		if ( redirectPathForConciergeUpsell ) {
 			return redirectPathForConciergeUpsell;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the data anomaly issues we saw with the plan bump test which was originally implemented in https://github.com/Automattic/wp-calypso/pull/33344, then re-launched in https://github.com/Automattic/wp-calypso/pull/35134, and then once again re-launched with https://github.com/Automattic/wp-calypso/pull/36655.
* The main issue is that we had ineligible users still getting assigned to the test, and this PR fixes this issue. We want the upsell to only be shown to users who complete purchase of a Personal plan. However, the bug caused the test to be assigned to users who encountered a failed transaction for a Personal plan purchase. 
* The complete background and discussions that led upto this PR can be found in pa1C6h-z7-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1** _(Testing behaviour of `showPlanUpsellConcierge` A/B test)_

* Signup for a new account from http://calypso.localhost:3000/start.
* Add a Personal plan to cart and complete the purchase
* Verify the following:
    - That you are shown the premium upgrade upsell if on the `variantShowPlanBump` variation of `showPlanUpsellConcierge` test.
    - That you are shown the concierge upsell if on the `control` variation of `showPlanUpsellConcierge` test.

If on the plan upsell nudge, verify the following:
- Clicking the `No thanks ...` button should take you to the checklist page.
- Clicking the `Yes, I'd love to try ....` button should take you to the checkout page with the Premium plan added to cart and **credits applied**. Verify that after you complete the purchase, you are **not shown the concierge upsell** but instead taken to the checklist page.

If on the concierge upsell nudge, verify the following:
- Clicking Skip on the nudge should take you to checklist.
- Clicking Accept on the nudge, and completing the concierge session purchase should take you checklist. _**No more upsell nudges should be shown**_.

**Scenario 2** _(Test that the test is not assigned when the user is eligible for GSuite upsell)_
* Go through the signup flow and checkout with a Personal plan and domain. Complete purchase.
* In your browser console, type `localStorage.ABTests;`. The object should not include the `showPlanUpsellConcierge` test.

**Scenario 3** _(Test that an invalid card(checkout error) does not lead to a test assignment)_
* Go through the signup flow and checkout with a Personal plan. 
* In the Checkout page, use an invalid visa card number and click the Purchase button(I used `4539747991309129 `).
* You should get a Transaction declined message.
* In your browser console, type `localStorage.ABTests;`. The object should not include the `showPlanUpsellConcierge` test.
* Now complete the purchase with a valid credit card(which can just be the store sandbox credit card number).
* In your browser console, type `localStorage.ABTests;`. The object _should include_ the `showPlanUpsellConcierge` test.

**Scenario 4** _(Test that the offer is shown when upgrading from a lower tier plan to Personal)_
* Login to a site having a Free or Blogger plan, go to /plans page and upgrade to Personal
* After purchase completes, verify the following:
    - That you are shown the premium upgrade upsell if on the `variantShowPlanBump` variation of `showPlanUpsellConcierge` test.
    - That you are shown the concierge upsell if on the `control` variation of `showPlanUpsellConcierge` test.
In both cases above, complete the upsell purchase and verify that you are not show any more upsell nudges.

**Scenario 5** 
* Verify status quo i.e current behaviour is maintained for non-Personal plan purchases.
* Add a Premium plan to cart and complete signup. Verify that only the concierge upsell nudge is shown. In browser console, type `localStorage.ABTests;` and verify that it does not list the `showPlanUpsellConcierge` test. 


**Scenario 6** _(Test that a failed purchase does not lead to a test assignment)_
* Go through the signup flow and checkout with a Personal plan. 
* In the Checkout page, click on PayPal as your payment method.
* After you're redirected to paypal.com, click the `Cancel and return to WordPress.com` link(if sandboxed, this will appear with a different wording).
* In your browser console, type `localStorage.ABTests;`. The object should not include the `showPlanUpsellConcierge` test.
* Now try PayPal again and this time, complete the purchase
* You should still not be assigned to the test. Since we don't have a reliable way to know if a redirect payment type failed before determining the `successUrl`, we will exclude all redirect payment types from this test.


