### PR TITLE
Products Page: Minor wording update to match designs

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -116,7 +116,7 @@ export const JETPACK_PRODUCTS = [
 		optionDescriptions: {
 			...JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
 		},
-		optionsLabel: translate( 'Backup Options' ),
+		optionsLabel: translate( 'Backup Options:' ),
 		productUpsells: {
 			[ PRODUCT_JETPACK_BACKUP_DAILY ]: PRODUCT_JETPACK_BACKUP_REALTIME,
 			[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add the colon to the end of the options text.

Before:
![Screen Shot 2019-11-06 at 9 44 31 AM](https://user-images.githubusercontent.com/115071/68282679-5cbb2480-007a-11ea-9038-71fb813dd9c4.png)
After:

![Screen Shot 2019-11-06 at 9 44 10 AM](https://user-images.githubusercontent.com/115071/68282681-5cbb2480-007a-11ea-92e0-989313ccba6b.png)


#### Testing instructions

Go to the plans page. http://calypso.localhost:3000/plans/monthly/
Does the wording match the designs.
