### PR TITLE
SIWA: Update the login return uri

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -23,24 +23,26 @@ export function login( {
 	site,
 	useMagicLink,
 } = {} ) {
-	let url = config( 'login_url' );
+	let url = '';
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {
-		url = '/log-in';
-
 		if ( socialService ) {
-			url += '/' + socialService + '/callback';
+			url = `/${ socialService === 'apple' ? 'sign-in' : 'log-in' }/${ socialService }/callback`;
 		} else if ( twoFactorAuthType && isJetpack ) {
-			url += '/jetpack/' + twoFactorAuthType;
+			url = '/log-in/jetpack/' + twoFactorAuthType;
 		} else if ( twoFactorAuthType ) {
-			url += '/' + twoFactorAuthType;
+			url = '/log-in/' + twoFactorAuthType;
 		} else if ( socialConnect ) {
-			url += '/social-connect';
+			url = '/log-in/social-connect';
 		} else if ( isJetpack ) {
-			url += '/jetpack';
+			url = '/log-in/jetpack';
 		} else if ( useMagicLink ) {
-			url += '/link';
+			url = '/log-in/link';
+		} else {
+			url = '/log-in';
 		}
+	} else {
+		url = config( 'login_url' );
 	}
 
 	if ( locale && locale !== 'en' ) {

--- a/server/api/sign-in-with-apple.js
+++ b/server/api/sign-in-with-apple.js
@@ -26,11 +26,17 @@ function loginWithApple( request, response, next ) {
 	}
 
 	const idToken = request.body.id_token;
-	const user = request.body.user || {};
+	const user = JSON.parse( request.body.user || '{}' );
 	const userEmail = user.email;
 	const userName = user.name
 		? `${ user.name.firstName || '' } ${ user.name.lastName || '' }`.trim()
 		: undefined;
+
+	request.user_openid_data = {
+		id_token: idToken,
+		user_email: userEmail,
+		user_name: userName,
+	};
 
 	// An `id_token` is not enough to log a user in (one might have 2FA enabled or an existing account with the same email)
 	// Thus we need to return `id_token` to the front-end so it can handle all sign-up/sign-in cases.
@@ -41,31 +47,43 @@ function loginWithApple( request, response, next ) {
 			.undocumented()
 			.usersSocialNew( {
 				...loginEndpointData(),
-				id_token: idToken,
-				user_email: userEmail,
-				user_name: userName,
+				...request.user_openid_data,
 			} )
 			.catch( () => {
 				// ignore errors
-			} );
+			} )
+			.finally( next );
+	} else {
+		next();
+	}
+}
+
+function redirectToCalypso( request, response, next ) {
+	if ( ! request.user_openid_data ) {
+		return next();
 	}
 
 	const originalUrlPath = request.originalUrl.split( '#' )[ 0 ];
 	const hashString = qs.stringify( {
-		id_token: idToken,
-		user_email: userEmail,
-		user_name: userName,
+		...request.user_openid_data,
 		client_id: config( 'apple_oauth_client_id' ),
 		state: request.body.state,
 	} );
 
-	response.redirect( originalUrlPath + '#' + hashString );
+	// `POST /log-in` is blacklisted, let's use `POST /sign-in` and redirect to `/log-in`
+	const newLocation = originalUrlPath.replace(
+		'/sign-in/apple/callback',
+		'/log-in/apple/callback'
+	);
+
+	response.redirect( newLocation + '#' + hashString );
 }
 
 module.exports = function( app ) {
 	return app.post(
-		[ '/log-in/apple/callback', '/start/user', '/me/security/social-login' ],
+		[ '/sign-in/apple/callback', '/start/user', '/me/security/social-login' ],
 		bodyParser.urlencoded(),
-		loginWithApple
+		loginWithApple,
+		redirectToCalypso
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the login return url for sign in with apple from `POST /log-in/apple/callback` to `POST /sign-in/apple/callback`.
* It also updates how we parse the JSON `user` object coming from apple as there seems to have been some changes around this.

#### Testing instructions

- Run this branch locally `npm start`
- Disable your a11n proxy and proxy https://wordpress.com to http://calypso.localhost:3000
- Try signing in with apple to an existing account from https://wordpress.com/log-in
- Optional: try signing up from https://wordpress.com/log-in and/or https://wordpress.com/start/user after removing your Apple ID association with WordPress.

Fixes https://github.com/Automattic/wp-calypso/issues/37336