### PR TITLE
Remove i18n-calypso moment from a few places.

### DIFF
--- a/client/blocks/calendar-popover/docs/example.jsx
+++ b/client/blocks/calendar-popover/docs/example.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -16,6 +13,8 @@ import CalendarPopover from 'blocks/calendar-popover';
 const tomorrow = date => date.date( date.date() + 1 );
 
 class CalendarPopoverExample extends PureComponent {
+	buttonRef = React.createRef();
+
 	state = { show: false, currentDate: tomorrow( moment() ) };
 
 	toggle = () => this.setState( { show: ! this.state.show } );
@@ -25,12 +24,12 @@ class CalendarPopoverExample extends PureComponent {
 	render() {
 		return (
 			<div>
-				<Button primary ref="button" onClick={ this.toggle }>
+				<Button primary ref={ this.buttonRef } onClick={ this.toggle }>
 					Show Popover
 				</Button>
 
 				<CalendarPopover
-					context={ this.refs && this.refs.button }
+					context={ this.buttonRef.current }
 					isVisible={ this.state.show }
 					selectedDay={ this.state.currentDate }
 					onClose={ this.close }

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -1,11 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -19,6 +17,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class AppointmentInfo extends Component {
 	static propTypes = {
@@ -29,6 +28,7 @@ class AppointmentInfo extends Component {
 		const {
 			appointment: { beginTimestamp, endTimestamp, id, scheduleId, meta },
 			translate,
+			moment,
 			site,
 		} = this.props;
 
@@ -122,6 +122,7 @@ class AppointmentInfo extends Component {
 		const {
 			appointment: { beginTimestamp, endTimestamp },
 			translate,
+			moment,
 		} = this.props;
 
 		const beginTimeFormat = translate( 'LL [at] LT', {
@@ -152,4 +153,4 @@ class AppointmentInfo extends Component {
 	}
 }
 
-export default localize( AppointmentInfo );
+export default localize( withLocalizedMoment( AppointmentInfo ) );

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -1,9 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
-import { localize, moment } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -15,13 +14,13 @@ import formatCurrency from '@automattic/format-currency';
  */
 import Card from 'components/card';
 import Button from 'components/button';
+import { useLocalizedMoment } from 'components/localized-moment';
 import { getSite, getSiteTitle, getSiteDomain } from 'state/sites/selectors';
 import PurchaseSiteHeader from '../purchases/purchases-site/header';
 import { purchaseType as getPurchaseType, getName } from 'lib/purchases';
 import { paymentMethodName } from 'lib/cart-values';
 
 export function PendingListItem( {
-	translate,
 	paymentType,
 	totalCost,
 	currency,
@@ -31,6 +30,9 @@ export function PendingListItem( {
 	dateCreated,
 	products,
 } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	// products being populated is not guaranteed
 	const initialProduct = get( products, '0', {} );
 	let productName = getName( initialProduct ) || '';
@@ -91,4 +93,4 @@ export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteId ),
 	siteTitle: getSiteTitle( state, props.siteId ),
 	siteDomain: getSiteDomain( state, props.siteId ),
-} ) )( localize( PendingListItem ) );
+} ) )( PendingListItem );

--- a/client/me/pending-payments/test/index.js
+++ b/client/me/pending-payments/test/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -85,7 +83,7 @@ describe( 'PendingPayments', () => {
 		const rules = [
 			'Main.pending-payments Connect(MeSidebarNavigation)',
 			'Main.pending-payments Connect(Localized(PurchasesHeader))[section="pending"]',
-			'Main.pending-payments Connect(Localized(PendingListItem))',
+			'Main.pending-payments Connect(PendingListItem)',
 		];
 
 		rules.forEach( rule => {

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -1,16 +1,19 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
 import { shallow } from 'enzyme';
+import moment from 'moment';
 
 /**
  * Internal dependencies
  */
 import { PendingListItem } from '../pending-list-item';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
+import * as localizedMoment from 'components/localized-moment';
+
+jest.mock( 'components/localized-moment' );
+localizedMoment.useLocalizedMoment.mockReturnValue( moment );
 
 describe( 'PendingListItem', () => {
 	const defaultProps = {


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

It switches a few components to `localized-moment`, and updates tests where needed. It also does some small drive-by fixes on those components.

Note: If I added you and you feel you're not the right person to review these changes, I apologise for that; please feel free to ignore or remove yourself. I just went with the default GitHub suggestions since I had no idea who to add 🤷‍♂

Please feel free to add whomever you feel should be included in the reviewers list.

#### Changes proposed in this Pull Request

* Replace `i18n-calypso` `moment` with `localized-moment` on several components.
* Update `pending-payments` tests to work with `localized-moment`.

#### Testing instructions

There's not a lot of need for testing, as the changes are fairly self-contained. The main thing to ensure is that dates are still localised correctly in these components. The calendar popover example can be found at `/devdocs/blocks/calendar-popover`, but I'm not sure how to test the other components.
