### PR TITLE
Gutenboarding: update site vertical selector

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
 
 import React from 'react';
 import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +21,8 @@ interface Props {
 }
 
 export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
-	const { siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
+	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div
@@ -42,7 +44,7 @@ export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }:
 				role="toolbar"
 			></div>
 			<div className="gutenboarding__header-actions">
-				<Button isPrimary isLarge>
+				<Button isPrimary isLarge disabled={ isEmpty( siteVertical ) }>
 					{ NO__( 'Next' ) }
 				</Button>
 				<IconButton

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -2,16 +2,17 @@
  * External dependencies
  */
 import { __ as NO__ } from '@wordpress/i18n';
-import { Button, FormTokenField } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { isEmpty, map } from 'lodash';
 import { useDispatch, useSelect } from '@wordpress/data';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 /**
  * Internal dependencies
  */
 import { SiteType, isFilledFormValue } from '../store/types';
 import { STORE_KEY } from '../store';
+import VerticalSelect from './vertical-select';
 import './style.scss';
 
 const siteTypeOptions: Record< SiteType, string > = {
@@ -21,39 +22,9 @@ const siteTypeOptions: Record< SiteType, string > = {
 };
 
 export default function OnboardingEdit() {
-	const [ verticalId, setVerticalId ] = useState< string >();
-
-	const { siteTitle, siteType } = useSelect( select => select( STORE_KEY ).getState() );
-
-	// This is a difficult section for working with FormToken field. Not ideal for our use case.
-	const [ verticalLabels, verticalLabelToId ] = useSelect( select => {
-		const vs = select( STORE_KEY ).getVerticals();
-		if ( ! vs ) {
-			return [ [], {} ];
-		}
-		return vs.reduce< [ string[], Record< string, string > ] >(
-			( [ labels, labelToId ], v ) => [
-				labels.concat( v.vertical_name ),
-				Object.assign( labelToId, { [ v.vertical_name ]: v.vertical_id } ),
-			],
-			[ [], {} ]
-		);
-	} );
-	const verticalLabel = useSelect(
-		select => {
-			if ( ! verticalId ) {
-				return [];
-			}
-			const v = select( STORE_KEY ).getVerticalItem( verticalId );
-			return v ? [ v.vertical_name ] : [];
-		},
-		[ verticalId ]
+	const { siteTitle, siteType, siteVertical } = useSelect( select =>
+		select( STORE_KEY ).getState()
 	);
-	const updateVerticalId = useCallback(
-		( [ nextLabel ] ) => setVerticalId( verticalLabelToId[ nextLabel ] ),
-		[ setVerticalId, verticalLabels, verticalLabelToId ]
-	);
-	// END: FormTokenField difficult section
 
 	const { resetSiteType, setSiteType, setSiteTitle } = useDispatch( STORE_KEY );
 
@@ -98,17 +69,17 @@ export default function OnboardingEdit() {
 					</div>
 				) }
 			</div>
-			{ /* FormTokenField sufficient for first round, but not ideal. Simpler component for single autocomplete is needed */ }
-			{ ( isFilledFormValue( siteType ) || ! isEmpty( verticalLabel ) ) && (
-				<FormTokenField
-					label={ NO__( 'My site is about' ) }
-					maxLength={ 1 }
-					onChange={ updateVerticalId }
-					suggestions={ verticalLabels }
-					value={ verticalLabel }
-				/>
+
+			{ ( isFilledFormValue( siteType ) || ! isEmpty( siteVertical ) ) && (
+				<div className="onboarding-block__question">
+					<span>{ NO__( 'My site is about' ) }</span>
+					<div className="onboarding-block__multi-question">
+						<VerticalSelect inputClass="onboarding-block__question-input" />
+					</div>
+				</div>
 			) }
-			{ ( ! isEmpty( verticalLabel ) || siteTitle ) && (
+
+			{ ( ! isEmpty( siteVertical ) || siteTitle ) && (
 				<>
 					<label className="onboarding-block__question">
 						<span>{ NO__( "It's called" ) }</span>

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -4,11 +4,11 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { __ as NO__ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { Suggestions } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import Suggestions from 'components/suggestions';
 import { STORE_KEY } from '../../store';
 import { SiteVertical, isFilledFormValue } from '../../store/types';
 

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -1,4 +1,3 @@
-/** @format */
 
 /**
  * External dependencies

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -1,0 +1,129 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { useState, useCallback, useRef } from 'react';
+import { __ as NO__ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import Suggestions from '../../../../components/suggestions';
+import { STORE_KEY } from '../../store';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+import { SiteVertical, isFilledFormValue } from '../../store/types';
+
+interface Props {
+	inputClass: string;
+}
+
+export default function VerticalSelect( { inputClass }: Props ) {
+	const popular = [
+		NO__( 'Travel Agency' ),
+		NO__( 'Digital Marketing' ),
+		NO__( 'Cameras & Photography' ),
+		NO__( 'Website Designer' ),
+		NO__( 'Restaurants' ),
+		NO__( 'Fashion Designer' ),
+		NO__( 'Real Estate Agent' ),
+	];
+
+	const [ inputValue, setInputValue ] = useState( '' );
+	const [ suggestionsVisibility, setsuggestionsVisibility ] = useState( false );
+
+	const suggestionRef = useRef< Suggestions >( null );
+	const inputRef = useRef< HTMLInputElement >( null );
+
+	const verticals = useSelect( select =>
+		select( STORE_KEY )
+			.getVerticals()
+			.map( x => ( {
+				label: x.vertical_name,
+				id: x.vertical_id,
+			} ) )
+	);
+
+	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
+	const { setSiteVertical } = useDispatch( STORE_KEY );
+
+	const showSuggestions = () => setsuggestionsVisibility( true );
+	const hideSuggestions = () => setsuggestionsVisibility( false );
+
+	const handleSuggestionChangeEvent = useCallback(
+		( e: React.ChangeEvent< HTMLInputElement > ) => setInputValue( e.target.value as string ),
+		[ setInputValue ]
+	);
+
+	const handleSuggestionKeyDown = useCallback(
+		( e: React.KeyboardEvent< HTMLInputElement > ) => {
+			if ( suggestionRef && suggestionRef.current ) {
+				if ( suggestionRef.current.props.suggestions.length > 0 && e.key === 'Enter' ) {
+					e.preventDefault();
+				}
+
+				suggestionRef.current.handleKeyEvent( e );
+			}
+		},
+		[ setInputValue ]
+	);
+
+	const handleSelect = ( vertical: SiteVertical ) => {
+		setSiteVertical( vertical );
+		hideSuggestions();
+		if ( inputRef && inputRef.current ) {
+			inputRef.current.blur();
+		}
+	};
+
+	const getInputValue = () =>
+		suggestionsVisibility || ! isFilledFormValue( siteVertical ) ? inputValue : siteVertical.label;
+
+	const getSuggestions = () => {
+		if ( ! verticals.length ) {
+			return [
+				{
+					label: '',
+					category: NO__( 'Loading, please wait...' ),
+				},
+			];
+		}
+		if ( ! inputValue.length ) {
+			return popular.map( label => ( {
+				...verticals.find( vertical => vertical.label.includes( label ) ),
+				category: NO__( 'Popular' ),
+			} ) );
+		}
+
+		return verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
+	};
+
+	return (
+		<div className="vertical-select">
+			<input
+				ref={ inputRef }
+				className={ inputClass }
+				placeholder={ NO__( 'enter a topic' ) }
+				onChange={ handleSuggestionChangeEvent }
+				onFocus={ showSuggestions }
+				onBlur={ hideSuggestions }
+				onKeyDown={ handleSuggestionKeyDown }
+				autoComplete="off"
+				value={ getInputValue() }
+			/>
+			{ suggestionsVisibility && (
+				<Suggestions
+					ref={ suggestionRef }
+					query={ inputValue }
+					suggestions={ getSuggestions() }
+					suggest={ handleSelect }
+				/>
+			) }
+		</div>
+	);
+}

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import Suggestions from '../../../../components/suggestions';
+import Suggestions from 'components/suggestions';
 import { STORE_KEY } from '../../store';
 
 /**

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -11,12 +10,12 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import Suggestions from 'components/suggestions';
 import { STORE_KEY } from '../../store';
+import { SiteVertical, isFilledFormValue } from '../../store/types';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import { SiteVertical, isFilledFormValue } from '../../store/types';
 
 interface Props {
 	inputClass: string;

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -71,35 +71,33 @@ export default function VerticalSelect( { inputClass }: Props ) {
 		[ setInputValue ]
 	);
 
-	const handleSelect = ( vertical: SiteVertical ) => {
-		setSiteVertical( vertical );
-		hideSuggestions();
-		if ( inputRef && inputRef.current ) {
-			inputRef.current.blur();
-		}
-	};
+	const handleSelect = useCallback(
+		( vertical: SiteVertical ) => {
+			setSiteVertical( vertical );
+			hideSuggestions();
+			if ( inputRef && inputRef.current ) {
+				inputRef.current.blur();
+			}
+		},
+		[ setSiteVertical, hideSuggestions ]
+	);
 
-	const getInputValue = () =>
+	const value =
 		suggestionsVisibility || ! isFilledFormValue( siteVertical ) ? inputValue : siteVertical.label;
 
-	const getSuggestions = () => {
-		if ( ! verticals.length ) {
-			return [
-				{
-					label: '',
-					category: NO__( 'Loading, please wait...' ),
-				},
-			];
-		}
-		if ( ! inputValue.length ) {
-			return popular.map( label => ( {
+	const loadingMessage = [
+		{
+			label: '',
+			category: NO__( 'Loading, please wait...' ),
+		},
+	];
+
+	const suggestions = ! inputValue.length
+		? popular.map( label => ( {
 				...verticals.find( vertical => vertical.label.includes( label ) ),
 				category: NO__( 'Popular' ),
-			} ) );
-		}
-
-		return verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
-	};
+		  } ) )
+		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
 
 	return (
 		<div className="vertical-select">
@@ -112,13 +110,13 @@ export default function VerticalSelect( { inputClass }: Props ) {
 				onBlur={ hideSuggestions }
 				onKeyDown={ handleSuggestionKeyDown }
 				autoComplete="off"
-				value={ getInputValue() }
+				value={ value }
 			/>
 			{ suggestionsVisibility && (
 				<Suggestions
 					ref={ suggestionRef }
 					query={ inputValue }
-					suggestions={ getSuggestions() }
+					suggestions={ ! verticals.length ? loadingMessage : suggestions }
 					suggest={ handleSelect }
 				/>
 			) }

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/style.scss
@@ -1,0 +1,31 @@
+@import 'assets/stylesheets/gutenberg-base-styles/style';
+
+.vertical-select {
+	.onboarding-block__question-input {
+		width: 100%;
+	}
+	.suggestions__category-heading {
+		padding: 12px 16px;
+		color: $dark-gray-300;
+		line-height: 18px;
+		border: 1px solid $light-gray-500;
+	}
+	.suggestions__wrapper {
+		max-height: 440px;
+		overflow: auto;
+		border: 1px solid $blue-medium-focus;
+	}
+	.suggestions__item {
+		border-color: $light-gray-500;
+		.suggestions__label.is-emphasized {
+			font-weight: normal;
+			color: $blue-medium-900;
+		}
+		&:focus, 
+		&:active {
+			.suggestions__label.is-emphasized {
+				color: $blue-medium-focus;
+			}
+		}
+	}
+}

--- a/client/landing/gutenboarding/store/actions.ts
+++ b/client/landing/gutenboarding/store/actions.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ActionType, SiteType, Vertical } from './types';
+import { ActionType, SiteType, SiteVertical, Vertical } from './types';
 
 export const resetSiteType = () => ( {
 	type: ActionType.RESET_SITE_TYPE as const,
@@ -10,6 +10,11 @@ export const resetSiteType = () => ( {
 export const setSiteType = ( siteType: SiteType ) => ( {
 	type: ActionType.SET_SITE_TYPE as const,
 	siteType,
+} );
+
+export const setSiteVertical = ( siteVertical: SiteVertical ) => ( {
+	type: ActionType.SET_SITE_VERTICAL as const,
+	siteVertical,
 } );
 
 export const setSiteTitle = ( siteTitle: string ) => ( {

--- a/client/landing/gutenboarding/store/reducer.ts
+++ b/client/landing/gutenboarding/store/reducer.ts
@@ -7,7 +7,7 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { ActionType, FormValue, SiteType, EMPTY_FORM_VALUE, Vertical } from './types';
+import { ActionType, FormValue, SiteType, EMPTY_FORM_VALUE, Vertical, SiteVertical } from './types';
 import * as Actions from './actions';
 
 const siteType: Reducer<
@@ -43,7 +43,17 @@ const verticals: Reducer< Vertical[], ReturnType< typeof Actions[ 'receiveVertic
 	return state;
 };
 
-const reducer = combineReducers( { siteType, siteTitle, verticals } );
+const siteVertical: Reducer<
+	FormValue< SiteVertical >,
+	ReturnType< typeof Actions[ 'setSiteVertical' ] >
+> = ( state = EMPTY_FORM_VALUE, action ) => {
+	if ( action.type === ActionType.SET_SITE_VERTICAL ) {
+		return action.siteVertical;
+	}
+	return state;
+};
+
+const reducer = combineReducers( { siteType, siteTitle, verticals, siteVertical } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/client/landing/gutenboarding/store/selectors.ts
+++ b/client/landing/gutenboarding/store/selectors.ts
@@ -5,6 +5,3 @@ import { State } from './reducer';
 
 export const getState = ( state: State ) => state;
 export const getVerticals = ( state: State ) => state.verticals;
-
-export const getVerticalItem = ( state: State, id: string ) =>
-	getVerticals( state ).find( v => v.vertical_id === id );

--- a/client/landing/gutenboarding/store/types.ts
+++ b/client/landing/gutenboarding/store/types.ts
@@ -4,6 +4,7 @@
 	RESET_SITE_TYPE = 'RESET_SITE_TYPE',
 	SET_SITE_TITLE = 'SET_SITE_TITLE',
 	SET_SITE_TYPE = 'SET_SITE_TYPE',
+	SET_SITE_VERTICAL = 'SET_SITE_VERTICAL',
 }
 export { ActionType };
 
@@ -11,6 +12,11 @@ export enum SiteType {
 	BLOG = 'blog',
 	STORE = 'store',
 	STORY = 'story',
+}
+
+export interface SiteVertical {
+	label: string;
+	id: string;
 }
 
 export const EMPTY_FORM_VALUE = Object.freeze( {} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Use `Suggestions` component instead of `FormTokenField` for vertical select and remove the _difficult section for working with FormToken field_
- Add selected `siteVertical` to store.
- Extract `VerticalSelect` to its own component.

#### Testing instructions
- UI implementation should follow the proposed design.
- When the vertical select input field is empty and focused, _Popular_ verticals should be displayed.
- After loading the page, if Network throttling is set to 'Slow 3G' or less, a _Loading_ message will be displayed briefly before verticals are downloaded.

#### Notes
Regardless of the component used to display and highlight vertical suggestions, we should consider using the vertical search REST API for 2 reasons:
- 60KB may be a bit much for mobile users. added a 'Loading' message for now when the select is open.
- We can improve UX by adding all the matching within `synonyms` Array of vertical API.
