### PR TITLE
Fix: Set site Public only on successful purchase

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -11,6 +11,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import notices from 'notices';
 import EmptyContent from 'components/empty-content';
 import CreditsPaymentBox from './credits-payment-box';
 import FreeTrialConfirmationBox from './free-trial-confirmation-box';
@@ -257,13 +258,17 @@ export class SecurePaymentForm extends Component {
 		try {
 			await this.maybeSetSiteToPublic( { cart } );
 		} catch ( e ) {
-			const errorMessage = {
-				message:
-					'There was a problem completing the checkout. <a href="/help/contact">Contact support</a>',
-			};
+			const message = this.props.translate(
+				'There was a problem completing the checkout. {{a}}Contact support{{/a}}.',
+				{
+					components: { a: <a href="/help/contact" /> },
+					comment:
+						"This is an error message that is shown when a user's purchase has failed at the checkout page",
+				}
+			);
 
 			debug( 'Error setting site to public', e );
-			displayError( errorMessage );
+			notices.error( message );
 
 			return;
 		}

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -80,7 +80,7 @@ export class SecurePaymentForm extends Component {
 			nextStep = this.props.transaction.step;
 
 		if ( ! isEqual( prevStep, nextStep ) ) {
-			this.handleTransactionStep( this.props );
+			await this.handleTransactionStep( this.props );
 		}
 	}
 
@@ -221,6 +221,7 @@ export class SecurePaymentForm extends Component {
 		const response = await this.props.saveSiteSettings( selectedSiteId, {
 			blog_public: 1,
 		} );
+
 		if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
 			throw 'Invalid response';
 		}
@@ -234,7 +235,7 @@ export class SecurePaymentForm extends Component {
 		this.displayNotices( cart, step );
 		recordTransactionAnalytics( cart, step, transaction?.payment?.paymentMethod );
 
-		this.finishIfLastStep( cart, selectedSite, step );
+		await this.finishIfLastStep( cart, selectedSite, step );
 	}
 
 	displayNotices( cart, step ) {
@@ -256,8 +257,14 @@ export class SecurePaymentForm extends Component {
 		try {
 			await this.maybeSetSiteToPublic( { cart } );
 		} catch ( e ) {
+			const errorMessage = {
+				message:
+					'There was a problem completing the checkout. <a href="/help/contact">Contact support</a>',
+			};
+
 			debug( 'Error setting site to public', e );
-			displayError();
+			displayError( errorMessage );
+
 			return;
 		}
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -70,7 +70,7 @@ export class SecurePaymentForm extends Component {
 		this.setInitialPaymentDetails();
 	}
 
-	componentDidUpdate( prevProps ) {
+	async componentDidUpdate( prevProps ) {
 		if ( this.getVisiblePaymentBox( prevProps ) !== this.getVisiblePaymentBox( this.props ) ) {
 			this.setInitialPaymentDetails();
 		}
@@ -226,7 +226,7 @@ export class SecurePaymentForm extends Component {
 		}
 	}
 
-	handleTransactionStep( { cart, selectedSite, transaction } ) {
+	async handleTransactionStep( { cart, selectedSite, transaction } ) {
 		const step = transaction.step;
 
 		debug( 'transaction step: ' + step.name );

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -182,14 +182,6 @@ export class SecurePaymentForm extends Component {
 			transaction.payment.paymentMethod = 'WPCOM_Billing_Ebanx';
 		}
 
-		try {
-			await this.maybeSetSiteToPublic( { cart } );
-		} catch ( e ) {
-			debug( 'Error setting site to public', e );
-			displayError();
-			return;
-		}
-
 		submit(
 			{
 				cart,
@@ -256,8 +248,16 @@ export class SecurePaymentForm extends Component {
 		}
 	}
 
-	finishIfLastStep( cart, selectedSite, step ) {
+	async finishIfLastStep( cart, selectedSite, step ) {
 		if ( ! step.last || step.error ) {
+			return;
+		}
+
+		try {
+			await this.maybeSetSiteToPublic( { cart } );
+		} catch ( e ) {
+			debug( 'Error setting site to public', e );
+			displayError();
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A failed purchase of a Business or eCommerce plan still sets the site "public".
* Checking Tracks trends for `calypso_cart_unrecognized_payment_method` shows a large number of these everyday. Similarly, we have a large number of `calypso_checkout_payment_error` events too. So, it's possible that a number of these users end up with a public site even though they didn't purchase a biz/eCom site due to a failed purchase.

**Note for translators**

The new string to be translated is an error notification that looks like this:

<img width="840" alt="Screenshot 2019-12-13 at 11 16 29 AM" src="https://user-images.githubusercontent.com/1269602/70772320-25871400-1d9a-11ea-811c-08f78e87b23c.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow and add a Business plan to cart
* Add an invalid credit card number. I used `4716965652794729 `
* This will fire a `calypso_checkout_payment_error` Tracks event. 
* On another tab, open http://calypso.localhost:3000/ and verify that your new site is still Private. Without this patch, the new site would have been Public.
