### PR TITLE
Google Drive: Add a feature flag

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -119,6 +119,14 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
+		if (
+			'google_drive' === service.ID &&
+			( ! config.isEnabled( 'google-drive' ) ||
+				! canCurrentUser( state, siteId, 'manage_options' ) )
+		) {
+			return false;
+		}
+
 		return true;
 	} );
 }

--- a/config/development.json
+++ b/config/development.json
@@ -58,6 +58,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"google-my-business": true,
+		"google-drive": true,
 		"gutenboarding": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
In order to develop the site keyring connection for Google Drive, we
need to be able to enable the option on the server side, without it
appearing in the list of available connections.

So far we have done this by restricting the connection to Automatticians
on the server side, but this has caused other problems. This change
creates and configures a feature flag so that the connection is only
available in the development environment.

#### Testing instructions

Using an Automattician account, view `/marketing/connections/` for a site both in a local dev environment and using calypso.live. You should see the Google Drive option in the development environment, but not in calypso.live.

