### PR TITLE
Record Tracks events for checkout button clicks in the product selector

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -506,6 +506,7 @@ ProductSelector.propTypes = {
 	fetchingSitePurchases: PropTypes.bool,
 	productSlugs: PropTypes.arrayOf( PropTypes.string ),
 	purchases: PropTypes.array,
+	recordTracksEvent: PropTypes.func.isRequired,
 	selectedSiteId: PropTypes.number,
 	selectedSiteSlug: PropTypes.string,
 	sitePlans: PropTypes.object,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `recordTracksEvent` for the checkout button clicks in case of new purchase, product upsell and plan upsell

#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/plans/ and select a Jetpack site
* In the dev tools console enable logging with `localStorage.setItem('debug', 'calypso:analytics:*');`
* Purchase the Backup Daily and confirm that a tracks event called `calypso_product_feature_upgrade_click` is logged and it contains `upgrading_to` and `current_plan` props
![Screenshot 2019-11-06 at 16 42 57](https://user-images.githubusercontent.com/478735/68314667-d5d86d00-00b6-11ea-8fd5-5f2d50d3069c.png)

* Purchase Backup Realtime and confirm that a tracks event called `calypso_product_feature_upgrade_click` is logged and it contains `upgrading_to` and `current_plan` and also `current_product` props
![Screenshot 2019-11-06 at 16 42 50](https://user-images.githubusercontent.com/478735/68314709-eab50080-00b6-11ea-8052-a72418ab5090.png)

* Select a Jetpack site that is on the Personal plan. Upgrade the plan to Business using the upsell/upgrade button located inside the product selector. Confirm that a tracks event called `calypso_product_feature_upgrade_click` is logged and it contains `upgrading_to` and `current_plan` props
![Screenshot 2019-11-06 at 16 48 42](https://user-images.githubusercontent.com/478735/68314679-dd981180-00b6-11ea-8de0-14f25444055f.png)

Fixes n/a
