### PR TITLE
Split decode utils in lib/url.

### DIFF
--- a/client/lib/url/decode-utils.ts
+++ b/client/lib/url/decode-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { Falsy } from 'utility-types';
+
+interface Stringable {
+	toString: () => string;
+}
+
+function decodeIfValid(
+	encodedItem: Stringable | Falsy,
+	decodingFunction: ( item: string ) => string
+) {
+	const encodedURIString: string =
+		encodedItem && encodedItem.toString ? encodedItem.toString() : '';
+
+	try {
+		return decodingFunction( encodedURIString );
+	} catch ( e ) {
+		return encodedURIString;
+	}
+}
+
+/**
+ * Wrap decodeURI in a try / catch block to prevent `URIError` on invalid input
+ * Passing a non-string value will return an empty string.
+ * @param  encodedURI URI to attempt to decode
+ * @return            Decoded URI (or passed in value on error)
+ */
+export function decodeURIIfValid( encodedURI: Stringable | Falsy ): string {
+	return decodeIfValid( encodedURI, decodeURI );
+}
+
+/**
+ * Wrap decodeURIComponent in a try / catch block to prevent `URIError` on invalid input
+ * Passing a non-string value will return an empty string.
+ * @param  encodedURIComponent URI component to attempt to decode
+ * @return                     Decoded URI component (or passed in value on error)
+ */
+export function decodeURIComponentIfValid( encodedURIComponent: Stringable | Falsy ): string {
+	return decodeIfValid( encodedURIComponent, decodeURIComponent );
+}

--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { format as formatUrl, parse as parseUrl } from 'url';
-import { has, isString, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +21,7 @@ export { URL_TYPE, determineUrlType } from './url-type';
 export { default as isOutsideCalypso } from './is-outside-calypso';
 export { default as isHttps } from './is-https';
 export { addSchemeIfMissing, setUrlScheme } from './scheme-utils';
+export { decodeURIIfValid, decodeURIComponentIfValid } from './decode-utils';
 
 /**
  * Removes given params from a url.
@@ -41,38 +42,4 @@ export function omitUrlParams( url: URL | Falsy, paramsToOmit: string | string[]
 
 	delete parsed.search;
 	return formatUrl( parsed );
-}
-
-/**
- * Wrap decodeURI in a try / catch block to prevent `URIError` on invalid input
- * Passing a non-string value will return an empty string.
- * @param  encodedURI URI to attempt to decode
- * @return            Decoded URI (or passed in value on error)
- */
-export function decodeURIIfValid( encodedURI: string ): URL {
-	if ( ! ( isString( encodedURI ) || has( encodedURI, 'toString' ) ) ) {
-		return '';
-	}
-	try {
-		return decodeURI( encodedURI );
-	} catch ( e ) {
-		return encodedURI;
-	}
-}
-
-/**
- * Wrap decodeURIComponent in a try / catch block to prevent `URIError` on invalid input
- * Passing a non-string value will return an empty string.
- * @param  encodedURIComponent URI component to attempt to decode
- * @return                     Decoded URI component (or passed in value on error)
- */
-export function decodeURIComponentIfValid( encodedURIComponent: string ): string {
-	if ( ! ( isString( encodedURIComponent ) || has( encodedURIComponent, 'toString' ) ) ) {
-		return '';
-	}
-	try {
-		return decodeURIComponent( encodedURIComponent );
-	} catch ( e ) {
-		return encodedURIComponent;
-	}
 }

--- a/client/lib/url/test/decode-utils.js
+++ b/client/lib/url/test/decode-utils.js
@@ -1,0 +1,68 @@
+/**
+ * Internal dependencies
+ */
+import { decodeURIIfValid, decodeURIComponentIfValid } from '../decode-utils';
+
+describe( 'decodeURIIfValid', () => {
+	test( 'should return an empty string when null is provided', () => {
+		const encodedURI = null;
+		const actual = decodeURIIfValid( encodedURI );
+		const expected = '';
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should return decoded URL when a valid URL with Unicode chars is provided', () => {
+		const encodedURI = 'http://example.com/?x=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF';
+		const actual = decodeURIIfValid( encodedURI );
+		const expected = 'http://example.com/?x=こんにちは';
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should return decoded URL when a valid URL with Unicode chars is provided as object', () => {
+		const encodedURI = {
+			toString: () => 'http://example.com/?x=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF',
+		};
+		const actual = decodeURIIfValid( encodedURI );
+		const expected = 'http://example.com/?x=こんにちは';
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should return the unmodified URL when an incorrectly-coded URL is provided', () => {
+		const encodedURI = 'http://example.com/?x=%E3%%0000000';
+		const actual = decodeURIIfValid( encodedURI );
+		const expected = encodedURI;
+		expect( actual ).toBe( expected );
+	} );
+} );
+
+describe( 'decodeURIComponentIfValid', () => {
+	test( 'should return an empty string when null is provided', () => {
+		const encodedURIComponent = null;
+		const actual = decodeURIComponentIfValid( encodedURIComponent );
+		const expected = '';
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should return decoded component when a valid component with Unicode chars is provided', () => {
+		const encodedURIComponent = '%3Fx%3D%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF';
+		const actual = decodeURIComponentIfValid( encodedURIComponent );
+		const expected = '?x=こんにちは';
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should return decoded component when a valid component with Unicode chars is provided as object', () => {
+		const encodedURIComponent = {
+			toString: () => '%3Fx%3D%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF',
+		};
+		const actual = decodeURIComponentIfValid( encodedURIComponent );
+		const expected = '?x=こんにちは';
+		expect( actual ).toBe( expected );
+	} );
+
+	test( 'should return the unmodified component when an incorrectly-coded component is provided', () => {
+		const encodedURIComponent = '%3Fx%3D%E3%%0000000';
+		const actual = decodeURIComponentIfValid( encodedURIComponent );
+		const expected = encodedURIComponent;
+		expect( actual ).toBe( expected );
+	} );
+} );


### PR DESCRIPTION
This is one of several PRs aiming at splitting up `lib/url` into several files for tree-shaking, replacing usage of the browserified node `url` module with native functionality, and generally improving it.

This PR focuses on `decodeURIIfValid` and `decodeURIComponentIfValid`, which I'm splitting into their own module, improving types, and adding tests for.

This PR was split out from #36531, which got too big.

#### Changes proposed in this Pull Request

* Split out `decodeURIIfValid` and `decodeURIComponentIfValid` in `lib/url`. 
* Add tests for these methods.

#### Testing instructions

The methods are simple, and the unit tests should ensure they work correctly.