### PR TITLE
G Suite: Remove misleading mentions to voice calls

### DIFF
--- a/client/components/gsuite/gsuite-features/index.jsx
+++ b/client/components/gsuite/gsuite-features/index.jsx
@@ -80,14 +80,12 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 			/>
 			<GSuiteSingleFeature
 				title={
-					compact ? translate( 'Video and voice calls' ) : translate( 'Connect with your team' )
+					compact ? translate( 'Video calls' ) : translate( 'Connect with your team' )
 				}
 				description={
 					compact
 						? undefined
-						: translate(
-								'Use text chats, voice calls, or video calls, with built in screen sharing.'
-						  )
+						: translate( 'Use text chats or video calls, with built in screen sharing.' )
 				}
 				imagePath={ '/calypso/images/g-suite/logo_hangouts_48dp.svg' }
 				imageAlt={ 'Google Hangouts Logo' }

--- a/client/components/gsuite/gsuite-features/test/__snapshots__/compact.js.snap
+++ b/client/components/gsuite/gsuite-features/test/__snapshots__/compact.js.snap
@@ -84,7 +84,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures in a list 1`] = 
       <h5
         className="gsuite-features__feature-header"
       >
-        Video and voice calls
+        Video calls
       </h5>
     </div>
   </div>
@@ -175,7 +175,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with basic plan 
       <h5
         className="gsuite-features__feature-header"
       >
-        Video and voice calls
+        Video calls
       </h5>
     </div>
   </div>
@@ -266,7 +266,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with business pl
       <h5
         className="gsuite-features__feature-header"
       >
-        Video and voice calls
+        Video calls
       </h5>
     </div>
   </div>
@@ -357,7 +357,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with no productS
       <h5
         className="gsuite-features__feature-header"
       >
-        Video and voice calls
+        Video calls
       </h5>
     </div>
   </div>

--- a/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
@@ -96,7 +96,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
         Connect with your team
       </h5>
       <p>
-        Use text chats, voice calls, or video calls, with built in screen sharing.
+        Use text chats or video calls, with built in screen sharing.
       </p>
     </div>
   </div>
@@ -199,7 +199,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
         Connect with your team
       </h5>
       <p>
-        Use text chats, voice calls, or video calls, with built in screen sharing.
+        Use text chats or video calls, with built in screen sharing.
       </p>
     </div>
   </div>
@@ -302,7 +302,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
         Connect with your team
       </h5>
       <p>
-        Use text chats, voice calls, or video calls, with built in screen sharing.
+        Use text chats or video calls, with built in screen sharing.
       </p>
     </div>
   </div>
@@ -405,7 +405,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
         Connect with your team
       </h5>
       <p>
-        Use text chats, voice calls, or video calls, with built in screen sharing.
+        Use text chats or video calls, with built in screen sharing.
       </p>
     </div>
   </div>

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
@@ -121,7 +121,7 @@ const GSuiteUpsellCard = ( {
 				>
 					<div className="gsuite-upsell-card__buttons">
 						<Button className="gsuite-upsell-card__skip-button" onClick={ handleSkipClick }>
-							{ translate( 'Skip' ) }
+							{ translate( 'Skip for now' ) }
 						</Button>
 
 						<Button

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -171,7 +171,7 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
             Connect with your team
           </h5>
           <p>
-            Use text chats, voice calls, or video calls, with built in screen sharing.
+            Use text chats or video calls, with built in screen sharing.
           </p>
         </div>
       </div>


### PR DESCRIPTION
This pull request removes misleading mentions to voice calls on the G Suite pages. We indeed do not offer Google Voice with G Suite accounts. This also renames the skip button on the upsell page to better convey the fact that users can purchase G Suite later if they want.

![screenshot](https://user-images.githubusercontent.com/594356/68318493-2ce14080-00bd-11ea-993d-f359476738fe.png)

![screenshot](https://user-images.githubusercontent.com/594356/68318799-995c3f80-00bd-11ea-87a5-d2f6fc812761.png)

#### Testing instructions

1. Run `git checkout update/gsuite-upsell` and start your server, or open a [live branch](https://calypso.live/?branch=update/gsuite-upsell)
2. Open the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
3. Select any domain, and provide registration details if required
4. Assert that voice calls are no longer mentioned
5. Assert that there is a `Skip for now` button on the upsell page
6. Navigate to the `Domain Settings` page of a domain eligible for G Suite
7. Click the `Email` link to access the `Email` page
8. Assert that voice calls are no longer mentioned
