### PR TITLE
Don't depend on the `moment` prop from `localize`.

### DIFF
--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -1,10 +1,16 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
+import { moment } from 'moment';
 
+/**
+ * Internal dependencies
+ */
 import getIsNoteApproved from '../state/selectors/get-is-note-approved';
 import { linkProps } from './functions';
-
 import FollowLink from './follow-link';
 
 function getDisplayURL( url ) {
@@ -39,7 +45,8 @@ export class UserBlock extends React.Component {
 			return '';
 		}
 
-		momentTime = this.props.moment( timestamp );
+		const localeSlug = getLocaleSlug();
+		momentTime = moment( timestamp ).locale( localeSlug );
 
 		if ( Date.now() - parsedTime > 1000 * DAY_IN_SECONDS * 5 ) {
 			// 30 Apr 2015

--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { moment } from 'moment';
+import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { noop, map } from 'lodash';
@@ -17,7 +16,6 @@ class EventsTooltip extends Component {
 	static propTypes = {
 		title: PropTypes.string,
 		events: PropTypes.array,
-		moment: PropTypes.func.isRequired,
 		maxEvents: PropTypes.number,
 		moreEvents: PropTypes.string,
 	};

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DayPicker from 'react-day-picker';
@@ -12,6 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { withLocalizedMoment } from 'components/localized-moment';
 import DayItem from './day';
 import DatePickerNavBar from './nav-bar';
 
@@ -270,4 +270,4 @@ class DatePicker extends PureComponent {
 	}
 }
 
-export default localize( DatePicker );
+export default localize( withLocalizedMoment( DatePicker ) );

--- a/client/components/date-range/test/__snapshots__/index.js.snap
+++ b/client/components/date-range/test/__snapshots__/index.js.snap
@@ -62,7 +62,7 @@ exports[`DateRange should render 1`] = `
         onInputFocus={[Function]}
         startDateValue="MM/DD/YYYY"
       />
-      <Localized(DatePicker)
+      <Localized(WithLocalizedMoment(DatePicker))
         calendarViewDate={null}
         disabledDays={
           Array [

--- a/client/components/input-chrono/docs/example.jsx
+++ b/client/components/input-chrono/docs/example.jsx
@@ -10,42 +10,43 @@ import { localize } from 'i18n-calypso';
  */
 import InputChrono from 'components/input-chrono';
 import Card from 'components/card';
+import { withLocalizedMoment } from 'components/localized-moment';
 
-/**
- * Date Picker Demo
- */
+// Date Picker Demo
 const InputChronoExample = localize(
-	class extends React.PureComponent {
-		state = {
-			date: this.props.moment(),
-		};
+	withLocalizedMoment(
+		class extends React.PureComponent {
+			state = {
+				date: this.props.moment(),
+			};
 
-		UNSAFE_componentWillMount() {
-			var self = this;
-			this.interval = setInterval( function() {
-				var date = self.props.moment( self.state.date );
-				date.hours( date.hours() + 1 );
-				self.setState( { date: date } );
-			}, 1000 );
+			componentDidMount() {
+				this.interval = setInterval( () => {
+					const date = this.props.moment( self.state.date );
+					date.hours( date.hours() + 1 );
+					self.setState( { date: date } );
+				}, 1000 );
+			}
+
+			componentWillUnmount() {
+				clearInterval( this.interval );
+			}
+
+			onSet = date => {
+				// eslint-disable-next-line no-console
+				console.log( `date: %s`, date.toDate() );
+				this.setState( { date: date } );
+			};
+
+			render() {
+				return (
+					<Card style={ { width: '300px', margin: 0 } }>
+						<InputChrono value={ this.state.date.calendar() } onSet={ this.onSet } />
+					</Card>
+				);
+			}
 		}
-
-		componentWillUnmount() {
-			clearInterval( this.interval );
-		}
-
-		onSet = date => {
-			console.log( `date: %s`, date.toDate() );
-			this.setState( { date: date } );
-		};
-
-		render() {
-			return (
-				<Card style={ { width: '300px', margin: 0 } }>
-					<InputChrono value={ this.state.date.calendar() } onSet={ this.onSet } />
-				</Card>
-			);
-		}
-	}
+	)
 );
 
 InputChronoExample.displayName = 'InputChrono';

--- a/client/components/input-chrono/index.jsx
+++ b/client/components/input-chrono/index.jsx
@@ -1,11 +1,15 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import chrono from 'chrono-node';
+
+/**
+ * Internal dependencies
+ */
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -101,4 +105,4 @@ class InputChrono extends React.Component {
 	}
 }
 
-export default localize( InputChrono );
+export default localize( withLocalizedMoment( InputChrono ) );

--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -1,7 +1,7 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
@@ -13,256 +13,272 @@ import PostSchedule from 'components/post-schedule';
 import Timezone from 'components/timezone';
 import Card from 'components/card';
 import EventsTooltip from 'components/date-picker/events-tooltip';
+import { withLocalizedMoment } from 'components/localized-moment';
 
-/**
- * Date Picker Demo
- */
+// Date Picker Demo
 const PostScheduleExample = localize(
-	class extends React.PureComponent {
-		constructor( props ) {
-			super( props );
-			let date = new Date();
-			const tz = 'America/Los_Angeles';
-			const tomorrow = new Date().setDate( date.getDate() + 1 );
+	withLocalizedMoment(
+		class extends React.PureComponent {
+			constructor( props ) {
+				super( props );
+				let date = new Date();
+				const tz = 'America/Los_Angeles';
+				const tomorrow = new Date().setDate( date.getDate() + 1 );
 
-			date.setDate( date.getDate() + 3 );
-			date.setMilliseconds( 0 );
-			date.setSeconds( 0 );
+				date.setDate( date.getDate() + 3 );
+				date.setMilliseconds( 0 );
+				date.setSeconds( 0 );
 
-			date = props.moment( date ).tz( tz );
-			date.set( { hour: 11, minute: 20 } );
+				date = props.moment( date ).tz( tz );
+				date.set( { hour: 11, minute: 20 } );
 
-			this.state = {
-				events: [
-					{
-						id: 1,
-						title: 'Happy 30th birthday',
-						date: new Date( '2015-07-18T15:00:00' ),
-						type: 'birthday',
-					},
-					{
-						id: 2,
-						title: 'Tomorrow is tomorrow',
-						date: tomorrow,
-					},
-					{
-						id: 3,
-						title: 'WordCamp Lima 2016!',
-						date: new Date( '2016-07-16T09:00:00' ),
-						type: 'wordcamp-event',
-					},
-				],
-				gmtOffset: 1,
-				timezone: tz,
-				date: date,
+				this.state = {
+					events: [
+						{
+							id: 1,
+							title: 'Happy 30th birthday',
+							date: new Date( '2015-07-18T15:00:00' ),
+							type: 'birthday',
+						},
+						{
+							id: 2,
+							title: 'Tomorrow is tomorrow',
+							date: tomorrow,
+						},
+						{
+							id: 3,
+							title: 'WordCamp Lima 2016!',
+							date: new Date( '2016-07-16T09:00:00' ),
+							type: 'wordcamp-event',
+						},
+					],
+					gmtOffset: 1,
+					timezone: tz,
+					date: date,
 
-				eventsByDay: [],
-				showTooltip: false,
-				tooltipContext: null,
+					eventsByDay: [],
+					showTooltip: false,
+					tooltipContext: null,
+				};
+			}
+
+			UNSAFE_componentWillMount() {
+				this.setState( {
+					isFuture: true,
+				} );
+			}
+
+			setDate = date => {
+				console.log( 'date: ', date.format() ); // eslint-disable-line no-console
+
+				this.setState( {
+					isFuture: +new Date() < +new Date( date ),
+					date: date,
+				} );
+			};
+
+			setMonth = date => {
+				console.log( 'month: %s', date.format() ); // eslint-disable-line no-console
+				this.setState( { month: date } );
+			};
+
+			setGMTOffset = event => {
+				if ( typeof event.target.value === 'undefined' ) {
+					return;
+				}
+
+				this.setState( { gmtOffset: Number( event.target.value ) } );
+			};
+
+			setTimezone = zone => {
+				this.setState( { timezone: zone } );
+			};
+
+			clearState = ( state, event ) => {
+				event.preventDefault();
+				this.setState( { [ state ]: null } );
+			};
+
+			handleDayMouseEnter = ( date, modifiers, event, eventsByDay ) => {
+				this.setState( {
+					eventsByDay,
+					tooltipContext: event.target,
+					showTooltip: true,
+				} );
+			};
+
+			handleDayMouseLeave = () => {
+				this.setState( {
+					eventsByDay: [],
+					tooltipContext: null,
+					showTooltip: false,
+				} );
+			};
+
+			render() {
+				return (
+					<div>
+						<Card
+							style={ {
+								width: '300px',
+								verticalAlign: 'top',
+								display: 'inline-block',
+								margin: 0,
+							} }
+						>
+							<PostSchedule
+								events={ this.state.events }
+								onDateChange={ this.setDate }
+								onMonthChange={ this.setMonth }
+								gmtOffset={ this.state.gmtOffset }
+								timezone={ this.state.timezone }
+								onDayMouseEnter={ this.handleDayMouseEnter }
+								onDayMouseLeave={ this.handleDayMouseLeave }
+								selectedDay={ this.state.date }
+							/>
+
+							<EventsTooltip
+								events={ this.state.eventsByDay }
+								context={ this.state.tooltipContext }
+								isVisible={ this.state.showTooltip }
+							/>
+						</Card>
+
+						<div
+							style={ {
+								width: '260px',
+								display: 'inline-block',
+								verticalAlign: 'top',
+								margin: ' 0 0 0 30px',
+							} }
+						>
+							<Card className="card__component-instance">
+								<h3>
+									<span>owner</span>
+									<Gridicon icon="arrow-right" size={ 18 } />
+									<span>ownee</span>
+								</h3>
+
+								<div className="card__block">
+									<label>
+										state.timezone
+										<div
+											className="state-value"
+											style={ { fontSize: '11px', marginBottom: '2px' } }
+										>
+											{ this.state.timezone || 'not defined' }
+										</div>
+									</label>
+
+									<Timezone selectedZone={ this.state.timezone } onSelect={ this.setTimezone } />
+
+									<button
+										className="card__property-action"
+										style={ {
+											top: '-8px',
+											position: 'relative',
+										} }
+										onClick={ this.clearState.bind( this, 'timezone' ) }
+										href="#"
+									>
+										clean timezone
+									</button>
+								</div>
+
+								<div className="card__block">
+									<label>
+										state.gmtOffset
+										<input
+											className="editable-property"
+											type="text"
+											onChange={ this.setGMTOffset }
+											value={ this.state.gmtOffset }
+										/>
+									</label>
+
+									<button
+										className="card__property-action"
+										onClick={ this.clearState.bind( this, 'gmtOffset' ) }
+										href="#"
+									>
+										clean gmtOffset
+									</button>
+								</div>
+
+								<div className="card__block">
+									<label>
+										state.date
+										<div className="state-value" style={ { fontSize: '11px' } }>
+											{ this.state.date ? this.state.date.format() : 'not defined' }
+										</div>
+									</label>
+
+									<button
+										className="card__property-action"
+										onClick={ this.clearState.bind( this, 'date' ) }
+										href="#"
+									>
+										clean selectedDay
+									</button>
+								</div>
+							</Card>
+
+							<Card className="card__component-instance">
+								<h3>
+									<span>owner</span>
+									<Gridicon icon="arrow-left" size={ 18 } />
+									<span>ownee</span>
+								</h3>
+
+								<div className="card__block">
+									<label>
+										prop.onDateChange( date )
+										<div className="state-value" style={ { fontSize: '11px' } }>
+											{ this.state.date ? this.state.date.format() : 'not defined' }
+										</div>
+									</label>
+								</div>
+
+								<div className="card__block">
+									<label>
+										prop.onMonthChange( date )
+										<div className="state-value" style={ { fontSize: '11px' } }>
+											{ this.state.month ? this.state.month.format() : 'not defined' }
+										</div>
+									</label>
+								</div>
+							</Card>
+
+							<Card className="card__component-instance">
+								<label>
+									chronologically:
+									{ this.renderDateReference() }
+								</label>
+							</Card>
+						</div>
+					</div>
+				);
+			}
+
+			renderDateReference = () => {
+				if ( ! this.state.date ) {
+					return;
+				}
+
+				return (
+					<span
+						className="state-value"
+						style={ {
+							marginLeft: '10px',
+							fontSize: '11px',
+						} }
+					>
+						{ this.state.isFuture ? 'FUTURE' : 'PRESENT or PAST' }
+					</span>
+				);
 			};
 		}
-
-		UNSAFE_componentWillMount() {
-			this.setState( {
-				isFuture: true,
-			} );
-		}
-
-		setDate = date => {
-			console.log( 'date: ', date.format() ); // eslint-disable-line no-console
-
-			this.setState( {
-				isFuture: +new Date() < +new Date( date ),
-				date: date,
-			} );
-		};
-
-		setMonth = date => {
-			console.log( 'month: %s', date.format() ); // eslint-disable-line no-console
-			this.setState( { month: date } );
-		};
-
-		setGMTOffset = event => {
-			if ( typeof event.target.value === 'undefined' ) {
-				return;
-			}
-
-			this.setState( { gmtOffset: Number( event.target.value ) } );
-		};
-
-		setTimezone = zone => {
-			this.setState( { timezone: zone } );
-		};
-
-		clearState = ( state, event ) => {
-			event.preventDefault();
-			this.setState( { [ state ]: null } );
-		};
-
-		handleDayMouseEnter = ( date, modifiers, event, eventsByDay ) => {
-			this.setState( {
-				eventsByDay,
-				tooltipContext: event.target,
-				showTooltip: true,
-			} );
-		};
-
-		handleDayMouseLeave = () => {
-			this.setState( {
-				eventsByDay: [],
-				tooltipContext: null,
-				showTooltip: false,
-			} );
-		};
-
-		render() {
-			return (
-				<div>
-					<Card
-						style={ {
-							width: '300px',
-							verticalAlign: 'top',
-							display: 'inline-block',
-							margin: 0,
-						} }
-					>
-						<PostSchedule
-							events={ this.state.events }
-							onDateChange={ this.setDate }
-							onMonthChange={ this.setMonth }
-							gmtOffset={ this.state.gmtOffset }
-							timezone={ this.state.timezone }
-							onDayMouseEnter={ this.handleDayMouseEnter }
-							onDayMouseLeave={ this.handleDayMouseLeave }
-							selectedDay={ this.state.date }
-						/>
-
-						<EventsTooltip
-							events={ this.state.eventsByDay }
-							context={ this.state.tooltipContext }
-							isVisible={ this.state.showTooltip }
-						/>
-					</Card>
-
-					<div
-						style={ {
-							width: '260px',
-							display: 'inline-block',
-							verticalAlign: 'top',
-							margin: ' 0 0 0 30px',
-						} }
-					>
-						<Card className="card__component-instance">
-							<h3>
-								<span>owner</span>
-								<Gridicon icon="arrow-right" size={ 18 } />
-								<span>ownee</span>
-							</h3>
-
-							<div className="card__block">
-								<label>state.timezone</label>
-								<div className="state-value" style={ { fontSize: '11px', marginBottom: '2px' } }>
-									{ this.state.timezone || 'not defined' }
-								</div>
-
-								<Timezone selectedZone={ this.state.timezone } onSelect={ this.setTimezone } />
-
-								<a
-									className="card__property-action"
-									style={ {
-										top: '-8px',
-										position: 'relative',
-									} }
-									onClick={ this.clearState.bind( this, 'timezone' ) }
-									href="#"
-								>
-									clean timezone
-								</a>
-							</div>
-
-							<div className="card__block">
-								<label>state.gmtOffset</label>
-								<input
-									className="editable-property"
-									type="text"
-									onChange={ this.setGMTOffset }
-									value={ this.state.gmtOffset }
-								/>
-
-								<a
-									className="card__property-action"
-									onClick={ this.clearState.bind( this, 'gmtOffset' ) }
-									href="#"
-								>
-									clean gmtOffset
-								</a>
-							</div>
-
-							<div className="card__block">
-								<label>state.date</label>
-								<div className="state-value" style={ { fontSize: '11px' } }>
-									{ this.state.date ? this.state.date.format() : 'not defined' }
-								</div>
-
-								<a
-									className="card__property-action"
-									onClick={ this.clearState.bind( this, 'date' ) }
-									href="#"
-								>
-									clean selectedDay
-								</a>
-							</div>
-						</Card>
-
-						<Card className="card__component-instance">
-							<h3>
-								<span>owner</span>
-								<Gridicon icon="arrow-left" size={ 18 } />
-								<span>ownee</span>
-							</h3>
-
-							<div className="card__block">
-								<label>prop.onDateChange( date )</label>
-								<div className="state-value" style={ { fontSize: '11px' } }>
-									{ this.state.date ? this.state.date.format() : 'not defined' }
-								</div>
-							</div>
-
-							<div className="card__block">
-								<label>prop.onMonthChange( date )</label>
-								<div className="state-value" style={ { fontSize: '11px' } }>
-									{ this.state.month ? this.state.month.format() : 'not defined' }
-								</div>
-							</div>
-						</Card>
-
-						<Card className="card__component-instance">
-							<label>chronologically: </label>
-							{ this.renderDateReference() }
-						</Card>
-					</div>
-				</div>
-			);
-		}
-
-		renderDateReference = () => {
-			if ( ! this.state.date ) {
-				return;
-			}
-
-			return (
-				<span
-					className="state-value"
-					style={ {
-						marginLeft: '10px',
-						fontSize: '11px',
-					} }
-				>
-					{ this.state.isFuture ? 'FUTURE' : 'PRESENT or PAST' }
-				</span>
-			);
-		};
-	}
+	)
 );
 
 PostScheduleExample.displayName = 'PostSchedule';

--- a/client/extensions/woocommerce/app/order/order-activity-log/day.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/day.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class OrderEventsByDay extends Component {
 	static propTypes = {
@@ -53,4 +54,4 @@ class OrderEventsByDay extends Component {
 	}
 }
 
-export default localize( OrderEventsByDay );
+export default localize( withLocalizedMoment( OrderEventsByDay ) );

--- a/client/extensions/woocommerce/app/order/order-activity-log/event.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/event.js
@@ -14,6 +14,7 @@ import { EVENT_TYPES } from 'woocommerce/state/sites/orders/activity-log/selecto
 import LabelItem from 'woocommerce/woocommerce-services/views/shipping-label/label-item';
 import LabelItemInProgress from 'woocommerce/woocommerce-services/views/shipping-label/label-item-in-progress';
 import { decodeEntities, stripHTML } from 'lib/formatting';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class OrderEvent extends Component {
 	static propTypes = {
@@ -178,4 +179,4 @@ class OrderEvent extends Component {
 	}
 }
 
-export default localize( OrderEvent );
+export default localize( withLocalizedMoment( OrderEvent ) );

--- a/client/extensions/woocommerce/app/promotions/fields/date-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/date-field.js
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import DatePicker from 'components/date-picker';
+import { withLocalizedMoment } from 'components/localized-moment';
 import FormField from './form-field';
 
 const DateField = props => {
@@ -39,4 +40,4 @@ DateField.propTypes = {
 	edit: PropTypes.func,
 };
 
-export default localize( DateField );
+export default localize( withLocalizedMoment( DateField ) );

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 function getPromotionTypeText( promotionType, translate ) {
 	switch ( promotionType ) {
@@ -56,7 +56,10 @@ function getTimeframeText( promotion, translate, moment ) {
 	return translate( 'No end date' );
 }
 
-const PromotionsListRow = ( { site, promotion, translate, moment } ) => {
+function PromotionsListRow( { site, promotion } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	return (
 		<TableRow href={ getLink( '/store/promotion/:site/' + promotion.id, site ) }>
 			<TableItem isTitle className="promotions__list-promotion">
@@ -68,7 +71,7 @@ const PromotionsListRow = ( { site, promotion, translate, moment } ) => {
 			<TableItem>{ getTimeframeText( promotion, translate, moment ) }</TableItem>
 		</TableRow>
 	);
-};
+}
 
 PromotionsListRow.propTypes = {
 	site: PropTypes.shape( {
@@ -77,4 +80,4 @@ PromotionsListRow.propTypes = {
 	promotion: PropTypes.shape( {} ),
 };
 
-export default localize( PromotionsListRow );
+export default PromotionsListRow;

--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -11,6 +11,7 @@ import qs from 'qs';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
+import { withLocalizedMoment } from 'components/localized-moment';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import Intervals from 'blocks/stats-navigation/intervals';
 import DatePicker from 'my-sites/stats/stats-date-picker';
@@ -84,4 +85,4 @@ StoreStatsPeriodNav.propTypes = {
 	queryParams: PropTypes.object,
 };
 
-export default localize( StoreStatsPeriodNav );
+export default localize( withLocalizedMoment( StoreStatsPeriodNav ) );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget-base/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget-base/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -17,6 +16,7 @@ import Card from 'components/card';
 import ErrorPanel from 'my-sites/stats/stats-error';
 import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
 import Pagination from 'components/pagination';
+import { withLocalizedMoment } from 'components/localized-moment';
 import getStoreReferrersByDate from 'state/selectors/get-store-referrers-by-date';
 
 class StoreStatsReferrerWidgetBase extends Component {
@@ -174,4 +174,4 @@ export default connect( ( state, ownProps ) => {
 	return {
 		data: fetchedData || getStoreReferrersByDate( state, ownProps ),
 	};
-} )( localize( StoreStatsReferrerWidgetBase ) );
+} )( localize( withLocalizedMoment( StoreStatsReferrerWidgetBase ) ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
@@ -13,6 +13,7 @@ import formatCurrency from '@automattic/format-currency';
  */
 import { Dialog } from '@automattic/components';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { withLocalizedMoment } from 'components/localized-moment';
 import {
 	closeRefundDialog,
 	confirmRefund,
@@ -103,4 +104,7 @@ const mapDispatchToProps = dispatch => {
 	return bindActionCreators( { closeRefundDialog, confirmRefund }, dispatch );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( RefundDialog ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( withLocalizedMoment( RefundDialog ) ) );

--- a/client/extensions/zoninator/components/settings/zone/zone-lock-warning-notice.jsx
+++ b/client/extensions/zoninator/components/settings/zone/zone-lock-warning-notice.jsx
@@ -12,6 +12,7 @@ import { flowRight } from 'lodash';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { requestFeed } from '../../../state/feeds/actions';
 import { requestLock, resetLock } from '../../../state/locks/actions';
 import { requestZones } from '../../../state/zones/actions';
@@ -65,4 +66,8 @@ const connectComponent = connect(
 	{ requestFeed, requestLock, requestZones, resetLock }
 );
 
-export default flowRight( connectComponent, localize )( ZoneLockWarningNotice );
+export default flowRight(
+	connectComponent,
+	localize,
+	withLocalizedMoment
+)( ZoneLockWarningNotice );

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { deleteApplicationPassword } from 'state/application-passwords/actions';
 import { errorNotice } from 'state/notices/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -56,4 +57,4 @@ export default connect( null, {
 	deleteApplicationPassword,
 	errorNotice,
 	recordGoogleEvent,
-} )( localize( ApplicationPasswordsItem ) );
+} )( localize( withLocalizedMoment( ApplicationPasswordsItem ) ) );

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -15,6 +15,7 @@ import TextareaAutosize from 'components/textarea-autosize';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
+import { withLocalizedMoment } from 'components/localized-moment';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { billingHistory } from 'me/purchases/paths';
 import QueryBillingTransaction from 'components/data/query-billing-transaction';
@@ -316,4 +317,4 @@ export default connect(
 		recordGoogleEvent,
 		requestBillingTransaction,
 	}
-)( localize( BillingReceipt ) );
+)( localize( withLocalizedMoment( BillingReceipt ) ) );

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -18,6 +17,7 @@ import Pagination from 'components/pagination';
 import TransactionsHeader from './transactions-header';
 import { groupDomainProducts, renderTransactionAmount } from './utils';
 import SearchCard from 'components/search-card';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { setPage, setQuery } from 'state/ui/billing-transactions/actions';
 import getBillingTransactionFilters from 'state/selectors/get-billing-transaction-filters';
 import getFilteredBillingTransactions from 'state/selectors/get-filtered-billing-transactions';
@@ -225,4 +225,4 @@ export default connect(
 		setPage,
 		setQuery,
 	}
-)( localize( TransactionsTable ) );
+)( localize( withLocalizedMoment( TransactionsTable ) ) );

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import ConnectedApplicationIcon from 'me/connected-application-icon';
 import FoldableCard from 'components/foldable-card';
+import { withLocalizedMoment } from 'components/localized-moment';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import { deleteConnectedApplication } from 'state/connected-applications/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -155,6 +156,7 @@ class ConnectedApplicationItem extends React.Component {
 					'{{detailTitle}}Authorized On{{/detailTitle}}{{detailDescription}}%(date)s{{/detailDescription}}',
 					{
 						components: {
+							// eslint-disable-next-line jsx-a11y/heading-has-content
 							detailTitle: <h2 />,
 							detailDescription: (
 								<p className="connected-application-item__connection-detail-description" />
@@ -226,4 +228,4 @@ class ConnectedApplicationItem extends React.Component {
 export default connect( null, {
 	deleteConnectedApplication,
 	recordGoogleEvent,
-} )( localize( ConnectedApplicationItem ) );
+} )( localize( withLocalizedMoment( ConnectedApplicationItem ) ) );

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -19,6 +19,7 @@ import QueryMembershipsSubscriptions from 'components/data/query-memberships-sub
 import SectionHeader from 'components/section-header';
 import CompactCard from 'components/card';
 import EmptyContent from 'components/empty-content';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -96,4 +97,4 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 
 export default connect( state => ( {
 	subscriptions: get( state, 'memberships.subscriptions.items', [] ),
-} ) )( localize( MembershipsHistory ) );
+} ) )( localize( withLocalizedMoment( MembershipsHistory ) ) );

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -23,6 +23,7 @@ import Gridicon from 'components/gridicon';
 import CompactCard from 'components/card/compact';
 import { requestSubscriptionStop } from 'state/memberships/subscriptions/actions';
 import Notice from 'components/notice';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -137,4 +138,4 @@ export default connect(
 	{
 		requestSubscriptionStop,
 	}
-)( localize( Subscription ) );
+)( localize( withLocalizedMoment( Subscription ) ) );

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
@@ -28,6 +27,7 @@ import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import observe from 'lib/mixins/data-observe';
 import Main from 'components/main';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
@@ -251,4 +251,9 @@ const NotificationSubscriptions = createReactClass( {
 
 const connectComponent = connect( null, { recordGoogleEvent } );
 
-export default flowRight( connectComponent, localize, protectForm )( NotificationSubscriptions );
+export default flowRight(
+	connectComponent,
+	localize,
+	protectForm,
+	withLocalizedMoment
+)( NotificationSubscriptions );

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -36,6 +36,7 @@ import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
+import { withLocalizedMoment } from 'components/localized-moment';
 import ProductLink from 'me/purchases/product-link';
 import titles from 'me/purchases/titles';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
@@ -241,4 +242,4 @@ export default connect( ( state, props ) => {
 		selectedSite: getSelectedSite( state ),
 		userId: getCurrentUserId( state ),
 	};
-} )( localize( CancelPurchase ) );
+} )( localize( withLocalizedMoment( CancelPurchase ) ) );

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import { Dialog } from '@automattic/components';
 import CancelAutoRenewalForm from 'components/marketing-survey/cancel-auto-renewal-form';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { isDomainRegistration, isPlan } from 'lib/products-values';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import { getSite } from 'state/sites/selectors';
@@ -236,4 +237,4 @@ class AutoRenewDisablingDialog extends Component {
 export default connect( ( state, { purchase } ) => ( {
 	isAtomicSite: isSiteAtomic( state, purchase.siteId ),
 	selectedSite: getSite( state, purchase.siteId ),
-} ) )( localize( AutoRenewDisablingDialog ) );
+} ) )( localize( withLocalizedMoment( AutoRenewDisablingDialog ) ) );

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -32,6 +31,7 @@ import {
 import { isDomainTransfer, isConciergeSession } from 'lib/products-values';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { isMonthly } from 'lib/plans/constants';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
@@ -333,4 +333,6 @@ class PurchaseNotice extends Component {
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( PurchaseNotice ) );
+export default connect( null, { recordTracksEvent } )(
+	localize( withLocalizedMoment( PurchaseNotice ) )
+);

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -43,6 +42,7 @@ import AutoRenewToggle from './auto-renew-toggle';
 import PaymentLogo from 'components/payment-logo';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import UserItem from 'components/user';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
 
@@ -397,4 +397,4 @@ export default connect( ( state, { purchaseId } ) => {
 		owner: purchase ? getUser( state, purchase.userId ) : null,
 		isAutorenewalEnabled: purchase ? ! isExpiring( purchase ) : null,
 	};
-} )( localize( PurchaseMeta ) );
+} )( localize( withLocalizedMoment( PurchaseMeta ) ) );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -35,6 +35,7 @@ import {
 import Notice from 'components/notice';
 import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'components/gridicon';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { managePurchase } from '../paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { getPlanTermLabel } from 'lib/plans';
@@ -265,4 +266,4 @@ PurchaseItem.propTypes = {
 	isJetpack: PropTypes.bool,
 };
 
-export default localize( PurchaseItem );
+export default localize( withLocalizedMoment( PurchaseItem ) );

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -17,6 +17,7 @@ import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import Tooltip from 'components/tooltip';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 import getSiteComment from 'state/selectors/get-site-comment';
@@ -149,4 +150,4 @@ const mapStateToProps = ( state, { commentId } ) => {
 	};
 };
 
-export default connect( mapStateToProps )( localize( CommentAuthor ) );
+export default connect( mapStateToProps )( localize( withLocalizedMoment( CommentAuthor ) ) );

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -21,6 +21,7 @@ import InfoPopover from 'components/info-popover';
 import Popover from 'components/popover';
 import PostSchedule from 'components/post-schedule';
 import QuerySiteSettings from 'components/data/query-site-settings';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { decodeEntities } from 'lib/formatting';
 import {
 	bumpStat,
@@ -282,4 +283,7 @@ const mapDispatchToProps = ( dispatch, { commentId } ) => ( {
 	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 } );
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentEdit ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( withLocalizedMoment( CommentEdit ) ) );

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -13,6 +13,7 @@ import { delay, each, get, map, reduce, reject } from 'lodash';
 import AddImageDialog from 'my-sites/comments/comment/comment-html-editor/add-image-dialog';
 import AddLinkDialog from 'my-sites/comments/comment/comment-html-editor/add-link-dialog';
 import Button from 'components/button';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 export class CommentHtmlEditor extends Component {
 	static propTypes = {
@@ -242,4 +243,4 @@ export class CommentHtmlEditor extends Component {
 	}
 }
 
-export default localize( CommentHtmlEditor );
+export default localize( withLocalizedMoment( CommentHtmlEditor ) );

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -12,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { emailManagement } from 'my-sites/email/paths';
 import PendingGSuiteTosNoticeAction from './pending-gsuite-tos-notice-action';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -232,4 +232,4 @@ const finishSetupNoticeClick = siteSlug =>
 export default connect( null, {
 	finishSetupNoticeClick,
 	recordShowPendingAccountNotice,
-} )( localize( PendingGSuiteTosNotice ) );
+} )( localize( withLocalizedMoment( PendingGSuiteTosNotice ) ) );

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -22,6 +22,7 @@ import Property from './card/property';
 import SubscriptionSettings from './card/subscription-settings';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
+import { withLocalizedMoment } from 'components/localized-moment';
 import IcannVerificationCard from 'my-sites/domains/domain-management/components/icann-verification';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
@@ -209,4 +210,4 @@ const paymentSettingsClick = domain =>
 
 export default connect( null, {
 	paymentSettingsClick,
-} )( localize( RegisteredDomain ) );
+} )( localize( withLocalizedMoment( RegisteredDomain ) ) );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -49,6 +49,7 @@ import { type } from 'lib/domains/constants';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -536,4 +537,4 @@ export default connect(
 			undoChangePrimary: domain => dispatch( undoChangePrimary( domain ) ),
 		};
 	}
-)( localize( List ) );
+)( localize( withLocalizedMoment( List ) ) );

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -17,6 +16,7 @@ import DomainTransferFlag from 'my-sites/domains/domain-management/components/do
 import Notice from 'components/notice';
 import { type as domainTypes, gdprConsentStatus } from 'lib/domains/constants';
 import Spinner from 'components/spinner';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class ListItem extends React.PureComponent {
 	static propTypes = {
@@ -185,4 +185,4 @@ class ListItem extends React.PureComponent {
 	}
 }
 
-export default localize( ListItem );
+export default localize( withLocalizedMoment( ListItem ) );

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -35,6 +34,7 @@ import { userCan } from 'lib/site/utils';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import ExternalLink from 'components/external-link';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -496,4 +496,6 @@ const mapStateToProps = state => {
 	};
 };
 
-export default connect( mapStateToProps, { requestSubscribers } )( localize( MembershipsSection ) );
+export default connect( mapStateToProps, { requestSubscribers } )(
+	localize( withLocalizedMoment( MembershipsSection ) )
+);

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -23,6 +23,7 @@ import GSuiteUserItem from 'my-sites/email/email-management/gsuite-user-item';
 import Notice from 'components/notice';
 import PendingGSuiteTosNotice from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
 import SectionHeader from 'components/section-header';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -200,4 +201,4 @@ export default connect(
 		user: getCurrentUser( state ),
 	} ),
 	{ addGoogleAppsUserClick, manageClick }
-)( localize( GSuiteUsersCard ) );
+)( localize( withLocalizedMoment( GSuiteUsersCard ) ) );

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 
 /**
@@ -17,6 +16,7 @@ import getEditorUrl from 'state/selectors/get-editor-url';
 import PostMetadata from 'lib/post-metadata';
 import { getTheme } from 'state/themes/selectors';
 import QueryTheme from 'components/data/query-theme';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -40,8 +40,6 @@ const getContentLink = ( state, siteId, page ) => {
 const ICON_SIZE = 12;
 
 function PageCardInfo( {
-	translate,
-	moment,
 	page,
 	showTimestamp,
 	isFront,
@@ -51,6 +49,9 @@ function PageCardInfo( {
 	theme,
 	themeId,
 } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	const renderTimestamp = function() {
 		if ( page.status === 'future' ) {
 			return (
@@ -112,4 +113,4 @@ export default connect( ( state, props ) => {
 		themeId,
 		contentLink: getContentLink( state, props.page.site_ID, props.page ),
 	};
-} )( localize( PageCardInfo ) );
+} )( PageCardInfo );

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -20,6 +20,7 @@ import Gravatar from 'components/gravatar';
 import Button from 'components/button';
 import QuerySiteInvites from 'components/data/query-site-invites';
 import EmptyContent from 'components/empty-content';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { getSelectedSite } from 'state/ui/selectors';
 import {
 	isRequestingInvitesForSite,
@@ -219,4 +220,4 @@ export default connect(
 		};
 	},
 	{ deleteInvite }
-)( localize( PeopleInviteDetails ) );
+)( localize( withLocalizedMoment( PeopleInviteDetails ) ) );

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -15,6 +15,7 @@ import { decodeEntities } from 'lib/formatting';
  */
 import Gravatar from 'components/gravatar';
 import InfoPopover from 'components/info-popover';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { requestExternalContributors } from 'state/data-getters';
 /**
  * Style dependencies
@@ -280,4 +281,4 @@ export default connect( ( _state, { siteId, user } ) => {
 			undefined !== linkedUserId ? linkedUserId : userId
 		),
 	};
-} )( localize( PeopleProfile ) );
+} )( localize( withLocalizedMoment( PeopleProfile ) ) );

--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -11,6 +10,7 @@ import { capitalize, includes } from 'lodash';
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
+import { withLocalizedMoment } from 'components/localized-moment';
 import DateFormatOption from './date-format-option';
 import StartOfWeekOption from './start-of-week-option';
 import TimeFormatOption from './time-format-option';
@@ -166,4 +166,4 @@ export class DateTimeFormat extends Component {
 	}
 }
 
-export default localize( DateTimeFormat );
+export default localize( withLocalizedMoment( DateTimeFormat ) );

--- a/client/my-sites/site-settings/date-time-format/start-of-week-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/start-of-week-option.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Internal dependencies
@@ -12,22 +12,27 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 
-export const StartOfWeekOption = ( { disabled, moment, onChange, startOfWeek, translate } ) => (
-	<FormFieldset>
-		<FormLabel>{ translate( 'Week starts on' ) }</FormLabel>
-		<FormSelect
-			disabled={ disabled }
-			name="start_of_week"
-			onChange={ onChange }
-			value={ startOfWeek || 0 }
-		>
-			{ moment.weekdays().map( ( day, index ) => (
-				<option key={ day } value={ index }>
-					{ day }
-				</option>
-			) ) }
-		</FormSelect>
-	</FormFieldset>
-);
+export const StartOfWeekOption = ( { disabled, onChange, startOfWeek } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 
-export default localize( StartOfWeekOption );
+	return (
+		<FormFieldset>
+			<FormLabel>{ translate( 'Week starts on' ) }</FormLabel>
+			<FormSelect
+				disabled={ disabled }
+				name="start_of_week"
+				onChange={ onChange }
+				value={ startOfWeek || 0 }
+			>
+				{ moment.weekdays().map( ( day, index ) => (
+					<option key={ day } value={ index }>
+						{ day }
+					</option>
+				) ) }
+			</FormSelect>
+		</FormFieldset>
+	);
+};
+
+export default StartOfWeekOption;

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -19,6 +19,7 @@ import syncSelectors from 'state/jetpack-sync/selectors';
 import { getSyncStatus, scheduleJetpackFullysync } from 'state/jetpack-sync/actions';
 import { Interval, EVERY_TEN_SECONDS } from 'lib/interval';
 import NoticeAction from 'components/notice/notice-action';
+import { withLocalizedMoment } from 'components/localized-moment';
 import analytics from 'lib/analytics';
 
 /**
@@ -208,4 +209,4 @@ export default connect(
 		};
 	},
 	dispatch => bindActionCreators( { getSyncStatus, scheduleJetpackFullysync }, dispatch )
-)( localize( JetpackSyncPanel ) );
+)( localize( withLocalizedMoment( JetpackSyncPanel ) ) );

--- a/client/my-sites/site-settings/settings-section-header.jsx
+++ b/client/my-sites/site-settings/settings-section-header.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -19,11 +19,11 @@ const SettingsSectionHeader = ( {
 	onButtonClick,
 	showButton,
 	title,
-	translate,
-	moment,
 	numberFormat,
 	...buttonProps
 } ) => {
+	const translate = useTranslate();
+
 	return (
 		<SectionHeader label={ title } id={ id }>
 			{ children }
@@ -48,4 +48,4 @@ SettingsSectionHeader.propTypes = {
 	translate: PropTypes.func,
 };
 
-export default localize( SettingsSectionHeader );
+export default SettingsSectionHeader;

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -19,6 +18,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
 import ErrorPanel from 'my-sites/stats/stats-error';
 import QuerySiteStats from 'components/data/query-site-stats';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -212,4 +212,4 @@ export default connect( state => {
 		siteId,
 		siteSlug,
 	};
-} )( localize( AnnualSiteStats ) );
+} )( localize( withLocalizedMoment( AnnualSiteStats ) ) );

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -20,6 +20,7 @@ import StatsNavigation from 'blocks/stats-navigation';
 import titlecase from 'to-title-case';
 import Main from 'components/main';
 import JetpackColophon from 'components/jetpack-colophon';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { getCurrentUser } from 'state/current-user/selectors';
 import getVisibleSites from 'state/selectors/get-visible-sites';
 
@@ -110,6 +111,7 @@ class StatsOverview extends Component {
 
 		// TODO: a separate StatsSectionTitle component should be created
 		items.push(
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<h3 key="header-placeholder" className="stats-section-title">
 				&nbsp;
 			</h3>
@@ -128,4 +130,4 @@ export default connect( state => {
 		user: getCurrentUser( state ),
 		sites: getVisibleSites( state ),
 	};
-} )( localize( StatsOverview ) );
+} )( localize( withLocalizedMoment( StatsOverview ) ) );

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -21,6 +20,7 @@ import Emojify from 'components/emojify';
 import SectionHeader from 'components/section-header';
 import QueryPosts from 'components/data/query-posts';
 import QueryPostStats from 'components/data/query-post-stats';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { isRequestingPostsForQuery, getPostsForQuery } from 'state/posts/selectors';
 import { getPostStat } from 'state/stats/posts/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -170,4 +170,4 @@ const connectComponent = connect(
 	{ recordTracksEvent }
 );
 
-export default flowRight( connectComponent, localize )( StatsPostPerformance );
+export default flowRight( connectComponent, localize, withLocalizedMoment )( StatsPostPerformance );

--- a/client/my-sites/stats/post-trends/month.jsx
+++ b/client/my-sites/stats/post-trends/month.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -9,6 +8,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import { withLocalizedMoment } from 'components/localized-moment';
 import Week from './week';
 
 class PostTrendsMonth extends Component {
@@ -63,4 +63,4 @@ class PostTrendsMonth extends Component {
 	}
 }
 
-export default localize( PostTrendsMonth );
+export default localize( withLocalizedMoment( PostTrendsMonth ) );

--- a/client/my-sites/stats/post-trends/week.jsx
+++ b/client/my-sites/stats/post-trends/week.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -12,6 +11,7 @@ import { connect } from 'react-redux';
  */
 import Day from './day';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class PostTrendsWeek extends Component {
 	static propTypes = {
@@ -74,5 +74,5 @@ class PostTrendsWeek extends Component {
 }
 
 export default connect( state => ( { userLocale: getCurrentUserLocale( state ) } ) )(
-	localize( PostTrendsWeek )
+	localize( withLocalizedMoment( PostTrendsWeek ) )
 );

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -15,6 +14,7 @@ import getSiteStatsQueryDate from 'state/selectors/get-site-stats-query-date';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { isAutoRefreshAllowedForQuery } from 'state/stats/lists/utils';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -198,4 +198,4 @@ const connectComponent = connect( ( state, { query, statsType, showQueryDate } )
 	};
 } );
 
-export default flowRight( connectComponent, localize )( StatsDatePicker );
+export default flowRight( connectComponent, localize, withLocalizedMoment )( StatsDatePicker );

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -1,7 +1,7 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
-
 import React from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -17,6 +17,7 @@ import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleContent from '../stats-module/content-text';
 import QueryPostStats from 'components/data/query-post-stats';
 import QueryPosts from 'components/data/query-posts';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { getPostStats, isRequestingPostStats } from 'state/stats/posts/selectors';
 import { getSitePost } from 'state/posts/selectors';
 import toggleInfo from '../toggle-info';
@@ -214,4 +215,9 @@ const connectComponent = connect( ( state, { siteId, postId } ) => {
 	};
 } );
 
-export default flowRight( connectComponent, localize, toggleInfo )( StatsPostDetailWeeks );
+export default flowRight(
+	connectComponent,
+	localize,
+	toggleInfo,
+	withLocalizedMoment
+)( StatsPostDetailWeeks );

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -105,7 +105,6 @@ const StatsInsights = props => {
 
 StatsInsights.propTypes = {
 	followList: PropTypes.object.isRequired,
-	moment: PropTypes.func,
 	translate: PropTypes.func,
 };
 

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -15,6 +15,7 @@ const debug = debugFactory( 'calypso:stats:list-item' );
  */
 import analytics from 'lib/analytics';
 import Emojify from 'components/emojify';
+import { withLocalizedMoment } from 'components/localized-moment';
 import Follow from './action-follow';
 import Page from './action-page';
 import Spam from './action-spam';
@@ -378,4 +379,4 @@ class StatsListItem extends React.Component {
 	}
 }
 
-export default localize( StatsListItem );
+export default localize( withLocalizedMoment( StatsListItem ) );

--- a/client/my-sites/stats/stats-module/availability-warning.tsx
+++ b/client/my-sites/stats/stats-module/availability-warning.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import moment from 'moment';
+import { Moment } from 'moment';
 import Gridicon from 'components/gridicon';
 import { localize, LocalizeProps } from 'i18n-calypso';
 
 interface Props {
 	statType?: string;
-	startOfPeriod?: moment.Moment;
+	startOfPeriod?: Moment;
 }
 
 // File downloads were only recorded from 1st July 2019 onwards,

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -50,7 +50,6 @@ class StatsModule extends Component {
 		statType: PropTypes.string,
 		showSummaryLink: PropTypes.bool,
 		translate: PropTypes.func,
-		moment: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { flowRight } from 'lodash';
@@ -15,6 +14,7 @@ import qs from 'qs';
  * Internal dependencies
  */
 import { withRtl } from 'components/rtl';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { recordGoogleEvent as recordGoogleEventAction } from 'state/analytics/actions';
 
 /**
@@ -123,4 +123,9 @@ class StatsPeriodNavigation extends PureComponent {
 
 const connectComponent = connect( null, { recordGoogleEvent: recordGoogleEventAction } );
 
-export default flowRight( connectComponent, localize, withRtl )( StatsPeriodNavigation );
+export default flowRight(
+	connectComponent,
+	localize,
+	withRtl,
+	withLocalizedMoment
+)( StatsPeriodNavigation );

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -15,6 +14,7 @@ import SummaryChart from '../stats-summary';
 import SectionNav from 'components/section-nav';
 import SegmentedControl from 'components/segmented-control';
 import QueryPostStats from 'components/data/query-post-stats';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { getPostStats, isRequestingPostStats } from 'state/stats/posts/selectors';
 
 /**
@@ -174,4 +174,4 @@ const connectComponent = connect( ( state, { siteId, postId } ) => {
 	};
 } );
 
-export default flowRight( connectComponent, localize )( StatsPostSummary );
+export default flowRight( connectComponent, localize, withLocalizedMoment )( StatsPostSummary );

--- a/client/my-sites/stats/stats-video-summary/index.jsx
+++ b/client/my-sites/stats/stats-video-summary/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -13,6 +12,7 @@ import { flowRight } from 'lodash';
  */
 import SummaryChart from '../stats-summary';
 import QuerySiteStats from 'components/data/query-site-stats';
+import { withLocalizedMoment } from 'components/localized-moment';
 import {
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery,
@@ -85,4 +85,4 @@ const connectComponent = connect( ( state, { postId } ) => {
 	};
 } );
 
-export default flowRight( connectComponent, localize )( StatsVideoSummary );
+export default flowRight( connectComponent, localize, withLocalizedMoment )( StatsVideoSummary );

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -12,6 +12,7 @@ import page from 'page';
  */
 import { formatNumberMetric } from 'lib/format-number-compact';
 import Popover from 'components/popover';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class Month extends PureComponent {
 	static propTypes = {
@@ -227,4 +228,4 @@ const StatsViewsMonths = props => {
 	);
 };
 
-export default localize( StatsViewsMonths );
+export default localize( withLocalizedMoment( StatsViewsMonths ) );

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -31,7 +30,6 @@ import './style.scss';
 
 export class EditPostStatus extends Component {
 	static propTypes = {
-		moment: PropTypes.func,
 		setPostDate: PropTypes.func,
 		onSave: PropTypes.func,
 		post: PropTypes.object,

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { identity, noop, get, findLast } from 'lodash';
-import moment from 'moment';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
@@ -42,7 +41,6 @@ export class EditorGroundControl extends React.Component {
 		isPublishing: PropTypes.bool,
 		isSaving: PropTypes.bool,
 		isSidebarOpened: PropTypes.bool,
-		moment: PropTypes.func,
 		onPreview: PropTypes.func,
 		onPublish: PropTypes.func,
 		onSave: PropTypes.func,
@@ -61,7 +59,6 @@ export class EditorGroundControl extends React.Component {
 		isSaveBlocked: false,
 		isPublishing: false,
 		isSaving: false,
-		moment,
 		onPublish: noop,
 		onSaveDraft: noop,
 		site: {},
@@ -142,7 +139,7 @@ export class EditorGroundControl extends React.Component {
 	}
 
 	getCloseButtonPath() {
-		const editorPathRegex = /^(\/block-editor)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
+		const editorPathRegex = /^(\/block-editor)?\/(post|page|(edit\/[^/]+))(\/|$)/i;
 		// find the last non-editor path in routeHistory, default to "all posts"
 		const lastNonEditorPath = findLast(
 			this.props.routeHistory,

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -40,6 +39,7 @@ import EditorMediaModal from 'post-editor/editor-media-modal';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
 import config from 'config';
 import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -722,4 +722,7 @@ const mapDispatchToProps = {
 	settingsUpdate,
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( EditorHtmlToolbar ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( withLocalizedMoment( EditorHtmlToolbar ) ) );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -18,6 +17,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { isMobile } from 'lib/viewport';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -263,4 +263,4 @@ export default connect(
 		setLayoutFocus,
 		recordTracksEvent,
 	}
-)( localize( EditorNotice ) );
+)( localize( withLocalizedMoment( EditorNotice ) ) );

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDom from 'react-dom';
@@ -15,6 +14,7 @@ import { intersection } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { withLocalizedMoment } from 'components/localized-moment';
 import PostScheduler from './post-scheduler';
 import * as utils from 'state/posts/utils';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -198,4 +198,4 @@ export default connect( state => {
 	return {
 		site: getSelectedSite( state ),
 	};
-} )( localize( EditorPublishDate ) );
+} )( localize( withLocalizedMoment( EditorPublishDate ) ) );

--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -17,6 +16,7 @@ import EditorStatusLabelPlaceholder from './placeholder';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId, isEditorNewPost } from 'state/ui/editor/selectors';
 import { getSitePost } from 'state/posts/selectors';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -140,4 +140,4 @@ export default connect( state => {
 	const isNew = isEditorNewPost( state );
 
 	return { isNew, post };
-} )( localize( EditorStatusLabel ) );
+} )( localize( withLocalizedMoment( EditorStatusLabel ) ) );

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -11,6 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { playtime } from 'lib/media/utils';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class EditorMediaModalDetailFileInfo extends React.Component {
 	static displayName = 'EditorMediaModalDetailFileInfo';
@@ -114,4 +114,4 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 	}
 }
 
-export default localize( EditorMediaModalDetailFileInfo );
+export default localize( withLocalizedMoment( EditorMediaModalDetailFileInfo ) );


### PR DESCRIPTION
The `localize` HOC from `i18n-calypso` adds a `moment` prop to wrapped components.

If we're to remove the `moment` dependency from `i18n-calypso`, we'll need to stop components depending on this prop, and instead using the same prop from the `withLocalizedMoment` HOC.

This PR attempts to change every instance of a dependency on `localize`'s `moment` prop into a dependency on `withLocalizedMoment`'s `moment` prop.

**Note**: This PR will report a number of linting issues. These were already present, and I decided it was out of scope to try to fix them, particularly taking into account the scale of the PR and the amount of work needed to get things cleaned up in some of these files.

#### Changes proposed in this Pull Request

* Add `withLocalizedMoment` HOC to every component depending on a `moment` prop.
* Make `apps/notifications` check the locale slug from `i18n-calypso` instead of using the `withLocalizedMoment` HOC. We can't make `apps/notifications` depend on `localized-moment` without extracting that out, which would be complicated due to how it's tied to state in Calypso. The user block notifications will fail to update timestamps when the user changes locales, but that's already the current behaviour.
* Minor drive-by fixes on changed files.

#### Testing instructions

This is one of those large PRs that is hard to test for. I'd recommend a thorough code inspection (there are many files, but the changes are mostly mechanical), and the rest I'd leave to the E2E suite.
