### PR TITLE
SIWA: Make sure we have sent the apple user info to the server before redirecting

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -23,24 +23,26 @@ export function login( {
 	site,
 	useMagicLink,
 } = {} ) {
-	let url = config( 'login_url' );
+	let url = '';
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {
-		url = '/log-in';
-
 		if ( socialService ) {
-			url += '/' + socialService + '/callback';
+			url = `/${ socialService === 'apple' ? 'sign-in' : 'log-in' }/${ socialService }/callback`;
 		} else if ( twoFactorAuthType && isJetpack ) {
-			url += '/jetpack/' + twoFactorAuthType;
+			url = '/log-in/jetpack/' + twoFactorAuthType;
 		} else if ( twoFactorAuthType ) {
-			url += '/' + twoFactorAuthType;
+			url = '/log-in/' + twoFactorAuthType;
 		} else if ( socialConnect ) {
-			url += '/social-connect';
+			url = '/log-in/social-connect';
 		} else if ( isJetpack ) {
-			url += '/jetpack';
+			url = '/log-in/jetpack';
 		} else if ( useMagicLink ) {
-			url += '/link';
+			url = '/log-in/link';
+		} else {
+			url = '/log-in';
 		}
+	} else {
+		url = config( 'login_url' );
 	}
 
 	if ( locale && locale !== 'en' ) {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -23,26 +23,24 @@ export function login( {
 	site,
 	useMagicLink,
 } = {} ) {
-	let url = '';
+	let url = config( 'login_url' );
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {
+		url = '/log-in';
+
 		if ( socialService ) {
-			url = `/${ socialService === 'apple' ? 'sign-in' : 'log-in' }/${ socialService }/callback`;
+			url += '/' + socialService + '/callback';
 		} else if ( twoFactorAuthType && isJetpack ) {
-			url = '/log-in/jetpack/' + twoFactorAuthType;
+			url += '/jetpack/' + twoFactorAuthType;
 		} else if ( twoFactorAuthType ) {
-			url = '/log-in/' + twoFactorAuthType;
+			url += '/' + twoFactorAuthType;
 		} else if ( socialConnect ) {
-			url = '/log-in/social-connect';
+			url += '/social-connect';
 		} else if ( isJetpack ) {
-			url = '/log-in/jetpack';
+			url += '/jetpack';
 		} else if ( useMagicLink ) {
-			url = '/log-in/link';
-		} else {
-			url = '/log-in';
+			url += '/link';
 		}
-	} else {
-		url = config( 'login_url' );
 	}
 
 	if ( locale && locale !== 'en' ) {

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -28,6 +28,7 @@ class SocialLoginActionButton extends Component {
 		connectSocialUser: PropTypes.func.isRequired,
 		disconnectSocialUser: PropTypes.func.isRequired,
 		socialServiceResponse: PropTypes.object,
+		redirectUri: PropTypes.string,
 	};
 
 	state = {
@@ -85,7 +86,7 @@ class SocialLoginActionButton extends Component {
 	};
 
 	render() {
-		const { service, isConnected, isUpdatingSocialConnection, translate } = this.props;
+		const { service, isConnected, isUpdatingSocialConnection, redirectUri, translate } = this.props;
 
 		const { fetchingUser } = this.state;
 
@@ -121,8 +122,6 @@ class SocialLoginActionButton extends Component {
 
 		if ( service === 'apple' ) {
 			const uxMode = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : 'popup';
-			const redirectUri =
-				typeof window !== 'undefined' ? window.location.origin + window.location.pathname : null;
 			return (
 				<AppleLoginButton
 					clientId={ config( 'apple_oauth_client_id' ) }

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -41,7 +41,9 @@ class SocialLogin extends Component {
 	};
 
 	renderContent() {
-		const { translate, errorUpdatingSocialConnection } = this.props;
+		const { translate, errorUpdatingSocialConnection, path } = this.props;
+
+		const redirectUri = typeof window !== 'undefined' ? window.location.origin + path : null;
 
 		return (
 			<div>
@@ -64,6 +66,7 @@ class SocialLogin extends Component {
 					<SocialLoginService
 						service="apple"
 						icon={ <AppleIcon /> }
+						redirectUri={ redirectUri }
 						socialServiceResponse={
 							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
 						}

--- a/client/me/social-login/service.jsx
+++ b/client/me/social-login/service.jsx
@@ -16,6 +16,7 @@ const SocialLoginService = ( {
 	service,
 	icon,
 	isConnected,
+	redirectUri,
 	socialConnectionEmail,
 	socialServiceResponse,
 } ) => (
@@ -29,6 +30,7 @@ const SocialLoginService = ( {
 
 			<div className="social-login__header-action">
 				<SocialLoginActionButton
+					redirectUri={ redirectUri }
 					service={ service }
 					isConnected={ isConnected }
 					socialServiceResponse={ socialServiceResponse }

--- a/server/api/sign-in-with-apple.js
+++ b/server/api/sign-in-with-apple.js
@@ -26,11 +26,17 @@ function loginWithApple( request, response, next ) {
 	}
 
 	const idToken = request.body.id_token;
-	const user = request.body.user || {};
+	const user = JSON.parse( request.body.user || '{}' );
 	const userEmail = user.email;
 	const userName = user.name
 		? `${ user.name.firstName || '' } ${ user.name.lastName || '' }`.trim()
 		: undefined;
+
+	request.user_openid_data = {
+		id_token: idToken,
+		user_email: userEmail,
+		user_name: userName,
+	};
 
 	// An `id_token` is not enough to log a user in (one might have 2FA enabled or an existing account with the same email)
 	// Thus we need to return `id_token` to the front-end so it can handle all sign-up/sign-in cases.
@@ -41,31 +47,43 @@ function loginWithApple( request, response, next ) {
 			.undocumented()
 			.usersSocialNew( {
 				...loginEndpointData(),
-				id_token: idToken,
-				user_email: userEmail,
-				user_name: userName,
+				...request.user_openid_data,
 			} )
 			.catch( () => {
 				// ignore errors
-			} );
+			} )
+			.finally( next );
+	} else {
+		next();
+	}
+}
+
+function redirectToCalypso( request, response, next ) {
+	if ( ! request.user_openid_data ) {
+		return next();
 	}
 
 	const originalUrlPath = request.originalUrl.split( '#' )[ 0 ];
 	const hashString = qs.stringify( {
-		id_token: idToken,
-		user_email: userEmail,
-		user_name: userName,
+		...request.user_openid_data,
 		client_id: config( 'apple_oauth_client_id' ),
 		state: request.body.state,
 	} );
 
-	response.redirect( originalUrlPath + '#' + hashString );
+	// `POST /log-in` is blacklisted, let's use `POST /sign-in` and redirect to `/log-in`
+	const newLocation = originalUrlPath.replace(
+		'/sign-in/apple/callback',
+		'/log-in/apple/callback'
+	);
+
+	response.redirect( newLocation + '#' + hashString );
 }
 
 module.exports = function( app ) {
 	return app.post(
-		[ '/log-in/apple/callback', '/start/user', '/me/security/social-login' ],
+		[ '/sign-in/apple/callback', '/start/user', '/me/security/social-login' ],
 		bodyParser.urlencoded(),
-		loginWithApple
+		loginWithApple,
+		redirectToCalypso
 	);
 };

--- a/server/api/sign-in-with-apple.js
+++ b/server/api/sign-in-with-apple.js
@@ -70,18 +70,12 @@ function redirectToCalypso( request, response, next ) {
 		state: request.body.state,
 	} );
 
-	// `POST /log-in` is blacklisted, let's use `POST /sign-in` and redirect to `/log-in`
-	const newLocation = originalUrlPath.replace(
-		'/sign-in/apple/callback',
-		'/log-in/apple/callback'
-	);
-
-	response.redirect( newLocation + '#' + hashString );
+	response.redirect( originalUrlPath + '#' + hashString );
 }
 
 module.exports = function( app ) {
 	return app.post(
-		[ '/sign-in/apple/callback', '/start/user', '/me/security/social-login' ],
+		[ '/log-in/apple/callback', '/start/user', '/me/security/social-login' ],
 		bodyParser.urlencoded(),
 		loginWithApple,
 		redirectToCalypso


### PR DESCRIPTION
~[Initial attempt](https://github.com/Automattic/wp-calypso/pull/37353) was reverted (before hitting production) as nginx isn't actually configured to forward `/sign-in/apple/callback` to calypso~
**Update:** we don't need to deploy that change as `/log-in/apple/callback` is now whitelisted

#### Changes proposed in this Pull Request

* This PR updates how we parse the JSON `user` object coming from apple as there seems to have been some changes around this.
* It also refactors the sign in with apple server side code and makes sure the `usersSocialNew` request is completed before redirecting the user

#### Testing instructions

- Run this branch locally `npm start`
- Disable your a11n proxy and proxy https://wordpress.com to http://calypso.localhost:3000
- Try signing in with apple to an existing account from https://wordpress.com/log-in
- Optional: try signing up from https://wordpress.com/log-in and/or https://wordpress.com/start/user after removing your Apple ID association with WordPress.
