### PR TITLE
Update canSiteViewAtomicHosting to include user capabilities check

### DIFF
--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -11,7 +11,8 @@ import { get } from 'lodash';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isEnabled } from 'config';
-import { isBusinessPlan } from 'lib/plans';
+import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
+import canCurrentUser from 'state/selectors/can-current-user';
 
 /**
  * TODO: this selector should be backed by an API response instead
@@ -29,13 +30,21 @@ export default function canSiteViewAtomicHosting( state ) {
 	// This is also enforced on the server, please remove client checks later.
 	// ID of site added 31 Oct 2019, so only sites newer currently eligible
 	if ( siteId > 168768859 ) {
-		const isAtomicSite = !! isSiteAutomatedTransfer( state, siteId );
+		const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 
-		if ( isAtomicSite ) {
+		if ( ! canManageOptions ) {
+			return false;
+		}
+
+		const isAtomicSite = !! isSiteAutomatedTransfer( state, siteId );
+		const planSlug = get( getSelectedSite( state ), [ 'plan', 'product_slug' ] );
+		const hasEligablePlan = isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
+
+		if ( isAtomicSite && hasEligablePlan ) {
 			return true;
 		}
 
-		if ( isEnabled( 'hosting/non-atomic-support' ) ) {
+		if ( ! isAtomicSite && hasEligablePlan && isEnabled( 'hosting/non-atomic-support' ) ) {
 			return isBusinessPlan( get( getSelectedSite( state ), [ 'plan', 'product_slug' ] ) );
 		}
 	}


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/37231 users without the `manage_options` capability may no longer directly visit the route `/hosting-admin`

I've opted to not show a notice/disabled cards since the entire manage section does not render in the sidebar when the user is missing this capability.

<img width="274" alt="Screen Shot 2019-11-06 at 2 37 41 PM" src="https://user-images.githubusercontent.com/1270189/68344812-d7009e80-00a4-11ea-8bcf-7d4c8acacfca.png">
 
### Testing Instructions
- Create a new Business or Ecommerce site
- Transfer to Atomic (if Business)
- Create a second user with the Editor role or lower
- Verify that visiting `/hosting-admin` directly, redirects to My Sites root.