### PR TITLE
Gutenberg-first theme ThanksModal

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -110,9 +110,14 @@ class ThanksModal extends Component {
 	};
 
 	goToCustomizer = () => {
+		const { customizeUrl, shouldEditHomepageWithGutenberg } = this.props;
+
 		this.trackClick( 'thanks modal customize' );
 		this.onCloseModal();
-		window.open( this.props.customizeUrl, '_blank' );
+
+		shouldEditHomepageWithGutenberg
+			? page( customizeUrl )
+			: window.open( this.props.customizeUrl, '_blank' );
 	};
 
 	renderThemeInfo = () => {
@@ -185,15 +190,22 @@ class ThanksModal extends Component {
 
 	getEditSiteLabel = () => {
 		const { shouldEditHomepageWithGutenberg, hasActivated } = this.props;
-		return hasActivated ? (
-			<span className="thanks-modal__button-customize">
+		if ( ! hasActivated ) {
+			return translate( 'Activating theme…' );
+		}
+
+		const gutenbergContent = translate( 'Edit Homepage' );
+		const customizerContent = (
+			<>
 				<Gridicon icon="external" />
-				{ shouldEditHomepageWithGutenberg
-					? translate( 'Edit Homepage' )
-					: translate( 'Customize site' ) }
+				{ translate( 'Customize site' ) }
+			</>
+		);
+
+		return (
+			<span className="thanks-modal__button-customize">
+				{ shouldEditHomepageWithGutenberg ? gutenbergContent : customizerContent }
 			</span>
-		) : (
-			translate( 'Activating theme…' )
 		);
 	};
 

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -181,36 +181,61 @@ class ThanksModal extends Component {
 		);
 	};
 
-	render() {
-		const { currentTheme, hasActivated, isActivating } = this.props;
-		const customizeSiteText = hasActivated ? (
+	getEditSiteLabel = () => {
+		const { shouldUseGutenbergFlows } = this.props;
+		return (
 			<span className="thanks-modal__button-customize">
 				<Gridicon icon="external" />
-				{ translate( 'Customize site' ) }
+				{ shouldUseGutenbergFlows ? translate( 'Edit Site' ) : translate( 'Customize site' ) }
 			</span>
-		) : (
-			translate( 'Activating theme…' )
 		);
-		const buttons = [
-			{
-				action: 'learn',
-				label: translate( 'Learn about this theme' ),
-				onClick: this.learnThisTheme,
-			},
+	};
+
+	getButtons = () => {
+		const { shouldUseGutenbergFlows, hasActivated } = this.props;
+
+		if ( ! hasActivated ) {
+			return [
+				{
+					label: translate( 'Activating theme…' ),
+					disabled: ! hasActivated,
+				},
+			];
+		}
+
+		const firstButton = shouldUseGutenbergFlows
+			? {
+					action: 'view', // @TODO: What to use here?
+					label: translate( 'View Site' ),
+					onClick: this.visitSite,
+			  }
+			: {
+					action: 'learn',
+					label: translate( 'Learn about this theme' ),
+					onClick: this.learnThisTheme,
+			  };
+
+		return [
+			firstButton,
 			{
 				action: 'customizeSite',
-				label: customizeSiteText,
+				label: this.getEditSiteLabel(),
 				isPrimary: true,
-				disabled: ! hasActivated,
 				onClick: this.goToCustomizer,
 			},
 		];
+	};
+
+	render() {
+		const { currentTheme, hasActivated, isActivating } = this.props;
+
+		// const buttons = ! hasActivated ? activationButtons : this.getButtons();
 
 		return (
 			<Dialog
 				className="themes__thanks-modal"
 				isVisible={ isActivating || hasActivated }
-				buttons={ buttons }
+				buttons={ this.getButtons() }
 				onClose={ this.onCloseModal }
 			>
 				{ hasActivated && currentTheme ? this.renderContent() : this.renderLoading() }
@@ -234,6 +259,7 @@ export default connect(
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),
 			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
+			shouldUseGutenbergFlows: true,
 		};
 	},
 	dispatch => {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -115,9 +115,7 @@ class ThanksModal extends Component {
 		this.trackClick( 'thanks modal customize' );
 		this.onCloseModal();
 
-		shouldEditHomepageWithGutenberg
-			? page( customizeUrl )
-			: window.open( this.props.customizeUrl, '_blank' );
+		shouldEditHomepageWithGutenberg ? page( customizeUrl ) : window.open( customizeUrl, '_blank' );
 	};
 
 	renderThemeInfo = () => {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -24,12 +24,12 @@ import {
 	isActivatingTheme,
 	hasActivatedTheme,
 	isWpcomTheme,
-	isThemeGutenbergFirst,
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { requestSite } from 'state/sites/actions';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
+import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize-homepage-with-gutenberg';
 
 /**
  * Style dependencies
@@ -252,7 +252,9 @@ export default connect(
 		const siteUrl = get( getSelectedSite( state ), 'URL', null );
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
-		const shouldEditHomepageWithGutenberg = isThemeGutenbergFirst( state, currentThemeId );
+
+		// Note: Gutenberg buttons will only show if the homepage is a page.
+		const shouldEditHomepageWithGutenberg = shouldCustomizeHomepageWithGutenberg( state, siteId );
 
 		return {
 			siteId,

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
-
+import { get } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -253,7 +253,7 @@ class ThanksModal extends Component {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
-		const siteUrl = getSelectedSite( state ).URL;
+		const siteUrl = get( getSelectedSite( state ), 'URL', null );
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
 		const shouldEditThemeWithGutenberg = isThemeGutenbergFirst( state, currentThemeId );

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -187,7 +187,9 @@ class ThanksModal extends Component {
 		return hasActivated ? (
 			<span className="thanks-modal__button-customize">
 				<Gridicon icon="external" />
-				{ shouldEditThemeWithGutenberg ? translate( 'Edit Site' ) : translate( 'Customize site' ) }
+				{ shouldEditThemeWithGutenberg
+					? translate( 'Edit Homepage' )
+					: translate( 'Customize site' ) }
 			</span>
 		) : (
 			translate( 'Activating theme…' )

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -26,10 +26,11 @@ import {
 	isWpcomTheme,
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestSite } from 'state/sites/actions';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize-homepage-with-gutenberg';
+import getSiteUrl from 'state/selectors/get-site-url';
 
 /**
  * Style dependencies
@@ -252,7 +253,7 @@ class ThanksModal extends Component {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
-		const siteUrl = get( getSelectedSite( state ), 'URL', null );
+		const siteUrl = getSiteUrl( state, siteId );
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
 

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -27,7 +27,7 @@ import {
 	shouldEditThemeWithGutenberg as isThemeGutenbergFirst,
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { requestSite } from 'state/sites/actions';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
@@ -76,7 +76,7 @@ class ThanksModal extends Component {
 
 	visitSite = () => {
 		this.trackClick( 'visit site' );
-		page( this.props.visitSiteUrl );
+		window.open( this.props.siteUrl, '_blank' );
 	};
 
 	goBack = () => {
@@ -196,13 +196,22 @@ class ThanksModal extends Component {
 		);
 	};
 
+	getViewSiteLabel = () => {
+		return (
+			<span className="thanks-modal__button-customize">
+				<Gridicon icon="external" />
+				{ translate( 'View Site' ) }
+			</span>
+		);
+	};
+
 	getButtons = () => {
 		const { shouldEditThemeWithGutenberg, hasActivated } = this.props;
 
 		const firstButton = shouldEditThemeWithGutenberg
 			? {
 					action: 'view',
-					label: translate( 'View Site' ),
+					label: this.getViewSiteLabel(),
 					onClick: this.visitSite,
 			  }
 			: {
@@ -244,12 +253,14 @@ class ThanksModal extends Component {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
+		const siteUrl = getSelectedSite( state ).URL;
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
 		const shouldEditThemeWithGutenberg = isThemeGutenbergFirst( state, currentThemeId );
 
 		return {
 			siteId,
+			siteUrl,
 			currentTheme,
 			shouldEditThemeWithGutenberg,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -24,6 +24,7 @@ import {
 	isActivatingTheme,
 	hasActivatedTheme,
 	isWpcomTheme,
+	shouldEditThemeWithGutenberg as isThemeGutenbergFirst,
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -182,30 +183,23 @@ class ThanksModal extends Component {
 	};
 
 	getEditSiteLabel = () => {
-		const { shouldUseGutenbergFlows } = this.props;
-		return (
+		const { shouldEditThemeWithGutenberg, hasActivated } = this.props;
+		return hasActivated ? (
 			<span className="thanks-modal__button-customize">
 				<Gridicon icon="external" />
-				{ shouldUseGutenbergFlows ? translate( 'Edit Site' ) : translate( 'Customize site' ) }
+				{ shouldEditThemeWithGutenberg ? translate( 'Edit Site' ) : translate( 'Customize site' ) }
 			</span>
+		) : (
+			translate( 'Activating theme…' )
 		);
 	};
 
 	getButtons = () => {
-		const { shouldUseGutenbergFlows, hasActivated } = this.props;
+		const { shouldEditThemeWithGutenberg, hasActivated } = this.props;
 
-		if ( ! hasActivated ) {
-			return [
-				{
-					label: translate( 'Activating theme…' ),
-					disabled: ! hasActivated,
-				},
-			];
-		}
-
-		const firstButton = shouldUseGutenbergFlows
+		const firstButton = shouldEditThemeWithGutenberg
 			? {
-					action: 'view', // @TODO: What to use here?
+					action: 'view',
 					label: translate( 'View Site' ),
 					onClick: this.visitSite,
 			  }
@@ -221,6 +215,7 @@ class ThanksModal extends Component {
 				action: 'customizeSite',
 				label: this.getEditSiteLabel(),
 				isPrimary: true,
+				disabled: ! hasActivated,
 				onClick: this.goToCustomizer,
 			},
 		];
@@ -249,17 +244,18 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
+		const shouldEditThemeWithGutenberg = isThemeGutenbergFirst( state, currentThemeId );
 
 		return {
 			siteId,
 			currentTheme,
+			shouldEditThemeWithGutenberg,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
 			customizeUrl: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId ),
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),
 			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
-			shouldUseGutenbergFlows: true,
 		};
 	},
 	dispatch => {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -24,7 +24,7 @@ import {
 	isActivatingTheme,
 	hasActivatedTheme,
 	isWpcomTheme,
-	shouldEditThemeWithGutenberg as isThemeGutenbergFirst,
+	isThemeGutenbergFirst,
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
@@ -183,11 +183,11 @@ class ThanksModal extends Component {
 	};
 
 	getEditSiteLabel = () => {
-		const { shouldEditThemeWithGutenberg, hasActivated } = this.props;
+		const { shouldEditHomepageWithGutenberg, hasActivated } = this.props;
 		return hasActivated ? (
 			<span className="thanks-modal__button-customize">
 				<Gridicon icon="external" />
-				{ shouldEditThemeWithGutenberg
+				{ shouldEditHomepageWithGutenberg
 					? translate( 'Edit Homepage' )
 					: translate( 'Customize site' ) }
 			</span>
@@ -204,9 +204,9 @@ class ThanksModal extends Component {
 	);
 
 	getButtons = () => {
-		const { shouldEditThemeWithGutenberg, hasActivated } = this.props;
+		const { shouldEditHomepageWithGutenberg, hasActivated } = this.props;
 
-		const firstButton = shouldEditThemeWithGutenberg
+		const firstButton = shouldEditHomepageWithGutenberg
 			? {
 					action: 'view',
 					label: this.getViewSiteLabel(),
@@ -233,8 +233,6 @@ class ThanksModal extends Component {
 	render() {
 		const { currentTheme, hasActivated, isActivating } = this.props;
 
-		// const buttons = ! hasActivated ? activationButtons : this.getButtons();
-
 		return (
 			<Dialog
 				className="themes__thanks-modal"
@@ -254,13 +252,13 @@ export default connect(
 		const siteUrl = get( getSelectedSite( state ), 'URL', null );
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
-		const shouldEditThemeWithGutenberg = isThemeGutenbergFirst( state, currentThemeId );
+		const shouldEditHomepageWithGutenberg = isThemeGutenbergFirst( state, currentThemeId );
 
 		return {
 			siteId,
 			siteUrl,
 			currentTheme,
-			shouldEditThemeWithGutenberg,
+			shouldEditHomepageWithGutenberg,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
 			customizeUrl: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId ),
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -219,7 +219,10 @@ class ThanksModal extends Component {
 			  };
 
 		return [
-			firstButton,
+			{
+				...firstButton,
+				disabled: ! hasActivated,
+			},
 			{
 				action: 'customizeSite',
 				label: this.getEditSiteLabel(),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
-import { get } from 'lodash';
+
 /**
  * Internal dependencies
  */

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -196,14 +196,12 @@ class ThanksModal extends Component {
 		);
 	};
 
-	getViewSiteLabel = () => {
-		return (
-			<span className="thanks-modal__button-customize">
-				<Gridicon icon="external" />
-				{ translate( 'View Site' ) }
-			</span>
-		);
-	};
+	getViewSiteLabel = () => (
+		<span className="thanks-modal__button-customize">
+			<Gridicon icon="external" />
+			{ translate( 'View Site' ) }
+		</span>
+	);
 
 	getButtons = () => {
 		const { shouldEditThemeWithGutenberg, hasActivated } = this.props;

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -30,7 +30,7 @@ import {
 	isThemePremium,
 	isPremiumThemeAvailable,
 	isThemeAvailableOnJetpackSite,
-	shouldEditThemeWithGutenberg,
+	isThemeGutenbergFirst,
 } from 'state/themes/selectors';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -135,7 +135,7 @@ const tryandcustomize = {
 			! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
 		( isJetpackSite( state, siteId ) &&
 			! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ) ||
-		shouldEditThemeWithGutenberg( state, themeId ),
+		isThemeGutenbergFirst( state, themeId ),
 };
 
 const preview = {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -30,6 +30,7 @@ import {
 	isThemePremium,
 	isPremiumThemeAvailable,
 	isThemeAvailableOnJetpackSite,
+	shouldEditThemeWithGutenberg,
 } from 'state/themes/selectors';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -132,7 +133,9 @@ const tryandcustomize = {
 		( isThemePremium( state, themeId ) &&
 			isJetpackSite( state, siteId ) &&
 			! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
-		( isJetpackSite( state, siteId ) && ! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ),
+		( isJetpackSite( state, siteId ) &&
+			! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ) ||
+		shouldEditThemeWithGutenberg( state, themeId ),
 };
 
 const preview = {

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -20,10 +20,12 @@ import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
  * @return {String}           Customizer or Block Editor URL
  */
 export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId ) {
-	if (
-		! isSiteUsingFullSiteEditing( state, siteId ) ||
-		! isThemeActive( state, themeId, siteId )
-	) {
+	let shouldUseGutenbergFlows = true;
+
+	shouldUseGutenbergFlows =
+		true ||
+		( isSiteUsingFullSiteEditing( state, siteId ) && ! isThemeActive( state, themeId, siteId ) );
+	if ( ! shouldUseGutenbergFlows ) {
 		return getThemeCustomizeUrl( state, themeId, siteId );
 	}
 	return getFrontPageEditorUrl( state, siteId );

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -3,14 +3,10 @@
 /**
  * Internal dependencies
  */
-import {
-	getThemeCustomizeUrl,
-	isThemeActive,
-	shouldEditThemeWithGutenberg,
-} from 'state/themes/selectors';
+import { getThemeCustomizeUrl, isThemeActive } from 'state/themes/selectors';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
-
+import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize/homepage/with/gutenberg';
 /**
  * Returns the URL for opening customizing the given site in either the block editor with
  * Full Site Editing, or the Customizer for unsupported sites. Can be used wherever
@@ -25,7 +21,8 @@ import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
  */
 export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId ) {
 	const shouldUseGutenberg =
-		shouldEditThemeWithGutenberg( state, themeId ) || isSiteUsingFullSiteEditing( state, siteId );
+		shouldCustomizeHomepageWithGutenberg( state, siteId ) ||
+		isSiteUsingFullSiteEditing( state, siteId );
 
 	// If the theme is not active, use the other function to preview customization with the theme.
 	if ( shouldUseGutenberg && isThemeActive( state, themeId, siteId ) ) {

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -3,7 +3,11 @@
 /**
  * Internal dependencies
  */
-import { getThemeCustomizeUrl, isThemeActive } from 'state/themes/selectors';
+import {
+	getThemeCustomizeUrl,
+	isThemeActive,
+	shouldEditThemeWithGutenberg,
+} from 'state/themes/selectors';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
 
@@ -20,13 +24,13 @@ import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
  * @return {String}           Customizer or Block Editor URL
  */
 export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId ) {
-	let shouldUseGutenbergFlows = true;
+	const shouldUseGutenberg =
+		shouldEditThemeWithGutenberg( state, themeId ) || isSiteUsingFullSiteEditing( state, siteId );
 
-	shouldUseGutenbergFlows =
-		true ||
-		( isSiteUsingFullSiteEditing( state, siteId ) && ! isThemeActive( state, themeId, siteId ) );
-	if ( ! shouldUseGutenbergFlows ) {
-		return getThemeCustomizeUrl( state, themeId, siteId );
+	// If the theme is not active, use the other function to preview customization with the theme.
+	if ( shouldUseGutenberg && isThemeActive( state, themeId, siteId ) ) {
+		return getFrontPageEditorUrl( state, siteId );
 	}
-	return getFrontPageEditorUrl( state, siteId );
+
+	return getThemeCustomizeUrl( state, themeId, siteId );
 }

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -6,7 +6,7 @@
 import { getThemeCustomizeUrl, isThemeActive } from 'state/themes/selectors';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
-import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize/homepage/with/gutenberg';
+import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize-homepage-with-gutenberg';
 /**
  * Returns the URL for opening customizing the given site in either the block editor with
  * Full Site Editing, or the Customizer for unsupported sites. Can be used wherever

--- a/client/state/selectors/should-customize-homepage-with-gutenberg.js
+++ b/client/state/selectors/should-customize-homepage-with-gutenberg.js
@@ -17,7 +17,7 @@ import { getActiveTheme, isThemeGutenbergFirst } from '../themes/selectors';
  */
 export default function shouldCustomizeHomepageWithGutenberg( state, siteId ) {
 	const theme = getActiveTheme( state, siteId );
-	const isGutenbergTheme = isThemeGutenbergFirst( theme );
+	const isGutenbergTheme = isThemeGutenbergFirst( state, theme );
 	const isHomepageAPage = 'page' === getSiteFrontPageType( state, siteId );
 	return isGutenbergTheme && isHomepageAPage;
 }

--- a/client/state/selectors/should-customize-homepage-with-gutenberg.js
+++ b/client/state/selectors/should-customize-homepage-with-gutenberg.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-import { getSiteFrontPageType } from 'state/selectors/get-site-front-page-type';
-import { getActiveTheme, isThemeGutenbergFirst } from 'state/themes/selectors';
+import getSiteFrontPageType from 'state/sites/selectors/get-site-front-page-type';
+import { getActiveTheme, isThemeGutenbergFirst } from '../themes/selectors';
 
 /**
  * Returns whether the homepage should be customized with Gutenberg.
@@ -15,11 +15,9 @@ import { getActiveTheme, isThemeGutenbergFirst } from 'state/themes/selectors';
  * @param {String} siteId The ID of the selected site.
  * @return {Boolean} True if Gutenberg should be opened.
  */
-export const shouldCustomizeHomepageWithGutenberg = ( state, siteId ) => {
+export default function shouldCustomizeHomepageWithGutenberg( state, siteId ) {
 	const theme = getActiveTheme( state, siteId );
 	const isGutenbergTheme = isThemeGutenbergFirst( theme );
 	const isHomepageAPage = 'page' === getSiteFrontPageType( state, siteId );
 	return isGutenbergTheme && isHomepageAPage;
-};
-
-export default shouldCustomizeHomepageWithGutenberg;
+}

--- a/client/state/selectors/should-customize-homepage-with-gutenberg.js
+++ b/client/state/selectors/should-customize-homepage-with-gutenberg.js
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getSiteFrontPageType } from 'state/selectors/get-site-front-page-type';
+import { getActiveTheme, isThemeGutenbergFirst } from 'state/themes/selectors';
+
+/**
+ * Returns whether the homepage should be customized with Gutenberg.
+ *
+ * Used to open the block editor instead of the customizer for some themes.
+ *
+ * @param {Object} state  The global state object.
+ * @param {String} siteId The ID of the selected site.
+ * @return {Boolean} True if Gutenberg should be opened.
+ */
+export const shouldCustomizeHomepageWithGutenberg = ( state, siteId ) => {
+	const theme = getActiveTheme( state, siteId );
+	const isGutenbergTheme = isThemeGutenbergFirst( theme );
+	const isHomepageAPage = 'page' === getSiteFrontPageType( state, siteId );
+	return isGutenbergTheme && isHomepageAPage;
+};
+
+export default shouldCustomizeHomepageWithGutenberg;

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find, includes, isEqual, omit, some, get, uniq } from 'lodash';
+import { find, includes, intersection, isEqual, omit, some, get, uniq } from 'lodash';
 import i18n from 'i18n-calypso';
 import createSelector from 'lib/create-selector';
 
@@ -28,6 +28,7 @@ import {
 	getNormalizedThemesQuery,
 	getSerializedThemesQuery,
 	getSerializedThemesQueryWithoutPage,
+	getThemeTaxonomySlugs,
 	isPremium,
 	oldShowcaseUrl,
 } from './utils';
@@ -740,4 +741,23 @@ export function getPremiumThemePrice( state, themeId, siteId ) {
 
 	const theme = getTheme( state, 'wpcom', themeId );
 	return get( theme, 'price' );
+}
+
+/**
+ * Checks if a theme should be customized primarily with Gutenberg.
+ *
+ * Examples include Template First Themes, which can be determined by the feature
+ * global-styles or auto-loading-homepage.
+ *
+ * @param {Object} state   Global state tree
+ * @param {String} themeId An identifier for the theme - like
+ *                         `independent-publisher-2` or `maywood`.
+ * @return {Boolean} True if the theme should be edited with gutenberg.
+ */
+export function shouldEditThemeWithGutenberg( state, themeId ) {
+	const theme = getTheme( state, 'wpcom', themeId );
+	const themeFeatures = getThemeTaxonomySlugs( theme, 'theme_feature' );
+	const neededFeatures = [ 'global-styles', 'auto-loading-homepage' ];
+	// The theme should have a positive number of matching features to qualify.
+	return !! intersection( themeFeatures, neededFeatures ).length;
 }

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -754,7 +754,7 @@ export function getPremiumThemePrice( state, themeId, siteId ) {
  *                         `independent-publisher-2` or `maywood`.
  * @return {Boolean} True if the theme should be edited with gutenberg.
  */
-export function shouldEditThemeWithGutenberg( state, themeId ) {
+export function isThemeGutenbergFirst( state, themeId ) {
 	const theme = getTheme( state, 'wpcom', themeId );
 	const themeFeatures = getThemeTaxonomySlugs( theme, 'theme_feature' );
 	const neededFeatures = [ 'global-styles', 'auto-loading-homepage' ];

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -216,7 +216,7 @@ export function isThemeMatchingQuery( query, theme ) {
 	const queryWithDefaults = { ...DEFAULT_THEME_QUERY, ...query };
 	return every( queryWithDefaults, ( value, key ) => {
 		switch ( key ) {
-			case 'search':
+			case 'search': {
 				if ( ! value ) {
 					return true;
 				}
@@ -240,8 +240,8 @@ export function isThemeMatchingQuery( query, theme ) {
 						( theme.author && includes( theme.author.toLowerCase(), search ) ) ||
 						( theme.descriptionLong && includes( theme.descriptionLong.toLowerCase(), search ) ) )
 				);
-
-			case 'filter':
+			}
+			case 'filter': {
 				if ( ! value ) {
 					return true;
 				}
@@ -250,8 +250,21 @@ export function isThemeMatchingQuery( query, theme ) {
 				// { color: 'blue,red', feature: 'post-slider' }
 				const filters = value.split( ',' );
 				return every( filters, f => some( theme.taxonomies, terms => some( terms, { slug: f } ) ) );
+			}
 		}
 
 		return true;
 	} );
+}
+
+/**
+ * Returns the slugs of the theme's given taxonomy.
+ *
+ * @param  {Object} theme    The theme object.
+ * @param  {String} taxonomy The taxonomy items to get.
+ * @return {Array}           An array of theme taxonomy slugs.
+ */
+export function getThemeTaxonomySlugs( theme, taxonomy ) {
+	const items = get( theme, [ 'taxonomies', taxonomy ], [] );
+	return items.map( ( { slug } ) => slug );
 }


### PR DESCRIPTION
### Screenshot:

<img width="664" alt="Screen Shot 2019-11-06 at 4 36 27 PM" src="https://user-images.githubusercontent.com/6265975/68349927-a2e0aa00-00b3-11ea-85d2-028c6da4e2ad.png">


### Changes proposed in this Pull Request
* Add selector to determine if a theme is "gutenberg-first" (i.e. the user should be taken to the block editor instead of customizer). For now, a theme is gutenberg first if it supports global styles and/or autopopulating homepages. At the moment, this maps directly to the template first themes.

* Render alternate buttons for the ThanksModal for gutenberg-first themes.

### Known Issues:
If you are currently on theme A (Gutenberg-first) and then activate theme B (non-Gutenberg), the dialogue will display Gutenberg-first buttons until theme B becomes active. For example, you will see the "View Site" button instead of the "Theme Info" button. This also happens going from B-> A. Thankfully, it's a non-issue when switching between two gutenberg first themes, etc. 

This would not be trivial to fix, so I'm not planning on solving it now. The easiest solution here would be to not show any buttons until the theme has finished activating.

### Testing instructions
1. Pull this PR.
2. Test activating a template-first theme like Maywood:
a) You should see a view site button, which takes you to the site front end.
b) You should see an edit homepage button, which takes you to Gutenberg.
3. Test activating a non-template-first theme. You should get the same behavior.
4. Expand the more button of a template first theme. There should be no try and customize button.
5. Expand the more button of a non-template first theme. There should be a try and customize button.

Fixes #37286