### PR TITLE
checkout-composite: Add visual wrapper around payment button

### DIFF
--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -156,8 +156,7 @@ function CheckIcon() {
 const StepWrapper = styled.div`
 	padding-bottom: ${ props => ( props.finalStep ? '0' : '32px' ) };
 	position: relative;
-	border-bottom: ${ ( { finalStep, theme } ) =>
-		finalStep ? '0' : '1px solid ' + theme.colors.borderColorLight }
+	border-bottom: 1px solid ${ props => props.theme.colors.borderColorLight }
 	padding: 16px;
 
 	@media ( ${ props => props.theme.breakpoints.tabletUp } ) {

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -82,7 +82,10 @@ export default function Checkout( {
 					isComplete={ stepNumber > 3 }
 					ReviewContent={ ReviewContent }
 				/>
-				<CheckoutSubmitButton isActive={ stepNumber === 3 } />
+				<CheckoutWrapper>
+					<CheckoutSubmitButton isActive={ stepNumber === 3 } />
+				</CheckoutWrapper>
+
 				{ UpSell && <UpSell /> }
 			</MainContent>
 		</Container>
@@ -122,6 +125,11 @@ const MainContent = styled.div`
 		box-sizing: border-box;
 		max-width: 556px;
 	}
+`;
+
+const CheckoutWrapper = styled.div`
+	background: ${props => props.theme.colors.background};
+	padding: 24px;
 `;
 
 function OrderSummaryStep( { CheckoutHeader } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
![image](https://user-images.githubusercontent.com/6981253/68358145-9d03bc80-00e5-11ea-980d-d360f2872454.png)

This PR adds a visual wrapper around the payment button. 

#### Testing instructions
* See screen shot or follow: https://github.com/Automattic/wp-calypso/pull/37013
