### PR TITLE
Contact Details Form: Fix country select width

### DIFF
--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -86,6 +86,10 @@
 		min-width: 100px;
 	}
 
+	.phone-input__country-select {
+		min-width: 0;
+	}
+
 }
 
 .contact-details-form-fields__extra-fields {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue with the phone input in the contact form by resetting its `min-width`. Currently the country `select` overflows onto the text field for the phone input, and clicking anywhere in the circled area in the screenshot below will cause the country list to expand.

<img width="353" alt="Issue" src="https://user-images.githubusercontent.com/13062352/68380407-0fa98200-0150-11ea-96b1-112490dcec65.png">

#### Testing instructions

To reproduce the issue:

* Try editing the contact info for a domain you own (or add a domain to cart, and during checkout you'll see the contact form)
* Verify that you are able to expand the country list by clicking the area that is circled in the screenshot above

After applying the fix, verify that the issue above no longer occurs.


