### PR TITLE
Reconfigure Renovate ( Remove Calypso Packages groupname )

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
 		{
 			"paths": [ "packages/**" ],
 			"packagePatterns": [ "*" ],
-			"groupName": "calypso-packages",
 			"rangeStrategy": "replace"
 		},
 		{


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* This should prevent Renovate from creating the all encompassing updates to packages under `packages/**`, like https://github.com/Automattic/wp-calypso/pull/37154
* These glommed together updates make it harder to review individual updates and break single PR upgrades of things like babel.

