### PR TITLE
Jetpack Backups: Consider current plan and product in all states

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -74,6 +74,19 @@ export class ProductSelector extends Component {
 		);
 	}
 
+	getPurchaseByCurrentPlan() {
+		const { currentPlanSlug, purchases } = this.props;
+
+		if ( ! currentPlanSlug ) {
+			return null;
+		}
+
+		return find(
+			purchases,
+			purchase => purchase.active && purchase.productSlug === currentPlanSlug
+		);
+	}
+
 	getProductSlugByCurrentPlan() {
 		const { currentPlanSlug, productSlugs } = this.props;
 
@@ -326,7 +339,11 @@ export class ProductSelector extends Component {
 		return map( products, product => {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 			const stateKey = this.getStateKey( product.id, intervalType );
-			const purchase = this.getPurchaseByProduct( product );
+			let purchase = this.getPurchaseByProduct( product );
+
+			if ( currentPlanIncludesProduct ) {
+				purchase = this.getPurchaseByCurrentPlan();
+			}
 
 			let billingTimeFrame, fullPrice, discountedPrice, subtitle;
 			if ( currentPlanIncludesProduct ) {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -25,6 +25,7 @@ import { getSitePlanSlug, isRequestingSitePlans } from 'state/sites/plans/select
 import { getSitePurchases, isFetchingSitePurchases } from 'state/purchases/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getPlan, planHasFeature } from 'lib/plans';
+import { isRequestingPlans } from 'state/plans/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 
 export class ProductSelector extends Component {
@@ -300,6 +301,7 @@ export class ProductSelector extends Component {
 		const {
 			currencyCode,
 			currentPlanSlug,
+			fetchingPlans,
 			fetchingSitePlans,
 			fetchingSitePurchases,
 			intervalType,
@@ -309,7 +311,7 @@ export class ProductSelector extends Component {
 			translate,
 		} = this.props;
 
-		if ( isEmpty( storeProducts ) || fetchingSitePurchases || fetchingSitePlans ) {
+		if ( isEmpty( storeProducts ) || fetchingSitePurchases || fetchingSitePlans || fetchingPlans ) {
 			return map( products, product => {
 				return (
 					<ProductCard
@@ -454,6 +456,7 @@ const connectComponent = connect( ( state, { products, siteId } ) => {
 		availableProducts,
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		currentPlanSlug: getSitePlanSlug( state, selectedSiteId ),
+		fetchingPlans: isRequestingPlans( state ),
 		fetchingSitePlans: isRequestingSitePlans( state ),
 		fetchingSitePurchases: isFetchingSitePurchases( state ),
 		productSlugs,

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -65,7 +65,11 @@ export class ProductSelector extends Component {
 
 		return find(
 			purchases,
-			purchase => purchase.active && includes( productSlugs, purchase.productSlug )
+			purchase =>
+				purchase.active &&
+				( includes( productSlugs, purchase.productSlug ) ||
+					includes( productSlugs, this.getRelatedYearlyProductSlug( purchase.productSlug ) ) ||
+					includes( productSlugs, this.getRelatedMonthlyProductSlug( purchase.productSlug ) ) )
 		);
 	}
 
@@ -220,6 +224,20 @@ export class ProductSelector extends Component {
 			productPriceMatrix,
 			relatedMonthlyProduct => relatedMonthlyProduct.relatedProduct === monthlyProductSlug
 		);
+	}
+
+	getRelatedMonthlyProductSlug( yearlyProductSlug ) {
+		const { productPriceMatrix } = this.props;
+
+		if ( ! productPriceMatrix ) {
+			return null;
+		}
+
+		if ( ! productPriceMatrix[ yearlyProductSlug ] ) {
+			return null;
+		}
+
+		return productPriceMatrix[ yearlyProductSlug ].relatedProduct;
 	}
 
 	getProductOptionFullPrice( productSlug ) {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -21,7 +21,7 @@ import { extractProductSlugs, filterByProductSlugs } from './utils';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePlanSlug } from 'state/sites/plans/selectors';
+import { getSitePlanSlug, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { getSitePurchases, isFetchingSitePurchases } from 'state/purchases/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getPlan, planHasFeature } from 'lib/plans';
@@ -306,6 +306,7 @@ export class ProductSelector extends Component {
 		const {
 			currencyCode,
 			currentPlanSlug,
+			fetchingSitePlans,
 			fetchingSitePurchases,
 			intervalType,
 			products,
@@ -314,7 +315,7 @@ export class ProductSelector extends Component {
 			translate,
 		} = this.props;
 
-		if ( isEmpty( storeProducts ) || fetchingSitePurchases ) {
+		if ( isEmpty( storeProducts ) || fetchingSitePurchases || fetchingSitePlans ) {
 			return map( products, product => {
 				return (
 					<ProductCard
@@ -459,6 +460,7 @@ const connectComponent = connect( ( state, { products, siteId } ) => {
 		availableProducts,
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		currentPlanSlug: getSitePlanSlug( state, selectedSiteId ),
+		fetchingSitePlans: isRequestingSitePlans( state ),
 		fetchingSitePurchases: isFetchingSitePurchases( state ),
 		productSlugs,
 		purchases: getSitePurchases( state, selectedSiteId ),

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -323,12 +323,12 @@ export class ProductSelector extends Component {
 		}
 
 		const currentPlan = currentPlanSlug && getPlan( currentPlanSlug );
+		const currentPlanIncludesProduct = !! this.getProductSlugByCurrentPlan();
 
 		return map( products, product => {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 			const stateKey = this.getStateKey( product.id, intervalType );
 			const purchase = this.getPurchaseByProduct( product );
-			const currentPlanIncludesProduct = !! this.getProductSlugByCurrentPlan();
 
 			let billingTimeFrame, fullPrice, discountedPrice, subtitle;
 			if ( currentPlanIncludesProduct ) {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -110,7 +110,7 @@ export class ProductSelector extends Component {
 
 		// Description, obtained from a product that's included in a purchased plan
 		const planProductSlug = this.getProductSlugByCurrentPlan();
-		if ( planProductSlug && optionDescriptions[ planProductSlug ] ) {
+		if ( planProductSlug && optionDescriptions && optionDescriptions[ planProductSlug ] ) {
 			return optionDescriptions[ planProductSlug ];
 		}
 
@@ -144,7 +144,7 @@ export class ProductSelector extends Component {
 
 		// Product display name, obtained from a product that's included in a purchased plan
 		const planProductSlug = this.getProductSlugByCurrentPlan();
-		if ( planProductSlug && optionDisplayNames[ planProductSlug ] ) {
+		if ( planProductSlug && optionDisplayNames && optionDisplayNames[ planProductSlug ] ) {
 			return optionDisplayNames[ planProductSlug ];
 		}
 
@@ -252,11 +252,7 @@ export class ProductSelector extends Component {
 	getRelatedMonthlyProductSlug( yearlyProductSlug ) {
 		const { productPriceMatrix } = this.props;
 
-		if ( ! productPriceMatrix ) {
-			return null;
-		}
-
-		if ( ! productPriceMatrix[ yearlyProductSlug ] ) {
+		if ( ! productPriceMatrix || ! productPriceMatrix[ yearlyProductSlug ] ) {
 			return null;
 		}
 
@@ -427,8 +423,9 @@ ProductSelector.propTypes = {
 	// Connected props
 	availableProducts: PropTypes.object,
 	currencyCode: PropTypes.string,
-	currentPlan: PropTypes.object,
 	currentPlanSlug: PropTypes.string,
+	fetchingPlans: PropTypes.bool,
+	fetchingSitePlans: PropTypes.bool,
 	fetchingSitePurchases: PropTypes.bool,
 	productSlugs: PropTypes.arrayOf( PropTypes.string ),
 	purchases: PropTypes.array,

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -183,12 +183,6 @@ export class ProductSelector extends Component {
 		} );
 	}
 
-	currentPlanIncludesProduct = productSlug => {
-		const { currentPlanSlug } = this.props;
-
-		return planHasFeature( currentPlanSlug, productSlug );
-	};
-
 	renderCheckoutButton( product ) {
 		const { intervalType, storeProducts, translate } = this.props;
 		const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
@@ -334,7 +328,7 @@ export class ProductSelector extends Component {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 			const stateKey = this.getStateKey( product.id, intervalType );
 			const purchase = this.getPurchaseByProduct( product );
-			const currentPlanIncludesProduct = this.currentPlanIncludesProduct( selectedProductSlug );
+			const currentPlanIncludesProduct = !! this.getProductSlugByCurrentPlan();
 
 			let billingTimeFrame, fullPrice, discountedPrice, subtitle;
 			if ( currentPlanIncludesProduct ) {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -721,7 +721,10 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY ],
+		getHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_DAILY,
+			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+		],
 	},
 
 	[ constants.PLAN_JETPACK_PREMIUM_MONTHLY ]: {
@@ -780,7 +783,10 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
-		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY ],
+		getHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_DAILY,
+			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+		],
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL ]: {
@@ -822,7 +828,10 @@ export const PLANS_LIST = {
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY ],
+		getHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_DAILY,
+			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+		],
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL_MONTHLY ]: {
@@ -863,7 +872,10 @@ export const PLANS_LIST = {
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
-		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY ],
+		getHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_DAILY,
+			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+		],
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS ]: {
@@ -924,7 +936,10 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_REALTIME ],
+		getHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_REALTIME,
+			constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
+		],
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS_MONTHLY ]: {
@@ -984,7 +999,10 @@ export const PLANS_LIST = {
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
-		getHiddenFeatures: () => [ constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY ],
+		getHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_REALTIME,
+			constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
+		],
 	},
 };
 


### PR DESCRIPTION
This PR updates the `ProductSelector` to consider the current Jetpack backup products and current plan in all states, regardless of what product option is selected and what billing interval is selected. This makes the overall experience with this piece of UI more consistent, and is basically the improved version of #37357.

#### Changes proposed in this Pull Request

* Includes #37388 in it (should be rebased when it lands)
* Update the `ProductSelector` to consider the current Jetpack backup product that has been purchased.
* Update the `ProductSelector` to consider current Jetpack plan that has been purchased.
* Update the `ProductSelector` to consider the above in all states, regardless of what product option is selected and what billing interval is selected.

#### Testing instructions

* Checkout this branch.
* Make sure you don't have a Jetpack plan or Jetpack product.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site.
* Verify you can purchase any Jetpack backup product, and the prices, descriptions, titles still make sense and remain unchanged like before.
* Try the following with all 4 combinations of Jetpack backup product: yearly/monthly, daily/realtime.
  * Make sure you don't have a Jetpack backup product currently.
  * Purchase the Jetpack backup product.
  * Go back to the plans page.
  * Verify that the current Jetpack backup product is propagated through all billing intervals, you see adequate titles, subtitles and descriptions, and you don't see any product options below.
* Try the following with different kinds of plans (monthly personal, yearly premium, yearly professional)
  * Purchase the Jetpack plan.
  * Go back to the plans page.
  * Verify that in any billing interval, the plans page respects the current plan that includes your Jetpack backup product, and it displays the right info about the Jetpack backup product it contains (Professional plan contains Real-time backup product, lower tier plans contain a Daily backup product)
