### PR TITLE
Popup Monitor: Ensure all events are fired in Firefox

### DIFF
--- a/client/lib/popup-monitor/index.js
+++ b/client/lib/popup-monitor/index.js
@@ -97,7 +97,12 @@ PopupMonitor.prototype.isOpen = function( name ) {
 PopupMonitor.prototype.checkStatus = function() {
 	for ( const name in this.intervals ) {
 		if ( this.intervals.hasOwnProperty( name ) && ! this.isOpen( name ) ) {
-			this.emit( 'close', name );
+			setTimeout(
+				function() {
+					this.emit( 'close', name );
+				}.bind( this ),
+				0
+			);
 			delete this.intervals[ name ];
 		}
 	}
@@ -105,7 +110,12 @@ PopupMonitor.prototype.checkStatus = function() {
 	if ( 0 === Object.keys( this.intervals ).length ) {
 		clearInterval( this.monitorInterval );
 		delete this.monitorInterval;
-		window.removeEventListener( 'message', this.onMessage );
+		setTimeout(
+			function() {
+				window.removeEventListener( 'message', this.onMessage );
+			}.bind( this ),
+			0
+		);
 	}
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

During some testing of site keyring connections it was discovered that
Firefox was not receiving the keyring ID from the `postMessage` call
when connecting to Google My Business. After some research it was
suspected that the event listener was being removed before the message
had been received.

In the documentation it says:

> postMessage() schedules the MessageEvent to be dispatched only after
> all pending execution contexts have finished. For example, if postMessage()
> is invoked in an event handler, that event handler will run to completion,
> as will any remaining handlers for that same event, before the MessageEvent
> is dispatched.

So this change emits the `close` event and removes the event listener
after the current execution context has completed, which appears to fix
the problem.

#### Testing instructions

Using Firefox (the problem was observed with 71.0b6 (64-bit)) try creating a Google My Business connection from the connect button in `/marketing/connections`. Without this change the auth window will close and you will be returned to the screen with 'Connect' still on the button. 

With this change, you should then be asked to confirm the business to connect, and the connection will be setup. The button will then change to 'Disconnect'
