### PR TITLE
Starter Page Templates: Add all SPT themes home templates to the template selector

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -206,11 +206,7 @@ class Starter_Page_Templates {
 		if ( false === $vertical_templates || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
 			$vertical_id = get_option( 'site_vertical', 'default' );
 			$request_url = add_query_arg(
-				[
-					'_locale'       => $this->get_iso_639_locale(),
-					'theme'         => get_stylesheet(),
-					'all_templates' => true,
-				],
+				[ '_locale' => $this->get_iso_639_locale() ],
 				'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates'
 			);
 			$response    = wp_remote_get( esc_url_raw( $request_url ) );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -207,8 +207,9 @@ class Starter_Page_Templates {
 			$vertical_id = get_option( 'site_vertical', 'default' );
 			$request_url = add_query_arg(
 				[
-					'_locale' => $this->get_iso_639_locale(),
-					'theme'   => get_stylesheet(),
+					'_locale'       => $this->get_iso_639_locale(),
+					'theme'         => get_stylesheet(),
+					'all_templates' => true,
 				],
 				'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates'
 			);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -4,6 +4,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { isEmpty, isArray, debounce } from 'lodash';
 /* eslint-enable import/no-extraneous-dependencies */
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -104,7 +105,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 	if ( isEmpty( blocks ) || ! isArray( blocks ) ) {
 		return (
-			<div className="template-selector-preview">
+			<div className={ classnames( 'template-selector-preview', 'is-blank-preview' ) }>
 				<div className="template-selector-preview__placeholder">
 					{ __( 'Select a layout to preview.', 'full-site-editing' ) }
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -226,7 +226,7 @@ class PageTemplateModal extends Component {
 								</fieldset>
 								<fieldset className="page-template-modal__list">
 									<legend className="page-template-modal__form-title">
-										{ __( 'Homepage Layouts', 'full-site-editing' ) }
+										{ __( 'Homepage layouts', 'full-site-editing' ) }
 									</legend>
 									<TemplateSelectorControl
 										label={ __( 'Layout', 'full-site-editing' ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, get, keyBy, mapValues } from 'lodash';
+import { isEmpty, reduce, get, keyBy, mapValues, partition } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -170,6 +170,11 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
+		const [ additional_homepage_templates, default_templates ] = partition(
+			templates,
+			'is_additional_homepage_template'
+		);
+
 		return (
 			<Modal
 				title={ __( 'Select Page Layout', 'full-site-editing' ) }
@@ -211,7 +216,22 @@ class PageTemplateModal extends Component {
 									</legend>
 									<TemplateSelectorControl
 										label={ __( 'Layout', 'full-site-editing' ) }
-										templates={ templates }
+										templates={ default_templates }
+										blocksByTemplates={ blocksByTemplateSlug }
+										onTemplateSelect={ this.previewTemplate }
+										useDynamicPreview={ false }
+										siteInformation={ siteInformation }
+										selectedTemplate={ previewedTemplate }
+										handleTemplateConfirmation={ this.handleConfirmation }
+									/>
+								</fieldset>
+								<fieldset className="page-template-modal__list">
+									<legend className="page-template-modal__form-title">
+										{ __( 'Or choose a homepage layout from another theme…', 'full-site-editing' ) }
+									</legend>
+									<TemplateSelectorControl
+										label={ __( 'Layout', 'full-site-editing' ) }
+										templates={ additional_homepage_templates }
 										blocksByTemplates={ blocksByTemplateSlug }
 										onTemplateSelect={ this.previewTemplate }
 										useDynamicPreview={ false }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -170,10 +170,9 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
-		const [ additional_homepage_templates, default_templates ] = partition(
-			templates,
-			'is_additional_homepage_template'
-		);
+		const [ homepage_templates, default_templates ] = partition( templates, {
+			category: 'home',
+		} );
 
 		return (
 			<Modal
@@ -227,11 +226,11 @@ class PageTemplateModal extends Component {
 								</fieldset>
 								<fieldset className="page-template-modal__list">
 									<legend className="page-template-modal__form-title">
-										{ __( 'Or choose a homepage layout from another theme…', 'full-site-editing' ) }
+										{ __( 'Homepage Layouts', 'full-site-editing' ) }
 									</legend>
 									<TemplateSelectorControl
 										label={ __( 'Layout', 'full-site-editing' ) }
-										templates={ additional_homepage_templates }
+										templates={ homepage_templates }
 										blocksByTemplates={ blocksByTemplateSlug }
 										onTemplateSelect={ this.previewTemplate }
 										useDynamicPreview={ false }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -124,6 +124,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 }
 
+.page-template-modal__list {
+	margin-bottom: 20px;
+}
+
 .page-template-modal__list,
 .sidebar-modal-opener {
 	.components-base-control__label {
@@ -515,7 +519,7 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	.template-selector-item__label {
 		max-width: 300px;
 	}
-	
+
 	.template-selector-item__template-title {
 		font-size: 1.2rem;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -350,6 +350,14 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		height: calc( 100vh - 130px );
 	}
 
+	@media screen and ( min-width: 660px ) {
+		&.is-blank-preview {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+	}
+
 	position: fixed;
 	top: 111px;
 	bottom: 24px;
@@ -414,22 +422,9 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 }
 
 .template-selector-preview__placeholder {
-	position: absolute;
-	top: 24%;
-	left: 50%;
-	transform: translateX( -50% );
-	width: 80%;
-	text-align: center;
+	color: var( --color-text-subtle );
 	font-size: 15px;
 	font-weight: 400;
-	color: var( --color-text-subtle );
-
-	@media screen and ( min-width: 1441px ) {
-		left: auto;
-		right: 0;
-		transform: none;
-		width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
-	}
 }
 
 // Preview adjustments.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update SPT to request all SPT themes homepage templates.
* Display these homepage templates in a new additional grouping in the SPT selector.

| Before | After |
| - | - |
| <img width="1741" alt="Screenshot 2019-11-07 at 16 46 33" src="https://user-images.githubusercontent.com/2070010/68408963-367ead00-017e-11ea-88f8-df69c8bcfe9d.png"> | <img width="1406" alt="Screenshot 2019-11-08 at 12 25 14" src="https://user-images.githubusercontent.com/2070010/68476539-d8f06c00-0222-11ea-9cf5-baf022b30887.png"> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D35170-code and sandbox the API.
* Build this PR with `npx lerna run build --scope='@automattic/full-site-editing'` on a site with SPT enabled (a local FSE test environment is fine, but it might lack some blocks required by the theme).
* Create a new page on that site and make sure it shows the Starter Page Templates selector.
* Make sure it has both the expected 9 vertical templates (Blank, Home, etc.), and a second grouping with many other templates named after their themes (e.g. Mayland, Rivington, Dalston, etc.).

Fixes #37282
