### PR TITLE
Analytics: unify calypso_user_registration_complete events and move identifyUser() inside recordRegistration()

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -130,8 +130,8 @@ class PasswordlessSignupForm extends Component {
 		const userId =
 			( response && response.signup_sandbox_user_id ) || ( response && response.user_id );
 
-		analytics.recordPasswordlessRegistration( { flow: this.props.flowName } );
-		analytics.identifyUser( { ID: userId, username, email: this.state.email } );
+		analytics.recordRegistration( { flow: this.props.flowName, type: 'passwordless' } );
+		analytics.identifyUser( username, userId );
 
 		this.submitStep( {
 			username,

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -124,15 +124,18 @@ class PasswordlessSignupForm extends Component {
 			isSubmitting: false,
 		} );
 
-		const username =
-			( response && response.signup_sandbox_username ) || ( response && response.username );
+		const userId = ( response && response.signup_sandbox_user_id ) || ( response && response.user_id );
 
-		const userId =
-			( response && response.signup_sandbox_user_id ) || ( response && response.user_id );
+		const username = ( response && response.signup_sandbox_username ) || ( response && response.username );
+
+		const userData = {
+			ID: userId, 
+			username: username, 
+			email: this.state.email
+		};
 
 		analytics.recordRegistration( {
-			username,
-			userId,
+			userData,
 			flow: this.props.flowName,
 			type: 'passwordless',
 		} );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -130,8 +130,12 @@ class PasswordlessSignupForm extends Component {
 		const userId =
 			( response && response.signup_sandbox_user_id ) || ( response && response.user_id );
 
-		analytics.recordRegistration( { flow: this.props.flowName, type: 'passwordless' } );
-		analytics.identifyUser( username, userId );
+		analytics.recordRegistration( {
+			username,
+			userId,
+			flow: this.props.flowName,
+			type: 'passwordless',
+		} );
 
 		this.submitStep( {
 			username,

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1671,7 +1671,7 @@ function recordOrderInGoogleAds( cart, orderId ) {
  */
 function quantcastAsynchronousTagURL() {
 	const protocolAndSubdomain =
-		document.location.protocol === 'https:' ? 'https://secure' : 'http://edge';
+		window.location.protocol === 'https:' ? 'https://secure' : 'http://edge';
 
 	return protocolAndSubdomain + '.quantserve.com/quant.js';
 }
@@ -1711,7 +1711,7 @@ function setupWpcomFloodlightGtag() {
  * 2. `ad-tracking` feature is disabled
  * 3. `Do Not Track` is enabled
  * 4. the current user could be in the GDPR zone and hasn't consented to tracking
- * 5. `document.location.href` may contain personally identifiable information
+ * 5. `window.location.href` may contain personally identifiable information
  *
  * Note that doNotTrack() and isPiiUrl() can change at any time which is why we do not cache them.
  *

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -82,7 +82,7 @@ if ( typeof window !== 'undefined' ) {
 function getUrlParameter( name ) {
 	name = name.replace( /[[]/g, '\\[' ).replace( /[\]]/g, '\\]' );
 	const regex = new RegExp( '[\\?&]' + name + '=([^&#]*)' );
-	const results = regex.exec( location.search );
+	const results = regex.exec( window.location.search );
 	return results === null ? '' : decodeURIComponent( results[ 1 ].replace( /\+/g, ' ' ) );
 }
 
@@ -98,7 +98,7 @@ function createRandomId( randomBytesLength = 9 ) {
 		randomBytes = times( randomBytesLength, () => Math.floor( Math.random() * 256 ) );
 	}
 
-	return btoa( String.fromCharCode.apply( String, randomBytes ) );
+	return window.btoa( String.fromCharCode.apply( String, randomBytes ) );
 }
 
 function checkForBlockedTracks() {
@@ -213,8 +213,8 @@ const analytics = {
 
 			if ( config( 'mc_analytics_enabled' ) ) {
 				const uriComponent = buildQuerystring( group, name );
-				new Image().src =
-					document.location.protocol +
+				new window.Image().src =
+					window.location.protocol +
 					'//pixel.wp.com/g.gif?v=wpcom-no-pv' +
 					uriComponent +
 					'&t=' +
@@ -232,8 +232,8 @@ const analytics = {
 
 			if ( config( 'mc_analytics_enabled' ) ) {
 				const uriComponent = buildQuerystringNoPrefix( group, name );
-				new Image().src =
-					document.location.protocol +
+				new window.Image().src =
+					window.location.protocol +
 					'//pixel.wp.com/g.gif?v=wpcom' +
 					uriComponent +
 					'&t=' +
@@ -375,7 +375,11 @@ const analytics = {
 		{ isNewUser, isNewSite, hasCartItems, flow, isNew7DUserSite },
 		now
 	) {
-		analyticsDebug( 'recordSignupComplete', { isNewUser, isNewSite, hasCartItems, flow, isNew7DUserSite }, `now=${now}` );
+		analyticsDebug(
+			'recordSignupComplete',
+			{ isNewUser, isNewSite, hasCartItems, flow, isNew7DUserSite },
+			`now=${ now }`
+		);
 
 		if ( ! now ) {
 			// Delay using the analytics localStorage queue.
@@ -593,7 +597,7 @@ const analytics = {
 				);
 
 				const imgUrl = statsdTimingUrl( featureSlug, eventType, duration );
-				new Image().src = imgUrl;
+				new window.Image().src = imgUrl;
 			}
 		},
 
@@ -606,7 +610,7 @@ const analytics = {
 				);
 
 				const imgUrl = statsdCountingUrl( featureSlug, eventType, increment );
-				new Image().src = imgUrl;
+				new window.Image().src = imgUrl;
 			}
 		},
 	},

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -355,7 +355,8 @@ const analytics = {
 		recordSignupStart( { flow } );
 	},
 
-	recordRegistration: function( { flow, type } ) {
+	recordRegistration: function( { username, userId, flow, type } ) {
+		analytics.identifyUser( username, userId );
 		// Tracks
 		analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow, type } );
 		// Google Analytics

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -355,29 +355,11 @@ const analytics = {
 		recordSignupStart( { flow } );
 	},
 
-	recordRegistration: function( { flow } ) {
+	recordRegistration: function( { flow, type } ) {
 		// Tracks
-		analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow } );
+		analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow, type } );
 		// Google Analytics
 		analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
-		// Marketing
-		recordRegistration();
-	},
-
-	recordPasswordlessRegistration: function( { flow } ) {
-		// Tracks
-		analytics.tracks.recordEvent( 'calypso_user_registration_passwordless_complete', { flow } );
-		// Google Analytics
-		analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_passwordless_complete' );
-		// Marketing
-		recordRegistration();
-	},
-
-	recordSocialRegistration: function() {
-		// Tracks
-		analytics.tracks.recordEvent( 'calypso_user_registration_social_complete' );
-		// Google Analytics
-		analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_social_complete' );
 		// Marketing
 		recordRegistration();
 	},

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -45,6 +45,7 @@ import { getFeatureSlugFromPageUrl } from './feature-slug';
 /**
  * Module variables
  */
+const analyticsDebug = debug( 'calypso:analytics' );
 const initializeDebug = debug( 'calypso:analytics:initialize' );
 const identifyUserDebug = debug( 'calypso:analytics:identifyUser' );
 const blockedTracksDebug = debug( 'calypso:analytics:blockedTracks' );
@@ -347,6 +348,8 @@ const analytics = {
 	},
 
 	recordSignupStart: function( { flow, ref } ) {
+		analyticsDebug( 'recordSignupStart', { flow, ref } );
+
 		// Tracks
 		analytics.tracks.recordEvent( 'calypso_signup_start', { flow, ref } );
 		// Google Analytics
@@ -355,8 +358,11 @@ const analytics = {
 		recordSignupStart( { flow } );
 	},
 
-	recordRegistration: function( { username, userId, flow, type } ) {
-		analytics.identifyUser( username, userId );
+	recordRegistration: function( { userData, flow, type } ) {
+		analyticsDebug( 'recordRegistration', { userData, flow, type } );
+
+		// Tracks user identification
+		analytics.identifyUser( userData );
 		// Tracks
 		analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow, type } );
 		// Google Analytics
@@ -369,6 +375,8 @@ const analytics = {
 		{ isNewUser, isNewSite, hasCartItems, flow, isNew7DUserSite },
 		now
 	) {
+		analyticsDebug( 'recordSignupComplete', { isNewUser, isNewSite, hasCartItems, flow, isNew7DUserSite }, `now=${now}` );
+
 		if ( ! now ) {
 			// Delay using the analytics localStorage queue.
 			return analytics.queue.add(
@@ -415,6 +423,8 @@ const analytics = {
 	},
 
 	recordAddToCart: function( { cartItem } ) {
+		analyticsDebug( 'recordAddToCart', { cartItem } );
+
 		// TODO: move Tracks event here?
 		// Google Analytics
 		const usdValue = costToUSD( cartItem.cost, cartItem.currency );
@@ -429,6 +439,8 @@ const analytics = {
 	},
 
 	recordPurchase: function( { cart, orderId } ) {
+		analyticsDebug( 'recordPurchase', { cart, orderId } );
+
 		if ( cart.total_cost >= 0.01 ) {
 			// Google Analytics
 			const usdValue = costToUSD( cart.total_cost, cart.currency );

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -75,7 +75,7 @@ function setUtmCookie( name, value ) {
 		// would require additional custom logic to work out the root domain name.
 		domain:
 			'.' +
-			document.location.hostname
+			window.location.hostname
 				.split( '.' )
 				.slice( -2 )
 				.join( '.' ),
@@ -86,12 +86,12 @@ function setUtmCookie( name, value ) {
  * Updates tracking based on URL query parameters.
  */
 export function updateQueryParamsTracking() {
-	if ( ! document.location.search ) {
+	if ( ! window.location.search ) {
 		debug( 'No query data in URL.' );
 		return;
 	}
 
-	const query = urlParseAmpCompatible( document.location.href ).query;
+	const query = urlParseAmpCompatible( window.location.href ).query;
 
 	// Sanitize query params
 	const sanitized_query = {};

--- a/client/lib/analytics/utils/is-ad-tracking-allowed.js
+++ b/client/lib/analytics/utils/is-ad-tracking-allowed.js
@@ -16,9 +16,9 @@ import mayWeTrackCurrentUserGdpr from './may-we-track-current-user-gdpr';
  * 1. 'ad-tracking' is disabled
  * 2. `Do Not Track` is enabled
  * 3. the current user could be in the GDPR zone and hasn't consented to tracking
- * 4. `document.location.href` may contain personally identifiable information
+ * 4. `window.location.href` may contain personally identifiable information
  *
- * @returns {Boolean} Is ad tracking is allowed?
+ * @returns {boolean} Is ad tracking is allowed?
  */
 export default function isAdTrackingAllowed() {
 	const result =

--- a/client/lib/analytics/utils/is-pii-url.js
+++ b/client/lib/analytics/utils/is-pii-url.js
@@ -30,10 +30,10 @@ const forbiddenPiiPatternsEnc = forbiddenPiiPatterns.map( pattern => {
 /**
  * Whether the current URL can potentially contain personally identifiable info.
  *
- * @returns {Boolean} true if the current URL can potentially contain personally identifiable info.
+ * @returns {boolean} true if the current URL can potentially contain personally identifiable info.
  */
 export default function isPiiUrl() {
-	const href = document.location.href;
+	const href = window.location.href;
 	const match = pattern => href.indexOf( pattern ) !== -1;
 	const result = forbiddenPiiPatterns.some( match ) || forbiddenPiiPatternsEnc.some( match );
 

--- a/client/lib/analytics/utils/is-url-blacklisted-for-performance.js
+++ b/client/lib/analytics/utils/is-url-blacklisted-for-performance.js
@@ -9,10 +9,10 @@ const blacklistedRoutes = [ '/log-in' ];
 /**
  * Are tracking pixels forbidden from the given URL for better performance (except for Google Analytics)?
  *
- * @returns {Boolean} true if the current URL is blacklisted.
+ * @returns {boolean} true if the current URL is blacklisted.
  */
 export default function isUrlBlacklistedForPerformance() {
-	const { href } = document.location;
+	const { href } = window.location;
 	const match = pattern => href.indexOf( pattern ) !== -1;
 	const result = blacklistedRoutes.some( match );
 

--- a/client/lib/analytics/utils/url-parse-amp-compatible.js
+++ b/client/lib/analytics/utils/url-parse-amp-compatible.js
@@ -12,8 +12,8 @@ import debug from './debug';
 /**
  * Decodes a url-safe base64 encoded string.
  *
- * @param {String} str The url-safe base64 encoded string
- * @return {String} The decoded string
+ * @param {string} str The url-safe base64 encoded string
+ * @returns {string} The decoded string
  */
 function urlSafeBase64DecodeString( str ) {
 	const decodeMap = {
@@ -22,15 +22,15 @@ function urlSafeBase64DecodeString( str ) {
 		'.': '=',
 	};
 
-	return atob( str.replace( /[-_.]/g, ch => decodeMap[ ch ] ) );
+	return window.atob( str.replace( /[-_.]/g, ch => decodeMap[ ch ] ) );
 }
 
 /**
  * Decodes a URL param encoded by AMP's linker.js
  * See also https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/linker-id-receiving.md
  *
- * @param {String} value Value to be decoded
- * @return {null|Object} null or and object containing key/value pairs
+ * @param {string} value Value to be decoded
+ * @returns {null|object} null or and object containing key/value pairs
  */
 function parseAmpEncodedParams( value ) {
 	value = value
@@ -54,8 +54,8 @@ function parseAmpEncodedParams( value ) {
  * URL parameters explicitly present in the URL take precedence over the ones extracted from `tk_amp`.
  * This function is used to support AMP-compatible tracking.
  *
- * @param {String} url URL to be parsed like `document.location.href`.
- * @return {Object} An object equivalent to what url.parse( url, true ) would return plus the data extracted from in `tk_amp`
+ * @param {string} url URL to be parsed like `window.location.href`.
+ * @returns {object} An object equivalent to what url.parse( url, true ) would return plus the data extracted from in `tk_amp`
  */
 export default function urlParseAmpCompatible( url ) {
 	const parsedUrl = parseUrl( url, true );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -415,17 +415,24 @@ export function createAccount(
 					);
 				}
 
-				const username =
-					( response && response.signup_sandbox_username ) ||
-					( response && response.username ) ||
-					userData.username;
-
 				const userId =
 					( response && response.signup_sandbox_user_id ) ||
 					( response && response.user_id ) ||
 					userData.ID;
 
-				analytics.recordRegistration( { username, userId, flow: flowName, type: 'social' } );
+				const username =
+					( response && response.signup_sandbox_username ) ||
+					( response && response.username ) ||
+					userData.username;
+
+				const registrationUserData = {
+					ID: userId,
+					username: username,
+					email: userData.email
+				};
+
+				// Fire after a new user registers.
+				analytics.recordRegistration( { registrationUserData, flow: flowName, type: 'social' } );
 
 				callback( undefined, pick( response, [ 'username', 'bearer_token' ] ) );
 			}
@@ -478,18 +485,24 @@ export function createAccount(
 					);
 				}
 
-				const username =
-					( response && response.signup_sandbox_username ) ||
-					( response && response.username ) ||
-					userData.username;
-
 				const userId =
 					( response && response.signup_sandbox_user_id ) ||
 					( response && response.user_id ) ||
 					userData.ID;
 
+				const username =
+					( response && response.signup_sandbox_username ) ||
+					( response && response.username ) ||
+					userData.username;
+
+				const registrationUserData = {
+					ID: userId,
+					username: username,
+					email: userData.email
+				};
+
 				// Fire after a new user registers.
-				analytics.recordRegistration( { username, userId, flow: flowName, type: 'default' } );
+				analytics.recordRegistration( { registrationUserData, flow: flowName, type: 'default' } );
 
 				const providedDependencies = assign( { username }, bearerToken );
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -415,7 +415,17 @@ export function createAccount(
 					);
 				}
 
-				analytics.recordRegistration( { flow: flowName, type: 'social' } );
+				const username =
+					( response && response.signup_sandbox_username ) ||
+					( response && response.username ) ||
+					userData.username;
+
+				const userId =
+					( response && response.signup_sandbox_user_id ) ||
+					( response && response.user_id ) ||
+					userData.ID;
+
+				analytics.recordRegistration( { username, userId, flow: flowName, type: 'social' } );
 
 				callback( undefined, pick( response, [ 'username', 'bearer_token' ] ) );
 			}
@@ -479,8 +489,7 @@ export function createAccount(
 					userData.ID;
 
 				// Fire after a new user registers.
-				analytics.recordRegistration( { flow: flowName, type: 'default' } );
-				analytics.identifyUser( username, userId );
+				analytics.recordRegistration( { username, userId, flow: flowName, type: 'default' } );
 
 				const providedDependencies = assign( { username }, bearerToken );
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -415,7 +415,7 @@ export function createAccount(
 					);
 				}
 
-				analytics.recordSocialRegistration();
+				analytics.recordRegistration( { flow: flowName, type: 'social' } );
 
 				callback( undefined, pick( response, [ 'username', 'bearer_token' ] ) );
 			}
@@ -479,8 +479,8 @@ export function createAccount(
 					userData.ID;
 
 				// Fire after a new user registers.
-				analytics.recordRegistration( { flow: flowName } );
-				analytics.identifyUser( { ID: userId, username, email: userData.email } );
+				analytics.recordRegistration( { flow: flowName, type: 'default' } );
+				analytics.identifyUser( username, userId );
 
 				const providedDependencies = assign( { username }, bearerToken );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1) Unifies `calypso_user_registration_complete` events into one.
2) Moves `identifyUser()` inside the one `recordRegistration()` thus making sure `calypso_user_registration_complete` is already aliased and `identifyUser()` happens no matter what new signup method will be added in the future.
3) A few more cosmetic fixes reported by either CI or the JS linter.

#### Testing instructions

* Enabled trackers and logs:
```
document.cookie = 'flags=gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
document.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
localStorage.setItem( 'debug', 'calypso:analytics*' );
```

* Test normal registration, passwordless registration, social registration
* Make sure `flow` and `type` props are present and properly set in the `calypso_user_registration_complete` Tracks event.
* Make sure there are no regressions with https://github.com/Automattic/wp-calypso/pull/37263

p2-pbmxuV-U
