### PR TITLE
Signup: Add sub-header to plans step.

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -209,9 +209,11 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			props: {
 				headerText: i18n.translate( 'Getting ready to launch your website' ),
-				subHeaderText: i18n.translate( "Pick a plan that's right for you. Update it as you grow." ),
+				subHeaderText: i18n.translate(
+					"Pick a plan that's right for you. Upgrade it as you grow."
+				),
 				fallbackHeaderText: i18n.translate(
-					"Almost there, pick a plan that's right for you. Update it as you grow."
+					"Almost there, pick a plan that's right for you. Upgrade it as you grow."
 				),
 				isLaunchPage: true,
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -209,8 +209,10 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			props: {
 				headerText: i18n.translate( 'Getting ready to launch your website' ),
-				subHeaderText: i18n.translate( "Pick a plan that's right for you." ),
-				fallbackHeaderText: i18n.translate( "Almost there, pick a plan that's right for you." ),
+				subHeaderText: i18n.translate( "Pick a plan that's right for you. Update it as you grow." ),
+				fallbackHeaderText: i18n.translate(
+					"Almost there, pick a plan that's right for you. Update it as you grow."
+				),
 				isLaunchPage: true,
 			},
 		},

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -172,9 +172,11 @@ export class PlansStep extends Component {
 		const { flowName, stepName, positionInFlow, translate, selectedSite, siteSlug } = this.props;
 
 		const headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
-
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
-		const subHeaderText = this.props.subHeaderText;
+		const subHeaderText =
+			this.props.subHeaderText || translate( 'Choose a plan. Update it as you grow.' );
+		const fallbackSubHeaderText = this.props.fallbackSubHeaderText || subHeaderText;
+
 		let backUrl, backLabelText;
 
 		if ( 0 === positionInFlow && selectedSite ) {
@@ -190,6 +192,7 @@ export class PlansStep extends Component {
 				headerText={ headerText }
 				fallbackHeaderText={ fallbackHeaderText }
 				subHeaderText={ subHeaderText }
+				fallbackSubHeaderText={ fallbackSubHeaderText }
 				isWideLayout={ true }
 				stepContent={ this.plansFeaturesList() }
 				allowBackFirstStep={ !! selectedSite }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -174,7 +174,7 @@ export class PlansStep extends Component {
 		const headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
 		const subHeaderText =
-			this.props.subHeaderText || translate( 'Choose a plan. Update it as you grow.' );
+			this.props.subHeaderText || translate( 'Choose a plan. Upgrade it as you grow.' );
 		const fallbackSubHeaderText = this.props.fallbackSubHeaderText || subHeaderText;
 
 		let backUrl, backLabelText;


### PR DESCRIPTION
This adds a sub-header to the Signup and launch flow plans screens, to let users know that they can change their text later.

Fixes #37251

<img width="1552" alt="Screen Shot 2019-11-07 at 1 43 14 PM" src="https://user-images.githubusercontent.com/942359/68417610-b730af80-0164-11ea-9170-19bfea19dbfb.png">

**To test:**
- visit `/start/`
- proceed through Signup
- when you get to the plans page, verify that the sub-header is shown
- launch your site by clicking on the launch banner on the front-end
- when you get to the plans page, verify that the sub-header is shown