### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,13 +14,15 @@
 	],
 	"statusCheckVerify": true,
 	"ignoreDeps": [ "jquery" ],
-	"labels": [ "Framework", "[Type] Task", "[Status] Needs Review" ],
+	"labels": [ "Framework", "[Type] Task" ],
 	"lockFileMaintenance": {
 		"enabled": true,
 		"schedule": "every weekday"
 	},
 	"prConcurrentLimit": 0,
-	"prHourlyLimit": 50,
+	"prHourlyLimit": 6,
 	"semanticCommits": true,
-	"semanticCommitType": "chore"
+	"semanticCommitType": "chore",
+	"masterIssue": true,
+	"masterIssueTitle": "Outstanding Dependency Updates"
 }


### PR DESCRIPTION
- Cut down hourly PR creation rate to 6 / hr to prevent swamping CI
- Stop auto adding 'needs review', which can swamp the e2e system
- Turn on the Master Issue feature so we have one place to track what's going on with Renovate
