### PR TITLE
Update sauce chrome config

### DIFF
--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -22,7 +22,7 @@
 			"browserName": "chrome",
 			"platform": "OS X 10.14",
 			"screenResolution": "2048x1536",
-			"version": "77.0"
+			"version": "latest-1"
 		},
 		"osx-firefox": {
 			"browserName": "firefox",

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -20,9 +20,9 @@
 	"sauceConfigurations": {
 		"osx-chrome": {
 			"browserName": "chrome",
-			"platform": "OS X 10.13",
+			"platform": "OS X 10.14",
 			"screenResolution": "2048x1536",
-			"version": "64.0"
+			"version": "77.0"
 		},
 		"osx-firefox": {
 			"browserName": "firefox",

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -275,9 +275,7 @@ export function setWhenSettable(
 ) {
 	const self = this;
 	const logValue = secureValue === true ? '*********' : value;
-	if ( global.browserName === 'chrome' && pauseBetweenKeysMS === 0 ) {
-		pauseBetweenKeysMS = 1;
-	}
+
 	return driver.wait(
 		async function() {
 			await self.waitForFieldClearable( driver, selector );

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -217,25 +217,25 @@ export async function resizeBrowser( driver, screenSize ) {
 				await driver
 					.manage()
 					.window()
-					.setRect( { width: 400, height: 1000 } );
+					.setRect( { x: 0, y: 0, width: 400, height: 1000 } );
 				break;
 			case 'tablet':
 				await driver
 					.manage()
 					.window()
-					.setRect( { width: 1024, height: 1000 } );
+					.setRect( { x: 0, y: 0, width: 1024, height: 1000 } );
 				break;
 			case 'desktop':
 				await driver
 					.manage()
 					.window()
-					.setRect( { width: 1440, height: 1000 } );
+					.setRect( { x: 0, y: 0, width: 1440, height: 1000 } );
 				break;
 			case 'laptop':
 				await driver
 					.manage()
 					.window()
-					.setRect( { width: 1400, height: 790 } );
+					.setRect( { x: 0, y: 0, width: 1400, height: 790 } );
 				break;
 			default:
 				throw new Error(

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -88,6 +88,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 		const sauceURL = 'http://ondemand.saucelabs.com:80/wd/hub';
 		const sauceConfig = config.get( 'sauceConfig' );
 		const caps = config.get( 'sauceConfigurations' )[ sauceConfig ];
+		builder = new webdriver.Builder();
 
 		caps.username = config.get( 'sauceUsername' );
 		caps.accessKey = config.get( 'sauceAccessKey' );
@@ -108,13 +109,17 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 		if ( process.env.CIRCLE_BUILD_NUM ) {
 			caps.name += ' - CircleCI Build #' + process.env.CIRCLE_BUILD_NUM;
 		}
+		if ( browser.toLowerCase() === 'chrome' ) {
+			options = new chrome.Options();
+			options.addArguments( '--app=https://www.wordpress.com' );
+			builder.setChromeOptions( options );
+		}
 
 		global._sauceLabs = new SauceLabs( {
 			username: caps.username,
 			password: caps.accessKey,
 		} );
 
-		builder = new webdriver.Builder();
 		global.browserName = caps.browserName;
 		global.__BROWSER__ = driver = builder
 			.usingServer( sauceURL )

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -109,7 +109,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 		if ( process.env.CIRCLE_BUILD_NUM ) {
 			caps.name += ' - CircleCI Build #' + process.env.CIRCLE_BUILD_NUM;
 		}
-		if ( browser.toLowerCase() === 'chrome' ) {
+		if ( caps.browserName === 'chrome' ) {
 			options = new chrome.Options();
 			options.addArguments( '--app=https://www.wordpress.com' );
 			builder.setChromeOptions( options );

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -31,6 +31,7 @@ function joinStr { local IFS="$1"; shift; echo "$*"; }
 I18N_CONFIG="\"browser\":\"chrome\",\"proxy\":\"system\",\"saveAllScreenshots\":true"
 IE11_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"win-ie11\""
 SAFARI_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"osx-safari\""
+CHROME_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"osx-chrome\""
 
 declare -a MAGELLAN_CONFIGS
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -31,7 +31,6 @@ function joinStr { local IFS="$1"; shift; echo "$*"; }
 I18N_CONFIG="\"browser\":\"chrome\",\"proxy\":\"system\",\"saveAllScreenshots\":true"
 IE11_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"win-ie11\""
 SAFARI_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"osx-safari\""
-CHROME_CONFIG="\"sauce\":\"true\",\"sauceConfig\":\"osx-chrome\""
 
 declare -a MAGELLAN_CONFIGS
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the sauce configuration and makes some changes that will make running canaries in sauce easier. 

The change to driver helper was because it was running extremely slow in Sauce, pausing between every letter entered. It seemed to be unnecessary so I removed it. It could also speed up all tests.

To Test:
- ensure that tests pass in circleCI
- run `./run.sh -R -C -l osx-chrome` locally and ensure it passes.

