### PR TITLE
Hosting: Correct whitespace around the SFTP card's table.

### DIFF
--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -46,7 +46,7 @@
 
 .sftp-card__info-table {
 	border: 1px solid var( --color-border-subtle );
-	margin-top: 15px;
+	margin: 0;
 	table-layout: fixed;
 
 	th {


### PR DESCRIPTION
This PR removes `table` margins that add too much whitespace to the SFTP card.

Fixes: #37391 

<img width="1173" alt="Screen Shot 2019-11-07 at 4 19 02 PM" src="https://user-images.githubusercontent.com/349751/68439040-041f8080-017b-11ea-88c8-db581de46d8d.png">
