### PR TITLE
Check if an arbitrary theme supports FSE 

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -158,8 +158,7 @@ function is_site_eligible_for_full_site_editing() {
  */
 function is_theme_supported() {
 	// Use un-normalized theme slug because get_theme requires the full string.
-	$theme_slug = get_theme_slug();
-	$theme      = wp_get_theme( $theme_slug );
+	$theme = wp_get_theme( get_theme_slug() );
 	return ! $theme->errors() && in_array( 'full-site-editing', $theme->tags, true );
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -70,9 +70,9 @@ function is_full_site_editing_active() {
 /**
  * Returns the slug for the current theme.
  *
- * This even works for the WordPress.com context where the current theme is not
- * correct. The filter correctly switches to the correct blog context if that is
- * the case.
+ * This even works for the WordPress.com API context where the current theme is
+ * not correct. The filter correctly switches to the correct blog context if
+ * that is the case.
  *
  * @return string Theme slug.
  */

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -36,7 +36,7 @@ function load_full_site_editing() {
 	Full_Site_Editing::get_instance();
 }
 // Full Site Editing should load after theme setup finishes.
-add_action( 'after_setup_theme', __NAMESPACE__ . '\load_full_site_editing', 99 );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
 
 /**
  * NOTE: In most cases, you should NOT use this function. Please use

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -35,7 +35,6 @@ function load_full_site_editing() {
 	dangerously_load_full_site_editing_files();
 	Full_Site_Editing::get_instance();
 }
-// Full Site Editing should load after theme setup finishes.
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -129,28 +129,6 @@ function normalize_theme_slug( $theme_slug ) {
 }
 
 /**
- * Returns a normalized slug for the current theme.
- *
- * In some cases, the theme is located in a subfolder like `pub/maywood`. Use
- * this function to get the slug without the prefix.
- *
- * @param string $theme_slug The raw theme_slug to normalize.
- * @return string Theme slug.
- */
-function normalize_theme_slug( $theme_slug ) {
-	// Normalize the theme slug.
-	if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
-		$theme_slug = substr( $theme_slug, 4 );
-	}
-
-	if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
-		$theme_slug = substr( $theme_slug, 0, -6 );
-	}
-
-	return $theme_slug;
-}
-
-/**
  * Whether or not the site is eligible for FSE. This is essentially a feature
  * gate to disable FSE on some sites which could theoretically otherwise use it.
  *

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -22,9 +22,6 @@ namespace A8C\FSE;
  */
 define( 'PLUGIN_VERSION', '0.15.1' );
 
-// Themes which are supported by Full Site Editing (not the same as the SPT themes).
-const SUPPORTED_THEMES = [ 'maywood' ];
-
 /**
  * Load Full Site Editing.
  */
@@ -38,7 +35,8 @@ function load_full_site_editing() {
 	dangerously_load_full_site_editing_files();
 	Full_Site_Editing::get_instance();
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
+// Full Site Editing should load after theme setup finishes.
+add_action( 'after_setup_theme', __NAMESPACE__ . '\load_full_site_editing', 99 );
 
 /**
  * NOTE: In most cases, you should NOT use this function. Please use
@@ -150,7 +148,22 @@ function is_site_eligible_for_full_site_editing() {
  * @return bool True if current theme supports FSE, false otherwise.
  */
 function is_theme_supported() {
-	return in_array( get_theme_slug(), SUPPORTED_THEMES, true );
+	// This only works when the action `after_setup_theme` finishes.
+	// Shortcut to avoid loading the full theme if not neccessary.
+	if ( current_theme_supports( 'full-site-editing' ) ) {
+		return true;
+	}
+	/**
+	 * Used to check if the theme supports FSE.
+	 *
+	 * Needed to get theme support in the WordPress.com API context since the
+	 * theme in that context can be different. Additionally, in the API, theme
+	 * PHP files are not loaded, so we have to use a different method to check
+	 * theme support.
+	 *
+	 * @param bool true if the theme supports FSE locally.
+	 */
+	return apply_filters( 'a8c_fse_check_theme_support', false );
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -209,7 +209,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_posts_list_block' );
  */
 function load_starter_page_templates() {
 	// We don't want the user to choose a template when copying a post.
-	// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['jetpack-copy'] ) ) {
 		return;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -59,12 +59,28 @@ function dangerously_load_full_site_editing_files() {
 
 /**
  * Whether or not FSE is active.
- * If false, FSE functionality can be disabled.
+ * If false, FSE functionality should be disabled.
  *
  * @returns bool True if FSE is active, false otherwise.
  */
 function is_full_site_editing_active() {
-	return is_site_eligible_for_full_site_editing() && is_theme_supported() && did_insert_template_parts();
+	/**
+	 * There are times when this function is called from the WordPress.com public
+	 * API context. In this case, we need to switch to the correct blog so that
+	 * the functions reference the correct blog context.
+	 */
+	$multisite_id  = apply_filters( 'a8c_fse_get_multisite_id', false );
+	$should_switch = is_multisite() && $multisite_id;
+	if ( $should_switch ) {
+		switch_to_blog( $multisite_id );
+	}
+
+	$is_active = is_site_eligible_for_full_site_editing() && is_theme_supported() && did_insert_template_parts();
+
+	if ( $should_switch ) {
+		restore_current_blog();
+	}
+	return $is_active;
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -264,12 +264,15 @@ function load_global_styles() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
 
 /**
- * Inserts default full site editing data for current theme during plugin activation.
+ * Inserts default full site editing data for current theme on plugin/theme activation.
  *
- * We usually perform this on theme activation hook, but this is needed to handle
- * the cases in which FSE supported theme was activated prior to the plugin. This will
- * populate the default header and footer for current theme, and create About and Contact
- * pages provided that they don't already exist.
+ * We put this here outside of the normal FSE class because FSE is not active
+ * until the template parts are inserted. This makes sure we insert the template
+ * parts when switching to a theme which supports FSE.
+ *
+ * This will populate the default header and footer for current theme, and create
+ * About and Contact pages. Nothing will populate if the data already exists, or
+ * if the theme is unsupported.
  */
 function populate_wp_template_data() {
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
@@ -280,6 +283,7 @@ function populate_wp_template_data() {
 	$fse->insert_default_data();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
+add_action( 'after_switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
 
 /**
  * Add front-end CoBlocks gallery block scripts.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -179,7 +179,8 @@ function is_theme_supported() {
 function did_insert_template_parts() {
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 
-	$inserter = new WP_Template_Inserter( get_theme_slug() );
+	$theme_slug = normalize_theme_slug( get_theme_slug() );
+	$inserter   = new WP_Template_Inserter( $theme_slug );
 	return $inserter->is_template_data_inserted();
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -63,7 +63,7 @@ class Full_Site_Editing {
 		add_action( 'transition_post_status', [ $this, 'restrict_template_drafting' ], 10, 3 );
 		add_action( 'admin_menu', [ $this, 'remove_wp_admin_menu_items' ] );
 
-		$this->theme_slug           = $this->normalize_theme_slug( get_stylesheet() );
+		$this->theme_slug           = normalize_theme_slug( get_stylesheet() );
 		$this->wp_template_inserter = new WP_Template_Inserter( $this->theme_slug );
 	}
 
@@ -94,29 +94,6 @@ class Full_Site_Editing {
 
 		$this->wp_template_inserter->insert_default_template_data();
 		$this->wp_template_inserter->insert_default_pages();
-	}
-
-	/**
-	 * Returns normalized theme slug for the current theme.
-	 *
-	 * Normalize WP.com theme slugs that differ from those that we'll get on self hosted sites.
-	 * For example, we will get 'modern-business-wpcom' when retrieving theme slug on self hosted sites,
-	 * but due to WP.com setup, on Simple sites we'll get 'pub/modern-business' for the theme.
-	 *
-	 * @param string $theme_slug Theme slug to check support for.
-	 *
-	 * @return string Normalized theme slug.
-	 */
-	public function normalize_theme_slug( $theme_slug ) {
-		if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
-			$theme_slug = substr( $theme_slug, 4 );
-		}
-
-		if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
-			$theme_slug = substr( $theme_slug, 0, -6 );
-		}
-
-		return $theme_slug;
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -50,7 +50,6 @@ class Full_Site_Editing {
 		add_filter( 'wp_insert_post_data', [ $this, 'remove_template_components' ], 10, 2 );
 		add_filter( 'admin_body_class', [ $this, 'toggle_editor_post_title_visibility' ] );
 		add_filter( 'block_editor_settings', [ $this, 'set_block_template' ] );
-		add_action( 'after_switch_theme', [ $this, 'insert_default_data' ] );
 		add_filter( 'body_class', array( $this, 'add_fse_body_class' ) );
 
 		add_filter( 'post_row_actions', [ $this, 'remove_trash_row_action_for_template_post_types' ], 10, 2 );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -131,6 +131,18 @@ class WP_Template_Inserter {
 		}
 
 		$api_response = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! empty( $api_response['code'] ) && 'not_found' === $api_response['code'] ) {
+			do_action(
+				'a8c_fse_log',
+				'template_population_failure',
+				[
+					'context'    => 'WP_Template_Inserter->fetch_template_parts',
+					'error'      => 'Did not find remote template data for the given theme.',
+					'theme_slug' => $this->theme_slug,
+				]
+			);
+			return;
+		}
 
 		// Default to first returned header for now. Support for multiple headers will be added in future iterations.
 		if ( ! empty( $api_response['headers'] ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -50,32 +50,8 @@ class WP_Template {
 		if ( ! isset( $theme ) ) {
 			$theme = get_stylesheet();
 		}
-		$this->current_theme_name = $this->normalize_theme_slug( $theme );
+		$this->current_theme_name = normalize_theme_slug( $theme );
 	}
-
-	/**
-	 * Returns normalized theme slug for the current theme.
-	 *
-	 * Normalize WP.com theme slugs that differ from those that we'll get on self hosted sites.
-	 * For example, we will get 'modern-business-wpcom' when retrieving theme slug on self hosted sites,
-	 * but due to WP.com setup, on Simple sites we'll get 'pub/modern-business' for the theme.
-	 *
-	 * @param string $theme_slug Theme slug to check support for.
-	 *
-	 * @return string Normalized theme slug.
-	 */
-	public function normalize_theme_slug( $theme_slug ) {
-		if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
-			$theme_slug = substr( $theme_slug, 4 );
-		}
-
-		if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
-			$theme_slug = substr( $theme_slug, 0, -6 );
-		}
-
-		return $theme_slug;
-	}
-
 
 	/**
 	 * Checks whether the provided template type is supported in FSE.


### PR DESCRIPTION
The final approach: theme tags!

### Changes proposed in this Pull Request
* Check theme tags to determine if the current theme supports FSE flows.
* Include a check for existing template parts in the `is_fse_active` check so that existing users on a non-FSE theme don't see FSE flows when we add FSE support to the theme.
* Cleanup and clarify some comments.
* Split `normalize_theme_slug` into a separate function and stopped duplicating it in two other files.

### Testing instructions
_Note that Maywood, Exford, and Shawburn include FSE in their tags._

**A) Local Changes:**
1. Pull this to your local machine. First check that this works properly with your local install. Verify that the front end loads templates and that you can edit pages and templates correctly.
2. Activate an FSE theme you did not activate yet like Shawburn and make sure you see template parts.

**B) Set up these sites on WordPress.com **_before_** syncing:**
S1. An existing site on Maywood which has FSE flows active.
S2. A site which had FSE flows with Maywood, but has been changed to the Exford theme.
S3. A site which has never had an FSE support.

Only continue after you have marked these sites down / created them! Don't sync any changes to the sandbox until all of these sites are ready to go.

**C) Sync this branch to your sandbox and sandbox the above sites and the public API. Also apply `D35568-code`.**

**D) Test the API:**
1. Go to https://developer.wordpress.com/docs/api/console/.
2. Request `/me/sites` from the wpcom-api (not the rest api).
3. Site S1 should have `is_fse_active: true`. Site S2 should have `is_fse_active: false`. Site S3. should have `is_fse_active: false`.

**E) Test FSE flows:**
1. Go to the page editor for each of the test sites. S1 should show FSE, S2 and S3 should not show FSE.

**F) Test re-activating S2's theme.**
1. On site S2, change the theme to something other than Exford.
2. Switch the theme back to Exford. At this point, you **should** start seeing FSE flows even though you should not have before.
3. Check the API again as in part D and make sure that `is_fse_active` is now true for S2.

**G) Test a new site.**
1. Go through this flow: https://horizon.wordpress.com/start/test-fse and create a new site. (You should sandbox the URL of the site before you create it.)
2. With Maywood active, you should see FSE in the page editor.
3. Activate Exford. You should still see FSE in the page editor with Exford stylings.
4. Activate Shawburn. You should _not_ see FSE in the page editor because there are no template parts for Shawburn yet.

Closes #35794.