### PR TITLE
Build: Divide workers between concurrent builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
 		"build-client": "npm run build-client-evergreen",
 		"build-client-fallback": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only && npm run validate-fallback-es5",
 		"build-client-evergreen": "cross-env-shell BROWSERSLIST_ENV=evergreen NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
-		"build-client-both": "concurrently -c cyan -n \"fallback ,evergreen\" \"npm run build-client-fallback\" \"npm run build-client-evergreen\"",
+		"build-client-both": "CONCURRENT_BUILDS=2 concurrently -c cyan -n \"fallback ,evergreen\" \"npm run build-client-fallback\" \"npm run build-client-evergreen\"",
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-both",
 		"build-client-if-desktop": "node -e \"(process.env.CALYPSO_ENV === 'desktop' || process.env.CALYPSO_ENV === 'desktop-development') && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-fallback",
 		"build-packages": "npx lerna run prepare --stream",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -10,6 +10,8 @@ if ( process.env.CIRCLECI ) {
 	workerCount = Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) );
 }
 
+workerCount = Math.max( 1, Math.floor( workerCount / 2 ) );
+
 module.exports = {
 	workerCount,
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,16 +1,40 @@
 /* eslint-disable import/no-nodejs-modules */
 
-let workerCount;
+/**
+ * Get an env var that should be a positive integer greater than 0
+ *
+ * @param {string} envVarName   Environment variable name
+ * @param {number} defaultValue Fallback in case env variable isn't present or invalid
+ * @return {number} Value
+ */
+function getEnvVarAsNaturalNumber( envVarName, defaultValue ) {
+	if ( typeof envVarName !== 'string' ) {
+		throw new TypeError( 'Expected string environment variable name' );
+	}
+	if ( typeof defaultValue !== 'number' ) {
+		throw new TypeError( 'Expected number defaultValue' );
+	}
 
-if ( process.env.CIRCLECI ) {
-	workerCount = 2;
-} else if ( process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) ) ) {
-	workerCount = Math.max( 1, parseInt( process.env.WORKERS, 10 ) );
-} else {
-	workerCount = Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) );
+	if ( process.env[ envVarName ] && ! Number.isNaN( parseInt( process.env[ envVarName ], 10 ) ) ) {
+		return Math.max( 1, parseInt( process.env[ envVarName ], 10 ) );
+	}
+	return defaultValue;
 }
 
-workerCount = Math.max( 1, Math.floor( workerCount / 2 ) );
+let workerCount;
+if ( process.env.CIRCLECI ) {
+	workerCount = 2;
+} else {
+	workerCount = getEnvVarAsNaturalNumber(
+		'WORKERS',
+		Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) )
+	);
+}
+
+const concurrentBuilds = getEnvVarAsNaturalNumber( 'CONCURRENT_BUILDS', 1 );
+if ( concurrentBuilds > 1 ) {
+	workerCount = Math.max( 1, Math.floor( workerCount / concurrentBuilds ) );
+}
 
 module.exports = {
 	workerCount,


### PR DESCRIPTION
We recently increased the number of builds running concurrently without adjusting our worker counts. With twice the builds running concurrently, each build should be using half the workers.

This change halves the workers provided to the build. We could add another variable to disable this in the case that we know we're running exactly one build concurrently, but halving the workers is likely the correct assumption for most situations.

## Testing

Run the following and check the output:

```
$ WORKERS=1 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1

$ WORKERS=1 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1

$ CONCURRENT_BUILDS=1 WORKERS=1 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1

$ CONCURRENT_BUILDS=2 WORKERS=1 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1

$ CONCURRENT_BUILDS=2 WORKERS=1 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1

$ CONCURRENT_BUILDS=2 WORKERS=2 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1

$ CONCURRENT_BUILDS=2 WORKERS=2 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1

$ CONCURRENT_BUILDS=1 WORKERS=2 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 2

$ CONCURRENT_BUILDS=1 WORKERS=11 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 11

$ CONCURRENT_BUILDS=2 WORKERS=11 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 5

$ CONCURRENT_BUILDS=20 WORKERS=11 node -e 'console.log( "Calculated workers: %o", require( "./webpack.common.js" ).workerCount );'
Calculated workers: 1
```