### PR TITLE
Jetpack Product Purchace redirect the user to the my plans page

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -399,6 +399,11 @@ export class Checkout extends React.Component {
 			if ( isJetpackNotAtomic && ! isJetpackProduct ) {
 				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
 			}
+			// If we just purchased a Jetpack product, redirect to the my plans page.
+			if ( isJetpackNotAtomic ) {
+				return `/plans/my-plan/${ selectedSiteSlug }`;
+			}
+
 			return selectedFeature && isValidFeatureKey( selectedFeature )
 				? `/checkout/thank-you/features/${ selectedFeature }/${ selectedSiteSlug }/${ pendingOrReceiptId }`
 				: `/checkout/thank-you/${ selectedSiteSlug }/${ pendingOrReceiptId }`;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -395,13 +395,13 @@ export class Checkout extends React.Component {
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
 			const isJetpackProduct = product && includes( JETPACK_BACKUP_PRODUCTS, product );
 
-			// If we just purchased a Jetpack plan (not a Jetpack product), redirect to the Jetpack onboarding plugin install flow.
-			if ( isJetpackNotAtomic && ! isJetpackProduct ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
-			}
-			// If we just purchased a Jetpack product, redirect to the my plans page.
 			if ( isJetpackNotAtomic ) {
-				return `/plans/my-plan/${ selectedSiteSlug }`;
+				if ( isJetpackProduct ) {
+					return `/plans/my-plan/${ selectedSiteSlug }`;
+				}
+
+				// If we just purchased a Jetpack plan redirect to the Jetpack onboarding plugin install flow.
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
 			}
 
 			return selectedFeature && isValidFeatureKey( selectedFeature )

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -395,13 +395,13 @@ export class Checkout extends React.Component {
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
 			const isJetpackProduct = product && includes( JETPACK_BACKUP_PRODUCTS, product );
 
-			if ( isJetpackNotAtomic ) {
-				if ( isJetpackProduct ) {
-					return `/plans/my-plan/${ selectedSiteSlug }`;
-				}
-
-				// If we just purchased a Jetpack plan redirect to the Jetpack onboarding plugin install flow.
+			// If we just purchased a Jetpack plan (not a Jetpack product), redirect to the Jetpack onboarding plugin install flow.
+			if ( isJetpackNotAtomic && ! isJetpackProduct ) {
 				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
+			}
+			// If we just purchased a Jetpack product, redirect to the my plans page.
+			if ( isJetpackNotAtomic ) {
+				return `/plans/my-plan/${ selectedSiteSlug }`;
 			}
 
 			return selectedFeature && isValidFeatureKey( selectedFeature )


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Redirect the to the plans page right after buying the product. 

#### Testing instructions

* On a site running jetpack 7.9 that doesn't have a plan. Buy a backup product. 
Notice that you get redirected to the my plans page.