### PR TITLE
Plans: record feature link click Tracks events in the grid

### DIFF
--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -12,7 +12,15 @@ import ExternalLink from 'components/external-link';
 
 class MyComponent extends React.Component {
 	render() {
-		return <ExternalLink icon={ true } href="https://wordpress.org" onClick="somefunction()">WordPress.org</ExternalLink>;
+		return (
+			<ExternalLink
+				icon={ true }
+				href="https://wordpress.org"
+				onClick={ () => somefunction() }
+			>
+				WordPress.org
+			</ExternalLink>;
+		);
 	}
 }
 ```
@@ -47,7 +55,7 @@ class MyComponent extends React.Component {
 			<ExternalLinkWithTracking
 				icon={ true }
 				href="https://wordpress.org"
-				onClick="somefunction()"
+				onClick={ () => somefunction() }
 				tracksEventName="tracks_event_name"
 				tracksEventProps={ { foo: 'baz' } }
 			>

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -14,9 +14,9 @@ class MyComponent extends React.Component {
 	render() {
 		return (
 			<ExternalLink
-				icon={ true }
+				icon
 				href="https://wordpress.org"
-				onClick={ () => somefunction() }
+				onClick={ () => {} }
 			>
 				WordPress.org
 			</ExternalLink>;
@@ -53,9 +53,9 @@ class MyComponent extends React.Component {
 	render() {
 		return (
 			<ExternalLinkWithTracking
-				icon={ true }
+				icon
 				href="https://wordpress.org"
-				onClick={ () => somefunction() }
+				onClick={ () => {} }
 				tracksEventName="tracks_event_name"
 				tracksEventProps={ { foo: 'baz' } }
 			>

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -60,7 +60,7 @@ class MyComponent extends React.Component {
 				tracksEventProps={ { foo: 'baz' } }
 			>
 				WordPress.org
-			</ExternalLinkWithTracking>;
+			</ExternalLinkWithTracking>
 		);
 	}
 }

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -19,7 +19,7 @@ class MyComponent extends React.Component {
 				onClick={ () => {} }
 			>
 				WordPress.org
-			</ExternalLink>;
+			</ExternalLink>
 		);
 	}
 }

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -27,3 +27,43 @@ The following props can be passed to the External Link component:
 ## Other Props
 Any other props that you pass into the `a` tag will be rendered as expected.
 For example `onClick` and `href`.
+
+External Link with Tracking
+=======
+
+External Link with Tracking is a React component for rendering an external link that is connected to the Redux store
+and is capable of recording Tracks events.
+
+## Usage
+
+```jsx
+
+import React from 'react';
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+
+class MyComponent extends React.Component {
+	render() {
+		return (
+			<ExternalLinkWithTracking
+				icon={ true }
+				href="https://wordpress.org"
+				onClick="somefunction()"
+				tracksEventName="tracks_event_name"
+				tracksEventProps={ { foo: 'baz' } }
+			>
+				WordPress.org
+			</ExternalLinkWithTracking>;
+		);
+	}
+}
+```
+
+## Props
+In addition to the props that the unconnected `<ExternalLink />` component accepts, you
+can pass the following Tracks-related props to the `<ExternalLinkWithTracking />` component:
+
+
+| property           | type   | required | comment |
+| ------------------ | ------ | -------- | ------- |
+| `tracksEventName`  | string | yes      | Tracks event name |
+| `tracksEventProps` | object | no       | Additional parameters that can be tracked along with the event |

--- a/client/components/external-link/with-tracking.jsx
+++ b/client/components/external-link/with-tracking.jsx
@@ -13,13 +13,15 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class ExternalLinkWithTracking extends Component {
 	handleClickEvent() {
-		const { onClick, tracksEventName, tracksEventProps } = this.props;
+		return () => {
+			const { onClick, tracksEventName, tracksEventProps } = this.props;
 
-		this.props.recordTracksEvent( tracksEventName, tracksEventProps );
+			this.props.recordTracksEvent( tracksEventName, tracksEventProps );
 
-		if ( onClick ) {
-			onClick();
-		}
+			if ( onClick ) {
+				onClick();
+			}
+		};
 	}
 
 	render() {
@@ -31,7 +33,7 @@ class ExternalLinkWithTracking extends Component {
 			...props
 		} = this.props;
 
-		return <ExternalLink onClick={ () => this.handleClickEvent() } { ...props } />;
+		return <ExternalLink onClick={ this.handleClickEvent() } { ...props } />;
 	}
 }
 

--- a/client/components/external-link/with-tracking.jsx
+++ b/client/components/external-link/with-tracking.jsx
@@ -1,37 +1,49 @@
 /**
  * External dependencies
  */
-
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from './index.jsx';
+import ExternalLink from './index';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-const ExternalLinkWIthTracking = ( {
-	onClick,
-	recordTracksEvent: recordEvent,
-	tracksEventName,
-	tracksEventProps,
-	...props
-} ) => {
-	const clickHandler = () => {
-		recordEvent( tracksEventName, tracksEventProps );
+class ExternalLinkWithTracking extends Component {
+	handleClickEvent() {
+		const { onClick, tracksEventName, tracksEventProps } = this.props;
+
+		this.props.recordTracksEvent( tracksEventName, tracksEventProps );
 
 		if ( onClick ) {
 			onClick();
 		}
-	};
+	}
 
-	return <ExternalLink onClick={ clickHandler } { ...props } />;
-};
+	render() {
+		const {
+			onClick,
+			recordTracksEvent: recordEvent,
+			tracksEventName,
+			tracksEventProps,
+			...props
+		} = this.props;
 
-ExternalLinkWIthTracking.propTypes = {
+		return <ExternalLink onClick={ () => this.handleClickEvent() } { ...props } />;
+	}
+}
+
+ExternalLinkWithTracking.propTypes = {
+	className: PropTypes.string,
+	href: PropTypes.string,
 	onClick: PropTypes.func,
+	icon: PropTypes.bool,
+	iconSize: PropTypes.number,
+	target: PropTypes.string,
+	showIconFirst: PropTypes.bool,
+	iconClassName: PropTypes.string,
 	tracksEventName: PropTypes.string.isRequired,
 	tracksEventProps: PropTypes.object,
 
@@ -42,4 +54,4 @@ ExternalLinkWIthTracking.propTypes = {
 export default connect(
 	null,
 	{ recordTracksEvent }
-)( ExternalLinkWIthTracking );
+)( ExternalLinkWithTracking );

--- a/client/components/external-link/with-tracking.jsx
+++ b/client/components/external-link/with-tracking.jsx
@@ -40,12 +40,12 @@ class ExternalLinkWithTracking extends Component {
 ExternalLinkWithTracking.propTypes = {
 	className: PropTypes.string,
 	href: PropTypes.string,
-	onClick: PropTypes.func,
 	icon: PropTypes.bool,
-	iconSize: PropTypes.number,
-	target: PropTypes.string,
-	showIconFirst: PropTypes.bool,
 	iconClassName: PropTypes.string,
+	iconSize: PropTypes.number,
+	onClick: PropTypes.func,
+	showIconFirst: PropTypes.bool,
+	target: PropTypes.string,
 	tracksEventName: PropTypes.string.isRequired,
 	tracksEventProps: PropTypes.object,
 

--- a/client/components/external-link/with-tracking.jsx
+++ b/client/components/external-link/with-tracking.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from './index.jsx';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+const ExternalLinkWIthTracking = ( {
+	onClick,
+	recordTracksEvent: recordEvent,
+	tracksEventName,
+	tracksEventProps,
+	...props
+} ) => {
+	const clickHandler = () => {
+		recordEvent( tracksEventName, tracksEventProps );
+
+		if ( onClick ) {
+			onClick();
+		}
+	};
+
+	return <ExternalLink onClick={ clickHandler } { ...props } />;
+};
+
+ExternalLinkWIthTracking.propTypes = {
+	onClick: PropTypes.func,
+	tracksEventName: PropTypes.string.isRequired,
+	tracksEventProps: PropTypes.object,
+
+	// Connected props
+	recordTracksEvent: PropTypes.func.isRequired,
+};
+
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( ExternalLinkWIthTracking );

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -32,7 +32,7 @@ export const FEATURES_LIST = {
 							tracksEventName="calypso_plan_link_click"
 							tracksEventProps={ {
 								link_location: 'plan_features_list_item',
-								plan_slug: constants.PLAN_JETPACK_FREE,
+								plan_feature_slug: constants.FEATURE_ALL_FREE_FEATURES_JETPACK,
 							} }
 						/>
 					),
@@ -60,7 +60,7 @@ export const FEATURES_LIST = {
 							tracksEventName="calypso_plan_link_click"
 							tracksEventProps={ {
 								link_location: 'plan_features_list_item',
-								plan_slug: constants.PLAN_JETPACK_PERSONAL,
+								plan_feature_slug: constants.FEATURE_ALL_PERSONAL_FEATURES_JETPACK,
 							} }
 						/>
 					),
@@ -91,7 +91,7 @@ export const FEATURES_LIST = {
 							tracksEventName="calypso_plan_link_click"
 							tracksEventProps={ {
 								link_location: 'plan_features_list_item',
-								plan_slug: constants.PLAN_JETPACK_PREMIUM,
+								plan_feature_slug: constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 							} }
 						/>
 					),

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -32,7 +32,7 @@ export const FEATURES_LIST = {
 							tracksEventName="calypso_plan_link_click"
 							tracksEventProps={ {
 								link_location: 'plan_features_list_item',
-								plan_feature_slug: constants.FEATURE_ALL_FREE_FEATURES_JETPACK,
+								link_slug: constants.FEATURE_ALL_FREE_FEATURES_JETPACK,
 							} }
 						/>
 					),
@@ -60,7 +60,7 @@ export const FEATURES_LIST = {
 							tracksEventName="calypso_plan_link_click"
 							tracksEventProps={ {
 								link_location: 'plan_features_list_item',
-								plan_feature_slug: constants.FEATURE_ALL_PERSONAL_FEATURES_JETPACK,
+								link_slug: constants.FEATURE_ALL_PERSONAL_FEATURES_JETPACK,
 							} }
 						/>
 					),
@@ -91,7 +91,7 @@ export const FEATURES_LIST = {
 							tracksEventName="calypso_plan_link_click"
 							tracksEventProps={ {
 								link_location: 'plan_features_list_item',
-								plan_feature_slug: constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
+								link_slug: constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 							} }
 						/>
 					),

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -12,6 +12,7 @@ import { invoke } from 'lodash';
  */
 import * as constants from './constants';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'lib/url/support';
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 
 export const FEATURES_LIST = {
 	[ constants.FEATURE_BLANK ]: {
@@ -25,15 +26,18 @@ export const FEATURES_LIST = {
 			i18n.translate( '{{a}}All free features{{/a}}', {
 				components: {
 					a: (
-						<a
+						<ExternalLinkWithTracking
 							href="https://jetpack.com/features/comparison"
 							target="_blank"
-							rel="noopener noreferrer"
+							tracksEventName="calypso_plan_link_click"
+							tracksEventProps={ {
+								link_location: 'plan_features_list_item',
+								plan_slug: constants.PLAN_JETPACK_FREE,
+							} }
 						/>
 					),
 				},
 			} ),
-		getTrackingLabel: () => 'All Free features',
 		getDescription: () =>
 			i18n.translate( 'Also includes all features offered in the free version of Jetpack.' ),
 	},
@@ -50,15 +54,18 @@ export const FEATURES_LIST = {
 			i18n.translate( '{{a}}All Personal features{{/a}}', {
 				components: {
 					a: (
-						<a
+						<ExternalLinkWithTracking
 							href="https://jetpack.com/features/comparison"
 							target="_blank"
-							rel="noopener noreferrer"
+							tracksEventName="calypso_plan_link_click"
+							tracksEventProps={ {
+								link_location: 'plan_features_list_item',
+								plan_slug: constants.PLAN_JETPACK_PERSONAL,
+							} }
 						/>
 					),
 				},
 			} ),
-		getTrackingLabel: () => 'All Personal features',
 		getDescription: () =>
 			i18n.translate( 'Also includes all features offered in the Personal plan.' ),
 	},
@@ -78,15 +85,18 @@ export const FEATURES_LIST = {
 			i18n.translate( '{{a}}All Premium features{{/a}}', {
 				components: {
 					a: (
-						<a
+						<ExternalLinkWithTracking
 							href="https://jetpack.com/features/comparison"
 							target="_blank"
-							rel="noopener noreferrer"
+							tracksEventName="calypso_plan_link_click"
+							tracksEventProps={ {
+								link_location: 'plan_features_list_item',
+								plan_slug: constants.PLAN_JETPACK_PREMIUM,
+							} }
 						/>
 					),
 				},
 			} ),
-		getTrackingLabel: () => 'All Premium features',
 		getDescription: () =>
 			i18n.translate( 'Also includes all features offered in the Premium plan.' ),
 	},

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -33,6 +33,7 @@ export const FEATURES_LIST = {
 					),
 				},
 			} ),
+		getTrackingLabel: () => 'All Free features',
 		getDescription: () =>
 			i18n.translate( 'Also includes all features offered in the free version of Jetpack.' ),
 	},
@@ -57,6 +58,7 @@ export const FEATURES_LIST = {
 					),
 				},
 			} ),
+		getTrackingLabel: () => 'All Personal features',
 		getDescription: () =>
 			i18n.translate( 'Also includes all features offered in the Personal plan.' ),
 	},
@@ -84,6 +86,7 @@ export const FEATURES_LIST = {
 					),
 				},
 			} ),
+		getTrackingLabel: () => 'All Premium features',
 		getDescription: () =>
 			i18n.translate( 'Also includes all features offered in the Premium plan.' ),
 	},

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -7,7 +7,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
@@ -64,7 +64,17 @@ export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = translate(
 	'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
 	{
 		components: {
-			a: <ExternalLink href="https://jetpack.com/upgrade/backup/" icon />,
+			a: (
+				<ExternalLinkWithTracking
+					href="https://jetpack.com/upgrade/backup/"
+					tracksEventName="calypso_plan_link_click"
+					tracksEventProps={ {
+						link_location: 'single_product_plan_description',
+						product_slug: PRODUCT_JETPACK_BACKUP,
+					} }
+					icon
+				/>
+			),
 		},
 	}
 );

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -69,8 +69,8 @@ export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = translate(
 					href="https://jetpack.com/upgrade/backup/"
 					tracksEventName="calypso_plan_link_click"
 					tracksEventProps={ {
-						link_location: 'single_product_plan_description',
-						product_slug: PRODUCT_JETPACK_BACKUP,
+						link_location: 'product_jetpack_backup_description',
+						link_slug: 'which-one-do-i-need',
 					} }
 					icon
 				/>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -679,14 +679,6 @@ export class PlanFeatures extends Component {
 		const description = feature.getDescription
 			? feature.getDescription( abtest, this.props.domainName )
 			: null;
-
-		const recordEvent = feature.getTrackingLabel
-			? () =>
-					this.props.recordTracksEvent( 'calypso_plan_link_click', {
-						label: feature.getTrackingLabel(),
-					} )
-			: null;
-
 		return (
 			<PlanFeaturesItem
 				key={ index }
@@ -695,9 +687,7 @@ export class PlanFeatures extends Component {
 				hideGridicon={ this.props.withScroll }
 			>
 				<span className="plan-features__item-info">
-					<span className="plan-features__item-title" onClick={ recordEvent } role="presentation">
-						{ feature.getTitle() }
-					</span>
+					<span className="plan-features__item-title">{ feature.getTitle() }</span>
 				</span>
 			</PlanFeaturesItem>
 		);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -679,6 +679,14 @@ export class PlanFeatures extends Component {
 		const description = feature.getDescription
 			? feature.getDescription( abtest, this.props.domainName )
 			: null;
+
+		const recordEvent = feature.getTrackingLabel
+			? () =>
+					this.props.recordTracksEvent( 'calypso_plan_link_click', {
+						label: feature.getTrackingLabel(),
+					} )
+			: null;
+
 		return (
 			<PlanFeaturesItem
 				key={ index }
@@ -687,7 +695,9 @@ export class PlanFeatures extends Component {
 				hideGridicon={ this.props.withScroll }
 			>
 				<span className="plan-features__item-info">
-					<span className="plan-features__item-title">{ feature.getTitle() }</span>
+					<span className="plan-features__item-title" onClick={ recordEvent } role="presentation">
+						{ feature.getTitle() }
+					</span>
 				</span>
 			</PlanFeaturesItem>
 		);


### PR DESCRIPTION
As per the specs, this adds Tracks events recording to the external links displayed in the Jetpack plans grid:

<img width="755" alt="Jetpack_plans_links" src="https://user-images.githubusercontent.com/478735/68477540-0b539680-022e-11ea-8f94-177de068a181.png">

Additionally, it adds tracking for the link in the single product plan description field as per the mockup:

<img width="705" alt="Jetpack_backup_events" src="https://user-images.githubusercontent.com/478735/68672360-b7102580-0551-11ea-8e30-67d7ba7cb8a0.png">

Please note that as per the discussion in this PR and on Slack, instead of textual labels attached to events, we now use a slug-like link location descriptor along with the plan/product name.

Here are examples of recorded events:
![Screenshot 2019-11-12 at 13 20 02](https://user-images.githubusercontent.com/478735/68672661-5b926780-0552-11ea-9f3e-c812bf975546.png)
![Screenshot 2019-11-12 at 13 20 11](https://user-images.githubusercontent.com/478735/68672689-6b11b080-0552-11ea-95aa-28c752dd7bfb.png)
![Screenshot 2019-11-12 at 13 19 36](https://user-images.githubusercontent.com/478735/68672704-74028200-0552-11ea-9d5a-9997445973bb.png)
![Screen Shot on 2019-11-12 at 13-19-14 (1)](https://user-images.githubusercontent.com/478735/68672739-8a104280-0552-11ea-8052-a445690d9c2c.png)


#### Changes proposed in this Pull Request

* Add `<ExternalLinkWithTracking />` component used for Tracks events recording
* Record feature link click Tracks events in the grid
* Record link clicks in the single product plan card description

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Go to http://calypso.localhost:3000/plans and select a Jetpack site
* Toggle debug mode in the console:
```js
localStorage.setItem('debug', 'calypso:analytics:*');
```
* Click on each of the 3 links in the plans grid ("All free features", "All Personal features" and "All Premium features") and confirm that correct events are being logged in the console.
* Click on the "Which one do I need" link in the Jetpack Backup description and confirm a Tracks event is logged in the console. 

Fixes n/a
