### PR TITLE
Atomic Hosting: Display data loss warning

### DIFF
--- a/client/my-sites/hosting/data-loss-warning/index.js
+++ b/client/my-sites/hosting/data-loss-warning/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const DataLossWarning = ( { translate } ) => (
+	<div className={ 'data-loss-warning' }>
+		<h2>{ translate( 'Unsure of what all this means?' ) }</h2>
+		<p>
+			<strong>
+				{ translate(
+					"Mistakes when editing your website's files and database can lead to data loss."
+				) }
+			</strong>
+			&nbsp;
+			{ translate(
+				'If you need help or have any questions our Happiness Engineers are here when you need them!'
+			) }
+		</p>
+		<Button href={ '/help/contact/' }>{ translate( 'Contact us' ) }</Button>
+	</div>
+);
+
+export default localize( DataLossWarning );

--- a/client/my-sites/hosting/data-loss-warning/index.js
+++ b/client/my-sites/hosting/data-loss-warning/index.js
@@ -4,28 +4,43 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { Button } from '@automattic/components';
+import { connect } from 'react-redux';
+import { shuffle } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import Gravatar from 'components/gravatar';
+import QueryHappinessEngineers from 'components/data/query-happiness-engineers';
+import { getHappinessEngineers } from 'state/happiness-engineers/selectors';
 
-const DataLossWarning = ( { translate } ) => (
-	<div className={ 'data-loss-warning' }>
-		<h2>{ translate( 'Unsure of what all this means?' ) }</h2>
-		<p>
-			<strong>
+const DataLossWarning = ( { avatars, translate } ) => {
+	return (
+		<div className="data-loss-warning">
+			{ ! avatars && <QueryHappinessEngineers /> }
+			<h2>{ translate( 'Unsure of what all this means?' ) }</h2>
+			<p>
+				<strong>
+					{ translate(
+						"Mistakes when editing your website's files and database can lead to data loss."
+					) }
+				</strong>
+				&nbsp;
 				{ translate(
-					"Mistakes when editing your website's files and database can lead to data loss."
+					'If you need help or have any questions our Happiness Engineers are here when you need them!'
 				) }
-			</strong>
-			&nbsp;
-			{ translate(
-				'If you need help or have any questions our Happiness Engineers are here when you need them!'
-			) }
-		</p>
-		<Button href={ '/help/contact/' }>{ translate( 'Contact us' ) }</Button>
-	</div>
-);
+			</p>
+			<div className="data-loss-warning__contact">
+				<Button href={ '/help/contact/' }>{ translate( 'Contact us' ) }</Button>
+				{ shuffle( avatars ).map( avatar => (
+					<Gravatar key={ avatar } user={ { avatar_URL: avatar } } size={ 42 } />
+				) ) }
+			</div>
+		</div>
+	);
+};
 
-export default localize( DataLossWarning );
+export default connect( state => ( {
+	avatars: getHappinessEngineers( state ),
+} ) )( localize( DataLossWarning ) );

--- a/client/my-sites/hosting/data-loss-warning/style.scss
+++ b/client/my-sites/hosting/data-loss-warning/style.scss
@@ -1,6 +1,7 @@
 .data-loss-warning {
 	margin-top: 40px;
 	margin-bottom: 64px;
+	max-width: 700px;
 
 	@include breakpoint( '<660px' ) {
 		padding: 24px;

--- a/client/my-sites/hosting/data-loss-warning/style.scss
+++ b/client/my-sites/hosting/data-loss-warning/style.scss
@@ -1,5 +1,6 @@
 .data-loss-warning {
 	margin-top: 40px;
+	margin-bottom: 64px;
 
 	@include breakpoint( '<660px' ) {
 		padding: 24px;

--- a/client/my-sites/hosting/data-loss-warning/style.scss
+++ b/client/my-sites/hosting/data-loss-warning/style.scss
@@ -1,0 +1,9 @@
+.data-loss-warning {
+	margin-top: 40px;
+
+	h2 {
+		font-size: 21px;
+		font-weight: 400;
+		margin-bottom: 10px;
+	}
+}

--- a/client/my-sites/hosting/data-loss-warning/style.scss
+++ b/client/my-sites/hosting/data-loss-warning/style.scss
@@ -5,10 +5,27 @@
 		padding: 24px;
 		margin-top: 0;
 	}
+}
 
-	h2 {
-		font-size: 21px;
-		font-weight: 400;
-		margin-bottom: 10px;
-	}
+.data-loss-warning h2 {
+	font-size: 21px;
+	font-weight: 400;
+	margin-bottom: 10px;
+}
+
+.data-loss-warning__contact {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	height: 42px;
+	overflow: hidden;
+}
+
+.data-loss-warning__contact .button {
+	margin-right: 20px;
+}
+
+.data-loss-warning__contact .gravatar {
+	margin-right: 10px;
 }

--- a/client/my-sites/hosting/data-loss-warning/style.scss
+++ b/client/my-sites/hosting/data-loss-warning/style.scss
@@ -1,6 +1,11 @@
 .data-loss-warning {
 	margin-top: 40px;
 
+	@include breakpoint( '<660px' ) {
+		padding: 24px;
+		margin-top: 0;
+	}
+
 	h2 {
 		font-size: 21px;
 		font-weight: 400;

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -19,6 +19,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import SFTPCard from './sftp-card';
 import PhpMyAdminCard from './phpmyadmin-card';
+import DataLossWarning from './data-loss-warning';
 
 /**
  * Style dependencies
@@ -45,6 +46,7 @@ const Hosting = ( { translate, isDisabled } ) => {
 				<SFTPCard disabled={ isDisabled } />
 				<PhpMyAdminCard disabled={ isDisabled } />
 			</div>
+			{ ! isDisabled && <DataLossWarning /> }
 		</Main>
 	);
 };

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -12,17 +12,25 @@
 	.card {
 		display: flex;
 		flex-direction: row;
-		width: calc( 100% - 10px );
+		width: 100%;
+		margin-left: 0;
+		margin-right: 0;
 
 		.card-heading {
 			margin-top: 0;
 		}
 
 		@include breakpoint( '>1280px' ) {
-			width: calc( 40% - 10px );
-
 			&:first-child {
-				width: calc( 60% - 10px );
+				width: calc( 60% - 5px );
+				margin-left: 0;
+				margin-right: 5px;
+			}
+
+			&:last-child {
+				width: calc( 40% - 5px );
+				margin-left: 5px;
+				margin-right: 0;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Displays a data loss warning in the Atomic Hosting Panel providing support help before folks try to modify their site

| Desktop | Tablet | Mobile |
|---|---|---|
| <img width="400" alt="Screen Shot 2019-11-11 at 17 20 23" src="https://user-images.githubusercontent.com/1233880/68602993-bd49c780-04a7-11ea-8821-411ac4d533fd.png"> | <img width="200" alt="Screen Shot 2019-11-11 at 17 20 10" src="https://user-images.githubusercontent.com/1233880/68603021-c9ce2000-04a7-11ea-99f3-3bee0271f360.png"> | <img width="100" alt="Screen Shot 2019-11-11 at 17 19 56" src="https://user-images.githubusercontent.com/1233880/68603042-d488b500-04a7-11ea-875f-094d33f4a6a8.png"> |

#### Testing instructions

* Switch to an Atomic site created after Oct 31, 2019.
* Go to "Manage > SFTP & MySQL".
* Note the "Unsure of what all this means?" warning.
* Verify the button redirects to the contact page (`/help/contact`).

Fixes #37257
