### PR TITLE
Signup: update Plans sub-header.

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -209,11 +209,9 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			props: {
 				headerText: i18n.translate( 'Getting ready to launch your website' ),
-				subHeaderText: i18n.translate(
-					"Pick a plan that's right for you. Upgrade it as you grow."
-				),
+				subHeaderText: i18n.translate( "Pick a plan that's right for you. Upgrade as you grow." ),
 				fallbackHeaderText: i18n.translate(
-					"Almost there, pick a plan that's right for you. Upgrade it as you grow."
+					"Almost there, pick a plan that's right for you. Upgrade as you grow."
 				),
 				isLaunchPage: true,
 			},

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -174,7 +174,7 @@ export class PlansStep extends Component {
 		const headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
 		const subHeaderText =
-			this.props.subHeaderText || translate( 'Choose a plan. Upgrade it as you grow.' );
+			this.props.subHeaderText || translate( 'Choose a plan. Upgrade as you grow.' );
 		const fallbackSubHeaderText = this.props.fallbackSubHeaderText || subHeaderText;
 
 		let backUrl, backLabelText;


### PR DESCRIPTION
Quick change to the sub-header, suggested in #37415 