### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,8 @@
 			"packagePatterns": [
 				"^@babel",
 				"^babel-",
-				"^react",
-				"^redux",
+				"^react$",
+				"^redux$",
 				"^webpack",
 				"lodash",
 				"typescript"

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,12 @@
 		{
 			"packagePatterns": [ "^@wordpress" ],
 			"groupName": "wordpress-monorepo",
-			"separateMajorMinor": false
+			"separateMajorMinor": false,
+			"prPriority": 2
+		},
+		{
+			"packagePatterns": [ "react", "lodash", "^webpack", "typescript" ],
+			"prPriority": 1
 		}
 	],
 	"statusCheckVerify": true,
@@ -19,7 +24,7 @@
 		"enabled": true,
 		"schedule": "every weekday"
 	},
-	"prConcurrentLimit": 0,
+	"prConcurrentLimit": 10,
 	"prHourlyLimit": 6,
 	"semanticCommits": true,
 	"semanticCommitType": "chore",

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,15 @@
 			"prPriority": 2
 		},
 		{
-			"packagePatterns": [ "react", "lodash", "^webpack", "typescript" ],
+			"packagePatterns": [
+				"^@babel",
+				"^babel-",
+				"^react",
+				"^redux",
+				"^webpack",
+				"lodash",
+				"typescript"
+			],
 			"prPriority": 1
 		}
 	],

--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,12 @@
 			"packagePatterns": [
 				"^@babel",
 				"^babel-",
+				"^lodash$",
+				"^react-redux$",
 				"^react$",
 				"^redux$",
-				"^webpack",
-				"lodash",
-				"typescript"
+				"^typescript$",
+				"^webpack"
 			],
 			"prPriority": 1
 		}

--- a/renovate.json
+++ b/renovate.json
@@ -7,22 +7,32 @@
 			"rangeStrategy": "replace"
 		},
 		{
-			"packagePatterns": [ "^@wordpress" ],
-			"groupName": "wordpress-monorepo",
+			"extends": "monorepo:wordpress",
 			"separateMajorMinor": false,
 			"prPriority": 2
 		},
 		{
-			"packagePatterns": [
-				"^@babel",
-				"^babel-",
-				"^lodash$",
-				"^react-redux$",
-				"^react$",
-				"^redux$",
-				"^typescript$",
-				"^webpack"
-			],
+			"extends": "monorepo:babel",
+			"prPriority": 1
+		},
+		{
+			"extends": "monorepo:lodash",
+			"prPriority": 1
+		},
+		{
+			"extends": "monorepo:react",
+			"prPriority": 1
+		},
+		{
+			"packagePatterns": [ "^redux$", "^react-redux$" ],
+			"prPriority": 1
+		},
+		{
+			"packageName": "typescript",
+			"prPriority": 1
+		},
+		{
+			"packagePatterns": [ "^webpack" ],
 			"prPriority": 1
 		}
 	],
@@ -38,5 +48,5 @@
 	"semanticCommits": true,
 	"semanticCommitType": "chore",
 	"masterIssue": true,
-	"masterIssueTitle": "Outstanding Dependency Updates"
+	"masterIssueTitle": "Renovate Dependency Updates"
 }


### PR DESCRIPTION
- Limit us to 10 concurrent renovate PRs
- Prioritize updates to the WordPress monorepo, babel, react, redux, react-redux, lodash, webpack, typescript
