### PR TITLE
Add upgrade button click events tracking in product selector

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -184,6 +184,19 @@ export class ProductSelector extends Component {
 		} );
 	}
 
+	handleCheckoutForProduct = productObject => {
+		const { currentPlanSlug, intervalType, selectedSiteSlug } = this.props;
+
+		return () => {
+			this.props.recordTracksEvent( 'calypso_plan_features_upgrade_click', {
+				current_plan: currentPlanSlug,
+				product_name: productObject.product_slug,
+				billing_cycle: intervalType,
+			} );
+			page( '/checkout/' + selectedSiteSlug + '/' + productObject.product_slug );
+		};
+	};
+
 	handleProductOptionSelect( stateKey, productSlug ) {
 		this.setState( {
 			[ stateKey ]: productSlug,
@@ -191,26 +204,13 @@ export class ProductSelector extends Component {
 	}
 
 	renderCheckoutButton( product ) {
-		const {
-			currentPlanSlug,
-			intervalType,
-			selectedSiteSlug,
-			storeProducts,
-			translate,
-		} = this.props;
+		const { intervalType, storeProducts, translate } = this.props;
 		const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 		const productObject = storeProducts[ selectedProductSlug ];
 
 		return (
 			<ProductCardAction
-				onClick={ () => {
-					this.props.recordTracksEvent( 'calypso_plan_features_upgrade_click', {
-						current_plan: currentPlanSlug,
-						product_name: productObject.product_slug,
-						billing_cycle: intervalType,
-					} );
-					page( '/checkout/' + selectedSiteSlug + '/' + productObject.product_slug );
-				} }
+				onClick={ this.handleCheckoutForProduct( productObject ) }
 				intro={ this.getIntervalDiscount( selectedProductSlug ) }
 				label={ translate( 'Get %(productName)s', {
 					args: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add upgrade button click events tracking in the `<ProductSelector />`

![Screenshot 2019-11-08 at 16 12 54](https://user-images.githubusercontent.com/478735/68487052-ad7d7980-0242-11ea-857b-c22ddfe7a0ab.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Go to http://calypso.localhost:3000/plans and select a Jetpack site that has no Jetpack Backup product
* Toggle debug mode in the console:
```js
localStorage.setItem('debug', 'calypso:analytics:*');
```
* Purchase one of the Jetpack Backup products and confirm that correct event is being logged in the console.

Fixes n/a
