### PR TITLE
Gutenberg: Load selected images in gallery block

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -193,9 +193,20 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.mediaSelectPort = ports[ 0 ];
 
 			if ( value ) {
-				const selectedItems = Array.isArray( value )
-					? map( value, item => ( { ID: parseInt( item, 10 ) } ) )
-					: [ { ID: parseInt( value, 10 ) } ];
+				const ids = Array.isArray( value )
+					? value.map( item => parseInt( item, 10 ) )
+					: [ parseInt( value, 10 ) ];
+				const selectedItems = ids.map( id => {
+					const media = MediaStore.get( siteId, id );
+					if ( ! media ) {
+						MediaActions.fetch( siteId, id );
+					}
+					return {
+						ID: id,
+						...media,
+					};
+				} );
+
 				MediaActions.setLibrarySelectedItems( siteId, selectedItems );
 			} else {
 				MediaActions.setLibrarySelectedItems( siteId, [] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Loads the selected images on the media modal before opening it to ensure they remain selected.

Previously, we were relying on the default behavior of the media modal which only loads the images that are visible on the dialog, so any non-loaded image (i.e. if a user has lots of images that are only loaded when scrolling down) would be removed from the gallery.

#### Testing instructions

* Make sure you have lots of images in your media library, so the media modal load images when scrolling dow.
* Follow the steps that appears in [this video](https://cloudup.com/cRDvvvTYFP7):
  * Create a post.
  * Add a gallery block.
  * Add images that are loaded when scrolling down.
  * Save the post.
  * Reload the browser.
  * Edit the gallery.
  * Add an image that is already loaded by the media modal (i.e. the first one).
* Make sure the new selected image is added and the previous images remain in the gallery.

Fixes #37389
