### PR TITLE
Move site theme utils to their own module.

### DIFF
--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -1,5 +1,3 @@
-/** @format **/
-
 /**
  * External dependencies
  */
@@ -94,18 +92,6 @@ export const siteStyleOptions = {
 		},
 	],
 };
-
-/**
- * Returns a theme base CSS URI.
- *
- * @param  {String}  themeSlug A theme slug, e.g., `pub/business`
- * @param  {Boolean} isRtl     If the current locale is a right-to-left language
- * @return {String}            The theme CSS URI.
- */
-export const getThemeCssUri = ( themeSlug, isRtl ) =>
-	`https://s0.wp.com/wp-content/themes/${ themeSlug }/style${ isRtl ? '-rtl' : '' }.css`;
-
-export const DEFAULT_FONT_URI = 'https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,500,700';
 
 /**
  * Returns a style definition object

--- a/client/lib/signup/site-theme.js
+++ b/client/lib/signup/site-theme.js
@@ -1,0 +1,11 @@
+/**
+ * Returns a theme base CSS URI.
+ *
+ * @param  {String}  themeSlug A theme slug, e.g., `pub/business`
+ * @param  {Boolean} isRtl     If the current locale is a right-to-left language
+ * @return {String}            The theme CSS URI.
+ */
+export const getThemeCssUri = ( themeSlug, isRtl ) =>
+	`https://s0.wp.com/wp-content/themes/${ themeSlug }/style${ isRtl ? '-rtl' : '' }.css`;
+
+export const DEFAULT_FONT_URI = 'https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,500,700';

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -24,7 +23,7 @@ import {
 	getSiteVerticalSlug,
 } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
-import { getThemeCssUri, DEFAULT_FONT_URI as defaultFontUri } from 'lib/signup/site-styles';
+import { getThemeCssUri, DEFAULT_FONT_URI as defaultFontUri } from 'lib/signup/site-theme';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';


### PR DESCRIPTION
They were living in the `site-styles` module, together with some rather large SVG-in-JS icons, which are apparently only used in the `site-styles` step (and that step, as far as I can tell, is not being used).

Extracting the theme utils to their own module removes the SVGs from the main signup bundle, bringing its size down by 6.5KB (compressed) with no change in functionality.

#### Changes proposed in this Pull Request

* Move theme utils (`getThemeCssUri` and `DEFAULT_FONT_URI `) from `lib/signup/site-styles.js` to their own module.
* Update consumers (a single file, actually) accordingly.

#### Testing instructions

There aren't any specific testing instructions, other than testing site mockups in signup and ensuring that they still work normally.