### PR TITLE
composite-checkout: Fix margin issue on Safari

### DIFF
--- a/packages/composite-checkout/src/components/coupon.js
+++ b/packages/composite-checkout/src/components/coupon.js
@@ -88,6 +88,7 @@ const ApplyButton = styled( Button )`
 	right: 4px;
 	padding: 7px;
 	animation: ${animateIn} 0.2s ease-out;
+	margin: 0;
 `;
 
 function handleFieldInput( input, setCouponFieldValue, setIsApplyButtonActive, setHasCouponError ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a styling issue in Safari.

**Before:**
![image](https://user-images.githubusercontent.com/6981253/68498311-86b04a80-0224-11ea-9021-3abef4cd97d6.png)

**After:**
![image](https://user-images.githubusercontent.com/6981253/68498287-7bf5b580-0224-11ea-8d69-e4ae27249efb.png)


#### Testing instructions

* Get setup: https://github.com/Automattic/wp-calypso/pull/37013
* Expand the coupon field in Safari and type.
