### PR TITLE
composite-checkout: Add apple pay using stripejs

### DIFF
--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -70,9 +70,37 @@ const stripeMethod = createStripeMethod( {
 
 const creditCardMethod = createCreditCardMethod();
 
-const applePayMethod = createApplePayMethod();
+const applePayMethod = isApplePayAvailable()
+	? createApplePayMethod( {
+			registerStore,
+			fetchStripeConfiguration,
+	  } )
+	: null;
 
 const paypalMethod = createPayPalMethod( { registerStore, makePayPalExpressRequest } );
+
+export function isApplePayAvailable() {
+	// Our Apple Pay implementation uses the Payment Request API, so check that first.
+	if ( ! window.PaymentRequest ) {
+		return false;
+	}
+
+	// Check if Apple Pay is available. This can be very expensive on certain
+	// Safari versions due to a bug (https://trac.webkit.org/changeset/243447/webkit),
+	// and there is no way it can change during a page request, so cache the
+	// result.
+	if ( typeof isApplePayAvailable.canMakePayments === 'undefined' ) {
+		try {
+			isApplePayAvailable.canMakePayments = Boolean(
+				window.ApplePaySession && window.ApplePaySession.canMakePayments()
+			);
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+			return false;
+		}
+	}
+	return isApplePayAvailable.canMakePayments;
+}
 
 const handleEvent = setItems => () => {
 	const cardholderName = select( 'stripe' ).getCardholderName();
@@ -113,8 +141,10 @@ function MyCheckout() {
 			onFailure={ onFailure }
 			successRedirectUrl={ successRedirectUrl }
 			failureRedirectUrl={ failureRedirectUrl }
-			paymentMethods={ [ applePayMethod, creditCardMethod, stripeMethod, paypalMethod ] }
 			registry={ registry }
+			paymentMethods={ [ applePayMethod, creditCardMethod, stripeMethod, paypalMethod ].filter(
+				Boolean
+			) }
 		>
 			<Checkout OrderSummary={ WPCheckoutOrderSummary } ReviewContent={ WPCheckoutOrderReview } />
 		</CheckoutProvider>

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalize } from '../lib/localize';
+
+// The react-stripe-elements PaymentRequestButtonElement cannot have its
+// paymentRequest updated once it has been rendered, so this is a custom one.
+// See: https://github.com/stripe/react-stripe-elements/issues/284
+export default function PaymentRequestButton( {
+	paymentRequest,
+	paymentType,
+	disabled,
+	disabledReason,
+} ) {
+	const localize = useLocalize();
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const onClick = event => {
+		event.persist();
+		event.preventDefault();
+		setIsSubmitting( true );
+		paymentRequest.on( 'cancel', () => setIsSubmitting( false ) );
+		paymentRequest.show();
+	};
+	if ( ! paymentRequest ) {
+		disabled = true;
+	}
+
+	if ( isSubmitting ) {
+		return (
+			<button disabled>
+				{ localize( 'Completing your purchase', { context: 'Loading state on /checkout' } ) }
+			</button>
+		);
+	}
+	if ( disabled ) {
+		return (
+			<React.Fragment>
+				<button disabled>{ disabledReason }</button>
+			</React.Fragment>
+		);
+	}
+
+	if ( paymentType === 'apple-pay' ) {
+		return <button className="payment-request-button" onClick={ onClick } />;
+	}
+	return (
+		<button onClick={ onClick }>
+			{ localize( 'Select a payment card', { context: 'Loading state on /checkout' } ) }
+		</button>
+	);
+}
+
+PaymentRequestButton.propTypes = {
+	paymentRequest: PropTypes.object,
+	paymentType: PropTypes.string.isRequired,
+	disabled: PropTypes.bool,
+	disabledReason: PropTypes.string,
+};

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -3,11 +3,13 @@
  */
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
 import { useLocalize } from '../lib/localize';
+import Button from './button';
 
 // The react-stripe-elements PaymentRequestButtonElement cannot have its
 // paymentRequest updated once it has been rendered, so this is a custom one.
@@ -33,26 +35,26 @@ export default function PaymentRequestButton( {
 
 	if ( isSubmitting ) {
 		return (
-			<button disabled>
+			<Button disabled fullWidth>
 				{ localize( 'Completing your purchase', { context: 'Loading state on /checkout' } ) }
-			</button>
+			</Button>
 		);
 	}
 	if ( disabled ) {
 		return (
-			<React.Fragment>
-				<button disabled>{ disabledReason }</button>
-			</React.Fragment>
+			<Button disabled fullWidth>
+				{ disabledReason }
+			</Button>
 		);
 	}
 
 	if ( paymentType === 'apple-pay' ) {
-		return <button className="payment-request-button" onClick={ onClick } />;
+		return <ApplePayButton onClick={ onClick } />;
 	}
 	return (
-		<button onClick={ onClick }>
+		<Button onClick={ onClick } fullWidth>
 			{ localize( 'Select a payment card', { context: 'Loading state on /checkout' } ) }
-		</button>
+		</Button>
 	);
 }
 
@@ -62,3 +64,10 @@ PaymentRequestButton.propTypes = {
 	disabled: PropTypes.bool,
 	disabledReason: PropTypes.string,
 };
+
+const ApplePayButton = styled.button`
+	-webkit-appearance: -apple-pay-button;
+	-apple-pay-button-style: black;
+	-apple-pay-button-type: plain;
+	width: 100%;
+`;

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -144,7 +144,10 @@ function usePaymentRequestOptions() {
 	const { stripeConfiguration } = useStripe();
 	const [ items, total ] = useLineItems();
 	const countryCode = getProcessorCountryFromStripeConfiguration( stripeConfiguration );
-	const currency = items.reduce( ( firstCurrency, item ) => firstCurrency || item.amount.currency );
+	const currency = items.reduce(
+		( firstCurrency, item ) => firstCurrency || item.amount.currency,
+		null
+	);
 	const paymentRequestOptions = useMemo(
 		() => ( {
 			country: countryCode,

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -84,12 +84,24 @@ export function ApplePayLabel() {
 }
 
 export function ApplePaySubmitButton() {
+	const localize = useLocalize();
 	const { onSuccess } = useCheckoutHandlers();
 	const paymentRequestOptions = usePaymentRequestOptions();
-	const { paymentRequest } = useStripePaymentRequest( {
+	const { paymentRequest, canMakePayment } = useStripePaymentRequest( {
 		paymentRequestOptions,
 		onSubmit: onSuccess,
 	} );
+
+	if ( ! canMakePayment ) {
+		return (
+			<PaymentRequestButton
+				paymentRequest={ paymentRequest }
+				paymentType="apple-pay"
+				disabled
+				disabledReason={ localize( 'This payment type is not supported' ) }
+			/>
+		);
+	}
 
 	return <PaymentRequestButton paymentRequest={ paymentRequest } paymentType="apple-pay" />;
 }

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -1,17 +1,65 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import styled from 'styled-components';
+import React, { useState, useEffect, useMemo } from 'react';
 
 /**
  * Internal dependencies
  */
+import { StripeHookProvider, useStripe } from '../../lib/stripe';
+import { useLineItems, useCheckoutHandlers } from '../../public-api';
 import { useLocalize } from '../../lib/localize';
-import Button from '../../components/button';
 import BillingFields from '../../components/billing-fields';
+import PaymentRequestButton from '../../components/payment-request-button';
 
-export function createApplePayMethod() {
+export function createApplePayMethod( { registerStore, fetchStripeConfiguration } ) {
+	const actions = {
+		setStripeError( payload ) {
+			return { type: 'STRIPE_TRANSACTION_ERROR', payload };
+		},
+		*getConfiguration( payload ) {
+			let configuration;
+			try {
+				configuration = yield { type: 'STRIPE_CONFIGURATION_FETCH', payload };
+			} catch ( error ) {
+				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
+			}
+			return { type: 'STRIPE_CONFIGURATION_SET', payload: configuration };
+		},
+	};
+
+	registerStore( 'apple-pay', {
+		reducer( state = {}, action ) {
+			switch ( action.type ) {
+				case 'STRIPE_TRANSACTION_ERROR':
+					return {
+						...state,
+						transactionStatus: 'error',
+						transactionError: action.payload,
+					};
+				case 'STRIPE_CONFIGURATION_SET':
+					return { ...state, stripeConfiguration: action.payload };
+			}
+			return state;
+		},
+		actions,
+		selectors: {
+			getStripeConfiguration( state ) {
+				return state.stripeConfiguration;
+			},
+			getTransactionError( state ) {
+				return state.transactionError;
+			},
+			getTransactionStatus( state ) {
+				return state.transactionStatus;
+			},
+		},
+		controls: {
+			STRIPE_CONFIGURATION_FETCH( action ) {
+				return fetchStripeConfiguration( action.payload );
+			},
+		},
+	} );
 	return {
 		id: 'apple-pay',
 		LabelComponent: ApplePayLabel,
@@ -19,6 +67,7 @@ export function createApplePayMethod() {
 		BillingContactComponent: BillingFields,
 		SubmitButtonComponent: ApplePaySubmitButton,
 		SummaryComponent: ApplePaySummary,
+		CheckoutWrapper: StripeHookProvider,
 		getAriaLabel: localize => localize( 'Apple Pay' ),
 	};
 }
@@ -35,22 +84,15 @@ export function ApplePayLabel() {
 }
 
 export function ApplePaySubmitButton() {
-	return (
-		<Button
-			onClick={ submitApplePayPayment }
-			buttonState="primary"
-			buttonType="apple-pay"
-			aria-label="Submit payment with Apple Pay"
-			fullWidth
-		>
-			<ButtonApplePayIcon fill="white" />
-		</Button>
-	);
-}
+	const { onSuccess } = useCheckoutHandlers();
+	const paymentRequestOptions = usePaymentRequestOptions();
+	const { paymentRequest } = useStripePaymentRequest( {
+		paymentRequestOptions,
+		onSubmit: onSuccess,
+	} );
 
-const ButtonApplePayIcon = styled( ApplePayIcon )`
-	transform: translateY( 3px );
-`;
+	return <PaymentRequestButton paymentRequest={ paymentRequest } paymentType="apple-pay" />;
+}
 
 export function ApplePaySummary() {
 	const localize = useLocalize();
@@ -91,7 +133,84 @@ function ApplePayIcon( { fill, className } ) {
 		</svg>
 	);
 }
+const PAYMENT_REQUEST_OPTIONS = {
+	requestPayerName: true,
+	requestPayerPhone: false,
+	requestPayerEmail: false,
+	requestShipping: false,
+};
 
-function submitApplePayPayment() {
-	alert( 'Thank you!' );
+function usePaymentRequestOptions() {
+	const { stripeConfiguration } = useStripe();
+	const [ items, total ] = useLineItems();
+	const countryCode = getProcessorCountryFromStripeConfiguration( stripeConfiguration );
+	const currency = items.reduce( ( firstCurrency, item ) => firstCurrency || item.amount.currency );
+	const paymentRequestOptions = useMemo(
+		() => ( {
+			country: countryCode,
+			currency: currency && currency.toLowerCase(),
+			displayItems: getDisplayItemsForLineItems( items ),
+			total: getPaymentRequestTotalFromTotal( total ),
+			...PAYMENT_REQUEST_OPTIONS,
+		} ),
+		[ countryCode, currency, items, total ]
+	);
+	return paymentRequestOptions;
+}
+
+function useStripePaymentRequest( { paymentRequestOptions, onSubmit } ) {
+	const { stripe } = useStripe();
+	const [ canMakePayment, setCanMakePayment ] = useState( false );
+	const [ paymentRequest, setPaymentRequest ] = useState();
+
+	// We have to memoize this to prevent re-creating the paymentRequest
+	const callback = useMemo(
+		() => paymentMethodResponse => {
+			completePaymentMethodTransaction( {
+				onSubmit,
+				...paymentMethodResponse,
+			} );
+		},
+		[ onSubmit ]
+	);
+
+	useEffect( () => {
+		let isSubscribed = true;
+		if ( ! stripe ) {
+			return;
+		}
+		setCanMakePayment( false );
+		const request = stripe.paymentRequest( paymentRequestOptions );
+		request.canMakePayment().then( result => {
+			isSubscribed && setCanMakePayment( !! result );
+		} );
+		request.on( 'paymentmethod', callback );
+		setPaymentRequest( request );
+		return () => ( isSubscribed = false );
+	}, [ stripe, paymentRequestOptions, callback ] );
+
+	return { paymentRequest, canMakePayment };
+}
+
+function getDisplayItemsForLineItems( items ) {
+	return items.map( ( { label, amount } ) => ( {
+		label,
+		amount: amount.value,
+	} ) );
+}
+
+function getPaymentRequestTotalFromTotal( total ) {
+	return {
+		label: total.label,
+		amount: total.amount.value,
+	};
+}
+
+function completePaymentMethodTransaction( { onSubmit, complete } ) {
+	onSubmit();
+	complete( 'success' );
+}
+
+function getProcessorCountryFromStripeConfiguration( stripeConfiguration ) {
+	return stripeConfiguration && stripeConfiguration.processor_id === 'stripe_ie' ? 'IE' : 'US';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the Apple Pay payment method to use a real payment request button and Stripe.

#### Testing instructions

- Add a file called `packages/composite-checkout/demo/private.js` and inside it put the following: `export const stripeKey = 'TEST KEY HERE';`
- Run `npm run composite-checkout-demo`.
- Visit https://localhost:3000 in Chrome.
- Be sure that the form loads and that you _do not_ see the "Apple Pay" payment method.
- Configure your computer using a proxy to route `https://composite-checkout.localhost` to `http://localhost:3000` with a fake SSL certificate. (This may be tricky; feel free to ask for help.)
- Visit https://composite-checkout.localhost in Safari.
- Be sure that the form loads and that you _do_ see the "Apple Pay" payment method.