### PR TITLE
FSE: Allow manual use of WP_Template and WP_Template_Inserter classes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -201,17 +201,14 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
  * the cases in which FSE supported theme was activated prior to the plugin. This will
  * populate the default header and footer for current theme, and create About and Contact
  * pages provided that they don't already exist.
- *
- * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
- * @param boolean $should_add_pages      True if the pages should also be inserted.
  */
-function populate_wp_template_data( $should_fetch_from_api = true, $should_add_pages = true ) {
+function populate_wp_template_data() {
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 
 	$fse = Full_Site_Editing::get_instance();
-	$fse->insert_default_data( $should_fetch_from_api, $should_add_pages );
+	$fse->insert_default_data();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -193,14 +193,17 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
  * the cases in which FSE supported theme was activated prior to the plugin. This will
  * populate the default header and footer for current theme, and create About and Contact
  * pages provided that they don't already exist.
+ *
+ * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
+ * @param boolean $should_add_pages      True if the pages should also be inserted.
  */
-function populate_wp_template_data() {
+function populate_wp_template_data( $should_fetch_from_api = true, $should_add_pages = true ) {
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 
 	$fse = Full_Site_Editing::get_instance();
-	$fse->insert_default_data();
+	$fse->insert_default_data( $should_fetch_from_api, $should_add_pages );
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -34,7 +34,8 @@ function load_full_site_editing() {
 	if ( ! is_full_site_editing_active() ) {
 		return;
 	}
-	load_full_site_editing_files_without_verification();
+	// Not dangerous here since we have already checked for eligibility.
+	dangerously_load_full_site_editing_files();
 	Full_Site_Editing::get_instance();
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
@@ -45,7 +46,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
  * to include the FSE files somewhere like a script. I.e. if you want to access
  * a class defined here without needing full FSE functionality.
  */
-function load_full_site_editing_files_without_verification() {
+function dangerously_load_full_site_editing_files() {
 	require_once __DIR__ . '/full-site-editing/blocks/navigation-menu/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/site-description/index.php';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -34,7 +34,18 @@ function load_full_site_editing() {
 	if ( ! is_full_site_editing_active() ) {
 		return;
 	}
+	load_full_site_editing_files_without_verification();
+	Full_Site_Editing::get_instance();
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
 
+/**
+ * NOTE: In most cases, you should NOT use this function. Please use
+ * load_full_site_editing instead. This function should only be used if you need
+ * to include the FSE files somewhere like a script. I.e. if you want to access
+ * a class defined here without needing full FSE functionality.
+ */
+function load_full_site_editing_files_without_verification() {
 	require_once __DIR__ . '/full-site-editing/blocks/navigation-menu/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/site-description/index.php';
@@ -47,10 +58,7 @@ function load_full_site_editing() {
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/serialize-block-fallback.php';
-
-	Full_Site_Editing::get_instance();
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
 
 /**
  * Whether or not FSE is active.
@@ -154,7 +162,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_posts_list_block' );
  */
 function load_starter_page_templates() {
 	// We don't want the user to choose a template when copying a post.
-	// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['jetpack-copy'] ) ) {
 		return;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -83,34 +83,24 @@ class Full_Site_Editing {
 	}
 
 	/**
-	 * Determines whether provided theme supports FSE.
-	 *
-	 * @deprecated being replaced soon by an is_active static method - don't add new usages
-	 * @param string $theme_slug Theme slug to check support for.
-	 *
-	 * @return bool True if passed theme supports FSE, false otherwise.
-	 */
-	// phpcs:disable
-	public function is_supported_theme( $theme_slug = null ) {
-		// phpcs:enable
-		// now in reality is_current_theme_supported.
-		return current_theme_supports( 'full-site-editing' );
-	}
-
-	/**
 	 * Inserts template data for the theme we are currently switching to.
 	 *
 	 * This insertion will only happen if theme supports FSE.
 	 * It is hooked into after_switch_theme action.
+	 *
+	 * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
+	 * @param boolean $should_add_pages      True if the pages should also be inserted.
 	 */
-	public function insert_default_data() {
+	public function insert_default_data( $should_fetch_from_api = true, $should_add_pages = true ) {
 		// Bail if current theme doesn't support FSE.
-		if ( ! $this->is_supported_theme() ) {
+		if ( ! is_theme_supported() ) {
 			return;
 		}
 
-		$this->wp_template_inserter->insert_default_template_data();
-		$this->wp_template_inserter->insert_default_pages();
+		$this->wp_template_inserter->insert_default_template_data( $should_fetch_from_api );
+		if ( $should_add_pages ) {
+			$this->wp_template_inserter->insert_default_pages();
+		}
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -87,20 +87,15 @@ class Full_Site_Editing {
 	 *
 	 * This insertion will only happen if theme supports FSE.
 	 * It is hooked into after_switch_theme action.
-	 *
-	 * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
-	 * @param boolean $should_add_pages      True if the pages should also be inserted.
 	 */
-	public function insert_default_data( $should_fetch_from_api = true, $should_add_pages = true ) {
+	public function insert_default_data() {
 		// Bail if current theme doesn't support FSE.
 		if ( ! is_theme_supported() ) {
 			return;
 		}
 
-		$this->wp_template_inserter->insert_default_template_data( $should_fetch_from_api );
-		if ( $should_add_pages ) {
-			$this->wp_template_inserter->insert_default_pages();
-		}
+		$this->wp_template_inserter->insert_default_template_data();
+		$this->wp_template_inserter->insert_default_pages();
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -10,7 +10,7 @@ namespace A8C\FSE;
 /**
  * The strategy to use for loading the default template part content.
  *
- * @typedef {"use-api"|"use-local"} LoadingStrategy
+ * @typedef {String="use-api","use-local"} LoadingStrategy
  */
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -234,7 +234,7 @@ class WP_Template_Inserter {
 		}
 
 		// Set header and footer content based on data fetched from the WP.com API.
-		$this->fetch_template_parts( $should_fetch_from_api );
+		$this->fetch_template_parts();
 
 		// Avoid creating template parts if data hasn't been fetched properly.
 		if ( empty( $this->header_content ) || empty( $this->footer_content ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -8,6 +8,12 @@
 namespace A8C\FSE;
 
 /**
+ * The strategy to use for loading the default template part content.
+ *
+ * @typedef {"use-api"|"use-local"} LoadingStrategy
+ */
+
+/**
  * Class WP_Template_Inserter
  */
 class WP_Template_Inserter {
@@ -58,14 +64,27 @@ class WP_Template_Inserter {
 	private $fse_page_data_option = 'fse-page-data-v1';
 
 	/**
+	 * The strategy to use for default data insertion.
+	 *
+	 * 'use-api' will use the wpcom API to get specifc content depending on the theme.
+	 *
+	 * 'use-local' will use the locally defined defaults.
+	 *
+	 * @var {LoadingStrategy} $loading_strategy
+	 */
+	private $loading_strategy;
+
+	/**
 	 * WP_Template_Inserter constructor.
 	 *
-	 * @param string $theme_slug Current theme slug.
+	 * @param string            $theme_slug Current theme slug.
+	 * @param {LoadingStrategy} $loading_strategy The strategy to use to load the template part content.
 	 */
-	public function __construct( $theme_slug ) {
-		$this->theme_slug     = $theme_slug;
-		$this->header_content = '';
-		$this->footer_content = '';
+	public function __construct( $theme_slug, $loading_strategy = 'use-api' ) {
+		$this->theme_slug       = $theme_slug;
+		$this->header_content   = '';
+		$this->footer_content   = '';
+		$this->loading_strategy = $loading_strategy;
 
 		/*
 		 * Previously the option suffix was '-fse-template-data'. Bumping this to '-fse-template-data-v1'
@@ -76,14 +95,13 @@ class WP_Template_Inserter {
 		$this->fse_template_data_option = $this->theme_slug . '-fse-template-data-v1';
 	}
 
+
 	/**
-	 * Retrieves template parts content from WP.com API.
-	 *
-	 * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
+	 * Retrieves template parts content.
 	 */
-	public function fetch_template_parts( $should_fetch_from_api = true ) {
+	public function fetch_template_parts() {
 		// Use default data if we don't want to fetch from the API.
-		if ( ! $should_fetch_from_api ) {
+		if ( 'use-local' === $this->loading_strategy ) {
 			$this->header_content = $this->get_default_header();
 			$this->footer_content = $this->get_default_footer();
 			return;
@@ -187,10 +205,8 @@ class WP_Template_Inserter {
 
 	/**
 	 * This function will be called on plugin activation hook.
-	 *
-	 * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
 	 */
-	public function insert_default_template_data( $should_fetch_from_api = true ) {
+	public function insert_default_template_data() {
 		do_action(
 			'a8c_fse_log',
 			'before_template_population',

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -78,8 +78,17 @@ class WP_Template_Inserter {
 
 	/**
 	 * Retrieves template parts content from WP.com API.
+	 *
+	 * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
 	 */
-	public function fetch_template_parts() {
+	public function fetch_template_parts( $should_fetch_from_api = true ) {
+		// Use default data if we don't want to fetch from the API.
+		if ( ! $should_fetch_from_api ) {
+			$this->header_content = $this->get_default_header();
+			$this->footer_content = $this->get_default_footer();
+			return;
+		}
+
 		$request_url = 'https://public-api.wordpress.com/wpcom/v2/full-site-editing/templates';
 
 		$request_args = [
@@ -178,8 +187,10 @@ class WP_Template_Inserter {
 
 	/**
 	 * This function will be called on plugin activation hook.
+	 *
+	 * @param boolean $should_fetch_from_api True if the template part data should be fetched from the API.
 	 */
-	public function insert_default_template_data() {
+	public function insert_default_template_data( $should_fetch_from_api = true ) {
 		do_action(
 			'a8c_fse_log',
 			'before_template_population',
@@ -207,7 +218,7 @@ class WP_Template_Inserter {
 		}
 
 		// Set header and footer content based on data fetched from the WP.com API.
-		$this->fetch_template_parts();
+		$this->fetch_template_parts( $should_fetch_from_api );
 
 		// Avoid creating template parts if data hasn't been fetched properly.
 		if ( empty( $this->header_content ) || empty( $this->footer_content ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -41,9 +41,16 @@ class WP_Template {
 
 	/**
 	 * A8C_WP_Template constructor.
+	 *
+	 * @param string $theme Defaults to the current theme slug, but can be
+	 *                      overriden to use this class with themes which are
+	 *                      not currently active.
 	 */
-	public function __construct() {
-		$this->current_theme_name = $this->normalize_theme_slug( get_stylesheet() );
+	public function __construct( $theme = null ) {
+		if ( ! isset( $theme ) ) {
+			$theme = get_stylesheet();
+		}
+		$this->current_theme_name = $this->normalize_theme_slug( $theme );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This allows us to use the default template part content to populate the demo site without having to retrieve data from the API.

#### Testing instructions
* see D35247-code.

Fixes #35795. (Or, at least, the phabricator diff does.)
