### PR TITLE
Prime Calypso.live earlier in the workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,8 +637,6 @@ workflows:
     jobs:
       - setup
       - prime-calypso-live:
-          requires:
-            - setup
           filters:
             branches:
               ignore: master


### PR DESCRIPTION
Running this in parallel with setup can give calypso.live an extra ~3m to get the build ready. That should cut down wait time in wait-for-calypso-live.

#### Testing instructions

* Peek at the workflow for this PR. Verify that prime calypso live happens in parallel with setup

