### PR TITLE
Photon: try and reduce bundle size

### DIFF
--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -34,11 +34,16 @@
 		"crc32": "0.2.2",
 		"debug": "^3.2.6",
 		"seed-random": "2.2.0",
-		"url": "^0.11.0"
+		"native-url": "0.2.0"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
 		"prepare": "transpile"
+	},
+	"resolve": {
+		"alias": {
+			"url": "native-url"
+		}
 	}
 }

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -34,16 +34,11 @@
 		"crc32": "0.2.2",
 		"debug": "^3.2.6",
 		"seed-random": "2.2.0",
-		"native-url": "0.2.0"
+		"url": "^0.11.0"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
 		"prepare": "transpile"
-	},
-	"resolve": {
-		"alias": {
-			"url": "native-url"
-		}
 	}
 }

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -33,7 +33,6 @@
 	"dependencies": {
 		"crc32": "0.2.2",
 		"debug": "^3.2.6",
-		"seed-random": "2.2.0",
 		"url": "^0.11.0"
 	},
 	"scripts": {

--- a/packages/photon/src/index.js
+++ b/packages/photon/src/index.js
@@ -3,7 +3,6 @@
  */
 import { parse as parseUrl, format as formatUrl } from 'url';
 import crc32 from 'crc32';
-import seed from 'seed-random';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'photon' );
@@ -101,9 +100,7 @@ function isAlreadyPhotoned( host ) {
  * @return {string}          The hostname for the pathname
  */
 function serverFromPathname( pathname ) {
-	const hash = crc32( pathname );
-	const rng = seed( hash );
-	const server = 'i' + Math.floor( rng() * 3 );
+	const server = 'i' + Math.abs( crc32( pathname ) % 3 );
 	debug( 'determined server "%s" to use with "%s"', server, pathname );
 	return server + '.wp.com';
 }

--- a/packages/photon/src/index.js
+++ b/packages/photon/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import url from 'url';
+import { parse as parseUrl, format as formatUrl } from 'url';
 import crc32 from 'crc32';
 import seed from 'seed-random';
 import debugFactory from 'debug';
@@ -33,7 +33,7 @@ const mappings = {
  */
 export default function photon( imageUrl, opts ) {
 	// parse the URL, assuming //host.com/path style URLs are ok and parse the querystring
-	const parsedUrl = url.parse( imageUrl, true, true );
+	const parsedUrl = parseUrl( imageUrl, true, true );
 	const wasSecure = parsedUrl.protocol === 'https:';
 
 	delete parsedUrl.protocol;
@@ -56,7 +56,7 @@ export default function photon( imageUrl, opts ) {
 		if ( parsedUrl.search ) {
 			return null;
 		}
-		const formattedUrl = url.format( parsedUrl );
+		const formattedUrl = formatUrl( parsedUrl );
 		params.pathname =
 			0 === formattedUrl.indexOf( '//' ) ? formattedUrl.substring( 1 ) : formattedUrl;
 		params.hostname = serverFromPathname( params.pathname );
@@ -84,8 +84,7 @@ export default function photon( imageUrl, opts ) {
 	}
 
 	// do this after so a passed opt can't override it
-
-	const photonUrl = url.format( params );
+	const photonUrl = formatUrl( params );
 	debug( 'generated Photon URL: %s', photonUrl );
 	return photonUrl;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Experimenting with imported packages in Photon. We use `photon` in Jetpack Search, and it adds around 20kb to our bundle.

#### Testing instructions

`cd packages/photon && node_modules/.bin/jest .`