### PR TITLE
WP Migration: Add confirmation step and start migration

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2532,4 +2532,11 @@ Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function(
 	} );
 };
 
+Undocumented.prototype.startMigration = function( sourceSiteId, targetSiteId ) {
+	return this.wpcom.req.post( {
+		path: `/sites/${ sourceSiteId }/migrate-to/${ targetSiteId }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
 export default Undocumented;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2532,6 +2532,13 @@ Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function(
 	} );
 };
 
+Undocumented.prototype.getMigrationStatus = function( targetSiteId ) {
+	return this.wpcom.req.get( {
+		path: `/sites/${ targetSiteId }/migration-status`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
 Undocumented.prototype.startMigration = function( sourceSiteId, targetSiteId ) {
 	return this.wpcom.req.post( {
 		path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2539,6 +2539,13 @@ Undocumented.prototype.getMigrationStatus = function( targetSiteId ) {
 	} );
 };
 
+Undocumented.prototype.resetMigration = function( targetSiteId ) {
+	return this.wpcom.req.post( {
+		path: `/sites/${ targetSiteId }/reset-migration`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
 Undocumented.prototype.startMigration = function( sourceSiteId, targetSiteId ) {
 	return this.wpcom.req.post( {
 		path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2534,7 +2534,7 @@ Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function(
 
 Undocumented.prototype.startMigration = function( sourceSiteId, targetSiteId ) {
 	return this.wpcom.req.post( {
-		path: `/sites/${ sourceSiteId }/migrate-to/${ targetSiteId }`,
+		path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,
 		apiNamespace: 'wpcom/v2',
 	} );
 };

--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -13,7 +13,7 @@ import { isEnabled } from 'config';
 
 export function migrateSite( context, next ) {
 	if ( isEnabled( 'tools/migrate' ) ) {
-		context.primary = <SectionMigrate />;
+		context.primary = <SectionMigrate sourceSiteId={ context.params.sourceSiteId || null } />;
 		return next();
 	}
 

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -23,4 +23,14 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
+
+	page(
+		'/migrate/:sourceSiteId/:site_id',
+		siteSelection,
+		navigation,
+		redirectWithoutSite( '/migrate' ),
+		migrateSite,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -118,7 +118,7 @@ class SectionMigrate extends Component {
 	}
 
 	renderMigrationConfirmation() {
-		const { sourceSite, targetSite, translate } = this.props;
+		const { sourceSite, targetSite } = this.props;
 
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
@@ -126,13 +126,11 @@ class SectionMigrate extends Component {
 		return (
 			<CompactCard>
 				<div className="migrate__confirmation">
-					{ translate(
-						'Do you want to migrate all content from %(sourceSite)s to %(targetSite)s? All existing content on %(sourceSite)s will be lost.',
-						{ args: { sourceSite: sourceSiteDomain, targetSite: targetSiteDomain } }
-					) }
+					Do you want to migrate all content from { sourceSiteDomain } to { targetSiteDomain }? All
+					existing content on { sourceSiteDomain } will be lost.
 				</div>
 				<Button primary onClick={ this.startMigration }>
-					{ translate( 'Start Migration' ) }
+					Start Migration
 				</Button>
 			</CompactCard>
 		);
@@ -161,8 +159,6 @@ class SectionMigrate extends Component {
 	}
 
 	renderSourceSiteSelector() {
-		const { translate } = this.props;
-
 		return (
 			<CompactCard className="migrate__card">
 				<SiteSelector
@@ -172,16 +168,16 @@ class SectionMigrate extends Component {
 					filter={ this.jetpackSiteFilter }
 				/>
 				<Button primary onClick={ this.selectSourceSite } disabled={ ! this.state.sourceSiteId }>
-					{ translate( 'Continue' ) }
+					Continue
 				</Button>
 			</CompactCard>
 		);
 	}
 
 	render() {
-		const { sourceSiteId, translate } = this.props;
-		const headerText = translate( 'Migrate' );
-		const subHeaderText = translate( 'Migrate your WordPress site to WordPress.com' );
+		const { sourceSiteId } = this.props;
+		const headerText = 'Migrate';
+		const subHeaderText = 'Migrate your WordPress site to WordPress.com';
 
 		let migrationElement;
 
@@ -212,7 +208,7 @@ class SectionMigrate extends Component {
 		return (
 			<Main>
 				<Interval onTick={ this.updateFromAPI } period={ EVERY_MINUTE } />
-				<DocumentHead title={ translate( 'Migrate' ) } />
+				<DocumentHead title="Migrate" />
 				<SidebarNavigation />
 				<FormattedHeader
 					className="migrate__section-header"

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -6,7 +6,6 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
 import { get } from 'lodash';
-import wpLib from 'lib/wp';
 
 /**
  * Internal dependencies
@@ -18,8 +17,10 @@ import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSelector from 'components/site-selector';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { Interval, EVERY_FIVE_SECONDS } from 'lib/interval';
 import { getSite } from 'state/sites/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import wpLib from 'lib/wp';
 
 /**
  * Style dependencies
@@ -30,13 +31,24 @@ const wpcom = wpLib.undocumented();
 
 class SectionMigrate extends Component {
 	state = {
+		migrationStatus: 'unknown',
 		sourceSiteId: null,
 	};
+
+	componentDidMount() {
+		this.updateFromAPI();
+	}
 
 	jetpackSiteFilter = sourceSite => {
 		const { targetSiteId } = this.props;
 
 		return sourceSite.jetpack && sourceSite.ID !== targetSiteId;
+	};
+
+	resetMigration = () => {
+		const { targetSiteId, targetSiteSlug } = this.props;
+
+		wpcom.resetMigration( targetSiteId ).then( () => page( `/migrate/${ targetSiteSlug }` ) );
 	};
 
 	selectSourceSite = () => {
@@ -63,6 +75,44 @@ class SectionMigrate extends Component {
 		wpcom.startMigration( sourceSiteId, targetSiteId );
 	};
 
+	updateFromAPI = () => {
+		const { targetSiteId } = this.props;
+		wpcom
+			.getMigrationStatus( targetSiteId )
+			.then( response => {
+				const { status: migrationStatus } = response;
+				if ( migrationStatus ) {
+					this.setState( { migrationStatus } );
+				}
+			} )
+			.catch( () => {
+				// @TODO: handle status error
+			} );
+	};
+
+	renderLoading() {
+		return (
+			<CompactCard>
+				<span className="migrate__placeholder">Loading...</span>
+			</CompactCard>
+		);
+	}
+
+	renderMigrationComplete() {
+		const { targetSite } = this.props;
+		const viewSiteURL = get( targetSite, 'URL' );
+
+		return (
+			<CompactCard>
+				<div className="migrate__status">Your migration has completed successfully.</div>
+				<Button primary href={ viewSiteURL }>
+					View site
+				</Button>
+				<Button onClick={ this.resetMigration }>Start over</Button>
+			</CompactCard>
+		);
+	}
+
 	renderMigrationConfirmation() {
 		const { sourceSite, targetSite, translate } = this.props;
 
@@ -82,6 +132,23 @@ class SectionMigrate extends Component {
 				</Button>
 			</CompactCard>
 		);
+	}
+
+	renderMigrationError() {
+		return (
+			<CompactCard>
+				<div className="migrate__status">There was an error with your migration.</div>
+				<Button primary onClick={ this.resetMigration }>
+					Try again
+				</Button>
+			</CompactCard>
+		);
+	}
+
+	renderMigrationStatus() {
+		const { migrationStatus } = this.state;
+
+		return <div>{ migrationStatus }</div>;
 	}
 
 	renderSourceSiteSelector() {
@@ -107,8 +174,35 @@ class SectionMigrate extends Component {
 		const headerText = translate( 'Migrate' );
 		const subHeaderText = translate( 'Migrate your WordPress site to WordPress.com' );
 
+		let migrationElement;
+
+		switch ( this.state.migrationStatus ) {
+			case 'inactive':
+				migrationElement = sourceSiteId
+					? this.renderMigrationConfirmation()
+					: this.renderSourceSiteSelector();
+				break;
+
+			case 'restoring':
+				migrationElement = this.renderMigrationStatus();
+				break;
+
+			case 'done':
+				migrationElement = this.renderMigrationComplete();
+				break;
+
+			case 'error':
+				migrationElement = this.renderMigrationError();
+				break;
+
+			case 'unknown':
+			default:
+				migrationElement = this.renderLoading();
+		}
+
 		return (
 			<Main>
+				<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
 				<DocumentHead title={ translate( 'Migrate' ) } />
 				<SidebarNavigation />
 				<FormattedHeader
@@ -116,7 +210,7 @@ class SectionMigrate extends Component {
 					headerText={ headerText }
 					subHeaderText={ subHeaderText }
 				/>
-				{ sourceSiteId ? this.renderMigrationConfirmation() : this.renderSourceSiteSelector() }
+				{ migrationElement }
 			</Main>
 		);
 	}

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -127,7 +127,7 @@ class SectionMigrate extends Component {
 			<CompactCard>
 				<div className="migrate__confirmation">
 					Do you want to migrate all content from { sourceSiteDomain } to { targetSiteDomain }? All
-					existing content on { sourceSiteDomain } will be lost.
+					existing content on { targetSiteDomain } will be lost.
 				</div>
 				<Button primary onClick={ this.startMigration }>
 					Start Migration

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -2,6 +2,6 @@
 	min-height: 400px;
 }
 
-.migrate__source-site {
+.migrate__source-site, .migrate__confirmation {
 	margin-bottom: 16px;
 }

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -1,7 +1,9 @@
-.migrate__card {
-	min-height: 400px;
+.migrate__placeholder {
+	color: transparent;
+	background-color: var( --studio-gray-10 );
+	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
-.migrate__source-site, .migrate__confirmation {
+.migrate__source-site, .migrate__confirmation, .migrate__status {
 	margin-bottom: 16px;
 }


### PR DESCRIPTION
**This feature is behind the feature-flag `tools/migrate` and is part of a larger project. See pbkcP4-8-p2.**

#### Changes proposed in this Pull Request

* Adds a confirmation screen
* Adds the API calls to trigger a migration, see its status, and reset a migration
* Adds status screen

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this pull request and run Calypso locally, or view it on calypso.live with the flag `tools/migrate`.
* Viewing `calypso.localhost:3000/migrate/`, you should see a `SiteSelector` component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another `SiteSelector` component, listing all the Jetpack sites your account has access to.
* When you select a site and continue, you should see a confirmation screen.
* If you continue on the confirmation screen, your migration should start and you should see the status. The status should update once the migration is complete. Both sites must be eligible for migration, otherwise you'll receive an error. See pbkcP4-8-p2

