### PR TITLE
Product box: Update the link to a button

### DIFF
--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -176,3 +176,5 @@ The following props can be passed to the Product Card Action component:
 * `intro`: ( string | element | node ) Intro text to be displayed above the action button. It can be a string, a node or a React element (e.g. `<Fragment>`)
 * `label`: ( string ) Action button text
 * `onClick`: ( func ) Action button click event handler
+* `href`: ( string ) Url that the button click will take you to
+* `primary`: ( bool ) If we the action should be primary (default true) 

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -10,14 +10,14 @@ import { noop } from 'lodash';
  */
 import Button from 'components/button';
 
-const ProductCardAction = ( { intro, label, onClick, isPrimary, href } ) => (
+const ProductCardAction = ( { intro, label, onClick, primary, href } ) => (
 	<div className="product-card__action">
 		{ intro && <h4 className="product-card__action-intro">{ intro }</h4> }
 		<Button
 			className="product-card__action-button"
 			href={ href }
 			onClick={ onClick }
-			primary={ isPrimary }
+			primary={ primary }
 		>
 			{ label }
 		</Button>
@@ -29,13 +29,13 @@ ProductCardAction.propTypes = {
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
 	href: PropTypes.string,
-	isPrimary: PropTypes.boolean,
+	primary: PropTypes.bool,
 };
 
 ProductCardAction.defaultProps = {
 	href: null,
 	onClick: noop,
-	isPrimary: true,
+	primary: true,
 };
 
 export default ProductCardAction;

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -3,16 +3,22 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 
-const ProductCardAction = ( { intro, label, onClick } ) => (
+const ProductCardAction = ( { intro, label, onClick, isPrimary, href } ) => (
 	<div className="product-card__action">
 		{ intro && <h4 className="product-card__action-intro">{ intro }</h4> }
-		<Button className="product-card__action-button" onClick={ onClick } primary>
+		<Button
+			className="product-card__action-button"
+			href={ href }
+			onClick={ onClick }
+			primary={ isPrimary }
+		>
 			{ label }
 		</Button>
 	</div>
@@ -22,6 +28,14 @@ ProductCardAction.propTypes = {
 	intro: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
+	href: PropTypes.string,
+	primary: PropTypes.boolean,
+};
+
+ProductCardAction.defaultProps = {
+	href: null,
+	onClick: noop,
+	isPrimary: true,
 };
 
 export default ProductCardAction;

--- a/client/components/product-card/action.jsx
+++ b/client/components/product-card/action.jsx
@@ -29,7 +29,7 @@ ProductCardAction.propTypes = {
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
 	href: PropTypes.string,
-	primary: PropTypes.boolean,
+	isPrimary: PropTypes.boolean,
 };
 
 ProductCardAction.defaultProps = {

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import ProductCardPriceGroup from './price-group';
 import { managePurchase } from 'me/purchases/paths';
@@ -59,14 +60,14 @@ const ProductCard = ( {
 				</div>
 			</div>
 			<div className="product-card__description">
+				{ description && <p>{ description }</p> }
 				{ purchase && (
 					<p>
-						<a href={ managePurchase( purchase.domain, purchase.id ) }>
+						<Button href={ managePurchase( purchase.domain, purchase.id ) }>
 							{ translate( 'Manage Subscription' ) }
-						</a>
+						</Button>
 					</p>
 				) }
-				{ description && <p>{ description }</p> }
 			</div>
 			{ children }
 		</Card>

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -62,11 +62,14 @@ const ProductCard = ( {
 			<div className="product-card__description">
 				{ description && <p>{ description }</p> }
 				{ purchase && (
-					<p>
-						<Button href={ managePurchase( purchase.domain, purchase.id ) }>
+					<div class="product-card__action">
+						<Button
+							className="product-card__action-button"
+							href={ managePurchase( purchase.domain, purchase.id ) }
+						>
 							{ translate( 'Manage Subscription' ) }
 						</Button>
-					</p>
+					</div>
 				) }
 			</div>
 			{ children }

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -9,8 +9,8 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import Button from 'components/button';
+import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import ProductCardPriceGroup from './price-group';
 import { managePurchase } from 'me/purchases/paths';

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -9,9 +9,9 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
+import ProductCardAction from './action';
 import ProductCardPriceGroup from './price-group';
 import { managePurchase } from 'me/purchases/paths';
 
@@ -62,14 +62,11 @@ const ProductCard = ( {
 			<div className="product-card__description">
 				{ description && <p>{ description }</p> }
 				{ purchase && (
-					<div className="product-card__action">
-						<Button
-							className="product-card__action-button"
-							href={ managePurchase( purchase.domain, purchase.id ) }
-						>
-							{ translate( 'Manage Subscription' ) }
-						</Button>
-					</div>
+					<ProductCardAction
+						href={ managePurchase( purchase.domain, purchase.id ) }
+						label={ translate( 'Manage Subscription' ) }
+						isPrimary={ false }
+					/>
 				) }
 			</div>
 			{ children }

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -65,7 +65,7 @@ const ProductCard = ( {
 					<ProductCardAction
 						href={ managePurchase( purchase.domain, purchase.id ) }
 						label={ translate( 'Manage Subscription' ) }
-						isPrimary={ false }
+						primary={ false }
 					/>
 				) }
 			</div>

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -62,7 +62,7 @@ const ProductCard = ( {
 			<div className="product-card__description">
 				{ description && <p>{ description }</p> }
 				{ purchase && (
-					<div class="product-card__action">
+					<div className="product-card__action">
 						<Button
 							className="product-card__action-button"
 							href={ managePurchase( purchase.domain, purchase.id ) }

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -207,14 +207,7 @@
 	a:not( .button ) {
 		@extend %product-card-link-plain;
 	}
-	.button {
-		margin-left: auto;
-		margin-right: auto;
-		display: block;
-		width: 100%;
-		max-width: 320px;
-		text-align: center;
-	}
+
 	p:last-child {
 		margin: 0;
 	}

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -204,10 +204,16 @@
 	line-height: 20px;
 	color: var( --color-text-subtle );
 
-	a {
+	a:not( .button ) {
 		@extend %product-card-link-plain;
 	}
-
+	.button {
+		margin-left: auto;
+		margin-right: auto;
+		display: block;
+		max-width: 200px;
+		text-align: center;
+	}
 	p:last-child {
 		margin: 0;
 	}

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -211,7 +211,8 @@
 		margin-left: auto;
 		margin-right: auto;
 		display: block;
-		max-width: 200px;
+		width: 100%;
+		max-width: 320px;
 		text-align: center;
 	}
 	p:last-child {


### PR DESCRIPTION
- Move the button to the center.
- Move the button below the description

#### Changes proposed in this Pull Request
Before: 
![Screen Shot 2019-11-11 at 11 19 25 AM](https://user-images.githubusercontent.com/115071/68580956-bf942d80-0477-11ea-8201-84dbf3edec64.png)

After:
![Screen Shot 2019-11-11 at 11 28 54 AM](https://user-images.githubusercontent.com/115071/68580961-c3c04b00-0477-11ea-9b6d-2779e2c42905.png)

Design: 
![Screen Shot 2019-11-11 at 11 29 10 AM](https://user-images.githubusercontent.com/115071/68580972-c884ff00-0477-11ea-88cc-0cf252b39b54.png)


#### Testing instructions
* Visit the plans page for a jetpack site that has Jetpack 7.9 installed and running.
* Make sure you have a buy a backup product. 
* Notice that the updated design look like you expect. 
* Notice that there were no changes to the design of the plan page. When the user doesn't have a plan.



