### PR TITLE
Blocks: Update ProductSelector to default to last option as selected

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -37,7 +37,8 @@ export class ProductSelector extends Component {
 		this.state = {
 			...products.reduce( ( acc, product ) => {
 				map( product.options, ( slugs, interval ) => {
-					acc[ this.getStateKey( product.id, interval ) ] = slugs[ 0 ];
+					// Default to the last option as the selected one
+					acc[ this.getStateKey( product.id, interval ) ] = slugs[ slugs.length - 1 ];
 				} );
 				return acc;
 			}, {} ),


### PR DESCRIPTION
This PR updates the `ProductSelector` block so regardless of the selected billing interval, the last option is selected by default.

#### Changes proposed in this Pull Request

* Blocks: Update ProductSelector to have the last product option as the default selected one.

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is the slug of a Jetpack site without any plans or products.
* Verify that you can see the "real time backups" option as the selected one.
* Switch to the monthly billing interval.
* Verify that you can see the "real time backups" option as the selected one again.
