### PR TITLE
Dockerignore node_modules anywhere in directory tree

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ Dockerfile
 /.babel-cache
 /build
 /cached-requests.json
-/node_modules
+**/node_modules
 /public
 /server/bundler/*.json
 /server/devdocs/components-usage-stats.json


### PR DESCRIPTION
In the monorepo, node_modules may exist in different places in the
application. This can cause bad versions to be shared with the Docker
context. Ensure that node_modules are not included in the Docker context
by ignoring node_modules anywhere in the application source directories.

> Docker also supports a special wildcard string ** that matches any
> number of directories (including zero). For example, **/*.go will
> exclude all files that end with .go that are found in all directories,
> including the root of the build context.

Reference:
https://docs.docker.com/engine/reference/builder/#dockerignore-file

Discovered while debugging https://github.com/Automattic/wp-calypso/pull/37480

## Testing
- If you install dependencies of the application, then attempt `npm run build-docker`, Docker may error because it has an incompatible version of the node-sass binary (or any other architecture dependent package).
  This is due to the host `node_modules` leaking into the container and should be prevented by this change.