### PR TITLE
Avoid layout recalcs on mount in section-nav tabs.

### DIFF
--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -43,7 +43,7 @@ class NavTabs extends Component {
 	};
 
 	navGroupRef = React.createRef();
-	tabWidthMap = new Map();
+	tabRefMap = new Map();
 
 	componentDidMount() {
 		this.setDropdownAfterLayoutFlush();
@@ -62,21 +62,20 @@ class NavTabs extends Component {
 		this.setDropdownAfterLayoutFlush.cancel();
 	}
 
-	/* Ref that stores the width of given tab element */
-	storeTabWidth( index ) {
+	/* Ref that stores the given tab element */
+	storeTabRefs( index ) {
 		return tabElement => {
 			if ( tabElement === null ) {
-				this.tabWidthMap.delete( index );
+				this.tabRefMap.delete( index );
 			} else {
-				const tabWidth = ReactDom.findDOMNode( tabElement ).offsetWidth;
-				this.tabWidthMap.set( index, tabWidth );
+				this.tabRefMap.set( index, tabElement );
 			}
 		};
 	}
 
 	render() {
 		const tabs = React.Children.map( this.props.children, ( child, index ) => {
-			return child && React.cloneElement( child, { ref: this.storeTabWidth( index ) } );
+			return child && React.cloneElement( child, { ref: this.storeTabRefs( index ) } );
 		} );
 
 		const tabsClassName = classNames( 'section-nav-tabs', {
@@ -106,7 +105,8 @@ class NavTabs extends Component {
 	getTabWidths() {
 		let totalWidth = 0;
 
-		this.tabWidthMap.forEach( tabWidth => {
+		this.tabRefMap.forEach( tabElement => {
+			const tabWidth = ReactDom.findDOMNode( tabElement ).offsetWidth;
 			totalWidth += tabWidth;
 		} );
 


### PR DESCRIPTION
While the width of the group was only being retrieved at appropriate times (after a layout flush), the individual tab refs were running immediately, regardless of timing.

It appears @jsnajdr had fixed this in the past, but subsequent work brought the issue back.

#### Changes proposed in this Pull Request

* Delay retrieval of individual tab widths until an appropriate time.

#### Testing instructions

To test functionality:

* Ensure the tabs at the top of a nav section (e.g. Stats) continue to work correctly.

To test performance:

* Ensure you have React DevTools installed
* Open Chrome DevTools and open the Performance tab
* Open "My Sites"
* Switch between stats and another section (e.g. Plans) a few times, ending with the other section
* Start recording
* Hover over Stats in the side bar and wait a few seconds
* Click it and don't move your mouse for several seconds
* Stop recording
* Analyse the graph. It should look like the graph below, with 2 (not 3) layout recalcs, none of them caused by the tabs component.

![image](https://user-images.githubusercontent.com/409615/68607809-647b2e80-04a9-11ea-945d-823867968e32.png)
(ignore the tooltip)