### PR TITLE
PropTypes: Disable some non-offensive lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,8 +154,6 @@ module.exports = {
 		// Allows Chai `expect` expressions. Now that we're on jest, hopefully we can remove this one.
 		'no-unused-expressions': 0,
 
-		'react/forbid-foreign-prop-types': 'error',
-
 		// enforce our classname namespacing rules
 		'wpcalypso/jsx-classname-namespace': [
 			2,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,6 +154,8 @@ module.exports = {
 		// Allows Chai `expect` expressions. Now that we're on jest, hopefully we can remove this one.
 		'no-unused-expressions': 0,
 
+		'react/forbid-foreign-prop-types': 'error',
+
 		// enforce our classname namespacing rules
 		'wpcalypso/jsx-classname-namespace': [
 			2,

--- a/client/my-sites/marketing/connections/services/eventbrite.js
+++ b/client/my-sites/marketing/connections/services/eventbrite.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { last, isEqual } from 'lodash';
 
@@ -16,6 +13,8 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 
 export class Eventbrite extends SharingService {
 	static propTypes = {
+		// This foreign propTypes access should be safe because we expect all of them to be removed
+		// eslint-disable-next-line react/forbid-foreign-prop-types
 		...SharingService.propTypes,
 		saveRequests: PropTypes.object,
 		saveSiteSettings: PropTypes.func,

--- a/client/my-sites/marketing/connections/services/facebook.js
+++ b/client/my-sites/marketing/connections/services/facebook.js
@@ -12,6 +12,8 @@ import { SharingService, connectFor } from 'my-sites/marketing/connections/servi
 
 export class Facebook extends SharingService {
 	static propTypes = {
+		// This foreign propTypes access should be safe because we expect all of them to be removed
+		// eslint-disable-next-line react/forbid-foreign-prop-types
 		...SharingService.propTypes,
 	};
 

--- a/client/my-sites/marketing/connections/services/google-my-business.js
+++ b/client/my-sites/marketing/connections/services/google-my-business.js
@@ -25,6 +25,8 @@ import {
 
 export class GoogleMyBusiness extends SharingService {
 	static propTypes = {
+		// This foreign propTypes access should be safe because we expect all of them to be removed
+		// eslint-disable-next-line react/forbid-foreign-prop-types
 		...SharingService.propTypes,
 		saveRequests: PropTypes.object,
 		siteSettings: PropTypes.object,

--- a/client/my-sites/marketing/connections/services/google-photos.js
+++ b/client/my-sites/marketing/connections/services/google-photos.js
@@ -16,6 +16,8 @@ import { SharingService, connectFor } from 'my-sites/marketing/connections/servi
 
 export class GooglePhotos extends SharingService {
 	static propTypes = {
+		// This foreign propTypes access should be safe because we expect all of them to be removed
+		// eslint-disable-next-line react/forbid-foreign-prop-types
 		...SharingService.propTypes,
 		deleteStoredKeyringConnection: PropTypes.func,
 	};

--- a/client/my-sites/marketing/connections/services/instagram.js
+++ b/client/my-sites/marketing/connections/services/instagram.js
@@ -15,6 +15,8 @@ import { SharingService, connectFor } from 'my-sites/marketing/connections/servi
 
 export class Instagram extends SharingService {
 	static propTypes = {
+		// This foreign propTypes access should be safe because we expect all of them to be removed
+		// eslint-disable-next-line react/forbid-foreign-prop-types
 		...SharingService.propTypes,
 		deleteStoredKeyringConnection: PropTypes.func,
 	};

--- a/client/my-sites/marketing/connections/services/mailchimp.js
+++ b/client/my-sites/marketing/connections/services/mailchimp.js
@@ -15,6 +15,8 @@ import { SharingService, connectFor } from 'my-sites/marketing/connections/servi
 
 export class Mailchimp extends SharingService {
 	static propTypes = {
+		// This foreign propTypes access should be safe because we expect all of them to be removed
+		// eslint-disable-next-line react/forbid-foreign-prop-types
 		...SharingService.propTypes,
 		deleteStoredKeyringConnection: PropTypes.func,
 	};


### PR DESCRIPTION
Add some lint disable comments to non-offensive usage of foreign propTypes.

See #37344 which adds the a propTypes babel transform and lint rule.