### PR TITLE
composite-checkout: Add wordpress/data to dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -477,6 +477,7 @@
 			"version": "file:packages/composite-checkout",
 			"dev": true,
 			"requires": {
+				"@wordpress/data": "^4.9.2",
 				"prop-types": "^15.7.2",
 				"react": "^16.8.6",
 				"react-stripe-elements": "^5.1.0",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -34,6 +34,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/composite-checkout#readme",
 	"dependencies": {
+		"@wordpress/data": "^4.9.2",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",
 		"react-stripe-elements": "^5.1.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to #37462 which switched the composite-checkout package's internal data registry system to use `@wordpress/data` instead. That diff should have also added the package to the dependencies array in `package.json`, but I forgot since the monorepo allowed the package to work anyway. This change corrects that oversight.

#### Testing instructions

None