### PR TITLE
Update query param used for the new WooCommerce + Jetpack Onboarding UI

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -434,7 +434,7 @@ export default connect(
 		linkingSocialService: getSocialAccountLinkService( state ),
 		partnerSlug: getPartnerSlugFromQuery( state ),
 		isJetpackWooCommerceFlow:
-			'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' ),
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{ recordTracksEvent }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -626,7 +626,7 @@ export default connect(
 			isLoggedIn: Boolean( getCurrentUserId( state ) ),
 			oauth2Client: getCurrentOAuth2Client( state ),
 			isJetpackWooCommerceFlow:
-				'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' ),
+				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 			redirectTo: getRedirectToOriginal( state ),
 			requestError: getRequestError( state ),
 			socialAccountIsLinking: getSocialAccountIsLinking( state ),

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1002,7 +1002,7 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 		sectionName: getSectionName( state ),
 		isJetpackWooCommerceFlow:
-			'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' ),
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -78,7 +78,7 @@ class Document extends React.Component {
 		const isJetpackWooCommerceFlow =
 			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
 			'jetpack-connect' === sectionName &&
-			'woocommerce-setup-wizard' === requestFrom;
+			'woocommerce-onboarding' === requestFrom;
 
 		return (
 			<html

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -148,7 +148,7 @@ export class JetpackAuthorize extends Component {
 
 		if (
 			this.isSso( nextProps ) ||
-			this.isWoo( nextProps ) ||
+			this.isWooRedirect( nextProps ) ||
 			this.isFromJpo( nextProps ) ||
 			this.shouldRedirectJetpackStart( nextProps ) ||
 			this.props.isVip
@@ -212,7 +212,7 @@ export class JetpackAuthorize extends Component {
 
 		if (
 			this.isSso() ||
-			this.isWoo() ||
+			this.isWooRedirect() ||
 			this.isFromJpo() ||
 			this.shouldRedirectJetpackStart() ||
 			getRoleFromScope( scope ) === 'subscriber'
@@ -242,9 +242,7 @@ export class JetpackAuthorize extends Component {
 		const { alreadyAuthorized, authApproved, from } = this.props.authQuery;
 		return (
 			this.isSso() ||
-			( 'woocommerce-services-auto-authorize' === from ||
-				( ! config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-					'woocommerce-setup-wizard' === from ) ) ||
+			( 'woocommerce-services-auto-authorize' === from || 'woocommerce-setup-wizard' === from ) || // Auto authorize the old WooCommerce setup wizard only.
 			( ! this.props.isAlreadyOnSitesList &&
 				! alreadyAuthorized &&
 				( this.props.calypsoStartedConnection || authApproved ) )
@@ -269,9 +267,21 @@ export class JetpackAuthorize extends Component {
 		return 'sso' === from && isSsoApproved( clientId );
 	}
 
-	isWoo( props = this.props ) {
+	isWooRedirect( props = this.props ) {
 		const { from } = props.authQuery;
-		return includes( [ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ], from );
+		return includes(
+			[
+				'woocommerce-services-auto-authorize',
+				'woocommerce-setup-wizard',
+				'woocommerce-onboarding',
+			],
+			from
+		);
+	}
+
+	isWooOnboarding( props = this.props ) {
+		const { from } = props.authQuery;
+		return includes( [ 'woocommerce-onboarding' ], from );
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {
@@ -294,10 +304,7 @@ export class JetpackAuthorize extends Component {
 	handleSignIn = () => {
 		const { recordTracksEvent } = this.props;
 		const { from } = this.props.authQuery;
-		if (
-			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-			'woocommerce-setup-wizard' === from
-		) {
+		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { different_account: true } );
 		}
 	};
@@ -307,10 +314,7 @@ export class JetpackAuthorize extends Component {
 		const { from } = this.props.authQuery;
 		recordTracksEvent( 'calypso_jpc_signout_click' );
 
-		if (
-			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-			'woocommerce-setup-wizard' === from
-		) {
+		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { create_jetpack: true } );
 		}
 
@@ -364,10 +368,7 @@ export class JetpackAuthorize extends Component {
 
 		recordTracksEvent( 'calypso_jpc_approve_click' );
 
-		if (
-			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-			'woocommerce-setup-wizard' === from
-		) {
+		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
 		}
 
@@ -644,7 +645,7 @@ export class JetpackAuthorize extends Component {
 						isJetpack: true,
 						isNative: config.isEnabled( 'login/native-login-links' ),
 						redirectTo: window.location.href,
-						isWoo: this.isWoo(),
+						isWoo: this.isWooOnboarding(),
 					} ) }
 					onClick={ this.handleSignIn }
 				>
@@ -698,14 +699,14 @@ export class JetpackAuthorize extends Component {
 
 	render() {
 		return (
-			<MainWrapper isWoo={ this.isWoo() }>
+			<MainWrapper isWoo={ this.isWooOnboarding() }>
 				<div className="jetpack-connect__authorize-form">
 					<div className="jetpack-connect__logged-in-form">
 						<QueryUserConnection
 							siteId={ this.props.authQuery.clientId }
 							siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
 						/>
-						<AuthFormHeader authQuery={ this.props.authQuery } isWoo={ this.isWoo() } />
+						<AuthFormHeader authQuery={ this.props.authQuery } isWoo={ this.isWooOnboarding() } />
 						<Card className="jetpack-connect__logged-in-card">
 							<Gravatar user={ this.props.user } size={ 64 } />
 							<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -242,7 +242,7 @@ export class JetpackAuthorize extends Component {
 		const { alreadyAuthorized, authApproved, from } = this.props.authQuery;
 		return (
 			this.isSso() ||
-			( 'woocommerce-services-auto-authorize' === from || 'woocommerce-setup-wizard' === from ) || // Auto authorize the old WooCommerce setup wizard only.
+			includes( [ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ], from ) || // Auto authorize the old WooCommerce setup wizard only.
 			( ! this.props.isAlreadyOnSitesList &&
 				! alreadyAuthorized &&
 				( this.props.calypsoStartedConnection || authApproved ) )
@@ -281,7 +281,7 @@ export class JetpackAuthorize extends Component {
 
 	isWooOnboarding( props = this.props ) {
 		const { from } = props.authQuery;
-		return includes( [ 'woocommerce-onboarding' ], from );
+		return 'woocommerce-onboarding' === from;
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -14,7 +14,7 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { includes, flowRight, get, noop } from 'lodash';
+import { flowRight, get, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -87,7 +87,7 @@ export class JetpackSignup extends Component {
 
 	isWoo() {
 		const { authQuery } = this.props;
-		return includes( [ 'woocommerce-onboarding' ], authQuery.from );
+		return 'woocommerce-onboarding' === authQuery.from;
 	}
 
 	getLoginRoute() {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -87,10 +87,7 @@ export class JetpackSignup extends Component {
 
 	isWoo() {
 		const { authQuery } = this.props;
-		return includes(
-			[ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ],
-			authQuery.from
-		);
+		return includes( [ 'woocommerce-onboarding' ], authQuery.from );
 	}
 
 	getLoginRoute() {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -10,7 +10,6 @@ import deepFreeze from 'deep-freeze';
 import React from 'react';
 import { identity, noop } from 'lodash';
 import { shallow } from 'enzyme';
-import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -128,22 +127,27 @@ describe( 'JetpackAuthorize', () => {
 		} );
 	} );
 
-	describe( 'isWoo', () => {
-		const isWoo = new JetpackAuthorize().isWoo;
+	describe( 'isWooRedirect', () => {
+		const isWooRedirect = new JetpackAuthorize().isWooRedirect;
 
 		test( 'should return true for woo services', () => {
 			const props = { authQuery: { from: 'woocommerce-services-auto-authorize' } };
-			expect( isWoo( props ) ).toBe( true );
+			expect( isWooRedirect( props ) ).toBe( true );
 		} );
 
-		test( 'should return true for woo wizard', () => {
+		test( 'should return true for old woo setup wizard', () => {
 			const props = { authQuery: { from: 'woocommerce-setup-wizard' } };
-			expect( isWoo( props ) ).toBe( true );
+			expect( isWooRedirect( props ) ).toBe( true );
+		} );
+
+		test( 'should return true for new woo onboarding', () => {
+			const props = { authQuery: { from: 'woocommerce-onboarding' } };
+			expect( isWooRedirect( props ) ).toBe( true );
 		} );
 
 		test( 'returns false with non-woo from', () => {
 			const props = { authQuery: { from: 'elsewhere' } };
-			expect( isWoo( props ) ).toBe( false );
+			expect( isWooRedirect( props ) ).toBe( false );
 		} );
 	} );
 
@@ -177,7 +181,7 @@ describe( 'JetpackAuthorize', () => {
 			component.setProps( {
 				authQuery: {
 					...DEFAULT_PROPS.authQuery,
-					from: 'woocommerce-setup-wizard',
+					from: 'woocommerce-onboarding',
 				},
 			} );
 			const result = component.instance().shouldAutoAuthorize();
@@ -185,15 +189,7 @@ describe( 'JetpackAuthorize', () => {
 			expect( result ).toBe( false );
 		} );
 
-		test( 'should return true for woocommerce onboarding when the feature flag is disabled', () => {
-			isEnabled.mockImplementation( flag => {
-				if ( flag === 'jetpack/connect/woocommerce' ) {
-					return false;
-				}
-
-				return true;
-			} );
-
+		test( 'should return true for the old woocommerc setup wizard', () => {
 			const renderableComponent = <JetpackAuthorize { ...DEFAULT_PROPS } />;
 			const component = shallow( renderableComponent );
 			component.setProps( {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -194,7 +194,7 @@ export default connect( state => {
 	const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 	const isJetpackWooCommerceFlow =
 		( 'jetpack-connect' === sectionName || 'login' === sectionName ) &&
-		'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' );
+		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -141,7 +141,7 @@ export default connect( state => {
 	const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 	const isJetpackWooCommerceFlow =
-		'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' );
+		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 
 	return {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -68,7 +68,7 @@ export function login( {
 	}
 
 	if ( isWoo ) {
-		url = addQueryArgs( { from: 'woocommerce-setup-wizard' }, url );
+		url = addQueryArgs( { from: 'woocommerce-onboarding' }, url );
 	}
 
 	if ( wccomFrom ) {

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -79,7 +79,7 @@ describe( 'index', () => {
 		test( 'should return the login url with WooCommerce from handler', () => {
 			const url = login( { isNative: true, isJetpack: true, isWoo: true } );
 
-			expect( url ).toEqual( '/log-in/jetpack?from=woocommerce-setup-wizard' );
+			expect( url ).toEqual( '/log-in/jetpack?from=woocommerce-onboarding' );
 		} );
 
 		test( 'should return the login url with WooCommerce.com handler', () => {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -315,7 +315,7 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 		query: getCurrentQueryArguments( state ),
 		isJetpackWooCommerceFlow:
-			'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' ),
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-admin/issues/3055.

We are working on enabling the new WooCommerce Onboarding experience for testing (currently behind a feature flag). We want to show the new experience to 10% of WooCommerce Core users at first, so we need to be able to run both the new and existing onboarding flows alongside each other.

Our initial implementation of the new Calypso UI used a query parameter named `?from=woocommerce-setup-wizard` -- which was already being passed by the current WooCommerce core onboarding experience.

This updates the logic that displays the new UI to use a different query parameter instead ( `woocommerce-onboarding`).

This allows both query parameters to work along side each other and show their respective versions of the Jetpack connect UI.

#### Testing instructions

* Run `npm run test` and make sure all tests pass.

This PR is easiest to test alongside this WooCommerce Admin, since you need to get to a specific flow with valid Jetpack connection parameters.

* Install WooCommerce
* Install WooCommerce Admin and run this branch: https://github.com/woocommerce/woocommerce-admin/pull/3207.
* Go to `WooCommerce > Orders > Help > Setup Wizard`. Press the connect button under `Quickly access the Jetpack connection flow in Calypso`
* Verify you see the new UI pictured below

#### Screenshots

<img width="1050" alt="Screen Shot 2019-11-11 at 1 35 47 PM" src="https://user-images.githubusercontent.com/689165/68612169-e196ab80-0489-11ea-979a-3dff6f9aa9b1.png">

