### PR TITLE
Plans: Update single purpose title to Solutions

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -429,7 +429,7 @@ export class PlansFeaturesMain extends Component {
 		return (
 			<div className="plans-features-main__group is-narrow">
 				<FormattedHeader
-					headerText={ translate( 'Single Products' ) }
+					headerText={ translate( 'Solutions' ) }
 					subHeaderText={ translate( 'Just looking for backups? We’ve got you covered.' ) }
 					compactOnMobile
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update single purpose plans section title to "Solutions" as suggested by @eeeeevon13 

#### Preview

Before:
![](https://cldup.com/P7zPyeY5Gn.png)

After:
![](https://cldup.com/PZBPwYmC0M.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site with the latest Jetpack version.
* Verify heading says "Solutions" and looks well.
