### PR TITLE
Domains: Remove redundant SectionHeader label

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -175,7 +175,7 @@ export class List extends React.Component {
 
 				{ this.domainCreditsInfoNotice() }
 
-				<SectionHeader label={ headerText }>{ this.headerButtons() }</SectionHeader>
+				<SectionHeader>{ this.headerButtons() }</SectionHeader>
 
 				<div className="domain-management-list__items">
 					{ this.notice() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* "Domains" as a title is repeated three times on mobile devices.
* We're in the process of adding page headings to all Calypso pages, including Domains. This renders the SectionHeader title redundant, and we already display the title elsewhere on this page as part of the SectionNav and in the site title area on mobile.

**Before**

<img width="858" alt="Screen Shot 2019-11-11 at 4 29 04 PM" src="https://user-images.githubusercontent.com/2124984/68622573-6ee4fa80-04a0-11ea-98ca-60ddf5db1959.png">
<img width="323" alt="Screen Shot 2019-11-11 at 4 29 19 PM" src="https://user-images.githubusercontent.com/2124984/68622574-6ee4fa80-04a0-11ea-85e8-37a815d09435.png">

**After**

<img width="863" alt="Screen Shot 2019-11-11 at 4 22 07 PM" src="https://user-images.githubusercontent.com/2124984/68622508-4a891e00-04a0-11ea-93ef-2e97a6265437.png">
<img width="320" alt="Screen Shot 2019-11-11 at 4 22 28 PM" src="https://user-images.githubusercontent.com/2124984/68622510-4a891e00-04a0-11ea-9281-3326ae519dc5.png">

#### Testing instructions

* Switch to this PR
* Navigate to Manage -> Domains
* You should no longer see a `SectionHeader` label. 
* Make sure there are no visual bugs as a result of removing the label.