### PR TITLE
Domains: Remove redundant DNS Records SectionHeader

### DIFF
--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -22,7 +22,6 @@ import Main from 'components/main';
 import { domainManagementEdit, domainManagementNameServers } from 'my-sites/domains/paths';
 import { getSelectedDomain, isMappedDomain, isRegisteredDomain } from 'lib/domains';
 import Card from 'components/card/compact';
-import SectionHeader from 'components/section-header';
 import DnsTemplates from '../name-servers/dns-templates';
 import VerticalNav from 'components/vertical-nav';
 import DomainConnectRecord from './domain-connect-record';
@@ -87,7 +86,6 @@ class Dns extends React.Component {
 					{ translate( 'DNS Records' ) }
 				</Header>
 
-				<SectionHeader label={ translate( 'DNS Records' ) } />
 				<Card>
 					<DnsDetails />
 

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -1,11 +1,3 @@
-.dns__details {
-	display: block;
-	margin-top: 5px;
-	font-size: 13px;
-	font-style: italic;
-	color: var( --color-text-subtle );
-}
-
 .dns__form {
 	border-top: 1px solid var( --color-neutral-0 );
 	overflow: visible;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We show the page title twice, both in the SectionNav and in a SectionHeader. This PR removes the SectionHeader to reduce redundancy.
* Also changes the styling on the explanatory copy above the settings to be easier to read; increase contrast and font size.
* Fixing the Flows will also be adding proper headings to all Calypso pages, so this will become even more redundant soon.

**Before**

<img width="752" alt="Screen Shot 2019-11-11 at 4 36 24 PM" src="https://user-images.githubusercontent.com/2124984/68623336-465e0000-04a2-11ea-9d9b-7377382dec5a.png">
<img width="325" alt="Screen Shot 2019-11-11 at 4 36 41 PM" src="https://user-images.githubusercontent.com/2124984/68623337-465e0000-04a2-11ea-862c-506dc82f292f.png">

**After**

<img width="747" alt="Screen Shot 2019-11-11 at 4 37 09 PM" src="https://user-images.githubusercontent.com/2124984/68623340-465e0000-04a2-11ea-8618-5a51fc59c8ca.png">
<img width="323" alt="Screen Shot 2019-11-11 at 4 44 40 PM" src="https://user-images.githubusercontent.com/2124984/68623477-9b9a1180-04a2-11ea-8a02-7b101ab287db.png">

#### Testing instructions

* Switch to this PR
* Navigate to Manage -> Domains
* Click on a custom domain name to view its settings
* Click DNS Records
* Check to see that there is a title present on both desktop and mobile devices.
* Also check to make sure there are no visual bugs as a result of removing the SectionHeader.
