### PR TITLE
Reader: link to the original post when a post is unavailable

### DIFF
--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -1,9 +1,8 @@
-/** @format */
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import config from 'config';
 import { localize } from 'i18n-calypso';
 import { noop, get } from 'lodash';
@@ -14,6 +13,7 @@ import { noop, get } from 'lodash';
 import ReaderMain from 'reader/components/reader-main';
 import DocumentHead from 'components/data/document-head';
 import BackButton from 'components/back-button';
+import ExternalLink from 'components/external-link';
 
 const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 	const statusCode = get( post, [ 'error', 'statusCode' ] );
@@ -34,6 +34,8 @@ const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 		errorTitle = translate( 'Post not found' );
 	}
 
+	const postPermalink = get( post, [ 'error', 'data', 'permalink' ] );
+
 	return (
 		<ReaderMain className="reader-full-post reader-full-post__unavailable">
 			<BackButton onClick={ onBackClick } />
@@ -44,9 +46,23 @@ const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 					<div className="reader-full-post__unavailable-body">
 						<p className="reader-full-post__unavailable-message">{ errorDescription }</p>
 						{ errorHelp && <p className="reader-full-post__unavailable-message">{ errorHelp }</p> }
-						{ config.isEnabled( 'reader/full-errors' ) ? (
+						{ postPermalink && (
+							<Fragment>
+								<p>
+									{ translate( 'The original post is located at:', {
+										comment: 'Followed by a URL to the original post on an external site',
+									} ) }
+								</p>
+								<p>
+									<ExternalLink href={ postPermalink } icon={ true }>
+										{ postPermalink }
+									</ExternalLink>
+								</p>
+							</Fragment>
+						) }
+						{ config.isEnabled( 'reader/full-errors' ) && (
 							<pre>{ JSON.stringify( post, null, '  ' ) }</pre>
-						) : null }
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

@tcn33 noted that it is frustrating when using a `/read/blogs/:blog_id/posts/:post_id` link and you don't have access to the post. You are shown an error message with no way to visit the original content to find out what the issue is.

This PR adds the original post permalink URL to the error message where available (added to the API response in D35279-code) so that the user can visit the original site. For example, this enables internal users to visit P2s and add themselves to the blog.

<img width="613" alt="Screen Shot 2019-11-12 at 11 57 23" src="https://user-images.githubusercontent.com/17325/68627845-b2dd0b80-0543-11ea-88ef-c4bcc3216ce8.png">

#### Testing instructions

Visit a post that you do not have access to in Reader. As a non-superuser, you can try this post:

http://calypso.localhost:3000/read/blogs/82798297/posts/127

You should be offered a permalink to the original post in the error message, as shown in the screenshot above.

Fixes #24644.
