### PR TITLE
FSE - add template selector access through document sidebar

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -176,7 +176,7 @@ class Starter_Page_Templates {
 				'templates'       => array_merge( $default_templates, $vertical_templates ),
 				'vertical'        => $vertical,
 				'segment'         => $segment,
-				'screen'          => get_current_screen(),
+				'screenAction'    => $screen->action,
 			]
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -130,7 +130,7 @@ class Starter_Page_Templates {
 		$screen = get_current_screen();
 
 		// Return early if we don't meet conditions to show templates.
-		if ( 'page' !== $screen->id || 'add' !== $screen->action ) {
+		if ( 'page' !== $screen->id ) {
 			return;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -176,6 +176,7 @@ class Starter_Page_Templates {
 				'templates'       => array_merge( $default_templates, $vertical_templates ),
 				'vertical'        => $vertical,
 				'segment'         => $segment,
+				'screen'          => get_current_screen(),
 			]
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -29,7 +29,8 @@ class SidebarModalOpener extends Component {
 		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
 	};
 
-	getLastTemplateUsed = ( { templateUsedSlug, templates } = this.props ) => {
+	getLastTemplateUsed = () => {
+		const { templateUsedSlug, templates } = this.props;
 		if ( ! templateUsedSlug || templateUsedSlug === 'blank' ) {
 			// If no template used or 'blank', preview any other template (1 is currently 'Home' template).
 			return templates[ 1 ];

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -30,12 +30,12 @@ class SidebarModalOpener extends Component {
 	};
 
 	getLastTemplateUsed = () => {
-		const { templateUsedSlug, templates } = this.props;
-		if ( ! templateUsedSlug || templateUsedSlug === 'blank' ) {
+		const { lastTemplateUsedSlug, templates } = this.props;
+		if ( ! lastTemplateUsedSlug || lastTemplateUsedSlug === 'blank' ) {
 			// If no template used or 'blank', preview any other template (1 is currently 'Home' template).
 			return templates[ 1 ];
 		}
-		return templates.find( temp => temp.slug === templateUsedSlug );
+		return templates.find( temp => temp.slug === lastTemplateUsedSlug );
 	};
 
 	render() {
@@ -101,7 +101,7 @@ class SidebarModalOpener extends Component {
 
 const SidebarTemplatesPlugin = compose(
 	withSelect( select => ( {
-		templateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+		lastTemplateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 			._starter_page_template,
 	} ) )
 )( SidebarModalOpener );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -32,11 +32,11 @@ class SidebarModalOpener extends Component {
 		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
 	};
 
-	getLastTemplateUsed = () => {
-		if ( ! this.props.templateUsedSlug || this.props.templateUsedSlug === 'blank' ) {
-			return this.props.templates[ 1 ];
+	getLastTemplateUsed = ( { templateUsedSlug, templates } = this.props ) => {
+		if ( ! templateUsedSlug || templateUsedSlug === 'blank' ) {
+			return templates[ 1 ];
 		}
-		return this.props.templates.filter( temp => temp.slug === this.props.templateUsedSlug )[ 0 ];
+		return templates.find( temp => temp.slug === templateUsedSlug );
 	};
 
 	// The TemplateSelectorItem wants a function to run when clicked, we want it to do nothing from here.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -61,7 +61,7 @@ class SidebarModalOpener extends Component {
 					{ __( 'Change Layout' ) }
 				</Button>
 
-				{ this.state.isTemplateModalOpen ? (
+				{ this.state.isTemplateModalOpen && (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
 						templates={ templates }
@@ -70,9 +70,9 @@ class SidebarModalOpener extends Component {
 						toggleTemplateModal={ this.toggleTemplateModal }
 						isPromptedFromSidebar
 					/>
-				) : null }
+				) }
 
-				{ this.state.isWarningOpen ? (
+				{ this.state.isWarningOpen && (
 					<Modal
 						title={ __( 'Overwrite Page Content?' ) }
 						isDismissible={ false }
@@ -93,7 +93,7 @@ class SidebarModalOpener extends Component {
 							</Button>
 						</div>
 					</Modal>
-				) : null }
+				) }
 			</div>
 		);
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -39,6 +39,9 @@ class SidebarModalOpener extends Component {
 		return this.props.templates.filter( temp => temp.slug === this.props.templateUsedSlug )[ 0 ];
 	};
 
+	// The TemplateSelectorItem wants a function to run when clicked, we want it to do nothing from here.
+	onSelectOverride = () => {};
+
 	render() {
 		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
 		const { templates, vertical, segment, siteInformation } = this.props;
@@ -51,6 +54,7 @@ class SidebarModalOpener extends Component {
 					label={ replacePlaceholders( title, siteInformation ) }
 					staticPreviewImg={ preview }
 					staticPreviewImgAlt={ previewAlt }
+					onSelect={ this.onSelectOverride }
 				/>
 
 				<Button

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -40,9 +40,6 @@ class SidebarModalOpener extends Component {
 		return templates.find( temp => temp.slug === templateUsedSlug );
 	};
 
-	// The TemplateSelectorItem wants a function to run when clicked, we want it to do nothing from here.
-	onSelectOverride = () => {};
-
 	render() {
 		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
 		const { templates, vertical, segment, siteInformation } = this.props;
@@ -55,7 +52,7 @@ class SidebarModalOpener extends Component {
 					label={ replacePlaceholders( title, siteInformation ) }
 					staticPreviewImg={ preview }
 					staticPreviewImgAlt={ previewAlt }
-					onSelect={ this.onSelectOverride }
+					onSelect={ this.toggleWarningModal }
 				/>
 
 				<Button

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -34,6 +34,7 @@ class SidebarModalOpener extends Component {
 
 	getLastTemplateUsed = ( { templateUsedSlug, templates } = this.props ) => {
 		if ( ! templateUsedSlug || templateUsedSlug === 'blank' ) {
+			// If no template used or 'blank', preview any other template (1 is currently 'Home' template).
 			return templates[ 1 ];
 		}
 		return templates.find( temp => temp.slug === templateUsedSlug );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -6,6 +6,7 @@ import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { Button, Modal } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -16,12 +17,15 @@ import replacePlaceholders from '../utils/replace-placeholders';
 
 export class SidebarTemplateOpener extends Component {
 	state = {
-		isOpen: false,
+		isTemplateModalOpen: false,
 		isWarningOpen: false,
 	};
 
 	togglePlugin = () => {
-		this.setState( { isOpen: ! this.state.isOpen, isWarningOpen: false } );
+		this.setState( {
+			isTemplateModalOpen: ! this.state.isTemplateModalOpen,
+			isWarningOpen: false,
+		} );
 	};
 
 	toggleWarningModal = () => {
@@ -48,7 +52,7 @@ export class SidebarTemplateOpener extends Component {
 					justifyContent: 'center',
 				} }
 			>
-				{ this.state.isOpen ? (
+				{ this.state.isTemplateModalOpen ? (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
 						templates={ templates }
@@ -60,22 +64,22 @@ export class SidebarTemplateOpener extends Component {
 				) : null }
 				{ this.state.isWarningOpen ? (
 					<Modal
-						title="Are You Sure?"
-						// labelledby="Changing the page's layout will remove any customizations or edits you have already made."
+						title={ __( 'Are You Sure?' ) }
 						isDismissible={ false }
 						onRequestClose={ this.toggleWarningModal }
 						className="sidebar-modal-opener__warning-modal"
 					>
 						<div className="sidebar-modal-opener__warning-text">
-							Changing the page's layout will remove any customizations or edits you have already
-							made.
+							{ __(
+								`Changing the page's layout will remove any customizations or edits you have already made.`
+							) }
 						</div>
 						<div className="sidebar-modal-opener__warning-options">
 							<Button isDefault onClick={ this.toggleWarningModal }>
-								Cancel
+								{ __( 'Cancel' ) }
 							</Button>
 							<Button isPrimary onClick={ this.togglePlugin }>
-								Change Layout
+								{ __( 'Change Layout' ) }
 							</Button>
 						</div>
 					</Modal>
@@ -94,7 +98,7 @@ export class SidebarTemplateOpener extends Component {
 					onClick={ this.toggleWarningModal }
 					className="sidebar-modal-opener__button"
 				>
-					Change Layout
+					{ __( 'Change Layout' ) }
 				</Button>
 			</div>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -46,7 +46,7 @@ class SidebarModalOpener extends Component {
 		return (
 			<div className="sidebar-modal-opener">
 				<TemplateSelectorItem
-					id="sidebar-modal-opener__template-preview"
+					id="sidebar-modal-opener__last-template-used-preview"
 					value={ slug }
 					label={ replacePlaceholders( title, siteInformation ) }
 					staticPreviewImg={ preview }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -44,14 +44,7 @@ export class SidebarTemplateOpener extends Component {
 		const { templates, vertical, segment, siteInformation } = this.props;
 
 		return (
-			<div
-				style={ {
-					display: 'flex',
-					flexDirection: 'column',
-					alignItems: 'center',
-					justifyContent: 'center',
-				} }
-			>
+			<div className="sidebar-modal-opener">
 				{ this.state.isTemplateModalOpen ? (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
@@ -64,7 +57,7 @@ export class SidebarTemplateOpener extends Component {
 				) : null }
 				{ this.state.isWarningOpen ? (
 					<Modal
-						title={ __( 'Are You Sure?' ) }
+						title={ __( 'Overwrite Page Content?' ) }
 						isDismissible={ false }
 						onRequestClose={ this.toggleWarningModal }
 						className="sidebar-modal-opener__warning-modal"

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -15,13 +15,13 @@ import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
 /* eslint-enable import/no-extraneous-dependencies */
 
-export class SidebarTemplateOpener extends Component {
+class SidebarModalOpener extends Component {
 	state = {
 		isTemplateModalOpen: false,
 		isWarningOpen: false,
 	};
 
-	togglePlugin = () => {
+	toggleTemplateModal = () => {
 		this.setState( {
 			isTemplateModalOpen: ! this.state.isTemplateModalOpen,
 			isWarningOpen: false,
@@ -32,7 +32,7 @@ export class SidebarTemplateOpener extends Component {
 		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
 	};
 
-	getTemplateUsed = () => {
+	getLastTemplateUsed = () => {
 		if ( ! this.props.templateUsedSlug || this.props.templateUsedSlug === 'blank' ) {
 			return this.props.templates[ 1 ];
 		}
@@ -40,21 +40,38 @@ export class SidebarTemplateOpener extends Component {
 	};
 
 	render() {
-		const { slug, title, preview, previewAlt } = this.getTemplateUsed();
+		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
 		const { templates, vertical, segment, siteInformation } = this.props;
 
 		return (
 			<div className="sidebar-modal-opener">
+				<TemplateSelectorItem
+					id="sidebar-modal-opener__template-preview"
+					value={ slug }
+					label={ replacePlaceholders( title, siteInformation ) }
+					staticPreviewImg={ preview }
+					staticPreviewImgAlt={ previewAlt }
+				/>
+
+				<Button
+					isPrimary
+					onClick={ this.toggleWarningModal }
+					className="sidebar-modal-opener__button"
+				>
+					{ __( 'Change Layout' ) }
+				</Button>
+
 				{ this.state.isTemplateModalOpen ? (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
 						templates={ templates }
 						vertical={ vertical }
 						segment={ segment }
-						togglePlugin={ this.togglePlugin }
+						toggleTemplateModal={ this.toggleTemplateModal }
 						isPromptedFromSidebar
 					/>
 				) : null }
+
 				{ this.state.isWarningOpen ? (
 					<Modal
 						title={ __( 'Overwrite Page Content?' ) }
@@ -71,28 +88,12 @@ export class SidebarTemplateOpener extends Component {
 							<Button isDefault onClick={ this.toggleWarningModal }>
 								{ __( 'Cancel' ) }
 							</Button>
-							<Button isPrimary onClick={ this.togglePlugin }>
+							<Button isPrimary onClick={ this.toggleTemplateModal }>
 								{ __( 'Change Layout' ) }
 							</Button>
 						</div>
 					</Modal>
 				) : null }
-
-				<TemplateSelectorItem
-					id="sidebar-modal-opener__template-preview"
-					value={ slug }
-					label={ replacePlaceholders( title, siteInformation ) }
-					staticPreviewImg={ preview }
-					staticPreviewImgAlt={ previewAlt }
-				/>
-
-				<Button
-					isPrimary
-					onClick={ this.toggleWarningModal }
-					className="sidebar-modal-opener__button"
-				>
-					{ __( 'Change Layout' ) }
-				</Button>
 			</div>
 		);
 	}
@@ -103,6 +104,6 @@ const SidebarTemplatesPlugin = compose(
 		templateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 			._starter_page_template,
 	} ) )
-)( SidebarTemplateOpener );
+)( SidebarModalOpener );
 
 export default SidebarTemplatesPlugin;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -1,0 +1,111 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+import { Button, Modal } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+/**
+ * Internal dependencies
+ */
+import { PageTemplatesPlugin } from '../index';
+import TemplateSelectorItem from './template-selector-item';
+import replacePlaceholders from '../utils/replace-placeholders';
+/* eslint-enable import/no-extraneous-dependencies */
+
+export class SidebarTemplateOpener extends Component {
+	state = {
+		isOpen: false,
+		isWarningOpen: false,
+	};
+
+	togglePlugin = () => {
+		this.setState( { isOpen: ! this.state.isOpen, isWarningOpen: false } );
+	};
+
+	toggleWarningModal = () => {
+		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
+	};
+
+	getTemplateUsed = () => {
+		if ( ! this.props.templateUsedSlug || this.props.templateUsedSlug === 'blank' ) {
+			return this.props.templates[ 1 ];
+		}
+		return this.props.templates.filter( temp => temp.slug === this.props.templateUsedSlug )[ 0 ];
+	};
+
+	render() {
+		const { slug, title, preview, previewAlt } = this.getTemplateUsed();
+		const { templates, vertical, segment, siteInformation } = this.props;
+
+		return (
+			<div
+				style={ {
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'center',
+					justifyContent: 'center',
+				} }
+			>
+				{ this.state.isOpen ? (
+					<PageTemplatesPlugin
+						shouldPrefetchAssets={ false }
+						templates={ templates }
+						vertical={ vertical }
+						segment={ segment }
+						togglePlugin={ this.togglePlugin }
+						isPromptedFromSidebar
+					/>
+				) : null }
+				{ this.state.isWarningOpen ? (
+					<Modal
+						title="Are You Sure?"
+						// labelledby="Changing the page's layout will remove any customizations or edits you have already made."
+						isDismissible={ false }
+						onRequestClose={ this.toggleWarningModal }
+						className="sidebar-modal-opener__warning-modal"
+					>
+						<div className="sidebar-modal-opener__warning-text">
+							Changing the page's layout will remove any customizations or edits you have already
+							made.
+						</div>
+						<div className="sidebar-modal-opener__warning-options">
+							<Button isDefault onClick={ this.toggleWarningModal }>
+								Cancel
+							</Button>
+							<Button isPrimary onClick={ this.togglePlugin }>
+								Change Layout
+							</Button>
+						</div>
+					</Modal>
+				) : null }
+
+				<TemplateSelectorItem
+					id="sidebar-modal-opener__template-preview"
+					value={ slug }
+					label={ replacePlaceholders( title, siteInformation ) }
+					staticPreviewImg={ preview }
+					staticPreviewImgAlt={ previewAlt }
+				/>
+
+				<Button
+					isPrimary
+					onClick={ this.toggleWarningModal }
+					className="sidebar-modal-opener__button"
+				>
+					Change Layout
+				</Button>
+			</div>
+		);
+	}
+}
+
+const SidebarTemplatesPlugin = compose(
+	withSelect( select => ( {
+		templateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+			._starter_page_template,
+	} ) )
+)( SidebarTemplateOpener );
+
+export default SidebarTemplatesPlugin;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -22,10 +22,7 @@ class SidebarModalOpener extends Component {
 	};
 
 	toggleTemplateModal = () => {
-		this.setState( {
-			isTemplateModalOpen: ! this.state.isTemplateModalOpen,
-			isWarningOpen: false,
-		} );
+		this.setState( { isTemplateModalOpen: ! this.state.isTemplateModalOpen } );
 	};
 
 	toggleWarningModal = () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -299,10 +299,15 @@ if ( window.location.toString().includes( 'post-new' ) ) {
 export class SidebarTemplateOpener extends Component {
 	state = {
 		isOpen: false,
+		isWarningOpen: false,
 	};
 
 	togglePlugin = () => {
-		this.setState( { isOpen: ! this.state.isOpen } );
+		this.setState( { isOpen: ! this.state.isOpen, isWarningOpen: false } );
+	};
+
+	toggleWarningModal = () => {
+		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
 	};
 
 	render() {
@@ -316,14 +321,30 @@ export class SidebarTemplateOpener extends Component {
 						segment={ segment }
 						togglePlugin={ this.togglePlugin }
 					/>
-				) : (
-					<button
-						onClick={ this.togglePlugin }
-						className="page-template-modal__sidebar-button components-button components-icon-button is-button is-default"
+				) : null }
+				{ this.state.isWarningOpen ? (
+					<Modal
+						title="Are You Sure?"
+						// labelledby="Changing the page's layout will remove any customizations or edits you have already made."
+						isDismissible={ false }
+						onRequestClose={ this.toggleWarningModal }
 					>
-						Open Layout Selector
-					</button>
-				) }
+						<div>
+							Changing the page's layout will remove any customizations or edits you have already
+							made.
+						</div>
+						<Button isDefault onClick={ this.toggleWarningModal }>
+							Cancel
+						</Button>
+						<Button isPrimary onClick={ this.togglePlugin }>
+							Change Layout
+						</Button>
+					</Modal>
+				) : null }
+
+				<Button isPrimary onClick={ this.toggleWarningModal }>
+					Open Layout Selector
+				</Button>
 			</>
 		);
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -12,7 +12,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
 import { parse as parseBlocks } from '@wordpress/blocks';
-
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 /**
  * Internal dependencies
  */
@@ -127,6 +127,7 @@ class PageTemplateModal extends Component {
 		}
 
 		this.setTemplate( slug );
+		this.props.togglePlugin();
 	};
 
 	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
@@ -290,4 +291,51 @@ registerPlugin( 'page-templates', {
 			/>
 		);
 	},
+} );
+
+class SidebarTemplateOpener extends Component {
+	state = {
+		isOpen: false,
+	};
+
+	togglePlugin = () => {
+		this.setState( { isOpen: ! this.state.isOpen } );
+	};
+
+	render() {
+		return (
+			<>
+				{ this.state.isOpen ? (
+					<PageTemplatesPlugin
+						shouldPrefetchAssets={ false }
+						templates={ templates }
+						vertical={ vertical }
+						segment={ segment }
+						togglePlugin={ this.togglePlugin }
+					/>
+				) : (
+					<button
+						onClick={ this.togglePlugin }
+						className="page-template-modal__sidebar-button components-button components-icon-button is-button is-default"
+					>
+						Open Layout Selector
+					</button>
+				) }
+			</>
+		);
+	}
+}
+
+const PluginDocumentSettingPanelDemo = () => (
+	<PluginDocumentSettingPanel
+		name="Template Plugin Opener"
+		title="Choose a Layout"
+		className="page-template-modal__sidebar"
+	>
+		<SidebarTemplateOpener />
+	</PluginDocumentSettingPanel>
+);
+
+registerPlugin( 'page-templates-sidebar', {
+	render: PluginDocumentSettingPanelDemo,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -280,20 +280,23 @@ if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );
 }
 
-registerPlugin( 'page-templates', {
-	render: () => {
-		return (
-			<PageTemplatesPlugin
-				shouldPrefetchAssets={ false }
-				templates={ templates }
-				vertical={ vertical }
-				segment={ segment }
-			/>
-		);
-	},
-} );
+// !? - better way?  can acess get_current_screen or wordpress screen object?
+if ( window.location.toString().includes( 'post-new' ) ) {
+	registerPlugin( 'page-templates', {
+		render: () => {
+			return (
+				<PageTemplatesPlugin
+					shouldPrefetchAssets={ false }
+					templates={ templates }
+					vertical={ vertical }
+					segment={ segment }
+				/>
+			);
+		},
+	} );
+}
 
-class SidebarTemplateOpener extends Component {
+export class SidebarTemplateOpener extends Component {
 	state = {
 		isOpen: false,
 	};

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -22,6 +22,7 @@ import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
 import replacePlaceholders from './utils/replace-placeholders';
 import ensureAssets from './utils/ensure-assets';
+import SidebarTemplatesPlugin from './components/sidebar-modal-opener';
 /* eslint-enable import/no-extraneous-dependencies */
 
 // Load config passed from backend.
@@ -245,7 +246,7 @@ class PageTemplateModal extends Component {
 	}
 }
 
-const PageTemplatesPlugin = compose(
+export const PageTemplatesPlugin = compose(
 	withSelect( select => ( {
 		getMeta: () => select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
 		postContentBlock: select( 'core/editor' )
@@ -305,105 +306,18 @@ if ( window.location.toString().includes( 'post-new' ) ) {
 	} );
 }
 
-import TemplateSelectorItem from './components/template-selector-item';
-
-export class SidebarTemplateOpener extends Component {
-	state = {
-		isOpen: false,
-		isWarningOpen: false,
-	};
-
-	togglePlugin = () => {
-		this.setState( { isOpen: ! this.state.isOpen, isWarningOpen: false } );
-	};
-
-	toggleWarningModal = () => {
-		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
-	};
-
-	getTemplateUsed = () => {
-		if ( ! this.props.templateUsedSlug ) {
-			return templates[ 1 ];
-		}
-		return templates.filter( temp => temp.slug === this.props.templateUsedSlug )[ 0 ];
-	};
-
-	render() {
-		// const blocksByTemplates = this.state.blocksByTemplateSlug;
-		const { slug, title, preview, previewAlt } = this.getTemplateUsed();
-
-		return (
-			<div
-				style={ {
-					display: 'flex',
-					flexDirection: 'column',
-					alignItems: 'center',
-					justifyContent: 'center',
-				} }
-			>
-				{ this.state.isOpen ? (
-					<PageTemplatesPlugin
-						shouldPrefetchAssets={ false }
-						templates={ templates }
-						vertical={ vertical }
-						segment={ segment }
-						togglePlugin={ this.togglePlugin }
-						isPromptedFromSidebar
-					/>
-				) : null }
-				{ this.state.isWarningOpen ? (
-					<Modal
-						title="Are You Sure?"
-						// labelledby="Changing the page's layout will remove any customizations or edits you have already made."
-						isDismissible={ false }
-						onRequestClose={ this.toggleWarningModal }
-					>
-						<div>
-							Changing the page's layout will remove any customizations or edits you have already
-							made.
-						</div>
-						<Button isDefault onClick={ this.toggleWarningModal }>
-							Cancel
-						</Button>
-						<Button isPrimary onClick={ this.togglePlugin }>
-							Change Layout
-						</Button>
-					</Modal>
-				) : null }
-
-				<TemplateSelectorItem
-					id="fubar--101"
-					value={ slug }
-					label={ replacePlaceholders( title, siteInformation ) }
-					// label={ templates[2].title || "??" }
-					staticPreviewImg={ preview }
-					staticPreviewImgAlt={ previewAlt }
-					// blocks={ blocksByTemplates.hasOwnProperty( templates[2].slug ) ? blocksByTemplates[ templates[2].slug ] : [] }
-					// onSelect={ () => {} }
-				/>
-
-				<Button isPrimary onClick={ this.toggleWarningModal }>
-					Change Layout
-				</Button>
-			</div>
-		);
-	}
-}
-
-const SidebarTemplatesPlugin = compose(
-	withSelect( select => ( {
-		templateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
-			._starter_page_template,
-	} ) )
-)( SidebarTemplateOpener );
-
 const PluginDocumentSettingPanelDemo = () => (
 	<PluginDocumentSettingPanel
 		name="Template Plugin Opener"
 		title="Page Layout"
 		className="page-template-modal__sidebar"
 	>
-		<SidebarTemplatesPlugin />
+		<SidebarTemplatesPlugin
+			templates={ templates }
+			vertical={ vertical }
+			segment={ segment }
+			siteInformation={ siteInformation }
+		/>
 	</PluginDocumentSettingPanel>
 );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -311,7 +311,6 @@ export class SidebarTemplateOpener extends Component {
 	state = {
 		isOpen: false,
 		isWarningOpen: false,
-		// blocksByTemplateSlug: {}
 	};
 
 	togglePlugin = () => {
@@ -322,8 +321,16 @@ export class SidebarTemplateOpener extends Component {
 		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
 	};
 
+	getTemplateUsed = () => {
+		if ( ! this.props.templateUsedSlug ) {
+			return templates[ 1 ];
+		}
+		return templates.filter( temp => temp.slug === this.props.templateUsedSlug )[ 0 ];
+	};
+
 	render() {
 		// const blocksByTemplates = this.state.blocksByTemplateSlug;
+		const { slug, title, preview, previewAlt } = this.getTemplateUsed();
 
 		return (
 			<div
@@ -366,12 +373,12 @@ export class SidebarTemplateOpener extends Component {
 
 				<TemplateSelectorItem
 					id="fubar--101"
-					value={ templates[ 5 ].slug }
-					label={ replacePlaceholders( templates[ 5 ].title, siteInformation ) }
-					// label={ templates[5].title || "??" }
-					staticPreviewImg={ templates[ 5 ].preview }
-					staticPreviewImgAlt={ templates[ 5 ].previewAlt }
-					// blocks={ blocksByTemplates.hasOwnProperty( templates[5].slug ) ? blocksByTemplates[ templates[5].slug ] : [] }
+					value={ slug }
+					label={ replacePlaceholders( title, siteInformation ) }
+					// label={ templates[2].title || "??" }
+					staticPreviewImg={ preview }
+					staticPreviewImgAlt={ previewAlt }
+					// blocks={ blocksByTemplates.hasOwnProperty( templates[2].slug ) ? blocksByTemplates[ templates[2].slug ] : [] }
 					// onSelect={ () => {} }
 				/>
 
@@ -383,13 +390,20 @@ export class SidebarTemplateOpener extends Component {
 	}
 }
 
+const SidebarTemplatesPlugin = compose(
+	withSelect( select => ( {
+		templateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+			._starter_page_template,
+	} ) )
+)( SidebarTemplateOpener );
+
 const PluginDocumentSettingPanelDemo = () => (
 	<PluginDocumentSettingPanel
 		name="Template Plugin Opener"
 		title="Page Layout"
 		className="page-template-modal__sidebar"
 	>
-		<SidebarTemplateOpener />
+		<SidebarTemplatesPlugin />
 	</PluginDocumentSettingPanel>
 );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -291,7 +291,7 @@ if ( tracksUserData ) {
 }
 
 // Don't open plugin if we arent creating new page.
-// Is there better way?  Can we acess get_current_screen or wordpress screen object like in php?
+// Is there better way?  Can we acess get_current_screen for wordpress screen object like in php?
 if ( window.location.toString().includes( 'post-new' ) ) {
 	registerPlugin( 'page-templates', {
 		render: () => {
@@ -307,21 +307,23 @@ if ( window.location.toString().includes( 'post-new' ) ) {
 	} );
 }
 
-const PluginDocumentSettingPanelDemo = () => (
-	<PluginDocumentSettingPanel
-		name="Template Plugin Opener"
-		title="Page Layout"
-		className="page-template-modal__sidebar"
-	>
-		<SidebarTemplatesPlugin
-			templates={ templates }
-			vertical={ vertical }
-			segment={ segment }
-			siteInformation={ siteInformation }
-		/>
-	</PluginDocumentSettingPanel>
-);
-
+// Always register ability to open from document sidebar.
 registerPlugin( 'page-templates-sidebar', {
-	render: PluginDocumentSettingPanelDemo,
+	render: () => {
+		return (
+			<PluginDocumentSettingPanel
+				name="Template Modal Opener"
+				title={ __( 'Page Layout' ) }
+				className="page-template-modal__sidebar"
+				icon="admin-page"
+			>
+				<SidebarTemplatesPlugin
+					templates={ templates }
+					vertical={ vertical }
+					segment={ segment }
+					siteInformation={ siteInformation }
+				/>
+			</PluginDocumentSettingPanel>
+		);
+	},
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -129,11 +129,6 @@ class PageTemplateModal extends Component {
 		}
 
 		this.setTemplate( slug );
-
-		// Turn off sidebar's rendering of modal
-		if ( this.props.isPromptedFromSidebar ) {
-			this.props.toggleTemplateModal();
-		}
 	};
 
 	previewTemplate = slug => this.setState( { previewedTemplate: slug } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -128,7 +128,11 @@ class PageTemplateModal extends Component {
 		}
 
 		this.setTemplate( slug );
-		this.props.toggleTemplateModal();
+
+		// Turn off sidebar's rendering of modal
+		if ( this.props.isPromptedFromSidebar ) {
+			this.props.toggleTemplateModal();
+		}
 	};
 
 	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
@@ -273,12 +277,11 @@ export const PageTemplatesPlugin = compose(
 				// Set post title.
 				editorDispatcher.editPost( { title } );
 
-				// Insert blocks.
+				// Replace blocks.
 				const postContentBlock = ownProps.postContentBlock;
-				dispatch( 'core/block-editor' ).insertBlocks(
-					blocks,
-					0,
+				dispatch( 'core/block-editor' ).replaceInnerBlocks(
 					postContentBlock ? postContentBlock.clientId : '',
+					blocks,
 					false
 				);
 			},

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -32,7 +32,7 @@ const {
 	segment,
 	tracksUserData,
 	siteInformation = {},
-	screen,
+	screenAction,
 } = window.starterPageTemplatesConfig;
 
 class PageTemplateModal extends Component {
@@ -295,7 +295,7 @@ if ( tracksUserData ) {
 }
 
 // Open plugin only if we are creating new page.
-if ( screen.action === 'add' ) {
+if ( screenAction === 'add' ) {
 	registerPlugin( 'page-templates', {
 		render: () => {
 			return (

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -129,6 +129,11 @@ class PageTemplateModal extends Component {
 		}
 
 		this.setTemplate( slug );
+
+		// Turn off sidebar's instance of modal
+		if ( this.props.isPromptedFromSidebar ) {
+			this.props.toggleTemplateModal();
+		}
 	};
 
 	previewTemplate = slug => this.setState( { previewedTemplate: slug } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -128,7 +128,7 @@ class PageTemplateModal extends Component {
 		}
 
 		this.setTemplate( slug );
-		this.props.togglePlugin();
+		this.props.toggleTemplateModal();
 	};
 
 	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
@@ -178,7 +178,7 @@ class PageTemplateModal extends Component {
 				{ isPromptedFromSidebar ? (
 					<IconButton
 						className="page-template-modal__close-button components-icon-button"
-						onClick={ this.props.togglePlugin }
+						onClick={ this.props.toggleTemplateModal }
 						icon="no-alt"
 						label={ __( 'Close Layout Selector' ) }
 					/>
@@ -290,7 +290,8 @@ if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );
 }
 
-// !? - better way?  can acess get_current_screen or wordpress screen object?
+// Don't open plugin if we arent creating new page.
+// Is there better way?  Can we acess get_current_screen or wordpress screen object like in php?
 if ( window.location.toString().includes( 'post-new' ) ) {
 	registerPlugin( 'page-templates', {
 		render: () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -32,6 +32,7 @@ const {
 	segment,
 	tracksUserData,
 	siteInformation = {},
+	screen,
 } = window.starterPageTemplatesConfig;
 
 class PageTemplateModal extends Component {
@@ -293,9 +294,8 @@ if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );
 }
 
-// Don't open plugin if we arent creating new page.
-// Is there better way?  Can we acess get_current_screen for wordpress screen object like in php?
-if ( window.location.toString().includes( 'post-new' ) ) {
+// Open plugin only if we are creating new page.
+if ( screen.action === 'add' ) {
 	registerPlugin( 'page-templates', {
 		render: () => {
 			return (

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -157,7 +157,7 @@ class PageTemplateModal extends Component {
 	render() {
 		/* eslint-disable no-shadow */
 		const { previewedTemplate, isOpen, isLoading, blocksByTemplateSlug } = this.state;
-		const { templates } = this.props;
+		const { templates, isPromptedFromSidebar } = this.props;
 		/* eslint-enable no-shadow */
 
 		if ( ! isOpen ) {
@@ -174,12 +174,21 @@ class PageTemplateModal extends Component {
 				isDismissable={ false }
 				isDismissible={ false }
 			>
-				<IconButton
-					className="page-template-modal__close-button components-icon-button"
-					onClick={ this.closeModal }
-					icon="arrow-left-alt2"
-					label={ __( 'Go back' ) }
-				/>
+				{ isPromptedFromSidebar ? (
+					<IconButton
+						className="page-template-modal__close-button components-icon-button"
+						onClick={ this.props.togglePlugin }
+						icon="no-alt"
+						label={ __( 'Close Layout Selector' ) }
+					/>
+				) : (
+					<IconButton
+						className="page-template-modal__close-button components-icon-button"
+						onClick={ this.closeModal }
+						icon="arrow-left-alt2"
+						label={ __( 'Go back' ) }
+					/>
+				) }
 
 				<div className="page-template-modal__inner">
 					{ isLoading ? (
@@ -296,10 +305,13 @@ if ( window.location.toString().includes( 'post-new' ) ) {
 	} );
 }
 
+import TemplateSelectorItem from './components/template-selector-item';
+
 export class SidebarTemplateOpener extends Component {
 	state = {
 		isOpen: false,
 		isWarningOpen: false,
+		// blocksByTemplateSlug: {}
 	};
 
 	togglePlugin = () => {
@@ -311,8 +323,17 @@ export class SidebarTemplateOpener extends Component {
 	};
 
 	render() {
+		// const blocksByTemplates = this.state.blocksByTemplateSlug;
+
 		return (
-			<>
+			<div
+				style={ {
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'center',
+					justifyContent: 'center',
+				} }
+			>
 				{ this.state.isOpen ? (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
@@ -320,6 +341,7 @@ export class SidebarTemplateOpener extends Component {
 						vertical={ vertical }
 						segment={ segment }
 						togglePlugin={ this.togglePlugin }
+						isPromptedFromSidebar
 					/>
 				) : null }
 				{ this.state.isWarningOpen ? (
@@ -342,10 +364,21 @@ export class SidebarTemplateOpener extends Component {
 					</Modal>
 				) : null }
 
+				<TemplateSelectorItem
+					id="fubar--101"
+					value={ templates[ 5 ].slug }
+					label={ replacePlaceholders( templates[ 5 ].title, siteInformation ) }
+					// label={ templates[5].title || "??" }
+					staticPreviewImg={ templates[ 5 ].preview }
+					staticPreviewImgAlt={ templates[ 5 ].previewAlt }
+					// blocks={ blocksByTemplates.hasOwnProperty( templates[5].slug ) ? blocksByTemplates[ templates[5].slug ] : [] }
+					// onSelect={ () => {} }
+				/>
+
 				<Button isPrimary onClick={ this.toggleWarningModal }>
-					Open Layout Selector
+					Change Layout
 				</Button>
-			</>
+			</div>
 		);
 	}
 }
@@ -353,7 +386,7 @@ export class SidebarTemplateOpener extends Component {
 const PluginDocumentSettingPanelDemo = () => (
 	<PluginDocumentSettingPanel
 		name="Template Plugin Opener"
-		title="Choose a Layout"
+		title="Page Layout"
 		className="page-template-modal__sidebar"
 	>
 		<SidebarTemplateOpener />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -72,33 +72,33 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 // Show close button only in full screen mode.
-.page-template-modal .components-modal__header::after,
+// .page-template-modal .components-modal__header::after,
+// .page-template-modal__close-button {
+// 	display: none;
+// }
+
+// body.is-fullscreen-mode {
 .page-template-modal__close-button {
-	display: none;
+	display: block;
+	position: absolute;
+	z-index: 20;
+	top: 9px;
+	width: 36px;
+	height: 36px;
+	left: 8px;
 }
 
-body.is-fullscreen-mode {
-	.page-template-modal__close-button {
+.page-template-modal .components-modal__header {
+	&::after {
 		display: block;
 		position: absolute;
-		z-index: 20;
-		top: 9px;
-		width: 36px;
-		height: 36px;
-		left: 8px;
-	}
-
-	.page-template-modal .components-modal__header {
-		&::after {
-			display: block;
-			position: absolute;
-			content: ' ';
-			border-right: 1px solid #e2e4e7;
-			height: 100%;
-			left: 54px;
-		}
+		content: ' ';
+		border-right: 1px solid #e2e4e7;
+		height: 100%;
+		left: 54px;
 	}
 }
+// }
 
 .page-template-modal .components-modal__content {
 	overflow-y: scroll;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -124,7 +124,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 }
 
-.page-template-modal__list {
+.page-template-modal__list,
+.sidebar-modal-opener {
 	.components-base-control__label {
 		@include screen-reader-text();
 	}
@@ -508,6 +509,10 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
+	
+	.template-selector-item__template-title {
+		font-size: 1.2rem;
+	}
 }
 
 .sidebar-modal-opener__button {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -509,6 +509,13 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 }
 
 // Sidebar modal opener goo.
+.sidebar-modal-opener {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+}
+
 .sidebar-modal-opener__button {
 	margin-top: 20px;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -71,13 +71,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	@include screen-reader-text();
 }
 
-// Show close button only in full screen mode.
-// .page-template-modal .components-modal__header::after,
-// .page-template-modal__close-button {
-// 	display: none;
-// }
-
-// body.is-fullscreen-mode {
+// Show close button in all modes.
+// Removed previous condition to only show in fullscreen with PR #37500.
 .page-template-modal__close-button {
 	display: block;
 	position: absolute;
@@ -98,7 +93,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		left: 54px;
 	}
 }
-// }
 
 .page-template-modal .components-modal__content {
 	overflow-y: scroll;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -507,3 +507,27 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 		float: none;
 	}
 }
+
+// Sidebar modal opener goo.
+.sidebar-modal-opener__button {
+	margin-top: 20px;
+}
+
+.sidebar-modal-opener__warning-modal {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+}
+
+.sidebar-modal-opener__warning-text {
+	max-width: 300px;
+	font-size: 1rem;
+	line-height: 1.5rem;
+}
+
+.sidebar-modal-opener__warning-options {
+	display: flex;
+	justify-content: space-around;
+	margin-top: 20px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds access to page template selector in document sidebar.
* Allows access to template selector for already existing pages.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Tested both locally and on sandbox.
* Run this PR.
* Navigate to add a new page.
* Verify template selector works as expected, select a template.
* Navigate to the document sidebar and the `Page Layout` dropdown.
* Verify the current template is rendered in the preview.
* Select the `change layout` button
* Verify warning modal appears and can be cancelled.
* Select 'change layout' from the warning modal.
* Select a new template and apply.
* Verify the new template is in place.

* Repeat this testing process for an already existing page.

![Screen Shot 2019-11-11 at 8 05 30 PM](https://user-images.githubusercontent.com/28742426/68633130-b4b0bb80-04be-11ea-91ce-61ceb53deb77.png)

![Screen Shot 2019-11-11 at 8 05 37 PM](https://user-images.githubusercontent.com/28742426/68633133-b8444280-04be-11ea-9091-cce10bee1fc2.png)

![Screen Shot 2019-11-11 at 8 05 56 PM](https://user-images.githubusercontent.com/28742426/68633134-ba0e0600-04be-11ea-825a-a8f0517aeb9a.png)


Fixes #37281
