### PR TITLE
Checkout: Add composite-checkout behind feature flag

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+	Checkout,
+	CheckoutProvider,
+	createRegistry,
+	createStripeMethod,
+	createApplePayMethod,
+	createPayPalMethod,
+	WPCheckoutOrderSummary,
+	WPCheckoutOrderReview,
+} from '@automattic/composite-checkout';
+import wp from 'lib/wp';
+
+const initialItems = [
+	{
+		label: 'WordPress.com Personal Plan',
+		id: 'wpcom-personal',
+		type: 'plan',
+		amount: { currency: 'USD', value: 6000, displayValue: '$60' },
+	},
+	{
+		label: 'Domain registration',
+		subLabel: 'example.com',
+		id: 'wpcom-domain',
+		type: 'domain',
+		amount: { currency: 'USD', value: 0, displayValue: '~~$17~~ 0' },
+	},
+];
+
+// These are used only for non-redirect payment methods
+const onSuccess = () => window.alert( 'Payment succeeded!' );
+const onFailure = error => window.alert( 'There was a problem with your payment: ' + error );
+
+// These are used only for redirect payment methods
+const successRedirectUrl = window.location.href;
+const failureRedirectUrl = window.location.href;
+
+const wpcom = wp.undocumented();
+
+async function fetchStripeConfiguration( requestArgs ) {
+	return wpcom.stripeConfiguration( requestArgs );
+}
+
+async function sendStripeTransaction() {
+	// return await wpcom.req.post( '/me/transactions', transaction );
+	return {
+		success: true,
+	};
+}
+
+async function makePayPalExpressRequest() {
+	// return this.wpcom.req.post( '/me/paypal-express-url', data );
+	return window.location.href;
+}
+
+const registry = createRegistry();
+const { registerStore, select, subscribe } = registry;
+
+const stripeMethod = createStripeMethod( {
+	registerStore,
+	fetchStripeConfiguration,
+	sendStripeTransaction,
+} );
+
+const applePayMethod = isApplePayAvailable()
+	? createApplePayMethod( {
+			registerStore,
+			fetchStripeConfiguration,
+	  } )
+	: null;
+
+const paypalMethod = createPayPalMethod( { registerStore, makePayPalExpressRequest } );
+
+function isApplePayAvailable() {
+	// Our Apple Pay implementation uses the Payment Request API, so check that first.
+	if ( ! window.PaymentRequest ) {
+		return false;
+	}
+
+	// Check if Apple Pay is available. This can be very expensive on certain
+	// Safari versions due to a bug (https://trac.webkit.org/changeset/243447/webkit),
+	// and there is no way it can change during a page request, so cache the
+	// result.
+	if ( typeof isApplePayAvailable.canMakePayments === 'undefined' ) {
+		try {
+			isApplePayAvailable.canMakePayments = Boolean(
+				window.ApplePaySession && window.ApplePaySession.canMakePayments()
+			);
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+			return false;
+		}
+	}
+	return isApplePayAvailable.canMakePayments;
+}
+
+const handleEvent = setItems => () => {
+	const cardholderName = select( 'stripe' ).getCardholderName();
+	if ( cardholderName === 'admin' ) {
+		setItems( items =>
+			items.map( item => ( { ...item, amount: { ...item.amount, value: 0, displayValue: '0' } } ) )
+		);
+	}
+};
+
+const getTotal = items => {
+	const lineItemTotal = items.reduce( ( sum, item ) => sum + item.amount.value, 0 );
+	const currency = items.reduce( ( lastCurrency, item ) => item.amount.currency, 'USD' );
+	return {
+		label: 'Total',
+		amount: {
+			currency,
+			value: lineItemTotal,
+			displayValue: formatValueForCurrency( currency, lineItemTotal ),
+		},
+	};
+};
+
+// This is the parent component which would be included on a host page
+export default function CompositeCheckoutContainer() {
+	const [ items, setItems ] = useState( initialItems );
+	useEffect( () => {
+		subscribe( handleEvent( setItems ) );
+	}, [] );
+	const total = useMemo( () => getTotal( items ), [ items ] );
+
+	return (
+		<CheckoutProvider
+			locale={ 'US' }
+			items={ items }
+			total={ total }
+			onSuccess={ onSuccess }
+			onFailure={ onFailure }
+			successRedirectUrl={ successRedirectUrl }
+			failureRedirectUrl={ failureRedirectUrl }
+			registry={ registry }
+			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
+		>
+			<Checkout OrderSummary={ WPCheckoutOrderSummary } ReviewContent={ WPCheckoutOrderReview } />
+		</CheckoutProvider>
+	);
+}
+
+function formatValueForCurrency( currency, value ) {
+	if ( currency !== 'USD' ) {
+		throw new Error( `Unsupported currency ${ currency }'` );
+	}
+	const floatValue = value / 100;
+	return '$' + floatValue.toString();
+}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -22,6 +22,8 @@ import UpsellNudge from './upsell-nudge';
 import { isGSuiteRestricted } from 'lib/gsuite';
 import { getRememberedCoupon } from 'lib/cart/actions';
 import { sites } from 'my-sites/controller';
+import config from 'config';
+import CompositeCheckoutContainer from './checkout/composite-checkout-container';
 
 export function checkout( context, next ) {
 	const { feature, plan, domainOrProduct, purchaseId } = context.params;
@@ -49,6 +51,12 @@ export function checkout( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 
 	context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
+
+	if ( config.isEnabled( 'composite-checkout' ) ) {
+		context.primary = <CompositeCheckoutContainer />;
+		next();
+		return;
+	}
 
 	context.primary = (
 		<CheckoutContainer

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	"dependencies": {
 		"@automattic/color-studio": "2.2.0",
 		"@automattic/components": "file:./packages/components",
+		"@automattic/composite-checkout": "file:./packages/composite-checkout",
 		"@automattic/format-currency": "file:./packages/format-currency",
 		"@automattic/load-script": "file:./packages/load-script",
 		"@automattic/material-design-icons": "file:./packages/material-design-icons",
@@ -300,7 +301,6 @@
 		"@automattic/babel-plugin-transform-wpcalypso-async": "file:./packages/babel-plugin-transform-wpcalypso-async",
 		"@automattic/calypso-build": "file:./packages/calypso-build",
 		"@automattic/calypso-color-schemes": "file:./packages/calypso-color-schemes",
-		"@automattic/composite-checkout": "file:./packages/composite-checkout",
 		"@automattic/webpack-config-flag-plugin": "file:packages/webpack-config-flag-plugin",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "file:./packages/webpack-extensive-lodash-replacement-plugin",
 		"@automattic/webpack-inline-constant-exports-plugin": "file:./packages/webpack-inline-constant-exports-plugin",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces the current checkout experience with the [@automattic/composite-checkout](https://github.com/Automattic/wp-calypso/blob/master/packages/composite-checkout/README.md) package. The feature flag `composite-checkout` (not enabled here) is used to activate this feature.

This form is still a work-in-progress. Many things are not hooked up yet. Notably, the product list is using mock data until #37099 is ready.

#### Testing instructions

Visit http://calypso.localhost:3000/checkout/[your-site-here]?flags=composite-checkout or [activate the feature flag when starting calypso](https://github.com/Automattic/wp-calypso/blob/master/config/README.md#testing-feature-flags-locally). to see the new form. You must be sandboxing the store to get the Stripe form to load correctly without an error. If you want to see the Apple Pay form, you'll need to use Safari and fake the https certificate.