### PR TITLE
Swap API call for passwordless signup to use usersNew endpoint

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
+import { abtest, getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import { recordGoogleRecaptchaAction } from 'lib/analytics/ad-tracking';
@@ -86,10 +86,14 @@ class PasswordlessSignupForm extends Component {
 		recaptchaPromise.then( recaptchaToken => {
 			wpcom
 				.undocumented()
-				.createUserAccountFromEmailAddress(
+				.usersNew(
 					{
 						email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
 						'g-recaptcha-response': recaptchaToken || undefined,
+						is_passwordless: true,
+						signup_flow_name: this.props.flowName,
+						validate: false,
+						ab_test_variations: getSavedVariations(),
 					},
 					null
 				)
@@ -125,7 +129,7 @@ class PasswordlessSignupForm extends Component {
 
 		this.submitStep( {
 			username: response.username,
-			bearer_token: response.token.access_token,
+			bearer_token: response.bearer_token,
 		} );
 	};
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -139,6 +139,7 @@ class PasswordlessSignupForm extends Component {
 		switch ( errorObj.error ) {
 			case 'already_taken':
 			case 'already_active':
+			case 'email_exists':
 				return (
 					<>
 						{ translate( 'An account with this email address already exists.' ) }
@@ -157,11 +158,8 @@ class PasswordlessSignupForm extends Component {
 					</>
 				);
 			default:
-				return (
-					errorObj.message ||
-					translate(
-						'Sorry, something went wrong when trying to create your account. Please try again.'
-					)
+				return translate(
+					'Sorry, something went wrong when trying to create your account. Please try again.'
 				);
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move passwordless signup to use the `usersNew` method with an `is_passwordless` flag
* Also pass in current flowName and A/B test variations

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D35282-code
* Go to `http://calypso.localhost:3000/start` and select the `passwordless` variant of the `passwordlessSignup` A/B test
* Enter an existing email address, and you should see the same error notification as before, asking you to log in
* Create a new account, and complete signup
