### PR TITLE
chore(build): Create a new layer for node modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,20 @@ ENV        NODE_PATH=/calypso/server:/calypso/client
 COPY       ./env-config.sh /tmp/env-config.sh
 RUN        bash /tmp/env-config.sh
 
+# Build a node_modules layer
+#
+# This one builds out our node_modules tree. Since we use
+# file: references, we have to copy over our 
+# package.json, lockfiles, and the contents of packages/*
+COPY package.json npm-shrinkwrap.json /calypso/
+COPY packages /calypso/packages
+RUN npm ci
+
 # Build a "source" layer
 #
 # This layer is populated with up-to-date files from
 # Calypso development.
 COPY       . /calypso/
-RUN        npm ci
 
 # Build the final layer
 #


### PR DESCRIPTION
Optimize the docker build a bit by creating a reusable layer for `node_modules` and `calypso-build` and friends. Since we use `file:` references in our `package.json` and we have a `post-install` step that builds out `packages/*`, we have to copy over both the root `package.json` and `lockfile` and everything in `packages/*`. This makes the layer a bit less reusable since changes to `packages/*` will invalidate the layer, but it may be good enough to speed up builds for most development now.

To test:
 1. `npm run build-docker`, notice the `npm ci` has a lot of output
 1. Change a file under `client/`, I chose to add some text to `client/state/action-types.js`
 1. `npm run build-docker`. The steps up to and including `npm ci` should resolve from cache, avoiding a `npm ci` run entirely

On a `master` variant, the same steps would result in an `npm ci` run at step 3.