### PR TITLE
Config: Enable Jetpack Backup in Plans page on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -86,7 +86,7 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-backup": false,
+		"plans/jetpack-backup": true,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,


### PR DESCRIPTION
This enables the Jetpack Backup purchase UI in staging, and will allow us to get some internal feedback early in the process.

#### Changes proposed in this Pull Request

* Enable Jetpack Backup in Plans page on staging 

#### Testing instructions

* Not needed - this only enables a feature flag on staging.
