### PR TITLE
Account Closure: List Sites to be Deleted

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -59,6 +59,7 @@ class SiteSelector extends Component {
 		selectedSite: PropTypes.object,
 		visibleSites: PropTypes.arrayOf( PropTypes.object ),
 		allSitesPath: PropTypes.string,
+		noResultsMessage: PropTypes.string,
 		navigateToSite: PropTypes.func.isRequired,
 	};
 
@@ -358,7 +359,9 @@ class SiteSelector extends Component {
 		if ( ! siteElements.length ) {
 			return (
 				<div className="site-selector__no-results">
-					{ this.props.translate( 'No sites found' ) }
+					{ this.props.noResultsMessage
+						? this.props.noResultsMessage
+						: this.props.translate( 'No sites found' ) }
 				</div>
 			);
 		}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -59,7 +59,6 @@ class SiteSelector extends Component {
 		selectedSite: PropTypes.object,
 		visibleSites: PropTypes.arrayOf( PropTypes.object ),
 		allSitesPath: PropTypes.string,
-		noResultsMessage: PropTypes.string,
 		navigateToSite: PropTypes.func.isRequired,
 	};
 
@@ -359,9 +358,7 @@ class SiteSelector extends Component {
 		if ( ! siteElements.length ) {
 			return (
 				<div className="site-selector__no-results">
-					{ this.props.noResultsMessage
-						? this.props.noResultsMessage
-						: this.props.translate( 'No sites found' ) }
+					{ this.props.translate( 'No sites found' ) }
 				</div>
 			);
 		}

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -35,6 +35,7 @@ import { hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purchases';
 import getUserPurchasedPremiumThemes from 'state/selectors/get-user-purchased-premium-themes';
 import userUtils from 'lib/user/utils';
+import { userCan } from 'lib/site/utils';
 
 /**
  * Style dependencies
@@ -85,8 +86,9 @@ class AccountSettingsClose extends Component {
 		}
 	};
 
-	siteFilter = site => {
-		return ! site.jetpack;
+	siteListFilter = site => {		
+		// Do not display sites that cannot be deleted.
+		return ! site.jetpack && userCan( 'manage_options', site );
 	};
 
 	render() {
@@ -126,10 +128,10 @@ class AccountSettingsClose extends Component {
 										{ translate( 'Personal details' ) }
 									</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem className="account-close__sites-item">
-										{ translate( 'Sites' ) }{' '}
+										{ translate( 'Sites' ) }
 										<Gridicon size={ 18 } onClick={ this.handleSiteDropdown } icon="chevron-down" />
 									</ActionPanelFigureListItem>
-									<SiteSelector filter={ this.siteFilter } />
+									<SiteSelector filter={ this.siteListFilter } />
 									<ActionPanelFigureListItem>{ translate( 'Posts' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Pages' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -45,7 +45,7 @@ import './style.scss';
 class AccountSettingsClose extends Component {
 	state = {
 		showConfirmDialog: false,
-		showSiteDropdown: false,
+		showSiteDropdown: true,
 	};
 
 	UNSAFE_componentWillReceiveProps = nextProps => {
@@ -86,7 +86,7 @@ class AccountSettingsClose extends Component {
 		}
 	};
 
-	siteListFilter = site => {		
+	siteListFilter = site => {
 		// Do not display sites that cannot be deleted.
 		return ! site.jetpack && userCan( 'manage_options', site );
 	};
@@ -131,7 +131,12 @@ class AccountSettingsClose extends Component {
 										{ translate( 'Sites' ) }
 										<Gridicon size={ 18 } onClick={ this.handleSiteDropdown } icon="chevron-down" />
 									</ActionPanelFigureListItem>
-									<SiteSelector filter={ this.siteListFilter } />
+									{ this.state.showSiteDropdown && (
+										<SiteSelector
+											filter={ this.siteListFilter }
+											noResultsMessage={ translate( 'You have no sites that will be deleted' ) }
+										/>
+									) }
 									<ActionPanelFigureListItem>{ translate( 'Posts' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Pages' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -130,7 +130,7 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>
 										{ translate( 'Personal details' ) }
 									</ActionPanelFigureListItem>
-									{ listSites !== '' && (
+									{ siteToBeDeleted.length > 0 && (
 										<Fragment>
 											<ActionPanelFigureListItem className="account-close__sites-item">
 												{ translate( 'Sites' ) }

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -93,21 +93,12 @@ class AccountSettingsClose extends Component {
 			hasCancelablePurchases,
 			isLoading,
 			purchasedPremiumThemes,
-			siteToBeDeleted,
 		} = this.props;
 		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasCancelablePurchases;
 		const containerClasses = classnames( 'account-close', 'main', {
 			'is-loading': isLoading,
 			'is-hiding-other-sites': this.state.showSiteDropdown,
 		} );
-
-		/* eslint-disable-next-line no-shadow */
-		const listSites = siteToBeDeleted.map( siteToBeDeleted => (
-			<li key={ siteToBeDeleted.slug }>
-				{ [ siteToBeDeleted.name ] }
-				<span>{ [ siteToBeDeleted.slug ] }</span>
-			</li>
-		) );
 
 		return (
 			<div className={ containerClasses } role="main">
@@ -130,7 +121,7 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>
 										{ translate( 'Personal details' ) }
 									</ActionPanelFigureListItem>
-									{ siteToBeDeleted.length > 0 && (
+									{ this.props.siteToBeDeleted.length > 0 && (
 										<Fragment>
 											<ActionPanelFigureListItem className="account-close__sites-item">
 												{ translate( 'Sites' ) }
@@ -140,7 +131,14 @@ class AccountSettingsClose extends Component {
 													icon="chevron-down"
 												/>
 												{ this.state.showSiteDropdown && (
-													<ul className="account-close__sites-list">{ listSites }</ul>
+													<ul className="account-close__sites-list">
+														{ this.props.siteToBeDeleted.map( siteToBeDeleted => (
+															<li key={ siteToBeDeleted.slug }>
+																{ [ siteToBeDeleted.name ] }
+																<span>{ [ siteToBeDeleted.slug ] }</span>
+															</li>
+														) ) }
+													</ul>
 												) }
 											</ActionPanelFigureListItem>
 											<ActionPanelFigureListItem>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -113,7 +113,7 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>
 										{ translate( 'Personal details' ) }
 									</ActionPanelFigureListItem>
-									{ this.props.siteToBeDeleted.length > 0 && (
+									{ this.props.sitesToBeDeleted.length > 0 && (
 										<Fragment>
 											<ActionPanelFigureListItem className="account-close__sites-item">
 												{ translate( 'Sites' ) }
@@ -124,10 +124,10 @@ class AccountSettingsClose extends Component {
 												/>
 												{ this.state.showSiteDropdown && (
 													<ul className="account-close__sites-list">
-														{ this.props.siteToBeDeleted.map( siteToBeDeleted => (
-															<li key={ siteToBeDeleted.slug }>
-																{ [ siteToBeDeleted.name ] }
-																<span>{ [ siteToBeDeleted.slug ] }</span>
+														{ this.props.sitesToBeDeleted.map( sitesToBeDeleted => (
+															<li key={ sitesToBeDeleted.slug }>
+																{ [ sitesToBeDeleted.name ] }
+																<span>{ [ sitesToBeDeleted.slug ] }</span>
 															</li>
 														) ) }
 													</ul>
@@ -288,6 +288,6 @@ export default connect( state => {
 		purchasedPremiumThemes,
 		hasAtomicSites: userHasAnyAtomicSites( state ),
 		isAccountClosed: isAccountClosed( state ),
-		siteToBeDeleted: getAccountClosureSites( state ),
+		sitesToBeDeleted: getAccountClosureSites( state ),
 	};
 } )( localize( AccountSettingsClose ) );

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -297,7 +297,6 @@ export default connect( state => {
 		isLoading,
 		hasCancelablePurchases: hasCancelableUserPurchases( state, currentUserId ),
 		purchasedPremiumThemes,
-		isJetpackSite: isJetpackSite( state, site.ID ),
 		hasAtomicSites: userHasAnyAtomicSites( state ),
 		isAccountClosed: isAccountClosed( state ),
 		siteToBeDeleted: getSites( state ).filter(

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -73,15 +73,9 @@ class AccountSettingsClose extends Component {
 	};
 
 	handleSiteDropdown = () => {
-		this.setState( {
-			showSiteDropdown: true,
-		} );
-
-		if ( this.state.showSiteDropdown ) {
-			this.setState( {
-				showSiteDropdown: false,
-			} );
-		}
+		this.setState( state => ( {
+			showSiteDropdown: ! state.showSiteDropdown,
+		} ) );
 	};
 
 	render() {

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -27,16 +27,14 @@ import AccountCloseConfirmDialog from './confirm-dialog';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import QuerySites from 'components/data/query-sites';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import hasLoadedSites from 'state/selectors/has-loaded-sites';
-import getSites from 'state/selectors/get-sites';
+import getAccountClosureSites from 'state/selectors/get-account-closure-sites';
 import userHasAnyAtomicSites from 'state/selectors/user-has-any-atomic-sites';
 import isAccountClosed from 'state/selectors/is-account-closed';
 import { hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purchases';
 import getUserPurchasedPremiumThemes from 'state/selectors/get-user-purchased-premium-themes';
 import userUtils from 'lib/user/utils';
-import { userCan } from 'lib/site/utils';
 
 /**
  * Style dependencies
@@ -103,10 +101,11 @@ class AccountSettingsClose extends Component {
 			'is-hiding-other-sites': this.state.showSiteDropdown,
 		} );
 
+		/* eslint-disable-next-line no-shadow */
 		const listSites = siteToBeDeleted.map( siteToBeDeleted => (
-			<li>
+			<li key={ siteToBeDeleted.slug }>
 				{ [ siteToBeDeleted.name ] }
-				<span>{ [ siteToBeDeleted.URL ] }</span>
+				<span>{ [ siteToBeDeleted.slug ] }</span>
 			</li>
 		) );
 
@@ -299,8 +298,6 @@ export default connect( state => {
 		purchasedPremiumThemes,
 		hasAtomicSites: userHasAnyAtomicSites( state ),
 		isAccountClosed: isAccountClosed( state ),
-		siteToBeDeleted: getSites( state ).filter(
-			site => ! isJetpackSite( state, site.ID ) && userCan( 'manage_options', site )
-		),
+		siteToBeDeleted: getAccountClosureSites( state ),
 	};
 } )( localize( AccountSettingsClose ) );

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -25,6 +23,7 @@ import ActionPanelFigureListItem from 'components/action-panel/figure-list-item'
 import ActionPanelLink from 'components/action-panel/link';
 import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
+import SiteSelector from 'components/site-selector';
 import AccountCloseConfirmDialog from './confirm-dialog';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import QuerySites from 'components/data/query-sites';
@@ -45,6 +44,7 @@ import './style.scss';
 class AccountSettingsClose extends Component {
 	state = {
 		showConfirmDialog: false,
+		showSiteDropdown: false,
 	};
 
 	UNSAFE_componentWillReceiveProps = nextProps => {
@@ -73,6 +73,22 @@ class AccountSettingsClose extends Component {
 		this.setState( { showConfirmDialog: false } );
 	};
 
+	handleSiteDropdown = () => {
+		this.setState( {
+			showSiteDropdown: true,
+		} );
+
+		if ( this.state.showSiteDropdown ) {
+			this.setState( {
+				showSiteDropdown: false,
+			} );
+		}
+	};
+
+	siteFilter = site => {
+		return ! site.jetpack;
+	};
+
 	render() {
 		const {
 			translate,
@@ -85,6 +101,7 @@ class AccountSettingsClose extends Component {
 		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasCancelablePurchases;
 		const containerClasses = classnames( 'account-close', 'main', {
 			'is-loading': isLoading,
+			'is-hiding-other-sites': this.state.showSiteDropdown,
 		} );
 
 		return (
@@ -108,7 +125,11 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>
 										{ translate( 'Personal details' ) }
 									</ActionPanelFigureListItem>
-									<ActionPanelFigureListItem>{ translate( 'Sites' ) }</ActionPanelFigureListItem>
+									<ActionPanelFigureListItem className="account-close__sites-item">
+										{ translate( 'Sites' ) }{' '}
+										<Gridicon size={ 18 } onClick={ this.handleSiteDropdown } icon="chevron-down" />
+									</ActionPanelFigureListItem>
+									<SiteSelector filter={ this.siteFilter } />
 									<ActionPanelFigureListItem>{ translate( 'Posts' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Pages' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -25,7 +25,6 @@ import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 import AccountCloseConfirmDialog from './confirm-dialog';
 import QueryUserPurchases from 'components/data/query-user-purchases';
-import QuerySites from 'components/data/query-sites';
 import { getCurrentUser } from 'state/current-user/selectors';
 import hasLoadedSites from 'state/selectors/has-loaded-sites';
 import getAccountClosureSites from 'state/selectors/get-account-closure-sites';
@@ -103,7 +102,6 @@ class AccountSettingsClose extends Component {
 		return (
 			<div className={ containerClasses } role="main">
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
-				<QuerySites allSites />
 				<HeaderCake onClick={ this.goBack }>
 					<h1>{ translate( 'Close account' ) }</h1>
 				</HeaderCake>

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -16,6 +16,7 @@
 		.gridicon {
 			cursor: pointer;
 			position: relative;
+			margin-left: 2px;
 			top: 4px;
 		}
 	}

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -23,13 +23,13 @@
 
 	.site-selector {
 		pointer-events: none;
+
+		&__no-results {
+			padding-top: 0;
+		}
 	}
 
 	&.is-hiding-other-sites {
-		.site-selector {
-			display: none;
-		}
-
 		.account-close__sites-item .gridicon {
 			transform: rotate( 180deg );
 		}

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -54,3 +54,4 @@
 .account-close.is-loading .action-panel__footer .button {
 	border: 0;
 }
+

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -27,6 +27,14 @@
 		&__no-results {
 			padding-top: 0;
 		}
+
+		.site-selector__sites {
+			border: 0;
+		}
+
+		.search {
+			display: none;
+		}
 	}
 
 	&.is-hiding-other-sites {

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -18,21 +18,21 @@
 		margin-left: 2px;
 		top: 4px;
 	}
-}
 
-.account-close__sites-list {
-	margin-top: 12px;
+	.account-close__sites-list {
+		margin-top: 12px;
 
-	li {
-		margin-bottom: 8px;
-	}
+		li {
+			margin-bottom: 8px;
+		}
 
-	span {
-		display: block;
-		font-size: 10px;
-		margin-left: 3px;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		span {
+			display: block;
+			font-size: 10px;
+			margin-left: 3px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
 	}
 }
 

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -21,19 +21,19 @@
 		}
 	}
 
-	.site-selector {
-		pointer-events: none;
+	.account-close__sites-list {
+		margin-top: 12px;
 
-		&__no-results {
-			padding-top: 0;
+		li {
+			margin-bottom: 8px;
 		}
 
-		.site-selector__sites {
-			border: 0;
-		}
-
-		.search {
-			display: none;
+		span {
+			display: block;
+			font-size: 10px;
+			margin-left: 3px;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 	}
 
@@ -54,4 +54,3 @@
 .account-close.is-loading .action-panel__footer .button {
 	border: 0;
 }
-

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -11,37 +11,33 @@
 	margin-bottom: 1em;
 }
 
-.account-close {
-	.account-close__sites-item {
-		.gridicon {
-			cursor: pointer;
-			position: relative;
-			margin-left: 2px;
-			top: 4px;
-		}
+.account-close__sites-item {
+	.gridicon {
+		cursor: pointer;
+		position: relative;
+		margin-left: 2px;
+		top: 4px;
+	}
+}
+
+.account-close__sites-list {
+	margin-top: 12px;
+
+	li {
+		margin-bottom: 8px;
 	}
 
-	.account-close__sites-list {
-		margin-top: 12px;
-
-		li {
-			margin-bottom: 8px;
-		}
-
-		span {
-			display: block;
-			font-size: 10px;
-			margin-left: 3px;
-			overflow: hidden;
-			text-overflow: ellipsis;
-		}
+	span {
+		display: block;
+		font-size: 10px;
+		margin-left: 3px;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
+}
 
-	&.is-hiding-other-sites {
-		.account-close__sites-item .gridicon {
-			transform: rotate( 180deg );
-		}
-	}
+.is-hiding-other-sites .account-close__sites-item .gridicon {
+	transform: rotate( 180deg );
 }
 
 // Placeholders

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -11,6 +11,30 @@
 	margin-bottom: 1em;
 }
 
+.account-close {
+	.account-close__sites-item {
+		.gridicon {
+			cursor: pointer;
+			position: relative;
+			top: 4px;
+		}
+	}
+
+	.site-selector {
+		pointer-events: none;
+	}
+
+	&.is-hiding-other-sites {
+		.site-selector {
+			display: none;
+		}
+
+		.account-close__sites-item .gridicon {
+			transform: rotate( 180deg );
+		}
+	}
+}
+
 // Placeholders
 .account-close.is-loading .account-close__body-copy,
 .account-close.is-loading .account-close__body-copy a,
@@ -21,4 +45,3 @@
 .account-close.is-loading .action-panel__footer .button {
 	border: 0;
 }
-

--- a/client/state/selectors/get-account-closure-sites.js
+++ b/client/state/selectors/get-account-closure-sites.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import getSites from 'state/selectors/get-sites';
+import { isJetpackSite } from 'state/sites/selectors';
+import { userCan } from 'lib/site/utils';
+
+/**
+ * Get all the sites which are deleted after account closure
+ *
+ * @param {Object} state  Global state tree
+ * @return {Array}        Array of site objects
+ */
+export default createSelector( state =>
+	getSites( state ).filter(
+		site => ! isJetpackSite( state, site.ID ) && userCan( 'manage_options', site )
+	)
+);

--- a/client/state/selectors/test/get-account-closure-sites.js
+++ b/client/state/selectors/test/get-account-closure-sites.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getAccountClosureSites from 'state/selectors/get-account-closure-sites';
+import { userState } from './fixtures/user-state';
+
+describe( 'getAccountClosureSites()', () => {
+	test( 'should return an empty array if no sites in state', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {},
+			},
+		};
+		const sites = getAccountClosureSites( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	test( 'should not return any Jetpack sites', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						jetpack: true,
+						name: 'WordPress.com Example Blog',
+						URL: 'http://example.com',
+						capabilities: {
+							manage_options: true,
+						},
+					},
+				},
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getAccountClosureSites( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	test( 'should not return any sites the user is not an admin on', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						jetpack: false,
+						name: 'WordPress.com Example Blog',
+						URL: 'http://example.com',
+						capabilities: {
+							manage_options: false,
+							publish_posts: true,
+						},
+					},
+				},
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getAccountClosureSites( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	test( 'should return sites that are not Jetpack and user is an admin on', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						jetpack: false,
+						name: 'WordPress.com Example Blog',
+						URL: 'http://example.com',
+						capabilities: {
+							manage_options: true,
+						},
+					},
+				},
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getAccountClosureSites( state );
+		expect( sites ).to.not.eql( [] );
+	} );
+} );

--- a/client/state/selectors/test/get-account-closure-sites.js
+++ b/client/state/selectors/test/get-account-closure-sites.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import getAccountClosureSites from 'state/selectors/get-account-closure-sites';
@@ -18,7 +13,7 @@ describe( 'getAccountClosureSites()', () => {
 			},
 		};
 		const sites = getAccountClosureSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should not return any Jetpack sites', () => {
@@ -42,7 +37,7 @@ describe( 'getAccountClosureSites()', () => {
 			},
 		};
 		const sites = getAccountClosureSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should not return any sites the user is not an admin on', () => {
@@ -67,7 +62,7 @@ describe( 'getAccountClosureSites()', () => {
 			},
 		};
 		const sites = getAccountClosureSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return sites that are not Jetpack and user is an admin on', () => {
@@ -91,6 +86,6 @@ describe( 'getAccountClosureSites()', () => {
 			},
 		};
 		const sites = getAccountClosureSites( state );
-		expect( sites ).to.not.eql( [] );
+		expect( sites ).not.toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This lists all sites that get deleted when an account is closed (I believe it's all sites except Jetpack ones? Please correct me if I'm wrong!). There's also a dropdown to hide them, just in case someone has a lot of sites.

#### Testing instructions

Visit `/me/account/close` on an account that can automatically be closed, and verify that the sites display and the toggle works.

**Where no sites will be deleted:**

<img width="890" alt="Screenshot 2019-11-15 at 22 22 01" src="https://user-images.githubusercontent.com/43215253/68981259-c1a11800-07fa-11ea-8e4b-dd2dd93ea026.png">

**Where sites will be deleted:**

<img width="833" alt="Screenshot 2019-11-16 at 09 52 46" src="https://user-images.githubusercontent.com/43215253/68991441-db704880-0856-11ea-9d03-a07bd93a439d.png">


cc @bluefuton 

Fixes #24939
