### PR TITLE
Plans Page: fix favour the product purchae.

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -356,8 +356,9 @@ export class ProductSelector extends Component {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 			const stateKey = this.getStateKey( product.id, intervalType );
 			let purchase = this.getPurchaseByProduct( product );
+			const hasProductPurchase = !! purchase;
 
-			if ( currentPlanIncludesProduct ) {
+			if ( currentPlanIncludesProduct && ! hasProductPurchase ) {
 				purchase = this.getPurchaseByCurrentPlan();
 			}
 
@@ -374,7 +375,8 @@ export class ProductSelector extends Component {
 						planLink: <a href={ `/plans/my-plan/${ selectedSiteSlug }` } />,
 					},
 				} );
-			} else {
+			}
+			if ( hasProductPurchase ) {
 				billingTimeFrame = this.getBillingTimeFrameLabel();
 				fullPrice = this.getProductOptionFullPrice( selectedProductSlug );
 				discountedPrice = this.getProductOptionDiscountedPrice( selectedProductSlug );


### PR DESCRIPTION
Currently the logic favors the plan this PR fixes this by making sure that the product is always favored in the Product card. If a user has both a plan and a product.

#### Changes proposed in this Pull Request
Before:

<img width="600" alt="Screen Shot 2019-11-12 at 11 00 00 AM" src="https://user-images.githubusercontent.com/115071/68665942-43ffb280-0543-11ea-9467-2e210bd75f36.png">

After:
<img width="569" alt="Screen Shot 2019-11-12 at 11 49 43 AM" src="https://user-images.githubusercontent.com/115071/68665927-3ba77780-0543-11ea-951f-2b749a1318a8.png">

#### Testing instructions
* on a Jetpack site that has a Jetpack 7.9
* Go to the plans page. 
* Buy a product. Does the plan look as expected?
* Buy a plan. Does the product card look as expected?
* Remove the product. Does the card look as expected.

