### PR TITLE
[Checklist] Move domain verification nudge to checklist

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -636,13 +636,12 @@ class WpcomChecklistComponent extends PureComponent {
 
 	renderSiteLaunchedTask = ( TaskComponent, baseProps, task ) => {
 		const {
-			needsVerification,
 			needsEmailVerification,
 			needsDomainVerification,
 			siteIsUnlaunched,
 			translate,
 		} = this.props;
-		const disabled = ! baseProps.completed && needsVerification;
+		const disabled = ! baseProps.completed && ( needsEmailVerification || needsDomainVerification );
 		let noticeText;
 		if ( disabled ) {
 			if ( needsDomainVerification ) {
@@ -1113,7 +1112,6 @@ export default connect(
 			userEmail: ( user && user.email ) || '',
 			needsEmailVerification,
 			needsDomainVerification,
-			needsVerification: needsEmailVerification || needsDomainVerification,
 			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 			domains: getDomainsBySiteId( state, siteId ),
 		};

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -454,9 +454,9 @@ class WpcomChecklistComponent extends PureComponent {
 				bannerImageSrc="/calypso/images/stats/tasks/create-tagline.svg"
 				buttonText={ translate( 'Verify' ) }
 				completedButtonText={ translate( 'Change' ) }
-				completedTitle={ translate( 'You verified your domain name' ) }
+				completedTitle={ translate( 'You verified the email address for your domain(s)' ) }
 				description={ translate(
-					'Email assigned to your domains has to be verified so we can get in touch with you when needed.'
+					'The email address for your domains has to be verified to allow your domains to work properly.'
 				) }
 				duration={ translate( '%d minute', '%d minutes', { count: 2, args: [ 2 ] } ) }
 				onClick={ this.handleTaskStart( {
@@ -470,10 +470,10 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={
 					task.unverifiedDomains.length === 1
-						? translate( 'Verify %(domainName)s', {
+						? translate( 'Verify email address for domain %(domainName)s', {
 								args: { domainName: task.unverifiedDomains[ 0 ] },
 						  } )
-						: translate( 'Verify your domains' )
+						: translate( 'Verify email address for domains' )
 				}
 				showSkip={ false }
 			/>
@@ -635,13 +635,19 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	renderSiteLaunchedTask = ( TaskComponent, baseProps, task ) => {
-		const { needsVerification, needsDomainVerification, siteIsUnlaunched, translate } = this.props;
+		const {
+			needsVerification,
+			needsEmailVerification,
+			needsDomainVerification,
+			siteIsUnlaunched,
+			translate,
+		} = this.props;
 		const disabled = ! baseProps.completed && needsVerification;
 		let noticeText;
 		if ( disabled ) {
 			if ( needsDomainVerification ) {
 				noticeText = translate( 'Verify your domain before launching your site.' );
-			} else if ( needsDomainVerification ) {
+			} else if ( needsEmailVerification ) {
 				noticeText = translate( 'Confirm your email address before launching your site.' );
 			}
 		}

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -452,7 +452,6 @@ class WpcomChecklistComponent extends PureComponent {
 			<TaskComponent
 				{ ...baseProps }
 				buttonText={ translate( 'Verify' ) }
-				completedButtonText={ translate( 'Change' ) }
 				completedTitle={ translate( 'You verified the email address for your domain' ) }
 				description={ translate(
 					'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -463,14 +463,16 @@ class WpcomChecklistComponent extends PureComponent {
 					task,
 					tourId: 'checklistSiteTagline',
 					url:
-						task.domains.length === 1
+						task.unverifiedDomains.length === 1
 							? domainManagementEdit( siteSlug, task.domains[ 0 ] )
 							: domainManagementList( siteSlug ),
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={
-					task.domains.length === 1
-						? translate( 'Verify %(domainName)s', { args: { domainName: task.domains[ 0 ] } } )
+					task.unverifiedDomains.length === 1
+						? translate( 'Verify %(domainName)s', {
+								args: { domainName: task.unverifiedDomains[ 0 ] },
+						  } )
 						: translate( 'Verify your domains' )
 				}
 				showSkip={ false }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -44,6 +44,7 @@ import {
 } from 'state/inline-help/actions';
 import { emailManagement } from 'my-sites/email/paths';
 import PendingGSuiteTosNoticeDialog from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog';
+import { domainManagementEdit, domainManagementList } from '../../domains/paths';
 
 const userLib = userFactory();
 
@@ -60,6 +61,7 @@ class WpcomChecklistComponent extends PureComponent {
 		super();
 
 		this.taskFunctions = {
+			domain_verified: this.renderDomainVerifiedTask,
 			email_verified: this.renderEmailVerifiedTask,
 			site_created: this.renderSiteCreatedTask,
 			address_picked: this.renderAddressPickedTask,
@@ -439,6 +441,39 @@ class WpcomChecklistComponent extends PureComponent {
 				title={ translate( 'Upload a site icon' ) }
 				showSkip={ false }
 				buttonText={ translate( 'Start' ) }
+			/>
+		);
+	};
+
+	renderDomainVerifiedTask = ( TaskComponent, baseProps, task ) => {
+		const { translate, siteSlug } = this.props;
+
+		return (
+			<TaskComponent
+				{ ...baseProps }
+				bannerImageSrc="/calypso/images/stats/tasks/create-tagline.svg"
+				buttonText={ translate( 'Verify' ) }
+				completedButtonText={ translate( 'Change' ) }
+				completedTitle={ translate( 'You verified your domain name' ) }
+				description={ translate(
+					'Email assigned to your domains has to be verified so we can get in touch with you when needed.'
+				) }
+				duration={ translate( '%d minute', '%d minutes', { count: 2, args: [ 2 ] } ) }
+				onClick={ this.handleTaskStart( {
+					task,
+					tourId: 'checklistSiteTagline',
+					url:
+						task.domains.length === 1
+							? domainManagementEdit( siteSlug, task.domains[ 0 ] )
+							: domainManagementList( siteSlug ),
+				} ) }
+				onDismiss={ this.handleTaskDismiss( task.id ) }
+				title={
+					task.domains.length === 1
+						? translate( 'Verify %(domainName)s', { args: { domainName: task.domains[ 0 ] } } )
+						: translate( 'Verify your domains' )
+				}
+				showSkip={ false }
 			/>
 		);
 	};

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -451,7 +451,6 @@ class WpcomChecklistComponent extends PureComponent {
 		return (
 			<TaskComponent
 				{ ...baseProps }
-				bannerImageSrc="/calypso/images/stats/tasks/create-tagline.svg"
 				buttonText={ translate( 'Verify' ) }
 				completedButtonText={ translate( 'Change' ) }
 				completedTitle={ translate( 'You verified the email address for your domain' ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -44,7 +44,7 @@ import {
 } from 'state/inline-help/actions';
 import { emailManagement } from 'my-sites/email/paths';
 import PendingGSuiteTosNoticeDialog from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog';
-import { domainManagementEdit, domainManagementList } from '../../domains/paths';
+import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
 
 const userLib = userFactory();
 
@@ -456,7 +456,7 @@ class WpcomChecklistComponent extends PureComponent {
 				completedButtonText={ translate( 'Change' ) }
 				completedTitle={ translate( 'You verified the email address for your domain' ) }
 				description={ translate(
-					'The email address for your domain has to be verified to allow your domains to work properly.'
+					'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
 				) }
 				duration={ translate( '%d minute', '%d minutes', { count: 2, args: [ 2 ] } ) }
 				onClick={ this.handleTaskStart( {
@@ -470,10 +470,10 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={
 					task.unverifiedDomains.length === 1
-						? translate( 'Verify email address for domain %(domainName)s', {
+						? translate( 'Verify the email address for %(domainName)s', {
 								args: { domainName: task.unverifiedDomains[ 0 ] },
 						  } )
-						: translate( 'Verify email address for domains' )
+						: translate( 'Verify the email address for your domains' )
 				}
 				showSkip={ false }
 			/>
@@ -647,7 +647,7 @@ class WpcomChecklistComponent extends PureComponent {
 		if ( disabled ) {
 			if ( needsDomainVerification ) {
 				noticeText = translate(
-					'Verify email address for your domain before launching your site.'
+					'Verify the email address for your domain before launching your site.'
 				);
 			} else if ( needsEmailVerification ) {
 				noticeText = translate( 'Confirm your email address before launching your site.' );

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -646,7 +646,9 @@ class WpcomChecklistComponent extends PureComponent {
 		let noticeText;
 		if ( disabled ) {
 			if ( needsDomainVerification ) {
-				noticeText = translate( 'Verify your domain before launching your site.' );
+				noticeText = translate(
+					'Verify email address for your domain before launching your site.'
+				);
 			} else if ( needsEmailVerification ) {
 				noticeText = translate( 'Confirm your email address before launching your site.' );
 			}

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -454,9 +454,9 @@ class WpcomChecklistComponent extends PureComponent {
 				bannerImageSrc="/calypso/images/stats/tasks/create-tagline.svg"
 				buttonText={ translate( 'Verify' ) }
 				completedButtonText={ translate( 'Change' ) }
-				completedTitle={ translate( 'You verified the email address for your domain(s)' ) }
+				completedTitle={ translate( 'You verified the email address for your domain' ) }
 				description={ translate(
-					'The email address for your domains has to be verified to allow your domains to work properly.'
+					'The email address for your domain has to be verified to allow your domains to work properly.'
 				) }
 				duration={ translate( '%d minute', '%d minutes', { count: 2, args: [ 2 ] } ) }
 				onClick={ this.handleTaskStart( {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -464,7 +464,7 @@ class WpcomChecklistComponent extends PureComponent {
 					tourId: 'checklistSiteTagline',
 					url:
 						task.unverifiedDomains.length === 1
-							? domainManagementEdit( siteSlug, task.domains[ 0 ] )
+							? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
 							: domainManagementList( siteSlug ),
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -15,6 +15,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import QuerySiteDomains from 'components/data/query-site-domains';
+import isUnlaunchedSite from '../../state/selectors/is-unlaunched-site';
 
 const ruleWhiteList = [
 	'unverifiedDomainsCanManage',
@@ -30,7 +31,13 @@ const ruleWhiteList = [
 	'pendingConsent',
 ];
 
-const CurrentSiteDomainWarnings = ( { domains, isAtomic, isJetpack, selectedSite } ) => {
+const CurrentSiteDomainWarnings = ( {
+	domains,
+	isAtomic,
+	isJetpack,
+	selectedSite,
+	siteIsUnlaunched,
+} ) => {
 	if ( ! selectedSite || ( isJetpack && ! isAtomic ) ) {
 		// Simple and Atomic sites. Not Jetpack sites.
 		return null;
@@ -45,6 +52,7 @@ const CurrentSiteDomainWarnings = ( { domains, isAtomic, isJetpack, selectedSite
 				selectedSite={ selectedSite }
 				domains={ domains }
 				ruleWhiteList={ ruleWhiteList }
+				siteIsUnlaunched={ siteIsUnlaunched }
 			/>
 		</div>
 	);
@@ -64,5 +72,6 @@ export default connect( state => {
 		isJetpack: isJetpackSite( state, selectedSiteId ),
 		isAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		selectedSite: getSelectedSite( state ),
+		siteIsUnlaunched: isUnlaunchedSite( state, selectedSiteId ),
 	};
 } )( CurrentSiteDomainWarnings );

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -15,7 +15,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import QuerySiteDomains from 'components/data/query-site-domains';
-import isUnlaunchedSite from '../../state/selectors/is-unlaunched-site';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 const ruleWhiteList = [
 	'unverifiedDomainsCanManage',

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -750,14 +750,6 @@ export class DomainWarnings extends React.PureComponent {
 	};
 
 	unverifiedDomainsCannotManage = () => {
-		if (
-			config.isEnabled( 'experience/domain-verification-in-checklist' ) &&
-			this.props.siteIsUnlaunched
-		) {
-			// Customer Home nudges this on unlaunched sites
-			return;
-		}
-
 		const domains = this.getDomains().filter(
 			domain => domain.isPendingIcannVerification && ! domain.currentUserCanManage
 		);

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -632,37 +632,26 @@ export class DomainWarnings extends React.PureComponent {
 					.isAfter()
 		);
 		const severity = isWithinTwoDays ? 'is-info' : 'is-error';
+		if ( severity !== 'is-error' ) {
+			return;
+		}
+
 		const { translate } = this.props;
 		const action = translate( 'Fix' );
 
 		if ( domains.length === 1 ) {
 			const domain = domains[ 0 ].name;
-			let fullMessage, compactMessage;
-			if ( severity === 'is-error' ) {
-				fullMessage = translate(
-					'Your domain {{strong}}%(domain)s{{/strong}} may be suspended because your email address is not verified.',
-					{
-						components: { strong: <strong /> },
-						args: { domain },
-					}
-				);
-				compactMessage = translate( 'Issues with {{strong}}%(domain)s{{/strong}}.', {
+			const fullMessage = translate(
+				'Your domain {{strong}}%(domain)s{{/strong}} may be suspended because your email address is not verified.',
+				{
 					components: { strong: <strong /> },
 					args: { domain },
-				} );
-			} else if ( severity === 'is-info' ) {
-				fullMessage = translate(
-					'{{strong}}%(domain)s{{/strong}} needs to be verified. You should receive an email shortly with more information.',
-					{
-						components: { strong: <strong /> },
-						args: { domain },
-					}
-				);
-				compactMessage = translate( 'Please verify {{strong}}%(domain)s{{/strong}}.', {
-					components: { strong: <strong /> },
-					args: { domain },
-				} );
-			}
+				}
+			);
+			const compactMessage = translate( 'Issues with {{strong}}%(domain)s{{/strong}}.', {
+				components: { strong: <strong /> },
+				args: { domain },
+			} );
 
 			return (
 				<Notice
@@ -680,50 +669,25 @@ export class DomainWarnings extends React.PureComponent {
 			);
 		}
 
-		let fullContent, compactContent, compactNoticeText;
-
 		const editLink = name => domainManagementEdit( this.props.selectedSite.slug, name );
-		if ( severity === 'is-error' ) {
-			fullContent = (
-				<span>
-					{ translate(
-						'Your domains may be suspended because your email address is not verified.'
-					) }
-					<ul>
-						{ domains.map( ( { name } ) => (
-							<li key={ name }>
-								{ name } <a href={ editLink( name ) }>{ action }</a>
-							</li>
-						) ) }
-					</ul>
-				</span>
-			);
-			compactNoticeText = translate( 'Issues with your domains' );
-			compactContent = (
-				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
-					{ action }
-				</NoticeAction>
-			);
-		} else if ( severity === 'is-info' ) {
-			fullContent = (
-				<span>
-					{ translate( 'Please verify ownership of domains:' ) }
-					<ul>
-						{ domains.map( ( { name } ) => (
-							<li key={ name }>
-								{ name } <a href={ editLink( name ) }>{ action }</a>
-							</li>
-						) ) }
-					</ul>
-				</span>
-			);
-			compactNoticeText = translate( 'Verification required for domains' );
-			compactContent = (
-				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
-					{ action }
-				</NoticeAction>
-			);
-		}
+		const fullContent = (
+			<span>
+				{ translate( 'Your domains may be suspended because your email address is not verified.' ) }
+				<ul>
+					{ domains.map( ( { name } ) => (
+						<li key={ name }>
+							{ name } <a href={ editLink( name ) }>{ action }</a>
+						</li>
+					) ) }
+				</ul>
+			</span>
+		);
+		const compactNoticeText = translate( 'Issues with your domains' );
+		const compactContent = (
+			<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
+				{ action }
+			</NoticeAction>
+		);
 
 		return (
 			<Notice

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -636,7 +636,7 @@ export class DomainWarnings extends React.PureComponent {
 		if (
 			config.isEnabled( 'experience/domain-verification-in-checklist' ) &&
 			this.props.siteIsUnlaunched &&
-			! isWithinTwoDays
+			isWithinTwoDays
 		) {
 			// Customer Home nudges this on unlaunched sites.
 			// After two days let's re-display the nudge

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -618,14 +618,6 @@ export class DomainWarnings extends React.PureComponent {
 	};
 
 	unverifiedDomainsCanManage = () => {
-		if (
-			config.isEnabled( 'experience/domain-verification-in-checklist' ) &&
-			this.props.siteIsUnlaunched
-		) {
-			// Customer Home nudges this on unlaunched sites
-			return;
-		}
-
 		const domains = this.getDomains().filter(
 			domain => domain.isPendingIcannVerification && domain.currentUserCanManage
 		);
@@ -641,6 +633,16 @@ export class DomainWarnings extends React.PureComponent {
 					.add( 2, 'days' )
 					.isAfter()
 		);
+		if (
+			config.isEnabled( 'experience/domain-verification-in-checklist' ) &&
+			this.props.siteIsUnlaunched &&
+			! isWithinTwoDays
+		) {
+			// Customer Home nudges this on unlaunched sites.
+			// After two days let's re-display the nudge
+			return;
+		}
+
 		const severity = isWithinTwoDays ? 'is-info' : 'is-error';
 		const { translate } = this.props;
 		const action = translate( 'Fix' );

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -275,7 +275,7 @@ describe( 'index', () => {
 				textContent = domNode.textContent,
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			expect( textContent ).to.contain( 'lease verify ownership of domains' );
+			expect( textContent ).to.contain( 'Please verify ownership of domains' );
 			assert(
 				links.some( link =>
 					link.href.endsWith( '/domains/manage/blog.example.com/edit/blog.example.com' )

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -247,6 +247,121 @@ describe( 'index', () => {
 		} );
 	} );
 
+	describe( 'verification nudge', () => {
+		test( 'should show a verification nudge with weak message for any unverified domains younger than 2 days', () => {
+			const props = {
+				translate: identity,
+				domains: [
+					{
+						name: 'blog.example.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: true,
+						isPendingIcannVerification: true,
+						registrationMoment: moment().subtract( 1, 'days' ),
+					},
+					{
+						name: 'mygroovysite.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: true,
+						isPendingIcannVerification: true,
+						registrationMoment: moment().subtract( 1, 'days' ),
+					},
+				],
+				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
+			};
+			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+
+			const domNode = ReactDom.findDOMNode( component ),
+				textContent = domNode.textContent,
+				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+
+			expect( textContent ).to.contain( 'lease verify ownership of domains' );
+			assert(
+				links.some( link =>
+					link.href.endsWith( '/domains/manage/blog.example.com/edit/blog.example.com' )
+				)
+			);
+			assert(
+				links.some( link =>
+					link.href.endsWith( '/domains/manage/mygroovysite.com/edit/blog.example.com' )
+				)
+			);
+		} );
+
+		test( 'should show a verification nudge with strong message for any unverified domains older than 2 days', () => {
+			const props = {
+				translate: identity,
+				domains: [
+					{
+						name: 'blog.example.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: true,
+						isPendingIcannVerification: true,
+						registrationMoment: moment().subtract( 3, 'days' ),
+					},
+					{
+						name: 'mygroovysite.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: true,
+						isPendingIcannVerification: true,
+						registrationMoment: moment().subtract( 3, 'days' ),
+					},
+				],
+				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
+			};
+			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+
+			const domNode = ReactDom.findDOMNode( component ),
+				textContent = domNode.textContent,
+				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+
+			expect( textContent ).to.contain(
+				'Your domains may be suspended because your email address is not verified.'
+			);
+			assert(
+				links.some( link =>
+					link.href.endsWith( '/domains/manage/blog.example.com/edit/blog.example.com' )
+				)
+			);
+			assert(
+				links.some( link =>
+					link.href.endsWith( '/domains/manage/mygroovysite.com/edit/blog.example.com' )
+				)
+			);
+		} );
+
+		test( "should show a verification nudge with strong message for users who can't manage the domain", () => {
+			const props = {
+				translate: identity,
+				domains: [
+					{
+						name: 'blog.example.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: false,
+						isPendingIcannVerification: true,
+						registrationMoment: moment().subtract( 1, 'days' ),
+					},
+					{
+						name: 'mygroovysite.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: false,
+						isPendingIcannVerification: true,
+						registrationMoment: moment().subtract( 1, 'days' ),
+					},
+				],
+				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
+			};
+			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+
+			const domNode = ReactDom.findDOMNode( component ),
+				textContent = domNode.textContent;
+
+			expect( textContent ).to.contain(
+				'Some domains on this site are about to be suspended because their owner has not'
+			);
+		} );
+	} );
+
 	describe( 'Mutations', () => {
 		test( 'should not mutate domain objects', () => {
 			const props = {

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -6,6 +6,7 @@ import { get, noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -21,7 +22,11 @@ const fromApi = payload => get( payload, 'body', payload );
 export const fetchChecklist = action =>
 	http(
 		{
-			path: `/sites/${ action.siteId }/checklist`,
+			path:
+				`/sites/${ action.siteId }/checklist` +
+				( config.isEnabled( 'experience/domain-verification-in-checklist' )
+					? '?with_domain_verification=1'
+					: '' ),
 			method: 'GET',
 			apiNamespace: 'rest/v1.1',
 			query: {

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -22,15 +22,14 @@ const fromApi = payload => get( payload, 'body', payload );
 export const fetchChecklist = action =>
 	http(
 		{
-			path:
-				`/sites/${ action.siteId }/checklist` +
-				( config.isEnabled( 'experience/domain-verification-in-checklist' )
-					? '?with_domain_verification=1'
-					: '' ),
+			path: `/sites/${ action.siteId }/checklist`,
 			method: 'GET',
 			apiNamespace: 'rest/v1.1',
 			query: {
 				http_envelope: 1,
+				with_domain_verification: config.isEnabled( 'experience/domain-verification-in-checklist' )
+					? 1
+					: 0,
 			},
 		},
 		action

--- a/config/development.json
+++ b/config/development.json
@@ -58,6 +58,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"experience/domain-verification-in-checklist": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,6 +32,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"experience/domain-verification-in-checklist": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1761,8 +1761,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Passwordless signup @parallel', function() {
-		const blogName = dataHelper.getNewBlogName();
+	// Disable test while Passwordless functionality is completely switched off
+	// https://github.com/Automattic/wp-calypso/pull/37054
+	describe.skip( 'Passwordless signup @parallel', function() {
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		let verificationLink;

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1761,7 +1761,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	// Disable test while Passwordless functionality is completely switched off		describe( 'Passwordless signup @parallel', function() {
+	// Disable test while Passwordless functionality is completely switched off
 	// https://github.com/Automattic/wp-calypso/pull/37054
 	describe.skip( 'Passwordless signup @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1761,9 +1761,10 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	// Disable test while Passwordless functionality is completely switched off
+	// Disable test while Passwordless functionality is completely switched off		describe( 'Passwordless signup @parallel', function() {
 	// https://github.com/Automattic/wp-calypso/pull/37054
 	describe.skip( 'Passwordless signup @parallel', function() {
+		const blogName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		let verificationLink;

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1761,9 +1761,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	// Disable test while Passwordless functionality is completely switched off
-	// https://github.com/Automattic/wp-calypso/pull/37054
-	describe.skip( 'Passwordless signup @parallel', function() {
+	describe( 'Passwordless signup @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds some feature-flag gated features:

##### Adds "Verify your domain" checklist item

<img width="737" alt="Zrzut ekranu 2019-11-12 o 14 53 32" src="https://user-images.githubusercontent.com/205419/68677326-360a5b80-055c-11ea-8f14-bdab62d31526.png">

This checklist task is incomplete only as long as the site is unlaunched. Completing that item and then adding another domain will re-activate this task. If you launch your site and then add another domain, this task will remain completed.

##### Hide "Verify your domain" nudge from sidebar for unlaunched sites.

<img width="402" alt="68437771-c4569a00-0176-11ea-9c67-7d42b45a9455" src="https://user-images.githubusercontent.com/205419/68677487-7b2e8d80-055c-11ea-95ea-00bc0eae3441.png">

That nudge will be only visible for launched sites (when email verification is required).

#### Testing instructions

1. Apply D35374-code
2. Create new account/site without paid domain, confirm the checklist doesn't contain "Verify domain" item and that the same as before
3. Create new account/site with paid domain, confirm the sidebar nudge is gone and that there's a new checklist item "Verify email address for (domain)"
4. Purchase another domain, verify that checklist item is still labeled in a way that makes sense
5. Add another admin user to that site, one that's ineligible to manage the domain. Confirm the sidebar nudge is visible for that user.
6. Verify email address for your domain, confirm the checklist item is now marked as complete.
7. Change email address for your domain, confirm the checklist item is incomplete again. Confirm the sidebar nudge is visible again.
8. Add another user to that site, one that's ineligible to manage the domain. Confirm the sidebar nudge is still in place.
9. Launch the site
10. Change email address for your domain, confirm the checklist item is still complete and that the sidebar nudge is in place instead.
11. Verify the email address, confirm the sidebar nudge is gone

#### Important notes:

* Domain verification is a pre-requisite to "Launch site" task, but it's still possible to launch the site by clicking link on site preview. If this PR proves valuable in user testing, we could sort that pre-requisite in a follow-up diff.
* With this PR we have two very similar tasks: `Verify email address for domain dsadas.blog` and `Confirm your email address`. Ideally we'd only require separate verification when email address assigned to domain is different from email address assigned to account. This is beyond the scope of this PR though.
* Sidebar nudge is only disabled for the first two days. If the user doesn't verify the domain in that timeframe, the nudge is back with a strong message.

#### Additional context

* This will be only open to users participating in usability testing at first.
* If it does well, it would be an A/B test later
* See the following discussion for more context: paObgF-GK-p2

Fixes #37427
