### PR TITLE
Add/post purchase modal backups

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -394,14 +394,13 @@ export class Checkout extends React.Component {
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
 			const isJetpackProduct = product && includes( JETPACK_BACKUP_PRODUCTS, product );
-
-			// If we just purchased a Jetpack plan (not a Jetpack product), redirect to the Jetpack onboarding plugin install flow.
-			if ( isJetpackNotAtomic && ! isJetpackProduct ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
-			}
 			// If we just purchased a Jetpack product, redirect to the my plans page.
+			if ( isJetpackNotAtomic && isJetpackProduct ) {
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&product=${ product }`;
+			}
+			// If we just purchased a Jetpack plan (not a Jetpack product), redirect to the Jetpack onboarding plugin install flow.
 			if ( isJetpackNotAtomic ) {
-				return `/plans/my-plan/${ selectedSiteSlug }`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
 			}
 
 			return selectedFeature && isValidFeatureKey( selectedFeature )

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -29,8 +29,15 @@ export function currentPlan( context, next ) {
 	}
 
 	const requestThankYou = context.query.hasOwnProperty( 'thank-you' );
+	const requestProduct = context.query.hasOwnProperty( 'product' );
 
-	context.primary = <CurrentPlan path={ context.path } requestThankYou={ requestThankYou } />;
+	context.primary = (
+		<CurrentPlan
+			path={ context.path }
+			requestThankYou={ requestThankYou }
+			requestProduct={ requestProduct }
+		/>
+	);
 
 	next();
 }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ThankYou from './thank-you';
+
+const BackupProductThankYou = ( { translate } ) => (
+	<ThankYou
+		illustration="/calypso/images/illustrations/security.svg"
+		showCalypsoIntro
+		showContinueButton
+		title={ translate( 'Hello backups!' ) }
+	>
+		<Fragment>
+			<p>{ translate( 'We just finished settup up backups for you.' ) }</p>
+			<p>
+				{ translate( 'Next, we’ll take a look at your new WordPress.com dashboard.' ) }
+				{ translate( 'You can manage your backups under “Activity” in the sidebar.' ) }
+				{ translate(
+					'There’s also a checklist to help you get the most out of your Jetpack plan.'
+				) }
+			</p>
+		</Fragment>
+	</ThankYou>
+);
+
+export default localize( BackupProductThankYou );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
@@ -19,8 +19,8 @@ const BackupProductThankYou = ( { translate } ) => (
 		<Fragment>
 			<p>{ translate( 'We just finished settup up backups for you.' ) }</p>
 			<p>
-				{ translate( 'Next, we’ll take a look at your new WordPress.com dashboard.' ) }
-				{ translate( 'You can manage your backups under “Activity” in the sidebar.' ) }
+				{ translate( 'Next, we’ll take a look at your new WordPress.com dashboard. ' ) }
+				{ translate( 'You can manage your backups under “Activity” in the sidebar. ' ) }
 				{ translate(
 					'There’s also a checklist to help you get the most out of your Jetpack plan.'
 				) }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
@@ -18,7 +18,9 @@ const BackupProductThankYou = ( { translate } ) => (
 		<p>{ translate( 'We just finished setting up backups for you.' ) }</p>
 		<p>
 			{ translate(
-				'Next, we’ll take a look at your new WordPress.com dashboard. You can manage your backups under “Tools > Activity” in the sidebar. There’s also a checklist to help you get the most out of your Jetpack plan.'
+				'Next, we’ll take a look at your new WordPress.com dashboard. ' +
+					'You can manage your backups under “Tools > Activity” in the sidebar. ' +
+					'There’s also a checklist to help you get the most out of your Jetpack plan.'
 			) }
 		</p>
 		<p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/backup-thank-you.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { localize } from 'i18n-calypso';
-import React, { Fragment } from 'react';
 
 /**
  * Internal dependencies
@@ -12,20 +12,20 @@ import ThankYou from './thank-you';
 const BackupProductThankYou = ( { translate } ) => (
 	<ThankYou
 		illustration="/calypso/images/illustrations/security.svg"
-		showCalypsoIntro
 		showContinueButton
 		title={ translate( 'Hello backups!' ) }
 	>
-		<Fragment>
-			<p>{ translate( 'We just finished settup up backups for you.' ) }</p>
-			<p>
-				{ translate( 'Next, we’ll take a look at your new WordPress.com dashboard. ' ) }
-				{ translate( 'You can manage your backups under “Activity” in the sidebar. ' ) }
-				{ translate(
-					'There’s also a checklist to help you get the most out of your Jetpack plan.'
-				) }
-			</p>
-		</Fragment>
+		<p>{ translate( 'We just finished setting up backups for you.' ) }</p>
+		<p>
+			{ translate(
+				'Next, we’ll take a look at your new WordPress.com dashboard. You can manage your backups under “Tools > Activity” in the sidebar. There’s also a checklist to help you get the most out of your Jetpack plan.'
+			) }
+		</p>
+		<p>
+			{ translate(
+				'You can return to your traditional WordPress dashboard anytime by using the link at the bottom of the sidebar.'
+			) }
+		</p>
 	</ThankYou>
 );
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -96,7 +96,7 @@ class CurrentPlan extends Component {
 		};
 	}
 
-	getThankYou() {
+	renderThankYou() {
 		const { isFreePlan, requestProduct } = this.props;
 
 		if ( requestProduct ) {
@@ -150,7 +150,7 @@ class CurrentPlan extends Component {
 					baseClassName="current-plan__dialog dialog__content dialog__backdrop"
 					isVisible={ showThankYou }
 				>
-					{ this.getThankYou() }
+					{ this.renderThankYou() }
 				</Dialog>
 
 				<PlansNavigation path={ path } />
@@ -229,6 +229,6 @@ export default connect( ( state, { requestThankYou, requestProduct } ) => {
 		purchase: currentPlan ? getByPurchaseId( state, currentPlan.id ) : null,
 		showJetpackChecklist: isJetpackNotAtomic,
 		showThankYou: requestThankYou && isJetpackNotAtomic,
-		requestProduct: requestProduct,
+		requestProduct,
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -38,6 +38,7 @@ import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import PaidPlanThankYou from './current-plan-thank-you/paid-plan-thank-you';
 import FreePlanThankYou from './current-plan-thank-you/free-plan-thank-you';
+import BackupProductThankYou from './current-plan-thank-you/backup-thank-you';
 import { getByPurchaseId } from 'state/purchases/selectors';
 import { isPartnerPurchase } from 'lib/purchases';
 
@@ -95,13 +96,25 @@ class CurrentPlan extends Component {
 		};
 	}
 
+	getThankYou() {
+		const { isFreePlan, requestProduct } = this.props;
+
+		if ( requestProduct ) {
+			return <BackupProductThankYou />;
+		}
+		if ( isFreePlan ) {
+			return <FreePlanThankYou />;
+		}
+
+		return <PaidPlanThankYou />;
+	}
+
 	render() {
 		const {
 			currentPlan,
 			domains,
 			hasDomainsLoaded,
 			isExpiring,
-			isFreePlan,
 			path,
 			purchase,
 			selectedSite,
@@ -137,7 +150,7 @@ class CurrentPlan extends Component {
 					baseClassName="current-plan__dialog dialog__content dialog__backdrop"
 					isVisible={ showThankYou }
 				>
-					{ isFreePlan ? <FreePlanThankYou /> : <PaidPlanThankYou /> }
+					{ this.getThankYou() }
 				</Dialog>
 
 				<PlansNavigation path={ path } />
@@ -191,7 +204,7 @@ class CurrentPlan extends Component {
 	}
 }
 
-export default connect( ( state, { requestThankYou } ) => {
+export default connect( ( state, { requestThankYou, requestProduct } ) => {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = getSelectedSiteId( state );
 	const domains = getDecoratedSiteDomains( state, selectedSiteId );
@@ -216,5 +229,6 @@ export default connect( ( state, { requestThankYou } ) => {
 		purchase: currentPlan ? getByPurchaseId( state, currentPlan.id ) : null,
 		showJetpackChecklist: isJetpackNotAtomic,
 		showThankYou: requestThankYou && isJetpackNotAtomic,
+		requestProduct: requestProduct,
 	};
 } )( localize( CurrentPlan ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR add a backup product module that appears after a user buys a jetpack product.
* I am expecting this PR to be short lived. Since there is a new flow being developed. 

Before: Nothing
After:
![Screen Shot 2019-11-13 at 10 40 39 AM](https://user-images.githubusercontent.com/115071/68751709-568cf100-0602-11ea-8e5a-a42fc928caf9.png)


#### Testing instructions
* For a jetpack site. 
* buy a jetpack product. (currently only backups are available)
* Does the model look like what you would expect?
* Buy a plan. 
* Does the model look like what you would expect. 

