### PR TITLE
Purchases: Display the plan and product overlap notices on single purchase page

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -61,10 +61,13 @@ import {
 	isConciergeSession,
 } from 'lib/products-values';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
+import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
+import { JETPACK_PLANS } from 'lib/plans/constants';
 import Main from 'components/main';
 import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
 import ProductLink from 'me/purchases/product-link';
+import ProductPlanOverlapNotices from 'blocks/product-plan-overlap-notices';
 import PurchaseMeta from './purchase-meta';
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';
@@ -485,6 +488,13 @@ class ManagePurchase extends Component {
 						purchase={ purchase }
 						editCardDetailsPath={ editCardDetailsPath }
 					/>
+					{ config.isEnabled( 'plans/jetpack-backup' ) && (
+						<ProductPlanOverlapNotices
+							plans={ JETPACK_PLANS }
+							products={ JETPACK_BACKUP_PRODUCTS }
+							siteId={ siteId }
+						/>
+					) }
 					{ this.renderPurchaseDetail() }
 				</Main>
 			</Fragment>


### PR DESCRIPTION
This PR updates the single purchase page so it displays the notices when the user has both a Jetpack product and plan together.

#### Changes proposed in this Pull Request

* Purchases: Display the plan and product overlap notices on the single purchase page.

#### Preview

![](https://cldup.com/Ddgu1ZMCMB.png)

#### Testing instructions
* Checkout this branch.
* On a Jetpack site, get a Jetpack Backup product.
* On that Jetpack site, get a Jetpack plan too.
* Go to http://calypso.localhost:3000/me/purchases
* Go to either the product or the plan purchase page for that site.
* Verify you can see a notice as shown on the screenshot, and that notice is correct.
* Try with different plan and product combinations and verify they work as expected, too.