### PR TITLE
Signup: Allow reCAPTCHA test selection for any locale

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -133,5 +133,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 };


### PR DESCRIPTION
We want this test to apply to all clients regardless of locale and geolocation.

Discussion: p1573569781187400-slack-CJEQFAAJU

#### Changes proposed in this Pull Request

* Add the `localeTargets: 'any',` directive to the `userStepRecaptcha` test config

#### Testing instructions

* None outside automated lint checks & a good visual syntax & declaration inspection
