### PR TITLE
Fix broken reconnection flow

### DIFF
--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -265,15 +265,11 @@ export class SharingService extends Component {
 	 */
 	refresh = ( connections = this.props.brokenConnections ) => {
 		this.getConnections( connections ).map( connection => {
-			const keyringConnection = find( this.props.keyringConnections, singleKeyringConnection => {
-				// Publicize connections store the keyring ID in keyring_connection_ID
-				// Since keyring connections don't have a keyring_connection_ID property,
-				// we need to check both the keyring_connection_ID and the ID
-				return (
-					( singleKeyringConnection.type === 'publicize' &&
-						singleKeyringConnection.ID === connection.keyring_connection_ID ) ||
-					singleKeyringConnection.ID === connection.ID
-				);
+			const keyringConnection = find( this.props.keyringConnections, token => {
+				// Publicize connections store the token id as `keyring_connection_ID`
+				const tokenID =
+					'publicize' === token.type ? connection.keyring_connection_ID : connection.ID;
+				return token.ID === tokenID;
 			} );
 
 			if ( keyringConnection ) {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -264,14 +264,14 @@ export class SharingService extends Component {
 	 *                            Default: All broken connections for this service.
 	 */
 	refresh = ( connections = this.props.brokenConnections ) => {
-		this.setState( { isRefreshing: true } );
-
 		this.getConnections( connections ).map( connection => {
 			const keyringConnection = find( this.props.keyringConnections, {
 				ID: connection.keyring_connection_ID,
 			} );
 
 			if ( keyringConnection ) {
+				this.setState( { isRefreshing: true } );
+
 				// Attempt to create a new connection. If a Keyring connection ID
 				// is not provided, the user will need to authorize the app
 				requestExternalAccess( connection.refresh_URL, () => {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -265,11 +265,15 @@ export class SharingService extends Component {
 	 */
 	refresh = ( connections = this.props.brokenConnections ) => {
 		this.getConnections( connections ).map( connection => {
-			const keyringConnection = find( this.props.keyringConnections, {
+			const keyringConnection = find( this.props.keyringConnections, singleKeyringConnection => {
 				// Publicize connections store the keyring ID in keyring_connection_ID
 				// Since keyring connections don't have a keyring_connection_ID property,
 				// we need to check both the keyring_connection_ID and the ID
-				ID: connection.keyring_connection_ID || connection.ID,
+				return (
+					( singleKeyringConnection.type === 'publicize' &&
+						singleKeyringConnection.ID === connection.keyring_connection_ID ) ||
+					singleKeyringConnection.ID === connection.ID
+				);
 			} );
 
 			if ( keyringConnection ) {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -266,6 +266,9 @@ export class SharingService extends Component {
 	refresh = ( connections = this.props.brokenConnections ) => {
 		this.getConnections( connections ).map( connection => {
 			const keyringConnection = find( this.props.keyringConnections, {
+				// Publicize connections store the keyring ID in keyring_connection_ID
+				// Since keyring connections don't have a keyring_connection_ID property,
+				// we need to check both the keyring_connection_ID and the ID
 				ID: connection.keyring_connection_ID || connection.ID,
 			} );
 

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -303,9 +303,7 @@ export class SharingService extends Component {
 	 * @param {Object} connection Connection to update.
 	 * @return {Function} Action thunk
 	 */
-	fetchConnection = connection => {
-		return this.props.fetchConnection( this.props.siteId, connection.ID );
-	};
+	fetchConnection = connection => this.props.fetchConnection( this.props.siteId, connection.ID );
 
 	/**
 	 * Checks whether any connection can be removed.

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -266,7 +266,7 @@ export class SharingService extends Component {
 	refresh = ( connections = this.props.brokenConnections ) => {
 		this.getConnections( connections ).map( connection => {
 			const keyringConnection = find( this.props.keyringConnections, {
-				ID: connection.keyring_connection_ID,
+				ID: connection.keyring_connection_ID || connection.ID,
 			} );
 
 			if ( keyringConnection ) {

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -43,6 +43,19 @@ export const getKeyringConnectionsByName = createSelector(
 );
 
 /**
+ * Returns an array of broken keyring connection objects for a specified service.
+ *
+ * @param  {Object} state   Global state tree
+ * @param  {String} service Service slug.
+ * @return {Array}         Keyring connections, if known.
+ */
+export function getBrokenKeyringConnectionsByName( state, service ) {
+	return filter( getKeyringConnectionsByName( state, service ), {
+		status: 'broken',
+	} );
+}
+
+/**
  * Returns an array of keyring connection objects for a specific user.
  *
  * @param  {Object} state  Global state tree

--- a/client/state/sharing/keyring/test/selectors.js
+++ b/client/state/sharing/keyring/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	getKeyringConnections,
 	getKeyringConnectionById,
 	getKeyringConnectionsByName,
+	getBrokenKeyringConnectionsByName,
 	getUserConnections,
 	isKeyringConnectionsFetching,
 } from '../selectors';
@@ -128,6 +129,47 @@ describe( 'selectors', () => {
 			const isFetching = isKeyringConnectionsFetching( defaultState );
 
 			expect( isFetching ).to.be.false;
+		} );
+	} );
+
+	const brokenState = {
+		sharing: {
+			keyring: {
+				items: {
+					1: { ID: 1, service: 'twitter', sites: [ '2916284' ] },
+					2: { ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1 },
+					3: {
+						ID: 3,
+						service: 'facebook',
+						sites: [ '2916284', '77203074' ],
+						shared: true,
+						status: 'broken',
+					},
+				},
+				isFetching: true,
+			},
+		},
+	};
+
+	describe( 'getBrokenKeyringConnectionsByName()', () => {
+		test( 'should return null for a connection which has not yet been fetched', () => {
+			const connections = getBrokenKeyringConnectionsByName( brokenState, 'twitter' );
+
+			expect( connections ).to.be.empty;
+		} );
+
+		test( 'should return the connection object for the ID', () => {
+			const connections = getBrokenKeyringConnectionsByName( brokenState, 'facebook' );
+
+			expect( connections ).to.eql( [
+				{
+					ID: 3,
+					service: 'facebook',
+					sites: [ '2916284', '77203074' ],
+					shared: true,
+					status: 'broken',
+				},
+			] );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the code necessary to make it possible to reconnect broken keyring connections. Calypso looks for the keyring_connection_ID key, which we don't have for keyring connections, so when a keyring connection breaks the reconnect button doesn't work.

This PR changes the way we look for broken connections to use the `ID` for non publicize connections.

To test:
- Go to http://calypso.localhost:3000/marketing/connections/%site%s
- Find a broken connection (you might need to change this on the server)
- Go through the reconnection flow
- Confirm that connection is restored
