### PR TITLE
Domains/Signup: Hide illustrations on mapping/transfer on small screens

### DIFF
--- a/client/components/domains/use-your-domain-step/style.scss
+++ b/client/components/domains/use-your-domain-step/style.scss
@@ -39,6 +39,10 @@
 		justify-content: center;
 		margin: 1em 0;
 		max-height: 150px;
+
+		@include breakpoint( '<660px' ) {
+			display: none;
+		}
 	}
 
 	.use-your-domain-step__option-illustration img {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The illustrations on the "Use a domain I own" step take up a lot of vertical real estate on narrow screens, and don't add much clarity to the experience.
* This PR hides them on small screens, which helps give the primary action more prominence.
* The illustrations remain on screens > 660px wide.

**Before**

<img width="322" alt="Screen Shot 2019-11-12 at 9 42 34 AM" src="https://user-images.githubusercontent.com/2124984/68681165-ebbfb500-0530-11ea-8436-7de6f804e41c.png">

**After**

<img width="323" alt="Screen Shot 2019-11-12 at 9 42 47 AM" src="https://user-images.githubusercontent.com/2124984/68681179-f0846900-0530-11ea-80c7-12339708a427.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/start` and sign up for a new site 
* At the domains step, click "Use a domain I own"
* View the screen on both mobile and desktop devices. Desktop devices should have illustrations, mobile should not.
* The same should apply if you go to Manage -> Domains, search for a new domain, and click "Use a domain I own"
