### PR TITLE
Rewrite several simple Query components.

### DIFF
--- a/client/components/data/query-active-promotions/index.jsx
+++ b/client/components/data/query-active-promotions/index.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,32 +10,16 @@ import { connect } from 'react-redux';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
 import { requestActivePromotions } from 'state/active-promotions/actions';
 
-class QueryActivePromotions extends Component {
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.requestingActivePromotions ) {
-			this.props.requestActivePromotions();
+export default function QueryActivePromotions() {
+	const requestingActivePromotions = useRef( useSelector( isRequestingActivePromotions ) );
+	const dispatch = useDispatch();
+
+	// Only runs on mount.
+	useEffect( () => {
+		if ( ! requestingActivePromotions.current ) {
+			dispatch( requestActivePromotions() );
 		}
-	}
+	}, [ dispatch ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
-
-QueryActivePromotions.propTypes = {
-	requestingActivePromotions: PropTypes.bool,
-	requestActivePromotions: PropTypes.func,
-};
-
-QueryActivePromotions.defaultProps = {
-	requestPlans: () => {},
-};
-
-export default connect(
-	state => {
-		return {
-			requestingPlans: isRequestingActivePromotions( state ),
-		};
-	},
-	{ requestActivePromotions }
-)( QueryActivePromotions );

--- a/client/components/data/query-active-promotions/index.jsx
+++ b/client/components/data/query-active-promotions/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,15 +10,17 @@ import { useSelector, useDispatch } from 'react-redux';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
 import { requestActivePromotions } from 'state/active-promotions/actions';
 
+const request = () => ( dispatch, getState ) => {
+	if ( ! isRequestingActivePromotions( getState() ) ) {
+		dispatch( requestActivePromotions() );
+	}
+};
+
 export default function QueryActivePromotions() {
-	const requestingActivePromotions = useRef( useSelector( isRequestingActivePromotions ) );
 	const dispatch = useDispatch();
 
-	// Only runs on mount.
 	useEffect( () => {
-		if ( ! requestingActivePromotions.current ) {
-			dispatch( requestActivePromotions() );
-		}
+		dispatch( request() );
 	}, [ dispatch ] );
 
 	return null;

--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,20 +11,18 @@ import { useSelector, useDispatch } from 'react-redux';
 import { requestPostCounts } from 'state/posts/counts/actions';
 import { isRequestingPostCounts } from 'state/posts/counts/selectors';
 
+const request = ( siteId, type ) => ( dispatch, getState ) => {
+	if ( ! isRequestingPostCounts( getState(), siteId, type ) ) {
+		dispatch( requestPostCounts( siteId, type ) );
+	}
+};
+
 export default function QuerySiteDomains( { siteId, type } ) {
-	const requesting = useSelector( state => isRequestingPostCounts( state, siteId, type ) );
 	const dispatch = useDispatch();
-	const previousId = useRef( undefined );
-	const previousType = useRef( undefined );
 
 	useEffect( () => {
-		if ( ! requesting && siteId !== previousId.current && type !== previousType.current ) {
-			dispatch( requestPostCounts( siteId, type ) );
-		}
-
-		previousId.current = siteId;
-		previousType.current = type;
-	}, [ dispatch, requesting, siteId, type ] );
+		dispatch( request( siteId, type ) );
+	}, [ dispatch, siteId, type ] );
 
 	return null;
 }

--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,45 +11,25 @@ import { connect } from 'react-redux';
 import { requestPostCounts } from 'state/posts/counts/actions';
 import { isRequestingPostCounts } from 'state/posts/counts/selectors';
 
-class QueryPostCounts extends Component {
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
-	}
+export default function QuerySiteDomains( { siteId, type } ) {
+	const requesting = useSelector( state => isRequestingPostCounts( state, siteId, type ) );
+	const dispatch = useDispatch();
+	const previousId = useRef( undefined );
+	const previousType = useRef( undefined );
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId && this.props.type === nextProps.type ) {
-			return;
+	useEffect( () => {
+		if ( ! requesting && siteId !== previousId.current && type !== previousType.current ) {
+			requestPostCounts( siteId, type )( dispatch );
 		}
 
-		this.request( nextProps );
-	}
+		previousId.current = siteId;
+		previousType.current = type;
+	}, [ dispatch, requesting, siteId, type ] );
 
-	request( props ) {
-		if ( props.requesting ) {
-			return;
-		}
-
-		props.requestPostCounts( props.siteId, props.type );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-QueryPostCounts.propTypes = {
+QuerySiteDomains.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	type: PropTypes.string.isRequired,
-	requesting: PropTypes.bool,
-	requestPostCounts: PropTypes.func,
 };
-
-export default connect(
-	( state, ownProps ) => {
-		const { siteId, type } = ownProps;
-		return {
-			requesting: isRequestingPostCounts( state, siteId, type ),
-		};
-	},
-	{ requestPostCounts }
-)( QueryPostCounts );

--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -17,7 +17,7 @@ const request = ( siteId, type ) => ( dispatch, getState ) => {
 	}
 };
 
-export default function QuerySiteDomains( { siteId, type } ) {
+export default function QueryPostCounts( { siteId, type } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
@@ -27,7 +27,7 @@ export default function QuerySiteDomains( { siteId, type } ) {
 	return null;
 }
 
-QuerySiteDomains.propTypes = {
+QueryPostCounts.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	type: PropTypes.string.isRequired,
 };

--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -19,7 +19,7 @@ export default function QuerySiteDomains( { siteId, type } ) {
 
 	useEffect( () => {
 		if ( ! requesting && siteId !== previousId.current && type !== previousType.current ) {
-			requestPostCounts( siteId, type )( dispatch );
+			dispatch( requestPostCounts( siteId, type ) );
 		}
 
 		previousId.current = siteId;

--- a/client/components/data/query-preferences/index.jsx
+++ b/client/components/data/query-preferences/index.jsx
@@ -17,7 +17,7 @@ export default function QueryPreferences() {
 	// Only runs on mount.
 	useEffect( () => {
 		if ( ! fetchingPreferences.current ) {
-			fetchPreferences()( dispatch );
+			dispatch( fetchPreferences() );
 		}
 	}, [ dispatch ] );
 

--- a/client/components/data/query-preferences/index.jsx
+++ b/client/components/data/query-preferences/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -17,13 +17,10 @@ const request = () => ( dispatch, getState ) => {
 };
 
 export default function QueryPreferences() {
-	const fetchingPreferences = useRef( useSelector( isFetchingPreferences ) );
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		if ( ! fetchingPreferences.current ) {
-			dispatch( request() );
-		}
+		dispatch( request() );
 	}, [ dispatch ] );
 
 	return null;

--- a/client/components/data/query-preferences/index.jsx
+++ b/client/components/data/query-preferences/index.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,28 +10,16 @@ import { connect } from 'react-redux';
 import { isFetchingPreferences } from 'state/preferences/selectors';
 import { fetchPreferences } from 'state/preferences/actions';
 
-class QueryPreferences extends Component {
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.fetchingPreferences ) {
-			this.props.fetchPreferences();
+export default function QueryPreferences() {
+	const fetchingPreferences = useRef( useSelector( isFetchingPreferences ) );
+	const dispatch = useDispatch();
+
+	// Only runs on mount.
+	useEffect( () => {
+		if ( ! fetchingPreferences.current ) {
+			fetchPreferences()( dispatch );
 		}
-	}
+	}, [ dispatch ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
-
-QueryPreferences.propTypes = {
-	fetchingPreferences: PropTypes.bool,
-	fetchPreferences: PropTypes.func,
-};
-
-QueryPreferences.defaultProps = {
-	fetchPreferences: () => {},
-	fetchingPreferences: false,
-};
-
-export default connect( state => ( { fetchingPreferences: isFetchingPreferences( state ) } ), {
-	fetchPreferences,
-} )( QueryPreferences );

--- a/client/components/data/query-preferences/index.jsx
+++ b/client/components/data/query-preferences/index.jsx
@@ -10,14 +10,19 @@ import { useSelector, useDispatch } from 'react-redux';
 import { isFetchingPreferences } from 'state/preferences/selectors';
 import { fetchPreferences } from 'state/preferences/actions';
 
+const request = () => ( dispatch, getState ) => {
+	if ( ! isFetchingPreferences( getState() ) ) {
+		dispatch( fetchPreferences() );
+	}
+};
+
 export default function QueryPreferences() {
 	const fetchingPreferences = useRef( useSelector( isFetchingPreferences ) );
 	const dispatch = useDispatch();
 
-	// Only runs on mount.
 	useEffect( () => {
 		if ( ! fetchingPreferences.current ) {
-			dispatch( fetchPreferences() );
+			dispatch( request() );
 		}
 	}, [ dispatch ] );
 

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -1,34 +1,25 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { isProductsListFetching as isFetching } from 'state/products-list/selectors';
+import { isProductsListFetching } from 'state/products-list/selectors';
 import { requestProductsList } from 'state/products-list/actions';
 
-class QueryProductsList extends Component {
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.isFetching ) {
-			this.props.requestProductsList();
+export default function QueryProductsList() {
+	const isFetching = useRef( useSelector( isProductsListFetching ) );
+	const dispatch = useDispatch();
+
+	// Only runs on mount.
+	useEffect( () => {
+		if ( ! isFetching.current ) {
+			requestProductsList()( dispatch );
 		}
-	}
+	}, [ dispatch ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
-
-QueryProductsList.propTypes = {
-	isFetching: PropTypes.bool,
-	requestProductsList: PropTypes.func,
-};
-
-export default connect( state => ( { isFetching: isFetching( state ) } ), { requestProductsList } )(
-	QueryProductsList
-);

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,15 +10,18 @@ import { useSelector, useDispatch } from 'react-redux';
 import { isProductsListFetching } from 'state/products-list/selectors';
 import { requestProductsList } from 'state/products-list/actions';
 
+const request = () => ( dispatch, getState ) => {
+	if ( ! isProductsListFetching( getState() ) ) {
+		dispatch( requestProductsList() );
+	}
+};
+
 export default function QueryProductsList() {
-	const isFetching = useRef( useSelector( isProductsListFetching ) );
 	const dispatch = useDispatch();
 
 	// Only runs on mount.
 	useEffect( () => {
-		if ( ! isFetching.current ) {
-			dispatch( requestProductsList() );
-		}
+		dispatch( request() );
 	}, [ dispatch ] );
 
 	return null;

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -17,7 +17,7 @@ export default function QueryProductsList() {
 	// Only runs on mount.
 	useEffect( () => {
 		if ( ! isFetching.current ) {
-			requestProductsList()( dispatch );
+			dispatch( requestProductsList() );
 		}
 	}, [ dispatch ] );
 

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -20,4 +20,4 @@ export default function QuerySiteChecklist( { siteId } ) {
 	return null;
 }
 
-QuerySiteChecklist.propTypes = { siteId: PropTypes.number };
+QuerySiteChecklist.propTypes = { siteId: PropTypes.number.isRequired };

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 /**
@@ -12,13 +12,9 @@ import { requestSiteChecklist } from 'state/checklist/actions';
 
 export default function QuerySiteChecklist( { siteId } ) {
 	const dispatch = useDispatch();
-	const previousId = useRef( undefined );
 
 	useEffect( () => {
-		if ( siteId !== previousId.current ) {
-			dispatch( requestSiteChecklist( siteId ) );
-		}
-		previousId.current = siteId;
+		dispatch( requestSiteChecklist( siteId ) );
 	}, [ dispatch, siteId ] );
 
 	return null;

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -1,43 +1,27 @@
 /**
  * External dependencies
  */
-
-import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { requestSiteChecklist } from 'state/checklist/actions';
 
-class QuerySiteChecklist extends Component {
-	static propTypes = {
-		requestSiteChecklist: PropTypes.func,
-		siteId: PropTypes.number,
-	};
+export default function QuerySiteChecklist( { siteId } ) {
+	const dispatch = useDispatch();
+	const previousId = useRef( undefined );
 
-	UNSAFE_componentWillMount() {
-		this.request( this.props.siteId );
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.siteId || this.props.siteId === nextProps.siteId ) {
-			return;
+	useEffect( () => {
+		if ( siteId !== previousId.current ) {
+			dispatch( requestSiteChecklist( siteId ) );
 		}
+		previousId.current = siteId;
+	}, [ dispatch, siteId ] );
 
-		this.request( nextProps.siteId );
-	}
-
-	request( siteId ) {
-		if ( siteId ) {
-			this.props.requestSiteChecklist( siteId );
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect( null, { requestSiteChecklist } )( QuerySiteChecklist );
+QuerySiteChecklist.propTypes = { siteId: PropTypes.number };

--- a/client/components/data/query-site-domains/index.jsx
+++ b/client/components/data/query-site-domains/index.jsx
@@ -27,4 +27,4 @@ export default function QuerySiteDomains( { siteId } ) {
 	return null;
 }
 
-QuerySiteDomains.propTypes = { siteId: PropTypes.number };
+QuerySiteDomains.propTypes = { siteId: PropTypes.number.isRequired };

--- a/client/components/data/query-site-domains/index.jsx
+++ b/client/components/data/query-site-domains/index.jsx
@@ -12,7 +12,7 @@ import { isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { fetchSiteDomains } from 'state/sites/domains/actions';
 
 const request = siteId => ( dispatch, getState ) => {
-	if ( ! isRequestingSiteDomains( getState(), siteId ) ) {
+	if ( siteId && ! isRequestingSiteDomains( getState(), siteId ) ) {
 		dispatch( fetchSiteDomains( siteId ) );
 	}
 };

--- a/client/components/data/query-site-domains/index.jsx
+++ b/client/components/data/query-site-domains/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,17 +11,18 @@ import { useSelector, useDispatch } from 'react-redux';
 import { isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { fetchSiteDomains } from 'state/sites/domains/actions';
 
+const request = siteId => ( dispatch, getState ) => {
+	if ( ! isRequestingSiteDomains( getState(), siteId ) ) {
+		dispatch( fetchSiteDomains( siteId ) );
+	}
+};
+
 export default function QuerySiteDomains( { siteId } ) {
-	const requestingSiteDomains = useSelector( state => isRequestingSiteDomains( state, siteId ) );
 	const dispatch = useDispatch();
-	const previousId = useRef( undefined );
 
 	useEffect( () => {
-		if ( ! requestingSiteDomains && siteId && siteId !== previousId.current ) {
-			dispatch( fetchSiteDomains( siteId ) );
-		}
-		previousId.current = siteId;
-	}, [ siteId, requestingSiteDomains, dispatch ] );
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
 	return null;
 }

--- a/client/components/data/query-site-domains/index.jsx
+++ b/client/components/data/query-site-domains/index.jsx
@@ -18,7 +18,7 @@ export default function QuerySiteDomains( { siteId } ) {
 
 	useEffect( () => {
 		if ( ! requestingSiteDomains && siteId && siteId !== previousId.current ) {
-			fetchSiteDomains( siteId )( dispatch );
+			dispatch( fetchSiteDomains( siteId ) );
 		}
 		previousId.current = siteId;
 	}, [ siteId, requestingSiteDomains, dispatch ] );

--- a/client/components/data/query-site-domains/index.jsx
+++ b/client/components/data/query-site-domains/index.jsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,55 +11,19 @@ import { bindActionCreators } from 'redux';
 import { isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { fetchSiteDomains } from 'state/sites/domains/actions';
 
-class QuerySiteDomains extends Component {
-	constructor( props ) {
-		super( props );
-		this.requestSiteDomains = this.requestSiteDomains.bind( this );
-	}
+export default function QuerySiteDomains( { siteId } ) {
+	const requestingSiteDomains = useSelector( state => isRequestingSiteDomains( state, siteId ) );
+	const dispatch = useDispatch();
+	const previousId = useRef( undefined );
 
-	UNSAFE_componentWillMount() {
-		this.requestSiteDomains();
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			nextProps.requestingSiteDomains ||
-			! nextProps.siteId ||
-			this.props.siteId === nextProps.siteId
-		) {
-			return;
+	useEffect( () => {
+		if ( ! requestingSiteDomains && siteId && siteId !== previousId.current ) {
+			fetchSiteDomains( siteId )( dispatch );
 		}
-		this.requestSiteDomains( nextProps );
-	}
+		previousId.current = siteId;
+	}, [ siteId, requestingSiteDomains, dispatch ] );
 
-	requestSiteDomains( props = this.props ) {
-		if ( ! props.requestingSiteDomains && props.siteId ) {
-			props.fetchSiteDomains( props.siteId );
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-QuerySiteDomains.propTypes = {
-	siteId: PropTypes.number,
-	requestingSiteDomains: PropTypes.bool,
-	fetchSiteDomains: PropTypes.func,
-};
-
-QuerySiteDomains.defaultProps = {
-	fetchSiteDomains: () => {},
-};
-
-export default connect(
-	( state, ownProps ) => {
-		return {
-			requestingSiteDomains: isRequestingSiteDomains( state, ownProps.siteId ),
-		};
-	},
-	dispatch => {
-		return bindActionCreators( { fetchSiteDomains }, dispatch );
-	}
-)( QuerySiteDomains );
+QuerySiteDomains.propTypes = { siteId: PropTypes.number };

--- a/client/components/data/query-site-plans/index.jsx
+++ b/client/components/data/query-site-plans/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,60 +11,19 @@ import { bindActionCreators } from 'redux';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 
-class QuerySitePlans extends Component {
-	constructor( props ) {
-		super( props );
-		this.requestPlans = this.requestPlans.bind( this );
-	}
+export default function QuerySitePlans( { siteId } ) {
+	const requestingSitePlans = useSelector( isRequestingSitePlans );
+	const dispatch = useDispatch();
+	const previousId = useRef( undefined );
 
-	requestPlans( props = this.props ) {
-		if ( ! props.requestingSitePlans && props.siteId ) {
-			props.fetchSitePlans( props.siteId );
+	useEffect( () => {
+		if ( ! requestingSitePlans && siteId && siteId !== previousId.current ) {
+			fetchSitePlans( siteId )( dispatch );
 		}
-	}
+		previousId.current = siteId;
+	}, [ dispatch, requestingSitePlans, siteId ] );
 
-	UNSAFE_componentWillMount() {
-		this.requestPlans();
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			nextProps.requestingSitePlans ||
-			! nextProps.siteId ||
-			this.props.siteId === nextProps.siteId
-		) {
-			return;
-		}
-		this.requestPlans( nextProps );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-QuerySitePlans.propTypes = {
-	siteId: PropTypes.number,
-	requestingPlans: PropTypes.bool,
-	fetchSitePlans: PropTypes.func,
-};
-
-QuerySitePlans.defaultProps = {
-	fetchSitePlans: () => {},
-};
-
-export default connect(
-	( state, ownProps ) => {
-		return {
-			requestingSitePlans: isRequestingSitePlans( state, ownProps.siteId ),
-		};
-	},
-	dispatch => {
-		return bindActionCreators(
-			{
-				fetchSitePlans,
-			},
-			dispatch
-		);
-	}
-)( QuerySitePlans );
+QuerySitePlans.propTypes = { siteId: PropTypes.number };

--- a/client/components/data/query-site-plans/index.jsx
+++ b/client/components/data/query-site-plans/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,17 +11,18 @@ import { useSelector, useDispatch } from 'react-redux';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 
+const request = siteId => ( dispatch, getState ) => {
+	if ( ! isRequestingSitePlans( getState(), siteId ) ) {
+		dispatch( fetchSitePlans() );
+	}
+};
+
 export default function QuerySitePlans( { siteId } ) {
-	const requestingSitePlans = useSelector( isRequestingSitePlans );
 	const dispatch = useDispatch();
-	const previousId = useRef( undefined );
 
 	useEffect( () => {
-		if ( ! requestingSitePlans && siteId && siteId !== previousId.current ) {
-			dispatch( fetchSitePlans( siteId ) );
-		}
-		previousId.current = siteId;
-	}, [ dispatch, requestingSitePlans, siteId ] );
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
 	return null;
 }

--- a/client/components/data/query-site-plans/index.jsx
+++ b/client/components/data/query-site-plans/index.jsx
@@ -12,7 +12,7 @@ import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 
 const request = siteId => ( dispatch, getState ) => {
-	if ( ! isRequestingSitePlans( getState(), siteId ) ) {
+	if ( siteId && ! isRequestingSitePlans( getState(), siteId ) ) {
 		dispatch( fetchSitePlans( siteId ) );
 	}
 };

--- a/client/components/data/query-site-plans/index.jsx
+++ b/client/components/data/query-site-plans/index.jsx
@@ -18,7 +18,7 @@ export default function QuerySitePlans( { siteId } ) {
 
 	useEffect( () => {
 		if ( ! requestingSitePlans && siteId && siteId !== previousId.current ) {
-			fetchSitePlans( siteId )( dispatch );
+			dispatch( fetchSitePlans( siteId ) );
 		}
 		previousId.current = siteId;
 	}, [ dispatch, requestingSitePlans, siteId ] );

--- a/client/components/data/query-site-plans/index.jsx
+++ b/client/components/data/query-site-plans/index.jsx
@@ -13,7 +13,7 @@ import { fetchSitePlans } from 'state/sites/plans/actions';
 
 const request = siteId => ( dispatch, getState ) => {
 	if ( ! isRequestingSitePlans( getState(), siteId ) ) {
-		dispatch( fetchSitePlans() );
+		dispatch( fetchSitePlans( siteId ) );
 	}
 };
 

--- a/client/components/data/query-site-selected-editor/index.jsx
+++ b/client/components/data/query-site-selected-editor/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 /**
@@ -12,13 +12,9 @@ import { requestSelectedEditor } from 'state/selected-editor/actions';
 
 export default function QuerySiteDomains( { siteId } ) {
 	const dispatch = useDispatch();
-	const previousId = useRef( undefined );
 
 	useEffect( () => {
-		if ( siteId !== previousId.current ) {
-			dispatch( requestSelectedEditor( siteId ) );
-		}
-		previousId.current = siteId;
+		dispatch( requestSelectedEditor( siteId ) );
 	}, [ dispatch, siteId ] );
 
 	return null;

--- a/client/components/data/query-site-selected-editor/index.jsx
+++ b/client/components/data/query-site-selected-editor/index.jsx
@@ -10,7 +10,7 @@ import { useDispatch } from 'react-redux';
  */
 import { requestSelectedEditor } from 'state/selected-editor/actions';
 
-export default function QuerySiteDomains( { siteId } ) {
+export default function QuerySiteSelectedEditor( { siteId } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
@@ -20,4 +20,4 @@ export default function QuerySiteDomains( { siteId } ) {
 	return null;
 }
 
-QuerySiteDomains.propTypes = { siteId: PropTypes.number };
+QuerySiteSelectedEditor.propTypes = { siteId: PropTypes.number };

--- a/client/components/data/query-site-selected-editor/index.jsx
+++ b/client/components/data/query-site-selected-editor/index.jsx
@@ -1,40 +1,27 @@
 /**
  * External dependencies
  */
-import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { requestSelectedEditor } from 'state/selected-editor/actions';
 
-export class QuerySiteSelectedEditor extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-	};
+export default function QuerySiteDomains( { siteId } ) {
+	const dispatch = useDispatch();
+	const previousId = useRef( undefined );
 
-	componentDidMount() {
-		this.request();
-	}
-
-	componentDidUpdate( { siteId } ) {
-		if ( siteId !== this.props.siteId ) {
-			this.request();
+	useEffect( () => {
+		if ( siteId !== previousId.current ) {
+			dispatch( requestSelectedEditor( siteId ) );
 		}
-	}
+		previousId.current = siteId;
+	}, [ dispatch, siteId ] );
 
-	request() {
-		const { siteId } = this.props;
-		if ( siteId ) {
-			this.props.requestSelectedEditor( siteId );
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect( null, { requestSelectedEditor } )( QuerySiteSelectedEditor );
+QuerySiteDomains.propTypes = { siteId: PropTypes.number };

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -13,7 +13,7 @@ exports[`Plans should render plans 1`] = `
     title="Plans"
   />
   <Connect(QueryPlans) />
-  <Connect(QuerySitePlans)
+  <QuerySitePlans
     siteId={1234567}
   />
   <Connect(Localized(JetpackPlansGrid))


### PR DESCRIPTION
Using hooks, these can be rewritten into a form that's much cleaner and easier to understand.

This also has the advantage of letting us change when actions get dispatched, and make sure it doesn't happen when the browser is busy rendering.

Looking for feedback on a few things, for which I added inline comments.

#### Changes proposed in this Pull Request

* Rewrite several `Query` components to use `react-redux` hooks instead of `connect`

#### Testing instructions

Ensure that the queries continue to be performed correctly. All of these are used in the stats page, so you can test them all in one go.
