### PR TITLE
Checkout: Fix payment method box

### DIFF
--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -119,7 +119,6 @@ export class PaymentBox extends PureComponent {
 		return (
 			<NavItem
 				key={ method }
-				className={ method }
 				href=""
 				onClick={ this.handlePaymentMethodChange( method ) }
 				selected={ this.props.currentPaymentMethod === method }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a style conflict introduced here: https://github.com/Automattic/wp-calypso/pull/36893. We're sharing style names with other components and as a result, styles applied to the other component bled over to the checkout. I removed the offending class name since it wasn't being used on checkout.

Before:
![image](https://user-images.githubusercontent.com/6981253/68696663-64336f80-054b-11ea-93f9-37cb22057669.png)


After:
![image](https://user-images.githubusercontent.com/6981253/68696632-54b42680-054b-11ea-8c2b-16ead20dbe0d.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make your way to checkout and ensure the tabs are displayed the same for all payment methods. 
* Checkout the credit card component in dev docs to ensure nothing has changed there. (/devdocs/design/credit-card)
