### PR TITLE
composite-checkout: Always render all CheckoutWrapper components

### DIFF
--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -40,9 +40,7 @@ export const CheckoutProvider = ( {
 	validateArg( successRedirectUrl, 'CheckoutProvider missing required prop: successRedirectUrl' );
 	validateArg( failureRedirectUrl, 'CheckoutProvider missing required prop: failureRedirectUrl' );
 
-	const CheckoutWrappers = allPaymentMethods
-		.map( method => method.CheckoutWrapper )
-		.filter( Boolean );
+	const wrappers = allPaymentMethods.map( method => method.CheckoutWrapper ).filter( Boolean );
 
 	// Create the registry automatically if it's not a prop
 	const registryRef = useRef( registry );
@@ -63,7 +61,7 @@ export const CheckoutProvider = ( {
 				<LocalizeProvider locale={ locale }>
 					<LineItemsProvider items={ items } total={ total }>
 						<CheckoutContext.Provider value={ value }>
-							<PaymentMethodWrapperProvider wrappers={ CheckoutWrappers }>
+							<PaymentMethodWrapperProvider wrappers={ wrappers }>
 								{ children }
 							</PaymentMethodWrapperProvider>
 						</CheckoutContext.Provider>

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -153,7 +153,7 @@ export function createStripeMethod( {
 	};
 }
 
-function StripeCreditCardFields() {
+function StripeCreditCardFields( isActive, summary ) {
 	const localize = useLocalize();
 	const theme = useContext( ThemeContext );
 	const { onFailure } = useCheckoutHandlers();

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -153,7 +153,7 @@ export function createStripeMethod( {
 	};
 }
 
-function StripeCreditCardFields( { isActive, summary } ) {
+function StripeCreditCardFields() {
 	const localize = useLocalize();
 	const theme = useContext( ThemeContext );
 	const { onFailure } = useCheckoutHandlers();

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -153,7 +153,7 @@ export function createStripeMethod( {
 	};
 }
 
-function StripeCreditCardFields( isActive, summary ) {
+function StripeCreditCardFields( { isActive, summary } ) {
 	const localize = useLocalize();
 	const theme = useContext( ThemeContext );
 	const { onFailure } = useCheckoutHandlers();

--- a/packages/composite-checkout/src/lib/stripe.js
+++ b/packages/composite-checkout/src/lib/stripe.js
@@ -289,13 +289,8 @@ export function StripeHookProvider( { children, configurationArgs } ) {
  */
 export function useStripe() {
 	const stripeData = useContext( StripeContext );
-	return (
-		stripeData || {
-			stripe: null,
-			stripeConfiguration: null,
-			isStripeLoading: false,
-			stripeLoadingError: null,
-			forceReload: () => {},
-		}
-	);
+	if ( ! stripeData ) {
+		throw new Error( 'useStripe can only be used in a StripeHookProvider' );
+	}
+	return stripeData;
 }


### PR DESCRIPTION
This changes the behavior of the `CheckoutWrapper` property of each Payment Method object so that it always uses the wrapper, even when a payment method is not active.

#### Testing instructions

- Add a file called packages/composite-checkout/demo/private.js and inside it put the following: `export const stripeKey = 'TEST KEY HERE'`;
- Run `npm run composite-checkout-demo`.
- Verify that the form works as expected.
