### PR TITLE
Revert "Signup: Allow reCAPTCHA test selection for any locale"

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,6 +123,5 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-		localeTargets: 'any',
 	},
 };


### PR DESCRIPTION
Reverts Automattic/wp-calypso#37516 - waiting on translations for the footer changes.