### PR TITLE
Give another minute to time out. Sauce takes longer

### DIFF
--- a/test/e2e/magellan.json
+++ b/test/e2e/magellan.json
@@ -10,5 +10,5 @@
 	"reporters": [ "./lib/reporter/magellan-reporter.js" ],
 	"executors": [ "testarmada-magellan-local-executor" ],
 	"local_browser": "chrome",
-	"bail_time": 300000
+	"bail_time": 360000
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This just extends test timeout. Sauce is taking longer so it is timing out too soon.
