### PR TITLE
Hosting: Correct grammar in warning.

### DIFF
--- a/client/my-sites/hosting/data-loss-warning/index.js
+++ b/client/my-sites/hosting/data-loss-warning/index.js
@@ -28,7 +28,7 @@ const DataLossWarning = ( { avatars, translate } ) => {
 				</strong>
 				&nbsp;
 				{ translate(
-					'If you need help or have any questions our Happiness Engineers are here when you need them!'
+					'If you need help or have any questions, our Happiness Engineers are here when you need them!'
 				) }
 			</p>
 			<div className="data-loss-warning__contact">


### PR DESCRIPTION
Correct grammar in the Hosting section's warning.

**Testing Instructions**

- Open this branch with a local install.
- Go to `/hosting-admin` and select a new Atomic site created after October 31.
- Verify the added comma.

<img width="787" alt="Screen Shot 2019-11-12 at 2 17 44 PM" src="https://user-images.githubusercontent.com/349751/68715620-453ada80-0557-11ea-9202-c5998e0291e8.png">
