### PR TITLE
Fix Build on Windows 10 [IGNORE]

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -242,11 +242,11 @@ const webpackConfig = {
 				includePaths: [ path.join( __dirname, 'client' ) ],
 				prelude: `@import '${ path.join(
 					__dirname,
-					'client/assets/stylesheets/shared/_utils.scss'
+					'client', 'assets', 'stylesheets', 'shared', '_utils.scss'
 				) }';`,
 			} ),
 			{
-				include: path.join( __dirname, 'client/sections.js' ),
+				include: path.join( __dirname, 'client','sections.js' ),
 				loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
 				options: {
 					include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
@@ -273,9 +273,9 @@ const webpackConfig = {
 		alias: Object.assign(
 			{
 				'react-virtualized': 'react-virtualized/dist/es',
-				debug: path.resolve( __dirname, 'node_modules/debug' ),
+				debug: path.resolve( __dirname, 'node_modules','debug' ),
 				store: 'store/dist/store.modern',
-				gridicons$: path.resolve( __dirname, 'client/components/gridicon' ),
+				gridicons$: path.resolve( __dirname, 'client', 'components', 'gridicon' ),
 			},
 			getAliasesForExtensions( {
 				extensionsDirectory: path.join( __dirname, 'client', 'extensions' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to fix the current (long-standing) build breakage of Calypso on Windows 10. Piggybacking off the work started by @stephanethomas in #27418.

This issue is currently a blocker with respect to ongoing efforts to build wp-desktop natively on Windows (in order to upgrade and maintain the Electron app).

Work is still in-progress but opening up a draft PR for any and all ideas/suggestions to debug/fix.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TODO

Fixes #27400
