### PR TITLE
Check that Atomic site is still on a paid plan

### DIFF
--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -13,6 +13,7 @@ import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import { isBusinessPlan } from 'lib/plans';
 import canCurrentUser from 'state/selectors/can-current-user';
+import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 
 /**
  * TODO: this selector should be backed by an API response instead
@@ -32,6 +33,10 @@ export default function canSiteViewAtomicHosting( state ) {
 	// ID of site added 31 Oct 2019, so only sites newer currently eligible
 	const isEligibleSite = siteId > 168768859;
 	if ( ! isEligibleSite ) {
+		return false;
+	}
+
+	if ( ! isSiteOnPaidPlan( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -13,7 +13,7 @@ import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import { isBusinessPlan } from 'lib/plans';
 import canCurrentUser from 'state/selectors/can-current-user';
-import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
+import isSiteOnAtomicPlan from 'state/selectors/is-site-on-atomic-plan';
 
 /**
  * TODO: this selector should be backed by an API response instead
@@ -36,7 +36,7 @@ export default function canSiteViewAtomicHosting( state ) {
 		return false;
 	}
 
-	if ( ! isSiteOnPaidPlan( state, siteId ) ) {
+	if ( ! isSiteOnAtomicPlan( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-site-on-atomic-plan.js
+++ b/client/state/selectors/is-site-on-atomic-plan.js
@@ -1,0 +1,26 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { isEcommercePlan, isBusinessPlan } from 'lib/plans';
+
+/**
+ * Returns true if site is on a paid plan that is eligible to be an Atomic site,
+ * false if not, or if the site or plan is unknown.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @return {Boolean} Whether site is on an atomic paid plan
+ */
+const isSiteOnAtomicPlan = ( state, siteId ) => {
+	const currentPlan = getCurrentPlan( state, siteId );
+
+	if ( ! currentPlan ) {
+		return false;
+	}
+
+	return isEcommercePlan( currentPlan.productSlug ) || isBusinessPlan( currentPlan.productSlug );
+};
+
+export default isSiteOnAtomicPlan;


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Check that Atomic site is still on relevant paid plan to prevent sftp/phpmyadmin feature being displayed if Atomic site has been deactivated or switched to an ineligible plan

#### Testing instructions

* Remove the subscription from an existing Atomic Site (you will need someone with StoreAdmin access to do this)
* View the site in local calypso and you should still have the Sftp/Mysql feature available
* Checkout this branch and check again - the feature should now be removed for that site

Before: 

<img width="545" alt="Screen Shot 2019-11-14 at 8 39 16 AM" src="https://user-images.githubusercontent.com/3629020/68799679-72090200-06bd-11ea-91d4-cfae06f31c0e.png">

After:
<img width="553" alt="Screen Shot 2019-11-14 at 8 38 27 AM" src="https://user-images.githubusercontent.com/3629020/68799708-8220e180-06bd-11ea-971c-dffdc4dd07c5.png">

The UI component of  #37363
