### PR TITLE
Fix broken image link in app promo component in the Reader sidebar

### DIFF
--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -188,7 +188,7 @@ export class AppPromo extends React.Component {
 				>
 					<img
 						className="app-promo__icon"
-						src="/calypso/images/reader/promo-app-icon.png"
+						src={ wordpressLogoImage }
 						width="32"
 						height="32"
 						alt="WordPress Desktop Icon"

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -191,7 +191,7 @@ export class AppPromo extends React.Component {
 						src={ wordpressLogoImage }
 						width="32"
 						height="32"
-						alt="WordPress Desktop Icon"
+						alt="WordPress App Icon"
 					/>
 					{ 'WordPress.com in the palm of your hands — download the mobile app.' }
 				</button>


### PR DESCRIPTION
This fixes a broken image link introduced in https://github.com/Automattic/wp-calypso/pull/36791 — just looks like one of the old `.png` image file references was missed. I think we probably didn't catch this earlier because the sidebar app promo component in the reader only displayed the broken image link 20% of the time due to [the random promo display](https://github.com/automattic/wp-calypso/blob/777ea4208d51936ab8db1e0bd24d1ac938aa9277/client/blocks/app-promo/index.jsx#L63).

#### Changes proposed in this Pull Request

* Fix broken image link in app promo component and replace with `wordPressLogoImage` reference
* Update alt text for this image (these strings aren't translated yet, but the AppPromo component is currently only used in the `en` locale at the moment, so I think this can wait until another time)

##### Before

![image](https://user-images.githubusercontent.com/14988353/68733723-c6fc3800-062b-11ea-8194-1f4720f25334.png)

##### After

![image](https://user-images.githubusercontent.com/14988353/68734168-771e7080-062d-11ea-97a8-1ae03cf5439c.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in and go to the reader `/` (in a user where you haven't dismissed the sidebar app promo) and reload the page a bunch of times until you see the text "Wordpress.com in the palm of your hands — download the mobile app", and the WordPress logo should display as in the screenshot.

(To force testing this locally in code, [replace this line](https://github.com/automattic/wp-calypso/blob/ff14be5d758a11eeaaefff4640ee15c5e4ebe094/client/blocks/app-promo/index.jsx#L63) with `return promoOptions[4];`)
