### PR TITLE
Enable domain step copy update feature for dev

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,4 +124,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	domainStepCopyUpdates: {
+		datestamp: '20291111',
+		variations: {
+			variantShowUpdates: 0,
+			control: 100,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -121,6 +121,19 @@ class DomainsStep extends React.Component {
 
 			props.goToNextStep();
 		}
+
+		if ( 'undefined' === typeof this.props.showExampleSuggestions ) {
+			if (
+				config.isEnabled( 'domain-step-copy-update' ) &&
+				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
+			) {
+				this.showExampleSuggestions = false;
+				this.showTestCopy = true;
+			} else {
+				this.showExampleSuggestions = true;
+				this.showTestCopy = false;
+			}
+		}
 	}
 
 	static getDerivedStateFromProps( nextProps ) {
@@ -381,21 +394,6 @@ class DomainsStep extends React.Component {
 			}
 		}
 
-		let showExampleSuggestions = this.props.showExampleSuggestions,
-			showTestCopy;
-		if ( 'undefined' === typeof showExampleSuggestions ) {
-			if (
-				config.isEnabled( 'domain-step-copy-update' ) &&
-				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
-			) {
-				showExampleSuggestions = false;
-				showTestCopy = true;
-			} else {
-				showExampleSuggestions = true;
-				showTestCopy = false;
-			}
-		}
-
 		let includeWordPressDotCom = this.props.includeWordPressDotCom;
 		if ( 'undefined' === typeof includeWordPressDotCom ) {
 			includeWordPressDotCom = ! this.props.isDomainOnly;
@@ -421,8 +419,8 @@ class DomainsStep extends React.Component {
 				includeWordPressDotCom={ includeWordPressDotCom }
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
-				showExampleSuggestions={ showExampleSuggestions }
-				showTestCopy={ showTestCopy }
+				showExampleSuggestions={ this.showExampleSuggestions }
+				showTestCopy={ this.showTestCopy }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor() }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -50,6 +50,8 @@ import { isDomainStepSkippable } from 'signup/config/steps';
 import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
+import { abtest } from 'lib/abtest';
+import config from 'config';
 
 /**
  * Style dependencies
@@ -379,9 +381,19 @@ class DomainsStep extends React.Component {
 			}
 		}
 
-		let showExampleSuggestions = this.props.showExampleSuggestions;
+		let showExampleSuggestions = this.props.showExampleSuggestions,
+			showTestCopy;
 		if ( 'undefined' === typeof showExampleSuggestions ) {
-			showExampleSuggestions = true;
+			if (
+				config.isEnabled( 'domain-step-copy-update' ) &&
+				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
+			) {
+				showExampleSuggestions = false;
+				showTestCopy = true;
+			} else {
+				showExampleSuggestions = true;
+				showTestCopy = false;
+			}
 		}
 
 		let includeWordPressDotCom = this.props.includeWordPressDotCom;
@@ -410,6 +422,7 @@ class DomainsStep extends React.Component {
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
+				showTestCopy={ showTestCopy }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor() }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -122,7 +122,10 @@ class DomainsStep extends React.Component {
 			props.goToNextStep();
 		}
 
-		if ( 'undefined' === typeof this.props.showExampleSuggestions ) {
+		this.showTestCopy = false;
+		this.showExampleSuggestions = this.props.showExampleSuggestions;
+
+		if ( 'undefined' === typeof this.showExampleSuggestions ) {
 			if (
 				config.isEnabled( 'domain-step-copy-update' ) &&
 				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )

--- a/config/development.json
+++ b/config/development.json
@@ -49,6 +49,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domain-step-copy-update": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/dashes-filter": true,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,6 +36,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domain-step-copy-update": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR creates a new A/B test for the domain copy updates changes as described in p8Eqe3-Uq-p2.
* We add a development feature flag and set the A/B test to a future date with a 0/100 split, just to ensure that no user will get assigned to the test.
* There's nothing more happening here other than enabling the config flag and the A/B test. Subsequent copy and UI updates will be built on top of this. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow and verify that you don't get assigned to the `domainStepCopyUpdates ` test (type `localStorage.ABTests;` in your browser console and verify this test is not present in the displayed object).
* Everything should just work like now, there are no user facing changes introduced in this PR.