### PR TITLE
Gutenboarding: Domains suggestion API fixups

### DIFF
--- a/client/landing/gutenboarding/stores/domain-suggestions/reducer.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/reducer.ts
@@ -7,20 +7,19 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { ActionType, DomainSuggestion, SerializedDomainsSuggestionsQuery } from './types';
+import { ActionType, DomainSuggestion } from './types';
 import * as Actions from './actions';
-import { getSerializedDomainsSuggestionsQuery } from 'state/domains/suggestions/utils';
+import { stringifyDomainQueryObject } from './utils';
 
 const domainSuggestions: Reducer<
-	Record< SerializedDomainsSuggestionsQuery, DomainSuggestion[] >,
+	Record< string, DomainSuggestion[] >,
 	ReturnType< typeof Actions[ 'receiveDomainSuggestions' ] >
 > = ( state = {}, action ) => {
 	if ( action.type === ActionType.RECEIVE_DOMAIN_SUGGESTIONS ) {
-		const serializedQuery =
-			action.queryObject && getSerializedDomainsSuggestionsQuery( action.queryObject );
-		if ( serializedQuery ) {
-			return { ...state, [ serializedQuery ]: action.suggestions };
-		}
+		return {
+			...state,
+			[ stringifyDomainQueryObject( action.queryObject ) ]: action.suggestions,
+		};
 	}
 	return state;
 };

--- a/client/landing/gutenboarding/stores/domain-suggestions/resolvers.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/resolvers.ts
@@ -7,10 +7,12 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import { DomainSuggestionQuery } from './types';
 import { receiveDomainSuggestions } from './actions';
 
-export function* getDomainSuggestions( queryObject: DomainSuggestionQuery ) {
+export function* __internalGetDomainSuggestions(
+	// Resolver has the same signature as corresponding selector without the initial state argument
+	queryObject: Parameters< typeof import('./selectors').__internalGetDomainSuggestions >[ 1 ]
+) {
 	const url = 'https://public-api.wordpress.com/rest/v1.1/domains/suggestions';
 
 	// `credentials` and `mode` args are needed since we're accessing the WP.com REST API

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -48,16 +48,18 @@ export const __internalGetDomainSuggestions = (
  */
 function normalizeDomainSuggestionQuery(
 	search: string,
-	q: DomainSuggestionSelectorOptions
+	queryOptions: DomainSuggestionSelectorOptions
 ): DomainSuggestionQuery {
-	return Object.assign(
-		{
-			query: search.toLocaleLowerCase(),
-			include_wordpressdotcom: q.include_wordpressdotcom || false, // @FIXME replace `||` with `??`
-			quantity: q.quantity || 5, // @FIXME replace `||` with `??`
-			vendor: 'variation2_front', // see client/lib/domains/suggestions/index.js
-		},
-		q.recommendation_context && { recommendation_context: q.recommendation_context },
-		q.vertical && { vertical: q.vertical }
-	);
+	return {
+		// Defaults
+		include_wordpressdotcom: false,
+		quantity: 5,
+		vendor: 'variation2_front',
+
+		// Merge options
+		...queryOptions,
+
+		// Add the search query
+		query: search.toLocaleLowerCase(),
+	};
 }

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -1,15 +1,63 @@
 /**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
+import { STORE_KEY } from '.';
 import { DomainSuggestionQuery } from './types';
 import { State } from './reducer';
-import { getSerializedDomainsSuggestionsQuery } from 'state/domains/suggestions/utils';
+import { stringifyDomainQueryObject } from './utils';
 
 export const getState = ( state: State ) => state;
-export const getDomainSuggestions = ( state: State, queryObject: DomainSuggestionQuery ) => {
-	const serializedQuery = getSerializedDomainsSuggestionsQuery( queryObject );
-	if ( serializedQuery ) {
-		return state.domainSuggestions[ serializedQuery ];
-	}
-	return null;
+
+type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;
+export const getDomainSuggestions = (
+	state: State,
+	search: string,
+	options: Partial< Exclude< DomainSuggestionQuery, 'query' > > = {}
+) => {
+	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
+
+	// We need to go through the `select` store to get the resolver action
+	return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
 };
+
+/**
+ * Do not use this selector. It is for internal use.
+ *
+ * @private
+ */
+export const __internalGetDomainSuggestions = (
+	state: State,
+	queryObject: DomainSuggestionQuery
+) => {
+	return state.domainSuggestions[ stringifyDomainQueryObject( queryObject ) ];
+};
+
+/**
+ * Normalize domain query
+ *
+ * It's important to have a consistent, reproduceable representation of a domains query so that the result can be
+ * stored and retrieved.
+ *
+ * @see client/state/domains/suggestions/utils.js
+ * @see client/components/data/query-domains-suggestions/index.jsx
+ */
+function normalizeDomainSuggestionQuery(
+	search: string,
+	q: DomainSuggestionSelectorOptions
+): DomainSuggestionQuery {
+	return Object.assign(
+		{
+			query: search.toLocaleLowerCase(),
+			include_wordpressdotcom: q.include_wordpressdotcom || false, // @FIXME replace `||` with `??`
+			quantity: q.quantity || 5, // @FIXME replace `||` with `??`
+			vendor: 'variation2_front', // see client/lib/domains/suggestions/index.js
+		},
+		q.recommendation_context && { recommendation_context: q.recommendation_context },
+		q.vertical && { vertical: q.vertical }
+	);
+}

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -29,6 +29,10 @@ export const getDomainSuggestions = (
  * Do not use this selector. It is for internal use.
  *
  * @private
+ *
+ * @param state Store state
+ * @param queryObject Normalized object representing the query
+ * @return suggestions
  */
 export const __internalGetDomainSuggestions = (
 	state: State,
@@ -45,6 +49,10 @@ export const __internalGetDomainSuggestions = (
  *
  * @see client/state/domains/suggestions/utils.js
  * @see client/components/data/query-domains-suggestions/index.jsx
+ *
+ * @param search       Domain search string
+ * @param queryOptions Optional paramaters for the query
+ * @return Normalized query object
  */
 function normalizeDomainSuggestionQuery(
 	search: string,

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -17,7 +17,7 @@ type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 
 export const getDomainSuggestions = (
 	state: State,
 	search: string,
-	options: Partial< Exclude< DomainSuggestionQuery, 'query' > > = {}
+	options: DomainSuggestionSelectorOptions = {}
 ) => {
 	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
 

--- a/client/landing/gutenboarding/stores/domain-suggestions/types.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/types.ts
@@ -6,14 +6,33 @@ export { ActionType };
 
 // See client/state/domains/suggestions/actions.js#requestDomainsSuggestions
 export interface DomainSuggestionQuery {
-	[ key: string ]: string | number | boolean | undefined;
-	query: string; // Domain query
-	quantity: number; // max results
-	vendor: string; // vendor
-	include_wordpressdotcom?: boolean; // adds wordpress subdomain suggestions when true
-}
+	/**
+	 * Domain query
+	 */
+	query: string;
 
-export type SerializedDomainsSuggestionsQuery = string;
+	/**
+	 * Number of results
+	 */
+	quantity: number;
+
+	/**
+	 * Vendor
+	 */
+	vendor: string;
+
+	/**
+	 * True to include WordPress.com subdomain suggestions
+	 */
+	include_wordpressdotcom: boolean;
+
+	recommendation_context?: string;
+
+	/**
+	 * The site vertical
+	 */
+	vertical?: string;
+}
 
 export interface DomainSuggestion {
 	domain_name: string;

--- a/client/landing/gutenboarding/stores/domain-suggestions/utils.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import deterministicStringify from 'fast-json-stable-stringify';
+
+/**
+ * Internal dependencies
+ */
+import { DomainSuggestionQuery } from './types';
+
+/**
+ * Stable transform to an object key for storage and access.
+ *
+ * @TODO Should we eliminate some properties from serialization like `getSerializedDomainsSuggestionsQuery`?
+ * @see client/state/domains/suggestions/utils.js
+ */
+export const stringifyDomainQueryObject: (
+	q: DomainSuggestionQuery
+) => string = deterministicStringify;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3215,6 +3215,12 @@
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
 		},
+		"@types/fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==",
+			"dev": true
+		},
 		"@types/glob": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -306,6 +306,7 @@
 		"@testing-library/react": "9.3.2",
 		"@types/classnames": "2.2.9",
 		"@types/debug": "4.1.4",
+		"@types/fast-json-stable-stringify": "2.0.0",
 		"@types/lodash": "4.14.146",
 		"@types/page": "1.8.0",
 		"@types/react": "16.9.11",


### PR DESCRIPTION
Follow-up to #37483 

#### Changes proposed in this Pull Request

- Don't rely on Calypso `/client`
- Rework selector with a simpler API
- Normalize inputs with sane defaults

#### Testing instructions

Try the following at `/gutenboarding`:

```js
wp.data.select('automattic/domains/suggestions').getDomainSuggestions('cats')
wp.data.select('automattic/domains/suggestions').getDomainSuggestions('dogs', { quantity: 1 })
wp.data.select('automattic/domains/suggestions').getDomainSuggestions('dogs')
wp.data.select('automattic/domains/suggestions').getDomainSuggestions('dogs', { quantity: 36 })
```

First run of the same query should produce nothing, but request should fire.
Subsequent runs (after request resolves) should return domain information.