### PR TITLE
Domain step test: Add header/sub-header copy changes

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -36,6 +36,9 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			domainsStepSubheader: i18n.translate(
 				'Enter a keyword that describes your site to get started.'
 			),
+			domainsStepHeaderTestCopy: "Let's get your site a domain!",
+			domainsStepSubheaderTestCopy:
+				"Enter your site's name or a few keywords, and we'll come up with some suggestions.",
 			// Site styles step
 			siteStyleSubheader: i18n.translate(
 				'This will help you get started with a theme you might like. You can change it later.'
@@ -102,6 +105,9 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."
 			),
+			domainsStepHeaderTestCopy: "Let's get your blog a domain!",
+			domainsStepSubheaderTestCopy:
+				"Enter your blog's name or a few keywords, and we'll come up with some suggestions.",
 		},
 		{
 			id: 1, // This value must correspond with its sibling in the /segments API results
@@ -118,6 +124,9 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your business's name or some keywords that describe it to get started."
 			),
+			domainsStepHeaderTestCopy: "Let's get your business a domain!",
+			domainsStepSubheaderTestCopy:
+				"Enter your business's name or a few keywords, and we'll come up with some suggestions.",
 			customerType: 'business',
 		},
 		{
@@ -154,6 +163,12 @@ export function getAllSiteTypes() {
 			customerType: 'business',
 			purchaseRequired: true,
 			forcePublicSite: true,
+			domainsStepSubheader: i18n.translate(
+				"Enter your site's name or some keywords that describe it to get started."
+			),
+			domainsStepHeaderTestCopy: "Let's get your store a domain!",
+			domainsStepSubheaderTestCopy:
+				"Enter your store's name or a few keywords, and we'll come up with some suggestions.",
 		},
 	];
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -38,7 +38,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			),
 			domainsStepHeaderTestCopy: "Let's get your site a domain!",
 			domainsStepSubheaderTestCopy:
-				"Enter your site's name or a few keywords, and we'll come up with some suggestions.",
+				"Tell us your site's name or a few keywords, and we'll come up with some suggestions.",
 			// Site styles step
 			siteStyleSubheader: i18n.translate(
 				'This will help you get started with a theme you might like. You can change it later.'
@@ -107,7 +107,7 @@ export function getAllSiteTypes() {
 			),
 			domainsStepHeaderTestCopy: "Let's get your blog a domain!",
 			domainsStepSubheaderTestCopy:
-				"Enter your blog's name or a few keywords, and we'll come up with some suggestions.",
+				"Tell us your blog's name or a few keywords, and we'll come up with some suggestions.",
 		},
 		{
 			id: 1, // This value must correspond with its sibling in the /segments API results
@@ -126,7 +126,7 @@ export function getAllSiteTypes() {
 			),
 			domainsStepHeaderTestCopy: "Let's get your business a domain!",
 			domainsStepSubheaderTestCopy:
-				"Enter your business's name or a few keywords, and we'll come up with some suggestions.",
+				"Tell us your business's name or a few keywords, and we'll come up with some suggestions.",
 			customerType: 'business',
 		},
 		{
@@ -168,7 +168,7 @@ export function getAllSiteTypes() {
 			),
 			domainsStepHeaderTestCopy: "Let's get your store a domain!",
 			domainsStepSubheaderTestCopy:
-				"Enter your store's name or a few keywords, and we'll come up with some suggestions.",
+				"Tell us your store's name or a few keywords, and we'll come up with some suggestions.",
 		},
 	];
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -692,4 +692,3 @@ export default connect(
 		showSitePreview,
 	}
 )( localize( DomainsStep ) );
-

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -504,10 +504,13 @@ class DomainsStep extends React.Component {
 
 	getSubHeaderText() {
 		const { flowName, siteType, translate } = this.props;
+		const subHeaderPropertyName = this.showTestCopy
+			? 'domainsStepSubheaderTestCopy'
+			: 'domainsStepSubheader';
 		const onboardingSubHeaderCopy =
 			siteType &&
-			includes( [ 'onboarding' ], flowName ) &&
-			getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+			includes( [ 'onboarding', 'ecommerce-onboarding' ], flowName ) &&
+			getSiteTypePropertyValue( 'slug', siteType, subHeaderPropertyName );
 
 		if ( onboardingSubHeaderCopy ) {
 			return onboardingSubHeaderCopy;
@@ -520,7 +523,11 @@ class DomainsStep extends React.Component {
 
 	getHeaderText() {
 		const { headerText, siteType } = this.props;
-		return getSiteTypePropertyValue( 'slug', siteType, 'domainsStepHeader' ) || headerText;
+		const headerPropertyName = this.showTestCopy
+			? 'domainsStepHeaderTestCopy'
+			: 'domainsStepHeader';
+
+		return getSiteTypePropertyValue( 'slug', siteType, headerPropertyName ) || headerText;
 	}
 
 	getAnalyticsSection() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -692,3 +692,4 @@ export default connect(
 		showSitePreview,
 	}
 )( localize( DomainsStep ) );
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR builds on top of the domain-copy A/B test introduced as a feature flag in https://github.com/Automattic/wp-calypso/pull/37546.

* The header and sub-header text for the domain step in the variant is added.

Desktop:

<img width="1253" alt="Screenshot 2019-11-13 at 4 53 05 PM" src="https://user-images.githubusercontent.com/1269602/68759652-18a9c000-0636-11ea-9d50-09c2d7c34e95.png">

Mobile:

<img width="351" alt="Screenshot 2019-11-14 at 11 15 46 AM" src="https://user-images.githubusercontent.com/1269602/68829891-2f9cf080-06d0-11ea-9aef-44e23f898ffa.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and put yourself in the variant `variantShowUpdates` of the `domainStepCopyUpdates` A/B test.
* The header and sub-header text for the domain step should show the new copy:

If site type is "blog" :
Header - `Let's get your blog a domain!`
Sub-Header - "Enter your blog's name or a few keywords, and we'll come up with some suggestions."

If site type is "business" :
Header - `Let's get your business a domain!`
Sub-Header - "Enter your business's name or a few keywords, and we'll come up with some suggestions."

If site type is "professional" :
Header - `Let's get your site a domain!`
Sub-Header - "Enter your site's name or a few keywords, and we'll come up with some suggestions."

If site type is "online store" :
Header - `Let's get your store a domain!`
Sub-Header - "Enter your store's name or a few keywords, and we'll come up with some suggestions."

If there's no site type, as in the domain only flow /start/domain, then:
Header - `Let's get your site a domain!`
Sub-Header - "Enter your site's name or a few keywords, and we'll come up with some suggestions."

**Mobile View**

* Verify alignment and copy checks out in mobile views.

**Check in other domain pages**

* Login to any account, and after assigning yourself to the variant, check the launch flow for privates sites and the Add domain page. In both places, the header/subheader should not show the new copy(we are showing the copy only during signup).

**Verify that the A/B test is not automatically assigned**
* Go to /start and without manually assigning yourself to an A/B test, just complete the signup flow. 
* In your Browser console, type `localstorage.ABTests;`. Verify that the `domainStepCopyUpdates ` test is not present in the object. This is because we do not yet want any user getting assigned to the test till all the pieces are deployed.