### PR TITLE
Build: Add support for optional chain and null coalesce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
 			"requires": {
 				"@babel/core": "7.7.2",
 				"@babel/plugin-proposal-class-properties": "7.7.0",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "7.4.4",
+				"@babel/plugin-proposal-optional-chaining": "7.6.0",
 				"@babel/plugin-syntax-dynamic-import": "7.2.0",
 				"@babel/plugin-transform-react-jsx": "7.7.0",
 				"@babel/plugin-transform-runtime": "7.6.2",
@@ -591,6 +593,16 @@
 				"@babel/plugin-syntax-json-strings": "^7.2.0"
 			}
 		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz",
+			"integrity": "sha512-Amph7Epui1Dh/xxUxS2+K22/MUi6+6JVTvy3P58tja3B6yKTSjwwx0/d83rF7551D6PVSSoplQb8GCwqec7HRw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0"
+			}
+		},
 		"@babel/plugin-proposal-object-rest-spread": {
 			"version": "7.6.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
@@ -609,6 +621,16 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz",
+			"integrity": "sha512-kj4gkZ6qUggkprRq3Uh5KP8XnE1MdIO0J7MhdDX8+rAbB6dJ2UrensGIS+0NPZAaaJ1Vr0PN6oLUgXMU1uMcSg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
@@ -657,6 +679,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz",
+			"integrity": "sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-syntax-object-rest-spread": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
@@ -670,6 +701,15 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
 			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+			"integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,8 @@
+# next
+
+- Add support for [optional chaining](https://github.com/tc39/proposal-optional-chaining).
+- Add support for [nullish coalescing](https://github.com/tc39/proposal-nullish-coalescing).
+
 # 5.0.1
 
 - Fix PostCSS config path default.

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -28,6 +28,8 @@ module.exports = ( api, opts ) => ( {
 	],
 	plugins: [
 		require.resolve( '@babel/plugin-proposal-class-properties' ),
+		require.resolve( '@babel/plugin-proposal-nullish-coalescing-operator' ),
+		require.resolve( '@babel/plugin-proposal-optional-chaining' ),
 		require.resolve( '@babel/plugin-syntax-dynamic-import' ),
 		[
 			require.resolve( '@babel/plugin-transform-runtime' ),

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -36,6 +36,8 @@
 	"dependencies": {
 		"@babel/core": "7.7.2",
 		"@babel/plugin-proposal-class-properties": "7.7.0",
+		"@babel/plugin-proposal-nullish-coalescing-operator": "7.4.4",
+		"@babel/plugin-proposal-optional-chaining": "7.6.0",
 		"@babel/plugin-syntax-dynamic-import": "7.2.0",
 		"@babel/plugin-transform-react-jsx": "7.7.0",
 		"@babel/plugin-transform-runtime": "7.6.2",


### PR DESCRIPTION
This aligns with TypeScript 3.7 and are stage 3 proposals at this time.

Cherry picked from #37548 where `??` nullish coalescing operator is used.

This is required to use these new features which are part of TypeScript 3.7 in addition to JavaScript stage 3 (candidate) proposals because we rely on babel to transform TypeScript rather than `tsc` the TypeScript compiler.

## Testing
- You can test #37548 or check out this branch and try to compile code using `optional?.chaining` and `null ?? 'ish coalescing'`.