### PR TITLE
Fix Popover regressions caused by react-redux upgrade

### DIFF
--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -70,5 +70,7 @@ export default connect(
 			iLike: isLikedPost( state, siteId, postId ),
 		};
 	},
-	{ like, unlike }
+	{ like, unlike },
+	null,
+	{ forwardRef: true }
 )( LikeButtonContainer );

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -97,15 +97,17 @@ class EllipsisMenu extends Component {
 				>
 					<Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" />
 				</Button>
-				<PopoverMenu
-					isVisible={ isMenuVisible }
-					onClose={ this.hideMenu }
-					position={ position }
-					context={ this.popoverContext.current }
-					className={ popoverClasses }
-				>
-					{ children }
-				</PopoverMenu>
+				{ isMenuVisible && (
+					<PopoverMenu
+						isVisible
+						onClose={ this.hideMenu }
+						position={ position }
+						context={ this.popoverContext.current }
+						className={ popoverClasses }
+					>
+						{ children }
+					</PopoverMenu>
+				) }
 			</span>
 		);
 	}

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -14,7 +14,6 @@ import PostLikesPopover from 'blocks/post-likes/popover';
 import { markPostSeen } from 'state/reader/posts/actions';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import { getPostByKey } from 'state/reader/posts/selectors';
-import { isEnabled } from 'config';
 import QueryPostLikes from 'components/data/query-post-likes';
 import getPostLikeCount from 'state/selectors/get-post-like-count';
 import isLikedPost from 'state/selectors/is-liked-post';
@@ -25,15 +24,12 @@ import isLikedPost from 'state/selectors/is-liked-post';
 import './style.scss';
 
 class ReaderLikeButton extends React.Component {
-	constructor( props ) {
-		super( props );
+	state = {
+		showLikesPopover: false,
+	};
 
-		this.hidePopoverTimeout = null;
-		this.state = {
-			showLikesPopover: false,
-			likesPopoverContext: null,
-		};
-	}
+	hidePopoverTimeout = null;
+	likeButtonRef = React.createRef();
 
 	componentWillUnmount() {
 		clearTimeout( this.hidePopoverTimeout );
@@ -59,22 +55,12 @@ class ReaderLikeButton extends React.Component {
 		}
 	};
 
-	setLikesPopoverContext = element => {
-		this.setState( { likesPopoverContext: element } );
-	};
-
-	maybeShowLikesPopover = () => {
-		if ( ! isEnabled( 'reader/likes-hover' ) ) {
-			return;
-		}
+	showLikesPopover = () => {
 		clearTimeout( this.hidePopoverTimeout );
 		this.setState( { showLikesPopover: true } );
 	};
 
-	maybeHideLikesPopover = () => {
-		if ( ! isEnabled( 'reader/likes-hover' ) ) {
-			return;
-		}
+	hideLikesPopover = () => {
 		this.hidePopoverTimeout = setTimeout( () => {
 			this.setState( { showLikesPopover: false } );
 		}, 200 );
@@ -82,7 +68,7 @@ class ReaderLikeButton extends React.Component {
 
 	render() {
 		const { siteId, postId, likeCount, iLike } = this.props;
-		const { showLikesPopover, likesPopoverContext } = this.state;
+		const { showLikesPopover } = this.state;
 		const hasEnoughLikes = ( likeCount > 0 && ! iLike ) || ( likeCount > 1 && iLike );
 
 		return (
@@ -90,21 +76,21 @@ class ReaderLikeButton extends React.Component {
 				<QueryPostLikes siteId={ siteId } postId={ postId } />
 				<LikeButtonContainer
 					{ ...this.props }
-					ref={ this.setLikesPopoverContext }
-					onMouseEnter={ this.maybeShowLikesPopover }
-					onMouseLeave={ this.maybeHideLikesPopover }
+					ref={ this.likeButtonRef }
+					onMouseEnter={ this.showLikesPopover }
+					onMouseLeave={ this.hideLikesPopover }
 					onLikeToggle={ this.recordLikeToggle }
 					likeSource="reader"
 				/>
 				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
 					<PostLikesPopover
 						className="reader-likes-popover" // eslint-disable-line
-						onMouseEnter={ this.maybeShowLikesPopover }
-						onMouseLeave={ this.maybeHideLikesPopover }
+						onMouseEnter={ this.showLikesPopover }
+						onMouseLeave={ this.hideLikesPopover }
 						siteId={ siteId }
 						postId={ postId }
 						showDisplayNames={ true }
-						context={ likesPopoverContext }
+						context={ this.likeButtonRef.current }
 					/>
 				) }
 			</Fragment>

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -84,7 +84,7 @@ class ReaderLikeButton extends React.Component {
 				/>
 				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
 					<PostLikesPopover
-						className="reader-likes-popover" // eslint-disable-line
+						className="reader-likes-popover ignore-click" // eslint-disable-line wpcalypso/jsx-classname-namespace
 						onMouseEnter={ this.showLikesPopover }
 						onMouseLeave={ this.hideLikesPopover }
 						siteId={ siteId }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -365,7 +365,6 @@ class ReaderStream extends React.Component {
 		return (
 			<PostLifecycle
 				key={ itemKey }
-				ref={ itemKey }
 				isSelected={ isSelected }
 				handleClick={ showPost }
 				postKey={ postKey }

--- a/config/development.json
+++ b/config/development.json
@@ -133,7 +133,6 @@
 		"reader": true,
 		"reader/comment-polling": true,
 		"reader/full-errors": true,
-		"reader/likes-hover": true,
 		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -97,7 +97,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/likes-hover": true,
 		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,6 @@
 		"privacy-policy": true,
 		"publicize-preview": true,
 		"reader": true,
-		"reader/likes-hover": true,
 		"reader/full-errors": true,
 		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,


### PR DESCRIPTION
Fixes a few regressions and dev-mode console warnings caused by recent react-redux upgrade in #37438. Mostly in Reader. None of them affects production.

**Reader Likes:**
We were not forwarding a `ref` to the `connect`-ed `LikeButtonContainer`, and therefore the Reader Likes popover couldn't align itself property to the like button:

<img width="200" alt="Screenshot 2019-11-13 at 12 00 57" src="https://user-images.githubusercontent.com/664258/68758205-a4f3bd00-060d-11ea-95fc-3b3a62848f66.png">

This feature never shipped to production and was hidden behind the `reader/likes-hover` feature flag. I fixed that, too, and removed the feature flag altogether.

**Unneeded refs in Reader Stream:**
`PostLifecycle` is a `connect`-ed component without `forwardRef`, and yet we're passing a `ref` to it. It's never used though, so I simply removed it.

**Conditionally render `PopoverMenu` inside `EllipsisMenu`:**
If we don't render it conditionally, the `popoverContext.current` value is initially `null`, because the refs are set only after initial render. When rerendering conditionally, there is a state update and `PopoverMenu` rerenders with the up-to-date ref value.

This stale ref situation is a design bug in `Popover`: the `render` method should never pass a ref value as a prop, because it can be stale. Hard to fix 😦 