### PR TITLE
Domain step test: Add the free domain for a year explainer textbox

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -348,15 +348,21 @@ const mapStateToProps = ( state, props ) => {
 	const productSlug = get( props, 'suggestion.product_slug' );
 	const productsList = getProductsList( state );
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
+	const showTestCopy = get( props, 'showTestCopy', false );
+	const stripZeros = showTestCopy ? true : false;
 
 	return {
 		showHstsNotice: isHstsRequired( productSlug, productsList ),
-		productCost: getDomainPrice( productSlug, productsList, currentUserCurrencyCode ),
-		productSaleCost: getDomainSalePrice( productSlug, productsList, currentUserCurrencyCode ),
+		productCost: getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros ),
+		productSaleCost: getDomainSalePrice(
+			productSlug,
+			productsList,
+			currentUserCurrencyCode,
+			stripZeros
+		),
 	};
 };
 
-export default connect(
-	mapStateToProps,
-	{ recordTracksEvent }
-)( localize( DomainRegistrationSuggestion ) );
+export default connect( mapStateToProps, { recordTracksEvent } )(
+	localize( DomainRegistrationSuggestion )
+);

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -105,7 +105,7 @@
 		align-items: center;
 		display: flex;
 		font-size: 12px;
-		margin-top: 16px;
+		margin-top: 10px;
 		order: 2;
 
 		.progress-bar {

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -38,9 +38,7 @@ class FreeDomainExplainer extends React.Component {
 							onClick={ this.handleClick }
 							href
 						>
-							Review our plans to get started{ ' ' }
-							<span className="free-domain-explainer__chevron-right">&rsaquo;</span>
-							<span className="free-domain-explainer__chevron-right">&rsaquo;</span>
+							Review our plans to get started &raquo;
 						</Button>
 					</p>
 				</header>

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -28,8 +28,11 @@ class FreeDomainExplainer extends React.Component {
 						next page.
 					</p>
 					<p className="free-domain-explainer__subtitle">
-						If you're not ready to choose, you can skip this step for now and claim your free custom
-						domain when you're ready. Review our plan options to get started.
+						If you’re not ready to choose, go with any paid plan and claim your free custom domain
+						when you’re ready.
+						<a className="free-domain-explainer__subtitle-link">
+							Review our plan options to get started.{' '}
+						</a>
 					</p>
 				</header>
 			</div>

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -18,7 +18,7 @@ class FreeDomainExplainer extends React.Component {
 	handleClick = () => {
 		const hideFreePlan = true;
 
-		this.props.onSkip( hideFreePlan );
+		this.props.onSkip( undefined, hideFreePlan );
 	};
 	render() {
 		const className = classNames( 'free-domain-explainer is-compact', {

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -32,19 +32,20 @@ class FreeDomainExplainer extends React.Component {
 						Get a free one-year domain registration with any paid plan.
 					</h1>
 					<p className="free-domain-explainer__subtitle">
-						We'll pay the registration fees for your new domain when you choose a paid plan on the
-						next page.
+						We'll pay the registration fees for your new domain when you choose a paid plan during
+						the next step.
 					</p>
 					<p className="free-domain-explainer__subtitle">
-						If you’re not ready to choose, go with any paid plan and claim your free custom domain
-						when you’re ready.
+						You can claim your free custom domain later if you aren't ready yet.
 						<Button
 							borderless
 							className="free-domain-explainer__subtitle-link"
 							onClick={ this.handleClick }
 							href
 						>
-							Review our plan options to get started.{ ' ' }
+							Review our plans to get started{ ' ' }
+							<span className="free-domain-explainer__chevron-right">&rsaquo;</span>
+							<span className="free-domain-explainer__chevron-right">&rsaquo;</span>
 						</Button>
 					</p>
 				</header>

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class FreeDomainExplainer extends React.Component {
+	render() {
+		const className = classNames( 'free-domain-explainer is-compact', {
+			card: this.props.isCard,
+		} );
+
+		return (
+			<div className={ className }>
+				<header>
+					<h1 className="free-domain-explainer__title">
+						Get a free one-year domain registration with any paid plan.
+					</h1>
+					<p className="free-domain-explainer__subtitle">
+						We'll pay the registration fees for your new domain when you choose a paid plan on the
+						next page.
+					</p>
+					<p className="free-domain-explainer__subtitle">
+						If you're not ready to choose, you can skip this step for now and claim your free custom
+						domain when you're ready. Review our plan options to get started.
+					</p>
+				</header>
+			</div>
+		);
+	}
+}
+
+export default FreeDomainExplainer;

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -7,11 +7,21 @@ import React from 'react';
 import classNames from 'classnames';
 
 /**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+/**
  * Style dependencies
  */
 import './style.scss';
 
 class FreeDomainExplainer extends React.Component {
+	handleClick = () => {
+		const hideFreePlan = true;
+
+		this.props.onSkip( hideFreePlan );
+	};
 	render() {
 		const className = classNames( 'free-domain-explainer is-compact', {
 			card: this.props.isCard,
@@ -30,9 +40,14 @@ class FreeDomainExplainer extends React.Component {
 					<p className="free-domain-explainer__subtitle">
 						If you’re not ready to choose, go with any paid plan and claim your free custom domain
 						when you’re ready.
-						<div className="button is-borderless free-domain-explainer__subtitle-link">
+						<Button
+							borderless
+							className="free-domain-explainer__subtitle-link"
+							onClick={ this.handleClick }
+							href
+						>
 							Review our plan options to get started.{ ' ' }
-						</div>
+						</Button>
 					</p>
 				</header>
 			</div>

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -6,8 +6,6 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import Button from 'components/button';
-
 /**
  * Style dependencies
  */
@@ -32,10 +30,9 @@ class FreeDomainExplainer extends React.Component {
 					<p className="free-domain-explainer__subtitle">
 						If you’re not ready to choose, go with any paid plan and claim your free custom domain
 						when you’re ready.
-						{ /* <a className="free-domain-explainer__subtitle-link">
-							Review our plan options to get started.{' '}
-						</a> */ }
-						<Button borderless>Review our plan options to get started. </Button>
+						<div className="button is-borderless free-domain-explainer__subtitle-link">
+							Review our plan options to get started.{ ' ' }
+						</div>
 					</p>
 				</header>
 			</div>

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,12 +20,8 @@ class FreeDomainExplainer extends React.Component {
 		this.props.onSkip( undefined, hideFreePlan );
 	};
 	render() {
-		const className = classNames( 'free-domain-explainer is-compact', {
-			card: this.props.isCard,
-		} );
-
 		return (
-			<div className={ className }>
+			<div className="free-domain-explainer card is-compact">
 				<header>
 					<h1 className="free-domain-explainer__title">
 						Get a free one-year domain registration with any paid plan.

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import Button from 'components/button';
+
 /**
  * Style dependencies
  */
@@ -30,9 +32,10 @@ class FreeDomainExplainer extends React.Component {
 					<p className="free-domain-explainer__subtitle">
 						If you’re not ready to choose, go with any paid plan and claim your free custom domain
 						when you’re ready.
-						<a className="free-domain-explainer__subtitle-link">
+						{ /* <a className="free-domain-explainer__subtitle-link">
 							Review our plan options to get started.{' '}
-						</a>
+						</a> */ }
+						<Button borderless>Review our plan options to get started. </Button>
 					</p>
 				</header>
 			</div>

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -24,10 +24,5 @@
         margin-left: 0.3em;
         text-decoration: underline;
         vertical-align: baseline;
-
-        & .free-domain-explainer__chevron-right {
-            display: inline-flex;
-            width: 4px;
-        }
     }
 }

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,6 +1,8 @@
 .free-domain-explainer {
-    @include breakpoint( '<480px' ) {
-        padding: 0 16px;
+    &:not( .card ) {
+        @include breakpoint( '<480px' ) {
+            padding: 0 16px;
+        }
     }
 }
 

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,3 +1,9 @@
+.free-domain-explainer {
+    @include breakpoint( '<480px' ) {
+        padding: 0 16px;
+    }
+}
+
 .free-domain-explainer__title {
 
     color: var( --color-text-inverted );

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -36,5 +36,10 @@
         .card & {
             color: var( --color-link );
         }
+
+        & .free-domain-explainer__chevron-right {
+            display: inline-flex;
+            width: 4px;
+        }
     }
 }

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -32,11 +32,12 @@
     & .button,
     & .button:hover,
     & .button:focus {
-        vertical-align: baseline;
-        text-decoration: underline;
         color: var( --color-text-inverted );
-        margin-left: 0.3em;
         display: inline;
+        font-size: 16px;
+        margin-left: 0.3em;
+        text-decoration: underline;
+        vertical-align: baseline;
 
         .card & {
             color: var( --color-link );

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -6,6 +6,10 @@
     margin: 0;
     margin-bottom: 0.7em;
 
+    @include breakpoint( '<480px' ) {
+        padding: 0 24px;
+    }
+
     .card & {
         color: var( --color-text );
     }
@@ -14,10 +18,13 @@
 .free-domain-explainer__subtitle {
     color: var( --color-text-inverted );
     font-weight: 400;
-    font-size: 14px;
+    font-size: 16px;
     margin: 0;
     margin-bottom: 0.3em;
-
+    
+    @include breakpoint( '<480px' ) {
+        padding: 0 24px;
+    }
     .card & {
         color: var( --color-text );
     }
@@ -29,25 +36,9 @@
         text-decoration: underline;
         color: var( --color-text-inverted );
         margin-left: 0.3em;
+        display: inline;
 
         .card & {
-            color: var( --color-text );
-        }
-    }
-
-    & .free-domain-explainer__subtitle-link {
-        color: var( --color-text-inverted );
-        display: inline;
-        vertical-align: baseline;
-        text-decoration: underline;
-        margin-left: 0.3em;
-        cursor: pointer;
-    }
-
-    .card & {
-        color: var( --color-text );
-
-        .free-domain-explainer__subtitle-link {
             color: var( --color-link );
         }
     }

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,0 +1,24 @@
+.free-domain-explainer__title {
+     
+    color: var( --color-text-inverted );
+    font-weight: 400;
+    font-size: 24px;
+    margin: 0;
+    margin-bottom: 0.7em;
+}
+
+.card .free-domain-explainer__title {
+    color: var( --color-text );
+}
+
+.free-domain-explainer__subtitle {
+    color: var( --color-text-inverted );
+    font-weight: 400;
+    font-size: 15px;
+    margin: 0;
+    margin-bottom: 0.7em;
+}
+
+.card .free-domain-explainer__subtitle {
+    color: var( --color-text );
+}

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -11,16 +11,29 @@
     }
 }
 
-.card .free-domain-explainer__title {
-    color: var( --color-text );
-}
-
 .free-domain-explainer__subtitle {
     color: var( --color-text-inverted );
     font-weight: 400;
     font-size: 14px;
     margin: 0;
-    margin-bottom: 0.7em;
+    margin-bottom: 0.3em;
+
+    .card & {
+        color: var( --color-text );
+    }
+    
+    & .button,
+    & .button:hover,
+    & .button:focus {
+        vertical-align: baseline;
+        text-decoration: underline;
+        color: var( --color-text-inverted );
+        margin-left: 0.3em;
+
+        .card & {
+            color: var( --color-text );
+        }
+    }
 
     & .free-domain-explainer__subtitle-link {
         color: var( --color-text-inverted );

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -2,9 +2,13 @@
      
     color: var( --color-text-inverted );
     font-weight: 400;
-    font-size: 24px;
+    font-size: 22px;
     margin: 0;
     margin-bottom: 0.7em;
+
+    .card & {
+        color: var( --color-text );
+    }
 }
 
 .card .free-domain-explainer__title {
@@ -14,11 +18,24 @@
 .free-domain-explainer__subtitle {
     color: var( --color-text-inverted );
     font-weight: 400;
-    font-size: 15px;
+    font-size: 14px;
     margin: 0;
     margin-bottom: 0.7em;
-}
 
-.card .free-domain-explainer__subtitle {
-    color: var( --color-text );
+    & .free-domain-explainer__subtitle-link {
+        color: var( --color-text-inverted );
+        display: inline;
+        vertical-align: baseline;
+        text-decoration: underline;
+        margin-left: 0.3em;
+        cursor: pointer;
+    }
+
+    .card & {
+        color: var( --color-text );
+
+        .free-domain-explainer__subtitle-link {
+            color: var( --color-link );
+        }
+    }
 }

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,14 +1,11 @@
 .free-domain-explainer__title {
-     
+
     color: var( --color-text-inverted );
     font-weight: 400;
-    font-size: 22px;
+    font-size: 20px;
+    line-height: 1.3;
     margin: 0;
     margin-bottom: 0.7em;
-
-    @include breakpoint( '<480px' ) {
-        padding: 0 24px;
-    }
 
     .card & {
         color: var( --color-text );
@@ -18,23 +15,20 @@
 .free-domain-explainer__subtitle {
     color: var( --color-text-inverted );
     font-weight: 400;
-    font-size: 16px;
+    font-size: 15px;
     margin: 0;
     margin-bottom: 0.3em;
-    
-    @include breakpoint( '<480px' ) {
-        padding: 0 24px;
-    }
+
     .card & {
         color: var( --color-text );
     }
-    
+
     & .button,
     & .button:hover,
     & .button:focus {
         color: var( --color-text-inverted );
         display: inline;
-        font-size: 16px;
+        font-size: 15px;
         margin-left: 0.3em;
         text-decoration: underline;
         vertical-align: baseline;

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,49 +1,29 @@
-.free-domain-explainer {
-    &:not( .card ) {
-        @include breakpoint( '<480px' ) {
-            padding: 0 16px;
-        }
-    }
-}
-
 .free-domain-explainer__title {
 
-    color: var( --color-text-inverted );
+    color: var( --color-text );
     font-weight: 400;
     font-size: 20px;
     line-height: 1.3;
     margin: 0;
     margin-bottom: 0.7em;
-
-    .card & {
-        color: var( --color-text );
-    }
 }
 
 .free-domain-explainer__subtitle {
-    color: var( --color-text-inverted );
+    color: var( --color-text );
     font-weight: 400;
     font-size: 15px;
     margin: 0;
     margin-bottom: 0.3em;
 
-    .card & {
-        color: var( --color-text );
-    }
-
     & .button,
     & .button:hover,
     & .button:focus {
-        color: var( --color-text-inverted );
+        color: var( --color-link );
         display: inline;
         font-size: 15px;
         margin-left: 0.3em;
         text-decoration: underline;
         vertical-align: baseline;
-
-        .card & {
-            color: var( --color-link );
-        }
 
         & .free-domain-explainer__chevron-right {
             display: inline-flex;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1122,7 +1122,7 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderFreeDomainExplainer( isCard = false ) {
-		return <FreeDomainExplainer isCard={ isCard } />;
+		return <FreeDomainExplainer isCard={ isCard } onSkip={ this.props.onSkip } />;
 	}
 
 	onAddDomain = suggestion => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -51,6 +51,7 @@ import DomainSkipSuggestion from 'components/domains/domain-skip-suggestion';
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import DomainSearchResults from 'components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
+import FreeDomainExplainer from 'components/domains/free-domain-explainer';
 import {
 	DropdownFilters,
 	FilterResetNotice,
@@ -575,6 +576,10 @@ class RegisterDomainStep extends React.Component {
 
 		if ( this.props.showExampleSuggestions ) {
 			return this.renderExampleSuggestions();
+		}
+
+		if ( this.props.showTestCopy ) {
+			return this.renderFreeDomainExplainer();
 		}
 
 		return this.renderInitialSuggestions();
@@ -1116,6 +1121,10 @@ class RegisterDomainStep extends React.Component {
 		);
 	}
 
+	renderFreeDomainExplainer( isCard = false ) {
+		return <FreeDomainExplainer isCard={ isCard } />;
+	}
+
 	onAddDomain = suggestion => {
 		const domain = get( suggestion, 'domain_name' );
 		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
@@ -1167,12 +1176,14 @@ class RegisterDomainStep extends React.Component {
 		const suggestions = this.getSuggestionsFromProps();
 
 		// the search returned no results
-		if (
-			suggestions.length === 0 &&
-			! this.state.loadingResults &&
-			this.props.showExampleSuggestions
-		) {
-			return this.renderExampleSuggestions();
+		if ( suggestions.length === 0 && ! this.state.loadingResults ) {
+			if ( this.props.showExampleSuggestions ) {
+				return this.renderExampleSuggestions();
+			}
+
+			if ( this.props.showTestCopy ) {
+				return this.renderFreeDomainExplainer();
+			}
 		}
 
 		const showTldFilterBar =
@@ -1183,6 +1194,10 @@ class RegisterDomainStep extends React.Component {
 			this.state.loadingResults;
 
 		const isSignup = this.props.isSignupStep ? '/signup' : '/domains';
+
+		const hasResults =
+			( Array.isArray( this.state.searchResults ) && this.state.searchResults.length ) > 0 &&
+			! this.state.loadingResults;
 
 		return (
 			<DomainSearchResults
@@ -1214,6 +1229,8 @@ class RegisterDomainStep extends React.Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				showTestCopy={ this.props.showTestCopy }
 			>
+				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer( true ) }
+
 				{ showTldFilterBar && (
 					<TldFilterBar
 						availableTlds={ this.state.availableTlds }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1077,6 +1077,7 @@ class RegisterDomainStep extends React.Component {
 						onButtonClick={ this.onAddDomain }
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
+						showTestCopy={ this.props.showTestCopy }
 					/>
 				);
 			}, this );
@@ -1227,6 +1228,7 @@ class RegisterDomainStep extends React.Component {
 				cart={ this.props.cart }
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
+				showTestCopy={ this.props.showTestCopy }
 			>
 				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer( true ) }
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -583,10 +583,6 @@ class RegisterDomainStep extends React.Component {
 			return this.renderExampleSuggestions();
 		}
 
-		if ( this.props.showTestCopy ) {
-			return this.renderFreeDomainExplainer();
-		}
-
 		return this.renderInitialSuggestions();
 	}
 
@@ -1126,8 +1122,8 @@ class RegisterDomainStep extends React.Component {
 		);
 	}
 
-	renderFreeDomainExplainer( isCard = false ) {
-		return <FreeDomainExplainer isCard={ isCard } onSkip={ this.props.hideFreePlan } />;
+	renderFreeDomainExplainer() {
+		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
 	}
 
 	onAddDomain = suggestion => {
@@ -1185,10 +1181,6 @@ class RegisterDomainStep extends React.Component {
 			if ( this.props.showExampleSuggestions ) {
 				return this.renderExampleSuggestions();
 			}
-
-			if ( this.props.showTestCopy ) {
-				return this.renderFreeDomainExplainer();
-			}
 		}
 
 		const showTldFilterBar =
@@ -1234,7 +1226,7 @@ class RegisterDomainStep extends React.Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				showTestCopy={ this.props.showTestCopy }
 			>
-				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer( true ) }
+				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer() }
 
 				{ showTldFilterBar && (
 					<TldFilterBar

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1177,10 +1177,12 @@ class RegisterDomainStep extends React.Component {
 		const suggestions = this.getSuggestionsFromProps();
 
 		// the search returned no results
-		if ( suggestions.length === 0 && ! this.state.loadingResults ) {
-			if ( this.props.showExampleSuggestions ) {
-				return this.renderExampleSuggestions();
-			}
+		if (
+			suggestions.length === 0 &&
+			! this.state.loadingResults &&
+			this.props.showExampleSuggestions
+		) {
+			return this.renderExampleSuggestions();
 		}
 
 		const showTldFilterBar =

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1127,7 +1127,7 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderFreeDomainExplainer( isCard = false ) {
-		return <FreeDomainExplainer isCard={ isCard } onSkip={ this.props.onSkip } />;
+		return <FreeDomainExplainer isCard={ isCard } onSkip={ this.props.hideFreePlan } />;
 	}
 
 	onAddDomain = suggestion => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -415,9 +415,13 @@ class RegisterDomainStep extends React.Component {
 		const { message: availabilityMessage, severity: availabilitySeverity } = showAvailabilityNotice
 			? getAvailabilityNotice( lastDomainSearched, availabilityError, availabilityErrorData )
 			: {};
+
+		const searchBoxClassName = classNames( 'register-domain-step__search', {
+			'register-domain-step__search-domain-step-test': this.props.showTestCopy,
+		} );
 		return (
 			<div className="register-domain-step">
-				<StickyPanel className="register-domain-step__search">
+				<StickyPanel className={ searchBoxClassName }>
 					<CompactCard className="register-domain-step__search-card">
 						<Search
 							additionalClasses={ this.state.clickedExampleSuggestion ? 'is-refocused' : undefined }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -144,6 +144,7 @@ class RegisterDomainStep extends React.Component {
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
+		showTestCopy: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,
@@ -1076,7 +1077,6 @@ class RegisterDomainStep extends React.Component {
 						onButtonClick={ this.onAddDomain }
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
-						showTestCopy={ this.props.showTestCopy }
 					/>
 				);
 			}, this );
@@ -1227,7 +1227,6 @@ class RegisterDomainStep extends React.Component {
 				cart={ this.props.cart }
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
-				showTestCopy={ this.props.showTestCopy }
 			>
 				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer( true ) }
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -4,7 +4,7 @@
 
 	&.register-domain-step__search-domain-step-test:not( .is-sticky ) {
 		padding-top: 18px;
-		padding-bottom: 48px;
+		padding-bottom: 28px;
 	}
 
 	.register-domain-step__search-card {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -2,6 +2,11 @@
 .register-domain-step__search {
 	padding-bottom: 12px;
 
+	&.register-domain-step__search-domain-step-test:not( .is-sticky ) {
+		padding-top: 18px;
+		padding-bottom: 48px;
+	}
+
 	.register-domain-step__search-card {
 		padding: 0;
 		display: flex;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -3,8 +3,11 @@
 	padding-bottom: 12px;
 
 	&.register-domain-step__search-domain-step-test:not( .is-sticky ) {
-		padding-top: 18px;
 		padding-bottom: 28px;
+
+		@include breakpoint( '>660px' ) {
+			padding-top: 18px;
+		}
 	}
 
 	.register-domain-step__search-card {

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -163,8 +163,8 @@ function isMappedDomain( domain ) {
 /**
  * Checks if the supplied domain is a mapped domain and has WordPress.com name servers.
  *
- * @param {Object} domain - domain object
- * @returns {Boolean} - true if the domain is mapped and has WordPress.com name servers, false otherwise
+ * @param {object} domain - domain object
+ * @returns {boolean} - true if the domain is mapped and has WordPress.com name servers, false otherwise
  */
 function isMappedDomainWithWpcomNameservers( domain ) {
 	return isMappedDomain( domain ) && get( domain, 'hasWpcomNameservers', false );
@@ -209,7 +209,7 @@ function hasMappedDomain( domains ) {
  * for our purposes, the approach should be "good enough" for a long time.
  *
  * @param {string}     domainName     The domain name parse the tld from
- * @return {string}                   The TLD or an empty string
+ * @returns {string}                   The TLD or an empty string
  */
 function getTld( domainName ) {
 	const lastIndexOfDot = domainName.lastIndexOf( '.' );
@@ -252,11 +252,11 @@ function getUnformattedDomainPrice( slug, productsList ) {
 	return price;
 }
 
-function getDomainPrice( slug, productsList, currencyCode ) {
+function getDomainPrice( slug, productsList, currencyCode, stripZeros = false ) {
 	let price = getUnformattedDomainPrice( slug, productsList );
 
 	if ( price ) {
-		price = formatCurrency( price, currencyCode );
+		price = formatCurrency( price, currencyCode, { stripZeros } );
 	}
 
 	return price;
@@ -277,11 +277,11 @@ function getUnformattedDomainSalePrice( slug, productsList ) {
 	return saleCost;
 }
 
-function getDomainSalePrice( slug, productsList, currencyCode ) {
+function getDomainSalePrice( slug, productsList, currencyCode, stripZeros = false ) {
 	let saleCost = getUnformattedDomainSalePrice( slug, productsList );
 
 	if ( saleCost ) {
-		saleCost = formatCurrency( saleCost, currencyCode );
+		saleCost = formatCurrency( saleCost, currencyCode, { stripZeros } );
 	}
 
 	return saleCost;

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -165,16 +165,10 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	// flowName isn't always passed in
 	const flowToCheck = flowName || lastKnownFlow;
+	const shouldSkipDomainStep = ! siteUrl && isDomainStepSkippable( flowToCheck );
+	const shouldHideFreePlan = get( getSignupDependencyStore( state ), 'shouldHideFreePlan', false );
 
-	if ( ! siteUrl && isDomainStepSkippable( flowToCheck ) ) {
-		newSiteParams.blog_name =
-			get( user.get(), 'username' ) ||
-			get( getSignupDependencyStore( state ), 'username' ) ||
-			siteTitle ||
-			siteType ||
-			getSiteVertical( state );
-		newSiteParams.find_available_url = true;
-	} else if ( get( getSignupDependencyStore( state ), 'shouldHideFreePlan', false ) ) {
+	if ( shouldSkipDomainStep || shouldHideFreePlan ) {
 		newSiteParams.blog_name =
 			get( user.get(), 'username' ) ||
 			get( getSignupDependencyStore( state ), 'username' ) ||

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -174,6 +174,14 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			siteType ||
 			getSiteVertical( state );
 		newSiteParams.find_available_url = true;
+	} else if ( get( getSignupDependencyStore( state ), 'skipToPaidPlanOptions' ) ) {
+		newSiteParams.blog_name =
+			get( user.get(), 'username' ) ||
+			get( getSignupDependencyStore( state ), 'username' ) ||
+			siteTitle ||
+			siteType ||
+			getSiteVertical( state );
+		newSiteParams.find_available_url = true;
 	} else {
 		newSiteParams.blog_name = siteUrl;
 		newSiteParams.find_available_url = !! isPurchasingItem;

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -174,7 +174,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			siteType ||
 			getSiteVertical( state );
 		newSiteParams.find_available_url = true;
-	} else if ( get( getSignupDependencyStore( state ), 'skipToPaidPlanOptions' ) ) {
+	} else if ( get( getSignupDependencyStore( state ), 'shouldHideFreePlan', false ) ) {
 		newSiteParams.blog_name =
 			get( user.get(), 'username' ) ||
 			get( getSignupDependencyStore( state ), 'username' ) ||

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -491,7 +491,13 @@ export function generateSteps( {
 		'domains-with-preview': {
 			stepName: 'domains-with-preview',
 			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem', 'hideFreePlan' ],
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+				'skipToPaidPlanOptions',
+			],
 			props: {
 				showSiteMockups: true,
 				isDomainOnly: false,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -491,7 +491,7 @@ export function generateSteps( {
 		'domains-with-preview': {
 			stepName: 'domains-with-preview',
 			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem', 'hideFreePlan' ],
 			props: {
 				showSiteMockups: true,
 				isDomainOnly: false,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -80,7 +80,7 @@ export function generateSteps( {
 			props: {
 				isDomainOnly: false,
 				showExampleSuggestions: false,
-				showTestCopy: false,
+				shouldShowDomainTestCopy: false,
 				includeWordPressDotCom: false,
 				showSkipButton: true,
 				headerText: i18n.translate( 'Getting ready to launch, pick a domain' ),

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -80,6 +80,7 @@ export function generateSteps( {
 			props: {
 				isDomainOnly: false,
 				showExampleSuggestions: false,
+				showTestCopy: false,
 				includeWordPressDotCom: false,
 				showSkipButton: true,
 				headerText: i18n.translate( 'Getting ready to launch, pick a domain' ),

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -496,8 +496,9 @@ export function generateSteps( {
 				'siteSlug',
 				'domainItem',
 				'themeItem',
-				'skipToPaidPlanOptions',
+				'shouldHideFreePlan',
 			],
+			optionalDependencies: [ 'shouldHideFreePlan' ],
 			props: {
 				showSiteMockups: true,
 				isDomainOnly: false,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -503,10 +503,8 @@ class Signup extends React.Component {
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
-		// console.log(get( currentStepProgress, 'hideFreePlan', false ));
 		const CurrentComponent = this.props.stepComponent;
 		const propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props );
-		// console.log( propsFromConfig );
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
 		const flow = flows.getFlow( this.props.flowName );
 		const planWithDomain =
@@ -514,10 +512,13 @@ class Signup extends React.Component {
 			( isDomainRegistration( domainItem ) ||
 				isDomainTransfer( domainItem ) ||
 				isDomainMapping( domainItem ) );
-		const hideFreePlan =
-			planWithDomain ||
-			this.props.isDomainOnlySite ||
-			get( currentStepProgress, 'hideFreePlan', false );
+		// Hide the free option as part of 'domainStepCopyUpdates' a/b test
+		const skipToPaidPlanOptions = get(
+			this.props,
+			'signupDependencies.skipToPaidPlanOptions',
+			false
+		);
+		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite || skipToPaidPlanOptions;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -503,8 +503,10 @@ class Signup extends React.Component {
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
+		// console.log(get( currentStepProgress, 'hideFreePlan', false ));
 		const CurrentComponent = this.props.stepComponent;
 		const propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props );
+		// console.log( propsFromConfig );
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
 		const flow = flows.getFlow( this.props.flowName );
 		const planWithDomain =
@@ -512,7 +514,10 @@ class Signup extends React.Component {
 			( isDomainRegistration( domainItem ) ||
 				isDomainTransfer( domainItem ) ||
 				isDomainMapping( domainItem ) );
-		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite;
+		const hideFreePlan =
+			planWithDomain ||
+			this.props.isDomainOnlySite ||
+			get( currentStepProgress, 'hideFreePlan', false );
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -513,12 +513,8 @@ class Signup extends React.Component {
 				isDomainTransfer( domainItem ) ||
 				isDomainMapping( domainItem ) );
 		// Hide the free option as part of 'domainStepCopyUpdates' a/b test
-		const skipToPaidPlanOptions = get(
-			this.props,
-			'signupDependencies.skipToPaidPlanOptions',
-			false
-		);
-		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite || skipToPaidPlanOptions;
+		const selectedHideFreePlan = get( this.props, 'signupDependencies.shouldHideFreePlan', false );
+		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -211,12 +211,12 @@ class DomainsStep extends React.Component {
 		return `${ repo }/${ themeSlug }`;
 	};
 
-	handleSkip = ( hideFreePlan = false ) => {
+	handleSkip = ( skipToPaidPlanOptions = false ) => {
 		const domainItem = undefined;
 		// console.log( 'hideFreePlan: ' + hideFreePlan );
 		this.props.submitSignupStep(
-			{ stepName: this.props.stepName, domainItem, hideFreePlan },
-			{ domainItem, hideFreePlan }
+			{ stepName: this.props.stepName, domainItem },
+			{ domainItem, skipToPaidPlanOptions }
 		);
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -213,7 +213,7 @@ class DomainsStep extends React.Component {
 
 	handleSkip = ( skipToPaidPlanOptions = false ) => {
 		const domainItem = undefined;
-		// console.log( 'hideFreePlan: ' + hideFreePlan );
+
 		this.props.submitSignupStep(
 			{ stepName: this.props.stepName, domainItem },
 			{ domainItem, skipToPaidPlanOptions }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, endsWith, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -568,8 +569,12 @@ class DomainsStep extends React.Component {
 			);
 		}
 
+		const stepContentClassName = classNames( 'domains__step-content', {
+			'domains__step-content-domain-step-test': this.showTestCopy,
+		} );
+
 		return (
-			<div key={ this.props.step + this.props.stepSectionName } className="domains__step-content">
+			<div key={ this.props.step + this.props.stepSectionName } className={ stepContentClassName }>
 				{ content }
 			</div>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -121,20 +121,11 @@ class DomainsStep extends React.Component {
 			props.goToNextStep();
 		}
 
-		this.showTestCopy = false;
-		this.showExampleSuggestions = this.props.showExampleSuggestions;
-
-		if ( 'undefined' === typeof this.showExampleSuggestions ) {
-			if (
-				config.isEnabled( 'domain-step-copy-update' ) &&
-				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
-			) {
-				this.showExampleSuggestions = false;
-				this.showTestCopy = true;
-			} else {
-				this.showExampleSuggestions = true;
-				this.showTestCopy = false;
-			}
+		if (
+			config.isEnabled( 'domain-step-copy-update' ) &&
+			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
+		) {
+			this.showTestCopy = true;
 		}
 	}
 
@@ -401,6 +392,11 @@ class DomainsStep extends React.Component {
 			}
 		}
 
+		let showExampleSuggestions = this.props.showExampleSuggestions;
+		if ( 'undefined' === typeof showExampleSuggestions ) {
+			showExampleSuggestions = true;
+		}
+
 		let includeWordPressDotCom = this.props.includeWordPressDotCom;
 		if ( 'undefined' === typeof includeWordPressDotCom ) {
 			includeWordPressDotCom = ! this.props.isDomainOnly;
@@ -426,7 +422,7 @@ class DomainsStep extends React.Component {
 				includeWordPressDotCom={ includeWordPressDotCom }
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
-				showExampleSuggestions={ this.showExampleSuggestions }
+				showExampleSuggestions={ showExampleSuggestions }
 				showTestCopy={ this.showTestCopy }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -124,7 +124,7 @@ class DomainsStep extends React.Component {
 		this.showTestCopy = false;
 
 		if (
-			false !== this.props.showTestCopy &&
+			false !== this.props.shouldShowDomainTestCopy &&
 			config.isEnabled( 'domain-step-copy-update' ) &&
 			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
 		) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -211,22 +211,21 @@ class DomainsStep extends React.Component {
 		return `${ repo }/${ themeSlug }`;
 	};
 
-	handleSkip = ( skipToPaidPlanOptions = false ) => {
+	handleSkip = () => {
 		const domainItem = undefined;
 
-		this.props.submitSignupStep(
-			{ stepName: this.props.stepName, domainItem },
-			{ domainItem, skipToPaidPlanOptions }
-		);
+		this.props.submitSignupStep( { stepName: this.props.stepName, domainItem }, { domainItem } );
 		this.props.goToNextStep();
 	};
 
-	submitWithDomain = googleAppsCartItem => {
+	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
 		const suggestion = this.props.step.suggestion,
-			isPurchasingItem = Boolean( suggestion.product_slug ),
-			siteUrl = isPurchasingItem
-				? suggestion.domain_name
-				: suggestion.domain_name.replace( '.wordpress.com', '' ),
+			isPurchasingItem = suggestion && Boolean( suggestion.product_slug ),
+			siteUrl =
+				suggestion &&
+				( isPurchasingItem
+					? suggestion.domain_name
+					: suggestion.domain_name.replace( '.wordpress.com', '' ) ),
 			domainItem = isPurchasingItem
 				? domainRegistration( {
 						domain: suggestion.domain_name,
@@ -234,7 +233,9 @@ class DomainsStep extends React.Component {
 				  } )
 				: undefined;
 
-		this.props.submitDomainStepSelection( suggestion, this.getAnalyticsSection() );
+		const shouldHideFreePlanItem = this.showTestCopy ? { shouldHideFreePlan } : {};
+
+		suggestion && this.props.submitDomainStepSelection( suggestion, this.getAnalyticsSection() );
 
 		this.props.submitSignupStep(
 			Object.assign(
@@ -248,14 +249,14 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			{ domainItem }
+			Object.assign( { domainItem }, shouldHideFreePlanItem )
 		);
 
 		this.props.setDesignType( this.getDesignType() );
 		this.props.goToNextStep();
 
 		// Start the username suggestion process.
-		this.props.fetchUsernameSuggestion( siteUrl.split( '.' )[ 0 ] );
+		siteUrl && this.props.fetchUsernameSuggestion( siteUrl.split( '.' )[ 0 ] );
 	};
 
 	handleAddMapping = ( sectionName, domain, state ) => {
@@ -434,6 +435,7 @@ class DomainsStep extends React.Component {
 				showSkipButton={ this.props.showSkipButton }
 				vertical={ this.props.vertical }
 				onSkip={ this.handleSkip }
+				hideFreePlan={ this.submitWithDomain }
 			/>
 		);
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -121,7 +121,10 @@ class DomainsStep extends React.Component {
 			props.goToNextStep();
 		}
 
+		this.showTestCopy = false;
+
 		if (
+			false !== this.props.showTestCopy &&
 			config.isEnabled( 'domain-step-copy-update' ) &&
 			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
 		) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -214,19 +214,22 @@ class DomainsStep extends React.Component {
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const suggestion = this.props.step.suggestion,
-			isPurchasingItem = suggestion && Boolean( suggestion.product_slug ),
-			siteUrl =
-				suggestion &&
-				( isPurchasingItem
-					? suggestion.domain_name
-					: suggestion.domain_name.replace( '.wordpress.com', '' ) ),
-			domainItem = isPurchasingItem
-				? domainRegistration( {
-						domain: suggestion.domain_name,
-						productSlug: suggestion.product_slug,
-				  } )
-				: undefined;
+		const suggestion = this.props.step.suggestion;
+
+		const isPurchasingItem = suggestion && Boolean( suggestion.product_slug );
+
+		const siteUrl =
+			suggestion &&
+			( isPurchasingItem
+				? suggestion.domain_name
+				: suggestion.domain_name.replace( '.wordpress.com', '' ) );
+
+		const domainItem = isPurchasingItem
+			? domainRegistration( {
+					domain: suggestion.domain_name,
+					productSlug: suggestion.product_slug,
+			  } )
+			: undefined;
 
 		const shouldHideFreePlanItem = this.showTestCopy ? { shouldHideFreePlan } : {};
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -211,9 +211,13 @@ class DomainsStep extends React.Component {
 		return `${ repo }/${ themeSlug }`;
 	};
 
-	handleSkip = () => {
+	handleSkip = ( hideFreePlan = false ) => {
 		const domainItem = undefined;
-		this.props.submitSignupStep( { stepName: this.props.stepName, domainItem }, { domainItem } );
+		// console.log( 'hideFreePlan: ' + hideFreePlan );
+		this.props.submitSignupStep(
+			{ stepName: this.props.stepName, domainItem, hideFreePlan },
+			{ domainItem, hideFreePlan }
+		);
 		this.props.goToNextStep();
 	};
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -6,6 +6,10 @@
 .is-section-signup .domains__step-content {
 	margin-bottom: 50px;
 
+	&.domains__step-content-domain-step-test {
+		margin-bottom: 20px;
+	}
+
 	.search .search__icon-navigation {
 		background: none;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR builds on top of the domain-copy A/B test introduced in https://github.com/Automattic/wp-calypso/pull/37546. Check the `What next?` section in that PR on how to review this and other PRs as part of this A/B test.

* Add the free domain for a year explainer textbox below the domain input box. The textbox is shown only when there are domain search results displayed.
* The CTA on the textbox will take you to the plans page with the free site option hidden(as discussed in pbm1bU-2G#comment-67-p2)
* For detailed context, check p8Eqe3-Uq-p2.

<img width="1375" alt="Screenshot 2019-11-20 at 8 24 31 PM" src="https://user-images.githubusercontent.com/1269602/69250202-41512d00-0bd5-11ea-950f-bc678ca2b0ca.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and put yourself in the variant variantShowUpdates of the domainStepCopyUpdates A/B test.
* The free-domain explainer textbox should be displayed with the same format and spacing alignments as shown in the screenshot above.
* Click the `Review plan options ...` link and verify that the plan page on the next step _does not show_ the free site option

<img width="680" alt="Screenshot 2019-11-15 at 8 37 18 PM" src="https://user-images.githubusercontent.com/1269602/68954356-e04ae300-07e9-11ea-8055-a3897dccb7d0.png">

* Complete signup after clicking `Review plan options ...` and verify that a new site is created for you.


**Mobile View**

* Verify alignment and copy checks out in mobile views.

**Check in other domain pages**

* Login to any account, and after assigning yourself to the variant, check the launch flow for privates sites and the Add domain page. In both places, the domain step copy changes should not be seen(as we are showing the copy only during signup).

**Verify that the A/B test is not automatically assigned**
* Go to /start and without manually assigning yourself to an A/B test, just complete the signup flow. 
* In your Browser console, type `localstorage.ABTests;`. Verify that the `domainStepCopyUpdates ` test is not present in the object. This is because we do not yet want any user getting assigned to the test till all the pieces are deployed.

