### PR TITLE
Reimplement QuerySites using react-redux hooks.

### DIFF
--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -51,7 +51,7 @@ function QuerySingle( { siteId } ) {
 
 const requestPrimaryAndRecent = siteIds => ( dispatch, getState ) => {
 	const state = getState();
-	if ( ! siteIds.length || hasAllSitesList( state ) ) {
+	if ( hasAllSitesList( state ) ) {
 		return;
 	}
 

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -50,14 +50,16 @@ function QuerySingle( { siteId } ) {
 }
 
 const requestPrimary = siteId => ( dispatch, getState ) => {
-	if ( siteId && ! hasAllSitesList( getState() ) && ! isRequestingSite( getState(), siteId ) ) {
+	const state = getState();
+	if ( siteId && ! hasAllSitesList( state ) && ! isRequestingSite( state, siteId ) ) {
 		dispatch( requestSite( siteId ) );
 	}
 };
 
 const requestRecent = siteIds => ( dispatch, getState ) => {
-	if ( siteIds.length && ! hasAllSitesList( getState() ) ) {
-		const isRequestingSomeSite = siteIds.some( siteId => isRequestingSite( getState(), siteId ) );
+	const state = getState();
+	if ( siteIds.length && ! hasAllSitesList( state ) ) {
+		const isRequestingSomeSite = siteIds.some( siteId => isRequestingSite( state, siteId ) );
 
 		if ( ! isRequestingSomeSite ) {
 			siteIds.forEach( siteId => dispatch( requestSite( siteId ) ) );

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -49,26 +49,13 @@ function QuerySingle( { siteId } ) {
 	return null;
 }
 
-const requestPrimary = siteId => ( dispatch, getState ) => {
-	const state = getState();
-	if ( siteId && ! hasAllSitesList( state ) && ! isRequestingSite( state, siteId ) ) {
-		dispatch( requestSite( siteId ) );
-	}
-};
-
-const requestRecent = siteIds => ( dispatch, getState ) => {
+const requestPrimaryAndRecent = siteIds => ( dispatch, getState ) => {
 	const state = getState();
 	if ( ! siteIds.length || hasAllSitesList( state ) ) {
 		return;
 	}
 
-	const isRequestingSomeSite = siteIds.some( siteId => isRequestingSite( state, siteId ) );
-
-	if ( ! isRequestingSomeSite ) {
-		return;
-	}
-
-	siteIds.forEach( siteId => dispatch( requestSite( siteId ) ) );
+	siteIds.forEach( siteId => dispatch( requestSingle( siteId ) ) );
 };
 
 function QueryPrimaryAndRecent() {
@@ -78,17 +65,12 @@ function QueryPrimaryAndRecent() {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( requestPrimary( primarySiteId ) );
-	}, [ dispatch, primarySiteId ] );
+		const siteIds = [ ...( primarySiteId ? [ primarySiteId ] : [] ), ...( recentSiteIds ?? [] ) ];
 
-	useEffect( () => {
-		if ( recentSiteIds && recentSiteIds.length ) {
-			dispatch(
-				requestRecent( recentSiteIds.filter( recentSiteId => recentSiteId !== primarySiteId ) )
-			);
+		if ( siteIds && siteIds.length ) {
+			dispatch( requestPrimaryAndRecent( siteIds ) );
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ dispatch, recentSiteIds ] );
+	}, [ dispatch, primarySiteId, recentSiteIds ] );
 
 	return null;
 }

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -58,13 +58,17 @@ const requestPrimary = siteId => ( dispatch, getState ) => {
 
 const requestRecent = siteIds => ( dispatch, getState ) => {
 	const state = getState();
-	if ( siteIds.length && ! hasAllSitesList( state ) ) {
-		const isRequestingSomeSite = siteIds.some( siteId => isRequestingSite( state, siteId ) );
-
-		if ( ! isRequestingSomeSite ) {
-			siteIds.forEach( siteId => dispatch( requestSite( siteId ) ) );
-		}
+	if ( ! siteIds.length || hasAllSitesList( state ) ) {
+		return;
 	}
+
+	const isRequestingSomeSite = siteIds.some( siteId => isRequestingSite( state, siteId ) );
+
+	if ( ! isRequestingSomeSite ) {
+		return;
+	}
+
+	siteIds.forEach( siteId => dispatch( requestSite( siteId ) ) );
 };
 
 function QueryPrimaryAndRecent() {


### PR DESCRIPTION
This is a good example of a more complex Query component, that still benefits massively from a move to `react-redux` hooks.

There were several issues with the previous implementation:
- It performed dispatches at a render-blocking time
- It compared arrays using a deep equality check, which is always a code smell
- It used a bound selector in `connect`
- It used a large number of selectors
- It made unnecessary use of `lodash`

The new implementation solves all of the above problems, and simplifies the logic significantly through careful use of thunks and effect dependency arrays.

#### Changes proposed in this Pull Request

* Reimplement `QuerySites` using `react-redux` hooks.

#### Testing instructions

* Ensure that e.g. the Stats page continues to work correctly, with the correct site information being pulled in.
