### PR TITLE
Lint: Remove valid-jsdoc rule

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,6 +1,3 @@
-/* eslint-disable valid-jsdoc */
-/** @format */
-
 /**
  * External dependencies
  */

--- a/packages/eslint-config-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-config-wpcalypso/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+- Remove deprecated [`valid-jsdoc`](https://eslint.org/docs/rules/valid-jsdoc) rule.
+
 ### v4.0.1 (2018-09-13)
 - Allow usage of eslint v5 (159e240)
 

--- a/packages/eslint-config-wpcalypso/index.js
+++ b/packages/eslint-config-wpcalypso/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 module.exports = {
 	env: {
 		es6: true,
@@ -109,7 +107,6 @@ module.exports = {
 		// Assumed by default with Babel
 		strict: [ 2, 'never' ],
 		'template-curly-spacing': [ 2, 'always' ],
-		'valid-jsdoc': [ 2, { requireReturn: false } ],
 		'wpcalypso/i18n-ellipsis': 2,
 		'wpcalypso/i18n-no-collapsible-whitespace': 2,
 		'wpcalypso/i18n-no-variables': 2,


### PR DESCRIPTION
[`valid-jsdoc`](https://eslint.org/docs/rules/valid-jsdoc) is deprecated. Remove it.

I would assert that the `valid-jsdoc` lint rule has not contributed to an increase in the quality of our JSDoc blocks in Calypso, but that is a matter of opinion.