### PR TITLE
Composite checkout: Update radio buttons

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -403,7 +403,7 @@ Each payment method has the following schema:
 {
 	id: string,
 	LabelComponent: component,
-	PaymentMethodComponent: component,
+	PaymentMethodComponent: ?component,
 	BillingContactComponent: component,
 	SubmitButtonComponent: component,
 	CheckoutWrapper: ?component,

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -111,7 +111,6 @@ function validatePaymentMethods( paymentMethods ) {
 function validatePaymentMethod( {
 	id,
 	LabelComponent,
-	PaymentMethodComponent,
 	BillingContactComponent,
 	SubmitButtonComponent,
 	SummaryComponent,
@@ -122,10 +121,6 @@ function validatePaymentMethod( {
 	validateArg(
 		BillingContactComponent,
 		`Invalid payment method '${ id }'; missing BillingContactComponent`
-	);
-	validateArg(
-		PaymentMethodComponent,
-		`Invalid payment method '${ id }'; missing PaymentMethodComponent`
 	);
 	validateArg(
 		SubmitButtonComponent,

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -16,6 +16,7 @@ export default function RadioButton( {
 	ariaLabel,
 } ) {
 	const [ isFocused, changeFocus ] = useState( false );
+
 	return (
 		<RadioButtonWrapper isFocused={ isFocused } checked={ checked }>
 			<Radio
@@ -37,7 +38,7 @@ export default function RadioButton( {
 			<Label checked={ checked } htmlFor={ id }>
 				{ label }
 			</Label>
-			{ children }
+			{ children && <div>{ children }</div> }
 		</RadioButtonWrapper>
 	);
 }

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -38,7 +38,7 @@ export default function RadioButton( {
 			<Label checked={ checked } htmlFor={ id }>
 				{ label }
 			</Label>
-			{ children && <div>{ children }</div> }
+			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
 		</RadioButtonWrapper>
 	);
 }
@@ -129,6 +129,11 @@ const Label = styled.label`
 	}
 `;
 
+const RadioButtonChildren = styled.div`
+	height: ${getChildrenHeight};
+	overflow: hidden;
+`;
+
 function getBorderColor( { checked, theme } ) {
 	return checked ? theme.colors.highlight : theme.colors.borderColor;
 }
@@ -139,6 +144,10 @@ function getBorderWidth( { checked } ) {
 
 function getRadioBorderWidth( { checked } ) {
 	return checked ? '5px' : '1px';
+}
+
+function getChildrenHeight( { checked } ) {
+	return checked ? 'auto' : '0';
 }
 
 function getGrayscaleValue( { checked } ) {

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -154,7 +154,7 @@ export function createStripeMethod( {
 	};
 }
 
-function StripeCreditCardFields( { isActive, summary } ) {
+function StripeCreditCardFields() {
 	const localize = useLocalize();
 	const theme = useTheme();
 	const { onFailure } = useCheckoutHandlers();
@@ -201,9 +201,6 @@ function StripeCreditCardFields( { isActive, summary } ) {
 		},
 	};
 
-	if ( ! isActive || summary ) {
-		return null;
-	}
 	if ( stripeLoadingError ) {
 		return <span>Error!</span>;
 	}

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -63,7 +63,6 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 	return {
 		id: 'apple-pay',
 		LabelComponent: ApplePayLabel,
-		PaymentMethodComponent: () => null,
 		BillingContactComponent: BillingFields,
 		SubmitButtonComponent: ApplePaySubmitButton,
 		SummaryComponent: ApplePaySummary,

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -18,7 +18,7 @@ export function createCreditCardMethod() {
 	return {
 		id: 'card',
 		LabelComponent: CreditCardLabel,
-		PaymentMethodComponent: ( { isActive } ) => ( isActive ? <CreditCardFields /> : null ),
+		PaymentMethodComponent: CreditCardFields,
 		BillingContactComponent: BillingFields,
 		SubmitButtonComponent: CreditCardSubmitButton,
 		SummaryComponent: CreditCardSummary,

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -80,7 +80,6 @@ export function createPayPalMethod( { registerStore, makePayPalExpressRequest } 
 	return {
 		id: 'paypal',
 		LabelComponent: PaypalLabel,
-		PaymentMethodComponent: () => null,
 		BillingContactComponent: BillingFields,
 		SubmitButtonComponent: PaypalSubmitButton,
 		SummaryComponent: () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the payment method fields so that they're all showing by default but visually hidden until the payment method is selected.

#### Testing instructions
* Follow instructions here: https://github.com/Automattic/wp-calypso/pull/37013
