### PR TITLE
composite-checkout: Update first-child to first-of-type

### DIFF
--- a/packages/composite-checkout/src/components/billing-fields.js
+++ b/packages/composite-checkout/src/components/billing-fields.js
@@ -69,7 +69,7 @@ const BillingFormFields = styled.div`
 
 const FormField = styled( Field )`
 	margin-top: 16px;
-	:first-child {
+	:first-of-type {
 		margin-top: 0;
 	}
 `;
@@ -77,7 +77,7 @@ const FormField = styled( Field )`
 const FieldRow = styled( GridRow )`
 	margin-top: 16px;
 
-	first-child {
+	:first-of-type {
 		margin-top: 0;
 	}
 `;

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -133,7 +133,7 @@ const CheckoutModalActions = styled.div`
 	justify-content: flex-end;
 	margin-top: 24px;
 
-	button:first-child {
+	button:first-of-type {
 		margin-right: 8px;
 	}
 `;

--- a/packages/composite-checkout/src/components/credit-card-fields.js
+++ b/packages/composite-checkout/src/components/credit-card-fields.js
@@ -187,7 +187,7 @@ const CreditCardFieldsWrapper = styled.div`
 const CreditCardField = styled( Field )`
 	margin-top: 16px;
 
-	:first-child {
+	:first-of-type {
 		margin-top: 0;
 	}
 `;

--- a/packages/composite-checkout/src/components/order-review-line-items.js
+++ b/packages/composite-checkout/src/components/order-review-line-items.js
@@ -62,7 +62,7 @@ const LineItemUI = styled( LineItem )`
 	border-bottom: ${( { theme, total, isSummaryVisible } ) =>
 		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
 
-	:first-child {
+	:first-of-type {
 		padding-top: 0;
 	}
 `;

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -60,7 +60,7 @@ const RadioButtonWrapper = styled.div`
 	width: 100%;
 	outline: ${getOutline};
 
-	:first-child {
+	:first-of-type {
 		margin: 0;
 	}
 

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -294,7 +294,7 @@ const CreditCardFieldsWrapper = styled.div`
 const CreditCardField = styled( Field )`
 	margin-top: 16px;
 
-	:first-child {
+	:first-of-type {
 		margin-top: 0;
 	}
 `;

--- a/packages/composite-checkout/src/components/wp-terms-and-conditions.js
+++ b/packages/composite-checkout/src/components/wp-terms-and-conditions.js
@@ -107,7 +107,7 @@ const TermsParagraph = styled.p`
 		text-decoration: underline;
 	}
 
-	:first-child {
+	:first-of-type {
 		margin-top: 0;
 	}
 `;

--- a/packages/composite-checkout/src/lib/styled-components/summary-details.js
+++ b/packages/composite-checkout/src/lib/styled-components/summary-details.js
@@ -7,7 +7,7 @@ export const SummaryDetails = styled.ul`
 	margin: 8px 0 0 0;
 	padding: 0;
 
-	:first-child {
+	:first-of-type {
 		margin-top: 0;
 	}
 `;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the console errors that were introduced after switching from styled components to emotion.

![image](https://user-images.githubusercontent.com/6981253/68772568-09a41d00-05f8-11ea-985f-2847b26d8af9.png)


#### Testing instructions
Run the new checkout with [these instructions](https://github.com/Automattic/wp-calypso/pull/37013) and check that the first-child error does not show.
