### PR TITLE
Composite checkout: Fix style issue for step border

### DIFF
--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -131,12 +131,12 @@ Stepper.propTypes = {
 };
 
 const StepWrapper = styled.div`
-	padding-bottom: ${ props => ( props.finalStep ? '0' : '32px' ) };
+	padding-bottom: ${props => ( props.finalStep ? '0' : '32px' )};
 	position: relative;
-	border-bottom: 1px solid ${ props => props.theme.colors.borderColorLight }
+	border-bottom: 1px solid ${props => props.theme.colors.borderColorLight};
 	padding: 16px;
 
-	@media ( ${ props => props.theme.breakpoints.tabletUp } ) {
+	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		padding: 24px;
 	}
 `;

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -360,7 +360,7 @@ const LockIconGraphic = styled( LockIcon )`
 	display: block;
 	position: absolute;
 	right: 10px;
-	top: 14px
+	top: 14px;
 	width: 20px;
 	height: 20px;
 `;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It looks like our new style library is a bit stricter on markup. This PR fixes a style issue where a border was not showing.

**Before**
![image](https://user-images.githubusercontent.com/6981253/68773127-02c9da00-05f9-11ea-9c95-12fa20e7e40e.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/68773090-f2196400-05f8-11ea-8e74-67aed7f64900.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run the new checkout with [these instructions](https://github.com/Automattic/wp-calypso/pull/37013) and check that the border shows after each step.