### PR TITLE
Lint: use jsdoc plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,14 +59,6 @@ module.exports = {
 					'@typescript-eslint/no-var-requires': 'off',
 					// REST API objects include underscores
 					'@typescript-eslint/camelcase': 'off',
-					'valid-jsdoc': [
-						2,
-						{
-							requireParamType: false,
-							requireReturn: false,
-							requireReturnType: false,
-						},
-					],
 				},
 			}
 		),
@@ -98,6 +90,9 @@ module.exports = {
 
 		// TODO: why did we turn this off?
 		'jest/valid-expect': 'off',
+
+		// Only use known tag names plus `jest-environment`.
+		'jsdoc/check-tag-names': [ 'error', { definedTags: [ 'jest-environment' ] } ],
 
 		// Deprecated rule, fails in some valid cases with custom input components
 		'jsx-a11y/label-has-for': 'off',

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,5 +1,3 @@
-/* eslint-disable valid-jsdoc */
-
 /**
  * External dependencies
  */

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -33,7 +33,7 @@ function restrictByOauthKeys( query ) {
 /**
  * Create an `Undocumented` instance
  *
- * @param {WPCOM} wpcom - The request handler
+ * @param {object} wpcom - The request handler
  * @returns {Undocumented} - An instance of Undocumented
  */
 function Undocumented( wpcom ) {
@@ -59,9 +59,8 @@ Undocumented.prototype.mailingList = function( category ) {
  * Retrieve Jetpack modules data for a site with id siteid.
  * Uses the REST API of the Jetpack site.
  *
- * @param {int}      [siteId]
+ * @param {number}      [siteId]
  * @param {Function} fn
- * @api public
  */
 Undocumented.prototype.getJetpackModules = function( siteId, fn ) {
 	return this.wpcom.req.get(
@@ -75,10 +74,9 @@ Undocumented.prototype.getJetpackModules = function( siteId, fn ) {
  * Activate a Jetpack module with slug moduleSlug for a site with id siteid.
  * Uses the REST API of the Jetpack site.
  *
- * @param {int} [siteId]
+ * @param {number} [siteId]
  * @param {string} [moduleSlug]
  * @param {Function} fn
- * @api public
  */
 Undocumented.prototype.jetpackModuleActivate = function( siteId, moduleSlug, fn ) {
 	return this.wpcom.req.post(
@@ -95,10 +93,9 @@ Undocumented.prototype.jetpackModuleActivate = function( siteId, moduleSlug, fn 
  * Deactivate a Jetpack module with slug moduleSlug for a site with id siteid.
  * Uses the REST API of the Jetpack site.
  *
- * @param {int} [siteId]
+ * @param {number} [siteId]
  * @param {string} [moduleSlug]
  * @param {Function} fn
- * @api public
  */
 Undocumented.prototype.jetpackModuleDeactivate = function( siteId, moduleSlug, fn ) {
 	return this.wpcom.req.post(
@@ -114,9 +111,8 @@ Undocumented.prototype.jetpackModuleDeactivate = function( siteId, moduleSlug, f
 /**
  * Fetches settings for the Monitor module.
  *
- * @param {int} [siteId] The site ID
+ * @param {number} [siteId] The site ID
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.fetchMonitorSettings = function( siteId, fn ) {
 	debug( '/jetpack-blogs/:site_id: query' );
@@ -141,9 +137,9 @@ Undocumented.prototype.updateMonitorSettings = function(
 /**
  * Disconnects a Jetpack site with id siteId from WP.com
  *
- * @param {int} [siteId] The site ID
+ * @param {number} [siteId] The site ID
  * @param {Function} fn The callback function
- * @api public
+ *
  */
 Undocumented.prototype.disconnectJetpack = function( siteId, fn ) {
 	debug( '/jetpack-blogs/:site_id:/mine/delete query' );
@@ -153,9 +149,8 @@ Undocumented.prototype.disconnectJetpack = function( siteId, fn ) {
 /**
  * Fetches plugin registration keys for WordPress.org sites with paid services
  *
- * @param {int} [siteId] The site ID
+ * @param {number} [siteId] The site ID
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.fetchJetpackKeys = function( siteId, fn ) {
 	debug( '/jetpack-blogs/:site_id:/keys query' );
@@ -165,9 +160,8 @@ Undocumented.prototype.fetchJetpackKeys = function( siteId, fn ) {
 /**
  * Test if a Jetpack Site is connected to .com
  *
- * @param {int} [siteId] The site ID
+ * @param {number} [siteId] The site ID
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.testConnectionJetpack = function( siteId, fn ) {
 	debug( '/jetpack-blogs/:site_id:/test-connection query' );
@@ -177,9 +171,8 @@ Undocumented.prototype.testConnectionJetpack = function( siteId, fn ) {
 /*
  * Retrieve current connection status of a Jetpack site.
  *
- * @param {int}      [siteId]
+ * @param {number}      [siteId]
  * @param {Function} fn
- * @api public
  */
 Undocumented.prototype.getJetpackConnectionStatus = function( siteId, fn ) {
 	return this.wpcom.req.get(
@@ -192,9 +185,8 @@ Undocumented.prototype.getJetpackConnectionStatus = function( siteId, fn ) {
 /*
  * Retrieve current user's connection data for a Jetpack site.
  *
- * @param {int}      [siteId]
+ * @param {number}      [siteId]
  * @param {Function} fn
- * @api public
  */
 Undocumented.prototype.getJetpackUserConnectionData = function( siteId, fn ) {
 	return this.wpcom.req.get(
@@ -249,9 +241,8 @@ Undocumented.prototype.jetpackIsUserConnected = function( siteId ) {
 /**
  * Gets the current status of a full sync for a Jetpack site.
  *
- * @param {int|string} siteId The site ID
+ * @param {number|string} siteId The site ID
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getJetpackSyncStatus = function( siteId, fn ) {
 	debug( '/sites/:site_id:/sync/status query' );
@@ -262,9 +253,8 @@ Undocumented.prototype.getJetpackSyncStatus = function( siteId, fn ) {
 /**
  * Schedules a full sync for a Jetpack site.
  *
- * @param {int|string} siteId The site ID
+ * @param {number|string} siteId The site ID
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.scheduleJetpackFullysync = function( siteId, fn ) {
 	debug( '/sites/:site_id:/sync query' );
@@ -349,11 +339,10 @@ function encode_backslash( value ) {
 /**
  * GET/POST site settings
  *
- * @param {int|string} [siteId] The site ID
+ * @param {number|string} [siteId] The site ID
  * @param {string} [method] The request method
  * @param {object} [data] The POST data
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.settings = function( siteId, method = 'get', data = {}, fn ) {
 	debug( '/sites/:site_id:/settings query' );
@@ -386,9 +375,8 @@ Undocumented.prototype.settings = function( siteId, method = 'get', data = {}, f
 /**
  * Get site keyrings
  *
- * @param {int|string} [siteId] The site ID
+ * @param {number|string} [siteId] The site ID
  * @param {Function} fn The callback function
- * @api public
  *
  * @returns {Promise} A promise that resolves when the request completes
  */
@@ -399,13 +387,12 @@ Undocumented.prototype.getSiteKeyrings = function getSiteKeyrings( siteId, fn ) 
 /**
  * Create a site keyring
  *
- * @param {int|string} [siteId] The site ID
- * @param {Object} [data] site keyring object to create with properties:
- * 	- keyring_id {int} the keyring id link the site to
+ * @param {number|string} [siteId] The site ID
+ * @param {object} [data] site keyring object to create with properties:
+ * 	- keyring_id {number} the keyring id link the site to
  * 	- external_user_id {string} Optional. The external user id to link the site to
  * 	- service {string} service name for this keyring id
  * @param {Function} fn The callback function
- * @api public
  *
  * @returns {Promise} A promise that resolves when the request completes
  */
@@ -416,11 +403,10 @@ Undocumented.prototype.createSiteKeyring = function createSiteKeyring( siteId, d
 /**
  * Update a site keyring
  *
- * @param {int|string} [siteId] The site ID
- * @param {int} [keyringId] The keyring id to update,
+ * @param {number|string} [siteId] The site ID
+ * @param {number} [keyringId] The keyring id to update,
  * @param {string} [externalUserId] The external user id to update on the site keyring
  * @param {Function} fn The callback function
- * @api public
  *
  * @returns {Promise} A promise that resolves when the request completes
  */
@@ -443,11 +429,10 @@ Undocumented.prototype.updateSiteKeyring = function updateSiteKeyring(
 /**
  * Delete a site keyring
  *
- * @param {int|string} [siteId] The site ID
- * @param {int} keyringId The keyring id
+ * @param {number|string} [siteId] The site ID
+ * @param {number} keyringId The keyring id
  * @param {string|null} externalUserId Optional, the external user id
  * @param {Function} fn The callback function
- * @api public
  *
  * @returns {Promise} A promise that resolves when the request completes
  */
@@ -488,11 +473,10 @@ Undocumented.prototype._sendRequest = function( originalParams, fn ) {
  * Determine whether a domain name is available for registration
  *
  * @param {string} domain - The domain name to check.
- * @param {int} blogId - Optional blogId to determine if domain is used on another site.
+ * @param {number} blogId - Optional blogId to determine if domain is used on another site.
  * @param {boolean} isCartPreCheck - specifies whether this availability check is for a domain about to be added to the cart.
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.isDomainAvailable = function( domain, blogId, isCartPreCheck, fn ) {
 	return this.wpcom.req.get(
@@ -513,7 +497,6 @@ Undocumented.prototype.isDomainAvailable = function( domain, blogId, isCartPreCh
  * @param {string} authCode - The auth code for the given domain to check.
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.checkAuthCode = function( domain, authCode, fn ) {
 	return this.wpcom.req.get(
@@ -529,7 +512,6 @@ Undocumented.prototype.checkAuthCode = function( domain, authCode, fn ) {
  * @param {string} domain - The domain name to check.
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.getInboundTransferStatus = function( domain, fn ) {
 	return this.wpcom.req.get(
@@ -543,12 +525,11 @@ Undocumented.prototype.getInboundTransferStatus = function( domain, fn ) {
 /**
  * Starts an inbound domain transfer that is in the pending_start state.
  *
- * @param {int|string} siteId The site ID
+ * @param {number|string} siteId The site ID
  * @param {string} domain The domain name
  * @param {string} authCode The auth code for the transfer
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.startInboundTransfer = function( siteId, domain, authCode, fn ) {
 	let query = {};
@@ -565,10 +546,10 @@ Undocumented.prototype.startInboundTransfer = function( siteId, domain, authCode
 
 /**
  * Initiates a resend of the inbound transfer verification email.
+ *
  * @param {string} domain - The domain name to check.
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.resendInboundTransferEmail = function( domain, fn ) {
 	return this.wpcom.req.get(
@@ -584,7 +565,6 @@ Undocumented.prototype.resendInboundTransferEmail = function( domain, fn ) {
  *
  * @param {object} query Optional query parameters
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.getAvailableTlds = function( query = {} ) {
 	return this.wpcom.req.get( '/domains/suggestions/tlds', query );
@@ -593,11 +573,10 @@ Undocumented.prototype.getAvailableTlds = function( query = {} ) {
 /**
  * Determine whether a domain name can be used for Site Redirect
  *
- * @param {int|string} siteId The site ID
+ * @param {number|string} siteId The site ID
  * @param {string} domain The domain name to check
- * @param {function} fn The callback function
+ * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.canRedirect = function( siteId, domain, fn ) {
 	domain = encodeURIComponent( domain.toLowerCase() );
@@ -608,9 +587,8 @@ Undocumented.prototype.canRedirect = function( siteId, domain, fn ) {
 /**
  * Retrieves the target of the site redirect.
  *
- * @param {int|string} siteId The site ID
+ * @param {number|string} siteId The site ID
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getSiteRedirect = function( siteId, fn ) {
 	debug( '/sites/:site_id/domains/redirect query' );
@@ -621,10 +599,9 @@ Undocumented.prototype.getSiteRedirect = function( siteId, fn ) {
 /**
  * Points the site redirect to the specified location.
  *
- * @param {int|string} siteId The site ID
+ * @param {number|string} siteId The site ID
  * @param {string} location The location to redirect the site to
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.setSiteRedirect = function( siteId, location, fn ) {
 	debug( '/sites/:site_id/domains/redirect' );
@@ -640,7 +617,6 @@ Undocumented.prototype.setSiteRedirect = function( siteId, location, fn ) {
  * Retrieves the domain contact information of the user.
  *
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getDomainContactInformation = function( fn ) {
 	debug( '/me/domain-contact-information query' );
@@ -691,10 +667,9 @@ function mapKeysRecursively( object, fn ) {
 /**
  * Validates the specified domain contact information against a list of domain names.
  *
- * @param {Object} contactInformation - user's contact information
+ * @param {object} contactInformation - user's contact information
  * @param {string[]} domainNames - list of domain names
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.validateDomainContactInformation = function(
 	contactInformation,
@@ -728,10 +703,9 @@ Undocumented.prototype.validateDomainContactInformation = function(
 /**
  * Validates the specified Google Apps contact information
  *
- * @param {Object} contactInformation - user's contact information
+ * @param {object} contactInformation - user's contact information
  * @param {Function} callback The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.validateGoogleAppsContactInformation = function(
 	contactInformation,
@@ -760,7 +734,6 @@ Undocumented.prototype.validateGoogleAppsContactInformation = function(
  * Get a list of WordPress.com products
  *
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getProducts = function( fn ) {
 	debug( '/products query' );
@@ -778,7 +751,6 @@ Undocumented.prototype.getProducts = function( fn ) {
  *
  * @param {Function} siteDomain The site slug
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
 	debug( '/sites/:site_domain:/plans query' );
@@ -803,7 +775,6 @@ Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
  *
  * @param {string} cartKey The cart's key.
  * @param {Function} fn The callback function.
- * @api public
  */
 Undocumented.prototype.getCart = function( cartKey, fn ) {
 	debug( 'GET: /me/shopping-cart/:cart-key' );
@@ -823,7 +794,6 @@ Undocumented.prototype.getCart = function( cartKey, fn ) {
  * @param {string} cartKey The cart's key.
  * @param {object} data The POST data.
  * @param {Function} fn The callback function.
- * @api public
  */
 Undocumented.prototype.setCart = function( cartKey, data, fn ) {
 	debug( 'POST: /me/shopping-cart/:cart-key', data );
@@ -842,7 +812,6 @@ Undocumented.prototype.setCart = function( cartKey, data, fn ) {
  * Get a list of the user's stored cards
  *
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getStoredCards = function( fn ) {
 	debug( '/me/stored-cards query' );
@@ -853,8 +822,7 @@ Undocumented.prototype.getStoredCards = function( fn ) {
  * Return a list of third-party services that WordPress.com can integrate with
  *
  * @param {Function} fn The callback function
- * @return {Promise} A Promise to resolve when complete
- * @api public
+ * @returns {Promise} A Promise to resolve when complete
  */
 Undocumented.prototype.metaKeyring = function( fn ) {
 	debug( '/meta/external-services query' );
@@ -870,10 +838,9 @@ Undocumented.prototype.metaKeyring = function( fn ) {
 /**
  * Return a list of third-party services that WordPress.com can integrate with for a specific site
  *
- * @param {int|string} siteId The site ID or domain
+ * @param {number|string} siteId The site ID or domain
  * @param {Function} fn The callback function
- * @return {Promise} A Promise to resolve when complete
- * @api public
+ * @returns {Promise} A Promise to resolve when complete
  */
 
 Undocumented.prototype.sitesExternalServices = function( siteId, fn ) {
@@ -891,7 +858,6 @@ Undocumented.prototype.sitesExternalServices = function( siteId, fn ) {
  * Return a list of happiness engineers gravatar urls
  *
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getHappinessEngineers = function( fn ) {
 	debug( 'meta/happiness-engineers/ query' );
@@ -903,10 +869,9 @@ Undocumented.prototype.getHappinessEngineers = function( fn ) {
  * Return a list of sharing buttons for the specified site, with optional
  * query parameters
  *
- * @param {int|string} siteId The site ID or domain
+ * @param {number|string} siteId The site ID or domain
  * @param {object} query Optional query parameters
  * @param {Function} fn Method to invoke when request is complete
- * @api public
  */
 Undocumented.prototype.sharingButtons = function( siteId, query, fn ) {
 	if ( 'undefined' === typeof fn && 'function' === typeof query ) {
@@ -921,10 +886,9 @@ Undocumented.prototype.sharingButtons = function( siteId, query, fn ) {
 /**
  * Saves the set of sharing buttons for the specified site
  *
- * @param {int|string} siteId The site ID or domain
+ * @param {number|string} siteId The site ID or domain
  * @param {Array} buttons An array of sharing button objects
  * @param {Function} fn Method to invoke when request is complete
- * @api public
  */
 Undocumented.prototype.saveSharingButtons = function( siteId, buttons, fn ) {
 	debug( '/sites/:site_id:/sharing-buttons query' );
@@ -941,9 +905,9 @@ Undocumented.prototype.saveSharingButtons = function( siteId, buttons, fn ) {
 /**
  * Return a list of user's connected services
  *
+ * @param {*} forceExternalUsersRefetch ???
  * @param {Function} fn The callback function
- * @api public
- * @return {Promise} A Promise to resolve when complete.
+ * @returns {Promise} A Promise to resolve when complete.
  */
 Undocumented.prototype.mekeyringConnections = function( forceExternalUsersRefetch, fn ) {
 	debug( '/me/keyring-connections query' );
@@ -964,7 +928,7 @@ Undocumented.prototype.mekeyringConnections = function( forceExternalUsersRefetc
 /**
  * Deletes a single keyring connection for the current user
  *
- * @param {int} keyringConnectionId The keyring connection ID to remove
+ * @param {number} keyringConnectionId The keyring connection ID to remove
  * @param {Function} fn Method to invoke when request is complete
  */
 Undocumented.prototype.deletekeyringConnection = function( keyringConnectionId, fn ) {
@@ -981,10 +945,9 @@ Undocumented.prototype.deletekeyringConnection = function( keyringConnectionId, 
 /**
  * Return a list of user's connected publicize services for the given site
  *
- * @param {Number|String} siteId The site ID or domain
+ * @param {number|string} siteId The site ID or domain
  * @param {Function}      fn     The callback function
- * @api public
- * @return {Promise} A Promise to resolve when complete.
+ * @returns {Promise} A Promise to resolve when complete.
  */
 Undocumented.prototype.siteConnections = function( siteId, fn ) {
 	debug( '/sites/:site_id:/publicize-connections query' );
@@ -1000,10 +963,10 @@ Undocumented.prototype.siteConnections = function( siteId, fn ) {
 /**
  * Deletes a single site connection
  *
- * @param {Number|String} siteId       The site ID or domain
- * @param {Number}        connectionId The connection ID to remove
+ * @param {number|string} siteId       The site ID or domain
+ * @param {number}        connectionId The connection ID to remove
  * @param {Function}      fn           Method to invoke when request is complete
- * @return {Promise} A Promise to resolve when complete.
+ * @returns {Promise} A Promise to resolve when complete.
  */
 Undocumented.prototype.deleteSiteConnection = function( siteId, connectionId, fn ) {
 	debug( '/sites/:site_id:/publicize-connections/:connection_id:/delete query' );
@@ -1019,7 +982,7 @@ Undocumented.prototype.deleteSiteConnection = function( siteId, connectionId, fn
 /**
  * Delete a site
  *
- * @param  {int|string} siteId The site ID or domain
+ * @param  {number|string} siteId The site ID or domain
  * @param  {Function} fn Function to invoke when request is complete
  */
 Undocumented.prototype.deleteSite = function( siteId, fn ) {
@@ -1031,13 +994,13 @@ Undocumented.prototype.deleteSite = function( siteId, fn ) {
  * Creates a single connection using the specified Keyring connection ID and an
  *  optional `options` object, which can include a `shared` property
  *
- * @param {Number}        keyringConnectionId The Keyring connection ID to use
- * @param {Number|String} siteId              The site ID or domain
- * @param {String}        externalUserId      User ID if not connecting to primary account
- * @param {Object}        options             Optional options
- * @param {Boolean}       options.shared      Whether this connection is available to other users.
+ * @param {number}        keyringConnectionId The Keyring connection ID to use
+ * @param {number|string} siteId              The site ID or domain
+ * @param {string}        externalUserId      User ID if not connecting to primary account
+ * @param {object}        options             Optional options
+ * @param {boolean}       options.shared      Whether this connection is available to other users.
  * @param {Function}      fn                  Method to invoke when request is complete
- * @return {Promise} A Promise to resolve when complete.
+ * @returns {Promise} A Promise to resolve when complete.
  */
 Undocumented.prototype.createConnection = function(
 	keyringConnectionId,
@@ -1072,12 +1035,13 @@ Undocumented.prototype.createConnection = function(
 /**
  * Share an arbitrary post using publicize connection
  *
- * @param {int}       siteId            The site ID
- * @param {int}       postId            The post ID
- * @param {String}    message           Message for social media
- * @param {Array(int)}skipped           CKeyring connection ids to skip publicizing
+ * @param {number}       siteId            The site ID
+ * @param {number}       postId            The post ID
+ * @param {string}    message           Message for social media
+ * @param {Array(int)} skippedConnections           Keyring connection ids to skip publicizing
+ * @param {Function}      fn           Function to invoke when request is complete
  *
- * @returns {Promise}
+ * @returns {Promise} A promise representing the request
  */
 Undocumented.prototype.publicizePost = function( siteId, postId, message, skippedConnections, fn ) {
 	const body = { skipped_connections: [] };
@@ -1097,11 +1061,11 @@ Undocumented.prototype.publicizePost = function( siteId, postId, message, skippe
 /**
  * Updates a single publicize connection
  *
- * @param {Number|String} siteId       An optional site ID or domain
- * @param {Number}        connectionId The connection ID to update
- * @param {Object}        data         The update request body
+ * @param {number|string} siteId       An optional site ID or domain
+ * @param {number}        connectionId The connection ID to update
+ * @param {object}        data         The update request body
  * @param {Function}      fn           Function to invoke when request is complete
- * @return {Promise} A Promise to resolve when complete.
+ * @returns {Promise} A Promise to resolve when complete.
  */
 Undocumented.prototype.updateConnection = function( siteId, connectionId, data, fn ) {
 	let path;
@@ -1130,7 +1094,6 @@ Undocumented.prototype.updateConnection = function( siteId, connectionId, data, 
  * @param {object} [data] The REQUEST data
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  *
  * The post data format is: {
  *		payment_method: {string} The payment gateway,
@@ -1161,9 +1124,8 @@ Undocumented.prototype.updateCreditCard = function( params, fn ) {
 /**
  * GET paygate configuration
  *
- * @param {Object} query - query parameters
+ * @param {object} query - query parameters
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.paygateConfiguration = function( query, fn ) {
 	debug( '/me/paygate-configuration query' );
@@ -1174,9 +1136,8 @@ Undocumented.prototype.paygateConfiguration = function( query, fn ) {
 /**
  * GET stripe configuration
  *
- * @param {Object} query - query parameters
+ * @param {object} query - query parameters
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.stripeConfiguration = function( query, fn ) {
 	debug( '/me/stripe-configuration query' );
@@ -1187,9 +1148,8 @@ Undocumented.prototype.stripeConfiguration = function( query, fn ) {
 /**
  * GET ebanx js configuration
  *
- * @param {Object} query - query parameters
+ * @param {object} query - query parameters
  * @param {Function} fn The callback function
- * @api public
  *
  * @returns {Promise} promise
  */
@@ -1204,7 +1164,6 @@ Undocumented.prototype.ebanxConfiguration = function( query, fn ) {
  *
  * @param {object} [data] The GET data
  * @param {Function} fn The callback function
- * @api public
  *
  * @returns {string} Url
  *
@@ -1225,10 +1184,9 @@ Undocumented.prototype.paypalExpressUrl = function( data, fn ) {
 /**
  * Update primary domain for blog
  *
- * @param {int} siteId The site ID
+ * @param {number} siteId The site ID
  * @param {string} domain The domain to set as primary
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.setPrimaryDomain = function( siteId, domain, fn ) {
 	debug( '/sites/:site_id/domains/primary' );
@@ -1359,8 +1317,7 @@ Undocumented.prototype.readSitePostRelated = function( query, fn ) {
  * @param {string} name - The name of the A/B test. No leading 'abtest_' needed
  * @param {string} variation - The variation the user is assigned to
  * @param {Function} callback - Function to invoke when request is complete
- * @api public
- * @returns {Object} wpcomRequest
+ * @returns {object} wpcomRequest
  */
 Undocumented.prototype.saveABTestData = function( name, variation, callback ) {
 	const body = {
@@ -1405,7 +1362,7 @@ Undocumented.prototype.usersNew = function( query, fn ) {
  * @param {object} query - an object with the following values: service, access_token, id_token (optional), signup_flow_name
  * @param {Function} fn - callback
  *
- * @return {Promise} A promise for the request
+ * @returns {Promise} A promise for the request
  */
 Undocumented.prototype.usersSocialNew = function( query, fn ) {
 	query.locale = getLocaleSlug();
@@ -1495,6 +1452,7 @@ Undocumented.prototype.usersEmailVerification = function( query, fn ) {
 
 /**
  * Request a "Magic Login" email be sent to a user so they can use it to log in
+ *
  * @param  {object} data - object containing an email address
  * @param  {Function} fn - Function to invoke when request is complete
  * @returns {Promise} promise
@@ -1545,7 +1503,7 @@ Undocumented.prototype.sitesNew = function( query, fn ) {
 /**
  * Launches a private site
  *
- * @param {string} - ID or slug of the site to be launched
+ * @param {string} siteIdOrSlug - ID or slug of the site to be launched
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.launchSite = function( siteIdOrSlug, fn ) {
@@ -1599,8 +1557,8 @@ Undocumented.prototype.jetpackThemeDetails = function( themeId, siteId, fn ) {
  * Whether the theme is installed from .com or .org is controlled by the themeId string
  * if it has a -wpcom suffix, .com is used.
  *
- * @param {String}    siteId   The site ID
- * @param {String}    themeId  WordPress.com theme with -wpcom suffix, WordPress.org otherwise
+ * @param {string}    siteId   The site ID
+ * @param {string}    themeId  WordPress.com theme with -wpcom suffix, WordPress.org otherwise
  * @param {Function}  fn       The callback function
  * @returns {Promise} promise
  */
@@ -1619,8 +1577,8 @@ Undocumented.prototype.installThemeOnJetpack = function( siteId, themeId, fn ) {
 /**
  * Delete a theme from Jetpack site.
  *
- * @param {Number}    siteId   The site ID
- * @param {String}    themeId  The theme ID
+ * @param {number}    siteId   The site ID
+ * @param {string}    themeId  The theme ID
  * @param {Function}  fn       The callback function
  * @returns {Promise} promise
  */
@@ -1811,9 +1769,9 @@ Undocumented.prototype.transferToUser = function( siteId, domainName, targetUser
 /**
  * Transfers a domain to the specified site
  *
- * @param {int} [siteId] The site ID
+ * @param {number} siteId The site ID
  * @param {string} [domainName] Name of the domain
- * @param {int} [targetSiteId] The target site ID
+ * @param {number} [targetSiteId] The target site ID
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
  */
@@ -1839,7 +1797,7 @@ Undocumented.prototype.fetchWhois = function( domainName, fn ) {
  * Updates WHOIS data for given domain.
  *
  * @param {string} [domainName]
- * @param {Object} [whois]
+ * @param {object} [whois]
  * @param {Function} [fn]
  */
 Undocumented.prototype.updateWhois = function( domainName, whois, transferLock, fn ) {
@@ -1860,7 +1818,7 @@ Undocumented.prototype.updateWhois = function( domainName, whois, transferLock, 
 /**
  * Add domain mapping for VIP clients.
  *
- * @param {int} [siteId] The site ID
+ * @param {number} siteId The site ID
  * @param {string} [domainName] Name of the domain mapping
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
@@ -1884,7 +1842,6 @@ Undocumented.prototype.addVipDomainMapping = function( siteId, domainName, fn ) 
  * @param {string} [siteSlug]
  * @param {string} [data]
  * @param {Function} fn
- * @api public
  */
 Undocumented.prototype.changeTheme = function( siteSlug, data, fn ) {
 	debug( '/site/:site_id/themes/mine' );
@@ -1981,7 +1938,6 @@ Undocumented.prototype.uploadExportFile = function( siteId, params ) {
  *
  * @param {string} searchQuery User input for help search
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getHelpLinks = function( searchQuery, fn ) {
 	debug( 'help-search/ searchQuery' );
@@ -2063,7 +2019,6 @@ Undocumented.prototype.cancelPlanTrial = function( planId, fn ) {
  *
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.getDirectlyConfiguration = function( fn ) {
 	return this.wpcom.req.get(
@@ -2099,9 +2054,8 @@ Undocumented.prototype.getKayakoConfiguration = function( fn ) {
 /**
  * Get the olark configuration for the current user
  *
- * @param {Object} client - current user
+ * @param {object} client - current user
  * @param {Function} fn The callback function
- * @api public
  */
 Undocumented.prototype.getOlarkConfiguration = function( client, fn ) {
 	return this.wpcom.req.get(
@@ -2127,10 +2081,9 @@ Undocumented.prototype.submitSupportForumsTopic = function( subject, message, lo
 /**
  * Get the available export configuration settings for a site
  *
- * @param {int}       siteId            The site ID
+ * @param {number}       siteId            The site ID
  * @param {Function}  fn                The callback function
  * @returns {Promise} A promise that resolves when the request completes
- * @api public
  */
 Undocumented.prototype.getExportSettings = function( siteId, fn ) {
 	return this.wpcom.req.get(
@@ -2145,8 +2098,8 @@ Undocumented.prototype.getExportSettings = function( siteId, fn ) {
 /*
  * Start an export
  *
- * @param {int}       siteId            The site ID
- * @param {Object}    advancedSettings  Advanced export configuration
+ * @param {number}       siteId            The site ID
+ * @param {object}    advancedSettings  Advanced export configuration
  * @param {Function}  fn                The callback function
  * @returns {Promise}                   A promise that resolves when the export started
  */
@@ -2164,8 +2117,8 @@ Undocumented.prototype.startExport = function( siteId, advancedSettings, fn ) {
 /**
  * Check the status of an export
  *
- * @param {Number|String} siteId - The site ID
- * @param {Object} exportId - Export ID (for future use)
+ * @param {number|string} siteId - The site ID
+ * @param {object} exportId - Export ID (for future use)
  * @param {Function} fn - The callback function
  * @returns {Promise}  promise
  */
@@ -2183,7 +2136,7 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
  * Check different info about WordPress and Jetpack status on a url
  *
  * @param  {string}  inputUrl The url of the site to check. Must use http or https protocol.
- * @return {Promise} promise  Request promise
+ * @returns {Promise} promise  Request promise
  */
 Undocumented.prototype.getSiteConnectInfo = function( inputUrl ) {
 	return this.wpcom.req.get( '/connect/site-info', { url: inputUrl } );
@@ -2195,7 +2148,7 @@ Undocumented.prototype.getSiteConnectInfo = function( inputUrl ) {
  * in the `opml` field.
  *
  * @param  {Function} fn      The callback function
- * @return {Promise}  promise
+ * @returns {Promise}  promise
  */
 Undocumented.prototype.exportReaderFeed = function( fn ) {
 	debug( '/read/following/mine/export' );
@@ -2231,9 +2184,9 @@ Undocumented.prototype.importReaderFeed = function( file, fn ) {
 /**
  * Creates a Push Notification registration for the device
  *
- * @param {String}     registration   The registration to be stored
- * @param {String}     deviceFamily   The device family
- * @param {String}     deviceName     The device name
+ * @param {string}     registration   The registration to be stored
+ * @param {string}     deviceFamily   The device family
+ * @param {string}     deviceName     The device name
  * @param {Function}   fn             The callback function
  * @returns {XMLHttpRequest}          The XHR instance
  */
@@ -2254,7 +2207,7 @@ Undocumented.prototype.registerDevice = function( registration, deviceFamily, de
 /**
  * Removes a Push Notification registration for the device
  *
- * @param {int}        deviceId       The device ID for the registration to be removed
+ * @param {number}        deviceId       The device ID for the registration to be removed
  * @param {Function}   fn             The callback function
  * @returns {XMLHttpRequest}          The XHR instance
  */
@@ -2266,8 +2219,8 @@ Undocumented.prototype.unregisterDevice = function( deviceId, fn ) {
 /**
  * Requests streamlined approval to WordAds program
  *
- * @param {int}       siteId            The site ID
- * @returns {Promise}
+ * @param {number}       siteId            The site ID
+ * @returns {Promise} A promise representing the request
  */
 Undocumented.prototype.wordAdsApprove = function( siteId ) {
 	debug( '/sites/:site:/wordads/approve' );
@@ -2278,7 +2231,7 @@ Undocumented.prototype.wordAdsApprove = function( siteId ) {
  * Initiate the Automated Transfer process, uploading a theme and/or selecting
  * a community plugin.
  *
- * @param {int} siteId -- the ID of the site
+ * @param {number} siteId -- the ID of the site
  * @param {string} [plugin] -- .org plugin slug
  * @param {File} [theme] -- theme zip to upload
  * @param {Function} [onProgress] -- called with upload progress status
@@ -2312,7 +2265,7 @@ Undocumented.prototype.initiateTransfer = function( siteId, plugin, theme, onPro
  * Returns a list of media from an external media service. Similar to Site.mediaList in use, but
  * with a more restricted set of query params.
  *
- * @param {Object} query - Media query, supports 'path', 'search', 'max', 'page_handle', and 'source'
+ * @param {object} query - Media query, supports 'path', 'search', 'max', 'page_handle', and 'source'
  * @param {Function} fn - The callback function
  *
  * @returns {Promise} promise for handling result
@@ -2326,8 +2279,8 @@ Undocumented.prototype.externalMediaList = function( query, fn ) {
 /**
  * Fetch the status of an Automated Transfer.
  *
- * @param {int} siteId -- the ID of the site being transferred
- * @param {int} transferId -- ID of the specific transfer
+ * @param {number} siteId -- the ID of the site being transferred
+ * @param {number} transferId -- ID of the specific transfer
  *
  * @returns {Promise} promise for handling result
  */
@@ -2340,10 +2293,11 @@ Undocumented.prototype.transferStatus = function( siteId, transferId ) {
 
 /**
  * Submit a response to the NPS Survey.
+ *
  * @param {string}     surveyName     The name of the NPS survey being submitted
- * @param {int}        score          The value for the survey response
+ * @param {number}        score          The value for the survey response
  * @param {Function}   fn             The callback function
- * @returns {Promise}
+ * @returns {Promise} A promise representing the request.
  */
 Undocumented.prototype.submitNPSSurvey = function( surveyName, score, fn ) {
 	return this.wpcom.req.post(
@@ -2356,9 +2310,10 @@ Undocumented.prototype.submitNPSSurvey = function( surveyName, score, fn ) {
 
 /**
  * Dismiss the NPS Survey.
+ *
  * @param {string}     surveyName     The name of the NPS survey being submitted
  * @param {Function}   fn             The callback function
- * @returns {Promise}
+ * @returns {Promise} A promise representing the request.
  */
 Undocumented.prototype.dismissNPSSurvey = function( surveyName, fn ) {
 	return this.wpcom.req.post(
@@ -2371,8 +2326,9 @@ Undocumented.prototype.dismissNPSSurvey = function( surveyName, fn ) {
 
 /**
  * Check the eligibility status for the NPS Survey.
+ *
  * @param {Function}   fn             The callback function
- * @returns {Promise}
+ * @returns {Promise} A promise representing the request.
  */
 Undocumented.prototype.checkNPSSurveyEligibility = function( fn ) {
 	return this.wpcom.req.get( { path: '/nps' }, { apiVersion: '1.2' }, {}, fn );
@@ -2380,10 +2336,11 @@ Undocumented.prototype.checkNPSSurveyEligibility = function( fn ) {
 
 /**
  * Send the optional feedback for the NPS Survey.
+ *
  * @param {string}   surveyName   The name of the NPS survey being submitted
  * @param {string}   feedback     The content
  * @param {Function} fn           The callback function
- * @returns {Promise} A promise
+ * @returns {Promise} A promise representing the request.
  */
 Undocumented.prototype.sendNPSSurveyFeedback = function( surveyName, feedback, fn ) {
 	return this.wpcom.req.post(
@@ -2396,9 +2353,10 @@ Undocumented.prototype.sendNPSSurveyFeedback = function( surveyName, feedback, f
 
 /**
  * Get OAuth2 Client data for a given client ID
+ *
  * @param {string}     clientId       The client ID
  * @param {Function}   fn             The callback function
- * @returns {Promise}  A promise
+ * @returns {Promise} A promise representing the request.
  */
 Undocumented.prototype.oauth2ClientId = function( clientId, fn ) {
 	return this.wpcom.req.get(
@@ -2410,6 +2368,7 @@ Undocumented.prototype.oauth2ClientId = function( clientId, fn ) {
 
 /**
  * Fetch the curated list of featured plugins.
+ *
  * @param {Function}   fn             The callback function
  * @returns {Promise}  A promise
  */
@@ -2419,7 +2378,8 @@ Undocumented.prototype.getFeaturedPlugins = function( fn ) {
 
 /**
  * Fetch a nonce to use in the `updateSiteAddress` call
- * @param {int}   siteId  The ID of the site for which to get a nonce.
+ *
+ * @param {number}   siteId  The ID of the site for which to get a nonce.
  * @returns {Promise}     A promise
  */
 Undocumented.prototype.getRequestSiteAddressChangeNonce = function( siteId ) {
@@ -2432,7 +2392,7 @@ Undocumented.prototype.getRequestSiteAddressChangeNonce = function( siteId ) {
 /**
  * Request server-side validation (including an availibility check) of the given site address.
  *
- * @param {int} [siteId] The siteId for which to validate
+ * @param {number} siteId The siteId for which to validate
  * @param {object} [siteAddress]	The site address to validate
  * @param {string} [domain] The domain name of the new site address (ex. news.blog, wordpress.com, etc.)
  * @param {string} [type] blog/dotblog - blog for wordpress.com, dotblog for .blog domains
@@ -2452,13 +2412,13 @@ Undocumented.prototype.checkSiteAddressValidation = function( siteId, siteAddres
 /**
  * Request a new .wordpress.com or .*.blog address for a site with the option to discard the current.
  *
- * @param {int} [siteId] The siteId for which to change the address
- * @param {object} [blogname]	The desired new site address
+ * @param {number} siteId The siteId for which to change the address
+ * @param {object} [blogname] The desired new site address
  * @param {string} [domain] The domain name of the new site address (ex. news.blog, wordpress.com, etc.)
  * @param {string} [oldDomain] The full domain name of the original site (ex. mysite.news.blog, mysite.wordpress.com, etc.)
  * @param {string} [type] blog/dotblog - blog for wordpress.com->wordpress.com, dotblog if the old and/or new domain is .blog
- * @param {bool} [discard]			Should the old site address name be discarded?
- * @param {string} [nonce]		A nonce provided by the API
+ * @param {boolean} [discard] Should the old site address name be discarded?
+ * @param {string} [nonce] A nonce provided by the API
  * @returns {Promise}  A promise
  */
 Undocumented.prototype.updateSiteAddress = function(

--- a/package-lock.json
+++ b/package-lock.json
@@ -7468,6 +7468,12 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
+		"comment-parser": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.0.tgz",
+			"integrity": "sha512-m0SGP0RFO4P3hIBlIor4sBFPe5Y4HUeGgo/UZK/1Zdea5eUiqxroQ3lFqBDDSfWo9z9Q6LLnt2u0JqwacVEd/A==",
+			"dev": true
+		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -10622,6 +10628,39 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-jsdoc": {
+			"version": "18.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-18.0.1.tgz",
+			"integrity": "sha512-ofNW3JmuZD9Gqn+qp/M6vPUfyaWHtfiNdmuoYmjyBcf5Xh2SMe1dnFa+gTGpfZLrjvBCdIbjxryRiF2QdqlQ0g==",
+			"dev": true,
+			"requires": {
+				"comment-parser": "^0.7.0",
+				"debug": "^4.1.1",
+				"jsdoctypeparser": "^6.0.0",
+				"lodash": "^4.17.15",
+				"object.entries-ponyfill": "^1.0.1",
+				"regextras": "^0.6.1",
+				"semver": "^6.3.0",
+				"spdx-expression-parse": "^3.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
 					}
 				},
 				"semver": {
@@ -15721,6 +15760,12 @@
 				}
 			}
 		},
+		"jsdoctypeparser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.0.0.tgz",
+			"integrity": "sha512-61VtBXLkHfOFSIdp/VDVNMksxK0ID0cPTNvxDR92tPA6K7r2AX0OcJegYxhJIwtpWKU4p3D9L3U02hhlP1kQLQ==",
+			"dev": true
+		},
 		"jsdom": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
@@ -18668,6 +18713,12 @@
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3"
 			}
+		},
+		"object.entries-ponyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+			"integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+			"dev": true
 		},
 		"object.fromentries": {
 			"version": "2.0.1",
@@ -23677,6 +23728,12 @@
 				"unicode-match-property-ecmascript": "^1.0.4",
 				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
+		},
+		"regextras": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
+			"integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA==",
+			"dev": true
 		},
 		"regjsgen": {
 			"version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
 		"eslint-config-wpcalypso": "file:./packages/eslint-config-wpcalypso",
 		"eslint-plugin-import": "2.18.2",
 		"eslint-plugin-jest": "23.0.3",
+		"eslint-plugin-jsdoc": "18.0.1",
 		"eslint-plugin-jsx-a11y": "6.2.3",
 		"eslint-plugin-react": "7.16.0",
 		"eslint-plugin-wpcalypso": "file:./packages/eslint-plugin-wpcalypso",

--- a/packages/eslint-config-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-config-wpcalypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+### next
+
+- Replace deprecated `valid-jsdoc` with [`eslint-plugin-jsdoc`](https://www.npmjs.com/package/eslint-plugin-jsdoc).
+
 ### v4.0.1 (2018-09-13)
 - Allow usage of eslint v5 (159e240)
 

--- a/packages/eslint-config-wpcalypso/index.js
+++ b/packages/eslint-config-wpcalypso/index.js
@@ -10,8 +10,8 @@ module.exports = {
 			jsx: true,
 		},
 	},
-	extends: 'eslint:recommended',
-	plugins: [ 'wpcalypso' ],
+	extends: [ 'eslint:recommended', 'plugin:jsdoc/recommended' ],
+	plugins: [ 'jsdoc', 'wpcalypso' ],
 	rules: {
 		'array-bracket-spacing': [ 2, 'always' ],
 		'brace-style': [ 2, '1tbs' ],
@@ -107,7 +107,30 @@ module.exports = {
 		// Assumed by default with Babel
 		strict: [ 2, 'never' ],
 		'template-curly-spacing': [ 2, 'always' ],
-		'valid-jsdoc': [ 2, { requireReturn: false } ],
+
+		// jsdoc plugin
+		'jsdoc/check-access': 2,
+		'jsdoc/check-alignment': 2,
+		'jsdoc/check-param-names': 2,
+		'jsdoc/check-tag-names': 0,
+		'jsdoc/check-types': 2,
+		'jsdoc/check-values': 2,
+		'jsdoc/empty-tags': 2,
+		'jsdoc/implements-on-classes': 2,
+		'jsdoc/newline-after-description': 2,
+		'jsdoc/no-undefined-types': 2,
+		'jsdoc/require-jsdoc': 0,
+		'jsdoc/require-param': 2,
+		'jsdoc/require-param-description': 2,
+		'jsdoc/require-param-name': 2,
+		'jsdoc/require-param-type': 0,
+		'jsdoc/require-returns': 0,
+		'jsdoc/require-returns-check': 2,
+		'jsdoc/require-returns-description': 2,
+		'jsdoc/require-returns-type': 0,
+		'jsdoc/valid-types': 0,
+
+		// wpcalypso plugin
 		'wpcalypso/i18n-ellipsis': 2,
 		'wpcalypso/i18n-no-collapsible-whitespace': 2,
 		'wpcalypso/i18n-no-variables': 2,

--- a/packages/eslint-config-wpcalypso/package.json
+++ b/packages/eslint-config-wpcalypso/package.json
@@ -25,6 +25,7 @@
 	},
 	"peerDependencies": {
 		"eslint": "^6.0.0",
+		"eslint-plugin-jsdoc": "^18.0.0",
 		"eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0"
 	},
 	"dependencies": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`valid-jsdoc` rule is deprecated, use the [jsdoc plugin](https://www.npmjs.com/package/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-valid-types).

This attempts to keep a similar setup to what we have now. Notably, type requirements are relaxed. We could continue requiring them and overriding for TypeScript.

Alternative: Closes #37556

Blocked by #37528 

#### Testing instructions

Check it out and see how the rule behaves in JSDoc.