### PR TITLE
Domains: Fix the domain only checkout thank you page to correctly redirect

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -279,7 +279,7 @@ export class CheckoutThankYou extends React.Component {
 			const failedPurchases = getFailedPurchases( props );
 			if ( purchases.length > 0 && ! failedPurchases.length ) {
 				const domainName = find( purchases, isDomainRegistration ).meta;
-				page( domainManagementList( domainName ) );
+				page.redirect( domainManagementList( domainName ) );
 			}
 		}
 	};


### PR DESCRIPTION
It seems that the domain only thank you page was not working as expected. I looked into it and in https://github.com/Automattic/wp-calypso/pull/31600 the thank you page was eliminated and a redirect was put in place. However since the `page` call does some weird internal redirect it does not reset the state and in the end nothing is rendered on the screen but the placeholders.

#### Changes proposed in this Pull Request

* use `page.redirect` instead of `page`

#### Testing instructions

* purchase a domain via /start/domain and chose "domain only" purchase. Once the purchase is complete you should get redirected to the domain management page.

Fixes https://github.com/Automattic/wp-calypso/issues/34354
