### PR TITLE
Signup: user testing flow

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -11,6 +11,7 @@ import { find, get } from 'lodash';
 const getSiteTypePropertyDefaults = propertyKey =>
 	get(
 		{
+			theme: 'pub/maywood',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -22,7 +22,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			siteTitleSubheader: i18n.translate(
 				'This will appear at the top of your site and can be changed at anytime.'
 			),
-			siteTitlePlaceholder: i18n.translate( 'default siteTitlePlaceholder' ),
+			siteTitlePlaceholder: i18n.translate( "E.g., Vail Renovations or Stevie's blog" ),
 			// Site topic step
 			siteTopicHeader: i18n.translate( 'What is your site about?' ),
 			siteTopicLabel: i18n.translate( 'What is your site about?' ),
@@ -57,8 +57,8 @@ const getSiteTypePropertyDefaults = propertyKey =>
  * @param {string} key A property name of a site types item
  * @param {string|number} value The value of `key` with which to filter items
  * @param {string} property The name of the property whose value you wish to return
- * @param {array} siteTypes (optional) A site type collection
- * @return {(string|int)?} value of `property` or `null` if none is found
+ * @param {Array} siteTypes (optional) A site type collection
+ * @returns {(string|number)?} value of `property` or `null` if none is found
  */
 export function getSiteTypePropertyValue( key, value, property, siteTypes = getAllSiteTypes() ) {
 	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
@@ -74,7 +74,7 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  *
  * Please don't modify the IDs for now until we can integrate the /segments API into Calypso.
  *
- * @return {Array} current list of site types
+ * @returns {Array} current list of site types
  */
 export function getAllSiteTypes() {
 	return [
@@ -87,7 +87,7 @@ export function getAllSiteTypes() {
 			theme: 'pub/maywood',
 			designType: 'blog',
 			siteTitleLabel: i18n.translate( "Tell us your blog's name" ),
-			siteTitlePlaceholder: i18n.translate( "E.g., Stevie's blog " ),
+			siteTitlePlaceholder: i18n.translate( "E.g., Stevie's blog" ),
 			siteTitleSubheader: i18n.translate(
 				'This will appear at the top of your blog and can be changed at anytime.'
 			),

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -140,15 +140,16 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	const siteType = getSiteType( state ).trim();
 	const siteStyle = getSiteStyle( state ).trim();
 	const siteSegment = getSiteTypePropertyValue( 'slug', siteType, 'id' );
+	const siteTypeTheme = getSiteTypePropertyValue( 'slug', siteType, 'theme' );
 
 	const newSiteParams = {
 		blog_title: siteTitle,
 		options: {
 			designType: designType || undefined,
-			// the theme can be provided in this step's dependencies or the
+			// The theme can be provided in this step's dependencies or the
 			// step object itself depending on if the theme is provided in a
 			// query. See `getThemeSlug` in `DomainsStep`.
-			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
+			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo || siteTypeTheme,
 			siteGoals: siteGoals || undefined,
 			site_style: siteStyle || undefined,
 			site_segment: siteSegment || undefined,
@@ -658,7 +659,7 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
  * It differs from `createPasswordlessUser` in that we don't require a verification step before the user can continue with onboarding.
  * Returns the dependencies for the step.
  *
- * @param {function} callback API callback function
+ * @param {Function} callback API callback function
  * @param {object}   data     An object sent via POST to WPCOM API with the following values: `email`
  */
 export function createUserAccountFromEmailAddress( callback, { email } ) {
@@ -675,7 +676,7 @@ export function createUserAccountFromEmailAddress( callback, { email } ) {
  * Creates a user account and sends the user a verification code via email to confirm the account.
  * Returns the dependencies for the step.
  *
- * @param {function} callback Callback function
+ * @param {Function} callback Callback function
  * @param {object}   data     POST data object
  */
 export function createPasswordlessUser( callback, { email } ) {
@@ -689,7 +690,7 @@ export function createPasswordlessUser( callback, { email } ) {
 /**
  * Verifies a passwordless user code.
  *
- * @param {function} callback Callback function
+ * @param {Function} callback Callback function
  * @param {object}   data     POST data object
  */
 export function verifyPasswordlessUser( callback, { email, code } ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -316,7 +316,7 @@ export function generateFlows( {
 
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
-			steps: [ 'passwordless-user', 'site-title', 'domains', 'plans' ],
+			steps: [ 'user', 'site-title', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'User testing Signup flow for Full Site Editing',
 			lastModified: '2019-11-19',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -316,17 +316,10 @@ export function generateFlows( {
 
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
-			steps: [
-				'user',
-				'site-type',
-				'site-topic-with-preview',
-				'site-title-with-preview',
-				'domains-with-preview',
-				'plans',
-			],
+			steps: [ 'passwordless-user', 'site-title', 'domains', 'plans' ],
 			destination: getSignupDestination,
-			description: 'A copy of `onboarding` for testing Full Site Editing',
-			lastModified: '2019-08-08',
+			description: 'User testing Signup flow for Full Site Editing',
+			lastModified: '2019-11-19',
 		};
 	}
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -229,7 +229,6 @@ export function generateSteps( {
 			props: {
 				isDomainOnly: false,
 			},
-			dependencies: [ 'themeSlugWithRepo' ],
 			delayApiRequestUntilComplete: true,
 		},
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -41,5 +41,8 @@ export default generateSteps( {
 } );
 
 export function isDomainStepSkippable( flowName ) {
-	return flowName === 'onboarding' && abtest( 'skippableDomainStep' ) === 'skippable';
+	return (
+		flowName === 'test-fse' ||
+		( flowName === 'onboarding' && abtest( 'skippableDomainStep' ) === 'skippable' )
+	);
 }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -31,10 +31,12 @@ class StepWrapper extends Component {
 		skipHeadingText: PropTypes.string,
 		// Displays an <hr> above the skip button and adds more white space
 		isLargeSkipLayout: PropTypes.bool,
+		isTopButtons: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		allowBackFirstStep: false,
+		isTopButtons: false,
 	};
 
 	renderBack() {
@@ -58,7 +60,7 @@ class StepWrapper extends Component {
 	renderSkip() {
 		if ( ! this.props.shouldHideNavButtons && this.props.goToNextStep ) {
 			return (
-				<>
+				<div className="step-wrapper__skip-wrapper">
 					{ !! this.props.skipHeadingText && (
 						<div className="step-wrapper__skip-heading">{ this.props.skipHeadingText }</div>
 					) }
@@ -71,7 +73,7 @@ class StepWrapper extends Component {
 						labelText={ this.props.skipLabelText }
 						cssClass={ !! this.props.skipHeadingText && ' navigation-link--has-skip-heading ' }
 					/>
-				</>
+				</div>
 			);
 		}
 	}
@@ -113,6 +115,7 @@ class StepWrapper extends Component {
 			hideSkip,
 			isLargeSkipLayout,
 			isWideLayout,
+			isTopButtons,
 		} = this.props;
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-wide-layout': isWideLayout,
@@ -134,9 +137,13 @@ class StepWrapper extends Component {
 						</FormattedHeader>
 					) }
 
+					{ ! hideSkip && isTopButtons && (
+						<div className="step-wrapper__buttons is-top-buttons">{ this.renderSkip() }</div>
+					) }
+
 					<div className="step-wrapper__content">{ stepContent }</div>
 
-					{ ! hideSkip && (
+					{ ! hideSkip && ! isTopButtons && (
 						<div className="step-wrapper__buttons">
 							{ isLargeSkipLayout && <hr className="step-wrapper__skip-hr" /> }
 							{ this.renderSkip() }

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -24,3 +24,35 @@
 		margin-bottom: 14px;
 	}
 }
+
+.step-wrapper__buttons.is-top-buttons {
+	text-align: center;
+	padding: 5px 0;
+	margin-bottom: 32px;
+}
+
+.step-wrapper__buttons.is-top-buttons .step-wrapper__skip-wrapper {
+	display: inline-block;
+	background: var( --color-surface );
+	border-radius: 3px;
+	padding: 2px 12px;
+	@include elevation ( 2dp );
+}
+
+.step-wrapper__buttons.is-top-buttons .step-wrapper__skip-heading {
+	display: inline;
+	color: var( --color-text );
+}
+
+.step-wrapper__buttons.is-top-buttons .navigation-link {
+	color: var( --color-accent );
+	text-decoration: underline;
+	transform: none;
+	vertical-align: baseline;
+	margin-left: 0.5em;
+	padding: 7px 0 9px !important;
+}
+
+.step-wrapper__buttons.is-top-buttons .navigation-link svg {
+	display: none;
+}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -615,7 +615,7 @@ class DomainsStep extends React.Component {
 				allowBackFirstStep={ !! selectedSite }
 				backLabelText={ backLabelText }
 				hideSkip={ ! showSkip }
-				isLargeSkipLayout={ showSkip }
+				isTopButtons={ showSkip }
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }
 				skipLabelText={ translate( 'Choose a domain later' ) }


### PR DESCRIPTION
Signup parts of: paObgF-GK-p2

This edits the `test-fse` Signup flow for our next round of user testing. Edits include:

- Remove site type and site topic steps
- Set pub/maywood as the theme default when one isn't passed via query string or step dependency
- Move the domains skip button to the top of the domains step (matching the plans step)

There was some wonkiness on using a passwordless user step that I believe needs to wait for #37697.

![Screen Shot 2019-11-13 at 10 10 17 AM](https://user-images.githubusercontent.com/942359/68780289-12025500-0604-11ea-884b-18891a027e08.png)

**To test:**
- visit `/start/test-fse/`
- steps should be: user, site title, domains (with top skip), plans
- verify that completing the flow results in a new site with the Maywood theme
- verify that skipping Signup auto-assigns a subdomain
- verify that a site title input in Signup is reflected on the end site
- visit `/start/onboarding/`
- complete Signup as normal (by picking a site type and topic, domain, and plan)
- verify that the resulting site looks as expected

FIxes #37659