### PR TITLE
Domains: Move Change Site Address tool to its own page

### DIFF
--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -93,24 +93,28 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 						new_domain: newDomainName,
 					} }
 				/>
-				<h1>{ translate( "Let's review…" ) }</h1>
-				<p>
-					{ translate(
-						"You're about to change your site address. Once you confirm the change, " +
-							'this site address will no longer be available for future use.'
-					) }
-				</p>
+				<h1 className="site-address-changer__dialog-heading">
+					{ translate( 'Confirm Site Address Change' ) }
+				</h1>
 				<div className="site-address-changer__confirmation-detail">
 					<Gridicon
 						icon="cross-circle"
 						size={ 18 }
 						className="site-address-changer__copy-deletion"
 					/>
-					<p className="site-address-changer__confirmation-detail-copy">
-						<strong className="site-address-changer__copy-deletion">{ currentDomainName }</strong>
-						{ currentDomainSuffix }
-						<br />
-						{ translate( 'Will be removed and unavailable for use.' ) }
+					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-deletion">
+						{ translate(
+							'{{strong}}%(currentDomainName)s{{/strong}}%(currentDomainSuffix)s will be removed and unavailable for use.',
+							{
+								components: {
+									strong: <strong />,
+								},
+								args: {
+									currentDomainName: currentDomainName,
+									currentDomainSuffix: currentDomainSuffix,
+								},
+							}
+						) }
 					</p>
 				</div>
 				<div className="site-address-changer__confirmation-detail">
@@ -119,14 +123,22 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 						size={ 18 }
 						className="site-address-changer__copy-addition"
 					/>
-					<p className="site-address-changer__confirmation-detail-copy">
-						<strong className="site-address-changer__copy-addition">{ newDomainName }</strong>
-						{ newDomainSuffix }
-						<br />
-						{ translate( 'Will be your new site address.' ) }
+					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-addition">
+						{ translate(
+							'{{strong}}%(newDomainName)s{{/strong}}%(newDomainSuffix)s will be your new site address.',
+							{
+								components: {
+									strong: <strong />,
+								},
+								args: {
+									newDomainName: newDomainName,
+									newDomainSuffix: newDomainSuffix,
+								},
+							}
+						) }
 					</p>
 				</div>
-				<h1>{ translate( 'Check the box to confirm' ) }</h1>
+				<h2>{ translate( 'Check the box to confirm' ) }</h2>
 				<FormLabel>
 					<FormInputCheckbox
 						checked={ this.state.isConfirmationChecked }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -15,10 +15,11 @@ import { connect } from 'react-redux';
  */
 import { Card } from '@automattic/components';
 import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
+import FormLabel from 'components/forms/form-label';
 import ConfirmationDialog from './dialog';
-import FormSectionHeading from 'components/forms/form-section-heading';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import {
 	requestSiteAddressChange,
@@ -37,7 +38,6 @@ import './style.scss';
 
 const SUBDOMAIN_LENGTH_MINIMUM = 4;
 const SUBDOMAIN_LENGTH_MAXIMUM = 50;
-const ADDRESS_CHANGE_SUPPORT_URL = 'https://support.wordpress.com/changing-blog-address/';
 const VALIDATION_DEBOUNCE_MS = 800;
 
 export class SiteAddressChanger extends Component {
@@ -313,8 +313,21 @@ export class SiteAddressChanger extends Component {
 						eventProperties={ { blog_id: siteId } }
 					/>
 					<Card className="site-address-changer__content">
-						<FormSectionHeading>{ translate( 'Change Site Address' ) }</FormSectionHeading>
+						<div className="site-address-changer__info">
+							<p>
+								{ translate(
+									'Once you change your site address, %(currentDomainName)s will no longer be available.',
+									{
+										args: { currentDomainName },
+									}
+								) }
+							</p>
+						</div>
+						<FormLabel htmlFor="site-address-changer__text-input">
+							{ translate( 'Enter your new site address' ) }
+						</FormLabel>
 						<FormTextInputWithAffixes
+							id="site-address-changer__text-input"
 							className="site-address-changer__input"
 							type="text"
 							value={ domainFieldValue }
@@ -322,33 +335,18 @@ export class SiteAddressChanger extends Component {
 							onChange={ this.onFieldChange }
 							placeholder={ currentDomainPrefix }
 							isError={ shouldShowValidationMessage && ! isAvailable }
+							noWrap
 						/>
 						<FormInputValidation
 							isHidden={ ! shouldShowValidationMessage }
 							isError={ ! isAvailable }
 							text={ validationMessage || '\u00A0' }
 						/>
-						<div className="site-address-changer__footer">
-							<div className="site-address-changer__info">
-								<Gridicon icon="info-outline" size={ 18 } />
-								<p>
-									{ translate(
-										'Once you change your site address, %(currentDomainName)s will no longer be available.',
-										{
-											args: { currentDomainName },
-										}
-									) }{ ' ' }
-									<a href={ ADDRESS_CHANGE_SUPPORT_URL } target="_blank" rel="noopener noreferrer">
-										{ translate(
-											'Before you confirm the change, please read this important information.'
-										) }
-									</a>
-								</p>
-							</div>
+						<FormButtonsBar className="site-address-changer__form-footer">
 							<FormButton disabled={ isDisabled } busy={ isBusy } type="submit">
 								{ translate( 'Change Site Address' ) }
 							</FormButton>
-						</div>
+						</FormButtonsBar>
 					</Card>
 				</form>
 			</div>

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -260,9 +260,12 @@ export class SiteAddressChanger extends Component {
 		);
 	}
 
-	handleAddDomainClick() {
-		this.props.recordTracksEvent( 'calypso_siteaddresschange_add_domain_click' );
-	}
+	handleAddDomainClick = () => {
+		const { siteId } = this.props;
+		this.props.recordTracksEvent( 'calypso_siteaddresschange_add_domain_click', {
+			blogid: siteId,
+		} );
+	};
 
 	render() {
 		const {

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -2,14 +2,23 @@
 .site-address-changer__dialog {
 	text-align: left;
 	max-width: 400px;
-	color: var( --color-neutral-50 );
+
+	h2 {
+		border-top: 1px solid var( --color-border-subtle );
+		font-weight: bold;
+		margin-top: 1.5em;
+		margin-bottom: 1em;
+		padding-top: 1.5em;
+	}
 }
 
-.site-address-changer__copy-addition {
+.site-address-changer__copy-addition strong,
+.site-address-changer__copy-addition.gridicon {
 	color: var( --color-success );
 }
 
-.site-address-changer__copy-deletion {
+.site-address-changer__copy-deletion strong,
+.site-address-changer__copy-deletion.gridicon {
 	color: var( --color-error );
 }
 
@@ -49,34 +58,7 @@
 }
 
 .site-address-changer__info {
-	color: var( --color-text-subtle );
-	flex-shrink: 1;
-	margin: 5px 0 0;
-	padding: 0;
-	text-align: center;
 	word-break: break-word;
-
-	@include breakpoint( '>660px' ) {
-		margin-right: 15px;
-		text-align: left;
-	}
-
-	span {
-		font-size: 12px;
-		margin: 0;
-
-		@include breakpoint( '>660px' ) {
-			margin-left: 24px;
-		}
-	}
-
-	.gridicon {
-		float: left;
-
-		@include breakpoint( '<660px' ) {
-			display: none;
-		}
-	}
 }
 
 .site-address-changer__only-owner-info {
@@ -97,35 +79,49 @@
 	}
 }
 
-.site-address-changer__footer {
-	align-items: center;
-	border-top-color: var( --color-neutral-0 );
+.site-address-changer__content {
+	@include breakpoint( '<480px' ) {
+		.form-text-input-with-affixes__suffix {
+			padding-left: 8px;
+			padding-right: 8px;
+		}
+	}
+}
+
+.site-address-changer__form-footer {
+	border-top: 1px solid var( --color-neutral-0 );
+	margin: 0 -16px -16px;
+	padding: 16px;
 	display: flex;
-	justify-content: space-between;
+	justify-content: flex-start;
 
-	button {
-		flex-shrink: 0;
-		margin-left: auto;
+	@include breakpoint( '>480px' ) {
+		padding: 24px;
+		margin: 24px -24px -24px;
 	}
 
-	p {
-		font-size: 12px;
-		margin: 0;
-
-		@include breakpoint( '>660px' ) {
-			margin-left: 24px;
-		}
+	@include breakpoint( '<480px' ) {
+		flex-direction: column;
 	}
 
-	@include breakpoint( '<660px' ) {
-		flex-direction: column-reverse;
+	.button {
+		margin: 0 0 0 15px;
 
-		em {
-			margin-top: 10px;
+		&.is-primary {
+			margin: 0 0 15px;
+
+			@include breakpoint( '>480px' ) {
+				margin: 0;
+			}
+
+			@include breakpoint( '<480px' ) {
+				order: 1;
+			}
 		}
 
-		button {
+		@include breakpoint( '<480px' ) {
 			width: 100%;
+			order: 2;
 		}
 	}
 }
@@ -149,4 +145,8 @@
 			margin-left: 24px;
 		}
 	}
+}
+
+.dialog__content h1.site-address-changer__dialog-heading {
+	line-height: 1.4em;
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -97,7 +97,7 @@
 
 	@include breakpoint( '>480px' ) {
 		padding: 24px;
-		margin: 24px -24px -24px;
+		margin: 0 -24px -24px;
 	}
 
 	@include breakpoint( '<480px' ) {

--- a/client/my-sites/domains/domain-management/change-site-address/index.jsx
+++ b/client/my-sites/domains/domain-management/change-site-address/index.jsx
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import page from 'page';
+import { localize, translate } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Header from 'my-sites/domains/domain-management/components/header';
+import Main from 'components/main';
+import SiteAddressChanger from 'blocks/site-address-changer';
+import { getSelectedDomain, isRegisteredDomain } from 'lib/domains';
+import { domainManagementEdit, domainManagementNameServers } from 'my-sites/domains/paths';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ChangeSiteAddress extends React.Component {
+	static propTypes = {
+		domains: PropTypes.array.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	};
+
+	goBack = () => {
+		let path;
+
+		if ( isRegisteredDomain( getSelectedDomain( this.props ) ) ) {
+			path = domainManagementNameServers;
+		} else {
+			path = domainManagementEdit;
+		}
+
+		page( path( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+	};
+
+	render() {
+		const domain = getSelectedDomain( this.props );
+		const dotblogSubdomain = get( domain, 'name', '' ).match( /\.\w+\.blog$/ );
+		const domainSuffix = dotblogSubdomain ? dotblogSubdomain[ 0 ] : '.wordpress.com';
+
+		return (
+			<Main className="change-site-address">
+				<Header onClick={ this.goBack } selectedDomainName={ domain }>
+					{ translate( 'Change Site Address' ) }
+				</Header>
+
+				<SiteAddressChanger currentDomain={ domain } currentDomainSuffix={ domainSuffix } />
+			</Main>
+		);
+	}
+}
+
+export default localize( ChangeSiteAddress );

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -11,6 +11,7 @@ import React from 'react';
 import DomainManagement from '.';
 import DomainManagementData from 'components/data/domain-management';
 import {
+	domainManagementChangeSiteAddress,
 	domainManagementContactsPrivacy,
 	domainManagementDns,
 	domainManagementEdit,
@@ -278,6 +279,20 @@ export default {
 				needsDomains
 				needsDomainInfo
 				needsUsers
+				selectedDomainName={ pageContext.params.domain }
+			/>
+		);
+		next();
+	},
+
+	domainManagementChangeSiteAddress( pageContext, next ) {
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementChangeSiteAddress( ':site', ':domain' ) }
+				analyticsTitle="Domain Management > Change Site Address"
+				component={ DomainManagement.ChangeSiteAddress }
+				context={ pageContext }
+				needsDomains
 				selectedDomainName={ pageContext.params.domain }
 			/>
 		);

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -14,10 +14,10 @@ import Header from './card/header';
 import Property from './card/property';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
-<<<<<<< HEAD
-import SiteAddressChanger from 'blocks/site-address-changer';
+import { domainManagementChangeSiteAddress } from 'my-sites/domains/paths';
 import { getDomainTypeText } from 'lib/domains';
 import { type as domainTypes } from 'lib/domains/constants';
+
 import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 
 class WpcomDomain extends React.Component {
@@ -31,15 +31,6 @@ class WpcomDomain extends React.Component {
 			'Domain Name',
 			domain.name
 		);
-=======
-import { type as domainTypes } from 'lib/domains/constants';
-import { domainManagementChangeSiteAddress } from 'my-sites/domains/paths';
-
-// eslint-disable-next-line react/prefer-es6-class
-const WpcomDomain = createReactClass( {
-	displayName: 'WpcomDomain',
-	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
->>>>>>> Move Change Site Address tool to its own page linked from the domain settings page. Updates to simplify copy and styles for mobile web.
 
 		this.props.recordTracksEvent( 'calypso_domain_management_edit_navigation_click', {
 			action: 'edit_site_address',
@@ -47,27 +38,32 @@ const WpcomDomain = createReactClass( {
 		} );
 	};
 
-	handleChangeSiteAddressClick() {
-		this.recordEvent( 'navigationClick', 'Change Site Address', this.props.domain );
-	},
+	handleChangeSiteAddressClick = () => {
+		const { domain } = this.props;
+		const domainType = getDomainTypeText( domain );
+
+		this.props.recordGoogleEvent(
+			'Domain Management',
+			`Clicked "Change Site Address" navigation link on a ${ domainType } in Edit`,
+			'Domain Name',
+			domain.name
+		);
+
+		this.props.recordTracksEvent( 'calypso_domain_management_change_navigation_click', {
+			action: 'change_site_address',
+			section: domain.type,
+		} );
+	};
 
 	getEditSiteAddressBlock() {
 		const { domain } = this.props;
-<<<<<<< HEAD
 
 		if ( domain.isWpcomStagingDomain ) {
 			return;
 		}
 
-		if ( get( domain, 'type' ) === domainTypes.WPCOM ) {
-			const dotblogSubdomain = get( domain, 'name', '' ).match( /\.\w+\.blog$/ );
-			const domainSuffix = dotblogSubdomain ? dotblogSubdomain[ 0 ] : '.wordpress.com';
-			return <SiteAddressChanger currentDomain={ domain } currentDomainSuffix={ domainSuffix } />;
-		}
-=======
 		const isWpcomDomain = get( domain, 'type' ) === domainTypes.WPCOM;
 		const path = domainManagementChangeSiteAddress( this.props.selectedSite.slug, domain.name );
->>>>>>> Move Change Site Address tool to its own page linked from the domain settings page. Updates to simplify copy and styles for mobile web.
 
 		return (
 			<VerticalNav>
@@ -116,12 +112,7 @@ const WpcomDomain = createReactClass( {
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
-<<<<<<< HEAD
 	}
 }
-=======
-	},
-} );
->>>>>>> Move Change Site Address tool to its own page linked from the domain settings page. Updates to simplify copy and styles for mobile web.
 
 export default connect( null, { recordTracksEvent, recordGoogleEvent } )( localize( WpcomDomain ) );

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -14,6 +14,7 @@ import Header from './card/header';
 import Property from './card/property';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
+<<<<<<< HEAD
 import SiteAddressChanger from 'blocks/site-address-changer';
 import { getDomainTypeText } from 'lib/domains';
 import { type as domainTypes } from 'lib/domains/constants';
@@ -30,6 +31,15 @@ class WpcomDomain extends React.Component {
 			'Domain Name',
 			domain.name
 		);
+=======
+import { type as domainTypes } from 'lib/domains/constants';
+import { domainManagementChangeSiteAddress } from 'my-sites/domains/paths';
+
+// eslint-disable-next-line react/prefer-es6-class
+const WpcomDomain = createReactClass( {
+	displayName: 'WpcomDomain',
+	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
+>>>>>>> Move Change Site Address tool to its own page linked from the domain settings page. Updates to simplify copy and styles for mobile web.
 
 		this.props.recordTracksEvent( 'calypso_domain_management_edit_navigation_click', {
 			action: 'edit_site_address',
@@ -37,8 +47,13 @@ class WpcomDomain extends React.Component {
 		} );
 	};
 
+	handleChangeSiteAddressClick() {
+		this.recordEvent( 'navigationClick', 'Change Site Address', this.props.domain );
+	},
+
 	getEditSiteAddressBlock() {
 		const { domain } = this.props;
+<<<<<<< HEAD
 
 		if ( domain.isWpcomStagingDomain ) {
 			return;
@@ -49,15 +64,27 @@ class WpcomDomain extends React.Component {
 			const domainSuffix = dotblogSubdomain ? dotblogSubdomain[ 0 ] : '.wordpress.com';
 			return <SiteAddressChanger currentDomain={ domain } currentDomainSuffix={ domainSuffix } />;
 		}
+=======
+		const isWpcomDomain = get( domain, 'type' ) === domainTypes.WPCOM;
+		const path = domainManagementChangeSiteAddress( this.props.selectedSite.slug, domain.name );
+>>>>>>> Move Change Site Address tool to its own page linked from the domain settings page. Updates to simplify copy and styles for mobile web.
 
 		return (
 			<VerticalNav>
 				<VerticalNavItem
-					path={ `https://${ this.props.domain.name }/wp-admin/index.php?page=my-blogs#blog_row_${ this.props.selectedSite.ID }` }
-					external={ true }
-					onClick={ this.handleEditSiteAddressClick }
+					path={
+						isWpcomDomain
+							? path
+							: `https://${ this.props.domain.name }/wp-admin/index.php?page=my-blogs#blog_row_${ this.props.selectedSite.ID }`
+					}
+					external={ isWpcomDomain ? false : true }
+					onClick={
+						isWpcomDomain ? this.handleChangeSiteAddressClick : this.handleEditSiteAddressClick
+					}
 				>
-					{ this.props.translate( 'Edit Site Address' ) }
+					{ isWpcomDomain
+						? this.props.translate( 'Change Site Address' )
+						: this.props.translate( 'Edit Site Address' ) }
 				</VerticalNavItem>
 			</VerticalNav>
 		);
@@ -89,7 +116,12 @@ class WpcomDomain extends React.Component {
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
+<<<<<<< HEAD
 	}
 }
+=======
+	},
+} );
+>>>>>>> Move Change Site Address tool to its own page linked from the domain settings page. Updates to simplify copy and styles for mobile web.
 
 export default connect( null, { recordTracksEvent, recordGoogleEvent } )( localize( WpcomDomain ) );

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import ChangeSiteAddress from './change-site-address';
 import ContactsPrivacy from './contacts-privacy';
 import Dns from './dns';
 import DomainConnectMapping from './domain-connect-mapping';
@@ -18,6 +19,7 @@ import TransferToOtherSite from './transfer/transfer-to-other-site';
 import TransferToOtherUser from './transfer/transfer-to-other-user';
 
 export default {
+	ChangeSiteAddress,
 	ContactsPrivacy,
 	Dns,
 	DomainConnectMapping,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -66,6 +66,14 @@ export default function() {
 	);
 
 	page(
+		paths.domainManagementChangeSiteAddress( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementChangeSiteAddress,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		paths.domainManagementRedirectSettings( ':site', ':domain' ),
 		...getCommonHandlers(),
 		domainManagementController.domainManagementRedirectSettings,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -67,6 +67,10 @@ export function domainManagementEmailForwarding( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'email-forwarding' );
 }
 
+export function domainManagementChangeSiteAddress( siteName, domainName ) {
+	return domainManagementEdit( siteName, domainName, 'change-site-address' );
+}
+
 export function domainManagementNameServers( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'name-servers' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new page for Change Site Address, linked from the domain settings screen.
* Adds a link with tracking to redirect folks to add a new domain, in case they've mistaken "Change Site Address" for wanting a custom domain.
* Adds a label to the text input for accessibility.
* Simplify copy to make it more concise.
* Simplify and standardize visual styles to match other Domains sections.

#### Testing instructions

* Switch to this PR and go to Manage -> Domains on a *.wordpress.com or *.*.blog site
* Click on the *.wordpress.com site address to edit it.
* Click Change Site Address
* Try to change your site address. Put in a URL you know you can't use, and one you can. Make sure the proper notifications show up.

Fixes #36737