### PR TITLE
SharingButtonsPreviewButton: add forwardRef flag to connect to make the button reffable

### DIFF
--- a/client/my-sites/marketing/buttons/preview-button.jsx
+++ b/client/my-sites/marketing/buttons/preview-button.jsx
@@ -99,8 +99,11 @@ class SharingButtonsPreviewButton extends React.Component {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
-export default connect( state => {
-	return {
+export default connect(
+	state => ( {
 		path: getCurrentRouteParameterized( state, getSelectedSiteId( state ) ),
-	};
-} )( SharingButtonsPreviewButton );
+	} ),
+	null,
+	null,
+	{ forwardRef: true }
+)( SharingButtonsPreviewButton );


### PR DESCRIPTION
Fixes #37562, a regression introduced by the `react-redux` upgrade in #37438.

A connected component is used with a `ref`, and it needs to forward it to the inner component.