### PR TITLE
Composite checkout: Add loading state to Stripe

### DIFF
--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React, { useEffect } from 'react';
-import styled, { keyframes } from '@emotion/styled';
+import styled from '@emotion/styled';
+import { keyframes } from '@emotion/core';
 import PropTypes from 'prop-types';
 
 /**

--- a/packages/composite-checkout/src/components/coupon.js
+++ b/packages/composite-checkout/src/components/coupon.js
@@ -89,6 +89,7 @@ const ApplyButton = styled( Button )`
 	right: 4px;
 	padding: 7px;
 	animation: ${animateIn} 0.2s ease-out;
+	animation-fill-mode: backwards;
 	margin: 0;
 `;
 

--- a/packages/composite-checkout/src/components/credit-card-fields.js
+++ b/packages/composite-checkout/src/components/credit-card-fields.js
@@ -13,7 +13,7 @@ import { useLocalize } from '../lib/localize';
 import { AmexLogo, VisaLogo, MastercardLogo } from './payment-logos';
 import { useSelect, useDispatch } from '../public-api';
 
-export default function CreditCardFields() {
+export default function CreditCardFields( { disabled } ) {
 	const localize = useLocalize();
 	const [ paymentIcon, setPaymentIcon ] = useState( <LockIcon /> );
 	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
@@ -68,30 +68,33 @@ export default function CreditCardFields() {
 				onChange={ value => {
 					handleCreditCardNumberChange( value );
 				} }
+				disabled={ disabled }
 			/>
 			<FieldRow gap="4%" columnWidths="48% 48%">
 				<Field
 					id="card-expiry"
 					type="Number"
-					label={ localize( 'Expiry Date' ) }
+					label={ localize( 'Expiry date' ) }
 					placeholder="MM / YY"
 					autoComplete="cc-exp"
 					value={ currentCreditCardData.cardExpiry || '' }
 					onChange={ value => {
 						updateCreditCard( 'cardExpiry', value );
 					} }
+					disabled={ disabled }
 				/>
 				<GridRow gap="4%" columnWidths="67% 29%">
 					<Field
 						id="card-cvc"
 						type="Number"
-						label={ localize( 'Security Code' ) }
-						placeholder="111"
+						label={ localize( 'Security code' ) }
+						placeholder="CVC"
 						autoComplete="cc-csc"
 						value={ currentCreditCardData.cardCvc || '' }
 						onChange={ value => {
 							updateCreditCard( 'cardCvc', value );
 						} }
+						disabled={ disabled }
 					/>
 					<CVVImage />
 				</GridRow>
@@ -107,6 +110,7 @@ export default function CreditCardFields() {
 				onChange={ value => {
 					updateCreditCard( 'cardHolderName', value );
 				} }
+				disabled={ disabled }
 			/>
 		</CreditCardFieldsWrapper>
 	);
@@ -203,7 +207,8 @@ const CVVImage = styled( CVV )`
 `;
 
 const LockIconGraphic = styled.svg`
-	width: 17px;
-	height: 17px;
+	width: 20px;
+	height: 20px;
 	display: block;
+	transform: translateY( 1px );
 `;

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -26,6 +26,7 @@ export default function Field( {
 	description,
 	errorMessage,
 	autoComplete,
+	disabled,
 } ) {
 	const fieldOnChange = event => {
 		if ( onChange ) {
@@ -41,7 +42,11 @@ export default function Field( {
 
 	return (
 		<div className={ className }>
-			{ label && <Label htmlFor={ id }>{ label }</Label> }
+			{ label && (
+				<Label htmlFor={ id } disabled={ disabled }>
+					{ label }
+				</Label>
+			) }
 
 			<InputWrapper>
 				<Input
@@ -55,6 +60,7 @@ export default function Field( {
 					tabIndex={ tabIndex }
 					isError={ isError }
 					autoComplete={ autoComplete }
+					disabled={ disabled }
 				/>
 				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
 			</InputWrapper>
@@ -83,6 +89,7 @@ Field.propTypes = {
 	description: PropTypes.string,
 	errorMessage: PropTypes.string,
 	autoComplete: PropTypes.string,
+	disabled: PropTypes.bool,
 };
 
 const Label = styled.label`
@@ -93,7 +100,7 @@ const Label = styled.label`
 	margin-bottom: 8px;
 
 	:hover {
-		cursor: pointer;
+		cursor: ${props => ( props.disabled ? 'default' : 'pointer' )};
 	}
 `;
 
@@ -104,7 +111,7 @@ const Input = styled.input`
 	font-size: 16px;
 	border: 1px solid
 		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
-	padding: 12px ${props => ( props.icon ? '60px' : '10px' )} 12px 10px;
+	padding: 13px ${props => ( props.icon ? '60px' : '10px' )} 12px 10px;
 
 	:focus {
 		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
@@ -120,6 +127,14 @@ const Input = styled.input`
 	[type='number'] {
 		-moz-appearance: none;
 		appearance: none;
+	}
+
+	::placeholder {
+		color: ${props => props.theme.colors.placeHolderTextColor};
+	}
+
+	:disabled {
+		background: ${props => props.theme.colors.disabledField};
 	}
 `;
 

--- a/packages/composite-checkout/src/components/spinner.js
+++ b/packages/composite-checkout/src/components/spinner.js
@@ -40,5 +40,7 @@ const SpinnerWrapper = styled.div`
 		opacity: 0.5;
 		content: '';
 		border-radius: 100%;
+		animation: ${rotate} 3s linear infinite;
+		animation-fill-mode: backwards;
 	}
 `;

--- a/packages/composite-checkout/src/components/spinner.js
+++ b/packages/composite-checkout/src/components/spinner.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import { keyframes } from '@emotion/core';
+
+export default function Spinner( { className } ) {
+	return <SpinnerWrapper className={ className } />;
+}
+
+const rotate = keyframes`
+	100% {
+		transform: rotate( 360deg );
+	}
+`;
+
+const SpinnerWrapper = styled.div`
+	display: block;
+	width: 20px;
+	height: 20px;
+	border: 3px solid transparent;
+	border-top-color: ${props => props.theme.colors.highlight};
+	border-radius: 100%;
+	box-sizing: border-box;
+	position: relative;
+	animation: ${rotate} 3s linear infinite;
+	animation-fill-mode: backwards;
+
+	:after {
+		position: absolute;
+		top: 0;
+		left: -1px;
+		width: 17px;
+		height: 17px;
+		border: 3px solid transparent;
+		border-top-color: ${props => props.theme.colors.highlight};
+		border-right-color: ${props => props.theme.colors.highlight};
+		box-sizing: border-box;
+		opacity: 0.5;
+		content: '';
+		border-radius: 100%;
+	}
+`;

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -31,6 +31,8 @@ import { VisaLogo, AmexLogo, MastercardLogo } from './payment-logos';
 import { CreditCardLabel } from '../lib/payment-methods/credit-card';
 import BillingFields, { getDomainDetailsFromPaymentData } from '../components/billing-fields';
 import { SummaryLine, SummaryDetails } from '../lib/styled-components/summary-details';
+import CreditCardFields from './credit-card-fields';
+import Spinner from './spinner';
 
 export function createStripeMethod( {
 	registerStore,
@@ -162,6 +164,7 @@ function StripeCreditCardFields() {
 	const [ cardNumberElementData, setCardNumberElementData ] = useState();
 	const [ cardExpiryElementData, setCardExpiryElementData ] = useState();
 	const [ cardCvcElementData, setCardCvcElementData ] = useState();
+	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
 	const cardholderName = useSelect( select => select( 'stripe' ).getCardholderName() );
 	const brand = useSelect( select => select( 'stripe' ).getBrand() );
 	const { changeCardholderName } = useDispatch( 'stripe' );
@@ -193,7 +196,7 @@ function StripeCreditCardFields() {
 			fontFamily: theme.fonts.body,
 			fontWeight: theme.weights.normal,
 			'::placeholder': {
-				color: theme.colors.textColorLight,
+				color: theme.colors.placeHolderTextColor,
 			},
 		},
 		invalid: {
@@ -205,75 +208,98 @@ function StripeCreditCardFields() {
 		return <span>Error!</span>;
 	}
 	if ( isStripeLoading ) {
-		return <span>Loading...</span>;
+		return (
+			<StripeFields>
+				<LoadingIndicator />
+				<CreditCardFields disabled={ true } />
+			</StripeFields>
+		);
 	}
 
 	return (
-		<CreditCardFieldsWrapper>
-			<Label>
-				<LabelText>{ localize( 'Card number' ) }</LabelText>
-				<StripeFieldWrapper hasError={ cardNumberElementData }>
-					<CardNumberElement
-						style={ cardNumberStyle }
-						onChange={ input => {
-							handleStripeFieldChange( input, setCardNumberElementData );
-						} }
-					/>
-					<CardFieldIcon brand={ brand } />
+		<StripeFields>
+			{ ! isStripeFullyLoaded && (
+				<React.Fragment>
+					<LoadingIndicator />
+					<CreditCardFields disabled={ true } />
+				</React.Fragment>
+			) }
 
-					{ cardNumberElementData && (
-						<StripeErrorMessage>{ cardNumberElementData }</StripeErrorMessage>
-					) }
-				</StripeFieldWrapper>
-			</Label>
-			<FieldRow gap="4%" columnWidths="48% 48%">
+			<CreditCardFieldsWrapper isLoaded={ isStripeFullyLoaded }>
 				<Label>
-					<LabelText>{ localize( 'Expiry date' ) }</LabelText>
-					<StripeFieldWrapper hasError={ cardExpiryElementData }>
-						<CardExpiryElement
+					<LabelText>{ localize( 'Card number' ) }</LabelText>
+					<StripeFieldWrapper hasError={ cardNumberElementData }>
+						<CardNumberElement
 							style={ cardNumberStyle }
+							onReady={ () => {
+								setIsStripeFullyLoaded( true );
+							} }
 							onChange={ input => {
-								handleStripeFieldChange( input, setCardExpiryElementData );
+								handleStripeFieldChange( input, setCardNumberElementData );
 							} }
 						/>
+						<CardFieldIcon brand={ brand } />
+
+						{ cardNumberElementData && (
+							<StripeErrorMessage>{ cardNumberElementData }</StripeErrorMessage>
+						) }
 					</StripeFieldWrapper>
-					{ cardExpiryElementData && (
-						<StripeErrorMessage>{ cardExpiryElementData }</StripeErrorMessage>
-					) }
 				</Label>
-				<GridRow gap="4%" columnWidths="67% 29%">
+				<FieldRow gap="4%" columnWidths="48% 48%">
 					<Label>
-						<LabelText>{ localize( 'Security code' ) }</LabelText>
-						<StripeFieldWrapper hasError={ cardCvcElementData }>
-							<CardCvcElement
+						<LabelText>{ localize( 'Expiry date' ) }</LabelText>
+						<StripeFieldWrapper hasError={ cardExpiryElementData }>
+							<CardExpiryElement
 								style={ cardNumberStyle }
 								onChange={ input => {
-									handleStripeFieldChange( input, setCardCvcElementData );
+									handleStripeFieldChange( input, setCardExpiryElementData );
 								} }
 							/>
 						</StripeFieldWrapper>
-						{ cardCvcElementData && (
-							<StripeErrorMessage>{ cardCvcElementData }</StripeErrorMessage>
+						{ cardExpiryElementData && (
+							<StripeErrorMessage>{ cardExpiryElementData }</StripeErrorMessage>
 						) }
 					</Label>
-					<CVVImage />
-				</GridRow>
-			</FieldRow>
+					<GridRow gap="4%" columnWidths="67% 29%">
+						<Label>
+							<LabelText>{ localize( 'Security code' ) }</LabelText>
+							<StripeFieldWrapper hasError={ cardCvcElementData }>
+								<CardCvcElement
+									style={ cardNumberStyle }
+									onChange={ input => {
+										handleStripeFieldChange( input, setCardCvcElementData );
+									} }
+								/>
+							</StripeFieldWrapper>
+							{ cardCvcElementData && (
+								<StripeErrorMessage>{ cardCvcElementData }</StripeErrorMessage>
+							) }
+						</Label>
+						<CVVImage />
+					</GridRow>
+				</FieldRow>
 
-			<CreditCardField
-				id="cardholderName"
-				type="Text"
-				label={ localize( 'Cardholder name' ) }
-				description={ localize( 'Enter your name as it’s written on the card' ) }
-				value={ cardholderName }
-				onChange={ changeCardholderName }
-			/>
-		</CreditCardFieldsWrapper>
+				<CreditCardField
+					id="cardholderName"
+					type="Text"
+					label={ localize( 'Cardholder name' ) }
+					description={ localize( 'Enter your name as it’s written on the card' ) }
+					value={ cardholderName }
+					onChange={ changeCardholderName }
+				/>
+			</CreditCardFieldsWrapper>
+		</StripeFields>
 	);
 }
 
+const StripeFields = styled.div`
+	position: relative;
+`;
+
 const CreditCardFieldsWrapper = styled.div`
 	padding: 16px;
+	position: relative;
+	display: ${props => ( props.isLoaded ? 'block' : 'none' )};
 	position: relative;
 
 	:after {
@@ -286,6 +312,12 @@ const CreditCardFieldsWrapper = styled.div`
 		top: 0;
 		left: 3px;
 	}
+`;
+
+const LoadingIndicator = styled( Spinner )`
+	position: absolute;
+	right: 15px;
+	top: 10px;
 `;
 
 const CreditCardField = styled( Field )`

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -210,20 +210,14 @@ function StripeCreditCardFields() {
 	if ( isStripeLoading ) {
 		return (
 			<StripeFields>
-				<LoadingIndicator />
-				<CreditCardFields disabled={ true } />
+				<LoadingFields />
 			</StripeFields>
 		);
 	}
 
 	return (
 		<StripeFields>
-			{ ! isStripeFullyLoaded && (
-				<React.Fragment>
-					<LoadingIndicator />
-					<CreditCardFields disabled={ true } />
-				</React.Fragment>
-			) }
+			{ ! isStripeFullyLoaded && <LoadingFields /> }
 
 			<CreditCardFieldsWrapper isLoaded={ isStripeFullyLoaded }>
 				<Label>
@@ -433,6 +427,15 @@ const BrandLogo = styled.span`
 	right: ${props => ( props.isSummary ? '0' : '10px' )};
 	transform: translateY( ${props => ( props.isSummary ? '4px' : '0' )} );
 `;
+
+function LoadingFields() {
+	return (
+		<React.Fragment>
+			<LoadingIndicator />
+			<CreditCardFields disabled={ true } />
+		</React.Fragment>
+	);
+}
 
 function CVV( { className } ) {
 	const localize = useLocalize();

--- a/packages/composite-checkout/src/theme.js
+++ b/packages/composite-checkout/src/theme.js
@@ -31,6 +31,8 @@ const theme = {
 		paypalGold: '#F0C443',
 		paypalGoldHover: '#FFB900',
 		modalBackground: 'rgba( 0,0,0,0.4 )',
+		disabledField: swatches.gray0,
+		placeHolderTextColor: swatches.gray30,
 	},
 	breakpoints: {
 		tabletUp: 'min-width: 700px',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR updates the loading state for the stripe fields. Some of our recent updates to initialize Stripe when we load checkout makes this screen really hard to catch but in the event that someone sees the loading state they will see this:

![image](https://user-images.githubusercontent.com/6981253/68791814-0caf0580-0618-11ea-84a1-819b453ee246.png)

In addition to the main loading state, I added an additional check to hold onto the loading state because I saw the fields took a second to load their placeholder content. After some digging, I [found an issue](https://github.com/stripe/react-stripe-elements/issues/308) where the Stripe folks suggested using the onReady function to determine if the fields had loaded. 

#### Testing instructions

* Run the new checkout with these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Try slow your connection down and pick the stripe fields (second credit card option) to see the loading state. 

