### PR TITLE
Domain step test: Badge styling for featured domains

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -238,7 +238,7 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let title, progressBarProps;
 		if ( isRecommended ) {
-			title = this.props.showTestCopy ? 'Our recommendation' : translate( 'Best Match' );
+			title = this.props.showTestCopy ? 'Our Recommendation' : translate( 'Best Match' );
 			progressBarProps = {
 				color: NOTICE_GREEN,
 				title,

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -238,7 +238,7 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let title, progressBarProps;
 		if ( isRecommended ) {
-			title = translate( 'Best Match' );
+			title = this.props.showTestCopy ? 'Our recommendation' : translate( 'Best Match' );
 			progressBarProps = {
 				color: NOTICE_GREEN,
 				title,
@@ -255,6 +255,18 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		if ( title ) {
+			if ( this.props.showTestCopy ) {
+				const badgeClassName = classNames( '', {
+					success: isRecommended,
+					blue: isBestAlternative,
+				} );
+				return (
+					<div className="domain-registration-suggestion__progress-bar">
+						<Badge type={ badgeClassName }>{ title }</Badge>
+					</div>
+				);
+			}
+
 			return (
 				<div className="domain-registration-suggestion__progress-bar">
 					<ProgressBar { ...progressBarProps } />
@@ -265,6 +277,10 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	renderMatchReason() {
+		if ( this.props.showTestCopy ) {
+			return null;
+		}
+
 		const {
 			suggestion: { domain_name: domain },
 			isFeatured,

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -259,6 +259,7 @@ class DomainSearchResults extends React.Component {
 					selectedSite={ this.props.selectedSite }
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
+					showTestCopy={ this.props.showTestCopy }
 				/>
 			);
 

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -123,6 +123,7 @@ export class FeaturedDomainSuggestions extends Component {
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
 						buttonStyles={ { primary: true } }
 						{ ...childProps }
+						showTestCopy={ this.props.showTestCopy }
 					/>
 				) }
 				{ secondarySuggestion && (
@@ -134,6 +135,7 @@ export class FeaturedDomainSuggestions extends Component {
 						uiPosition={ 1 }
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }
+						showTestCopy={ this.props.showTestCopy }
 					/>
 				) }
 			</div>

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -137,6 +137,11 @@
 			display: none;
 		}
 	}
+
+	.badge--blue {
+		background: var( --color-primary );
+		color: var( --color-text-inverted );
+	}
 }
 
 @include breakpoint( '<660px' ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1067,6 +1067,7 @@ class RegisterDomainStep extends React.Component {
 						onButtonClick={ this.onAddDomain }
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
+						showTestCopy={ this.props.showTestCopy }
 					/>
 				);
 			}, this );
@@ -1207,6 +1208,7 @@ class RegisterDomainStep extends React.Component {
 				cart={ this.props.cart }
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
+				showTestCopy={ this.props.showTestCopy }
 			>
 				{ showTldFilterBar && (
 					<TldFilterBar


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR builds on top of the domain-copy A/B test introduced as a feature flag in #37546. 
* The badge styling for featured domains is added for the variant.

**Web**

<img width="967" alt="Screenshot 2019-11-14 at 12 18 19 AM" src="https://user-images.githubusercontent.com/1269602/68794073-49104f00-0674-11ea-82ad-a37699689b39.png">

**Mobile**

![calypso localhost_3000_start_domains-with-preview(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/1269602/68862267-297c3380-0713-11ea-9ecd-5f69b6e21e6a.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and put yourself in the variant variantShowUpdates of the domainStepCopyUpdates A/B test.
* The featured domain boxes should show the new stylized badges as shown in the screenshot above

**Mobile View**

* Verify badge alignment checks out in mobile views.

**Check in other domain pages**

* Login to any account, and after assigning yourself to the variant, check the launch flow for privates sites and the Add domain page. In both places, the badge should not show.

**Verify that the A/B test is not automatically assigned**
* Go to /start and without manually assigning yourself to an A/B test, just complete the signup flow. 
* In your Browser console, type `localstorage.ABTests;`. Verify that the `domainStepCopyUpdates ` test is not present in the object. This is because we do not yet want any user getting assigned to the test till all the pieces are deployed.