### PR TITLE
Composite checkout: Add stripe error message

### DIFF
--- a/packages/composite-checkout/demo/private.js
+++ b/packages/composite-checkout/demo/private.js
@@ -1,0 +1,1 @@
+export const stripeKey = 'pk_test_zIh4nRbVgmaetTZqoG4XKxWT';

--- a/packages/composite-checkout/src/components/error-message.js
+++ b/packages/composite-checkout/src/components/error-message.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+
+export default function ErrorMessage( { children } ) {
+	return <Error>{ children }</Error>;
+}
+
+const Error = styled.div`
+	display: block;
+	padding: 24px 16px;
+	border-left: 3px solid ${props => props.theme.colors.error};
+	background: ${props => props.theme.colors.warningBackground};
+	box-sizing: border-box;
+	line-height: 1.2em;
+`;

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -33,6 +33,7 @@ import BillingFields, { getDomainDetailsFromPaymentData } from '../components/bi
 import { SummaryLine, SummaryDetails } from '../lib/styled-components/summary-details';
 import CreditCardFields from './credit-card-fields';
 import Spinner from './spinner';
+import ErrorMessage from './error-message';
 
 export function createStripeMethod( {
 	registerStore,
@@ -205,8 +206,17 @@ function StripeCreditCardFields() {
 	};
 
 	if ( stripeLoadingError ) {
-		return <span>Error!</span>;
+		return (
+			<CreditCardFieldsWrapper isLoaded={ true }>
+				<ErrorMessage>
+					{ localize(
+						'Our payment processor failed to load, please refresh your screen to try again or pick another payment method to proceed.'
+					) }
+				</ErrorMessage>
+			</CreditCardFieldsWrapper>
+		);
 	}
+
 	if ( isStripeLoading ) {
 		return (
 			<StripeFields>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds a new error message for when Stripe fails to load. This is what it looks like:

![image](https://user-images.githubusercontent.com/6981253/68794306-c60fda00-061c-11ea-9364-d7cb95c837d5.png)


#### Testing instructions
Review screenshot or find a way to prevent stripe from loading:

* Run checkout with these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Change line 205 in `packages/composite-checkout/src/components/error-message.js` to `if (true) {`

