### PR TITLE
Plans: Improve flows for upgrading private sites to the Business plan

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -133,10 +133,18 @@ export const EligibilityWarnings = ( {
 
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && translate( 'Please clear all issues above to proceed.' ) }
-					{ isEligible &&
-						warnings.length > 0 &&
-						translate( 'If you proceed you will no longer be able to use these features. ' ) }
+					{ ! isEligible && (
+						<>
+							{ translate( 'Please clear all issues above to proceed.' ) }
+							&nbsp;
+						</>
+					) }
+					{ isEligible && warnings.length > 0 && (
+						<>
+							{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
+							&nbsp;
+						</>
+					) }
 					{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
 						components: {
 							a: (

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
-import { get, defer, isEqual } from 'lodash';
+import { get, defer, find, isEqual } from 'lodash';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
 
@@ -47,8 +47,7 @@ import QueryPaymentCountries from 'components/data/query-countries/payments';
 import { INPUT_VALIDATION, RECEIVED_WPCOM_RESPONSE } from 'lib/store-transactions/step-types';
 import { displayError, clear } from './notices';
 import { isEbanxCreditCardProcessingEnabledForCountry } from 'lib/checkout/processor-specific';
-import { planHasFeature } from 'lib/plans';
-import { FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
+import { isWpComEcommercePlan } from 'lib/plans';
 import { recordTransactionAnalytics } from 'lib/store-transactions/analytics';
 
 /**
@@ -215,14 +214,13 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 
-		const forcedAtomicProducts = get( cart, 'products', [] ).filter( ( { product_slug = '' } ) => {
-			return (
-				planHasFeature( product_slug, FEATURE_UPLOAD_PLUGINS ) ||
-				planHasFeature( product_slug, FEATURE_UPLOAD_THEMES )
-			);
-		} );
+		const productsInCart = get( cart, 'products', [] );
 
-		if ( ! forcedAtomicProducts.length ) {
+		if (
+			! find( productsInCart, ( { product_slug = '' } ) => {
+				return isWpComEcommercePlan( product_slug );
+			} )
+		) {
 			return;
 		}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -38,8 +38,8 @@ import {
 	getMonthlyPlanByYearly,
 	getPlanPath,
 	isFreePlan,
+	isWpComEcommercePlan,
 	getPlanClass,
-	planHasFeature,
 } from 'lib/plans';
 import {
 	getCurrentPlan,
@@ -60,8 +60,6 @@ import {
 	isBestValue,
 	isMonthly,
 	isNew,
-	FEATURE_UPLOAD_PLUGINS,
-	FEATURE_UPLOAD_THEMES,
 	PLAN_FREE,
 	TYPE_BLOGGER,
 	TYPE_PERSONAL,
@@ -941,10 +939,7 @@ export default connect(
 				if ( displayJetpackPlans ) {
 					planFeatures = getPlanFeaturesObject( planConstantObj.getSignupFeatures( abtest ) );
 				}
-				const siteIsPrivateAndGoingAtomic =
-					siteIsPrivate &&
-					( planHasFeature( plan, FEATURE_UPLOAD_PLUGINS ) ||
-						planHasFeature( plan, FEATURE_UPLOAD_THEMES ) );
+				const siteIsPrivateAndGoingAtomic = siteIsPrivate && isWpComEcommercePlan( plan );
 
 				return {
 					availableForPurchase,


### PR DESCRIPTION
Since Business sites do not go Atomic until a specific action is performed (a plugin or theme is installed, for example), there's no need to gate the upgrade with a prompt or to set the site to public at upgrade time.  This change removes that behavior for Business plan upgrades, but keeps it for Online Store / eCommerce upgrades (because those are taken Atomic immediately).

We want to improve the UI for the post-upgrade pre-install plugin / theme screen, but that work is decoupled from this in #37868.

#### Changes proposed in this Pull Request

* Only show the Site Privacy Dialog for eCommerce plan Upgrades. No longer show it for Business Upgrades.

|Before|After|
|---|---|
|![unlaunched-biz-plan-upgrade-before](https://user-images.githubusercontent.com/1587282/69438947-f7bb2c00-0d13-11ea-827a-2c139b18c315.gif)|![unlaunched-biz-plan-upgrade-after](https://user-images.githubusercontent.com/1587282/69438958-00136700-0d14-11ea-867d-3d5c8adf3439.gif)|

* Only set eCommerce plans to public on checkout
* Add non breaking spaces between warning message & support text

|Before|After|
|---|---|
|![Screen Shot 2019-11-22 at 10 47 20 AM](https://user-images.githubusercontent.com/1587282/69439707-7fee0100-0d15-11ea-927c-979ef69ce6fc.png)|![Screen Shot 2019-11-22 at 10 47 28 AM](https://user-images.githubusercontent.com/1587282/69439721-87150f00-0d15-11ea-941f-a64998d28214.png)|


#### Testing instructions

##### Test the Business plan upgrade

* Browse to `/plans` for an unlaunched free site
* Click the button to initiate a Business plan upgrade
  * You should not see a `Site Privacy` modal
  * You should be taken to checkout immediately
  * You should be able to complete checkout
  * Your site should remain unlaunched after checkout
* Browse to `/plugins`
  * You should be prevented from uploading or installing a plugin without launching your site
* Browse to `/theme`
  * You should be prevented from uploading or installing a theme without launching your site
* Launch your site
  * You should be able to install a theme or plugin

##### Test the eCommerce plan upgrade

* Browse to `/plans` for a separate unlaunched free site
* Click the button to initiate an eCommerce plan upgrade
  * You should see a `Site Privacy` modal
* Click `Let's do it`
  * You should be taken to checkout
  * You should be able to complete checkout
  * Your site should be launched after checkout

Fixes #37783