### PR TITLE
Composite checkout: update field accessibility

### DIFF
--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -130,8 +130,7 @@ const Label = styled.label`
 `;
 
 const RadioButtonChildren = styled.div`
-	height: ${getChildrenHeight};
-	overflow: hidden;
+	display: ${props => ( props.checked ? 'block' : 'none' )};
 `;
 
 function getBorderColor( { checked, theme } ) {
@@ -144,10 +143,6 @@ function getBorderWidth( { checked } ) {
 
 function getRadioBorderWidth( { checked } ) {
 	return checked ? '5px' : '1px';
-}
-
-function getChildrenHeight( { checked } ) {
-	return checked ? 'auto' : '0';
 }
 
 function getGrayscaleValue( { checked } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes some accessibility issues with the hidden payment method fields. Hiding them by setting the height to zero and overflow to none still means they're accessible by keyboard. With this change, the keyboard behaviour acts as it should by skipping the hidden payment method fields if the corresponding payment method isn't selected. 

#### Testing instructions

* Get checkout running by following these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Tab through the first credit card payment method, after passing Cardholder name, you should go to the continue button. (noting that you need to use the up/down arrows to navigate between radio buttons) 

