### PR TITLE
Remove verticalSuggestedTheme ab test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,15 +89,6 @@ export default {
 		defaultVariation: 'notSkippable',
 		allowExistingUsers: true,
 	},
-	verticalSuggestedThemes: {
-		datestamp: '20191031',
-		variations: {
-			control: 90,
-			test: 10,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	passwordlessSignup: {
 		datestamp: '20191029',
 		variations: {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -15,7 +15,7 @@ import { parse as parseURL } from 'url';
 import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
-import { abtest, getSavedVariations } from 'lib/abtest';
+import { getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import {
 	updatePrivacyForDomain,
@@ -142,7 +142,6 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	const siteType = getSiteType( state ).trim();
 	const siteStyle = getSiteStyle( state ).trim();
 	const siteSegment = getSiteTypePropertyValue( 'slug', siteType, 'id' );
-	const defaultSiteTypeTheme = getSiteTypePropertyValue( 'slug', siteType, 'theme' );
 
 	const newSiteParams = {
 		blog_title: siteTitle,
@@ -167,17 +166,6 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	// flowName isn't always passed in
 	const flowToCheck = flowName || lastKnownFlow;
-
-	if (
-		flowToCheck === 'onboarding' &&
-		siteSegment === 1 &&
-		newSiteParams.options.theme !== defaultSiteTypeTheme &&
-		abtest( 'verticalSuggestedThemes' ) === 'test'
-	) {
-		// Tell headstart to use the theme annotation, even though
-		// segment/vertical options are provided.
-		newSiteParams.options.use_theme_annotation = true;
-	}
 
 	if ( ! siteUrl && isDomainStepSkippable( flowToCheck ) ) {
 		newSiteParams.blog_name =

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -18,16 +18,10 @@ import { setVerticals } from 'state/signup/verticals/actions';
 import { SIGNUP_VERTICALS_REQUEST } from 'state/action-types';
 import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
 import { getCurrentFlowName } from 'state/signup/flow/selectors';
-import { abtest } from 'lib/abtest';
 
 // Some flows do not choose a site type before requesting verticals. In this
 // case don't send a site_type param to the API.
 export const requestVerticals = action => {
-	const verticalSuggestedThemeTest =
-		action.flowName === 'onboarding' &&
-		action.siteTypeId === 1 &&
-		abtest( 'verticalSuggestedThemes' ) === 'test';
-
 	return http(
 		{
 			apiNamespace: 'wpcom/v2',
@@ -39,7 +33,6 @@ export const requestVerticals = action => {
 				limit: action.limit,
 				include_preview: true,
 				allow_synonyms: true,
-				...( verticalSuggestedThemeTest && { suggest_theme: true } ),
 			},
 		},
 		action


### PR DESCRIPTION
Epic: Automattic/zelda-private#108

p8Eqe3-Ro-p2#comment-2699

Intentionally left support for screenshot previews in as I think we'll retest after some changes.

#### Changes proposed in this Pull Request

* Remove `verticalSuggestedThemes` AB test config
* Remove code that sends `suggest_theme` option to vertical API
* Remove code that sends `use_theme_annotation` headstart option

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Confirm `verticalSuggestedThemes` is gone from the ab test selector
* `/start`, create new **business** site, choose **restaurants** for the site topic
* Should see a Maywood preview with verticalised content
* Complete signup flow and confirm the `use_theme_annotation` option isn't used in `sites/new` API call