### PR TITLE
Lint: Fix some jest/expect-expect lints

### DIFF
--- a/client/state/account-recovery/test/selectors.js
+++ b/client/state/account-recovery/test/selectors.js
@@ -1,10 +1,3 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { assert } from 'chai';
-
 /**
  * Internal dependencies
  */
@@ -18,6 +11,6 @@ describe( '#account-recovery selector isFetchingAccountRecoverySettings:', () =>
 			},
 		};
 
-		assert.isTrue( isFetchingAccountRecoverySettings( state ) );
+		expect( isFetchingAccountRecoverySettings( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1,4 +1,5 @@
-/** @format */
+/* eslint jest/expect-expect: [ "error", { "assertFunctionNames": [ "expect", "chaiExpect" ] } ] */
+
 /**
  * External dependencies
  */

--- a/packages/photon/test/index.js
+++ b/packages/photon/test/index.js
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: [ "error", { "assertFunctionNames": [ "expect", "expectPathname", "expectQuery", "expectHostedOnPhoton", "expectHostedOnPhotonInsecurely" ] } ] */
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
I saw some of these lint errors from `jest/expect-expect` in another PR and I was curious so I fixed a few of them.

Changes are in tests and should be safe.

## Testing
- Lint passes
- Tests pass