### PR TITLE
Domain step test: Pricing copy update

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -46,7 +46,17 @@ class DomainProductPrice extends React.Component {
 				}
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
-				message = translate( 'First year included in paid plans' );
+				if ( this.props.showTestCopy ) {
+					message = (
+						<>
+							Registration fee: <del>{ this.props.price }</del>{' '}
+							<span className="domain-product-price__free-price">Free</span>
+						</>
+					);
+				} else {
+					message = translate( 'First year included in paid plans' );
+				}
+
 				if ( isMappingProduct ) {
 					message = translate( 'Included in paid plans' );
 				}
@@ -64,19 +74,23 @@ class DomainProductPrice extends React.Component {
 			return;
 		}
 
-		return (
-			<div className="domain-product-price__price">
-				{ this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
+		const priceText = this.props.showTestCopy
+			? `Renews at ${ this.props.price }/year`
+			: this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
 					args: { cost: this.props.price },
 					components: { small: <small /> },
-				} ) }
-			</div>
-		);
+			  } );
+
+		return <div className="domain-product-price__price">{ priceText }</div>;
 	}
 
 	renderFreeWithPlan() {
+		const className = classnames( 'domain-product-price', 'is-free-domain', {
+			'domain-product-price__domain-step-copy-updates': this.props.showTestCopy,
+		} );
+
 		return (
-			<div className={ classnames( 'domain-product-price', 'is-free-domain' ) }>
+			<div className={ className }>
 				{ this.renderFreeWithPlanText() }
 				{ this.renderFreeWithPlanPrice() }
 			</div>
@@ -84,9 +98,13 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderFree() {
+		const className = classnames( 'domain-product-price', {
+			'domain-product-price__domain-step-copy-updates': this.props.showTestCopy,
+		} );
+
 		return (
-			<div className={ classnames( 'domain-product-price' ) }>
-				<span className="domain-product-price__price">{ this.props.translate( 'Free' ) }</span>
+			<div className={ className }>
+				<div className="domain-product-price__price">{ this.props.translate( 'Free' ) }</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -104,7 +104,9 @@ class DomainProductPrice extends React.Component {
 
 		return (
 			<div className={ className }>
-				<div className="domain-product-price__price">{ this.props.translate( 'Free' ) }</div>
+				<div className="domain-product-price__price domain-product-price__free-price">
+					{ this.props.translate( 'Free' ) }
+				</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -102,11 +102,13 @@ class DomainProductPrice extends React.Component {
 			'domain-product-price__domain-step-copy-updates': this.props.showTestCopy,
 		} );
 
+		const productPriceClassName = classnames( 'domain-product-price__price', {
+			'domain-product-price__free-price': this.props.showTestCopy,
+		} );
+
 		return (
 			<div className={ className }>
-				<div className="domain-product-price__price domain-product-price__free-price">
-					{ this.props.translate( 'Free' ) }
-				</div>
+				<div className={ productPriceClassName }>{ this.props.translate( 'Free' ) }</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -64,7 +64,7 @@
 	}
 
 	.domain-product-price__free-price {
-		color: #00a32a;
+		color: var( --color-success );
 	}
 
 	.domain-product-price__price,

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -7,6 +7,7 @@
 	flex-direction: column;
 	text-align: right;
 
+	
 	@include breakpoint( '>660px' ) {
 		align-items: flex-end;
 		font-size: 16px;
@@ -14,9 +15,14 @@
 		.featured-domain-suggestions & {
 			align-items: flex-start;
 		}
-	}
 
-	.is-section-signup & {
+		&.domain-product-price__domain-step-copy-updates {
+			align-items: flex-start;
+		}
+	}
+		
+
+	.is-section-signup &:not( .domain-product-price__domain-step-copy-updates ) {
 		@include breakpoint( '>660px' ) {
 			padding-left: 1em;
 			padding-right: 2em;
@@ -55,6 +61,10 @@
 		@include breakpoint( '>660px' ) {
 			margin-left: 0;
 		}
+	}
+
+	.domain-product-price__free-price {
+		color: #00a32a;
 	}
 
 	.domain-product-price__price,

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -6,7 +6,6 @@
 	display: flex;
 	flex-direction: column;
 	text-align: right;
-
 	
 	@include breakpoint( '>660px' ) {
 		align-items: flex-end;

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -195,7 +195,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		const infoPopoverSize = isFeatured ? 22 : 18;
 
 		return (
-			<div className="domain-registration-suggestion__title-wrapper">
+			<div className="domain-registration-suggestion__title-wrapper domain-registration-suggestion__title-domain-copy-test">
 				<h3 className="domain-registration-suggestion__title">{ title }</h3>
 				{ productSaleCost && paidDomain && <Badge>{ saleBadgeText }</Badge> }
 				{ showHstsNotice && (
@@ -329,6 +329,8 @@ class DomainRegistrationSuggestion extends React.Component {
 				domainsWithPlansOnly={ domainsWithPlansOnly }
 				onButtonClick={ this.onButtonClick }
 				{ ...this.getButtonProps() }
+				showTestCopy={ this.props.showTestCopy }
+				isFeatured={ isFeatured }
 			>
 				{ this.renderDomain() }
 				{ this.renderProgressBar() }
@@ -350,6 +352,7 @@ const mapStateToProps = ( state, props ) => {
 	};
 };
 
-export default connect( mapStateToProps, { recordTracksEvent } )(
-	localize( DomainRegistrationSuggestion )
-);
+export default connect(
+	mapStateToProps,
+	{ recordTracksEvent }
+)( localize( DomainRegistrationSuggestion ) );

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -193,9 +193,13 @@ class DomainRegistrationSuggestion extends React.Component {
 			comment: 'Shown next to a domain that has a special discounted sale price',
 		} );
 		const infoPopoverSize = isFeatured ? 22 : 18;
+		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
+			'domain-registration-suggestion__title-domain-copy-test':
+				this.props.showTestCopy && ! this.props.isFeatured,
+		} );
 
 		return (
-			<div className="domain-registration-suggestion__title-wrapper domain-registration-suggestion__title-domain-copy-test">
+			<div className={ titleWrapperClassName }>
 				<h3 className="domain-registration-suggestion__title">{ title }</h3>
 				{ productSaleCost && paidDomain && <Badge>{ saleBadgeText }</Badge> }
 				{ showHstsNotice && (

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -282,6 +282,7 @@ class DomainSearchResults extends React.Component {
 						onButtonClick={ this.props.onClickResult }
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
+						showTestCopy={ this.props.showTestCopy }
 					/>
 				);
 			} );
@@ -328,4 +329,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	};
 };
 
-export default connect( mapStateToProps, { hideSitePreview } )( localize( DomainSearchResults ) );
+export default connect(
+	mapStateToProps,
+	{ hideSitePreview }
+)( localize( DomainSearchResults ) );

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -36,19 +36,6 @@ class DomainSuggestion extends React.Component {
 		showChevron: false,
 	};
 
-	renderDomainSuggestAction() {
-		const className = classNames( 'domain-suggestion__action', {
-			'domain-suggestion__action-domain-copy-test':
-				this.props.showTestCopy && ! this.props.isFeatured,
-		} );
-
-		return (
-			<Button className={ className } { ...this.props.buttonStyles }>
-				{ this.props.buttonContent }
-			</Button>
-		);
-	}
-
 	render() {
 		const {
 			children,
@@ -72,6 +59,14 @@ class DomainSuggestion extends React.Component {
 			extraClasses
 		);
 
+		const contentClassName = classNames( 'domain-suggestion__content', {
+			'domain-suggestion__content-domain-copy-test': showTestCopy && ! isFeatured,
+		} );
+
+		const actionClassName = classNames( 'domain-suggestion__action', {
+			'domain-suggestion__action-domain-copy-test': showTestCopy && ! isFeatured,
+		} );
+
 		/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus */
 		return (
 			<div
@@ -81,7 +76,7 @@ class DomainSuggestion extends React.Component {
 				role="button"
 				data-e2e-domain={ this.props.domain }
 			>
-				<div className="domain-suggestion__content">
+				<div className={ contentClassName }>
 					{ children }
 					{ ! hidePrice && (
 						<DomainProductPrice
@@ -91,10 +86,10 @@ class DomainSuggestion extends React.Component {
 							showTestCopy={ showTestCopy }
 						/>
 					) }
-					{ showTestCopy && ! isFeatured && this.renderDomainSuggestAction() }
 				</div>
-				{ ( ! showTestCopy || isFeatured ) && this.renderDomainSuggestAction() }
-
+				<Button className={ actionClassName } { ...this.props.buttonStyles }>
+					{ this.props.buttonContent }
+				</Button>
 				{ this.props.showChevron && (
 					<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
 				) }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -63,7 +63,8 @@ class DomainSuggestion extends React.Component {
 			'domain-suggestion__content-domain-copy-test': showTestCopy && ! isFeatured,
 		} );
 
-		/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus */
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/interactive-supports-focus */
 		return (
 			<div
 				className={ classes }
@@ -91,7 +92,8 @@ class DomainSuggestion extends React.Component {
 				) }
 			</div>
 		);
-		/* eslint-enable jsx-a11y/click-events-have-key-events jsx-a11y/interactive-supports-focus */
+		/* eslint-enable jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/interactive-supports-focus */
 	}
 }
 

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -36,8 +36,31 @@ class DomainSuggestion extends React.Component {
 		showChevron: false,
 	};
 
+	renderDomainSuggestAction() {
+		const className = classNames( 'domain-suggestion__action', {
+			'domain-suggestion__action-domain-copy-test':
+				this.props.showTestCopy && ! this.props.isFeatured,
+		} );
+
+		return (
+			<Button className={ className } { ...this.props.buttonStyles }>
+				{ this.props.buttonContent }
+			</Button>
+		);
+	}
+
 	render() {
-		const { children, extraClasses, hidePrice, isAdded, price, priceRule, salePrice } = this.props;
+		const {
+			children,
+			extraClasses,
+			hidePrice,
+			isAdded,
+			price,
+			priceRule,
+			salePrice,
+			showTestCopy,
+			isFeatured,
+		} = this.props;
 		const classes = classNames(
 			'domain-suggestion',
 			'card',
@@ -61,12 +84,17 @@ class DomainSuggestion extends React.Component {
 				<div className="domain-suggestion__content">
 					{ children }
 					{ ! hidePrice && (
-						<DomainProductPrice price={ price } salePrice={ salePrice } rule={ priceRule } />
+						<DomainProductPrice
+							price={ price }
+							salePrice={ salePrice }
+							rule={ priceRule }
+							showTestCopy={ showTestCopy }
+						/>
 					) }
+					{ showTestCopy && ! isFeatured && this.renderDomainSuggestAction() }
 				</div>
-				<Button className="domain-suggestion__action" { ...this.props.buttonStyles }>
-					{ this.props.buttonContent }
-				</Button>
+				{ ( ! showTestCopy || isFeatured ) && this.renderDomainSuggestAction() }
+
 				{ this.props.showChevron && (
 					<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
 				) }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -63,10 +63,6 @@ class DomainSuggestion extends React.Component {
 			'domain-suggestion__content-domain-copy-test': showTestCopy && ! isFeatured,
 		} );
 
-		const actionClassName = classNames( 'domain-suggestion__action', {
-			'domain-suggestion__action-domain-copy-test': showTestCopy && ! isFeatured,
-		} );
-
 		/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus */
 		return (
 			<div
@@ -87,7 +83,7 @@ class DomainSuggestion extends React.Component {
 						/>
 					) }
 				</div>
-				<Button className={ actionClassName } { ...this.props.buttonStyles }>
+				<Button className="domain-suggestion__action" { ...this.props.buttonStyles }>
 					{ this.props.buttonContent }
 				</Button>
 				{ this.props.showChevron && (

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -62,6 +62,10 @@
 	@include breakpoint( '>660px' ) {
 		display: flex;
 		justify-content: space-between;
+
+		&.domain-suggestion__content-domain-copy-test {
+			justify-content: initial;
+		}
 	}
 
 	.notice.is-compact {
@@ -132,8 +136,8 @@
 	flex-wrap: wrap;
 
 	&.domain-registration-suggestion__title-domain-copy-test {
-		max-width: 300px;
-		min-width: 300px;
+		max-width: 50%;
+		min-width: 50%;
 	}
 
 	.domain-registration-suggestion__title {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -136,8 +136,11 @@
 	flex-wrap: wrap;
 
 	&.domain-registration-suggestion__title-domain-copy-test {
-		max-width: 50%;
-		min-width: 50%;
+		@include breakpoint( '>480px' ) {
+			max-width: 50%;
+			min-width: 50%;
+			margin-right: 1em;
+		}
 	}
 
 	.domain-registration-suggestion__title {
@@ -202,20 +205,6 @@
 			flex: 1 0 auto;
 			margin-left: 1em;
 			margin-top: 0;
-		}
-	}
-
-	.is-section-signup &.domain-suggestion__action-domain-copy-test {
-		order: 4;
-		margin: auto 0;
-		
-		@include breakpoint( '<480px' ) {
-			width: 100%;
-		}
-
-		@include breakpoint( '>480px' ) {
-			flex-grow: 0;
-			margin-left: 0;
 		}
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -212,7 +212,6 @@
 		@include breakpoint( '>480px' ) {
 			flex-grow: 0;
 			margin-left: 0;
-			margin-top: 1em;
 		}
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -131,6 +131,11 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 
+	&.domain-registration-suggestion__title-domain-copy-test {
+		max-width: 300px;
+		min-width: 300px;
+	}
+
 	.domain-registration-suggestion__title {
 		width: auto;
 		max-width: 100%;
@@ -193,6 +198,21 @@
 			flex: 1 0 auto;
 			margin-left: 1em;
 			margin-top: 0;
+		}
+	}
+
+	.is-section-signup &.domain-suggestion__action-domain-copy-test {
+		order: 4;
+		margin: auto 0;
+		
+		@include breakpoint( '<480px' ) {
+			width: 100%;
+		}
+
+		@include breakpoint( '>480px' ) {
+			flex-grow: 0;
+			margin-left: 0;
+			margin-top: 1em;
 		}
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -116,7 +116,6 @@
 
 	.domain-registration-suggestion__match-reasons {
 		order: 3;
-		// margin-bottom: 0.7em;
 	}
 
 	.domain-registration-suggestion__match-reason {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -116,6 +116,7 @@
 
 	.domain-registration-suggestion__match-reasons {
 		order: 3;
+		// margin-bottom: 0.7em;
 	}
 
 	.domain-registration-suggestion__match-reason {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR builds on top of the domain-copy A/B test introduced as a feature flag in #37546. Check the `What next?` section in that PR on how to review this and other PRs as part of this A/B test.

* The copy for the domain product pricing is updated for the variant to show the registration fee as crossed out, and using "Free" to indicate that the domain is free for the first year.

**Web**

<img width="982" alt="Screenshot 2019-11-14 at 4 56 23 PM" src="https://user-images.githubusercontent.com/1269602/68853326-bb7a4100-06ff-11ea-822f-c53d16fa34d2.png">

**Mobile**

![calypso localhost_3000_start_domains-with-preview(iPhone 6_7_8)](https://user-images.githubusercontent.com/1269602/68858623-70fec180-070b-11ea-9b5b-2d4258425e33.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and put yourself in the variant variantShowUpdates of the domainStepCopyUpdates A/B test.
* The pricing for the domains should be displayed with the same format and spacing alignments as shown in the screenshot above.
* Try domain search with a really long input text, and verify that alignments are held in place. E.g. screenshot below:

<img width="450" alt="Screenshot 2019-11-14 at 6 27 54 PM" src="https://user-images.githubusercontent.com/1269602/68859143-ac4dc000-070c-11ea-9a77-27c06066986a.png">

**Mobile View**

* Verify alignment and copy checks out in mobile views.

**Check in other domain pages**

* Login to any account, and after assigning yourself to the variant, check the launch flow for privates sites and the Add domain page. In both places, the pricing copy changes should not be seen(as we are showing the copy only during signup).

**Verify that the A/B test is not automatically assigned**
* Go to /start and without manually assigning yourself to an A/B test, just complete the signup flow. 
* In your Browser console, type `localstorage.ABTests;`. Verify that the `domainStepCopyUpdates ` test is not present in the object. This is because we do not yet want any user getting assigned to the test till all the pieces are deployed.