### PR TITLE
Update/rename popular vertical to restaurant

### DIFF
--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -26,7 +26,7 @@ const POPULAR_TOPICS = {
 		translate( 'Website Designer' ),
 		translate( 'Real Estate Agent' ),
 		translate( 'Cameras & Photography' ),
-		translate( 'Restaurants' ),
+		translate( 'Restaurant' ),
 	],
 	blog: [
 		translate( 'People' ),

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -27,14 +27,14 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 	isActive,
 	onExpand,
 } ) => {
-	const popular = [
-		NO__( 'Travel Agency' ),
-		NO__( 'Digital Marketing' ),
-		NO__( 'Cameras & Photography' ),
-		NO__( 'Website Designer' ),
-		NO__( 'Restaurants' ),
-		NO__( 'Fashion Designer' ),
-		NO__( 'Real Estate Agent' ),
+	const popularVerticalSlugs = [
+		'Travel Agency',
+		'Digital Marketing',
+		'Cameras & Photography',
+		'Website Designer',
+		'Restaurants',
+		'Fashion Designer',
+		'Real Estate Agent',
 	];
 
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -56,6 +56,7 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 			.map( x => ( {
 				label: x.vertical_name,
 				id: x.vertical_id,
+				slug: x.vertical_slug,
 			} ) )
 	);
 
@@ -98,9 +99,9 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 	];
 
 	const suggestions = ! inputValue.length
-		? popular
-				.map( label => ( {
-					...verticals.find( vertical => vertical.label.includes( label ) ),
+		? popularVerticalSlugs
+				.map( slug => ( {
+					...verticals.find( vertical => vertical.slug === slug ),
 					category: NO__( 'Popular' ),
 				} ) )
 				.filter( x => x.hasOwnProperty( 'label' ) )

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -27,14 +27,14 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 	isActive,
 	onExpand,
 } ) => {
-	const popularVerticalSlugs = [
-		'Travel Agency',
-		'Digital Marketing',
-		'Cameras & Photography',
-		'Website Designer',
-		'Restaurant',
-		'Fashion Designer',
-		'Real Estate Agent',
+	const popular = [
+		NO__( 'Travel Agency' ),
+		NO__( 'Digital Marketing' ),
+		NO__( 'Cameras & Photography' ),
+		NO__( 'Website Designer' ),
+		NO__( 'Restaurant' ),
+		NO__( 'Fashion Designer' ),
+		NO__( 'Real Estate Agent' ),
 	];
 
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -56,7 +56,6 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 			.map( x => ( {
 				label: x.vertical_name,
 				id: x.vertical_id,
-				slug: x.vertical_slug,
 			} ) )
 	);
 
@@ -99,9 +98,9 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 	];
 
 	const suggestions = ! inputValue.length
-		? popularVerticalSlugs
-				.map( slug => ( {
-					...verticals.find( vertical => vertical.slug === slug ),
+		? popular
+				.map( label => ( {
+					...verticals.find( vertical => vertical.label === label ),
 					category: NO__( 'Popular' ),
 				} ) )
 				.filter( x => Object.prototype.hasOwnProperty.call( x, 'label' ) )

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -32,7 +32,7 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 		'Digital Marketing',
 		'Cameras & Photography',
 		'Website Designer',
-		'Restaurants',
+		'Restaurant',
 		'Fashion Designer',
 		'Real Estate Agent',
 	];

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -98,10 +98,12 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 	];
 
 	const suggestions = ! inputValue.length
-		? popular.map( label => ( {
-				...verticals.find( vertical => vertical.label.includes( label ) ),
-				category: NO__( 'Popular' ),
-		  } ) )
+		? popular
+				.map( label => ( {
+					...verticals.find( vertical => vertical.label.includes( label ) ),
+					category: NO__( 'Popular' ),
+				} ) )
+				.filter( x => x.hasOwnProperty( 'label' ) )
 		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
 
 	const label = NO__( 'My site is about' );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -104,7 +104,7 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 					...verticals.find( vertical => vertical.slug === slug ),
 					category: NO__( 'Popular' ),
 				} ) )
-				.filter( x => x.hasOwnProperty( 'label' ) )
+				.filter( x => Object.prototype.hasOwnProperty.call( x, 'label' ) )
 		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
 
 	const label = NO__( 'My site is about' );

--- a/client/my-sites/checklist/wpcom-checklist/vertical-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/vertical-task-list.js
@@ -34,7 +34,7 @@ const verticalTaskList = {
 	Photography: [ 'service_list_added' ],
 	'Real Estate & Housing': [],
 	Religion: [],
-	Restaurants: [],
+	Restaurant: [],
 	'Shopping & Retail': [],
 	Sports: [ 'service_list_added' ],
 	'Transportation & Logistics': [ 'service_list_added' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renames popular restaurant vertical to use singular to match D34431-code
* Gutenberg onboarding no longer crashes if the `/verticals` API response doesn't contain one of the verticals it expects
* Gutenberg onboarding uses slugs, rather than label matching, to find popular verticals in the API response

In Gutenberg onboarding: if we're going to load the vertical list before displaying the list of popular verticals then we should use the translations that come from the API too, in case they change.
If we don't change to compare by slug then until "Restaurants" is changed to "Restaurant" on the backend, "African Restaurants" appears in the popular list (because the label `.include` returns true) but it's not the vertical we're looking for.
Matching by vertical id would be another option, but that felt less self-documenting.

My current plan is to deploy this front-end change before D34431-code, so there will be a period of time when a popular vertical from the list won't provide any verticalised content. I think this is ok, we just don't want the signup flow to break.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before applying D34431-code
  * `/start`
    * Create a new business site
    * Choose "restaurant" from the popular list, should see an un-verticalised preview
    * Type in "restaurant" from scratch, it should want to auto-complete to "restaurants"
    * Choosing "restaurants" should show a verticalised preview
    * Continue and create the site, the checklist should be fine (testing that small checklist logic change hasn't broken anything)
  * `/gutenboarding`
    * Choose business
    * No restaurant type suggestion appears in the popular list
* After applying D34431-code
  * `/start`
    * "Restaurant" appears in popular list, and preview shows verticalised content
  * `/gutenboarding`
    * Choose business
    * Restaurant appears as a popular site topic

Partial fix for Automattic/zelda-private#238
