### PR TITLE
composite-checkout: Add wordpress/i18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -289,7 +289,9 @@
 				"@emotion/core": "10.0.22",
 				"@emotion/styled": "10.0.23",
 				"@wordpress/data": "^4.9.2",
+				"@wordpress/i18n": "3.6.1",
 				"emotion-theming": "10.0.19",
+				"interpolate-components": "1.1.1",
 				"prop-types": "^15.7.2",
 				"react": "^16.8.6",
 				"react-stripe-elements": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -350,6 +350,7 @@
 		"glob": "7.1.3",
 		"husky": "3.0.9",
 		"i18n-calypso-cli": "file:./packages/i18n-calypso-cli",
+		"interpolate-components": "1.1.1",
 		"jest": "24.9.0",
 		"jest-docblock": "24.9.0",
 		"jest-fetch-mock": "2.1.2",

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -138,7 +138,7 @@ function MyCheckout() {
 
 	return (
 		<CheckoutProvider
-			locale={ 'US' }
+			locale={ 'en' }
 			items={ items }
 			total={ total }
 			onSuccess={ onSuccess }

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/data": "^4.9.2",
 		"@wordpress/i18n": "3.6.1",
 		"emotion-theming": "10.0.19",
+		"interpolate-components": "1.1.1",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",
 		"react-stripe-elements": "^5.1.0"

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -37,6 +37,7 @@
 		"@emotion/core": "10.0.22",
 		"@emotion/styled": "10.0.23",
 		"@wordpress/data": "^4.9.2",
+		"@wordpress/i18n": "3.6.1",
 		"emotion-theming": "10.0.19",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",

--- a/packages/composite-checkout/src/components/billing-fields.js
+++ b/packages/composite-checkout/src/components/billing-fields.js
@@ -88,6 +88,7 @@ function isElligibleForVat() {
 }
 
 function DomainFieldsCheckbox( { toggleVisibility, isDomainContactVisible } ) {
+	const localize = useLocalize();
 	return (
 		<DomainRegistrationCheckBoxWrapper>
 			<DomainRegistrationCheckbox
@@ -98,7 +99,7 @@ function DomainFieldsCheckbox( { toggleVisibility, isDomainContactVisible } ) {
 				onChange={ toggleVisibility }
 			/>
 			<DomainRegistrationLabel htmlFor="domain-registration">
-				Use your billing details for your domain registration contact information.
+				{ localize( 'Use your billing details for your domain registration contact information.' ) }
 			</DomainRegistrationLabel>
 		</DomainRegistrationCheckBoxWrapper>
 	);

--- a/packages/composite-checkout/src/components/credit-card-fields.js
+++ b/packages/composite-checkout/src/components/credit-card-fields.js
@@ -104,7 +104,7 @@ export default function CreditCardFields( { disabled } ) {
 				id="card-holder-name"
 				type="Text"
 				label={ localize( 'Cardholder name' ) }
-				description={ localize( 'Enter your name as it’s written on the card' ) }
+				description={ localize( "Enter your name as it's written on the card" ) }
 				autoComplete="cc-name"
 				value={ currentCreditCardData.cardHolderName || '' }
 				onChange={ value => {

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -26,7 +26,7 @@ import {
 	useCheckoutRedirects,
 	renderDisplayValueMarkdown,
 } from '../public-api';
-import useLocalize from '../lib/localize';
+import useLocalize, { sprintf } from '../lib/localize';
 import { VisaLogo, AmexLogo, MastercardLogo } from './payment-logos';
 import { CreditCardLabel } from '../lib/payment-methods/credit-card';
 import BillingFields, { getDomainDetailsFromPaymentData } from '../components/billing-fields';
@@ -539,9 +539,9 @@ function StripePayButton() {
 		localize,
 	] );
 
-	// TODO: we need to use a placeholder for the value so the localization string can be generic
-	const buttonString = localize(
-		`Pay ${ renderDisplayValueMarkdown( total.amount.displayValue ) }`
+	const buttonString = sprintf(
+		localize( 'Pay %s' ),
+		renderDisplayValueMarkdown( total.amount.displayValue )
 	);
 	return (
 		<Button

--- a/packages/composite-checkout/src/components/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/components/stripe-credit-card-fields.js
@@ -287,7 +287,7 @@ function StripeCreditCardFields() {
 					id="cardholderName"
 					type="Text"
 					label={ localize( 'Cardholder name' ) }
-					description={ localize( 'Enter your name as it’s written on the card' ) }
+					description={ localize( "Enter your name as it's written on the card" ) }
 					value={ cardholderName }
 					onChange={ changeCardholderName }
 				/>

--- a/packages/composite-checkout/src/components/wp-terms-and-conditions.js
+++ b/packages/composite-checkout/src/components/wp-terms-and-conditions.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import styled from '@emotion/styled';
+import interpolateComponents from 'interpolate-components';
 
 /**
  * Internal dependencies
@@ -18,65 +19,65 @@ export default function WPTermsAndConditions() {
 	return (
 		<TermsAndConditionsWrapper>
 			<TermsParagraph>
-				{ localize(
-					'{strong}By checking out:{/strong} you agree to our {tosLink}Terms of Service{/tosLink} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {howSubscriptionWorks}how your subscription works{/howSubscriptionWorks} and {howToCancel}how to cancel{/howToCancel}. ',
-					{
-						components: {
-							strong: <strong />,
-							tosLink: (
-								<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />
-							),
-							howSubscriptionWorks: (
-								<a
-									href="https://en.support.wordpress.com/manage-purchases/#automatic-renewal"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							howToCancel: (
-								<a
-									href="https://en.support.wordpress.com/manage-purchases/#FAQ-Cancelling"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-				) }
+				{ interpolateComponents( {
+					mixedString: localize(
+						'{{strong}}By checking out:{{/strong}} you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{howSubscriptionWorks}}how your subscription works{{/howSubscriptionWorks}} and {{howToCancel}}how to cancel{{/howToCancel}}.'
+					),
+					components: {
+						strong: <strong />,
+						tosLink: (
+							<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />
+						),
+						howSubscriptionWorks: (
+							<a
+								href="https://en.support.wordpress.com/manage-purchases/#automatic-renewal"
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						howToCancel: (
+							<a
+								href="https://en.support.wordpress.com/manage-purchases/#FAQ-Cancelling"
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				} ) }
 			</TermsParagraph>
 			{ isDomainsTermsVisible && (
 				<React.Fragment>
 					<TermsParagraph>
-						{ localize(
-							'You agree to the {domainRegistrationAgreement}Domain Registration Agreement{/domainRegistrationAgreement} for domainname.com.',
-							{
-								components: {
-									domainRegistrationAgreement: (
-										<a
-											href="https://wordpress.com/automattic-domain-name-registration-agreement/"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
+						{ interpolateComponents( {
+							mixedString: localize(
+								'You agree to the {{domainRegistrationAgreement}}Domain Registration Agreement{{/domainRegistrationAgreement}} for domainname.com.'
+							),
+							components: {
+								domainRegistrationAgreement: (
+									<a
+										href="https://wordpress.com/automattic-domain-name-registration-agreement/"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
 					</TermsParagraph>
 					<TermsParagraph>
-						{ localize(
-							'You understand that {domainRefunds}domain name refunds{/domainRefunds} are limited to 96 hours after registration. Refunds of paid plans will deduct the standard cost of any domain name registered within a plan.',
-							{
-								components: {
-									domainRefunds: (
-										<a
-											href="https://en.support.wordpress.com/manage-purchases/#refund-policy"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
+						{ interpolateComponents( {
+							mixedString: localize(
+								'You understand that {{domainRefunds}}domain name refunds{{/domainRefunds}} are limited to 96 hours after registration. Refunds of paid plans will deduct the standard cost of any domain name registered within a plan.'
+							),
+							components: {
+								domainRefunds: (
+									<a
+										href="https://en.support.wordpress.com/manage-purchases/#refund-policy"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
 					</TermsParagraph>
 				</React.Fragment>
 			) }

--- a/packages/composite-checkout/src/lib/localize.js
+++ b/packages/composite-checkout/src/lib/localize.js
@@ -11,14 +11,8 @@ import { __, setLocaleData } from '@wordpress/i18n';
 import LocalizeContext from './localize-context';
 
 export default function localizeFactory( locale ) {
-	setLocaleData( {
-		locale_data: {
-			messages: {
-				'': { domain: 'messages', lang: locale, plural_forms: 'nplurals=2; plural=(n != 1);' },
-			},
-		},
-	} );
-	return __;
+	setLocaleData( getLocaleDataForLocale( locale ) );
+	return text => __( text, 'default' );
 }
 
 export function useLocalize() {
@@ -40,3 +34,55 @@ export function LocalizeProvider( { locale, children } ) {
 LocalizeProvider.propTypes = {
 	locale: PropTypes.string.isRequired,
 };
+
+// TODO: how do we get this data for the locale?
+function getLocaleDataForLocale( locale ) {
+	switch ( locale ) {
+		case 'fr':
+			return {
+				'': {
+					domain: 'default',
+					lang: 'fr',
+					plural_forms: 'nplurals=2; plural=(n != 1);',
+				},
+				'First name': [ 'Prénom' ],
+				'Last name': [ 'Nom' ],
+				'Email address': [ 'Adresse e-mail' ],
+				Address: [ 'Adresse' ],
+				City: [ 'Ville' ],
+				Province: [ 'Province' ],
+				'Postal code': [ 'Code postal' ],
+				Country: [ 'Pays' ],
+				'Phone number (Optional)': [ 'Numéro de téléphone (Optionnel)' ],
+				'Use your billing details for your domain registration contact information.': [
+					'Utilisez vos informations de facturation pour les informations de contact de votre domaine.',
+				],
+				'Enter your billing details': [ 'Entrez vos détails de facturation' ],
+				Continue: [ 'Continuez' ],
+				'Review your order': [ 'Vérifiez votre commande' ],
+				'You are all set to check out': [ 'Vous êtes prêt à partir' ],
+				'Pick a payment method': [ 'Choisissez un mode de paiement' ],
+				'Order Summary': [ 'Apitulatif de la commande' ],
+				'Add a coupon': [ 'Ajouter un coupon' ],
+				'Credit or debit card': [ 'Carte de crédit ou de débit' ],
+				'Card number': [ 'Numéro de carte' ],
+				'Expiry date': [ "Date d'expiration" ],
+				'Security code': [ 'Code de sécurité' ],
+				'Expiry Date': [ "Date d'expiration" ],
+				'Security Code': [ 'Code de sécurité' ],
+				'Cardholder name': [ 'Nom du titulaire' ],
+				"Enter your name as it's written on the card": [
+					"Entrez votre nom tel qu'il est écrit sur la carte",
+				],
+				'Pay %s': [ 'Payez %s' ],
+			};
+		default:
+			return {
+				'': {
+					domain: 'default',
+					lang: 'en',
+					plural_forms: 'nplurals=2; plural=(n != 1);',
+				},
+			};
+	}
+}

--- a/packages/composite-checkout/src/lib/localize.js
+++ b/packages/composite-checkout/src/lib/localize.js
@@ -3,7 +3,7 @@
  */
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { __, setLocaleData } from '@wordpress/i18n';
+import { __, setLocaleData, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -86,3 +86,5 @@ function getLocaleDataForLocale( locale ) {
 			};
 	}
 }
+
+export { sprintf };

--- a/packages/composite-checkout/src/lib/localize.js
+++ b/packages/composite-checkout/src/lib/localize.js
@@ -3,20 +3,23 @@
  */
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import { __, setLocaleData } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import LocalizeContext from './localize-context';
 
-// TODO: we need to implement this; probably delegated to i18n-calypso
-/* eslint-disable no-unused-vars */
 export default function localizeFactory( locale ) {
-	return text => {
-		return text;
-	};
+	setLocaleData( {
+		locale_data: {
+			messages: {
+				'': { domain: 'messages', lang: locale, plural_forms: 'nplurals=2; plural=(n != 1);' },
+			},
+		},
+	} );
+	return __;
 }
-/* eslint-enable no-unused-vars */
 
 export function useLocalize() {
 	const localize = useContext( LocalizeContext );

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -8,7 +8,7 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import Button from '../../components/button';
-import { useLocalize } from '../../lib/localize';
+import { useLocalize, sprintf } from '../../lib/localize';
 import { useSelect, useLineItems, renderDisplayValueMarkdown } from '../../public-api';
 import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
 import CreditCardFields from '../../components/credit-card-fields';
@@ -39,9 +39,9 @@ export function CreditCardLabel() {
 export function CreditCardSubmitButton() {
 	const localize = useLocalize();
 	const [ , total ] = useLineItems();
-	// TODO: we need to use a placeholder for the value so the localization string can be generic
-	const buttonString = localize(
-		`Pay ${ renderDisplayValueMarkdown( total.amount.displayValue ) }`
+	const buttonString = sprintf(
+		localize( 'Pay %s' ),
+		renderDisplayValueMarkdown( total.amount.displayValue )
 	);
 	return (
 		<Button onClick={ submitCreditCardPayment } buttonState="primary" fullWidth>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the `@wordpress/i18n` package to composite-checkout for string translation.

- ~~This renames the `localize()` function to `__()` (this is probably necessary when we add scanning for strings).~~ No functions have been renamed yet. We'll need to do that later.
- This uses `interpolate-components` for component substitutions.

This is an experiment and may need to be changed in the future. There is still no mechanism to generate the gettext translations and no mechanism to fetch that translation JSON. It currently has some hard-coded translations for the `fr` locale only.

![Screen Shot 2019-11-13 at 9 21 07 PM](https://user-images.githubusercontent.com/2036909/68821391-3558ee80-065c-11ea-9ec8-cd49f1748f13.png)

#### Testing instructions

- Add a file called `packages/composite-checkout/demo/private.js` and inside it put the following: `export const stripeKey = 'TEST KEY HERE'`;
- Modify `demo/index.js` to change the `locale` prop from `en` to `fr`.
- Run `npm run composite-checkout-demo`.
- Verify that the form works as expected.
- Verify that the Billing form fields are translated into French.