### PR TITLE
i18n-calypso-cli: Support for optional chaining & nullish coalescing

### DIFF
--- a/packages/i18n-calypso-cli/CHANGELOG.md
+++ b/packages/i18n-calypso-cli/CHANGELOG.md
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- Add support for parsing optional chaining
+- Add support for parsing nullish coalescing
+
 4.0.0
 -----
 

--- a/packages/i18n-calypso-cli/index.js
+++ b/packages/i18n-calypso-cli/index.js
@@ -44,6 +44,8 @@ module.exports = function i18nCalypso( config ) {
 				'objectRestSpread',
 				'trailingFunctionCommas',
 				'typescript',
+				'nullishCoalescingOperator',
+				'optionalChaining',
 			],
 			allowImportExportEverywhere: true,
 		},


### PR DESCRIPTION
Broad support was added for these features in #37552, but the `lint-and-translate` test was [running afoul](https://circleci.com/gh/Automattic/wp-calypso/503498) of these features:

> SyntaxError: This experimental syntax requires enabling the parser plugin: 'optionalChaining'

#### Changes proposed in this Pull Request

* Enable the `nullishCoalescingOperator` & `optionalChaining` plugins in the `parseOptions`

#### Testing instructions

* Either checkout a branch based on this one & add one or both of the new features in a file which has localized text or just consult #37574 whence I've `cherry-pick`ed this commit.
  * The `lint-and-translate` tests should pass
