### PR TITLE
Rename rewind to restore

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -279,10 +279,10 @@ class DisconnectJetpack extends PureComponent {
 					className="disconnect-jetpack__try-rewind disconnect-jetpack__block"
 				>
 					<p className="disconnect-jetpack__highlight">
-						{ translate( 'Experiencing connection issues? Try to go back and rewind your site.' ) }
+						{ translate( 'Experiencing connection issues? Try to go back and restore your site.' ) }
 					</p>
 					<div className="disconnect-jetpack__try-rewind-button-wrap">
-						<Button onClick={ this.handleTryRewind }>{ translate( 'Rewind site' ) }</Button>
+						<Button onClick={ this.handleTryRewind }>{ translate( 'Restore site' ) }</Button>
 						<HappychatButton borderless={ false } onClick={ this.props.trackTryRewindHelp } primary>
 							<Gridicon icon="chat" size={ 18 } />
 							{ translate( 'Get help' ) }

--- a/client/layout/guided-tours/tours/activity-log-tour/index.js
+++ b/client/layout/guided-tours/tours/activity-log-tour/index.js
@@ -50,7 +50,7 @@ export const ActivityLogTour = makeTour(
 						{ translate(
 							'Each block collects all the activities performed on your site ' +
 								'like publishing a post or updating a plugin. ' +
-								'To restore your site to a particular day, click its rewind button.'
+								'To restore your site to a particular day, click its restore button.'
 						) }
 					</p>
 					<ButtonRow>

--- a/client/my-sites/activity/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/error-banner.jsx
@@ -71,8 +71,8 @@ class ErrorBanner extends PureComponent {
 		} = this.props;
 		const strings = isUndefined( downloadId )
 			? {
-					title: translate( 'Problem rewinding your site' ),
-					details: translate( 'We came across a problem while trying to rewind your site.' ),
+					title: translate( 'Problem restoring your site' ),
+					details: translate( 'We came across a problem while trying to restore your site.' ),
 			  }
 			: {
 					title: translate( 'Problem preparing your file' ),

--- a/client/my-sites/activity/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/progress-banner.jsx
@@ -66,14 +66,14 @@ function ProgressBanner( {
 						? translate( 'The cloning process will start in a moment.' )
 						: translate( 'Away we go! Your site is being cloned.' );
 			} else {
-				title = translate( 'Currently rewinding your site' );
+				title = translate( 'Currently restoring your site' );
 				description = translate(
-					"We're rewinding your site back to %(dateTime)s. You'll be notified once it's complete.",
+					"We're restoring your site back to %(dateTime)s. You'll be notified once it's complete.",
 					{ args: { dateTime } }
 				);
 				statusMessage =
 					'queued' === status
-						? translate( 'Your rewind will start in a moment.' )
+						? translate( 'Your restore will start in a moment.' )
 						: translate( 'Away we go! Your site is being rewound.' );
 			}
 			break;

--- a/client/my-sites/activity/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/progress-banner.jsx
@@ -25,8 +25,8 @@ import { useLocalizedMoment } from 'components/localized-moment';
  * WordPress so no backups should already
  * exist prior to that date 😉
  *
- * @param {Number} ts timestamp in 's' or 'ms'
- * @returns {Number} timestamp in 'ms'
+ * @param {number} ts timestamp in 's' or 'ms'
+ * @returns {number} timestamp in 'ms'
  */
 const ms = ts =>
 	ts < 946702800000 // Jan 1, 2001 @ 00:00:00

--- a/client/my-sites/activity/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/progress-banner.jsx
@@ -74,7 +74,7 @@ function ProgressBanner( {
 				statusMessage =
 					'queued' === status
 						? translate( 'Your restore will start in a moment.' )
-						: translate( 'Away we go! Your site is being rewound.' );
+						: translate( 'Away we go! Your site is being restored.' );
 			}
 			break;
 

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -39,8 +39,8 @@ import './success-banner.scss';
  * WordPress so no backups should already
  * exist prior to that date 😉
  *
- * @param {Number} ts timestamp in 's' or 'ms'
- * @returns {Number} timestamp in 'ms'
+ * @param {number} ts timestamp in 's' or 'ms'
+ * @returns {number} timestamp in 'ms'
  */
 const ms = ts =>
 	ts < 946702800000 // Jan 1, 2001 @ 00:00:00

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -115,7 +115,7 @@ class SuccessBanner extends PureComponent {
 					title:
 						'alternate' === context
 							? translate( 'Your site has been successfully cloned' )
-							: translate( 'Your site has been successfully rewound' ),
+							: translate( 'Your site has been successfully restored' ),
 					icon: 'history',
 					track: (
 						<TrackComponentView
@@ -128,7 +128,7 @@ class SuccessBanner extends PureComponent {
 							? translate( 'We successfully cloned your site to the state as of %(date)s!', {
 									args: { date },
 							  } )
-							: translate( 'We successfully rewound your site back to %(date)s!', {
+							: translate( 'We successfully restored your site back to %(date)s!', {
 									args: { date },
 							  } ),
 					actionButton: (

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -49,7 +49,7 @@ const ActivityLogConfirmDialog = ( {
 			<div className="activity-log-confirm-dialog__partial-restore-settings">
 				<p>
 					{ notice
-						? translate( 'Choose the items you wish to rewind:' )
+						? translate( 'Choose the items you wish to restore:' )
 						: translate( 'Choose the items you wish to include in the download:' ) }
 				</p>
 				<FormLabel>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -349,7 +349,7 @@ class ActivityLogItem extends Component {
 						title={ translate( 'Restore Site' ) }
 						disableButton={ this.state.disableRestoreButton }
 					>
-						{ translate( '{{time/}} is the selected point for your site Restore.', {
+						{ translate( '{{time/}} is the selected point for your site restore.', {
 							components: {
 								time: <b>{ adjustedTime.format( 'LLL' ) }</b>,
 							},

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -252,7 +252,7 @@ class ActivityLogItem extends Component {
 			<div className="activity-log-item__action">
 				<EllipsisMenu>
 					<PopoverMenuItem disabled={ disableRestore } icon="history" onClick={ createRewind }>
-						{ translate( 'Rewind to this point' ) }
+						{ translate( 'Restore to this point' ) }
 					</PopoverMenuItem>
 
 					<PopoverMenuSeparator />
@@ -336,20 +336,20 @@ class ActivityLogItem extends Component {
 				{ mightRewind && (
 					<ActivityLogConfirmDialog
 						key="activity-rewind-dialog"
-						confirmTitle={ translate( 'Confirm Rewind' ) }
+						confirmTitle={ translate( 'Confirm Restore' ) }
 						notice={
 							this.state.disableRestoreButton
-								? translate( 'Please select at least one item to rewind.' )
+								? translate( 'Please select at least one item to restore.' )
 								: translate( 'This will override and remove all content created after this point.' )
 						}
 						onClose={ this.cancelRewindIntent }
 						onConfirm={ this.confirmRewind }
 						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/how-to-rewind"
-						title={ translate( 'Rewind Site' ) }
+						title={ translate( 'Restore Site' ) }
 						disableButton={ this.state.disableRestoreButton }
 					>
-						{ translate( '{{time/}} is the selected point for your site Rewind.', {
+						{ translate( '{{time/}} is the selected point for your site Restore.', {
 							components: {
 								time: <b>{ adjustedTime.format( 'LLL' ) }</b>,
 							},

--- a/client/my-sites/activity/activity-log-switch/index.jsx
+++ b/client/my-sites/activity/activity-log-switch/index.jsx
@@ -35,7 +35,7 @@ class ActivityLogSwitch extends Component {
 	};
 
 	/**
-	 * Renders the main button whose functionality and label varies depending on why Rewind is unavailable.
+	 * Renders the main button whose functionality and label varies depending on why restore is unavailable.
 	 *
 	 * @returns {object} Primary button.
 	 */
@@ -120,15 +120,15 @@ class ActivityLogSwitch extends Component {
 				</h3>
 				<Card className="activity-log-switch__feature">
 					<h4 className="activity-log-switch__feature-heading">
-						{ translate( 'Rewind to any event' ) }
+						{ translate( 'Restore to any event' ) }
 					</h4>
 					<div className="activity-log-switch__feature-content">
 						<p>
 							{ translate(
 								'As soon as you switch over, we will start tracking every change made ' +
-									'to your site and allow you to rewind to any past event. ' +
+									'to your site and allow you to restore to any past event. ' +
 									'If you lose a file, get hacked, or just liked your site better before some changes, ' +
-									'you can rewind with a click of a button.'
+									'you can restore with a click of a button.'
 							) }
 						</p>
 					</div>

--- a/client/my-sites/activity/activity-log-switch/index.jsx
+++ b/client/my-sites/activity/activity-log-switch/index.jsx
@@ -35,7 +35,7 @@ class ActivityLogSwitch extends Component {
 	};
 
 	/**
-	 * Renders the main button whose functionality and label varies depending on why restore is unavailable.
+	 * Renders the main button whose functionality and label varies depending on why Jetpack Backup is unavailable.
 	 *
 	 * @returns {object} Primary button.
 	 */

--- a/client/my-sites/activity/activity-log/rewind-unavailability-notice.jsx
+++ b/client/my-sites/activity/activity-log/rewind-unavailability-notice.jsx
@@ -33,7 +33,7 @@ export const RewindUnavailabilityNotice = ( {
 					href={ adminUrl }
 					title={ translate( 'The site is not connected.' ) }
 					description={ translate(
-						"We can't back up or rewind your site until it has been reconnected."
+						"We can't back up or restore your site until it has been reconnected."
 					) }
 				/>
 			);

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -46,7 +46,7 @@ class CredentialsConfigured extends Component {
 					<p>
 						{ translate(
 							"Your site's server was automatically connected to Jetpack to " +
-								'perform backups, rewinds, and security scans. You do not have to ' +
+								'perform backups, restores, and security scans. You do not have to ' +
 								'configure anything further, but you may revoke the credentials if necessary.'
 						) }
 					</p>

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -150,7 +150,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 				{ button: i18n.translate( 'Support chat' ), onClick: getHelp }
 			);
 			spreadHappiness(
-				'Rewind Credentials: update request failed on timeout (could be us or remote site)'
+				'Restore Credentials: update request failed on timeout (could be us or remote site)'
 			);
 			break;
 
@@ -158,7 +158,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 			announce(
 				i18n.translate( 'Something seems to be missing — please fill out all the required fields.' )
 			);
-			spreadHappiness( 'Rewind Credentials: missing API args (contact a dev)' );
+			spreadHappiness( 'Restore Credentials: missing API args (contact a dev)' );
 			break;
 
 		case 'invalid_args':
@@ -168,7 +168,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 						'another look to ensure everything is in the right place.'
 				)
 			);
-			spreadHappiness( 'Rewind Credentials: invalid API args (contact a dev)' );
+			spreadHappiness( 'Restore Credentials: invalid API args (contact a dev)' );
 			break;
 
 		case 'invalid_credentials':
@@ -177,7 +177,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 					"We couldn't connect to your site. Please verify your credentials and give it another try."
 				)
 			);
-			spreadHappiness( 'Rewind Credentials: invalid credentials' );
+			spreadHappiness( 'Restore Credentials: invalid credentials' );
 			break;
 
 		case 'invalid_wordpress_path':
@@ -188,18 +188,18 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 				),
 				{ button: i18n.translate( 'Get help' ), onClick: getHelp }
 			);
-			spreadHappiness( "Rewind Credentials: can't find WordPress installation files" );
+			spreadHappiness( "Restore Credentials: can't find WordPress installation files" );
 			break;
 
 		case 'read_only_install':
 			announce(
 				i18n.translate(
 					'It looks like your server is read-only. ' +
-						'To create backups and rewind your site, we need permission to write to your server.'
+						'To create backups and restore your site, we need permission to write to your server.'
 				),
 				{ button: i18n.translate( 'Get help' ), onClick: getHelp }
 			);
-			spreadHappiness( 'Rewind Credentials: creds only seem to provide read-only access' );
+			spreadHappiness( 'Restore Credentials: creds only seem to provide read-only access' );
 			break;
 
 		case 'unreachable_path':
@@ -209,12 +209,12 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 						"but it didn't work. Please make sure the directory is accessible and try again."
 				)
 			);
-			spreadHappiness( 'Rewind Credentials: creds might be for wrong site on right server' );
+			spreadHappiness( 'Restore Credentials: creds might be for wrong site on right server' );
 			break;
 
 		default:
 			announce( i18n.translate( 'Error saving. Please check your credentials and try again.' ) );
-			spreadHappiness( 'Rewind Credentials: unknown failure saving credentials' );
+			spreadHappiness( 'Restore Credentials: unknown failure saving credentials' );
 	}
 };
 

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -35,8 +35,7 @@ const navigateTo =
  * Makes sure that we can initialize a connection
  * to HappyChat. We'll need this on the API response
  *
- * @param {function} dispatch Redux dispatcher
- * @param {function} getState Redux getState
+ * @param {object} args Redux dispatcher, getState
  */
 export const primeHappychat = ( { dispatch, getState } ) => {
 	const state = getState();


### PR DESCRIPTION
## Changes proposed in this Pull Request
Update the wording from rewind to restore. 

## Before
<img width="228" alt="Screenshot 2019-12-02 at 16 10 37" src="https://user-images.githubusercontent.com/7767559/69975604-6c197a80-151f-11ea-9562-77daec585184.png">
<img width="969" alt="Screenshot 2019-12-02 at 16 10 52" src="https://user-images.githubusercontent.com/7767559/69975613-70de2e80-151f-11ea-85b1-f4fdb9fda16b.png">
<img width="962" alt="Screenshot 2019-12-02 at 16 11 31" src="https://user-images.githubusercontent.com/7767559/69975631-763b7900-151f-11ea-8c04-f38199981154.png">
<img width="965" alt="Screenshot 2019-12-02 at 16 17 57" src="https://user-images.githubusercontent.com/7767559/69975645-7a679680-151f-11ea-8d55-40c5917c28af.png">


## After

<img width="239" alt="Screenshot 2019-12-02 at 16 10 42" src="https://user-images.githubusercontent.com/7767559/69975610-6e7bd480-151f-11ea-8692-517bbd73a83e.png">

<img width="961" alt="Screenshot 2019-12-02 at 16 11 00" src="https://user-images.githubusercontent.com/7767559/69975616-72a7f200-151f-11ea-92f8-d85161ba4244.png">
<img width="955" alt="Screenshot 2019-12-02 at 16 11 10" src="https://user-images.githubusercontent.com/7767559/69975624-7471b580-151f-11ea-8fd1-7ffed4ab6a7a.png">
<img width="963" alt="Screenshot 2019-12-02 at 16 17 51" src="https://user-images.githubusercontent.com/7767559/69975639-78053c80-151f-11ea-8758-17f69acd0af6.png">



## Testing instructions
* Go to Tools -> Activity for a site using Jetpack Backup, enter site server credentials if necessary, and start a restore. Check all the copy.

