### PR TITLE
Show domain renewal expiration date in order summary

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -149,7 +149,6 @@ export class CartItem extends React.Component {
 
 	getProductInfo() {
 		const { cartItem, selectedSite } = this.props;
-
 		const domain =
 			cartItem.meta ||
 			get( cartItem, 'extra.domain_to_bundle' ) ||

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -139,6 +139,22 @@ export class CartItem extends React.Component {
 		return <em>{ translate( 'First year free with your plan' ) }</em>;
 	}
 
+	getDomainRenewalExpiryDateText() {
+		const { cartItem, moment } = this.props;
+
+		const domainRenewalExpirationDate =
+			get( cartItem, 'is_domain_registration' ) &&
+			get( cartItem, 'is_renewal' ) &&
+			get( cartItem, 'domain_post_renewal_expiration_date' );
+
+		let domainRenewalExpirationDateText;
+		if ( domainRenewalExpirationDate ) {
+			domainRenewalExpirationDateText = moment( domainRenewalExpirationDate ).format( 'LL' );
+		}
+
+		return domainRenewalExpirationDateText;
+	}
+
 	getFreeTrialPrice() {
 		const freeTrialText = this.props.translate( 'Free %(days)s Day Trial', {
 			args: { days: '14' },
@@ -185,6 +201,8 @@ export class CartItem extends React.Component {
 			name += ' - ' + translate( 'never expires' );
 		}
 
+		const domainRenewalExpiryDateText = this.getDomainRenewalExpiryDateText();
+
 		/*eslint-disable wpcalypso/jsx-classname-namespace*/
 		return (
 			<li className="cart-item">
@@ -193,6 +211,9 @@ export class CartItem extends React.Component {
 						{ name || translate( 'Loading…' ) }
 					</span>
 					<span className="product-domain">{ this.getProductInfo() }</span>
+					{ domainRenewalExpiryDateText && (
+						<span className="product-domain">Renew until { domainRenewalExpiryDateText }</span>
+					) }
 				</div>
 
 				<div className="secondary-details">

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -139,22 +139,6 @@ export class CartItem extends React.Component {
 		return <em>{ translate( 'First year free with your plan' ) }</em>;
 	}
 
-	getDomainRenewalExpiryDateText() {
-		const { cartItem, moment } = this.props;
-
-		const domainRenewalExpirationDate =
-			get( cartItem, 'is_domain_registration' ) &&
-			get( cartItem, 'is_renewal' ) &&
-			get( cartItem, 'domain_post_renewal_expiration_date' );
-
-		let domainRenewalExpirationDateText;
-		if ( domainRenewalExpirationDate ) {
-			domainRenewalExpirationDateText = moment( domainRenewalExpirationDate ).format( 'LL' );
-		}
-
-		return domainRenewalExpirationDateText;
-	}
-
 	getFreeTrialPrice() {
 		const freeTrialText = this.props.translate( 'Free %(days)s Day Trial', {
 			args: { days: '14' },
@@ -188,6 +172,35 @@ export class CartItem extends React.Component {
 		return info;
 	}
 
+	getDomainRenewalExpiryDate() {
+		const { cartItem } = this.props;
+
+		return (
+			get( cartItem, 'is_domain_registration' ) &&
+			get( cartItem, 'is_renewal' ) &&
+			get( cartItem, 'domain_post_renewal_expiration_date' )
+		);
+	}
+
+	renderDomainRenewalExpiryDate() {
+		const domainRenewalExpiryDate = this.getDomainRenewalExpiryDate();
+
+		if ( ! domainRenewalExpiryDate ) {
+			return null;
+		}
+
+		const { moment, translate } = this.props;
+		const domainRenewalExpiryDateText = translate( 'Renew until %(renewalDate)s', {
+			args: {
+				renewalDate: moment( domainRenewalExpiryDate ).format( 'LL' ),
+			},
+		} );
+
+		/*eslint-disable wpcalypso/jsx-classname-namespace*/
+		return <span className="product-domain-renewal-date">{ domainRenewalExpiryDateText }</span>;
+		/*eslint-enable wpcalypso/jsx-classname-namespace*/
+	}
+
 	render() {
 		const { cartItem, translate } = this.props;
 
@@ -201,8 +214,6 @@ export class CartItem extends React.Component {
 			name += ' - ' + translate( 'never expires' );
 		}
 
-		const domainRenewalExpiryDateText = this.getDomainRenewalExpiryDateText();
-
 		/*eslint-disable wpcalypso/jsx-classname-namespace*/
 		return (
 			<li className="cart-item">
@@ -211,9 +222,7 @@ export class CartItem extends React.Component {
 						{ name || translate( 'Loading…' ) }
 					</span>
 					<span className="product-domain">{ this.getProductInfo() }</span>
-					{ domainRenewalExpiryDateText && (
-						<span className="product-domain">Renew until { domainRenewalExpiryDateText }</span>
-					) }
+					{ this.renderDomainRenewalExpiryDate() }
 				</div>
 
 				<div className="secondary-details">

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -37,7 +37,8 @@
 			padding-right: 30px;
 		}
 
-		.product-domain {
+		.product-domain,
+		.product-domain-renewal-date {
 			color: var( --color-text-subtle );
 			display: block;
 			font-size: 12px;
@@ -438,7 +439,8 @@ div.popover-cart__popover {
 		width: 55%;
 	}
 
-	.product-domain {
+	.product-domain,
+	.product-domain-renewal-date {
 		width: 40%;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we will be allowing domains to be renewed up to their maximum term, we want to show the expiration date after renewal in the order summary to help users understand what they're purchasing when they renew.

Example:
<img width="287" alt="Screen Shot 2019-11-14 at 8 14 43 AM" src="https://user-images.githubusercontent.com/1379730/68860290-3f5c0b00-06b7-11ea-95e9-ebcb7c5d8371.png">


#### Testing instructions

Depends on D35323-code

- Apply the patch to the back end
- Add a domain renewal to the cart
- Check the order summary to make sure that the renews until date is correct
- Try adding other items (a new domain registration, a new plan, a plan renewal, etc )
- Make sure that nothing else breaks and that the renews until text only shows up for domain renewals