### PR TITLE
Gutenboarding: Add simple domain picker UI

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent, useState } from 'react';
+import { TextControl, Panel, PanelBody, PanelRow } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ as NO__ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { isFilledFormValue } from '../../stores/onboard/types';
+
+const DomainPicker: FunctionComponent = () => {
+	// User can search for a domain
+	const [ domainSearch, setDomainSearch ] = useState( '' );
+
+	// Without user search, we can provide recommendations based on title + vertical
+	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
+
+	const suggestions = useSelect(
+		select => {
+			if ( domainSearch.trim() ) {
+				return select( DOMAIN_STORE ).getDomainSuggestions( domainSearch, {
+					include_wordpressdotcom: true,
+				} );
+			} else if ( isFilledFormValue( siteTitle ) ) {
+				return select( DOMAIN_STORE ).getDomainSuggestions( siteTitle, {
+					include_wordpressdotcom: false,
+					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
+				} );
+			}
+		},
+		[ domainSearch, siteTitle, siteVertical ]
+	);
+
+	const label = NO__( 'Search for a domain' );
+
+	return (
+		<Panel className="domain-picker">
+			<PanelBody>
+				<PanelRow>
+					<TextControl
+						hideLabelFromVision
+						label={ label }
+						placeholder={ label }
+						onChange={ setDomainSearch }
+						value={ domainSearch }
+					/>
+				</PanelRow>
+				{ suggestions?.length /* @TODO: Add optional chain */ ? (
+					<PanelRow>
+						<ul>
+							{ suggestions.map( ( { domain_name } ) => (
+								<li key={ domain_name }>{ domain_name }</li>
+							) ) }
+						</ul>
+					</PanelRow>
+				) : null }
+			</PanelBody>
+		</Panel>
+	);
+};
+
+export default DomainPicker;

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -25,6 +25,7 @@ const DomainPicker: FunctionComponent = () => {
 			if ( domainSearch.trim() ) {
 				return select( DOMAIN_STORE ).getDomainSuggestions( domainSearch, {
 					include_wordpressdotcom: true,
+					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
 				} );
 			} else if ( isFilledFormValue( siteTitle ) ) {
 				return select( DOMAIN_STORE ).getDomainSuggestions( siteTitle, {
@@ -50,7 +51,7 @@ const DomainPicker: FunctionComponent = () => {
 						value={ domainSearch }
 					/>
 				</PanelRow>
-				{ suggestions?.length /* @TODO: Add optional chain */ ? (
+				{ suggestions?.length ? (
 					<PanelRow>
 						<ul>
 							{ suggestions.map( ( { domain_name } ) => (

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -20,21 +20,21 @@ const DomainPicker: FunctionComponent = () => {
 	// Without user search, we can provide recommendations based on title + vertical
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 
+	let search = domainSearch.trim();
+	if ( ! search && isFilledFormValue( siteTitle ) ) {
+		search = siteTitle;
+	}
+
 	const suggestions = useSelect(
 		select => {
-			if ( domainSearch.trim() ) {
-				return select( DOMAIN_STORE ).getDomainSuggestions( domainSearch, {
+			if ( search ) {
+				return select( DOMAIN_STORE ).getDomainSuggestions( search, {
 					include_wordpressdotcom: true,
-					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
-				} );
-			} else if ( isFilledFormValue( siteTitle ) ) {
-				return select( DOMAIN_STORE ).getDomainSuggestions( siteTitle, {
-					include_wordpressdotcom: false,
 					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
 				} );
 			}
 		},
-		[ domainSearch, siteTitle, siteVertical ]
+		[ search, siteVertical ]
 	);
 
 	const label = NO__( 'Search for a domain' );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -2,10 +2,9 @@
  * External dependencies
  */
 import { __ as NO__ } from '@wordpress/i18n';
-import { Button, Icon, IconButton } from '@wordpress/components';
+import { Button, Icon, IconButton, Popover } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-
-import React from 'react';
+import React, { useState } from 'react';
 import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';
 import { isEmpty } from 'lodash';
 
@@ -14,6 +13,7 @@ import { isEmpty } from 'lodash';
  */
 import { STORE_KEY } from '../../stores/onboard';
 import './style.scss';
+import DomainPicker from '../domain-picker';
 
 interface Props {
 	isEditorSidebarOpened: boolean;
@@ -21,6 +21,9 @@ interface Props {
 }
 
 export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
+	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState(
+		true /* @TODO: should be `false` by default, true for dev */
+	);
 	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -36,6 +39,18 @@ export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }:
 				<span className="gutenboarding__header-site-heading">
 					{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
 				</span>
+				<Button onClick={ () => setDomainPopoverVisibility( s => ! s ) }>
+					Pick a domain
+					{ isDomainPopoverVisible && (
+						<Popover
+							/* Prevent interaction in the domain picker from affecting the popover */
+							onClick={ e => e.stopPropagation() }
+							onKeyDown={ e => e.stopPropagation() }
+						>
+							<DomainPicker />
+						</Popover>
+					) }
+				</Button>
 			</div>
 			<div
 				aria-label={ NO__( 'Document tools' ) }

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -60,7 +60,7 @@ export function Gutenboard() {
 									className="edit-post-visual-editor editor-styles-wrapper"
 									role="region"
 									aria-label={ __( 'Onboarding screen content' ) }
-									tabIndex="-1"
+									tabIndex={ -1 }
 								>
 									<WritingFlow>
 										<ObserveTyping>

--- a/client/landing/gutenboarding/stores/domain-suggestions/actions.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/actions.ts
@@ -5,7 +5,7 @@ import { ActionType, DomainSuggestion, DomainSuggestionQuery } from './types';
 
 export const receiveDomainSuggestions = (
 	queryObject: DomainSuggestionQuery,
-	suggestions: DomainSuggestion[]
+	suggestions: DomainSuggestion[] | undefined
 ) => ( {
 	type: ActionType.RECEIVE_DOMAIN_SUGGESTIONS as const,
 	queryObject,

--- a/client/landing/gutenboarding/stores/domain-suggestions/reducer.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/reducer.ts
@@ -12,7 +12,7 @@ import * as Actions from './actions';
 import { stringifyDomainQueryObject } from './utils';
 
 const domainSuggestions: Reducer<
-	Record< string, DomainSuggestion[] >,
+	Record< string, DomainSuggestion[] | undefined >,
 	ReturnType< typeof Actions[ 'receiveDomainSuggestions' ] >
 > = ( state = {}, action ) => {
 	if ( action.type === ActionType.RECEIVE_DOMAIN_SUGGESTIONS ) {

--- a/client/landing/gutenboarding/stores/domain-suggestions/resolvers.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/resolvers.ts
@@ -15,6 +15,11 @@ export function* __internalGetDomainSuggestions(
 ) {
 	const url = 'https://public-api.wordpress.com/rest/v1.1/domains/suggestions';
 
+	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
+	if ( ! queryObject.query ) {
+		return receiveDomainSuggestions( queryObject, [] );
+	}
+
 	// `credentials` and `mode` args are needed since we're accessing the WP.com REST API
 	// (rather than the WP Core REST API)
 	const suggestions = yield apiFetch( {

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -14,11 +14,16 @@ import { stringifyDomainQueryObject } from './utils';
 export const getState = ( state: State ) => state;
 
 type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;
+
 export const getDomainSuggestions = (
 	state: State,
 	search: string,
 	options: DomainSuggestionSelectorOptions = {}
 ) => {
+	// The endpoint returns 404 if there are no alphanumeric characters
+	if ( search === '' ) {
+		return [];
+	}
 	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
 
 	// We need to go through the `select` store to get the resolver action

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -22,11 +22,6 @@ export const getDomainSuggestions = (
 ) => {
 	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
 
-	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
-	if ( ! normalizedQuery.query ) {
-		return [];
-	}
-
 	// We need to go through the `select` store to get the resolver action
 	return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
 };

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -20,11 +20,12 @@ export const getDomainSuggestions = (
 	search: string,
 	options: DomainSuggestionSelectorOptions = {}
 ) => {
-	// The endpoint returns 404 if there are no alphanumeric characters
-	if ( search === '' ) {
+	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
+
+	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
+	if ( ! normalizedQuery.query ) {
 		return [];
 	}
-	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
 
 	// We need to go through the `select` store to get the resolver action
 	return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
@@ -73,6 +74,6 @@ function normalizeDomainSuggestionQuery(
 		...queryOptions,
 
 		// Add the search query
-		query: search.toLocaleLowerCase(),
+		query: search.trim().toLocaleLowerCase(),
 	};
 }

--- a/client/landing/gutenboarding/stores/mapped-types.ts
+++ b/client/landing/gutenboarding/stores/mapped-types.ts
@@ -18,7 +18,7 @@
 export type SelectFromMap< S extends Record< string, ( ...args: any[] ) => any > > = {
 	[ selector in keyof S ]: (
 		...args: TailParameters< S[ selector ] >
-	) => ReturnType< S[ selector ] >;
+	) => ReturnType< S[ selector ] > | undefined;
 };
 
 /**

--- a/client/landing/gutenboarding/stores/mapped-types.ts
+++ b/client/landing/gutenboarding/stores/mapped-types.ts
@@ -18,7 +18,7 @@
 export type SelectFromMap< S extends Record< string, ( ...args: any[] ) => any > > = {
 	[ selector in keyof S ]: (
 		...args: TailParameters< S[ selector ] >
-	) => ReturnType< S[ selector ] > | undefined;
+	) => ReturnType< S[ selector ] >;
 };
 
 /**


### PR DESCRIPTION
Adding a first iteration of a domain picker.

Allows the user to enter keywords to look for; falls back to using the site title.

![domain picker](https://user-images.githubusercontent.com/96308/68924989-35680400-07ac-11ea-8353-b877dde95309.gif)

#### Testing Instructions

1. Go to http://calypso.localhost:3000/gutenboarding
2. Knock yourself out