### PR TITLE
Fix rules-of-hooks errors in packages

### DIFF
--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -5,7 +5,7 @@
  */
 import I18N from './i18n';
 import localizeFactory from './localize';
-import useTranslateFactory from './use-translate';
+import translateHookFactory from './use-translate';
 
 const i18n = new I18N();
 export { I18N };
@@ -27,4 +27,4 @@ export const on = i18n.on.bind( i18n );
 export const off = i18n.off.bind( i18n );
 export const emit = i18n.emit.bind( i18n );
 export const localize = localizeFactory( i18n );
-export const useTranslate = useTranslateFactory( i18n );
+export const useTranslate = translateHookFactory( i18n );


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* This fixes a weird case where the rules-of-hooks eslint plugin flagged a hook-looking function invocation. Just a simple rename of the default import alias gets past the rule.

#### Testing instructions

* Just make sure tests pass


