### PR TITLE
Fix inbound transfer to obey warnings

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -489,7 +489,7 @@ class TransferDomainStep extends React.Component {
 				return {
 					domain,
 					precheck:
-						prevState.domain !== null && ! submittingAvailability && ! submittingWhois && ! notice,
+						prevState.domain !== null && ! notice && ! submittingAvailability && ! submittingWhois,
 				};
 			} );
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -484,11 +484,12 @@ class TransferDomainStep extends React.Component {
 
 		Promise.all( [ this.getInboundTransferStatus(), this.getAvailability() ] ).then( () => {
 			this.setState( prevState => {
-				const { submittingAvailability, submittingWhois } = prevState;
+				const { notice, submittingAvailability, submittingWhois } = prevState;
 
 				return {
 					domain,
-					precheck: prevState.domain && ! submittingAvailability && ! submittingWhois,
+					precheck:
+						prevState.domain !== null && ! submittingAvailability && ! submittingWhois && ! notice,
 				};
 			} );
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -493,7 +493,12 @@ class TransferDomainStep extends React.Component {
 				};
 			} );
 
-			if ( this.props.isSignupStep && this.state.domain && ! this.transferIsRestricted() ) {
+			if (
+				this.props.isSignupStep &&
+				this.state.domain &&
+				! this.transferIsRestricted() &&
+				! this.state.notice
+			) {
 				this.props.onTransferDomain( domain );
 			}
 		} );

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -484,12 +484,16 @@ class TransferDomainStep extends React.Component {
 
 		Promise.all( [ this.getInboundTransferStatus(), this.getAvailability() ] ).then( () => {
 			this.setState( prevState => {
-				const { notice, submittingAvailability, submittingWhois } = prevState;
+				const { notice, submittingAvailability, submittingWhois, suggestion } = prevState;
 
 				return {
 					domain,
 					precheck:
-						prevState.domain !== null && ! notice && ! submittingAvailability && ! submittingWhois,
+						prevState.domain !== null &&
+						! notice &&
+						! suggestion &&
+						! submittingAvailability &&
+						! submittingWhois,
 				};
 			} );
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -84,16 +84,18 @@ class TransferDomainStep extends React.Component {
 	state = this.getDefaultState();
 
 	getDefaultState() {
+		const forcePrecheck = get( this.props, 'forcePrecheck', false );
 		return {
 			authCodeValid: null,
 			domain: null,
 			domainsWithPlansOnly: false,
 			inboundTransferStatus: {},
-			precheck: get( this.props, 'forcePrecheck', false ),
+			isTransferable: forcePrecheck,
+			precheck: forcePrecheck,
 			searchQuery: this.props.initialQuery || '',
 			submittingAuthCodeCheck: false,
 			submittingAvailability: false,
-			submittingWhois: get( this.props, 'forcePrecheck', false ),
+			submittingWhois: forcePrecheck,
 			supportsPrivacy: false,
 		};
 	}
@@ -379,6 +381,7 @@ class TransferDomainStep extends React.Component {
 			this.setState( {
 				domain: null,
 				inboundTransferStatus: {},
+				isTransferable: false,
 				precheck: false,
 				notice: null,
 				searchQuery: '',
@@ -478,19 +481,24 @@ class TransferDomainStep extends React.Component {
 
 		this.props.recordFormSubmitInTransferDomain( searchQuery );
 
-		this.setState( { notice: null, suggestion: null, submittingAvailability: true } );
+		this.setState( {
+			isTransferable: false,
+			notice: null,
+			suggestion: null,
+			submittingAvailability: true,
+		} );
 
 		this.props.recordGoButtonClickInTransferDomain( searchQuery, analyticsSection );
 
 		Promise.all( [ this.getInboundTransferStatus(), this.getAvailability() ] ).then( () => {
 			this.setState( prevState => {
-				const { notice, submittingAvailability, submittingWhois, suggestion } = prevState;
+				const { isTransferable, submittingAvailability, submittingWhois, suggestion } = prevState;
 
 				return {
 					domain,
 					precheck:
 						prevState.domain !== null &&
-						! notice &&
+						isTransferable &&
 						! suggestion &&
 						! submittingAvailability &&
 						! submittingWhois,
@@ -501,7 +509,7 @@ class TransferDomainStep extends React.Component {
 				this.props.isSignupStep &&
 				this.state.domain &&
 				! this.transferIsRestricted() &&
-				! this.state.notice
+				this.state.isTransferable
 			) {
 				this.props.onTransferDomain( domain );
 			}
@@ -524,6 +532,7 @@ class TransferDomainStep extends React.Component {
 						case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
 							this.setState( {
 								domain,
+								isTransferable: true,
 								supportsPrivacy: get( result, 'supports_privacy', false ),
 							} );
 							break;

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -133,7 +133,10 @@ class UseYourDomainStep extends React.Component {
 		buildTransferDomainUrl = `${ basePathForTransfer }/transfer`;
 
 		if ( selectedSite ) {
-			const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
+			const query = stringify( {
+				initialQuery: this.state.searchQuery.trim(),
+				useStandardBack: true,
+			} );
 			buildTransferDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix our inbound transfer logic to ensure that any notices are treated as blocking
* Fix the Back button when transferring a domain for an existing site

#### Testing instructions

There are two main flows to test here:
1. Transferring a domain during signup/site creation, and
2. Transferring a domain for an existing site.

**Site Creation**
* Start from `/start` and move through the signup flow.
* Work through the flow until you get to the domain search UI at `/start/domains-with-preview`.
* Search for a domain (the actual domain doesn't matter).
* When the results appear, scroll down to the "Already own a domain?" row and click on it.
* On the next page, click on the "Transfer to WordPress.com" button (which should be in the left card).
* On the next page, type in the following types of domains, click the "Transfer" button, and verify that you get the expected behaviour in each case:
  * Use a domain that is already registered *and* is in a TLD which we don't support transfers for, such as `cbc.ca` or `governo.it`. The following should occur:
    * The signup flow *does not* proceed to plan selection. (Note that this may occur for an available domain where we support registering the domain -- `.ca` is such a TLD.)
    * We display a notice for the TLD like: "We don't support transfers for domains ending with **.ca**, but you can map it instead."
    * If you click on "Transfer" again, you get the same notice and remain on the same page.
  * Use a domain that is available *and* is in a TLD that we support registrations for, such as `sometestsite97531.ca`. The following should occur:
    * You should be moved to the plan selection page, as we've switched to registering the domain.
  * Use a domain that is available *and* is in a TLD that we *don't* support registrations for, such as `sometestsite97531.it`. The following should occur:
    * The signup flow _should not proceed_ to plan selection.
    * We display a notice for the TLD like: "This domain is available to be registered, but we don't support transfers for domains ending with **.it**. If you register it elsewhere, you can map it instead."

**Adding a domain to a site**
* Start from a site you manage and go to *Manage* > *Domains*.
* Click on the "Add Domain" button.
* Scroll down to the "Already own a domain?" row and click on it.
* On the next page, click on the "Transfer to WordPress.com" button (which should be in the left card).
* Click on the "Back" link in the top left corner, and verify that you are returned to the screen above.
* click on the "Transfer to WordPress.com" button again.
* On the next page, type in the following types of domains, click the "Transfer" button, and verify that you get the expected behaviour in each case:
  * Use a domain that is already registered *and* is in a TLD which we don't support transfers for, such as `cbc.ca` or `governo.it`. The following should occur:
    * The page should not proceed to the transfer precheck page.
    * We display a notice for the TLD like: "We don't support transfers for domains ending with **.ca**, but you can map it instead."
    * If you click on "Transfer" again, you get the same notice and remain on the same page.
  * Use a domain that is available *and* is in a TLD that we support registrations for, such as `sometestsite97531.ca`. The following should occur:
    * The page should not proceed to the transfer precheck page.
    * An upgrade section/nudge should display for the domain with core text like "sometestsite97531.ca is available!". You should be able to click on the "Upgrade" or "Select" button and see checkout. ("Upgrade" is visible if you're on a free site; "Select" is visible if you're on a site with a plan.)
  * Use a domain that is available *and* is in a TLD that we *don't* support registrations for, such as `sometestsite97531.it`. The following should occur:
    * The page should not proceed to the transfer precheck page.
    * We display a notice for the TLD like: "This domain is available to be registered, but we don't support transfers for domains ending with **.it**. If you register it elsewhere, you can map it instead."

Fixes #36627 