### PR TITLE
Atomic Hosting: Prevent phpMyAdmin opening multiple tabs

### DIFF
--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -14,7 +14,7 @@ import CardHeading from 'components/card-heading';
 import MaterialIcon from 'components/material-icon';
 import Button from 'components/button';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
+import { getHttpData, requestHttpData, resetHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import RestorePasswordDialog from './restore-db-password';
 
@@ -42,10 +42,11 @@ export const requestPmaLink = siteId =>
 
 const PhpMyAdminCard = ( { translate, siteId, token, loading, disabled } ) => {
 	useEffect( () => {
-		if ( token && ! loading ) {
+		if ( token ) {
 			window.open( `https://wordpress.com/pma-login?token=${ token }` );
 		}
-	}, [ token, loading ] );
+		return () => resetHttpData( requestId( siteId ) );
+	}, [ token, siteId ] );
 
 	const [ isRestorePasswordDialogVisible, setIsRestorePasswordDialogVisible ] = useState( false );
 

--- a/client/state/data-layer/http-data.ts
+++ b/client/state/data-layer/http-data.ts
@@ -103,6 +103,8 @@ export const updateData = ( id: DataId, state: DataState, data: unknown ): typeo
 	}
 };
 
+export const resetHttpData = ( id: DataId ) => httpData.set( id, empty );
+
 export const update = ( id: DataId, state: DataState, data?: unknown ) => {
 	const updated = updateData( id, state, data );
 

--- a/client/state/data-layer/http-data.ts
+++ b/client/state/data-layer/http-data.ts
@@ -23,8 +23,8 @@ enum DataState {
 
 interface ResourceData {
 	state: DataState;
-	data: any;
-	error: any;
+	data: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	error: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	lastUpdated: TimestampMS;
 	pendingSince: TimestampMS | undefined;
 }
@@ -143,7 +143,7 @@ type ParseResult = SuccessfulParse | FailedParse;
  *
  * [ error?, [ [ id, data ], [ id, data ], … ] ]
  *
- * @example:
+ * @example
  *   --input--
  *   { data: { sites: {
  *     14: { is_active: true, name: 'foo' },
@@ -155,8 +155,9 @@ type ParseResult = SuccessfulParse | FailedParse;
  *
  * @param data - input data from API response
  * @param fromApi - transforms API response data
- * @return output data to store
+ * @returns output data to store
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const parseResponse = ( data: any, fromApi: ResponseParser ): ParseResult => {
 	try {
 		return [ undefined, fromApi( data ) ];
@@ -221,8 +222,8 @@ export const enhancer = ( next: StoreEnhancerStoreCreator ) => (
 	return store;
 };
 
-type ResourcePair = [ DataId, any ];
-type ResponseParser = ( apiData: any ) => ResourcePair[];
+type ResourcePair = [ DataId, any ]; // eslint-disable-line @typescript-eslint/no-explicit-any
+type ResponseParser = ( apiData: any ) => ResourcePair[]; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 interface RequestHttpDataOptions {
 	fromApi?: Lazy< ResponseParser >;
@@ -234,9 +235,10 @@ interface RequestHttpDataOptions {
  *
  * @param requestId - uniquely identifies the request or request type
  * @param fetchAction - action that when dispatched will request the data (may be wrapped in a lazy thunk)
- * @param fromApi - when called produces a function that validates and transforms API data into Calypso data
- * @param freshness - indicates how many ms stale data is allowed to be before refetching
- * @return stored data container for request
+ * @param options - object with options for the http request. Following options are allowed:
+ *     - fromAPI: when called produces a function that validates and transforms API data into Calypso data
+ *     - freshness - indicates how many ms stale data is allowed to be before refetching
+ * @returns stored data container for request
  */
 export const requestHttpData = (
 	requestId: DataId,
@@ -258,6 +260,7 @@ export const requestHttpData = (
 			type: HTTP_DATA_REQUEST,
 			id: requestId,
 			fetch: 'function' === typeof fetchAction ? fetchAction() : fetchAction,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			fromApi: 'function' === typeof fromApi ? fromApi : () => ( a: any ) => a,
 		};
 
@@ -283,7 +286,7 @@ type Results< T extends Query > = { [ P in keyof T ]: ReturnType< T[ P ] > };
  *  - _DO NOT USE_ when normal synchronous/data interactions suffice such
  *    as is the case in 99.999% of React component contexts
  *
- * @example:
+ * @example
  * waitForData( {
  *     geo: () => requestGeoLocation(),
  *     splines: () => requestSplines( siteId ),
@@ -295,7 +298,7 @@ type Results< T extends Query > = { [ P in keyof T ]: ReturnType< T[ P ] > };
  *
  * @param query - key/value pairs of data name and request
  * @param timeout - how many ms to wait until giving up on requests
- * @return fulfilled data of request (or partial if could not fulfill)
+ * @returns fulfilled data of request (or partial if could not fulfill)
  */
 export const waitForData = < T extends Query >(
 	query: T,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Cleans up the phpMyAdmin login token when the `PhpMyAdminCard` component is unmounted.

This prevents the Atomic Hosting section from opening phpMyAdmin in multiple tabs on every click on the sidebar.

#### Testing instructions

* Click on SFTP & MySQL
* Click on "Open phpMyAdmin"
* Click on a different sidebar item like "Settings"
* Click again on SFTP & MySQL
* Make sure phpMyAdmin is not opened automatically on a new tab.
* Make sure that clicking on "Open phpMyAdmin" opens phpMyAdmin in a new tab

Fixes #37364
