### PR TITLE
Activity Log: Don't truncate log for sites with backup-only products

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -6,7 +6,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, includes, isEmpty, isEqual } from 'lodash';
+import { find, get, includes, isEmpty, isEqual, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,6 +33,7 @@ import Pagination from 'components/pagination';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import RewindAlerts from './rewind-alerts';
 import QueryRewindState from 'components/data/query-rewind-state';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySiteSettings from 'components/data/query-site-settings'; // For site time offset
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
@@ -40,6 +41,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import RewindUnavailabilityNotice from './rewind-unavailability-notice';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSitePurchases } from 'state/purchases/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSiteSlug, getSiteTitle, isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
@@ -313,13 +315,13 @@ class ActivityLog extends Component {
 	}
 
 	renderNoLogsContent() {
-		const { filter, logLoadingState, siteId, translate, siteIsOnFreePlan, slug } = this.props;
+		const { filter, logLoadingState, siteId, translate, siteHasNoLog, slug } = this.props;
 
 		const isFilterEmpty = isEqual( emptyFilter, filter );
 
 		if ( logLoadingState === 'success' ) {
 			return isFilterEmpty ? (
-				<ActivityLogExample siteId={ siteId } siteIsOnFreePlan={ siteIsOnFreePlan } />
+				<ActivityLogExample siteId={ siteId } siteIsOnFreePlan={ siteHasNoLog } />
 			) : (
 				<Fragment>
 					<EmptyContent
@@ -358,7 +360,7 @@ class ActivityLog extends Component {
 			moment,
 			rewindState,
 			siteId,
-			siteIsOnFreePlan,
+			siteHasNoLog,
 			slug,
 			translate,
 			isAtomic,
@@ -412,7 +414,7 @@ class ActivityLog extends Component {
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
-				{ 'awaitingCredentials' === rewindState.state && ! siteIsOnFreePlan && (
+				{ 'awaitingCredentials' === rewindState.state && ! siteHasNoLog && (
 					<Banner
 						icon="history"
 						href={
@@ -438,7 +440,7 @@ class ActivityLog extends Component {
 					/>
 				) }
 				<IntroBanner siteId={ siteId } />
-				{ siteIsOnFreePlan && isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
+				{ siteHasNoLog && isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
 				{ this.renderErrorMessage() }
 				{ this.renderActionProgress() }
@@ -459,7 +461,7 @@ class ActivityLog extends Component {
 							total={ logs.length }
 						/>
 						<section className="activity-log__wrapper">
-							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
+							{ siteHasNoLog && <div className="activity-log__fader" /> }
 							{ theseLogs.map( log =>
 								log.isAggregate ? (
 									<Fragment key={ log.activityId }>
@@ -489,7 +491,7 @@ class ActivityLog extends Component {
 								)
 							) }
 						</section>
-						{ siteIsOnFreePlan && ! isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
+						{ siteHasNoLog && ! isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
 							compact={ isMobile() }
 							className="activity-log__pagination is-bottom-pagination"
@@ -508,10 +510,10 @@ class ActivityLog extends Component {
 	}
 
 	renderFilterbar() {
-		const { siteId, filter, logs, siteIsOnFreePlan, logLoadingState } = this.props;
+		const { siteId, filter, logs, siteHasNoLog, logLoadingState } = this.props;
 		const isFilterEmpty = isEqual( emptyFilter, filter );
 
-		if ( siteIsOnFreePlan ) {
+		if ( siteHasNoLog ) {
 			return null;
 		}
 
@@ -526,11 +528,12 @@ class ActivityLog extends Component {
 	}
 
 	render() {
-		const { canViewActivityLog, translate } = this.props;
+		const { canViewActivityLog, siteId, translate } = this.props;
 
 		if ( false === canViewActivityLog ) {
 			return (
 				<Main>
+					<QuerySitePurchases siteId={ siteId } />
 					<SidebarNavigation />
 					<EmptyContent
 						title={ translate( 'You are not authorized to view this page' ) }
@@ -540,7 +543,7 @@ class ActivityLog extends Component {
 			);
 		}
 
-		const { siteId, context, rewindState } = this.props;
+		const { context, rewindState } = this.props;
 
 		const rewindNoThanks = get( context, 'query.rewind-redirect', '' );
 		const rewindIsNotReady =
@@ -549,6 +552,7 @@ class ActivityLog extends Component {
 
 		return (
 			<Main wideLayout>
+				<QuerySitePurchases siteId={ siteId } />
 				<PageViewTracker path="/activity-log/:site" title="Activity" />
 				<DocumentHead title={ translate( 'Activity' ) } />
 				{ siteId && <QueryRewindState siteId={ siteId } /> }
@@ -564,6 +568,13 @@ class ActivityLog extends Component {
 
 const emptyList = [];
 
+const hasBackupProduct = purchases => {
+	return find(
+		purchases,
+		purchase => purchase.active && startsWith( purchase.productSlug, 'jetpack_backup_' )
+	);
+};
+
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
@@ -578,6 +589,8 @@ export default connect(
 		const siteIsOnFreePlan =
 			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
 			! isVipSite( state, siteId );
+		const purchases = getSitePurchases( state, siteId );
+		const siteHasNoLog = siteIsOnFreePlan && ! hasBackupProduct( purchases );
 		const isJetpack = isJetpackSite( state, siteId );
 
 		return {
@@ -602,7 +615,7 @@ export default connect(
 			siteTitle: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			timezone,
-			siteIsOnFreePlan,
+			siteHasNoLog,
 			isIntroDismissed: getPreference( state, 'dismissible-card-activity-introduction-banner' ),
 		};
 	},

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -6,7 +6,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, includes, isEmpty, isEqual, startsWith } from 'lodash';
+import { find, get, includes, isEmpty, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ import Filterbar from '../filterbar';
 import UpgradeBanner from '../activity-log-banner/upgrade-banner';
 import IntroBanner from '../activity-log-banner/intro-banner';
 import { isFreePlan } from 'lib/plans';
+import { isJetpackBackup } from 'lib/products-values';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -569,10 +570,7 @@ class ActivityLog extends Component {
 const emptyList = [];
 
 const hasBackupProduct = purchases => {
-	return find(
-		purchases,
-		purchase => purchase.active && startsWith( purchase.productSlug, 'jetpack_backup_' )
-	);
+	return find( purchases, purchase => purchase.active && isJetpackBackup( purchase ) );
 };
 
 export default connect(

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -6,7 +6,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, includes, isEmpty, isEqual } from 'lodash';
+import { find, get, includes, isEmpty, isEqual, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -570,7 +570,7 @@ class ActivityLog extends Component {
 const emptyList = [];
 
 const hasBackupProduct = purchases => {
-	return find( purchases, purchase => purchase.active && isJetpackBackup( purchase ) );
+	return some( purchases, purchase => purchase.active && isJetpackBackup( purchase ) );
 };
 
 export default connect(


### PR DESCRIPTION
Show full available Activity Log for Jetpack sites that have backup-only products. Previously the log was being truncated for any site on a free plan. We need to show the full log so that customers can restore to restore points in the log.

## Before
<img width="1261" alt="Screenshot 2019-11-14 at 16 07 55" src="https://user-images.githubusercontent.com/7767559/68874393-0d6b9880-06f9-11ea-8f42-9017b85c773c.png">

## After

<img width="1260" alt="Screenshot 2019-11-14 at 16 08 23" src="https://user-images.githubusercontent.com/7767559/68874398-0fcdf280-06f9-11ea-87e5-f4875f736391.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a Backup-only Jetpack product and ensure the activity log for the site is not truncated and fading out at the bottom.

Fixes #
