### PR TITLE
Contact Form: Improve phone no formatting 

### DIFF
--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -15,7 +15,7 @@ const debug = debugFactory( 'phone-input:metadata' );
 
 export const DIGIT_PLACEHOLDER = '\u7003';
 const STANDALONE_DIGIT_PATTERN = /\d(?=[^,}][^,}])/g;
-const CHARACTER_CLASS_PATTERN = /\[([^\[\]])*\]/g;
+const CHARACTER_CLASS_PATTERN = /\[([^[\]])*]/g;
 const LONGEST_NUMBER = '999999999999999';
 const LONGEST_NUMBER_MATCH = /9/g;
 export const MIN_LENGTH_TO_FORMAT = 3;
@@ -42,7 +42,7 @@ export function findCountryFromNumber( inputNumber ) {
 		const query = stripNonDigits( inputNumber )
 			.replace( /^0+/, '' )
 			.substr( 0, i );
-		if ( dialCodeMap.hasOwnProperty( query ) ) {
+		if ( Object.prototype.hasOwnProperty.call( dialCodeMap, query ) ) {
 			const exactMatch = dialCodeMap[ query ];
 			if ( exactMatch.length === 1 ) {
 				return countries[ exactMatch[ 0 ] ];

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -164,7 +164,7 @@ export function applyTemplate( phoneNumber, template, positionTracking = { pos: 
 export function processNumber( inputNumber, numberRegion ) {
 	let prefix = numberRegion.nationalPrefix || '';
 	let nationalNumber = stripNonDigits( inputNumber ).replace(
-		new RegExp( '^(0{0,}' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ),
+		new RegExp( '^(0*' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ),
 		''
 	);
 

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -163,10 +163,14 @@ export function applyTemplate( phoneNumber, template, positionTracking = { pos: 
  */
 export function processNumber( inputNumber, numberRegion ) {
 	let prefix = numberRegion.nationalPrefix || '';
-	const nationalNumber = stripNonDigits( inputNumber ).replace(
+	let nationalNumber = stripNonDigits( inputNumber ).replace(
 		new RegExp( '^(0{0,}' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ),
 		''
 	);
+
+	if ( numberRegion.nationalPrefix === '0' ) {
+		nationalNumber = nationalNumber.replace( /^0+/, '' );
+	}
 
 	debug( `National Number: ${ nationalNumber } for ${ inputNumber } in ${ numberRegion.isoCode }` );
 

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -164,7 +164,7 @@ export function applyTemplate( phoneNumber, template, positionTracking = { pos: 
 export function processNumber( inputNumber, numberRegion ) {
 	let prefix = numberRegion.nationalPrefix || '';
 	const nationalNumber = stripNonDigits( inputNumber ).replace(
-		new RegExp( '^(' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ),
+		new RegExp( '^(0{0,}' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ),
 		''
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR introduces an improvement of formatting code of the phone input in the contact form, fixing a few annoying issues, and increasing its stability in general 🙏 

#### Testing instructions

To replicate the issues (before applying the changes):

* Fill in a number with the country code (e.g. `+441234567`), and then insert a `0` between the `+` and the first digit of the country code (i.e. `+0441234567`). You'll notice the country code will be duplicated (in this example, it will become `+44441234567`)
* Open the Dev Tools. Clear the field, choose a country (e.g. UK), and enter a national phone no starting with a few zeros: (e.g `000123456`), and then save. In the `Network` tab of Dev Tools, check the phone number that is sent in the API call: it should be `+44.00123456` (i.e. only one zero removed)

After applying the fix:

* Verify that you can enter as many zeroes as you want between the `+` and the first digit of the country code. Also verify that those zeroes will be removed once you submit (check the API call as well)
* Verify that all zeroes before the national number are removed (e.g. `000123456` with UK chosen as the country, becomes `+44.123456` when sent to the backend)
* Trying to enter any amount of zeroes followed by the country code for the currently selected country should "strip" the country code from the input (e.g. choosing UK and entering 0044123, the number becomes 0123)
* Try to make it fail... _please_.
