### PR TITLE
Add My Plan Card design component to be used on `/plans/my-plan` page

### DIFF
--- a/client/components/my-plan-card/README.md
+++ b/client/components/my-plan-card/README.md
@@ -1,0 +1,42 @@
+My Plan Card
+=======
+
+My Plan Card is a React component for rendering a box with plan or product name, description and icon, its expiry
+date and a button to manage the payment.
+
+It's meant to be used on `plans/my-plan` page to display plans and products that the user purchased.
+
+See p1HpG7-7ET-p2 for more details.
+
+### How to use the `<MyPlanCard />`
+
+```jsx
+import React from 'react';
+import MyPlanCard from 'components/my-plan-card';
+
+export default class extends React.Component {
+	render() {
+		return (
+			<MyPlanCard
+				buttonLabel="Manage Plan"
+				buttonTarget="/me/purchases/"
+				expirationDate="2020-10-27T10:37:04+00:00"
+				plan="jetpack_personal"
+				tagLine="Your data is being securely backed up and you have access to priority support."
+				title="Jetpack Personal"
+			/>
+		);
+	}
+}
+```
+
+### `<MyPlanCard />` props
+
+The following props can be passed to the My Plan Card component:
+
+* `buttonLabel`: ( string ) Action button label
+* `buttonTarget`: ( string ) Action button target (`href`)
+* `expirationDate`: ( string ) Plan or product expiration date, e.g. `2019-11-14T16:53:25+00:00 ` (ISO 8601)
+* `plan`: ( string ) Plan or product slug
+* `tagLine`: ( string | element | node ) Plan or product tag line. It can be a string, a node or a React element (e.g. `<Fragment>`)
+* `title`: ( string | element | node ) Plan or product title. It can be a string, a node or a React element (e.g. `<Fragment>`)

--- a/client/components/my-plan-card/docs/example.jsx
+++ b/client/components/my-plan-card/docs/example.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import MyPlanCard from '../index';
+import { PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
+
+function MyPlanCardExample() {
+	return (
+		<Fragment>
+			<Card compact>
+				<strong>My Plan</strong>
+			</Card>
+			<MyPlanCard
+				buttonLabel="Manage Plan"
+				buttonTarget="#"
+				expirationDate="2020-10-27T10:37:04+00:00"
+				plan={ PLAN_JETPACK_PERSONAL }
+				tagLine="Your data is being securely backed up and you have access to priority support."
+				title="Jetpack Personal"
+			/>
+			<Card compact>
+				<strong>My Products</strong>
+			</Card>
+			<MyPlanCard
+				buttonLabel="Manage Product"
+				buttonTarget="#"
+				expirationDate="2020-11-06T06:12:09+00:00"
+				tagLine="Your data is being securely backed up as you edit."
+				title={
+					<Fragment>
+						Jetpack Backup <em>Real-Time</em>
+					</Fragment>
+				}
+			/>
+			<MyPlanCard
+				buttonLabel="Manage Product"
+				buttonTarget="#"
+				expirationDate="2020-08-29T02:38:13+00:00"
+				tagLine="Your data is being scanned for malware."
+				title="Jetpack Scan"
+			/>
+		</Fragment>
+	);
+}
+
+MyPlanCardExample.displayName = 'MyPlanCard';
+
+export default MyPlanCardExample;

--- a/client/components/my-plan-card/index.jsx
+++ b/client/components/my-plan-card/index.jsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import PlanIcon from 'components/plans/plan-icon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const MyPlanCard = ( {
+	buttonLabel,
+	buttonTarget,
+	expirationDate,
+	moment,
+	plan,
+	tagLine,
+	title,
+	translate,
+} ) => {
+	return (
+		<Card className="my-plan-card" compact>
+			<div className="my-plan-card__primary">
+				{ plan && (
+					<div className="my-plan-card__icon">
+						<PlanIcon plan={ plan } />
+					</div>
+				) }
+				<div className="my-plan-card__header">
+					{ title && <h2 className="my-plan-card__title">{ title }</h2> }
+					{ tagLine && <p className="my-plan-card__tag-line">{ tagLine }</p> }
+				</div>
+			</div>
+			<div className="my-plan-card__secondary">
+				{ expirationDate && (
+					<div className="my-plan-card__expiration-date">
+						{ translate( 'Expires on %(expirationDate)s', {
+							args: {
+								expirationDate: moment( expirationDate ).format( 'MMMM D, YYYY' ),
+							},
+						} ) }
+					</div>
+				) }
+				{ buttonTarget && buttonLabel && (
+					<div className="my-plan-card__action">
+						<Button href={ buttonTarget } compact>
+							{ buttonLabel }
+						</Button>
+					</div>
+				) }
+			</div>
+		</Card>
+	);
+};
+
+MyPlanCard.propTypes = {
+	buttonLabel: PropTypes.string,
+	buttonTarget: PropTypes.string,
+	expirationDate: PropTypes.string,
+	plan: PropTypes.string,
+	tagLine: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
+
+	// From localize HoC
+	moment: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( MyPlanCard );

--- a/client/components/my-plan-card/style.scss
+++ b/client/components/my-plan-card/style.scss
@@ -1,0 +1,92 @@
+// My Plan Card
+.my-plan-card.card {
+	@include breakpoint( '>960px' ) {
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: space-between;
+	}
+}
+
+.my-plan-card__primary {
+	display: flex;
+	flex-flow: row nowrap;
+	flex-grow: 1;
+}
+
+.my-plan-card__title {
+	font-size: 24px;
+	font-weight: 400;
+	line-height: 29px;
+	margin: 8px 0;
+	color: var( --color-neutral-100 );
+}
+
+.my-plan-card__tag-line {
+	font-size: 18px;
+	font-weight: 300;
+	line-height: 21px;
+	margin: 0 0 24px;
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 8px;
+	}
+}
+
+.my-plan-card__icon {
+	flex: 0 0 auto;
+	width: 64px;
+	height: 64px;
+	margin: 8px 20px 0 0;
+
+	@include breakpoint( '<960px' ) {
+		display: none;
+	}
+}
+
+.my-plan-card__secondary {
+	position: relative;
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 0 0;
+
+	@include breakpoint( '>960px' ) {
+		flex-flow: column nowrap;
+		justify-content: flex-start;
+		align-items: flex-end;
+		padding: 14px 0 0 16px;
+	}
+
+	&::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: -16px;
+		right: -16px;
+		border-top: 1px solid var( --color-border-subtle );
+
+		@include breakpoint( '>480px' ) {
+			left: -24px;
+			right: -24px;
+		}
+
+		@include breakpoint( '>960px' ) {
+			content: none;
+		}
+	}
+}
+
+.my-plan-card__expiration-date {
+	padding-top: 8px;
+	white-space: nowrap;
+	color: var( --color-text-subtle );
+
+	@include breakpoint( '>960px' ) {
+		padding-top: 0;
+	}
+}
+
+.my-plan-card__action {
+	padding-top: 8px;
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -82,6 +82,7 @@ import LineChart from 'components/line-chart/docs/example';
 import ListEnd from 'components/list-end/docs/example';
 import MarkedLinesExample from 'components/marked-lines/docs/example';
 import MultipleChoiceQuestionExample from 'components/multiple-choice-question/docs/example';
+import MyPlanCardExample from 'components/my-plan-card/docs/example';
 import Notices from 'components/notice/docs/example';
 import PaginationExample from 'components/pagination/docs/example';
 import PaymentLogo from 'components/payment-logo/docs/example';
@@ -245,6 +246,7 @@ class DesignAssets extends React.Component {
 					<ListEnd readmeFilePath="list-end" />
 					<MarkedLinesExample readmeFilePath="marked-lines" />
 					<MultipleChoiceQuestionExample readmeFilePath="multiple-choice-question" />
+					<MyPlanCardExample readmeFilePath="my-plan-card" />
 					<Notices readmeFilePath="notice" />
 					<PaginationExample readmeFilePath="pagination" />
 					<PaymentLogo readmeFilePath="payment-logo" />


### PR DESCRIPTION
This PR adds a new design component `<MyPlansCard />` that is meant to be used on /plans/my-plan page.

![Screenshot 2019-11-14 at 18 00 39](https://user-images.githubusercontent.com/478735/68878857-b66dbf80-0708-11ea-8d40-840911df7815.png)

Please note that the Jetpack Backup products in the example are missing the icons at this stage. The `<PlanIcon />` component will have to be updated for this to work as expected.

Another note is that at some point we may want to make this component a bit "smarter" so that it pulls in the plan/product data by itself, not requiring us to provide information such as `expirationDate` or `title`.

#### Changes proposed in this Pull Request

* Add `<MyPlansCard />` component along with devdocs

#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/devdocs/design/my-plan-card
* Confirm that the example components look as expected both on small and large screen and that it matches the design

Fixes n/a