### PR TITLE
Composite checkout: Add order summary to checkout

### DIFF
--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -13,13 +13,11 @@ export default function CheckoutOrderSummary() {
 	const [ items ] = useLineItems();
 
 	return (
-		<React.Fragment>
-			<ProductList>
-				{ items.map( ( product, index ) => {
-					return <ProductListItem key={ index }>{ product.label }</ProductListItem>;
-				} ) }
-			</ProductList>
-		</React.Fragment>
+		<ProductList>
+			{ items.map( product => {
+				return <ProductListItem key={ product.id }>{ product.label }</ProductListItem>;
+			} ) }
+		</ProductList>
 	);
 }
 

--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import { useLineItems } from '../public-api';
+
+export default function CheckoutOrderSummary() {
+	const [ items ] = useLineItems();
+
+	return (
+		<React.Fragment>
+			<ProductList>
+				{ items.map( ( product, index ) => {
+					return <ProductListItem key={ index }>{ product.label }</ProductListItem>;
+				} ) }
+			</ProductList>
+		</React.Fragment>
+	);
+}
+
+const ProductList = styled.ul`
+	margin: 0;
+	padding: 0;
+`;
+
+const ProductListItem = styled.li`
+	margin: 0;
+	padding: 0;
+	list-style-type: none;
+`;

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -59,7 +59,7 @@ export default function CheckoutStep( {
 CheckoutStep.propTypes = {
 	className: PropTypes.string,
 	stepNumber: PropTypes.number.isRequired,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.node.isRequired,
 	finalStep: PropTypes.bool,
 	stepSummary: PropTypes.node,
 	stepContent: PropTypes.node,
@@ -106,7 +106,7 @@ function CheckoutStepHeader( {
 CheckoutStepHeader.propTypes = {
 	className: PropTypes.string,
 	stepNumber: PropTypes.number.isRequired,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.node.isRequired,
 	isActive: PropTypes.bool,
 	isComplete: PropTypes.bool,
 	onEdit: PropTypes.func,
@@ -147,9 +147,9 @@ const StepWrapper = styled.div`
 const StepTitle = styled.span`
 	color: ${props =>
 		props.isActive ? props.theme.colors.textColorDark : props.theme.colors.textColor};
-	margin-right: 5px;
 	font-weight: ${props =>
 		props.isActive ? props.theme.weights.bold : props.theme.weights.normal};
+	flex: 1;
 `;
 
 const StepHeader = styled.h2`

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -19,7 +19,7 @@ import CheckoutSubmitButton from './checkout-submit-button';
 import { useSelect, useDispatch, useRegisterStore } from '../lib/registry';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import CheckoutOrderSummary from './checkout-order-summary';
-import { useTotal } from '../public-api';
+import { useTotal, renderDisplayValueMarkdown } from '../public-api';
 
 function useRegisterCheckoutStore() {
 	useRegisterStore( 'checkout', {
@@ -166,7 +166,9 @@ function OrderSummaryStep( { OrderSummary } ) {
 			title={
 				<CheckoutSummaryTitle>
 					<span>{ localize( 'You are all set to check out' ) }</span>
-					<CheckoutSummaryTotal>{ total.amount.displayValue }</CheckoutSummaryTotal>
+					<CheckoutSummaryTotal>
+						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
+					</CheckoutSummaryTotal>
 				</CheckoutSummaryTitle>
 			}
 			stepSummary={ <OrderSummary /> }

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -69,7 +69,7 @@ export default function Checkout( {
 	return (
 		<Container className={ joinClasses( [ className, 'checkout' ] ) }>
 			<MainContent className={ joinClasses( [ className, 'checkout__content' ] ) }>
-				<OrderSummaryStep OrderSummary={ OrderSummary ? OrderSummary : CheckoutOrderSummary } />
+				<OrderSummaryStep OrderSummary={ OrderSummary || CheckoutOrderSummary } />
 
 				<CheckoutErrorBoundary
 					errorMessage={ localize( 'There was a problem with the payment method form.' ) }

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -18,6 +18,8 @@ import CheckoutReviewOrder from './checkout-review-order';
 import CheckoutSubmitButton from './checkout-submit-button';
 import { useSelect, useDispatch, useRegisterStore } from '../lib/registry';
 import CheckoutErrorBoundary from './checkout-error-boundary';
+import CheckoutOrderSummary from './checkout-order-summary';
+import { useTotal } from '../public-api';
 
 function useRegisterCheckoutStore() {
 	useRegisterStore( 'checkout', {
@@ -67,7 +69,7 @@ export default function Checkout( {
 	return (
 		<Container className={ joinClasses( [ className, 'checkout' ] ) }>
 			<MainContent className={ joinClasses( [ className, 'checkout__content' ] ) }>
-				{ OrderSummary && <OrderSummaryStep OrderSummary={ OrderSummary } /> }
+				<OrderSummaryStep OrderSummary={ OrderSummary ? OrderSummary : CheckoutOrderSummary } />
 
 				<CheckoutErrorBoundary
 					errorMessage={ localize( 'There was a problem with the payment method form.' ) }
@@ -154,13 +156,19 @@ const CheckoutWrapper = styled.div`
 
 function OrderSummaryStep( { OrderSummary } ) {
 	const localize = useLocalize();
+	const total = useTotal();
 
 	return (
 		<CheckoutStep
 			isActive={ false }
 			isComplete={ true }
 			stepNumber={ 0 }
-			title={ localize( 'You are all set to check out' ) }
+			title={
+				<CheckoutSummaryTitle>
+					<span>{ localize( 'You are all set to check out' ) }</span>
+					<CheckoutSummaryTotal>{ total.amount.displayValue }</CheckoutSummaryTotal>
+				</CheckoutSummaryTitle>
+			}
 			stepSummary={ <OrderSummary /> }
 		/>
 	);
@@ -169,6 +177,15 @@ function OrderSummaryStep( { OrderSummary } ) {
 OrderSummaryStep.propTypes = {
 	OrderSummary: PropTypes.elementType,
 };
+
+const CheckoutSummaryTitle = styled.span`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const CheckoutSummaryTotal = styled.span`
+	font-weight: ${props => props.theme.weights.bold};
+`;
 
 function PaymentMethodsStep( { setStepNumber, isActive, isComplete, availablePaymentMethods } ) {
 	const localize = useLocalize();

--- a/packages/composite-checkout/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/wp-checkout-order-summary.js
@@ -23,8 +23,8 @@ export default function WPCheckoutOrderSummary() {
 		<React.Fragment>
 			<SummaryContent>
 				<ProductList>
-					{ items.map( ( product, index ) => {
-						return <ProductListItem key={ index }>{ product.label }</ProductListItem>;
+					{ items.map( product => {
+						return <ProductListItem key={ product.id }>{ product.label }</ProductListItem>;
 					} ) }
 				</ProductList>
 

--- a/packages/composite-checkout/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/wp-checkout-order-summary.js
@@ -8,29 +8,37 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { useLocalize } from '../lib/localize';
+import { useLineItems } from '../public-api';
 import Button from './button';
 import Coupon from './coupon';
 
 export default function WPCheckoutOrderSummary() {
 	const localize = useLocalize();
+	const [ items ] = useLineItems();
 	//TODO: tie the default coupon field visibility based on whether there is a coupon in the cart
 	const [ isCouponFieldVisible, setIsCouponFieldVisible ] = useState( false );
 	const [ hasCouponBeenApplied, setHasCouponBeenApplied ] = useState( false );
 
 	return (
-		<div>
-			{ localize( 'Order Summary' ) }
+		<React.Fragment>
+			<SummaryContent>
+				<ProductList>
+					{ items.map( ( product, index ) => {
+						return <ProductListItem key={ index }>{ product.label }</ProductListItem>;
+					} ) }
+				</ProductList>
 
-			{ ! hasCouponBeenApplied && ! isCouponFieldVisible && (
-				<AddCouponButton
-					buttonState="text-button"
-					onClick={ () => {
-						setIsCouponFieldVisible( true );
-					} }
-				>
-					{ localize( 'Add a coupon' ) }
-				</AddCouponButton>
-			) }
+				{ ! hasCouponBeenApplied && ! isCouponFieldVisible && (
+					<AddCouponButton
+						buttonState="text-button"
+						onClick={ () => {
+							setIsCouponFieldVisible( true );
+						} }
+					>
+						{ localize( 'Add a coupon' ) }
+					</AddCouponButton>
+				) }
+			</SummaryContent>
 
 			<CouponField
 				id="order-summary-coupon"
@@ -39,16 +47,32 @@ export default function WPCheckoutOrderSummary() {
 					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
 				} }
 			/>
-		</div>
+		</React.Fragment>
 	);
 }
+
+const SummaryContent = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+`;
+
+const ProductList = styled.ul`
+	margin: 0;
+	padding: 0;
+`;
+
+const ProductListItem = styled.li`
+	margin: 0;
+	padding: 0;
+	list-style-type: none;
+`;
 
 const CouponField = styled( Coupon )`
 	margin-top: 16px;
 `;
 
 const AddCouponButton = styled( Button )`
-	margin-top: 4px;
 	font-size: ${props => props.theme.fontSize.small};
 `;
 

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -82,9 +82,9 @@ describe( 'Checkout', () => {
 		it( 'renders the review step', () => {
 			const { getAllByText } = render( <MyCheckout /> );
 			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
 			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
 		} );
 
 		it( 'renders the payment method SubmitButtonComponent', () => {
@@ -154,9 +154,9 @@ describe( 'Checkout', () => {
 		it( 'renders the review step', () => {
 			const { getAllByText } = render( <MyCheckout /> );
 			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
 			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
 		} );
 
 		it( 'renders the payment method SubmitButtonComponent', () => {

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -81,10 +81,10 @@ describe( 'Checkout', () => {
 
 		it( 'renders the review step', () => {
 			const { getAllByText } = render( <MyCheckout /> );
-			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
+			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 2 );
 		} );
 
 		it( 'renders the payment method SubmitButtonComponent', () => {
@@ -153,10 +153,10 @@ describe( 'Checkout', () => {
 
 		it( 'renders the review step', () => {
 			const { getAllByText } = render( <MyCheckout /> );
-			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
+			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
+			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 2 );
 		} );
 
 		it( 'renders the payment method SubmitButtonComponent', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fills out the order summary with the line items and total.

**WP.com supplied summary**
![image](https://user-images.githubusercontent.com/6981253/68883796-ba391c00-06df-11ea-827c-2092782f5a99.png)

**Default summary**
![image](https://user-images.githubusercontent.com/6981253/68883841-d472fa00-06df-11ea-9db2-1a97957ce634.png)


#### Testing instructions

* Get checkout running by following these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* You should see the summary with the coupon. 
* Replace `<Checkout OrderSummary={ WPCheckoutOrderSummary } ReviewContent={ WPCheckoutOrderReview } />` with `<Checkout ReviewContent={ WPCheckoutOrderReview } />` from the [demo's index file](https://github.com/Automattic/wp-calypso/blob/master/packages/composite-checkout/demo/index.js#L153) if you want to see the default view.
