### PR TITLE
Composite checkout: Remove private key file

### DIFF
--- a/packages/composite-checkout/demo/private.js
+++ b/packages/composite-checkout/demo/private.js
@@ -1,1 +1,0 @@
-export const stripeKey = 'pk_test_zIh4nRbVgmaetTZqoG4XKxWT';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes a file that shouldn't have been committed. 

Per Stripe's Docs, it's not sensitive information, though: https://stripe.com/docs/keys

> Publishable API keys are meant solely to identify your account with Stripe, they aren't secret. In other words, they can safely be published in places like your Stripe.js JavaScript code, or in an Android or iPhone app. Publishable keys only have the power to create tokens.


