### PR TITLE
Checkout: remove excessive mocking from Enzyme tests

### DIFF
--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -14,21 +14,11 @@ import { identity, noop } from 'lodash';
  */
 import { CreditCardFormFields } from '../';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
+import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-specific-payment-fields';
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: x => x,
-	numberFormat: x => x,
-	translate: x => x,
+jest.mock( 'lib/checkout/processor-specific', () => ( {
+	shouldRenderAdditionalCountryFields: jest.fn( false ),
 } ) );
-
-jest.mock( 'lib/checkout/processor-specific', () => {
-	return {
-		shouldRenderAdditionalCountryFields: jest.fn( false ),
-	};
-} );
-
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
 
 const defaultProps = {
 	card: {},
@@ -48,7 +38,7 @@ describe( 'CreditCardFormFields', () => {
 
 	test( 'should not render ebanx fields', () => {
 		const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
-		expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 0 );
+		expect( wrapper.find( CountrySpecificPaymentFields ) ).toHaveLength( 0 );
 	} );
 
 	describe( 'with ebanx activated', () => {
@@ -62,13 +52,13 @@ describe( 'CreditCardFormFields', () => {
 		test( 'should display Ebanx fields when an Ebanx payment country is selected and there is a transaction in process', () => {
 			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
 			wrapper.setProps( { card: { country: 'BR' } } );
-			expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 1 );
+			expect( wrapper.find( CountrySpecificPaymentFields ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should not display Ebanx fields when there is a transaction in process', () => {
 			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
 			wrapper.setProps( { card: { country: 'BR' }, isNewTransaction: false } );
-			expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 0 );
+			expect( wrapper.find( CountrySpecificPaymentFields ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -9,7 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import CartToggle from './cart-toggle';
@@ -21,7 +21,7 @@ import SubscriptionText from './subscription-text';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import notices from 'notices';
-import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-specific-payment-fields';
+import CountrySpecificPaymentFields from './country-specific-payment-fields';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { validatePaymentDetails, maskField, unmaskField } from 'lib/checkout';
 import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
@@ -137,7 +137,7 @@ export class RedirectPaymentBox extends PureComponent {
 		}
 
 		this.setSubmitState( {
-			info: translate( 'Setting up your %(paymentProvider)s payment', {
+			info: this.props.translate( 'Setting up your %(paymentProvider)s payment', {
 				args: { paymentProvider: this.getPaymentProviderName() },
 			} ),
 			disabled: true,
@@ -180,7 +180,9 @@ export class RedirectPaymentBox extends PureComponent {
 			.then( result => {
 				if ( result.redirect_url ) {
 					this.setSubmitState( {
-						info: translate( 'Redirecting you to the payment partner to complete the payment.' ),
+						info: this.props.translate(
+							'Redirecting you to the payment partner to complete the payment.'
+						),
 						disabled: true,
 					} );
 					analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Redirect Payment Button' );
@@ -195,7 +197,9 @@ export class RedirectPaymentBox extends PureComponent {
 				if ( error.message ) {
 					errorMessage = error.message;
 				} else {
-					errorMessage = translate( "We've encountered a problem. Please try again later." );
+					errorMessage = this.props.translate(
+						"We've encountered a problem. Please try again later."
+					);
 				}
 
 				this.setSubmitState( {
@@ -207,7 +211,7 @@ export class RedirectPaymentBox extends PureComponent {
 
 	renderButtonText() {
 		if ( hasRenewalItem( this.props.cart ) ) {
-			return translate( 'Purchase %(price)s subscription with %(paymentProvider)s', {
+			return this.props.translate( 'Purchase %(price)s subscription with %(paymentProvider)s', {
 				args: {
 					price: this.props.cart.total_cost_display,
 					paymentProvider: this.getPaymentProviderName(),
@@ -215,7 +219,7 @@ export class RedirectPaymentBox extends PureComponent {
 			} );
 		}
 
-		return translate( 'Pay %(price)s with %(paymentProvider)s', {
+		return this.props.translate( 'Pay %(price)s with %(paymentProvider)s', {
 			args: {
 				price: this.props.cart.total_cost_display,
 				paymentProvider: this.getPaymentProviderName(),
@@ -246,7 +250,7 @@ export class RedirectPaymentBox extends PureComponent {
 			],
 		};
 		return [
-			{ value: '', label: translate( 'Please select your bank.' ) },
+			{ value: '', label: this.props.translate( 'Please select your bank.' ) },
 			...banks[ paymentType ],
 		];
 	}
@@ -255,12 +259,12 @@ export class RedirectPaymentBox extends PureComponent {
 		switch ( this.props.paymentType ) {
 			case 'ideal':
 				return this.createField( 'ideal-bank', Select, {
-					label: translate( 'Bank' ),
+					label: this.props.translate( 'Bank' ),
 					options: this.getBankOptions( 'ideal' ),
 				} );
 			case 'p24':
 				return this.createField( 'email', Input, {
-					label: translate( 'Email Address' ),
+					label: this.props.translate( 'Email Address' ),
 				} );
 			case 'netbanking':
 				return (
@@ -278,7 +282,7 @@ export class RedirectPaymentBox extends PureComponent {
 				return (
 					<Fragment>
 						{ this.createField( 'tef-bank', Select, {
-							label: translate( 'Bank' ),
+							label: this.props.translate( 'Bank' ),
 							options: this.getBankOptions( 'brazil-tef' ),
 						} ) }
 						<CountrySpecificPaymentFields
@@ -306,7 +310,7 @@ export class RedirectPaymentBox extends PureComponent {
 				<form onSubmit={ this.redirectToPayment }>
 					<div className="checkout__payment-box-section">
 						{ this.createField( 'name', Input, {
-							label: translate( 'Your Name' ),
+							label: this.props.translate( 'Your Name' ),
 						} ) }
 						{ this.renderAdditionalFields() }
 					</div>
@@ -335,7 +339,7 @@ export class RedirectPaymentBox extends PureComponent {
 							<div className="checkout__secure-payment">
 								<div className="checkout__secure-payment-content">
 									<Gridicon icon="lock" />
-									{ translate( 'Secure Payment' ) }
+									{ this.props.translate( 'Secure Payment' ) }
 								</div>
 							</div>
 

--- a/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
@@ -13,6 +13,8 @@ import React from 'react';
  * Internal dependencies
  */
 import { CreditCardPaymentBox } from '../credit-card-payment-box';
+import PaymentChatButton from '../payment-chat-button';
+import CheckoutTerms from '../checkout-terms';
 import { INPUT_VALIDATION } from 'lib/store-transactions/step-types';
 import {
 	PLAN_ECOMMERCE,
@@ -45,29 +47,12 @@ jest.mock( 'lib/cart-values', () => ( {
 	},
 } ) );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: x => x,
-	translate: x => x,
-} ) );
-
-jest.mock( '../terms-of-service', () => {
-	const react = require( 'react' );
-	return class TermsOfService extends react.Component {};
-} );
-jest.mock( '../payment-chat-button', () => {
-	const react = require( 'react' );
-	return class PaymentChatButton extends react.Component {};
-} );
-
 jest.mock( 'lib/abtest', () => ( { abtest: () => {} } ) );
 jest.mock( 'lib/cart-values', () => ( {
 	cartItems: {
 		hasRenewableSubscription: jest.fn( false ),
 	},
 } ) );
-
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
 
 jest.useFakeTimers();
 
@@ -86,7 +71,7 @@ describe( 'Credit Card Payment Box', () => {
 	test( 'does not blow up with default props', () => {
 		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
 		expect( wrapper ).toHaveLength( 1 );
-		expect( wrapper.find( 'CheckoutTerms' ) ).toHaveLength( 1 );
+		expect( wrapper.find( CheckoutTerms ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should set progress timer when incoming validation transaction step contains no errors', () => {
@@ -179,7 +164,7 @@ describe( 'Credit Card Payment Box - PaymentChatButton', () => {
 				},
 			};
 			const wrapper = shallow( <CreditCardPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 1 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -193,7 +178,7 @@ describe( 'Credit Card Payment Box - PaymentChatButton', () => {
 				},
 			};
 			const wrapper = shallow( <CreditCardPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -223,7 +208,7 @@ describe( 'Credit Card Payment Box - PaymentChatButton', () => {
 				},
 			};
 			const wrapper = shallow( <CreditCardPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/credits-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credits-payment-box.js
@@ -13,6 +13,8 @@ import { identity } from 'lodash';
  * Internal dependencies
  */
 import { CreditsPaymentBox } from '../credits-payment-box';
+import PaymentChatButton from '../payment-chat-button';
+import CheckoutTerms from '../checkout-terms';
 import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
@@ -44,23 +46,6 @@ jest.mock( 'lib/cart-values', () => ( {
 	},
 } ) );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: x => x,
-	translate: x => x,
-} ) );
-
-jest.mock( '../terms-of-service', () => {
-	const react = require( 'react' );
-	return class TermsOfService extends react.Component {};
-} );
-jest.mock( '../payment-chat-button', () => {
-	const react = require( 'react' );
-	return class PaymentChatButton extends react.Component {};
-} );
-
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
-
 const defaultProps = {
 	cart: {},
 	translate: identity,
@@ -71,7 +56,7 @@ describe( 'CreditsPaymentBox', () => {
 		const wrapper = shallow( <CreditsPaymentBox { ...defaultProps } /> );
 		expect( wrapper.find( '.payment-box-section' ) ).toHaveLength( 1 );
 		expect( wrapper.find( '.payment-box-actions' ) ).toHaveLength( 1 );
-		expect( wrapper.find( 'CheckoutTerms' ) ).toHaveLength( 1 );
+		expect( wrapper.find( CheckoutTerms ) ).toHaveLength( 1 );
 	} );
 
 	const eligiblePlans = [
@@ -92,7 +77,7 @@ describe( 'CreditsPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <CreditsPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 1 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -106,7 +91,7 @@ describe( 'CreditsPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <CreditsPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -136,7 +121,7 @@ describe( 'CreditsPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <CreditsPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/domain-details-form.js
+++ b/client/my-sites/checkout/checkout/test/domain-details-form.js
@@ -14,6 +14,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { DomainDetailsForm, DomainDetailsFormContainer } from '../domain-details-form';
+import PrivacyProtection from '../privacy-protection';
 import { domainRegistration } from 'lib/cart-values/cart-items';
 
 jest.mock( 'lib/analytics', () => ( {
@@ -21,10 +22,7 @@ jest.mock( 'lib/analytics', () => ( {
 		record: () => {},
 	},
 } ) );
-jest.mock( 'i18n-calypso', () => ( {
-	localize: x => x,
-	translate: x => x,
-} ) );
+
 jest.mock( 'lib/wp', () => {
 	const wpcomMock = {
 		undocumented: () => wpcomMock,
@@ -37,9 +35,6 @@ jest.mock( 'lib/wp', () => {
 
 	return wpcomMock;
 } );
-
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
 
 describe( 'Domain Details Form', () => {
 	const defaultProps = {
@@ -91,7 +86,7 @@ describe( 'Domain Details Form', () => {
 	test( 'does not render privacy with no domains', () => {
 		const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
 
-		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 0 );
+		expect( wrapper.find( PrivacyProtection ) ).to.have.length( 0 );
 	} );
 
 	test( 'should render the privacy upsell with a domain with privacy support', () => {
@@ -101,7 +96,7 @@ describe( 'Domain Details Form', () => {
 
 		const wrapper = shallow( <DomainDetailsForm { ...propsWithDomain } /> );
 
-		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 1 );
+		expect( wrapper.find( PrivacyProtection ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render privacy upsell for domain with support', () => {
@@ -111,7 +106,7 @@ describe( 'Domain Details Form', () => {
 
 		const wrapper = shallow( <DomainDetailsForm { ...propsWithDomainWithPrivacy } /> );
 
-		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 1 );
+		expect( wrapper.find( PrivacyProtection ) ).to.have.length( 1 );
 	} );
 
 	test( "should not render the privacy upsell with a domain that doesn't support privacy", () => {
@@ -120,7 +115,7 @@ describe( 'Domain Details Form', () => {
 		} );
 		const wrapper = shallow( <DomainDetailsForm { ...propsWithDomainWithNoPrivacy } /> );
 
-		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 0 );
+		expect( wrapper.find( PrivacyProtection ) ).to.have.length( 0 );
 	} );
 
 	test( 'should not render the privacy upsell with mixed privacy support', () => {
@@ -129,13 +124,13 @@ describe( 'Domain Details Form', () => {
 		} );
 		const wrapper = shallow( <DomainDetailsForm { ...mixedSupportProps } /> );
 
-		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 0 );
+		expect( wrapper.find( PrivacyProtection ) ).to.have.length( 0 );
 	} );
 
 	test( 'should render privacy upsell without explicit privacy support', () => {
 		const mixedSupportProps = merge( {}, defaultProps, { cart: { products: [ domainProduct ] } } );
 		const wrapper = shallow( <DomainDetailsForm { ...mixedSupportProps } /> );
 
-		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 1 );
+		expect( wrapper.find( PrivacyProtection ) ).to.have.length( 1 );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/paypal-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/paypal-payment-box.js
@@ -13,6 +13,8 @@ import { identity } from 'lodash';
  * Internal dependencies
  */
 import { PaypalPaymentBox } from '../paypal-payment-box';
+import PaymentChatButton from '../payment-chat-button';
+import CheckoutTerms from '../checkout-terms';
 import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
@@ -45,23 +47,6 @@ jest.mock( 'lib/cart-values', () => ( {
 	getTaxPostalCode: () => '12345',
 } ) );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: x => x,
-	translate: x => x,
-} ) );
-
-jest.mock( '../terms-of-service', () => {
-	const react = require( 'react' );
-	return class TermsOfService extends react.Component {};
-} );
-jest.mock( '../payment-chat-button', () => {
-	const react = require( 'react' );
-	return class PaymentChatButton extends react.Component {};
-} );
-
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
-
 const defaultProps = {
 	cart: {},
 	translate: identity,
@@ -72,7 +57,7 @@ describe( 'PaypalPaymentBox', () => {
 		const wrapper = shallow( <PaypalPaymentBox { ...defaultProps } /> );
 		expect( wrapper.find( '.checkout__payment-box-sections' ) ).toHaveLength( 1 );
 		expect( wrapper.find( '.checkout__payment-box-actions' ) ).toHaveLength( 1 );
-		expect( wrapper.find( 'CheckoutTerms' ) ).toHaveLength( 1 );
+		expect( wrapper.find( CheckoutTerms ) ).toHaveLength( 1 );
 	} );
 
 	const eligiblePlans = [
@@ -93,7 +78,7 @@ describe( 'PaypalPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <PaypalPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 1 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -107,7 +92,7 @@ describe( 'PaypalPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <PaypalPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -137,7 +122,7 @@ describe( 'PaypalPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <PaypalPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/redirect-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/redirect-payment-box.js
@@ -13,6 +13,9 @@ import { identity } from 'lodash';
  * Internal dependencies
  */
 import { RedirectPaymentBox } from '../redirect-payment-box';
+import CountrySpecificPaymentFields from '../country-specific-payment-fields';
+import PaymentChatButton from '../payment-chat-button';
+import TermsOfService from '../terms-of-service';
 import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
@@ -44,23 +47,6 @@ jest.mock( 'lib/cart-values', () => ( {
 	},
 } ) );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: x => x,
-	translate: x => x,
-} ) );
-
-jest.mock( '../terms-of-service', () => {
-	const react = require( 'react' );
-	return class TermsOfService extends react.Component {};
-} );
-jest.mock( '../payment-chat-button', () => {
-	const react = require( 'react' );
-	return class PaymentChatButton extends react.Component {};
-} );
-
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
-
 const defaultProps = {
 	cart: {},
 	translate: identity,
@@ -84,7 +70,7 @@ describe( 'RedirectPaymentBox', () => {
 		const wrapper = shallow( <RedirectPaymentBox { ...defaultProps } /> );
 		expect( wrapper.find( '.checkout__payment-box-section' ) ).toHaveLength( 1 );
 		expect( wrapper.find( '.checkout__payment-box-actions' ) ).toHaveLength( 1 );
-		expect( wrapper.find( 'TermsOfService' ) ).toHaveLength( 1 );
+		expect( wrapper.find( TermsOfService ) ).toHaveLength( 1 );
 	} );
 
 	const eligiblePlans = [
@@ -105,7 +91,7 @@ describe( 'RedirectPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 1 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -119,7 +105,7 @@ describe( 'RedirectPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -149,7 +135,7 @@ describe( 'RedirectPaymentBox', () => {
 				},
 			};
 			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
-			expect( wrapper.find( 'PaymentChatButton' ) ).toHaveLength( 0 );
+			expect( wrapper.find( PaymentChatButton ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -161,7 +147,7 @@ describe( 'RedirectPaymentBox', () => {
 			};
 			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
 			expect( wrapper.find( '[name="tef-bank"]' ) ).toHaveLength( 1 );
-			expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 1 );
+			expect( wrapper.find( CountrySpecificPaymentFields ) ).toHaveLength( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
Solves problem with failing tests discovered after updating `i18n-calypso` in #37593. Worth a separate PR.

The Enzyme tests for Checkout unnecessarily mock a lot of libraries (`i18n-calypso`, `lib/user`) and many of the subcomponents that the tested components are using.

That's not necessary. This PR removes that excessive mocking, and changes tests for subcomponents by replacing
```js
wrapper.find( 'FooBar' );
```
which is unreliable, because it depends on component's display name which can be changed by `localize` or `connect`, with
```js
import FooBar from 'foobar';

wrapper.find( FooBar );
```
Direct reference to the component constructor always works and doesn't need any mocking (especially when shallow rendering)