### PR TITLE
composite-checkout: Clean up payment request/wpcom paths

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card-fields.js
@@ -7,11 +7,11 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import Field from './field';
-import GridRow from './grid-row';
-import { useLocalize } from '../lib/localize';
-import { AmexLogo, VisaLogo, MastercardLogo } from './payment-logos';
-import { useSelect, useDispatch } from '../public-api';
+import Field from '../../components/field';
+import GridRow from '../../components/grid-row';
+import { useLocalize } from '../localize';
+import { AmexLogo, VisaLogo, MastercardLogo } from '../../components/payment-logos';
+import { useSelect, useDispatch } from '../../public-api';
 
 export default function CreditCardFields( { disabled } ) {
 	const localize = useLocalize();

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -11,7 +11,7 @@ import Button from '../../components/button';
 import { useLocalize, sprintf } from '../../lib/localize';
 import { useSelect, useLineItems, renderDisplayValueMarkdown } from '../../public-api';
 import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
-import CreditCardFields from '../../components/credit-card-fields';
+import CreditCardFields from './credit-card-fields';
 import BillingFields from '../../components/billing-fields';
 
 export function createCreditCardMethod() {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -9,15 +9,15 @@ import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stri
 /**
  * Internal dependencies
  */
-import Field from './field';
-import GridRow from './grid-row';
-import Button from './button';
+import Field from '../../components/field';
+import GridRow from '../../components/grid-row';
+import Button from '../../components/button';
 import {
 	useStripe,
 	createStripePaymentMethod,
 	confirmStripePaymentIntent,
 	StripeHookProvider,
-} from '../lib/stripe';
+} from '../stripe';
 import {
 	useSelect,
 	useDispatch,
@@ -25,15 +25,15 @@ import {
 	useLineItems,
 	useCheckoutRedirects,
 	renderDisplayValueMarkdown,
-} from '../public-api';
-import useLocalize, { sprintf } from '../lib/localize';
-import { VisaLogo, AmexLogo, MastercardLogo } from './payment-logos';
-import { CreditCardLabel } from '../lib/payment-methods/credit-card';
-import BillingFields, { getDomainDetailsFromPaymentData } from '../components/billing-fields';
-import { SummaryLine, SummaryDetails } from '../lib/styled-components/summary-details';
+} from '../../public-api';
+import useLocalize, { sprintf } from '../localize';
+import { VisaLogo, AmexLogo, MastercardLogo } from '../../components/payment-logos';
+import { CreditCardLabel } from './credit-card';
+import BillingFields, { getDomainDetailsFromPaymentData } from '../../components/billing-fields';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import CreditCardFields from './credit-card-fields';
-import Spinner from './spinner';
-import ErrorMessage from './error-message';
+import Spinner from '../../components/spinner';
+import ErrorMessage from '../../components/error-message';
 
 export function createStripeMethod( {
 	registerStore,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -24,8 +24,7 @@ import {
 	useSelect,
 	useDispatch,
 } from './lib/registry';
-import WPCheckoutOrderSummary from './components/wp-checkout-order-summary';
-import WPCheckoutOrderReview from './components/wp-checkout-order-review';
+import { WPCheckoutOrderSummary, WPCheckoutOrderReview } from './wpcom/index'; // TODO: remove this
 import { createStripeMethod } from './lib/payment-methods/stripe-credit-card-fields';
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -26,7 +26,7 @@ import {
 } from './lib/registry';
 import WPCheckoutOrderSummary from './components/wp-checkout-order-summary';
 import WPCheckoutOrderReview from './components/wp-checkout-order-review';
-import { createStripeMethod } from './components/stripe-credit-card-fields';
+import { createStripeMethod } from './lib/payment-methods/stripe-credit-card-fields';
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createCreditCardMethod } from './lib/payment-methods/credit-card';

--- a/packages/composite-checkout/src/wpcom/button.js
+++ b/packages/composite-checkout/src/wpcom/button.js
@@ -1,0 +1,219 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+export default function Button( {
+	buttonState,
+	buttonType,
+	onClick,
+	className,
+	fullWidth,
+	children,
+} ) {
+	return (
+		<CallToAction
+			buttonState={ buttonState }
+			buttonType={ buttonType }
+			padding={ buttonState === 'text-button' ? '0' : '10px 15px' }
+			onClick={ onClick }
+			className={ className }
+			fullWidth={ fullWidth }
+		>
+			{ children }
+		</CallToAction>
+	);
+}
+
+Button.propTypes = {
+	buttonState: PropTypes.string,
+	buttonType: PropTypes.string,
+	onClick: PropTypes.func,
+	fullWidth: PropTypes.bool,
+};
+
+const CallToAction = styled.button`
+	display: block;
+	width: ${ props => ( props.fullWidth ? '100%' : 'auto' ) };
+	font-size: 16px;
+	border-radius: ${ props => ( props.buttonType === 'paypal' ? '50px' : '3px' ) };
+	padding: ${ props => props.padding };
+	background: ${ getBackgroundColor };
+	border-width: ${ getBorderWeight };
+	border-style: solid;
+	border-color: ${ getBorderColor };
+	color: ${ getTextColor };
+	box-shadow: ${ getBoxShadow };
+	font-weight: ${ getFontWeight };
+	text-decoration: ${ getTextDecoration };
+
+	:hover {
+		cursor: pointer;
+		background: ${ getRollOverColor };
+		border-width: ${ getBorderWeight };
+		border-style: solid;
+		border-color: ${ getRollOverBorderColor };
+		box-shadow: ${ getBoxShadowHover };
+		text-decoration: none;
+		color: ${ props =>
+			props.buttonState === 'default' ? props.theme.colors.surface : getTextColor( props ) };
+		cursor: ${ ( { buttonState } ) =>
+			buttonState && buttonState.includes( 'disabled' ) ? 'not-allowed' : 'pointer' };
+	}
+
+	:active {
+		background: ${ getBackgroundColor };
+		border-width: ${ getBorderWeight };
+		border-style: solid;
+		border-color: ${ getBorderColor };
+		box-shadow: ${ getBoxShadow }
+		text-decoration: ${ getTextDecoration };
+		color: ${ getTextColor };
+	}
+
+	img {
+		margin-bottom: -1px;
+		transform: translateY(2px);
+		filter: ${ getImageFilter }
+		opacity: ${ getImageOpacity };
+	}
+`;
+
+function getImageFilter( { buttonType, buttonState } ) {
+	return `grayscale( ${ buttonState && buttonState.includes( 'primary' ) ? 0 : 100 } ) invert( ${
+		buttonState === 'primary' && buttonType === 'apple-pay' ? '100%' : 0
+	} );`;
+}
+
+function getImageOpacity( { buttonState } ) {
+	return buttonState && buttonState.includes( 'primary' ) ? 1 : '0.5';
+}
+
+function getBoxShadow( props ) {
+	return `0 ${ getBorderWeight( props ) } 0 ${ getBorderColor( props ) }`;
+}
+
+function getBoxShadowHover( props ) {
+	return `0 ${ getBorderWeight( props ) } 0 ${ getRollOverBorderColor( props ) }`;
+}
+
+function getBorderWeight( { buttonState } ) {
+	return buttonState === 'text-button' ? '0' : '1px';
+}
+
+function getRollOverColor( { buttonState, buttonType, theme } ) {
+	const { colors } = theme;
+	switch ( buttonState ) {
+		case 'primary':
+			if ( buttonType === 'apple-pay' ) {
+				return colors.applePayButtonRollOverColor;
+			}
+			if ( buttonType === 'paypal' ) {
+				return colors.paypalGoldHover;
+			}
+			return colors.highlight;
+		case 'secondary':
+			return colors.primary;
+		case 'disabled':
+			return colors.disabledPaymentButtons;
+		case 'text-button':
+			return 'none';
+		default:
+			return colors.highlight;
+	}
+}
+
+function getRollOverBorderColor( { buttonState, buttonType, theme } ) {
+	const { colors } = theme;
+	switch ( buttonState ) {
+		case 'primary':
+			if ( buttonType === 'apple-pay' ) {
+				return colors.applePayButtonRollOverColor;
+			}
+			if ( buttonType === 'paypal' ) {
+				return colors.paypalGoldHover;
+			}
+			return colors.highlightBorder;
+		case 'secondary':
+			return colors.primaryBorder;
+		case 'disabled':
+			if ( buttonType === 'paypal' ) {
+				return colors.disabledPaymentButtons;
+			}
+			return colors.disabledButtons;
+		default:
+			return colors.highlightBorder;
+	}
+}
+
+function getTextColor( { buttonState, theme } ) {
+	const { colors } = theme;
+	switch ( buttonState ) {
+		case 'primary':
+			return colors.surface;
+		case 'secondary':
+			return colors.surface;
+		case 'text-button':
+			return colors.highlight;
+		case 'disabled':
+			return colors.disabledButtons;
+		default:
+			return colors.textColor;
+	}
+}
+
+function getBackgroundColor( { buttonType, buttonState, theme } ) {
+	const { colors } = theme;
+	switch ( buttonState ) {
+		case 'primary':
+			if ( buttonType === 'apple-pay' ) {
+				return colors.applePayButtonColor;
+			}
+			if ( buttonType === 'paypal' ) {
+				return colors.paypalGold;
+			}
+			return colors.primary;
+		case 'disabled':
+			return colors.disabledPaymentButtons;
+		case 'secondary':
+			return colors.highlight;
+		default:
+			return 'none';
+	}
+}
+
+function getBorderColor( { buttonType, buttonState, theme } ) {
+	const { colors } = theme;
+	switch ( buttonState ) {
+		case 'primary':
+			if ( buttonType === 'apple-pay' ) {
+				return colors.applePayButtonColor;
+			}
+			if ( buttonType === 'paypal' ) {
+				return colors.paypalGold;
+			}
+			return colors.primaryBorder;
+		case 'secondary':
+			return colors.highlightBorder;
+		case 'disabled':
+			if ( buttonType === 'paypal' || buttonType === 'apple-pay' ) {
+				return colors.disabledPaymentButtons;
+			}
+			return colors.disabledButtons;
+		default:
+			return colors.borderColor;
+	}
+}
+
+function getFontWeight( { buttonState, theme } ) {
+	if ( buttonState === 'disabled' || buttonState === 'text-button' ) {
+		return theme.weights.normal;
+	}
+	return theme.weights.bold;
+}
+
+function getTextDecoration( { buttonState } ) {
+	return buttonState === 'text-button' ? 'underline' : 'none';
+}

--- a/packages/composite-checkout/src/wpcom/coupon.js
+++ b/packages/composite-checkout/src/wpcom/coupon.js
@@ -9,8 +9,8 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { useLocalize } from '../lib/localize';
-import joinClasses from '../lib/join-classes';
+import { useLocalize } from '../lib/localize'; // TODO: remove this
+import joinClasses from './join-classes';
 import Field from './field';
 import Button from './button';
 

--- a/packages/composite-checkout/src/wpcom/field.js
+++ b/packages/composite-checkout/src/wpcom/field.js
@@ -1,0 +1,205 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from './button';
+
+export default function Field( {
+	type,
+	id,
+	className,
+	isError,
+	onChange,
+	label,
+	value,
+	icon,
+	iconAction,
+	isIconVisible,
+	placeholder,
+	tabIndex,
+	description,
+	errorMessage,
+	autoComplete,
+	disabled,
+} ) {
+	const fieldOnChange = event => {
+		if ( onChange ) {
+			onChange( event.target.value );
+		}
+
+		return null;
+	};
+
+	const onBlurField = () => {
+		return null;
+	};
+
+	return (
+		<div className={ className }>
+			{ label && (
+				<Label htmlFor={ id } disabled={ disabled }>
+					{ label }
+				</Label>
+			) }
+
+			<InputWrapper>
+				<Input
+					id={ id }
+					icon={ icon }
+					value={ value }
+					type={ type }
+					onChange={ fieldOnChange }
+					onBlur={ onBlurField }
+					placeholder={ placeholder }
+					tabIndex={ tabIndex }
+					isError={ isError }
+					autoComplete={ autoComplete }
+					disabled={ disabled }
+				/>
+				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
+			</InputWrapper>
+			<RenderedDescription
+				isError={ isError }
+				description={ description }
+				errorMessage={ errorMessage }
+			/>
+		</div>
+	);
+}
+
+Field.propTypes = {
+	type: PropTypes.string,
+	id: PropTypes.string.isRequired,
+	className: PropTypes.string,
+	isError: PropTypes.bool,
+	onChange: PropTypes.func,
+	label: PropTypes.string,
+	value: PropTypes.string,
+	icon: PropTypes.node,
+	iconAction: PropTypes.func,
+	isIconVisible: PropTypes.bool,
+	placeholder: PropTypes.string,
+	tabIndex: PropTypes.string,
+	description: PropTypes.string,
+	errorMessage: PropTypes.string,
+	autoComplete: PropTypes.string,
+	disabled: PropTypes.bool,
+};
+
+const Label = styled.label`
+	display: block;
+	color: ${props => props.theme.colors.textColor};
+	font-weight: ${props => props.theme.weights.bold};
+	font-size: 14px;
+	margin-bottom: 8px;
+
+	:hover {
+		cursor: ${props => ( props.disabled ? 'default' : 'pointer' )};
+	}
+`;
+
+const Input = styled.input`
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	font-size: 16px;
+	border: 1px solid
+		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
+	padding: 13px ${props => ( props.icon ? '60px' : '10px' )} 12px 10px;
+
+	:focus {
+		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
+			auto 5px !important;
+	}
+
+	::-webkit-inner-spin-button,
+	::-webkit-outer-spin-button {
+		-webkit-appearance: none;
+	}
+
+	[type='number'],
+	[type='number'] {
+		-moz-appearance: none;
+		appearance: none;
+	}
+
+	::placeholder {
+		color: ${props => props.theme.colors.placeHolderTextColor};
+	}
+
+	:disabled {
+		background: ${props => props.theme.colors.disabledField};
+	}
+`;
+
+const InputWrapper = styled.div`
+	position: relative;
+`;
+
+const FieldIcon = styled.div`
+	position: absolute;
+	top: 50%;
+	transform: translateY( -50% );
+	right: 10px;
+`;
+
+const ButtonIconUI = styled.div`
+	position: absolute;
+	top: 0;
+	right: 0;
+
+	button {
+		border: 1px solid transparent;
+		box-shadow: none;
+	}
+
+	button:hover {
+		background: none;
+		border: 1px solid transparent;
+		box-shadow: none;
+
+		filter: brightness( 0 ) saturate( 100% ) invert( 35% ) sepia( 22% ) saturate( 3465% )
+			hue-rotate( 300deg ) brightness( 88% ) contrast( 98% );
+	}
+`;
+
+const Description = styled.p`
+	margin: 8px 0 0 0;
+	color: ${props =>
+		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight};
+	font-style: italic;
+	font-size: 14px;
+`;
+
+function RenderedIcon( { icon, iconAction, isIconVisible } ) {
+	if ( ! isIconVisible ) {
+		return null;
+	}
+
+	if ( iconAction ) {
+		return (
+			<ButtonIconUI>
+				<Button onClick={ iconAction }>{ icon }</Button>
+			</ButtonIconUI>
+		);
+	}
+
+	if ( icon ) {
+		return <FieldIcon>{ icon }</FieldIcon>;
+	}
+
+	return null;
+}
+
+function RenderedDescription( { description, isError, errorMessage } ) {
+	if ( description || isError ) {
+		return <Description isError={ isError }>{ isError ? errorMessage : description }</Description>;
+	}
+	return null;
+}

--- a/packages/composite-checkout/src/wpcom/index.js
+++ b/packages/composite-checkout/src/wpcom/index.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import WPCheckoutOrderReview from './wp-checkout-order-review';
+import WPCheckoutOrderSummary from './wp-checkout-order-summary';
+
+export { WPCheckoutOrderReview, WPCheckoutOrderSummary };

--- a/packages/composite-checkout/src/wpcom/join-classes.js
+++ b/packages/composite-checkout/src/wpcom/join-classes.js
@@ -1,0 +1,3 @@
+export default function joinClasses( classNames ) {
+	return classNames.filter( x => x ).join( ' ' );
+}

--- a/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
+++ b/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
@@ -8,15 +8,10 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import joinClasses from '../lib/join-classes';
-import { useLineItems, renderDisplayValueMarkdown } from '../public-api';
-import {
-	OrderReviewLineItems,
-	OrderReviewTotal,
-	OrderReviewSection,
-} from './order-review-line-items';
+import joinClasses from './join-classes';
 import Coupon from './coupon';
 import WPTermsAndConditions from './wp-terms-and-conditions';
+import { useLineItems, renderDisplayValueMarkdown, OrderReviewLineItems, OrderReviewTotal, OrderReviewSection } from '../public-api';
 
 export default function WPCheckoutOrderReview( { className } ) {
 	const [ items, total ] = useLineItems();

--- a/packages/composite-checkout/src/wpcom/wp-checkout-order-summary.js
+++ b/packages/composite-checkout/src/wpcom/wp-checkout-order-summary.js
@@ -7,7 +7,7 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { useLocalize } from '../lib/localize';
+import { useLocalize } from '../lib/localize'; // TODO: remove this
 import { useLineItems } from '../public-api';
 import Button from './button';
 import Coupon from './coupon';

--- a/packages/composite-checkout/src/wpcom/wp-terms-and-conditions.js
+++ b/packages/composite-checkout/src/wpcom/wp-terms-and-conditions.js
@@ -9,7 +9,7 @@ import interpolateComponents from 'interpolate-components';
  * Internal dependencies
  */
 import { useHasDomainsInCart } from '../public-api';
-import { useLocalize } from '../lib/localize';
+import { useLocalize } from '../lib/localize'; // TODO: remove this
 
 export default function WPTermsAndConditions() {
 	const isDomainsTermsVisible = useHasDomainsInCart();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

So far we've been a little loose about which files are stored in which directories. This change reorganizes a few files to be in their proper places.

- We move all payment method files into `src/lib/payment-methods/`.
- We move all WPCOM files _and all their dependencies_ into `src/wpcom/`.

The first change is because payment methods are conceptually a separate part of the package. They are never used by default and must be injected into the components by the host page. However, they share dependencies with the package and can remain part of the package for now. Perhaps at some point in the future we will move them to their own package, but for now I believe the dependency sharing (particularly translations) is too valuable to throw away.

The latter change is the first step toward removing the WPCOM files from this package and moving them into Calypso. Some dependencies (`Button`, `Field`) had to be duplicated to keep the packages separate. The only dependency I did not duplicate or remove was `useLocalize`, which will need to be replaced with Calypso's `useTranslate` when it is moved. 

Once #37099 is complete, we should be able to move everything from `src/wpcom` into there and remove it from this package.

#### Testing instructions

- Add a file called `packages/composite-checkout/demo/private.js` and inside it put the following: `export const stripeKey = 'TEST KEY HERE'`;
- Run `npm run composite-checkout-demo`.
- Verify that the form works as expected.