### PR TITLE
Fix - SPT Preview - remove scrollbar and resize icon from title

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -393,6 +393,8 @@ body.is-fullscreen-mode {
 				padding: 0;
 				height: $template-large-preview-title-height;
 				line-height: $template-large-preview-title-height;
+				overflow: hidden;
+				resize: none;
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Gets rid of scrollbar and resize icon in titles of SPT Layout Preview.

#### Testing instructions

Tested on local docker environment as well as sandbox.
* Run this PR.
* Navigate to create a new page.
* Verify the SPT selector preview no longer has the scrollbar and resize icon on the right side of the title.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before**
![Screen Shot 2019-11-14 at 3 16 25 PM](https://user-images.githubusercontent.com/28742426/68893538-59b3da00-06f3-11ea-8efd-c46663520977.png)

**After**
![Screen Shot 2019-11-14 at 3 29 18 PM](https://user-images.githubusercontent.com/28742426/68893634-8e279600-06f3-11ea-9313-22d049932bf4.png)


Fixes #37287
