### PR TITLE
SPT fix sidebar Preview width in tablet mode.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -509,6 +509,10 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
+
+	.template-selector-item__label {
+		max-width: 300px;
+	}
 	
 	.template-selector-item__template-title {
 		font-size: 1.2rem;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes oversized width of SPT document sidebar preview when it becomes a fullscreen dropdown at tablet widths.

#### Testing instructions
Tested both on local docker env and dotcom sandbox.
* Run this PR.
* Navigate to the page editor.
* Open the navigation sidebar.
* Narrow the browsers screen width until this disappears or becomes the fullscreen dropdown.
* Now that you are on the width to test, re-open the navigation dropdown if necessary.
* Ensure the preview under `Page Layout` is a reasonable size.

**Before**
![Screen Shot 2019-11-14 at 3 52 51 PM](https://user-images.githubusercontent.com/28742426/68895656-c03af700-06f7-11ea-852e-8afc68cbf101.png)

**After**
![Screen Shot 2019-11-14 at 3 52 20 PM](https://user-images.githubusercontent.com/28742426/68895674-c630d800-06f7-11ea-83a5-6f8fc28746e3.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Followup to fixing: #37281
