### PR TITLE
FSE - fix close button override centration

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
@@ -9,12 +9,12 @@
 	display: flex;
 	align-items: center;
 	padding: 9px 10px;
-	margin-left: -10px;
+	margin-left: -8px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
 
 	@media ( max-width: 599px ) {
-		margin-left: -4px;
+		margin-left: -2px;
 	}
 
 	@media ( max-width: 400px ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -80,7 +80,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	top: 9px;
 	width: 36px;
 	height: 36px;
-	left: 8px;
+	left: 10px;
 }
 
 .page-template-modal .components-modal__header {
@@ -90,7 +90,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		content: ' ';
 		border-right: 1px solid #e2e4e7;
 		height: 100%;
-		left: 54px;
+		left: 56px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes centration for close button in both:
*  Close button override
*  SPT selector modal

This was super hard to notice, thanks @vindl for pointing it out.  It seemed everything was off on the left side by about 2 pixels.

#### Testing instructions
* Run this PR.
* Navigate to the page editor.
* Squint really hard and inspect the close button icon to see that it is centered in the top-left.
* Open the SPT selector modal from the sidebar or from creating a new page and verify the above.

**Before** 
![Screen Shot 2019-11-14 at 4 24 50 PM](https://user-images.githubusercontent.com/28742426/68897859-5bce6680-06fc-11ea-9d8c-226dc41e61d2.png)
![Screen Shot 2019-11-14 at 4 24 29 PM](https://user-images.githubusercontent.com/28742426/68897998-9afcb780-06fc-11ea-9dae-1b2132247bec.png)

**After**
![Screen Shot 2019-11-14 at 4 22 08 PM](https://user-images.githubusercontent.com/28742426/68897877-62f57480-06fc-11ea-9e1a-f0967f97d1f6.png)
![Screen Shot 2019-11-14 at 4 21 42 PM](https://user-images.githubusercontent.com/28742426/68898003-9e903e80-06fc-11ea-8686-25a448dda153.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes # - Followup to PRs:
* #37500
* #37234