### PR TITLE
SPT: Use "Layout" instead of "Template"

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -106,7 +106,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 		return (
 			<div className="template-selector-preview">
 				<div className="template-selector-preview__placeholder">
-					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
+					{ __( 'Select a layout to preview.', 'full-site-editing' ) }
 				</div>
 			</div>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/template-selector-preview-test.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/template-selector-preview-test.js
@@ -41,7 +41,7 @@ describe( 'TemplateSelectorPreview', () => {
 				<TemplateSelectorPreview viewportWidth={ 960 } />
 			);
 
-			expect( getByText( 'Select a page template to preview.' ) ).toBeInTheDocument();
+			expect( getByText( 'Select a layout to preview.' ) ).toBeInTheDocument();
 			expect( queryByTestId( 'block-template-preview' ) ).not.toBeInTheDocument();
 		} );
 
@@ -58,7 +58,7 @@ describe( 'TemplateSelectorPreview', () => {
 				<TemplateSelectorPreview blocks={ invalidBlocksProp } viewportWidth={ 960 } />
 			);
 
-			expect( getByText( 'Select a page template to preview.' ) ).toBeInTheDocument();
+			expect( getByText( 'Select a layout to preview.' ) ).toBeInTheDocument();
 			expect( queryByTestId( 'block-template-preview' ) ).not.toBeInTheDocument();
 		} );
 	} );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -172,7 +172,7 @@ class PageTemplateModal extends Component {
 
 		return (
 			<Modal
-				title={ __( 'Select Page Template', 'full-site-editing' ) }
+				title={ __( 'Select Page Layout', 'full-site-editing' ) }
 				className="page-template-modal"
 				overlayClassName="page-template-modal-screen-overlay"
 				shouldCloseOnClickOutside={ false }
@@ -200,17 +200,17 @@ class PageTemplateModal extends Component {
 					{ isLoading ? (
 						<div className="page-template-modal__loading">
 							<Spinner />
-							{ __( 'Inserting template…', 'full-site-editing' ) }
+							{ __( 'Adding layout…', 'full-site-editing' ) }
 						</div>
 					) : (
 						<>
 							<form className="page-template-modal__form">
 								<fieldset className="page-template-modal__list">
 									<legend className="page-template-modal__form-title">
-										{ __( 'Choose a template…', 'full-site-editing' ) }
+										{ __( 'Choose a layout…', 'full-site-editing' ) }
 									</legend>
 									<TemplateSelectorControl
-										label={ __( 'Template', 'full-site-editing' ) }
+										label={ __( 'Layout', 'full-site-editing' ) }
 										templates={ templates }
 										blocksByTemplates={ blocksByTemplateSlug }
 										onTemplateSelect={ this.previewTemplate }
@@ -241,7 +241,7 @@ class PageTemplateModal extends Component {
 						onClick={ this.handleConfirmation }
 					>
 						{ sprintf(
-							__( 'Use %s template', 'full-site-editing' ),
+							__( 'Use %s layout', 'full-site-editing' ),
 							this.getTitleByTemplateSlug( previewedTemplate )
 						) }
 					</Button>


### PR DESCRIPTION
Does not change internal names (variables, filenames, etc), just user-facing copy. IMO it would be impractical to change all of the internal names at this point.

#### Changes proposed in this Pull Request

* Use Layout instead of template:

<img width="1565" alt="Screen Shot 2019-11-14 at 3 46 30 PM" src="https://user-images.githubusercontent.com/6265975/68905497-42c2b700-06f6-11ea-8117-1d9df5eddd88.png">


#### Testing instructions
1. Pull branch to your local environment
2. Create a new page -- you should not see any instance of the word template.
3. Open SPT from an existing page -- you should not see any instance of the word template.

Fixes #
