### PR TITLE
Theme Showcase: Add Translatabilty

### DIFF
--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -298,6 +298,24 @@ class KeyedSuggestions extends React.Component {
 		let noOfSuggestions = 0;
 		const rendered = [];
 
+		const taxonomyTranslations = {
+			feature: i18n.translate( 'Feature', {
+				context: 'Theme Showcase filter name',
+			} ),
+			layout: i18n.translate( 'Layout', {
+				context: 'Theme Showcase filter name',
+			} ),
+			column: i18n.translate( 'Columns', {
+				context: 'Theme Showcase filter name',
+			} ),
+			subject: i18n.translate( 'Subject', {
+				context: 'Theme Showcase filter name',
+			} ),
+			style: i18n.translate( 'Style', {
+				context: 'Theme Showcase filter name',
+			} ),
+		};
+
 		for ( const key in suggestions ) {
 			if ( ! has( suggestions, key ) ) {
 				continue;
@@ -308,7 +326,7 @@ class KeyedSuggestions extends React.Component {
 			//Add header
 			rendered.push(
 				<div className="keyed-suggestions__category" key={ key }>
-					<span className="keyed-suggestions__category-name">{ key }</span>
+					<span className="keyed-suggestions__category-name">{ taxonomyTranslations[ key ] }</span>
 					<span className="keyed-suggestions__category-counter">
 						{ i18n.translate( '%(filtered)s of %(total)s', {
 							args: { filtered, total },

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -112,8 +112,8 @@ class KeyedSuggestions extends React.Component {
 	 * Provides keybord support for suggestings component by managing items highlith position
 	 * and calling suggestion callback when user hits Enter
 	 *
-	 * @param  {Object} event  Keybord event
-	 * @return {Bool}          true indicates suggestion was chosen and send to parent using suggest prop callback
+	 * @param  {object} event  Keybord event
+	 * @returns {boolean}      true indicates suggestion was chosen and send to parent using suggest prop callback
 	 */
 	handleKeyEvent = event => {
 		switch ( event.key ) {
@@ -161,9 +161,9 @@ class KeyedSuggestions extends React.Component {
 	 * showAll parameter if provided sidesteps the matching logic for the key value in showAll
 	 * and passes all filters for that key. For showAll also soome reordering happens - explained in code
 	 *
-	 * @param  {String}  input   text that will be matched against the taxonomies
-	 * @param  {String}  showAll taxonomy for which we want all filters
-	 * @return {Object}          filtered taxonomy:[ terms ] object
+	 * @param  {string}  input   text that will be matched against the taxonomies
+	 * @param  {string}  showAll taxonomy for which we want all filters
+	 * @returns {object}          filtered taxonomy:[ terms ] object
 	 */
 	narrowDownAndSort = ( input, showAll = '' ) => {
 		const termsTable = this.props.terms;
@@ -237,8 +237,8 @@ class KeyedSuggestions extends React.Component {
 				const regex = new RegExp( multiRegex, 'iu' );
 				filtered[ key ] = take(
 					filter(
-						map( terms[ key ], ( term, key ) =>
-							term.name.match( regex ) || term.description.match( regex ) ? key : null
+						map( terms[ key ], ( term, k ) =>
+							term.name.match( regex ) || term.description.match( regex ) ? k : null
 						)
 					),
 					limit

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { isEqual, noop, times } from 'lodash';
+import { isEqual, isEmpty, noop, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -67,6 +67,10 @@ export class ThemesList extends React.Component {
 	}
 
 	renderTheme( theme, index ) {
+		if ( isEmpty( theme ) ) {
+			return null;
+		}
+
 		return (
 			<Theme
 				key={ 'theme-' + theme.id }

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -4,7 +4,7 @@
 
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { has, identity, mapValues, pickBy } from 'lodash';
 
 /**
@@ -35,164 +35,166 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import { getCurrentUser } from 'state/current-user/selectors';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
-const purchase = config.isEnabled( 'upgrades/checkout' )
-	? {
-			label: i18n.translate( 'Purchase', {
-				context: 'verb',
-			} ),
-			extendedLabel: i18n.translate( 'Purchase this design' ),
-			header: i18n.translate( 'Purchase on:', {
-				context: 'verb',
-				comment: 'label for selecting a site for which to purchase a theme',
-			} ),
-			getUrl: getThemePurchaseUrl,
-			hideForTheme: ( state, themeId, siteId ) =>
-				isJetpackSite( state, siteId ) || // No individual theme purchase on a JP site
-				! getCurrentUser( state ) || // Not logged in
-				! isThemePremium( state, themeId ) || // Not a premium theme
-				isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
-				isThemeActive( state, themeId, siteId ), // Already active
-	  }
-	: {};
+function getAllThemeOptions() {
+	const purchase = config.isEnabled( 'upgrades/checkout' )
+		? {
+				label: translate( 'Purchase', {
+					context: 'verb',
+				} ),
+				extendedLabel: translate( 'Purchase this design' ),
+				header: translate( 'Purchase on:', {
+					context: 'verb',
+					comment: 'label for selecting a site for which to purchase a theme',
+				} ),
+				getUrl: getThemePurchaseUrl,
+				hideForTheme: ( state, themeId, siteId ) =>
+					isJetpackSite( state, siteId ) || // No individual theme purchase on a JP site
+					! getCurrentUser( state ) || // Not logged in
+					! isThemePremium( state, themeId ) || // Not a premium theme
+					isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
+					isThemeActive( state, themeId, siteId ), // Already active
+		  }
+		: {};
 
-const upgradePlan = config.isEnabled( 'upgrades/checkout' )
-	? {
-			label: i18n.translate( 'Upgrade to activate', {
-				comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
-			} ),
-			extendedLabel: i18n.translate( 'Upgrade to activate', {
-				comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
-			} ),
-			header: i18n.translate( 'Upgrade on:', {
-				context: 'verb',
-				comment: 'label for selecting a site for which to upgrade a plan',
-			} ),
-			getUrl: ( state, themeId, siteId ) =>
-				getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ),
-			hideForTheme: ( state, themeId, siteId ) =>
-				! isJetpackSite( state, siteId ) ||
-				! getCurrentUser( state ) ||
-				! isThemePremium( state, themeId ) ||
-				isThemeActive( state, themeId, siteId ) ||
-				isPremiumThemeAvailable( state, themeId, siteId ),
-	  }
-	: {};
+	const upgradePlan = config.isEnabled( 'upgrades/checkout' )
+		? {
+				label: translate( 'Upgrade to activate', {
+					comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
+				} ),
+				extendedLabel: translate( 'Upgrade to activate', {
+					comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
+				} ),
+				header: translate( 'Upgrade on:', {
+					context: 'verb',
+					comment: 'label for selecting a site for which to upgrade a plan',
+				} ),
+				getUrl: ( state, themeId, siteId ) =>
+					getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ),
+				hideForTheme: ( state, themeId, siteId ) =>
+					! isJetpackSite( state, siteId ) ||
+					! getCurrentUser( state ) ||
+					! isThemePremium( state, themeId ) ||
+					isThemeActive( state, themeId, siteId ) ||
+					isPremiumThemeAvailable( state, themeId, siteId ),
+		  }
+		: {};
 
-const activate = {
-	label: i18n.translate( 'Activate' ),
-	extendedLabel: i18n.translate( 'Activate this design' ),
-	header: i18n.translate( 'Activate on:', {
-		comment: 'label for selecting a site on which to activate a theme',
-	} ),
-	action: activateAction,
-	hideForTheme: ( state, themeId, siteId ) =>
-		! getCurrentUser( state ) ||
-		isJetpackSiteMultiSite( state, siteId ) ||
-		isThemeActive( state, themeId, siteId ) ||
-		( isThemePremium( state, themeId ) && ! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
-		( isJetpackSite( state, siteId ) && ! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ),
-};
+	const activate = {
+		label: translate( 'Activate' ),
+		extendedLabel: translate( 'Activate this design' ),
+		header: translate( 'Activate on:', {
+			comment: 'label for selecting a site on which to activate a theme',
+		} ),
+		action: activateAction,
+		hideForTheme: ( state, themeId, siteId ) =>
+			! getCurrentUser( state ) ||
+			isJetpackSiteMultiSite( state, siteId ) ||
+			isThemeActive( state, themeId, siteId ) ||
+			( isThemePremium( state, themeId ) && ! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
+			( isJetpackSite( state, siteId ) &&
+				! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ),
+	};
 
-const deleteTheme = {
-	label: i18n.translate( 'Delete' ),
-	action: confirmDelete,
-	hideForTheme: ( state, themeId, siteId, origin ) =>
-		! isJetpackSite( state, siteId ) ||
-		origin === 'wpcom' ||
-		isThemeActive( state, themeId, siteId ),
-};
+	const deleteTheme = {
+		label: translate( 'Delete' ),
+		action: confirmDelete,
+		hideForTheme: ( state, themeId, siteId, origin ) =>
+			! isJetpackSite( state, siteId ) ||
+			origin === 'wpcom' ||
+			isThemeActive( state, themeId, siteId ),
+	};
 
-const customize = {
-	label: i18n.translate( 'Customize' ),
-	extendedLabel: i18n.translate( 'Customize this design' ),
-	header: i18n.translate( 'Customize on:', {
-		comment: 'label in the dialog for selecting a site for which to customize a theme',
-	} ),
-	icon: 'customize',
-	getUrl: getCustomizeOrEditFrontPageUrl,
-	hideForTheme: ( state, themeId, siteId ) =>
-		! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
-		! isThemeActive( state, themeId, siteId ),
-};
+	const customize = {
+		label: translate( 'Customize' ),
+		extendedLabel: translate( 'Customize this design' ),
+		header: translate( 'Customize on:', {
+			comment: 'label in the dialog for selecting a site for which to customize a theme',
+		} ),
+		icon: 'customize',
+		getUrl: getCustomizeOrEditFrontPageUrl,
+		hideForTheme: ( state, themeId, siteId ) =>
+			! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
+			! isThemeActive( state, themeId, siteId ),
+	};
 
-const tryandcustomize = {
-	label: i18n.translate( 'Try & Customize' ),
-	extendedLabel: i18n.translate( 'Try & Customize' ),
-	header: i18n.translate( 'Try & Customize on:', {
-		comment: 'label in the dialog for opening the Customizer with the theme in preview',
-	} ),
-	action: tryAndCustomizeAction,
-	hideForTheme: ( state, themeId, siteId ) =>
-		! getCurrentUser( state ) ||
-		( siteId &&
-			( ! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
-				( isJetpackSite( state, siteId ) && isJetpackSiteMultiSite( state, siteId ) ) ) ) ||
-		isThemeActive( state, themeId, siteId ) ||
-		( isThemePremium( state, themeId ) &&
-			isJetpackSite( state, siteId ) &&
-			! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
-		( isJetpackSite( state, siteId ) &&
-			! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ) ||
-		isThemeGutenbergFirst( state, themeId ),
-};
+	const tryandcustomize = {
+		label: translate( 'Try & Customize' ),
+		extendedLabel: translate( 'Try & Customize' ),
+		header: translate( 'Try & Customize on:', {
+			comment: 'label in the dialog for opening the Customizer with the theme in preview',
+		} ),
+		action: tryAndCustomizeAction,
+		hideForTheme: ( state, themeId, siteId ) =>
+			! getCurrentUser( state ) ||
+			( siteId &&
+				( ! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
+					( isJetpackSite( state, siteId ) && isJetpackSiteMultiSite( state, siteId ) ) ) ) ||
+			isThemeActive( state, themeId, siteId ) ||
+			( isThemePremium( state, themeId ) &&
+				isJetpackSite( state, siteId ) &&
+				! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
+			( isJetpackSite( state, siteId ) &&
+				! isThemeAvailableOnJetpackSite( state, themeId, siteId ) ) ||
+			isThemeGutenbergFirst( state, themeId ),
+	};
 
-const preview = {
-	label: i18n.translate( 'Live demo', {
-		comment: 'label for previewing the theme demo website',
-	} ),
-	action: themePreview,
-};
+	const preview = {
+		label: translate( 'Live demo', {
+			comment: 'label for previewing the theme demo website',
+		} ),
+		action: themePreview,
+	};
 
-const signupLabel = i18n.translate( 'Pick this design', {
-	comment: 'when signing up for a WordPress.com account with a selected theme',
-} );
+	const signupLabel = translate( 'Pick this design', {
+		comment: 'when signing up for a WordPress.com account with a selected theme',
+	} );
 
-const signup = {
-	label: signupLabel,
-	extendedLabel: signupLabel,
-	getUrl: getThemeSignupUrl,
-	hideForTheme: state => getCurrentUser( state ),
-};
+	const signup = {
+		label: signupLabel,
+		extendedLabel: signupLabel,
+		getUrl: getThemeSignupUrl,
+		hideForTheme: state => getCurrentUser( state ),
+	};
 
-const separator = {
-	separator: true,
-};
+	const separator = {
+		separator: true,
+	};
 
-const info = {
-	label: i18n.translate( 'Info', {
-		comment: 'label for displaying the theme info sheet',
-	} ),
-	icon: 'info',
-	getUrl: getThemeDetailsUrl,
-};
+	const info = {
+		label: translate( 'Info', {
+			comment: 'label for displaying the theme info sheet',
+		} ),
+		icon: 'info',
+		getUrl: getThemeDetailsUrl,
+	};
 
-const support = {
-	label: i18n.translate( 'Setup' ),
-	icon: 'help',
-	getUrl: getThemeSupportUrl,
-	hideForTheme: ( state, themeId ) => ! isThemePremium( state, themeId ),
-};
+	const support = {
+		label: translate( 'Setup' ),
+		icon: 'help',
+		getUrl: getThemeSupportUrl,
+		hideForTheme: ( state, themeId ) => ! isThemePremium( state, themeId ),
+	};
 
-const help = {
-	label: i18n.translate( 'Support' ),
-	getUrl: getThemeHelpUrl,
-};
+	const help = {
+		label: translate( 'Support' ),
+		getUrl: getThemeHelpUrl,
+	};
 
-const ALL_THEME_OPTIONS = {
-	customize,
-	preview,
-	purchase,
-	upgradePlan,
-	activate,
-	tryandcustomize,
-	deleteTheme,
-	signup,
-	separator,
-	info,
-	support,
-	help,
-};
-
+	return {
+		customize,
+		preview,
+		purchase,
+		upgradePlan,
+		activate,
+		tryandcustomize,
+		deleteTheme,
+		signup,
+		separator,
+		info,
+		support,
+		help,
+	};
+}
 export const connectOptions = connect(
 	( state, { siteId, origin = siteId } ) => {
 		let mapGetUrl = identity,
@@ -207,7 +209,7 @@ export const connectOptions = connect(
 			mapHideForTheme = hideForTheme => ( t, s ) => hideForTheme( state, t, s, origin );
 		}
 
-		return mapValues( ALL_THEME_OPTIONS, option =>
+		return mapValues( getAllThemeOptions(), option =>
 			Object.assign(
 				{},
 				option,
@@ -218,7 +220,7 @@ export const connectOptions = connect(
 		/* eslint-enable wpcalypso/redux-no-bound-selectors */
 	},
 	( dispatch, { siteId, source = 'unknown' } ) => {
-		const options = pickBy( ALL_THEME_OPTIONS, 'action' );
+		const options = pickBy( getAllThemeOptions(), 'action' );
 		let mapAction;
 
 		if ( siteId ) {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -177,7 +177,6 @@
 	margin: 0;
 	font-size: 13px;
 	line-height: 16px;
-	text-transform: capitalize;
 	cursor: pointer;
 	color: var( --color-neutral-70 );
 	transition: all 200ms ease-in;

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -47,8 +47,8 @@ class MagicSearchWelcome extends React.Component {
 	 * Provides keybord support for component by managing items highlith position
 	 * and calling suggestion callback when user hits Enter
 	 *
-	 * @param  {Object} event  Keybord event
-	 * @return {Bool}          true indicates suggestion was chosen and send to parent using suggestionsCallback prop callback
+	 * @param  {object} event  Keybord event
+	 * @returns {boolean}      true indicates suggestion was chosen and send to parent using suggestionsCallback prop callback
 	 */
 	handleKeyEvent = event => {
 		const position = this.state.suggestionPosition;

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -23,7 +23,7 @@ class MagicSearchWelcome extends React.Component {
 	state = { suggestionPosition: -1 };
 
 	onMouseDown = event => {
-		this.props.suggestionsCallback( event.target.textContent + ':' );
+		this.props.suggestionsCallback( event.target.getAttribute( 'data-key' ) + ':' );
 		event.stopPropagation();
 		event.preventDefault();
 	};
@@ -106,6 +106,7 @@ class MagicSearchWelcome extends React.Component {
 				className={ themesTokenTypeClass }
 				onMouseDownCapture={ this.onMouseDown }
 				key={ taxonomy }
+				data-key={ taxonomy }
 			>
 				<Gridicon
 					icon={ taxonomyToGridicon( taxonomy ) }

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -51,6 +51,7 @@ class MagicSearchWelcome extends React.Component {
 	 * @return {Bool}          true indicates suggestion was chosen and send to parent using suggestionsCallback prop callback
 	 */
 	handleKeyEvent = event => {
+		const position = this.state.suggestionPosition;
 		switch ( event.key ) {
 			case 'ArrowDown':
 				this.movePositionBy( +1 );
@@ -61,7 +62,6 @@ class MagicSearchWelcome extends React.Component {
 				event.preventDefault();
 				break;
 			case 'Enter':
-				const position = this.state.suggestionPosition;
 				if ( position !== -1 ) {
 					this.props.suggestionsCallback( this.visibleTaxonomies[ position ] + ':' );
 					event.stopPropagation();
@@ -83,6 +83,24 @@ class MagicSearchWelcome extends React.Component {
 			}
 		);
 
+		const taxonomyTranslations = {
+			feature: i18n.translate( 'Feature', {
+				context: 'Theme Showcase filter name',
+			} ),
+			layout: i18n.translate( 'Layout', {
+				context: 'Theme Showcase filter name',
+			} ),
+			column: i18n.translate( 'Columns', {
+				context: 'Theme Showcase filter name',
+			} ),
+			subject: i18n.translate( 'Subject', {
+				context: 'Theme Showcase filter name',
+			} ),
+			style: i18n.translate( 'Style', {
+				context: 'Theme Showcase filter name',
+			} ),
+		};
+
 		return (
 			<div
 				className={ themesTokenTypeClass }
@@ -94,7 +112,10 @@ class MagicSearchWelcome extends React.Component {
 					className="themes-magic-search-card__welcome-taxonomy-icon"
 					size={ 18 }
 				/>
-				{ taxonomy }
+				{ taxonomyTranslations[ taxonomy ] ||
+					i18n.translate( 'Unknown', {
+						context: 'Theme Showcase filter name',
+					} ) }
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix a crash when an empty theme is returned from the API.
* Make the Theme filter names transatable.

Before:

<img width="1357" alt="Screenshot 2019-11-15 at 21 14 22" src="https://user-images.githubusercontent.com/203408/68972824-f4dcaa80-07ec-11ea-9445-fa31b356a4eb.png">

<img width="476" alt="Screenshot 2019-11-15 at 21 14 27" src="https://user-images.githubusercontent.com/203408/68972829-f6a66e00-07ec-11ea-8716-24898f7b447c.png">

After:

<img width="1059" alt="Screenshot 2019-11-15 at 21 01 58" src="https://user-images.githubusercontent.com/203408/68972063-3a987380-07eb-11ea-8a3f-9b27283c367a.png">

<img width="322" alt="Screenshot 2019-11-15 at 21 12 10" src="https://user-images.githubusercontent.com/203408/68972700-b2b36900-07ec-11ea-827b-565784055d2d.png">

