### PR TITLE
Gutenboarding: Correct SiteTypeSelect options style

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/site-type-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/site-type-select/style.scss
@@ -33,7 +33,8 @@
 	}
 
 	.onboarding-block__multi-question-choice {
-		border-bottom: 3px solid transparent;
+		color: $blue-medium-900;
+		border-bottom: 3px solid $blue-medium-900;
 		cursor: pointer;
 		margin: 0 0 0 0.2em;
 		transition-property: border-color;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- change options color to look like links
- add solid color underline as suggested by design

#### Before:
<img width="754" alt="Screenshot 2019-11-15 at 14 35 38" src="https://user-images.githubusercontent.com/14192054/68944094-b24bab80-07b5-11ea-8485-da1a91c7166f.png">

#### After:
<img width="792" alt="Screenshot 2019-11-15 at 14 35 09" src="https://user-images.githubusercontent.com/14192054/68944101-b5df3280-07b5-11ea-900e-501df299cdda.png">