### PR TITLE
Build: Reorganize tsconfig and add gutenboarding-specific

### DIFF
--- a/client/landing/gutenboarding/tsconfig.json
+++ b/client/landing/gutenboarding/tsconfig.json
@@ -1,9 +1,8 @@
 {
-	"extends": "./base",
+	"extends": "../../../tsconfig/base",
 	"compilerOptions": {
 		// Disallow features that require cross-file information for emit.
 		// Must be used with babel typescript
 		"isolatedModules": true
-	},
-	"files": [ "../client/landing/gutenboarding/index" ]
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,44 +1,13 @@
 {
+	"extends": "./tsconfig/base",
 	"compilerOptions": {
-		// Target latest version of ECMAScript.
-		"target": "esnext",
-		// Search under node_modules for non-relative imports.
-		"moduleResolution": "node",
-		// Process & infer types from .js files.
-		"allowJs": true,
-		"jsx": "react",
-		// Don't emit; allow Babel to transform files.
-		"noEmit": true,
-		// Enable strictest settings like strictNullChecks & noImplicitAny.
-		"strict": true,
 		// Disallow features that require cross-file information for emit.
+		// Must be used with babel typescript
 		"isolatedModules": true,
-		// Import non-ES modules as default imports.
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"module": "es2015",
-		"baseUrl": ".",
+
 		"paths": {
 			"*": [ "*", "client/*", "server/*" ]
 		}
 	},
-	"include": [ "client", "server" ],
-	"exclude": [
-		"**/build-module/*",
-		"**/build-style/*",
-		"**/build/*",
-		"**/dist/*",
-		"**/node_modules/*",
-		"apps",
-		"build",
-		"cached-results.json",
-		"packages",
-		"public",
-		"server/bundler/assets*.json",
-		"server/devdocs/components-usage-stats.json",
-		"server/devdocs/proptypes-index.json",
-		"server/devdocs/search-index.js",
-		"stats.json"
-	],
-	"types": [ "webpack-env" ]
+	"include": [ "client", "server" ]
 }

--- a/tsconfig/base.json
+++ b/tsconfig/base.json
@@ -1,0 +1,39 @@
+{
+	"compilerOptions": {
+		// Target latest version of ECMAScript.
+		"target": "esnext",
+		// Search under node_modules for non-relative imports.
+		"moduleResolution": "node",
+		// Process & infer types from .js files.
+		"allowJs": true,
+		"jsx": "react",
+		// Don't emit; allow Babel to transform files.
+		"noEmit": true,
+		// Enable strictest settings like strictNullChecks & noImplicitAny.
+		"strict": true,
+		// Import non-ES modules as default imports.
+		"esModuleInterop": true,
+		"skipLibCheck": false,
+		"module": "esnext",
+		"baseUrl": ".."
+	},
+	"files": [ "client/landing/gutenboarding/index.ts" ],
+	"exclude": [
+		"**/build-module/*",
+		"**/build-style/*",
+		"**/build/*",
+		"**/dist/*",
+		"**/node_modules/*",
+		"apps",
+		"build",
+		"cached-results.json",
+		"packages",
+		"public",
+		"server/bundler/assets*.json",
+		"server/devdocs/components-usage-stats.json",
+		"server/devdocs/proptypes-index.json",
+		"server/devdocs/search-index.js",
+		"stats.json"
+	],
+	"types": [ "webpack-env" ]
+}

--- a/tsconfig/base.json
+++ b/tsconfig/base.json
@@ -17,7 +17,6 @@
 		"module": "esnext",
 		"baseUrl": ".."
 	},
-	"files": [ "client/landing/gutenboarding/index.ts" ],
 	"exclude": [
 		"**/build-module/*",
 		"**/build-style/*",

--- a/tsconfig/gutenboarding.json
+++ b/tsconfig/gutenboarding.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./base",
+	"compilerOptions": {
+		// Disallow features that require cross-file information for emit.
+		// Must be used with babel typescript
+		"isolatedModules": true
+	},
+	"files": [ "../client/landing/gutenboarding/index" ]
+}


### PR DESCRIPTION
Reorganize `tsconfg` into:
- A main `tsconfig.json` file in the repository root. It extends from `tsconfig/base.json`.
- Most of the general configuration has been moved to `tsconfig/base.json` for easy extensibility.
- Adds `tsconfig/gutenboarding.json`: this prototypes how a project can extend the base configuration.

Nothing changes with how the application is built or runs, just the configuration organization. This adds the possibility of typechecking the `gutenboarding` project.

## Testing

No functional changes.

A project specific typecheck can be run:

```sh
npm run typecheck -- --project tsconfig/gutenboarding.json
```

[Check the `typecheck` job](https://circleci.com/gh/Automattic/wp-calypso/515603), it should report the same output as [current `master`](https://circleci.com/gh/Automattic/wp-calypso/515527).