### PR TITLE
Starter Page Templates: Update modal and preview positioning

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -24,6 +24,12 @@ $template-large-preview-title-height: 120px;
 $wp-org-sidebar-reduced: 36px;
 $wp-org-sidebar-full: 160px;
 
+// Preview positioning
+$preview-max-width: 960px;
+$preview-right-margin: 24px;
+$preview-left-sidebar-reduced: calc( 30% + #{$wp-org-sidebar-reduced} );
+$preview-left-sidebar-full: calc( 30% + #{$wp-org-sidebar-full} );
+
 // Modal Overlay
 .page-template-modal-screen-overlay {
 	animation: none;
@@ -351,10 +357,18 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 	}
 
+	@media screen and ( min-width: 1648px ) {
+		right: unset;
+		left: calc( #{$preview-left-sidebar-full} + ( 100vw - #{$preview-left-sidebar-full} - #{$preview-max-width} - #{$preview-right-margin} ) / 2 );
+		body.folded & {
+			left: calc( #{$preview-left-sidebar-reduced} + ( 100vw - #{$preview-left-sidebar-reduced} - #{$preview-max-width} - #{$preview-right-margin} ) / 2 );
+		}
+	}
+
 	position: fixed;
 	top: 111px;
 	bottom: 24px;
-	right: 24px;
+	right: $preview-right-margin;
 	width: calc( 80% - 50px );
 	background: $template-selector-empty-background;
 	border-radius: 2px;
@@ -430,6 +444,8 @@ body:not( .is-fullscreen-mode ) {
 // Tweak styles which are inside of the preview container.
 .block-editor-block-preview__container,
 .template-selector-preview {
+	max-width: $preview-max-width;
+
 	.editor-styles-wrapper {
 		.wp-block {
 			width: 100%;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -125,13 +125,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	@media screen and ( min-width: 1200px ) {
 		max-width: 100%;
 	}
-
-	@media screen and ( min-width: 1441px ) {
-		max-width: 1440px;
-		display: flex;
-		align-content: flex-start;
-		justify-content: space-between;
-	}
 }
 
 .page-template-modal__list {
@@ -306,10 +299,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	@media screen and ( min-width: 783px ) {
 		max-width: 30%;
 	}
-
-	@media screen and ( min-width: 1441px ) {
-		width: 30%;
-	}
 }
 
 .page-template-modal__form-title {
@@ -352,12 +341,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 	@media screen and ( min-width: 783px ) {
 		width: calc( 70% - 50px );
-	}
-
-	@media screen and ( min-width: 1441px ) {
-		position: unset;
-		width: calc( 70% - 84px );
-		height: calc( 100vh - 130px );
 	}
 
 	@media screen and ( min-width: 660px ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -31,13 +31,23 @@ $wp-org-sidebar-full: 160px;
 }
 
 // When not in fullscreen mode allow space for WP.org sidebar
-body:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
-	@media screen and ( min-width: 783px ) {
-		left: $wp-org-sidebar-reduced;
-	}
+body:not( .is-fullscreen-mode ) {
+	.page-template-modal-screen-overlay {
+		@media screen and ( min-width: 783px ) {
+			left: $wp-org-sidebar-reduced;
+		}
 
-	@media screen and ( min-width: 961px ) {
-		left: $wp-org-sidebar-full;
+		@media screen and ( min-width: 961px ) {
+			left: $wp-org-sidebar-full;
+		}
+	}
+	@media screen and ( min-width: 783px ) {
+		&.folded .page-template-modal-screen-overlay {
+			left: $wp-org-sidebar-reduced;
+		}
+		&:not( .folded ):not( .auto-fold ) .page-template-modal-screen-overlay {
+			left: $wp-org-sidebar-full;
+		}
 	}
 }
 
@@ -407,17 +417,23 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 }
 
-body:not( .is-fullscreen-mode ) .template-selector-preview {
+body:not( .is-fullscreen-mode ) {
+	.template-selector-preview {
+		@media screen and ( min-width: 783px ) {
+			width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
+		}
+
+		@media screen and ( min-width: 961px ) {
+			width: calc( 70% - #{$wp-org-sidebar-full } );
+		}
+	}
 	@media screen and ( min-width: 783px ) {
-		width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
-	}
-
-	@media screen and ( min-width: 961px ) {
-		width: calc( 70% - #{$wp-org-sidebar-full } );
-	}
-
-	@media screen and ( min-width: 1441px ) {
-		width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
+		&.folded .template-selector-preview {
+			width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
+		}
+		&:not( .folded ):not( .auto-fold ) .template-selector-preview {
+			width: calc( 70% - #{$wp-org-sidebar-full } );
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reposition the modal taking into account all possible (non-mobile) wp-admin sidebar widths (open, closed, small screen, large screen, and combinations thereof).
* Make the layout preview fixed on large screens (`>1440px`) as well, and center align in the available space.

Note: the preview relies on a fixed `960px` width to calculate the scaling, and for this reason I haven't changed the width to occupay all the available space.

<img width="1907" alt="Screenshot 2019-11-15 at 14 20 50" src="https://user-images.githubusercontent.com/2070010/68950105-60a22180-07b3-11ea-80e7-44f33d676512.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR and build the Full Site Editing plugin on an (WPORG) FSE test site.
* Create a new page and make sure the SPT selector looks as expected.
* Try resizing the browser window so that the sidebar folds or expands, and make sure the SPT selector never covers it, or is not close to it.
* Also try folding and expanding the sidebar as well.
* Apply the all home templates diff (D35170-code) and sandbox the API, in order to show many layouts in the selector.
* Expand the browser window to >1440px, and try scrolling down a bit.
* Make sure the preview stays fixed in its place.

Fix #37634