### PR TITLE
Pages: Add an "unset posts page" action to the pages list

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -248,21 +248,20 @@ class Page extends Component {
 		];
 	}
 
-	setPostsPage = () =>
+	setPostsPage = pageId => () =>
 		this.props.updateSiteFrontPage( this.props.siteId, {
 			show_on_front: 'page',
-			page_for_posts: this.props.page.ID,
+			page_for_posts: pageId,
 		} );
 
 	getPostsPageItem() {
-		const { canManageOptions, isFullSiteEditing, translate } = this.props;
+		const { canManageOptions, isFullSiteEditing, page, translate } = this.props;
 
 		if (
 			! canManageOptions ||
 			isFullSiteEditing ||
 			! this.props.hasStaticFrontPage ||
-			'publish' !== this.props.page.status ||
-			this.props.isPostsPage ||
+			'publish' !== page.status ||
 			this.props.isFrontPage
 		) {
 			return null;
@@ -270,10 +269,18 @@ class Page extends Component {
 
 		return [
 			<MenuSeparator key="separator" />,
-			<PopoverMenuItem key="item" onClick={ this.setPostsPage }>
-				<Gridicon icon="posts" size={ 18 } />
-				{ translate( 'Set as Posts Page' ) }
-			</PopoverMenuItem>,
+			this.props.isPostsPage && (
+				<PopoverMenuItem key="item" onClick={ this.setPostsPage( 0 ) }>
+					<Gridicon icon="undo" size={ 18 } />
+					{ translate( 'Set as Normal Page' ) }
+				</PopoverMenuItem>
+			),
+			! this.props.isPostsPage && (
+				<PopoverMenuItem key="item" onClick={ this.setPostsPage( page.ID ) }>
+					<Gridicon icon="posts" size={ 18 } />
+					{ translate( 'Set as Posts Page' ) }
+				</PopoverMenuItem>
+			),
 		];
 	}
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -272,7 +272,7 @@ class Page extends Component {
 			this.props.isPostsPage && (
 				<PopoverMenuItem key="item" onClick={ this.setPostsPage( 0 ) }>
 					<Gridicon icon="undo" size={ 18 } />
-					{ translate( 'Set as Normal Page' ) }
+					{ translate( 'Set as Regular Page' ) }
 				</PopoverMenuItem>
 			),
 			! this.props.isPostsPage && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a "Set as Normal Page" action to the Pages list to unset the "latest posts" page (which also makes it deletable again).

<img width="916" alt="Screenshot 2019-11-15 at 16 29 14" src="https://user-images.githubusercontent.com/2070010/68958994-20e43580-07c5-11ea-839e-dbc853de5329.png">

This is especially important in Full Site Editing context, as it prevents accessing the Customizer, and automatically displays all pages in the Navigation Menu.

#### Notes

This is currently pending copy review (cc @benhuberman, pinged on Slack)

I've used the `undo` [Gridicon](http://automattic.github.io/gridicons/), but I'm totally open to suggestions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pick a site with a static front page (you can make it in Customizer -> Homepage Settings).
* Navigate to the `/pages` list.
* Select a page (not the posts page, if already set), and click **Set as Posts Page** in the actions menu.
* Make sure the page is now labeled as **Your latest posts**.
* Reload and make sure the change sticks.
* Open the actions menu again, and click **Set as Normal Page**.
* Make sure the page is now unlabeled.
* Reload and make sure the change sticks.

Fixes #37618