### PR TITLE
Checkout: Update Thank You page CTA to return to plugins or themes (feature flagged)

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -26,6 +26,7 @@ import { localize } from 'i18n-calypso';
 import { preventWidows } from 'lib/formatting';
 import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
+import getCheckoutUpgradeIntent from 'state/selectors/get-checkout-upgrade-intent';
 
 class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -268,14 +269,27 @@ class CheckoutThankYouHeader extends PureComponent {
 	};
 
 	getButtonText = () => {
-		const { translate, hasFailedPurchases, primaryPurchase, displayMode } = this.props;
-		const site = this.props.selectedSite.slug;
+		const {
+			displayMode,
+			hasFailedPurchases,
+			primaryPurchase,
+			selectedSite,
+			translate,
+			upgradeIntent,
+		} = this.props;
+
+		switch ( upgradeIntent ) {
+			case 'plugins':
+				return translate( 'Continue Installing Plugin' );
+			case 'themes':
+				return translate( 'Continue Installing Theme' );
+		}
 
 		if ( 'concierge' === displayMode ) {
 			return translate( 'Schedule my session' );
 		}
 
-		if ( ! site && hasFailedPurchases ) {
+		if ( ! selectedSite?.slug && hasFailedPurchases ) {
 			return translate( 'Register domain' );
 		}
 
@@ -373,7 +387,12 @@ class CheckoutThankYouHeader extends PureComponent {
 	}
 }
 
-export default connect( null, {
-	recordStartTransferClickInThankYou,
-	recordTracksEvent,
-} )( localize( CheckoutThankYouHeader ) );
+export default connect(
+	state => ( {
+		upgradeIntent: getCheckoutUpgradeIntent( state ),
+	} ),
+	{
+		recordStartTransferClickInThankYou,
+		recordTracksEvent,
+	}
+)( localize( CheckoutThankYouHeader ) );

--- a/client/state/selectors/get-checkout-upgrade-intent.js
+++ b/client/state/selectors/get-checkout-upgrade-intent.js
@@ -1,0 +1,9 @@
+/**
+ * Retrieve the "intent" that the client implied prior to upgrading so we can send them to the appropriate route after checkout
+ *
+ * @param {object} state  Global state tree
+ * @returns {string} The intent signaled by the customer for upgrade purposes
+ */
+export default function getCheckoutUpgradeIntent( state ) {
+	return state?.ui?.checkout?.upgradeIntent || '';
+}

--- a/client/state/selectors/get-checkout-upgrade-intent.js
+++ b/client/state/selectors/get-checkout-upgrade-intent.js
@@ -1,9 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+
+/**
  * Retrieve the "intent" that the client implied prior to upgrading so we can send them to the appropriate route after checkout
  *
  * @param {object} state  Global state tree
  * @returns {string} The intent signaled by the customer for upgrade purposes
  */
 export default function getCheckoutUpgradeIntent( state ) {
-	return state?.ui?.checkout?.upgradeIntent || '';
+	// This is gated by a config flag while we wait for translations
+	return ( isEnabled( 'checkout-upgrade-intent' ) && state?.ui?.checkout?.upgradeIntent ) || '';
 }

--- a/client/state/selectors/test/get-checkout-upgrade-intent.js
+++ b/client/state/selectors/test/get-checkout-upgrade-intent.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import getCheckoutUpgradeIntent from '../get-checkout-upgrade-intent';
+
+describe( 'getCheckoutUpgradeIntent()', () => {
+	test( 'should return empty string when undefined', () => {
+		expect( getCheckoutUpgradeIntent( {} ) ).toBe( '' );
+	} );
+
+	test( 'should return value', () => {
+		expect(
+			getCheckoutUpgradeIntent( {
+				ui: {
+					checkout: {
+						upgradeIntent: 'phoenix feather',
+					},
+				},
+			} )
+		).toBe( 'phoenix feather' );
+	} );
+} );

--- a/client/state/ui/checkout/reducer.js
+++ b/client/state/ui/checkout/reducer.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
-import { CHECKOUT_TOGGLE_CART_ON_MOBILE } from 'state/action-types';
+import { combineReducers, withSchemaValidation } from 'state/utils';
+import { CHECKOUT_TOGGLE_CART_ON_MOBILE, SECTION_SET } from 'state/action-types';
 
-function isShowingCartOnMobile( state = false, action ) {
+export function isShowingCartOnMobile( state = false, action ) {
 	switch ( action.type ) {
 		case CHECKOUT_TOGGLE_CART_ON_MOBILE:
 			return ! state;
@@ -13,6 +13,30 @@ function isShowingCartOnMobile( state = false, action ) {
 	}
 }
 
+export const upgradeIntent = withSchemaValidation( { type: 'string' }, ( state = '', action ) => {
+	if ( action.type !== SECTION_SET ) {
+		return state;
+	}
+
+	if ( action.isLoading || ! action.section?.name ) {
+		// Leave the intent alone until the new section is fully loaded
+		return state;
+	}
+
+	if ( [ 'checkout', 'checkout-thank-you', 'plans' ].includes( action.section.name ) ) {
+		// Leave the intent alone for sections that should not clear it
+		return state;
+	}
+
+	if ( [ 'plugins', 'themes' ].includes( action.section.name ) ) {
+		return action.section.name;
+	}
+
+	// Clear the intent when any other section is loaded
+	return '';
+} );
+
 export default combineReducers( {
 	isShowingCartOnMobile,
+	upgradeIntent,
 } );

--- a/client/state/ui/checkout/test/reducer.js
+++ b/client/state/ui/checkout/test/reducer.js
@@ -1,0 +1,121 @@
+/**
+ * Internal dependencies
+ */
+import {
+	CHECKOUT_TOGGLE_CART_ON_MOBILE,
+	DESERIALIZE,
+	SECTION_SET,
+	SERIALIZE,
+} from 'state/action-types';
+import reducer, { isShowingCartOnMobile, upgradeIntent } from '../reducer';
+
+describe( 'reducer', () => {
+	test( 'should include expected keys in return value', () => {
+		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual( [
+			'isShowingCartOnMobile',
+			'upgradeIntent',
+		] );
+	} );
+
+	describe( '#isShowingCartOnMobile', () => {
+		test( 'should default to false', () => {
+			const state = isShowingCartOnMobile( undefined, {} );
+			expect( state ).toBeFalse;
+		} );
+
+		test( 'should be true after toggle when false', () => {
+			const state = isShowingCartOnMobile( false, { type: CHECKOUT_TOGGLE_CART_ON_MOBILE } );
+			expect( state ).toBeTrue;
+		} );
+
+		test( 'should be false after toggle when true', () => {
+			const state = isShowingCartOnMobile( true, { type: CHECKOUT_TOGGLE_CART_ON_MOBILE } );
+			expect( state ).toBeFalse;
+		} );
+
+		test( 'should be unchanged after other action', () => {
+			const state = isShowingCartOnMobile( true, { type: 'WRONSKI_FEINT' } );
+			expect( state ).toBeTrue;
+		} );
+	} );
+
+	describe( '#upgradeIntent()', () => {
+		test( 'should persist value', () => {
+			const state = upgradeIntent( 'hallows', { type: SERIALIZE } );
+			expect( state ).toBe( 'hallows' );
+		} );
+
+		test( 'should restore value', () => {
+			const state = upgradeIntent( 'always', { type: DESERIALIZE } );
+			expect( state ).toBe( 'always' );
+		} );
+
+		test( 'should default to empty string', () => {
+			const state = upgradeIntent( undefined, {} );
+			expect( state ).toBe( '' );
+		} );
+
+		test( 'should return existing state for unsupported action type', () => {
+			const state = upgradeIntent( 'penseive', { type: 'EXPECTO_PATRONUM' } );
+			expect( state ).toBe( 'penseive' );
+		} );
+
+		test( 'should return existing state without section name', () => {
+			const state = upgradeIntent( 'time turner', { type: SECTION_SET } );
+			expect( state ).toBe( 'time turner' );
+		} );
+
+		test( 'should return existing state while loading', () => {
+			const state = upgradeIntent( 'quaffle', { type: SECTION_SET, isLoading: true } );
+			expect( state ).toBe( 'quaffle' );
+		} );
+
+		test( 'should return existing state for checkout', () => {
+			const state = upgradeIntent( 'bludger', {
+				type: SECTION_SET,
+				section: { name: 'checkout' },
+			} );
+			expect( state ).toBe( 'bludger' );
+		} );
+
+		test( 'should return existing state for checkout-thank-you', () => {
+			const state = upgradeIntent( 'snitch', {
+				type: SECTION_SET,
+				section: { name: 'checkout-thank-you' },
+			} );
+			expect( state ).toBe( 'snitch' );
+		} );
+
+		test( 'should return existing state for plans', () => {
+			const state = upgradeIntent( 'nimbus', {
+				type: SECTION_SET,
+				section: { name: 'plans' },
+			} );
+			expect( state ).toBe( 'nimbus' );
+		} );
+
+		test( 'should return plugins for plugins', () => {
+			const state = upgradeIntent( 'firebolt', {
+				type: SECTION_SET,
+				section: { name: 'plugins' },
+			} );
+			expect( state ).toBe( 'plugins' );
+		} );
+
+		test( 'should return themes for themes', () => {
+			const state = upgradeIntent( 'hippogryph', {
+				type: SECTION_SET,
+				section: { name: 'themes' },
+			} );
+			expect( state ).toBe( 'themes' );
+		} );
+
+		test( 'should return empty string for other section', () => {
+			const state = upgradeIntent( 'plugins', {
+				type: SECTION_SET,
+				section: { name: 'restricted section' },
+			} );
+			expect( state ).toBe( '' );
+		} );
+	} );
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -34,6 +34,7 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
+		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/test.json
+++ b/config/test.json
@@ -31,6 +31,7 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
+		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,6 +24,7 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
+		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
This is a step toward an improved upgrade flow & will enable us to get customers back to the task they were attempting to accomplish when they were nudged to upgrade so they can accomplish their goals more quickly.

Namely, if a customer signals intent to install a plugin or theme, they get directed back to that section. If no signal is recorded (e.g. the upgrade flow originated via another section), the existing behavior is still applied.

|Before|After|
|---|---|
|<img width="970" alt="Screen Shot 2019-11-15 at 12 17 43 PM" src="https://user-images.githubusercontent.com/1587282/68962151-f339c500-07a1-11ea-83f8-e1a89ba071fd.png">|<img width="976" alt="Screen Shot 2019-11-15 at 12 13 14 PM" src="https://user-images.githubusercontent.com/1587282/68961908-61ca5300-07a1-11ea-944e-926dd4d28487.png">|

This is pulled out of the larger effort to improve this flow in #37574 so we can consider this change independently.

#### Changes proposed in this Pull Request

* New config flag `checkout-upgrade-intent` enabled in: test, development, wpcalypso, & horizon envs
* New state node `state.ui.checkout.upgradeIntent` populated via `SECTION_SET` actions
* Selector for the above
  * Returns empty string (default) when the config flag is not enabled
* Update button text & CTA redirect location when intent is present (to send to plugin / theme sections)
* Name `siteSlug` variable appropriately
* Tidy a couple of places where we had "if, return, else if"s
* Tests:
  * `ui.checkout.upgradeIntent` reducer
  * `getCheckoutUpgradeIntent` selector
  * `isShowingCartOnMobile` (the other reducer node in `ui.checkout` since it was super quick & was uncovered)

#### Testing instructions

##### Run Automated Tests

`npm run test-client "client/state/(ui/checkout|selectors/test/get-checkout-upgrade-intent)"`

##### Manually test

* Browse to the plugins section (`/plugins`) for a free plan site
* Click the CTA to upgrade to the Business plan
* Complete the upgrade flow
  * On the "Thank you" page, you should see a CTA to `Continue installing plugin`
  * Clicking the CTA should take you to the plugins section

* Repeat the above from the themes section (`/themes`)
  * On the "Thank you" page, you should see a CTA to `Continue installing theme`
  * Clicking the CTA should take you to the themes section

* Repeat the above, but browse to some non-plugin / non-themes section
* Click the `Plans` sidebar item
* Click the CTA to upgrade to the Business plan
* Complete the upgrade flow
  * On the "Thank you" page, the CTA should behave as it does in production (e.g. to `Go to My Site`)
