### PR TITLE
Use native URL in several media modules.

### DIFF
--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -43,8 +43,7 @@ export class Gravatar extends Component {
 	getResizedImageURL( imageURL ) {
 		const { imgSize } = this.props;
 		imageURL = imageURL || 'https://www.gravatar.com/avatar/0';
-		const parsedURL = getUrlParts( imageURL );
-		delete parsedURL.search;
+		const { search, ...parsedURL } = getUrlParts( imageURL );
 
 		if ( /^([-a-zA-Z0-9_]+\.)*(gravatar.com)$/.test( parsedURL.hostname ) ) {
 			parsedURL.searchParams.set( 's', imgSize );

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -52,7 +52,7 @@ jest.mock( 'lib/redux-bridge', () => ( {
 } ) );
 
 describe( 'MediaActions', () => {
-	let MediaActions, sandbox, Dispatcher, MediaListStore;
+	let MediaActions, sandbox, Dispatcher, MediaListStore, savedCreateObjectURL;
 
 	beforeAll( function() {
 		Dispatcher = require( 'dispatcher' );
@@ -75,14 +75,15 @@ describe( 'MediaActions', () => {
 		MediaActions._fetching = {};
 		window.FileList = function() {};
 		window.FileList.prototype[ Symbol.iterator ] = Array.prototype[ Symbol.iterator ];
-		window.URL = { createObjectURL: sandbox.stub() };
+		savedCreateObjectURL = window.URL.createObjectURL;
+		window.URL.createObjectURL = sandbox.stub();
 		mockReduxPostId = null;
 	} );
 
 	afterEach( () => {
 		sandbox.restore();
 		delete window.FileList;
-		delete window.URL;
+		window.URL.createObjectURL = savedCreateObjectURL;
 	} );
 
 	describe( '#setQuery()', () => {
@@ -98,27 +99,29 @@ describe( 'MediaActions', () => {
 	} );
 
 	describe( '#fetch()', () => {
-		test( 'should call to the WordPress.com REST API', done => {
-			Dispatcher.handleViewAction.restore();
-			sandbox.stub( Dispatcher, 'handleViewAction' ).callsFake( function() {
-				expect( MediaActions._fetching ).to.have.all.keys( [
-					[ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join(),
-				] );
-			} );
-
-			MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID );
-
-			expect( Dispatcher.handleViewAction ).to.have.been.calledOnce;
-			expect( stubs.mediaGet ).to.have.been.calledOn( [ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join() );
-			process.nextTick( function() {
-				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-					type: 'RECEIVE_MEDIA_ITEM',
-					error: null,
-					siteId: DUMMY_SITE_ID,
-					data: DUMMY_API_RESPONSE,
+		test( 'should call to the WordPress.com REST API', () => {
+			return new Promise( done => {
+				Dispatcher.handleViewAction.restore();
+				sandbox.stub( Dispatcher, 'handleViewAction' ).callsFake( function() {
+					expect( MediaActions._fetching ).to.have.all.keys( [
+						[ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join(),
+					] );
 				} );
 
-				done();
+				MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID );
+
+				expect( Dispatcher.handleViewAction ).to.have.been.calledOnce;
+				expect( stubs.mediaGet ).to.have.been.calledOn( [ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join() );
+				process.nextTick( function() {
+					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+						type: 'RECEIVE_MEDIA_ITEM',
+						error: null,
+						siteId: DUMMY_SITE_ID,
+						data: DUMMY_API_RESPONSE,
+					} );
+
+					done();
+				} );
 			} );
 		} );
 
@@ -138,44 +141,48 @@ describe( 'MediaActions', () => {
 	} );
 
 	describe( '#fetchNextPage()', () => {
-		test( 'should call to the internal WordPress.com REST API', done => {
-			const query = MediaListStore.getNextPageQuery( DUMMY_SITE_ID );
+		test( 'should call to the internal WordPress.com REST API', () => {
+			return new Promise( done => {
+				const query = MediaListStore.getNextPageQuery( DUMMY_SITE_ID );
 
-			MediaActions.fetchNextPage( DUMMY_SITE_ID );
+				MediaActions.fetchNextPage( DUMMY_SITE_ID );
 
-			expect( stubs.mediaList ).to.have.been.calledOn( DUMMY_SITE_ID );
-			process.nextTick( function() {
-				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-					type: 'RECEIVE_MEDIA_ITEMS',
-					error: null,
-					siteId: DUMMY_SITE_ID,
-					data: DUMMY_API_RESPONSE,
-					query: query,
+				expect( stubs.mediaList ).to.have.been.calledOn( DUMMY_SITE_ID );
+				process.nextTick( function() {
+					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+						type: 'RECEIVE_MEDIA_ITEMS',
+						error: null,
+						siteId: DUMMY_SITE_ID,
+						data: DUMMY_API_RESPONSE,
+						query: query,
+					} );
+
+					done();
 				} );
-
-				done();
 			} );
 		} );
 
-		test( 'should call to the external WordPress.com REST API', done => {
-			MediaListStore._activeQueries[ DUMMY_SITE_ID ] = { query: { source: 'external' } };
+		test( 'should call to the external WordPress.com REST API', () => {
+			return new Promise( done => {
+				MediaListStore._activeQueries[ DUMMY_SITE_ID ] = { query: { source: 'external' } };
 
-			const query = MediaListStore.getNextPageQuery( DUMMY_SITE_ID );
+				const query = MediaListStore.getNextPageQuery( DUMMY_SITE_ID );
 
-			MediaActions.fetchNextPage( DUMMY_SITE_ID );
+				MediaActions.fetchNextPage( DUMMY_SITE_ID );
 
-			expect( stubs.mediaListExternal ).to.have.been.calledWithMatch( { source: 'external' } );
+				expect( stubs.mediaListExternal ).to.have.been.calledWithMatch( { source: 'external' } );
 
-			process.nextTick( function() {
-				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-					type: 'RECEIVE_MEDIA_ITEMS',
-					error: null,
-					siteId: DUMMY_SITE_ID,
-					data: DUMMY_API_RESPONSE,
-					query: query,
+				process.nextTick( function() {
+					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+						type: 'RECEIVE_MEDIA_ITEMS',
+						error: null,
+						siteId: DUMMY_SITE_ID,
+						data: DUMMY_API_RESPONSE,
+						query: query,
+					} );
+
+					done();
 				} );
-
-				done();
 			} );
 		} );
 	} );
@@ -352,20 +359,22 @@ describe( 'MediaActions', () => {
 			} );
 		} );
 
-		test( 'should call to the WordPress.com REST API', done => {
-			MediaActions.update( DUMMY_SITE_ID, item );
+		test( 'should call to the WordPress.com REST API', () => {
+			return new Promise( done => {
+				MediaActions.update( DUMMY_SITE_ID, item );
 
-			expect( stubs.mediaUpdate ).to.have.been.calledWithMatch( item );
+				expect( stubs.mediaUpdate ).to.have.been.calledWithMatch( item );
 
-			process.nextTick( function() {
-				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-					type: 'RECEIVE_MEDIA_ITEM',
-					error: null,
-					siteId: DUMMY_SITE_ID,
-					data: DUMMY_API_RESPONSE,
+				process.nextTick( function() {
+					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+						type: 'RECEIVE_MEDIA_ITEM',
+						error: null,
+						siteId: DUMMY_SITE_ID,
+						data: DUMMY_API_RESPONSE,
+					} );
+
+					done();
 				} );
-
-				done();
 			} );
 		} );
 	} );
@@ -383,19 +392,21 @@ describe( 'MediaActions', () => {
 			expect( stubs.mediaDelete ).to.have.been.calledTwice;
 		} );
 
-		test( 'should call to the WordPress.com REST API', done => {
-			MediaActions.delete( DUMMY_SITE_ID, item );
+		test( 'should call to the WordPress.com REST API', () => {
+			return new Promise( done => {
+				MediaActions.delete( DUMMY_SITE_ID, item );
 
-			expect( stubs.mediaDelete ).to.have.been.calledOn( [ DUMMY_SITE_ID, item.ID ].join() );
-			process.nextTick( function() {
-				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-					type: 'REMOVE_MEDIA_ITEM',
-					error: null,
-					siteId: DUMMY_SITE_ID,
-					data: DUMMY_API_RESPONSE,
+				expect( stubs.mediaDelete ).to.have.been.calledOn( [ DUMMY_SITE_ID, item.ID ].join() );
+				process.nextTick( function() {
+					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+						type: 'REMOVE_MEDIA_ITEM',
+						error: null,
+						siteId: DUMMY_SITE_ID,
+						data: DUMMY_API_RESPONSE,
+					} );
+
+					done();
 				} );
-
-				done();
 			} );
 		} );
 

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import urlLib from 'url';
 import path from 'path';
 import photon from 'photon';
 import { includes, omitBy, startsWith, get } from 'lodash';
@@ -22,6 +21,7 @@ import {
 import { stringify } from 'lib/shortcode';
 import impureLodash from 'lib/impure-lodash';
 import versionCompare from 'lib/version-compare';
+import { getUrlParts } from 'lib/url';
 
 const { uniqueId } = impureLodash;
 
@@ -95,7 +95,7 @@ export function url( media, options ) {
  * getFileExtension( new window.File( [''], 'example.gif' ) );
  * // All examples return 'gif'
  *
- * @param  {(string|File|object)} media Media object or string
+ * @param  {(string|window.File|object)} media Media object or string
  * @returns {string}                     File extension
  */
 export function getFileExtension( media ) {
@@ -111,7 +111,7 @@ export function getFileExtension( media ) {
 	if ( isString ) {
 		let filePath;
 		if ( isUri( media ) ) {
-			filePath = urlLib.parse( media ).pathname;
+			filePath = getUrlParts( media ).pathname;
 		} else {
 			filePath = media;
 		}
@@ -122,7 +122,7 @@ export function getFileExtension( media ) {
 	} else if ( media.extension ) {
 		extension = media.extension;
 	} else {
-		const pathname = urlLib.parse( media.URL || media.file || media.guid || '' ).pathname || '';
+		const pathname = getUrlParts( media.URL || media.file || media.guid || '' ).pathname || '';
 		extension = path.extname( pathname ).slice( 1 );
 	}
 
@@ -138,7 +138,7 @@ export function getFileExtension( media ) {
  * getMimeType( { mime_type: 'image/gif' } );
  * // All examples return 'image'
  *
- * @param  {(string|File|object)} media Media object or mime type string
+ * @param  {(string|window.File|object)} media Media object or mime type string
  * @returns {string}       The MIME type prefix
  */
 export function getMimePrefix( media ) {
@@ -165,7 +165,7 @@ export function getMimePrefix( media ) {
  * getMimeType( { mime_type: 'image/gif' } );
  * // All examples return 'image/gif'
  *
- * @param  {(string|File|object)} media Media object or string
+ * @param  {(string|window.File|object)} media Media object or string
  * @returns {string}                     Mime type of the media, if known
  */
 export function getMimeType( media ) {
@@ -186,7 +186,7 @@ export function getMimeType( media ) {
 	}
 
 	extension = extension.toLowerCase();
-	if ( MimeTypes.hasOwnProperty( extension ) ) {
+	if ( Object.keys( MimeTypes ).includes( extension ) ) {
 		return MimeTypes[ extension ];
 	}
 }
@@ -488,6 +488,8 @@ export function canUserDeleteItem( item, user, site ) {
  * @param {number} quality extracted image quality
  */
 export function canvasToBlob( canvas, callback, type, quality ) {
+	const { HTMLCanvasElement, Blob, atob } = window;
+
 	if ( ! HTMLCanvasElement.prototype.toBlob ) {
 		Object.defineProperty( HTMLCanvasElement.prototype, 'toBlob', {
 			value: function( polyfillCallback, polyfillType, polyfillQuality ) {
@@ -533,7 +535,7 @@ export function isTransientPreviewable( item ) {
  * Returns an object describing a transient media item which can be used in
  * optimistic rendering prior to media persistence to server.
  *
- * @param  {(string|object|Blob|File)} file URL or File object
+ * @param  {(string|object|window.Blob|window.File)} file URL or File object
  * @returns {object}                         Transient media object
  */
 export function createTransientMedia( file ) {

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -186,7 +186,7 @@ export function getMimeType( media ) {
 	}
 
 	extension = extension.toLowerCase();
-	if ( Object.keys( MimeTypes ).includes( extension ) ) {
+	if ( MimeTypes.hasOwnProperty( extension ) ) {
 		return MimeTypes[ extension ];
 	}
 }

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -73,21 +73,21 @@ export default function resizeImageUrl( imageUrl, resize, height, makeSafe = tru
 		return imageUrl;
 	}
 
-	const parsedUrl = getUrlParts( imageUrl );
-	delete parsedUrl.search;
+	const resultUrl = getUrlParts( imageUrl );
+	delete resultUrl.search;
 
-	if ( ! REGEXP_VALID_PROTOCOL.test( parsedUrl.protocol ) ) {
+	if ( ! REGEXP_VALID_PROTOCOL.test( resultUrl.protocol ) ) {
 		return imageUrl;
 	}
-	if ( ! parsedUrl.hostname ) {
+	if ( ! resultUrl.hostname ) {
 		// no hostname? must be a bad url.
 		return imageUrl;
 	}
 
-	SIZE_PARAMS.forEach( param => parsedUrl.searchParams.delete( param ) );
+	SIZE_PARAMS.forEach( param => resultUrl.searchParams.delete( param ) );
 
 	const service = Object.keys( SERVICE_HOSTNAME_PATTERNS ).find( key =>
-		parsedUrl.hostname.match( SERVICE_HOSTNAME_PATTERNS[ key ] )
+		resultUrl.hostname.match( SERVICE_HOSTNAME_PATTERNS[ key ] )
 	);
 
 	if ( 'number' === typeof resize ) {
@@ -119,8 +119,8 @@ export default function resizeImageUrl( imageUrl, resize, height, makeSafe = tru
 	} );
 
 	for ( const key of Object.keys( mapped ) ) {
-		parsedUrl.searchParams.set( key, mapped[ key ] );
+		resultUrl.searchParams.set( key, mapped[ key ] );
 	}
 
-	return getUrlFromParts( parsedUrl ).href;
+	return getUrlFromParts( resultUrl ).href;
 }

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -24,8 +24,7 @@ const REGEXP_VALID_PROTOCOL = /^https?:$/;
  *
  * @type {number}
  */
-const IMAGE_SCALE_FACTOR =
-	( typeof window !== 'undefined' && window?.devicePixelRatio ) > 1 ? 2 : 1;
+const IMAGE_SCALE_FACTOR = typeof window !== 'undefined' && window?.devicePixelRatio > 1 ? 2 : 1;
 
 /**
  * Query parameters to be treated as image dimensions
@@ -73,8 +72,7 @@ export default function resizeImageUrl( imageUrl, resize, height, makeSafe = tru
 		return imageUrl;
 	}
 
-	const resultUrl = getUrlParts( imageUrl );
-	delete resultUrl.search;
+	const { search, ...resultUrl } = getUrlParts( imageUrl );
 
 	if ( ! REGEXP_VALID_PROTOCOL.test( resultUrl.protocol ) ) {
 		return imageUrl;

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
-
 import photon from 'photon';
-import { parse as parseUrl } from 'url';
-import { endsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getUrlParts } from 'lib/url/url-parts';
 
 /**
  * Pattern matching URLs to be left unmodified.
@@ -12,8 +14,10 @@ import { endsWith } from 'lodash';
  * @type {RegExp}
  */
 let REGEX_EXEMPT_URL;
-if ( 'object' === typeof location ) {
-	REGEX_EXEMPT_URL = new RegExp( `^(/(?!/)|data:image/[^;]+;|blob:${ location.origin }/)` );
+if ( typeof globalThis.location === 'object' ) {
+	REGEX_EXEMPT_URL = new RegExp(
+		`^(/(?!/)|data:image/[^;]+;|blob:${ globalThis.location.origin }/)`
+	);
 } else {
 	REGEX_EXEMPT_URL = /^(\/(?!\/)|data:image\/[^;]+;)/;
 }
@@ -47,11 +51,7 @@ export default function safeImageUrl( url ) {
 		return url;
 	}
 
-	const { hostname, path, query } = parseUrl(
-		url,
-		/* parseQueryString */ false,
-		/* slashesDenoteHost */ true
-	);
+	const { hostname, pathname, search } = getUrlParts( url );
 
 	if ( REGEXP_A8C_HOST.test( hostname ) ) {
 		// Safely promote Automattic domains to HTTPS
@@ -59,12 +59,12 @@ export default function safeImageUrl( url ) {
 	}
 
 	// If there's a query string, bail out because Photon doesn't support them on external URLs
-	if ( query && query.length > 0 ) {
+	if ( search ) {
 		return null;
 	}
 
 	// Photon doesn't support SVGs
-	if ( endsWith( path, '.svg' ) ) {
+	if ( pathname.endsWith( '.svg' ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
This PR replaces usage of the deprecated browserified node `url` module (and `qs`) with the native `URL` and `URLSearchParams` across several media-related modules. It's one of many PRs working towards dropping 3rd-party libraries for URL and URL parameter handling and replacing them with native functionality.

It also reduces usage of `lodash`.

Note: If I added you and you feel you're not the right person to review these changes, I apologise for that; please feel free to ignore or remove yourself. I just went with the default GitHub suggestions since I had no idea who to add 🤷‍♂

#### Changes proposed in this Pull Request

* Replace usage of `url` with the native `URL`/`URLSearchParams` and `lib/url`.
* A number of changes to make the linter happy with the files I touched.

#### Testing instructions

The unit tests seem to cover the changes pretty thoroughly.