### PR TITLE
Domains: Defer the upsell for a second domain

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -114,10 +114,16 @@ export class SiteNotice extends React.Component {
 
 		const nonWPCOMDomains = reject(
 			this.props.domains,
-			domain => domain.isWPCOMDomain || domain.name.endsWith( '.wpcomstaging.com' )
+			domain =>
+				domain.isWPCOMDomain ||
+				domain.name.endsWith( '.wpcomstaging.com' ) ||
+				( domain.registrationDate &&
+					moment( domain.registrationDate )
+						.add( 7, 'days' )
+						.isAfter() )
 		);
 
-		if ( nonWPCOMDomains.length < 1 || nonWPCOMDomains.length > 2 ) {
+		if ( nonWPCOMDomains.length !== 1 ) {
 			return null;
 		}
 

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -112,7 +112,7 @@ export class SiteNotice extends React.Component {
 			return null;
 		}
 
-		const nonWPCOMDomains = reject(
+		const eligibleDomains = reject(
 			this.props.domains,
 			domain =>
 				domain.isWPCOMDomain ||
@@ -123,7 +123,7 @@ export class SiteNotice extends React.Component {
 						.isAfter() )
 		);
 
-		if ( nonWPCOMDomains.length !== 1 ) {
+		if ( eligibleDomains.length !== 1 ) {
 			return null;
 		}
 


### PR DESCRIPTION
The upsell for the second domain shows up as soon as the user lands in Calypso - we should defer that to 7 days after the first domain was purchased to avoid overloading the user with upsells after they've just finished onboarding.

<img width="258" alt="Screenshot 2019-11-17 at 09 42 21" src="https://user-images.githubusercontent.com/3392497/69005967-e8f20500-0920-11ea-98e3-85bacdfcd5e3.png">


### Testing instructions

In `domainUpsellNudge`, comment out the first `if` and then filter out so that the domains array looks like you want. For example, pick only the free WPCOM subdomain and one (primary?) custom domain:

```
const domains = filter( this.props.domains, ( domain ) => includes( [ 'example.wordpress.com', 'example.com' ], domain.name ) );
// domains[0].registrationDate = '2019-11-15T20:59:00+00:00'; // Uncomment to test a freshly registered domain
```

Then be sure to use that `domains` array instead of `this.props.domains` in the creation of `nonWPCOMDomains` just below.

Test different cases:
 - one custom domain that was bought less than 7 days ago - no upsell notice
 - one custom domain that was bought more than 7 days ago - show upsell notice
 - more than one custom domain - no matter how old/fresh, they should not trigger this upsell
 - no custom domain - no upsell notice

Fixes #37652