### PR TITLE
Launch the domain step test

### DIFF
--- a/client/components/badge/index.jsx
+++ b/client/components/badge/index.jsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 export default class Badge extends React.Component {
 	static propTypes = {
-		type: PropTypes.oneOf( [ 'warning', 'success', 'info' ] ).isRequired,
+		type: PropTypes.oneOf( [ 'warning', 'success', 'info', 'info-blue' ] ).isRequired,
 	};
 
 	static defaultProps = {

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -20,3 +20,8 @@
 	color: var( --color-neutral-70 );
 	background-color: var( --color-neutral-5 );
 }
+
+.badge--info-blue {
+	background-color: var( --color-primary );
+	color: var( --color-text-inverted );
+}

--- a/client/components/badge/test/index.js
+++ b/client/components/badge/test/index.js
@@ -32,7 +32,7 @@ describe( 'Badge', () => {
 	} );
 
 	test( 'should have proper type class (info-blue)', () => {
-		const badge = shallow( <Badge type="info" /> );
+		const badge = shallow( <Badge type="info-blue" /> );
 		assert.lengthOf( badge.find( '.badge.badge--info-blue' ), 1 );
 	} );
 

--- a/client/components/badge/test/index.js
+++ b/client/components/badge/test/index.js
@@ -31,6 +31,11 @@ describe( 'Badge', () => {
 		assert.lengthOf( badge.find( '.badge.badge--info' ), 1 );
 	} );
 
+	test( 'should have proper type class (info-blue)', () => {
+		const badge = shallow( <Badge type="info" /> );
+		assert.lengthOf( badge.find( '.badge.badge--info-blue' ), 1 );
+	} );
+
 	test( 'should have proper type class (default)', () => {
 		const badge = shallow( <Badge /> );
 		assert.lengthOf( badge.find( '.badge.badge--warning' ), 1 );

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -261,7 +261,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			if ( this.props.showTestCopy ) {
 				const badgeClassName = classNames( '', {
 					success: isRecommended,
-					blue: isBestAlternative,
+					'info-blue': isBestAlternative,
 				} );
 				return (
 					<div className="domain-registration-suggestion__progress-bar">

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -137,11 +137,6 @@
 			display: none;
 		}
 	}
-
-	.badge--blue {
-		background: var( --color-primary );
-		color: var( --color-text-inverted );
-	}
 }
 
 @include breakpoint( '<660px' ) {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,7 +115,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	domainStepCopyUpdates: {
-		datestamp: '20191118',
+		datestamp: '20191121',
 		variations: {
 			variantShowUpdates: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,10 +115,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	domainStepCopyUpdates: {
-		datestamp: '20291111',
+		datestamp: '20191118',
 		variations: {
-			variantShowUpdates: 0,
-			control: 100,
+			variantShowUpdates: 50,
+			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -263,7 +263,14 @@ export function generateSteps( {
 		'domains-theme-preselected': {
 			stepName: 'domains-theme-preselected',
 			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+				'shouldHideFreePlan',
+			],
+			optionalDependencies: [ 'shouldHideFreePlan' ],
 			props: {
 				isDomainOnly: false,
 			},

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -50,7 +50,6 @@ import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/acti
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
 import { abtest } from 'lib/abtest';
-import config from 'config';
 
 /**
  * Style dependencies
@@ -125,7 +124,6 @@ class DomainsStep extends React.Component {
 
 		if (
 			false !== this.props.shouldShowDomainTestCopy &&
-			config.isEnabled( 'domain-step-copy-update' ) &&
 			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
 		) {
 			this.showTestCopy = true;

--- a/config/development.json
+++ b/config/development.json
@@ -52,7 +52,6 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
-		"domain-step-copy-update": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/dashes-filter": true,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,7 +38,6 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
-		"domain-step-copy-update": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Launch the domain step copy update test `domainStepCopyUpdates` to 50% users and remove feature flag( introduced in #37546)
* The copy updates will only be seen in the signup flow, and not in launch flow or in the "Add domain" page.

**Web**

<img width="989" alt="Screenshot 2019-11-21 at 12 25 26 PM" src="https://user-images.githubusercontent.com/1269602/69314419-1e1c9100-0c5a-11ea-87d4-fa3f24c20b5b.png">

**Mobile**

![calypso localhost_3000_start_domains-with-preview(iPhone 5_SE)](https://user-images.githubusercontent.com/1269602/69314443-2d9bda00-0c5a-11ea-9a03-43a54e9db844.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow at /start
* If you are assigned to the `control` group of the `domainStepCopyUpdates` test, then verify the following:
    - The domain step UI and copy remains the same as before
    - Complete signup and check the launch flow steps - they should remain unchanged
* If you are assigned to the `variantShowUpdates` group, then verify the following:
    - The UI and copy for the domain step should match the screenshots above
    - Selecting the "Review plan options" cta should show the plan page with _free site option hidden_.
    - Selecting the Free *.wordpress.com(or *.home.blog etc) domain should show the free site option in the plan page. Selecting a custom domain should hide the free site option. This is same as the current behaviour.
    - The new UI and copy _should not show_ in the site launch flow or in the Add domain page.
    - Add new site should show the new UI and copy. 

**A/B test assignment**

1. If you drop off at any step before the domain step, verify that you do not get assigned to the A/B test. Verify this by typing `localStorage.ABTests` in your browser console and checking that the `domainStepCopyUpdates` is not present in the object.

2. Sign in to an existing account and go through the launch flow or view the Add domain page. Neither of these should assign you to the A/B test.





