### PR TITLE
Gutenboarding: Touch Up Domain Picker

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -45,7 +45,10 @@ const DomainPickerButton: FunctionComponent = () => {
 	const domainName = suggestions?.[ 1 ]?.domain_name;
 
 	return (
-		<Button onClick={ () => setDomainPopoverVisibility( s => ! s ) }>
+		<Button
+			className="domain-picker__button"
+			onClick={ () => setDomainPopoverVisibility( s => ! s ) }
+		>
 			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 			<span className="gutenboarding__header-site-heading">
 				{ siteTitle ? siteTitle : NO__( 'Create your site' ) }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -14,6 +14,8 @@ import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { isFilledFormValue } from '../../stores/onboard/types';
 
+import './style.scss';
+
 const DomainPickerButton: FunctionComponent = () => {
 	// // User can search for a domain
 	const [ domainSearch, setDomainSearch ] = useState( '' );
@@ -49,8 +51,7 @@ const DomainPickerButton: FunctionComponent = () => {
 			className="domain-picker__button"
 			onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 		>
-			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-			<span className="gutenboarding__header-site-heading">
+			<span className="domain-picker__site-title">
 				{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
 			</span>
 			{ domainName ? sprintf( NO__( '%s is available' ), domainName ) : null }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -34,8 +34,8 @@ const DomainPickerButton: FunctionComponent = () => {
 
 	const suggestions = useSelect(
 		select => {
-			if ( isFilledFormValue( search ) ) {
-				return select( DOMAIN_STORE ).getDomainSuggestions( siteTitle, {
+			if ( search ) {
+				return select( DOMAIN_STORE ).getDomainSuggestions( search, {
 					include_wordpressdotcom: true,
 					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
 				} );

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -46,6 +46,10 @@ const DomainPickerButton: FunctionComponent = () => {
 
 	return (
 		<Button onClick={ () => setDomainPopoverVisibility( s => ! s ) }>
+			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+			<span className="gutenboarding__header-site-heading">
+				{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
+			</span>
 			{ domainName ? sprintf( NO__( '%s is available' ), domainName ) : null }
 			{ isDomainPopoverVisible && (
 				<Popover

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -2,22 +2,43 @@
  * External dependencies
  */
 import React, { FunctionComponent, useState } from 'react';
-import { __ as NO__ } from '@wordpress/i18n';
+import { __ as NO__, sprintf } from '@wordpress/i18n';
 import { Button, Popover } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import DomainPicker from './list';
+import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { isFilledFormValue } from '../../stores/onboard/types';
 
 const DomainPickerButton: FunctionComponent = () => {
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState(
 		true /* @TODO: should be `false` by default, true for dev */
 	);
 
+	// Without user search, we can provide recommendations based on title + vertical
+	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
+
+	const suggestions = useSelect(
+		select => {
+			if ( isFilledFormValue( siteTitle ) ) {
+				return select( DOMAIN_STORE ).getDomainSuggestions( siteTitle, {
+					include_wordpressdotcom: true,
+					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
+				} );
+			}
+		},
+		[ siteTitle, siteVertical ]
+	);
+
+	const domainName = suggestions?.[ 1 ]?.domain_name;
+
 	return (
 		<Button onClick={ () => setDomainPopoverVisibility( s => ! s ) }>
-			{ NO__( 'Pick a domain' ) }
+			{ domainName ? sprintf( NO__( '%s is available' ), domainName ) : null }
 			{ isDomainPopoverVisible && (
 				<Popover
 					/* Prevent interaction in the domain picker from affecting the popover */

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent, useState } from 'react';
-import { __ as NO__, sprintf } from '@wordpress/i18n';
+import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Popover } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
@@ -46,7 +46,7 @@ const DomainPickerButton: FunctionComponent = () => {
 
 	// Free .wordpress.com subdomain at index 0,
 	// Best premium domain match at index 1.
-	const domainName = suggestions?.[ 1 ]?.domain_name;
+	const [ freeDomainSuggestion, ...paidDomainSuggestions ] = suggestions ?? [];
 
 	return (
 		<Button
@@ -56,7 +56,7 @@ const DomainPickerButton: FunctionComponent = () => {
 			<div className="domain-picker__site-title">
 				{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
 			</div>
-			<div>{ domainName ? sprintf( NO__( '%s is available' ), domainName ) : null }</div>
+			<div>{ freeDomainSuggestion?.domain_name }</div>
 			{ isDomainPopoverVisible && (
 				<Popover
 					/* Prevent interaction in the domain picker from affecting the popover */
@@ -66,7 +66,7 @@ const DomainPickerButton: FunctionComponent = () => {
 					<DomainPicker
 						domainSearch={ domainSearch }
 						setDomainSearch={ setDomainSearch }
-						suggestions={ suggestions }
+						suggestions={ paidDomainSuggestions }
 					/>
 				</Popover>
 			) }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -51,10 +51,10 @@ const DomainPickerButton: FunctionComponent = () => {
 			className="domain-picker__button"
 			onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 		>
-			<span className="domain-picker__site-title">
+			<div className="domain-picker__site-title">
 				{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
-			</span>
-			{ domainName ? sprintf( NO__( '%s is available' ), domainName ) : null }
+			</div>
+			<div>{ domainName ? sprintf( NO__( '%s is available' ), domainName ) : null }</div>
 			{ isDomainPopoverVisible && (
 				<Popover
 					/* Prevent interaction in the domain picker from affecting the popover */

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -15,6 +15,9 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { isFilledFormValue } from '../../stores/onboard/types';
 
 const DomainPickerButton: FunctionComponent = () => {
+	// // User can search for a domain
+	const [ domainSearch, setDomainSearch ] = useState( '' );
+
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState(
 		true /* @TODO: should be `false` by default, true for dev */
 	);
@@ -22,16 +25,21 @@ const DomainPickerButton: FunctionComponent = () => {
 	// Without user search, we can provide recommendations based on title + vertical
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 
+	let search = domainSearch.trim();
+	if ( ! search && isFilledFormValue( siteTitle ) ) {
+		search = siteTitle;
+	}
+
 	const suggestions = useSelect(
 		select => {
-			if ( isFilledFormValue( siteTitle ) ) {
+			if ( isFilledFormValue( search ) ) {
 				return select( DOMAIN_STORE ).getDomainSuggestions( siteTitle, {
 					include_wordpressdotcom: true,
 					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
 				} );
 			}
 		},
-		[ siteTitle, siteVertical ]
+		[ search, siteVertical ]
 	);
 
 	const domainName = suggestions?.[ 1 ]?.domain_name;
@@ -45,7 +53,11 @@ const DomainPickerButton: FunctionComponent = () => {
 					onClick={ e => e.stopPropagation() }
 					onKeyDown={ e => e.stopPropagation() }
 				>
-					<DomainPicker />
+					<DomainPicker
+						domainSearch={ domainSearch }
+						setDomainSearch={ setDomainSearch }
+						suggestions={ suggestions }
+					/>
 				</Popover>
 			) }
 		</Button>

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -44,6 +44,8 @@ const DomainPickerButton: FunctionComponent = () => {
 		[ search, siteVertical ]
 	);
 
+	// Free .wordpress.com subdomain at index 0,
+	// Best premium domain match at index 1.
 	const domainName = suggestions?.[ 1 ]?.domain_name;
 
 	return (

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -45,7 +45,7 @@ const DomainPickerButton: FunctionComponent = () => {
 	);
 
 	// Free .wordpress.com subdomain at index 0,
-	// Best premium domain match at index 1.
+	// Best paid domain match at index 1.
 	const [ freeDomainSuggestion, ...paidDomainSuggestions ] = suggestions ?? [];
 
 	return (

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -1,42 +1,26 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { TextControl, Panel, PanelBody, PanelRow } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { __ as NO__ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
-import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { isFilledFormValue } from '../../stores/onboard/types';
+import { DomainSuggestion } from '../../stores/domain-suggestions/types';
 
-const DomainPicker: FunctionComponent = () => {
-	// User can search for a domain
-	const [ domainSearch, setDomainSearch ] = useState( '' );
+interface Props {
+	domainSearch: string;
+	setDomainSearch: ( domainSearch: string ) => {};
+	suggestions: DomainSuggestion[];
+}
 
-	// Without user search, we can provide recommendations based on title + vertical
-	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
-
-	let search = domainSearch.trim();
-	if ( ! search && isFilledFormValue( siteTitle ) ) {
-		search = siteTitle;
-	}
-
-	const suggestions = useSelect(
-		select => {
-			if ( search ) {
-				return select( DOMAIN_STORE ).getDomainSuggestions( search, {
-					include_wordpressdotcom: true,
-					...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
-				} );
-			}
-		},
-		[ search, siteVertical ]
-	);
-
+const DomainPicker: FunctionComponent< Props > = ( {
+	domainSearch,
+	setDomainSearch,
+	suggestions,
+} ) => {
 	const label = NO__( 'Search for a domain' );
 
 	return (

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -27,6 +27,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		<Panel className="domain-picker">
 			<PanelBody>
 				<PanelRow>
+					<h3 className="domain-picker__choose-domain-header">{ NO__( 'Choose a new domain' ) }</h3>
 					<TextControl
 						hideLabelFromVision
 						label={ label }
@@ -35,8 +36,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						value={ domainSearch }
 					/>
 				</PanelRow>
+
 				{ suggestions?.length ? (
 					<PanelRow>
+						<h3 className="domain-picker__recommended-header">{ NO__( 'Recommended' ) }</h3>
 						<ul>
 							{ suggestions.map( ( { domain_name } ) => (
 								<li key={ domain_name }>{ domain_name }</li>

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -12,8 +12,8 @@ import { DomainSuggestion } from '../../stores/domain-suggestions/types';
 
 interface Props {
 	domainSearch: string;
-	setDomainSearch: ( domainSearch: string ) => {};
-	suggestions: DomainSuggestion[];
+	setDomainSearch: ( domainSearch: string ) => void;
+	suggestions: DomainSuggestion[] | undefined;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -7,3 +7,14 @@
 .domain-picker__site-title {
 	font-weight: bold;
 }
+
+.domain-picker__choose-domain-header,
+.domain-picker__recommended-header {
+	font-weight: bold;
+}
+
+.domain-picker {
+	.components-panel__row {
+		display: block;
+	}
+}

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -1,5 +1,7 @@
 .domain-picker__button {
+	display: block;
 	margin-left: 20px;
+	text-align: left;
 }
 
 .domain-picker__site-title {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -1,0 +1,7 @@
+.domain-picker__button {
+	margin-left: 20px;
+}
+
+.domain-picker__site-title {
+	font-weight: bold;
+}

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -15,6 +15,7 @@
 
 .domain-picker {
 	.components-panel__row {
-		display: block;
+		flex-direction: column;
+		align-items: stretch;
 	}
 }

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 
 export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
-	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
+	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -33,9 +33,6 @@ export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }:
 		>
 			<div className="gutenboarding__header-site">
 				<Icon icon="wordpress-alt" color="#066188" />
-				<span className="gutenboarding__header-site-heading">
-					{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
-				</span>
 				<DomainPickerButton />
 			</div>
 			<div

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -31,14 +31,6 @@
 	align-items: center;
 }
 
-.domain-picker__button {
-	margin-left: 20px;
-}
-
-.gutenboarding__header-site-heading {
-	font-weight: bold;
-}
-
 .gutenboarding__header-actions {
 	padding: 0 20px;
 

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -29,11 +29,12 @@
 	margin-left: 20px;
 	font-size: 14px;
 	align-items: center;
-
-	span {
-		margin-left: 20px;
-	}
 }
+
+.domain-picker__button {
+	margin-left: 20px;
+}
+
 .gutenboarding__header-site-heading {
 	font-weight: bold;
 }

--- a/client/landing/gutenboarding/stores/domain-suggestions/types.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/types.ts
@@ -33,13 +33,15 @@ export interface DomainSuggestionQuery {
 	vertical?: string;
 }
 
+export type DomainName = string;
+
 export interface DomainSuggestion {
 	/**
 	 * The domain name
 	 *
 	 * @example "example.com"
 	 */
-	domain_name: string;
+	domain_name: DomainName;
 
 	/**
 	 * Relevance as a percent: 0 <= relevance <= 1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make domain picker look more like mockups:
- Change domain picker label from 'Pick a domain' to 'example.com is available'
- Move under site title
- Add 'Choose a domain' and 'Recommended' headings.

Among other things, move the domain suggestions fetching logic to the `DomainPickerButton`. The reason is that we want to use a suggestion in the button label ("example.com is available"), and the criteria we need to retrieving that suggestion is the same as for retrieving the list. For the button, we just want to use the 2nd item from the list (the 1st one is the free `.wordpress.com` subdomain).

#### Screenshots

##### Before

![image](https://user-images.githubusercontent.com/96308/69126198-d1a64980-0ad1-11ea-808d-d41c76746e98.png)

##### After

![image](https://user-images.githubusercontent.com/96308/69126912-75442980-0ad3-11ea-8bed-1779e280be21.png)

#### Testing instructions

Go to http://calypso.localhost:3000/gutenboarding
Verify that the domain picker still works (try entering search terms)

#### Follow-up

- Make the Popover arrow visible
- Style 'Choose a domain' and 'Recommended' headings.
- Style list of results
- Fix horizontal alignment: The Popover moves around when entering different search terms :man_facepalming: 