### PR TITLE
Starter Page Templates: Update layout groupings and auto-selection

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -178,6 +178,8 @@ class Starter_Page_Templates {
 				'segment'         => $segment,
 				'screenAction'    => $screen->action,
 				'theme'           => get_stylesheet(),
+				// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+				'isFrontPage'     => isset( $_GET['post'] ) && get_option( 'page_on_front' ) === $_GET['post'],
 			]
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -177,6 +177,7 @@ class Starter_Page_Templates {
 				'vertical'        => $vertical,
 				'segment'         => $segment,
 				'screenAction'    => $screen->action,
+				'theme'           => get_stylesheet(),
 			]
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -1,4 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
+/* global starterPageTemplatesConfig */
+
 /**
  * External dependencies
  */
@@ -15,6 +17,8 @@ import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
 /* eslint-enable import/no-extraneous-dependencies */
 
+const { theme } = starterPageTemplatesConfig;
+
 class SidebarModalOpener extends Component {
 	state = {
 		isTemplateModalOpen: false,
@@ -30,12 +34,25 @@ class SidebarModalOpener extends Component {
 	};
 
 	getLastTemplateUsed = () => {
-		const { lastTemplateUsedSlug, templates } = this.props;
+		const { templates } = this.props;
+		let { lastTemplateUsedSlug } = this.props;
+		// Try to match the homepage of the theme. Note that as folks transition
+		// to using the slug-based version of the homepage (e.g. "shawburn"), the
+		// slug will work normally without going through this check.
+		if ( lastTemplateUsedSlug === 'home' ) {
+			lastTemplateUsedSlug = theme;
+		}
+
 		if ( ! lastTemplateUsedSlug || lastTemplateUsedSlug === 'blank' ) {
 			// If no template used or 'blank', preview any other template (1 is currently 'Home' template).
-			return templates[ 1 ];
+			return templates[ 0 ];
 		}
-		return templates.find( temp => temp.slug === lastTemplateUsedSlug );
+		const matchingTemplate = templates.find( temp => temp.slug === lastTemplateUsedSlug );
+		// If no matching template, return the blank template.
+		if ( ! matchingTemplate ) {
+			return templates[ 0 ];
+		}
+		return matchingTemplate;
 	};
 
 	render() {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -246,18 +246,18 @@ class PageTemplateModal extends Component {
 									<>
 										{ this.renderTemplatesList(
 											homepageTemplates,
-											__( 'Choose a layout…', 'full-site-editing' )
+											__( 'Homepage layouts', 'full-site-editing' )
 										) }
 										{ this.renderTemplatesList(
 											defaultTemplates,
-											__( 'Other layouts', 'full-site-editing' )
+											__( 'Other page layouts', 'full-site-editing' )
 										) }
 									</>
 								) : (
 									<>
 										{ this.renderTemplatesList(
 											defaultTemplates,
-											__( 'Choose a layout…', 'full-site-editing' )
+											__( 'Page layouts', 'full-site-editing' )
 										) }
 										{ this.renderTemplatesList(
 											homepageTemplates,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -184,15 +184,13 @@ class PageTemplateModal extends Component {
 			category: 'home',
 		} );
 
-		// If we are not editing the front page, just return the homepage templates sorted by title.
-		if ( ! isFrontPage ) {
-			return { homepageTemplates: sortBy( homepageTemplates, 'title' ), defaultTemplates };
-		}
-
-		// If we are editing the front page, extract the current theme's template and put it first.
 		const currentThemeTemplate =
 			find( this.props.templates, { slug: theme } ) ||
 			find( this.props.templates, { slug: DEFAULT_HOMEPAGE_TEMPLATE } );
+
+		if ( ! isFrontPage || ! currentThemeTemplate ) {
+			return { homepageTemplates: sortBy( homepageTemplates, 'title' ), defaultTemplates };
+		}
 
 		const otherHomepageTemplates = reject( homepageTemplates, { slug: currentThemeTemplate.slug } );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -160,9 +160,25 @@ class PageTemplateModal extends Component {
 		return get( this.state.titlesByTemplateSlug, [ slug ], '' );
 	}
 
+	renderTemplatesList = ( templatesList, legendLabel ) => (
+		<fieldset className="page-template-modal__list">
+			<legend className="page-template-modal__form-title">{ legendLabel }</legend>
+			<TemplateSelectorControl
+				label={ __( 'Layout', 'full-site-editing' ) }
+				templates={ templatesList }
+				blocksByTemplates={ this.state.blocksByTemplateSlug }
+				onTemplateSelect={ this.previewTemplate }
+				useDynamicPreview={ false }
+				siteInformation={ siteInformation }
+				selectedTemplate={ this.state.previewedTemplate }
+				handleTemplateConfirmation={ this.handleConfirmation }
+			/>
+		</fieldset>
+	);
+
 	render() {
 		/* eslint-disable no-shadow */
-		const { previewedTemplate, isOpen, isLoading, blocksByTemplateSlug } = this.state;
+		const { previewedTemplate, isOpen, isLoading } = this.state;
 		const { templates, isPromptedFromSidebar } = this.props;
 		/* eslint-enable no-shadow */
 
@@ -209,36 +225,14 @@ class PageTemplateModal extends Component {
 					) : (
 						<>
 							<form className="page-template-modal__form">
-								<fieldset className="page-template-modal__list">
-									<legend className="page-template-modal__form-title">
-										{ __( 'Choose a layout…', 'full-site-editing' ) }
-									</legend>
-									<TemplateSelectorControl
-										label={ __( 'Layout', 'full-site-editing' ) }
-										templates={ default_templates }
-										blocksByTemplates={ blocksByTemplateSlug }
-										onTemplateSelect={ this.previewTemplate }
-										useDynamicPreview={ false }
-										siteInformation={ siteInformation }
-										selectedTemplate={ previewedTemplate }
-										handleTemplateConfirmation={ this.handleConfirmation }
-									/>
-								</fieldset>
-								<fieldset className="page-template-modal__list">
-									<legend className="page-template-modal__form-title">
-										{ __( 'Homepage layouts', 'full-site-editing' ) }
-									</legend>
-									<TemplateSelectorControl
-										label={ __( 'Layout', 'full-site-editing' ) }
-										templates={ homepage_templates }
-										blocksByTemplates={ blocksByTemplateSlug }
-										onTemplateSelect={ this.previewTemplate }
-										useDynamicPreview={ false }
-										siteInformation={ siteInformation }
-										selectedTemplate={ previewedTemplate }
-										handleTemplateConfirmation={ this.handleConfirmation }
-									/>
-								</fieldset>
+								{ this.renderTemplatesList(
+									default_templates,
+									__( 'Choose a layout…', 'full-site-editing' )
+								) }
+								{ this.renderTemplatesList(
+									homepage_templates,
+									__( 'Homepage layouts', 'full-site-editing' )
+								) }
 							</form>
 							<TemplateSelectorPreview
 								blocks={ this.getBlocksByTemplateSlug( previewedTemplate ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find, isEmpty, reduce, get, keyBy, mapValues, partition } from 'lodash';
+import { find, isEmpty, reduce, get, keyBy, mapValues, partition, sortBy } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -87,9 +87,9 @@ class PageTemplateModal extends Component {
 			return blankTemplate;
 		}
 
-		if ( theme && find( props.templates, [ 'slug', theme ] ) ) {
+		if ( theme && find( props.templates, { slug: theme } ) ) {
 			return theme;
-		} else if ( isFrontPage && find( props.templates, [ 'slug', 'maywood' ] ) ) {
+		} else if ( isFrontPage && find( props.templates, { slug: 'maywood' } ) ) {
 			return 'maywood';
 		}
 		return blankTemplate;
@@ -177,6 +177,23 @@ class PageTemplateModal extends Component {
 		return get( this.state.titlesByTemplateSlug, [ slug ], '' );
 	}
 
+	getTemplateGroups = () => {
+		const [ homepageTemplates, defaultTemplates ] = partition( this.props.templates, {
+			category: 'home',
+		} );
+
+		const [ themeTemplate, otherHomepageTemplates ] = partition( homepageTemplates, {
+			slug: theme,
+		} );
+
+		const sortedHomepageTemplates = [
+			...themeTemplate,
+			...sortBy( otherHomepageTemplates, 'title' ),
+		];
+
+		return { homepageTemplates: sortedHomepageTemplates, defaultTemplates };
+	};
+
 	renderTemplatesList = ( templatesList, legendLabel ) => (
 		<fieldset className="page-template-modal__list">
 			<legend className="page-template-modal__form-title">{ legendLabel }</legend>
@@ -194,18 +211,14 @@ class PageTemplateModal extends Component {
 	);
 
 	render() {
-		/* eslint-disable no-shadow */
 		const { previewedTemplate, isOpen, isLoading } = this.state;
-		const { templates, isPromptedFromSidebar } = this.props;
-		/* eslint-enable no-shadow */
+		const { isPromptedFromSidebar } = this.props;
 
 		if ( ! isOpen ) {
 			return null;
 		}
 
-		const [ homepageTemplates, defaultTemplates ] = partition( templates, {
-			category: 'home',
-		} );
+		const { homepageTemplates, defaultTemplates } = this.getTemplateGroups();
 
 		return (
 			<Modal

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -246,22 +246,22 @@ class PageTemplateModal extends Component {
 									<>
 										{ this.renderTemplatesList(
 											homepageTemplates,
-											__( 'Homepage layouts', 'full-site-editing' )
+											__( 'Recommended Layouts', 'full-site-editing' )
 										) }
 										{ this.renderTemplatesList(
 											defaultTemplates,
-											__( 'Other page layouts', 'full-site-editing' )
+											__( 'Other Page Layouts', 'full-site-editing' )
 										) }
 									</>
 								) : (
 									<>
 										{ this.renderTemplatesList(
 											defaultTemplates,
-											__( 'Page layouts', 'full-site-editing' )
+											__( 'Recommended Layouts', 'full-site-editing' )
 										) }
 										{ this.renderTemplatesList(
 											homepageTemplates,
-											__( 'Homepage layouts', 'full-site-editing' )
+											__( 'Homepage Layouts', 'full-site-editing' )
 										) }
 									</>
 								) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, get, keyBy, mapValues, partition } from 'lodash';
+import { find, isEmpty, reduce, get, keyBy, mapValues, partition } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -33,6 +33,7 @@ const {
 	tracksUserData,
 	siteInformation = {},
 	screenAction,
+	theme,
 } = window.starterPageTemplatesConfig;
 
 class PageTemplateModal extends Component {
@@ -51,7 +52,14 @@ class PageTemplateModal extends Component {
 		this.state.isOpen = hasTemplates;
 		if ( hasTemplates ) {
 			// Select the first template automatically.
-			this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
+			if ( theme && find( props.templates, [ 'slug', theme ] ) ) {
+				this.state.previewedTemplate = theme;
+			} else if ( find( props.templates, [ 'slug', 'maywood' ] ) ) {
+				this.state.previewedTemplate = 'maywood';
+			} else {
+				// Blank template
+				this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
+			}
 			// Extract titles for faster lookup.
 			this.state.titlesByTemplateSlug = mapValues( keyBy( props.templates, 'slug' ), 'title' );
 		}
@@ -226,12 +234,12 @@ class PageTemplateModal extends Component {
 						<>
 							<form className="page-template-modal__form">
 								{ this.renderTemplatesList(
-									default_templates,
+									homepage_templates,
 									__( 'Choose a layout…', 'full-site-editing' )
 								) }
 								{ this.renderTemplatesList(
-									homepage_templates,
-									__( 'Homepage layouts', 'full-site-editing' )
+									default_templates,
+									__( 'Other layouts', 'full-site-editing' )
 								) }
 							</form>
 							<TemplateSelectorPreview

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -34,6 +34,7 @@ const {
 	siteInformation = {},
 	screenAction,
 	theme,
+	isFrontPage,
 } = window.starterPageTemplatesConfig;
 
 class PageTemplateModal extends Component {
@@ -52,14 +53,7 @@ class PageTemplateModal extends Component {
 		this.state.isOpen = hasTemplates;
 		if ( hasTemplates ) {
 			// Select the first template automatically.
-			if ( theme && find( props.templates, [ 'slug', theme ] ) ) {
-				this.state.previewedTemplate = theme;
-			} else if ( find( props.templates, [ 'slug', 'maywood' ] ) ) {
-				this.state.previewedTemplate = 'maywood';
-			} else {
-				// Blank template
-				this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
-			}
+			this.state.previewedTemplate = this.getDefaultSelectedTemplate( props );
 			// Extract titles for faster lookup.
 			this.state.titlesByTemplateSlug = mapValues( keyBy( props.templates, 'slug' ), 'title' );
 		}
@@ -85,6 +79,21 @@ class PageTemplateModal extends Component {
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { blocksByTemplateSlug } );
 	}
+
+	getDefaultSelectedTemplate = props => {
+		const blankTemplate = get( props.templates, [ 0, 'slug' ] );
+
+		if ( ! isFrontPage ) {
+			return blankTemplate;
+		}
+
+		if ( theme && find( props.templates, [ 'slug', theme ] ) ) {
+			return theme;
+		} else if ( isFrontPage && find( props.templates, [ 'slug', 'maywood' ] ) ) {
+			return 'maywood';
+		}
+		return blankTemplate;
+	};
 
 	setTemplate = slug => {
 		// Track selection and mark post as using a template in its postmeta.
@@ -194,7 +203,7 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
-		const [ homepage_templates, default_templates ] = partition( templates, {
+		const [ homepageTemplates, defaultTemplates ] = partition( templates, {
 			category: 'home',
 		} );
 
@@ -233,13 +242,28 @@ class PageTemplateModal extends Component {
 					) : (
 						<>
 							<form className="page-template-modal__form">
-								{ this.renderTemplatesList(
-									homepage_templates,
-									__( 'Choose a layout…', 'full-site-editing' )
-								) }
-								{ this.renderTemplatesList(
-									default_templates,
-									__( 'Other layouts', 'full-site-editing' )
+								{ isFrontPage ? (
+									<>
+										{ this.renderTemplatesList(
+											homepageTemplates,
+											__( 'Choose a layout…', 'full-site-editing' )
+										) }
+										{ this.renderTemplatesList(
+											defaultTemplates,
+											__( 'Other layouts', 'full-site-editing' )
+										) }
+									</>
+								) : (
+									<>
+										{ this.renderTemplatesList(
+											defaultTemplates,
+											__( 'Choose a layout…', 'full-site-editing' )
+										) }
+										{ this.renderTemplatesList(
+											homepageTemplates,
+											__( 'Homepage layouts', 'full-site-editing' )
+										) }
+									</>
 								) }
 							</form>
 							<TemplateSelectorPreview


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch the order of Starter Page Templates categories, showing homepage layouts first, and then the others.
* Homepage layouts always show the current theme's layout if it exists, and then all the others sorted by title.
* Auto-select the current theme's layout if it exists, or Maywood's, or Blank (which always exists, as it's created by the plugin itself).

| Front Page | Regular Page |
| - | - |
| <img width="1709" alt="Screenshot 2019-11-18 at 18 35 43" src="https://user-images.githubusercontent.com/2070010/69080023-1a5af580-0a33-11ea-9a3e-ab23fa2147be.png"> | <img width="1705" alt="Screenshot 2019-11-18 at 18 36 02" src="https://user-images.githubusercontent.com/2070010/69080030-1f1fa980-0a33-11ea-9c4f-18bbaf690967.png"> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D35170-code and sandbox the API.
* Build this PR on an FSE test site.
* Set a static front page in Settings -> Reading, or Customizer -> Homepage Settings.

With the Maywood theme:
* Create a new page.
  * The default layouts should be the first category.
  * The Blank layout is auto-selected.
  * The homepage layouts are sorted by title.
* Edit the front page and change its layout.
  * The homepage layouts should be the first category.
  * The Maywood layout is first, and all the other homepage layouts are sorted by title.
  * The Maywood layout is auto-selected.

With any other template-first theme (e.g. Exford):
* Create a new page.
  * The default layouts should be the first category.
  * The Blank layout is auto-selected.
  * The homepage layouts are sorted by title.
* Edit the front page and change its layout.
  * The homepage layouts should be the first category.
  * The current theme's layout is first, and all the other homepage layouts are sorted by title.
  * The current theme's layout is auto-selected.

With any other non-template-first theme (e.g. Twenty Twenty):
* Create a new page.
  * The default layouts should be the first category.
  * The Blank layout is auto-selected.
  * The homepage layouts are sorted by title.
* Edit the front page and change its layout.
  * The homepage layouts should be the first category.
  * The Maywood layout is first, and all the other homepage layouts are sorted by title.
  * The Maywood layout is auto-selected.