### PR TITLE
Gutenboarding: Don't await user().initialize()

### DIFF
--- a/client/landing/gutenboarding/index.ts
+++ b/client/landing/gutenboarding/index.ts
@@ -6,7 +6,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import user from 'lib/user';
 import { main, redirectIfNotEnabled } from './controller';
 import { render as clientRender } from 'controller';
 import { wpDataDebugMiddleware } from './devtools';
@@ -17,8 +16,7 @@ import { wpDataDebugMiddleware } from './devtools';
 import 'assets/stylesheets/gutenboarding.scss';
 import 'components/environment-badge/style.scss';
 
-window.AppBoot = async () => {
-	await user().initialize();
+window.AppBoot = () => {
 	page(
 		'/gutenboarding',
 		redirectIfNotEnabled,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

YOLO :sunglasses: 

(By definition, Gutenboarding -- onboarding -- is meant for logged-out users, at least prior to the signup step. I _think_ we should be able to drop user initialization, which will help us isolate our Gutenboarding entrypoint more from Calypso-the-app. Unless we need this for something like the WP.com proxy somehow.) /cc @jsnajdr 

#### Testing instructions

- Go to `http://calypso.localhost:3000/gutenboarding`
- Works? Great!
