### PR TITLE
Checkout: Track transaction payment method only when it exists

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -242,7 +242,7 @@ export class SecurePaymentForm extends Component {
 		debug( 'transaction step: ' + step.name );
 
 		this.displayNotices( cart, step );
-		recordTransactionAnalytics( cart, step, transaction.payment.paymentMethod );
+		recordTransactionAnalytics( cart, step, transaction?.payment?.paymentMethod );
 
 		this.finishIfLastStep( cart, selectedSite, step );
 	}


### PR DESCRIPTION
This fixes an error that occurs when there's a transaction with credits (or without a payment object) in the store. It occurs when trying to handle the payment and reusing the payment method from the last transaction, but for that one we used credits.

Reported in:

p1HpG7-7YS-p2#comment-35495
p1HpG7-7YS-p2#comment-35496
p1HpG7-7YS-p2#comment-35504
p1HpG7-7YS-p2#comment-35505

What a better reason to use optional chaining - p4TIVU-9k9-p2.

#### Changes proposed in this Pull Request

* Checkout: Track transaction payment method only when it exists

#### Testing instructions

* Checkout this branch.
* Start with a Jetpack site without a product/plan.
* Do the next steps without refreshing Calypso.
* Buy a Jetpack Backup daily product.
* Go back to the plans page and try to purchase a Personal plan.
* Make sure it goes well and doesn't error out.
* Go back to the plans page and try to upgrade to a Premium plan.
* Make sure it goes well and doesn't error out.
