### PR TITLE
Components: Display manage subscription only for current billing interval

### DIFF
--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -59,6 +59,7 @@ The following props can be passed to the Product Card component:
  displayed as a price range
 * `fullPrice`: ( number | array ) Full price of a product. If an array of 2 numbers is passed, it will be displayed as
  a price range
+* `isCurrent`: ( bool ) Flag indicating if a product is a currently purchased product
 * `isPlaceholder`: ( bool ) Flag indicating if a product price is in a loading state and should be rendered as a
   placeholder
 * `purchase`: ( object ) A purchase object, associated with the product. [Read more about the way this flag

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -59,7 +59,8 @@ The following props can be passed to the Product Card component:
  displayed as a price range
 * `fullPrice`: ( number | array ) Full price of a product. If an array of 2 numbers is passed, it will be displayed as
  a price range
-* `isCurrent`: ( bool ) Flag indicating if a product is a currently purchased product
+* `isCurrent`: ( bool ) Flag indicating if a product is a currently purchased product. When true, will display a
+ "Manage Subscription" button for the current product.
 * `isPlaceholder`: ( bool ) Flag indicating if a product price is in a loading state and should be rendered as a
   placeholder
 * `purchase`: ( object ) A purchase object, associated with the product. [Read more about the way this flag

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -27,6 +27,7 @@ const ProductCard = ( {
 	description,
 	discountedPrice,
 	fullPrice,
+	isCurrent,
 	isPlaceholder,
 	purchase,
 	subtitle,
@@ -61,7 +62,7 @@ const ProductCard = ( {
 			</div>
 			<div className="product-card__description">
 				{ description && <p>{ description }</p> }
-				{ purchase && (
+				{ purchase && isCurrent && (
 					<ProductCardAction
 						href={ managePurchase( purchase.domain, purchase.id ) }
 						label={ translate( 'Manage Subscription' ) }
@@ -83,6 +84,7 @@ ProductCard.propTypes = {
 		PropTypes.arrayOf( PropTypes.number ),
 	] ),
 	fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+	isCurrent: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	purchase: PropTypes.object,
 	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),


### PR DESCRIPTION
Currently, we'll display the "Manage Subscription" button, regardless of what the selected billing interval is (both yearly and monthly). This PR updates the block so it displays the "Manage Subscription"

#### Changes proposed in this Pull Request

* Components: Display manage subscription only for current billing interval

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site slug.
* With a yearly Jetpack backup product, verify you get the "Manage Subscription" button only when viewing the "Yearly"  billing interval on the plans page.
* With a monthly Jetpack backup product, verify you get the "Manage Subscription" button only when viewing the "Monthly" billing interval on the plans page.
* With a yearly Jetpack plan, verify you get the "Manage Subscription" button only when viewing the "Yearly"  billing interval on the plans page.
* With a monthly Jetpack plan, verify you get the "Manage Subscription" button only when viewing the "Monthly" billing interval on the plans page.
