### PR TITLE
Current Site: Disable DomainToPaidPlan nudge for Jetpack sites

### DIFF
--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -29,7 +29,7 @@ export class DomainToPaidPlanNotice extends Component {
 	render() {
 		const { eligible, isConflicting, isDomainOnly, isJetpack, site, translate } = this.props;
 
-		if ( ! site || ! eligible || isConflicting ) {
+		if ( ! site || ! eligible || isConflicting || isJetpack ) {
 			return null;
 		}
 
@@ -39,17 +39,13 @@ export class DomainToPaidPlanNotice extends Component {
 			  ) }&siteId=${ encodeURIComponent( site.ID ) }`
 			: `/plans/${ site.slug }`;
 
-		const text = isJetpack
-			? translate( 'Upgrade for full site backups.' )
-			: translate( 'Upgrade your site and save.' );
-
 		return (
 			<SidebarBanner
 				ctaName="domain-to-paid-sidebar"
 				ctaText={ translate( 'Go' ) }
 				href={ href }
 				icon="info-outline"
-				text={ text }
+				text={ translate( 'Upgrade your site and save.' ) }
 			/>
 		);
 	}


### PR DESCRIPTION
The `DomainToPaidPlan` notice currently displays for Jetpack sites, and I think that's unexpected. The purpose of that nudge is to display an upgrade notice for WP.com sites that have a domain only. So, it doesn't make sense to be displayed on Jetpack sites.

There is a sequence of reasons why it ended up displaying for Jetpack sites:

* The initial PR didn't consider Jetpack sites at all: #13544
* #21048 reported this, without verifying the original purpose of this nudge.
* #21076 fixed the above issue, following the misconception of the purpose of the existing nudge.

So, this PR is removing the nudge completely for Jetpack sites. If we want to display such a notice for Jetpack sites, it should be its own component for that purpose.

![](https://cldup.com/kkGKtK8ONZ.png)

#### Changes proposed in this Pull Request

* Current Site: Disable DomainToPaidPlan nudge for Jetpack sites

#### Testing instructions

* Checkout this branch.
* Open Calypso for a Jetpack site on a free plan.
* Verify you don't see the nudge.
* Open Calypso for a WP.com site on a free plan.
* Verify you still see the nudge.
