### PR TITLE
Composite checkout: fix css issues

### DIFF
--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -77,6 +77,8 @@ function CheckoutStepHeader( {
 	editButtonAriaLabel,
 } ) {
 	const localize = useLocalize();
+	const shouldShowEditButton = onEdit && isComplete && ! isActive;
+
 	return (
 		<StepHeader
 			isComplete={ isComplete }
@@ -86,7 +88,11 @@ function CheckoutStepHeader( {
 			<Stepper isComplete={ isComplete } isActive={ isActive }>
 				{ stepNumber }
 			</Stepper>
-			<StepTitle className="checkout-step__title" stepNumber={ stepNumber } isActive={ isActive }>
+			<StepTitle
+				className="checkout-step__title"
+				fullWidth={ ! shouldShowEditButton }
+				isActive={ isActive }
+			>
 				{ title }
 			</StepTitle>
 			{ onEdit && isComplete && ! isActive && (
@@ -149,8 +155,8 @@ const StepTitle = styled.span`
 		props.isActive ? props.theme.colors.textColorDark : props.theme.colors.textColor};
 	font-weight: ${props =>
 		props.isActive ? props.theme.weights.bold : props.theme.weights.normal};
-	margin-right: ${props => ( props.stepNumber === 0 ? '0' : '8px' )};
-	flex: ${props => ( props.stepNumber === 0 ? '1' : 'inherit' )};
+	margin-right: ${props => ( props.fullWidth ? '0' : '8px' )};
+	flex: ${props => ( props.fullWidth ? '1' : 'inherit' )};
 `;
 
 const StepHeader = styled.h2`

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -95,7 +95,7 @@ function CheckoutStepHeader( {
 			>
 				{ title }
 			</StepTitle>
-			{ onEdit && isComplete && ! isActive && (
+			{ shouldShowEditButton && (
 				<Button
 					buttonState="text-button"
 					className="checkout-step__edit"

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -86,7 +86,7 @@ function CheckoutStepHeader( {
 			<Stepper isComplete={ isComplete } isActive={ isActive }>
 				{ stepNumber }
 			</Stepper>
-			<StepTitle className="checkout-step__title" isActive={ isActive }>
+			<StepTitle className="checkout-step__title" stepNumber={ stepNumber } isActive={ isActive }>
 				{ title }
 			</StepTitle>
 			{ onEdit && isComplete && ! isActive && (
@@ -149,7 +149,8 @@ const StepTitle = styled.span`
 		props.isActive ? props.theme.colors.textColorDark : props.theme.colors.textColor};
 	font-weight: ${props =>
 		props.isActive ? props.theme.weights.bold : props.theme.weights.normal};
-	flex: 1;
+	margin-right: ${props => ( props.stepNumber === 0 ? '0' : '8px' )};
+	flex: ${props => ( props.stepNumber === 0 ? '1' : 'inherit' )};
 `;
 
 const StepHeader = styled.h2`

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -68,7 +68,7 @@ export default function Checkout( {
 
 	return (
 		<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
-			<MainContent className={ joinClasses( [ className, 'composite-checkout__content' ] ) }>
+			<MainContent className={ joinClasses( [ className, 'checkout__content' ] ) }>
 				<OrderSummaryStep OrderSummary={ OrderSummary || CheckoutOrderSummary } />
 
 				<CheckoutErrorBoundary
@@ -243,7 +243,7 @@ function BillingDetailsStep( { isActive, isComplete, setStepNumber } ) {
 
 	return (
 		<CheckoutStep
-			className="composite-checkout__billing-details-step"
+			className="checkout__billing-details-step"
 			isActive={ isActive }
 			isComplete={ isComplete }
 			stepNumber={ 2 }
@@ -281,7 +281,7 @@ function ReviewOrderStep( { isActive, isComplete, ReviewContent } ) {
 	return (
 		<CheckoutStep
 			finalStep
-			className="composite-checkout__review-order-step"
+			className="checkout__review-order-step"
 			isActive={ isActive }
 			isComplete={ isComplete }
 			stepNumber={ 3 }

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -67,7 +67,7 @@ export default function Checkout( {
 	const { changeStep } = useDispatch( 'checkout' );
 
 	return (
-		<Container className={ joinClasses( [ className, 'checkout' ] ) }>
+		<Container className={ joinClasses( [ className, 'checkout-wrapper' ] ) }>
 			<MainContent className={ joinClasses( [ className, 'checkout__content' ] ) }>
 				<OrderSummaryStep OrderSummary={ OrderSummary || CheckoutOrderSummary } />
 
@@ -123,14 +123,6 @@ Checkout.propTypes = {
 };
 
 const Container = styled.div`
-	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
-		display: flex;
-		align-items: flex-start;
-		justify-content: space-between;
-		max-width: 910px;
-		margin: 0 auto;
-	}
-
 	*:focus {
 		outline: ${props => props.theme.colors.outline} auto 5px;
 	}

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -67,8 +67,8 @@ export default function Checkout( {
 	const { changeStep } = useDispatch( 'checkout' );
 
 	return (
-		<Container className={ joinClasses( [ className, 'checkout-wrapper' ] ) }>
-			<MainContent className={ joinClasses( [ className, 'checkout__content' ] ) }>
+		<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
+			<MainContent className={ joinClasses( [ className, 'composite-checkout__content' ] ) }>
 				<OrderSummaryStep OrderSummary={ OrderSummary || CheckoutOrderSummary } />
 
 				<CheckoutErrorBoundary
@@ -243,7 +243,7 @@ function BillingDetailsStep( { isActive, isComplete, setStepNumber } ) {
 
 	return (
 		<CheckoutStep
-			className="checkout__billing-details-step"
+			className="composite-checkout__billing-details-step"
 			isActive={ isActive }
 			isComplete={ isComplete }
 			stepNumber={ 2 }
@@ -281,7 +281,7 @@ function ReviewOrderStep( { isActive, isComplete, ReviewContent } ) {
 	return (
 		<CheckoutStep
 			finalStep
-			className="checkout__review-order-step"
+			className="composite-checkout__review-order-step"
 			isActive={ isActive }
 			isComplete={ isComplete }
 			stepNumber={ 3 }

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -600,7 +600,6 @@ function StripePayButton() {
 				} )
 			}
 			buttonState="primary"
-			buttonType="apple-pay"
 			fullWidth
 		>
 			{ buttonString }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes a couple tiny tweaks to the CSS to fix:
- The position of the edit button
- change class name to prevent leaky styles
- Remove redundant CSS
- Change the submit button style for the stripe payment method

**Before:**
![image](https://user-images.githubusercontent.com/6981253/69060573-8e6eac80-09e5-11ea-8876-acde18144d77.png)


**After:**
![image](https://user-images.githubusercontent.com/6981253/69060536-7bf47300-09e5-11ea-888b-e78bad6d58db.png)

#### Testing instructions

* Get checkout up and running by following these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Review checkout in Calypso by running calypso and visiting: Visit http://calypso.localhost:3000/checkout/[your-site-here]?flags=composite-checkout