### PR TITLE
Plans: Make product plan overlap notices non-dismissable

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -131,6 +131,7 @@ class ProductPlanOverlapNotices extends Component {
 
 				{ this.hasOverlap() && (
 					<Notice
+						showDismiss={ false }
 						status="is-warning"
 						text={ translate(
 							'Your %(planName)s Plan includes %(featureName)s. ' +


### PR DESCRIPTION
Currently, the notice that appears when having both a Jetpack product and a Jetpack plan will display a dismissal button which doesn't work. This PR hides this "dismiss" button, as we don't want it there anyway.

#### Changes proposed in this Pull Request

* Plans: Make product plan overlap notices non-dismissable

#### Preview

Before:
![](https://cldup.com/wl8lmGiHre.png)

After:
![](https://cldup.com/QrE5gdFbcc.png)

#### Testing instructions

* Checkout this branch.
* Go to a Jetpack site with both a Daily Backup product and a Premium plan (if you don't have one, start with a free plan, then buy the product, then the plan).
* Verify you can no longer see the dismiss button in the notice.
