### PR TITLE
Blocks: Move ProductSelector PropTypes to the Component

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -30,6 +30,58 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 
 export class ProductSelector extends Component {
+	static propTypes = {
+		basePlansPath: PropTypes.string,
+		intervalType: PropTypes.string.isRequired,
+		products: PropTypes.arrayOf(
+			PropTypes.shape( {
+				title: PropTypes.string,
+				id: PropTypes.string,
+				description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+				options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
+				optionDescriptions: PropTypes.objectOf(
+					PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] )
+				),
+				optionDisplayNames: PropTypes.objectOf(
+					PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
+				),
+				optionShortNames: PropTypes.objectOf(
+					PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
+				),
+				optionsLabel: PropTypes.string,
+			} )
+		).isRequired,
+		productPriceMatrix: PropTypes.shape( {
+			relatedProduct: PropTypes.string,
+			ratio: PropTypes.number,
+		} ),
+		siteId: PropTypes.number,
+
+		// Connected props
+		availableProducts: PropTypes.object,
+		currencyCode: PropTypes.string,
+		currentPlanSlug: PropTypes.string,
+		fetchingPlans: PropTypes.bool,
+		fetchingSitePlans: PropTypes.bool,
+		fetchingSitePurchases: PropTypes.bool,
+		productSlugs: PropTypes.arrayOf( PropTypes.string ),
+		purchases: PropTypes.array,
+		recordTracksEvent: PropTypes.func.isRequired,
+		selectedSiteId: PropTypes.number,
+		selectedSiteSlug: PropTypes.string,
+		storeProducts: PropTypes.object,
+
+		// From localize() HoC
+		translate: PropTypes.func.isRequired,
+
+		// From withLocalizedMoment() HoC
+		moment: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		productPriceMatrix: {},
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -433,58 +485,6 @@ export class ProductSelector extends Component {
 		);
 	}
 }
-
-ProductSelector.propTypes = {
-	basePlansPath: PropTypes.string,
-	intervalType: PropTypes.string.isRequired,
-	products: PropTypes.arrayOf(
-		PropTypes.shape( {
-			title: PropTypes.string,
-			id: PropTypes.string,
-			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
-			options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
-			optionDescriptions: PropTypes.objectOf(
-				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] )
-			),
-			optionDisplayNames: PropTypes.objectOf(
-				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
-			),
-			optionShortNames: PropTypes.objectOf(
-				PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
-			),
-			optionsLabel: PropTypes.string,
-		} )
-	).isRequired,
-	productPriceMatrix: PropTypes.shape( {
-		relatedProduct: PropTypes.string,
-		ratio: PropTypes.number,
-	} ),
-	siteId: PropTypes.number,
-
-	// Connected props
-	availableProducts: PropTypes.object,
-	currencyCode: PropTypes.string,
-	currentPlanSlug: PropTypes.string,
-	fetchingPlans: PropTypes.bool,
-	fetchingSitePlans: PropTypes.bool,
-	fetchingSitePurchases: PropTypes.bool,
-	productSlugs: PropTypes.arrayOf( PropTypes.string ),
-	purchases: PropTypes.array,
-	recordTracksEvent: PropTypes.func.isRequired,
-	selectedSiteId: PropTypes.number,
-	selectedSiteSlug: PropTypes.string,
-	storeProducts: PropTypes.object,
-
-	// From localize() HoC
-	translate: PropTypes.func.isRequired,
-
-	// From withLocalizedMoment() HoC
-	moment: PropTypes.func.isRequired,
-};
-
-ProductSelector.defaultProps = {
-	productPriceMatrix: {},
-};
 
 const connectComponent = connect(
 	( state, { products, siteId } ) => {


### PR DESCRIPTION
Currently, we're declaring the proptypes of the `ProductSelector` block outside of the `Component` declaration. This janitorial PR moves them in for consistency.

#### Changes proposed in this Pull Request

* Blocks: Move ProductSelector props to the Component

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site slug.
* Verify things work just like before and you see no React warnings.