### PR TITLE
Purchases: Display overlap notices on purchases list page

### DIFF
--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -13,7 +13,10 @@ import { some, times } from 'lodash';
  */
 import { getSite, isRequestingSite } from 'state/sites/selectors';
 import { isJetpackPlan } from 'lib/products-values';
+import { JETPACK_PLANS } from 'lib/plans/constants';
+import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import QuerySites from 'components/data/query-sites';
+import ProductPlanOverlapNotices from 'blocks/product-plan-overlap-notices';
 import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
 import PurchaseReconnectNotice from './reconnect-notice';
@@ -54,6 +57,7 @@ const PurchasesSite = ( {
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
 			<QuerySites siteId={ siteId } />
+
 			<PurchaseSiteHeader
 				siteId={ siteId }
 				name={ name }
@@ -62,6 +66,12 @@ const PurchasesSite = ( {
 			/>
 
 			{ items }
+
+			<ProductPlanOverlapNotices
+				plans={ JETPACK_PLANS }
+				products={ JETPACK_BACKUP_PRODUCTS }
+				siteId={ siteId }
+			/>
 
 			{ ! isPlaceholder && hasLoadedSite && ! site && (
 				<PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } />


### PR DESCRIPTION
Currently, we're displaying the product and plan overlap notices in the purchase detail page, and on the Plans page. This PR adds it to the purchases list page, too.

#### Changes proposed in this Pull Request

* Purchases: Display overlap notices on purchases list page

#### Preview

![](https://cldup.com/kOK75C9wtC.png)

Displaying them at the bottom makes sense, because that's what we're currently doing for other errors/notices too:

![](https://cldup.com/ov6Rsa4TeW.png)

#### Testing instructions

* Checkout this branch.
* Go to a Jetpack site with both a Daily Backup product and a Premium plan (if you don't have one, start with a free plan, then buy the product, then the plan).
* Go to `/me/purchases`
* Verify you can see the notice below the 2 products in your Jetpack site, and it looks good.
