### PR TITLE
G Suite: Fix Tracks event for learn more link never fired

### DIFF
--- a/client/components/gsuite/gsuite-learn-more/index.jsx
+++ b/client/components/gsuite/gsuite-learn-more/index.jsx
@@ -18,6 +18,7 @@ import './style.scss';
 
 const GSuiteLearnMore = ( { onLearnMoreClick } ) => {
 	const translate = useTranslate();
+
 	return (
 		<div className="gsuite-learn-more">
 			<p>

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -66,6 +66,7 @@ export const GSuitePurchaseCta = ( {
 			noticeStatus="is-info"
 		>
 			<QueryProductsList />
+
 			<CompactCard>
 				<header>
 					<h3 className="gsuite-purchase-cta__product-logo">
@@ -74,6 +75,7 @@ export const GSuitePurchaseCta = ( {
 					</h3>
 				</header>
 			</CompactCard>
+
 			<CompactCard className="gsuite-purchase-cta__header">
 				<div className="gsuite-purchase-cta__header-description">
 					<h2 className="gsuite-purchase-cta__header-description-title">
@@ -86,8 +88,10 @@ export const GSuitePurchaseCta = ( {
 								'storage, docs, calendars, and more integrated with your site.'
 						) }
 					</p>
+
 					<div>
 						<GSuitePrice cost={ gsuiteBasicCost } currencyCode={ currencyCode } showMonthlyPrice />
+
 						{ upgradeAvailable && (
 							<Button
 								className="gsuite-purchase-cta__get-gsuite-button"
@@ -106,9 +110,10 @@ export const GSuitePurchaseCta = ( {
 					<img alt="G Suite Logo" src="/calypso/images/g-suite/g-suite.svg" />
 				</div>
 			</CompactCard>
+
 			<CompactCard className="gsuite-purchase-cta__info">
 				<GSuiteFeatures domainName={ domainName } productSlug={ 'gapps' } />
-				<GSuiteLearnMore onClick={ handleLearnMoreClick } />
+				<GSuiteLearnMore onLearnMoreClick={ handleLearnMoreClick } />
 			</CompactCard>
 		</EmailVerificationGate>
 	);


### PR DESCRIPTION
This pull request fixes the `calypso_email_gsuite_purchase_cta_learn_more_click` Tracks event that would otherwise never be fired when clicking the following _learn more_ link:

![screenshot](https://user-images.githubusercontent.com/594356/69069001-08268a80-0a26-11ea-82ff-047f4a84e737.png)

#### Testing instructions

1. Run `git checkout fix/gsuite-tracks-event` and start your server, or open a [live branch](https://calypso.live/?branch=fix/gsuite-tracks-event)
2. Log in to an account that has a domain without G suite
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Enable logging by running the following command in your browser's console:
```javascript
localStorage.setItem( 'debug', 'calypso:analytics:*' )
```
5. Reload the page, and clicks the `Learn more about integrating G Suite with your site` link
6. Assert that a `calypso_email_gsuite_purchase_cta_learn_more_click` event was fired
