### PR TITLE
Composite checkout: Update html markup

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -108,7 +108,7 @@ function CreditCardLogos() {
 	);
 }
 
-const LogoWrapper = styled.div`
+const LogoWrapper = styled.span`
 	display: flex;
 `;
 

--- a/packages/composite-checkout/src/wpcom/coupon.js
+++ b/packages/composite-checkout/src/wpcom/coupon.js
@@ -85,7 +85,7 @@ const CouponWrapper = styled.form`
 
 const ApplyButton = styled( Button )`
 	position: absolute;
-	top: 4px;
+	top: 5px;
 	right: 4px;
 	padding: 7px;
 	animation: ${animateIn} 0.2s ease-out;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes some really minor tweaks that I came across while doing browser/accessibility testing. I changed a div to a span because it appeared within a label and adjusted some spacing for the coupon button.

#### Testing instructions

* Get checkout running by following these instructions: https://github.com/Automattic/wp-calypso/pull/37013

