### PR TITLE
FSE: Require the site credit file before populating the template data

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -205,8 +205,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
  */
 function populate_wp_template_data() {
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
+	// These files define functions/classes used by the main FSE class.
 	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
+	require_once __DIR__ . '/full-site-editing/blocks/site-credit/index.php';
 
 	$fse = Full_Site_Editing::get_instance();
 	$fse->insert_default_data();


### PR DESCRIPTION
Though I was not able to reproduce this on `master`, I think a condition can be triggered here in which a function defined in the site-credit block's  `index.php` does not exist. This is because we don't load all the files when calling the populate data function.

I noticed the errors when I also hooked `populate_wp_template_data ` into the theme activation action as well as the plugin activation action. So just to be safe, this should fix that error. (Though it is possible that it does not occur on master.)

 #### Changes proposed in this Pull Request
* Fix a possible error where a function was undefined

#### Testing instructions
1. Make sure FSE loads locally with no issues
