### PR TITLE
eslint: Drop the no-prototype-builtins rule

### DIFF
--- a/packages/eslint-config-wpcalypso/index.js
+++ b/packages/eslint-config-wpcalypso/index.js
@@ -55,6 +55,7 @@ module.exports = {
 		'no-nested-ternary': 2,
 		'no-new': 2,
 		'no-process-exit': 2,
+		'no-prototype-builtins': 0, // we've been using this for years without real issue
 		'no-redeclare': 2,
 		'no-shadow': 2,
 		'no-spaced-func': 2,


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* We have a bunch of code that [uses hasOwnPropery](https://eslint.org/docs/rules/no-prototype-builtins) which we've been using for years without issue. Agree to disagree with eslint:recommended

#### Testing instructions

* No errors from `no-prototype-builtins` in eslint output

