### PR TITLE
close button labeled and added to posts type

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -3,17 +3,27 @@
 /**
  * External dependencies
  */
+/* eslint-disable import/no-extraneous-dependencies */
 import domReady from '@wordpress/dom-ready';
 import ReactDOM from 'react-dom';
 import { __ } from '@wordpress/i18n';
 import { Button, Dashicon } from '@wordpress/components';
+/* eslint-disable import/no-extraneous-dependencies */
+
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 
 domReady( () => {
 	const { closeButtonLabel, closeButtonUrl, editorPostType } = fullSiteEditing;
 
 	// Only alter for the page and template part editors.
-	if ( 'wp_template_part' !== editorPostType && 'page' !== editorPostType ) {
+	if (
+		'wp_template_part' !== editorPostType &&
+		'page' !== editorPostType &&
+		'post' !== editorPostType
+	) {
 		return;
 	}
 
@@ -50,12 +60,25 @@ domReady( () => {
 			newCloseButton.prepend( thinContent );
 		} else if ( 'page' === editorPostType ) {
 			newCloseButton.href = 'edit.php?post_type=page';
-			const newLabel = __( 'Back to Page List' );
+			const newLabel = __( 'Pages' );
 			newCloseButton.setAttribute( 'aria-label', newLabel );
 
 			ReactDOM.render(
 				<Button className="components-button components-icon-button">
 					<Dashicon icon="arrow-left-alt2" />
+					<div className="close-button-override__label">{ newLabel }</div>
+				</Button>,
+				newCloseButton
+			);
+		} else if ( 'post' === editorPostType ) {
+			newCloseButton.href = 'edit.php?post_type=post';
+			const newLabel = __( 'Posts' );
+			newCloseButton.setAttribute( 'aria-label', newLabel );
+
+			ReactDOM.render(
+				<Button className="components-button components-icon-button">
+					<Dashicon icon="arrow-left-alt2" />
+					<div className="close-button-override__label">{ newLabel }</div>
 				</Button>,
 				newCloseButton
 			);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -17,8 +17,9 @@ import './style.scss';
 
 domReady( () => {
 	const { closeButtonLabel, closeButtonUrl, editorPostType } = fullSiteEditing;
+	let newLabel;
 
-	// Only alter for the page and template part editors.
+	// Only alter for the page, post, and template part editors.
 	if (
 		'wp_template_part' !== editorPostType &&
 		'page' !== editorPostType &&
@@ -45,12 +46,13 @@ domReady( () => {
 		// Create custom close button and append to components toolbar.
 		const newCloseButton = document.createElement( 'a' );
 		// When closing Template CPT (e.g. header) to navigate back to parent page.
-		if ( 'wp_template_part' === editorPostType && closeButtonUrl ) {
-			newCloseButton.href = closeButtonUrl;
-			newCloseButton.setAttribute( 'aria-label', closeButtonLabel );
+		if ( 'wp_template_part' === editorPostType ) {
+			newCloseButton.href = closeButtonUrl || 'edit.php?post_type=page';
+			const backupLabel = __( 'Go Back' );
+			newCloseButton.setAttribute( 'aria-label', closeButtonLabel || backupLabel );
 			newCloseButton.className = 'components-button components-icon-button is-button is-default';
 			const wideContent = document.createElement( 'div' );
-			wideContent.innerHTML = closeButtonLabel;
+			wideContent.innerHTML = closeButtonLabel || backupLabel;
 			wideContent.className = 'close-button-override-wide';
 			newCloseButton.prepend( wideContent );
 			const thinContent = document.createElement( 'div' );
@@ -60,19 +62,14 @@ domReady( () => {
 			newCloseButton.prepend( thinContent );
 		} else if ( 'page' === editorPostType ) {
 			newCloseButton.href = 'edit.php?post_type=page';
-			const newLabel = __( 'Pages' );
-			newCloseButton.setAttribute( 'aria-label', newLabel );
-
-			ReactDOM.render(
-				<Button className="components-button components-icon-button">
-					<Dashicon icon="arrow-left-alt2" />
-					<div className="close-button-override__label">{ newLabel }</div>
-				</Button>,
-				newCloseButton
-			);
+			newLabel = __( 'Pages' );
 		} else if ( 'post' === editorPostType ) {
 			newCloseButton.href = 'edit.php?post_type=post';
-			const newLabel = __( 'Posts' );
+			newLabel = __( 'Posts' );
+			newCloseButton.setAttribute( 'aria-label', newLabel );
+		}
+
+		if ( 'page' === editorPostType || 'post' === editorPostType ) {
 			newCloseButton.setAttribute( 'aria-label', newLabel );
 
 			ReactDOM.render(

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
@@ -1,17 +1,31 @@
 .post-type-wp_template_part .edit-post-fullscreen-mode-close__toolbar,
 .post-type-page .edit-post-fullscreen-mode-close__toolbar,
+.post-type-post .edit-post-fullscreen-mode-close__toolbar,
 .close-button-override-thin {
 	display: none;
 }
 
 .post-type-wp_template_part .edit-post-fullscreen-mode-close__toolbar__override,
-.post-type-page .edit-post-fullscreen-mode-close__toolbar__override {
+.post-type-page .edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-post .edit-post-fullscreen-mode-close__toolbar__override {
 	display: flex;
 	align-items: center;
 	padding: 9px 10px;
 	margin-left: -8px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
+
+	a,
+	a:link,
+	a:visited,
+	a:hover,
+	a:active {
+		text-decoration: none;
+	}
+
+	.close-button-override__label {
+		font-size: 13px;
+	}
 
 	@media ( max-width: 599px ) {
 		margin-left: -2px;
@@ -23,6 +37,9 @@
 		}
 		.close-button-override-thin {
 			display: flex;
+		}
+		.close-button-override__label {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds label to back button override for page editor.
* Adds back button override to post editor for consistent labeling.
* Labels are made to no longer render below 400px screen width.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Tested on local docker environment and wpcom sandbox.
* Run this PR
* Navigate to the Page editor.
* Verify label is shown and does not render below 400px screen width.
* Navigate to Posts editor.
* Verify label is shown and does not render below 400px screen width.
* Verify back button takes you back to the appropriate screen (calypso or wp-admin respectively)

**Before**
![Screen Shot 2019-11-18 at 5 08 48 PM](https://user-images.githubusercontent.com/28742426/69098319-53d93400-0a26-11ea-9e17-5cc142a18940.png)


**After**
![Screen Shot 2019-11-18 at 5 09 01 PM](https://user-images.githubusercontent.com/28742426/69098320-55a2f780-0a26-11ea-9400-f62ba07bdfc0.png)



Fixes #37284