### PR TITLE
FSE: Fix editor frame styles after Gutenberg update.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -1,11 +1,3 @@
-.post-content-block.alignfull {
-	padding: 0 12px;
-
-	@media ( max-width: 768px ) {
-		overflow-x: hidden;
-	}
-}
-
 .post-content-block__selector {
 	width: 300px;
 	a {
@@ -35,25 +27,6 @@
 
 	.post-content-block .editor-post-title {
 		display: block;
-	}
-}
-
-// Fix the size and positioning full-width blocks inside the Post Content block
-// TODO: Replace the magic numbers!
-.post-content-block .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] {
-	@media ( max-width: 768px ) {
-		max-width: 768px;
-		margin-left: 0;
-		margin-right: 0;
-
-		.block-editor-block-mover {
-			left: 60px;
-		}
-	}
-	@media ( min-width: 768px ) {
-		max-width: calc( 100vw - 81px );
-		margin-left: 3px;
-		margin-right: 3px;
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -5,6 +5,12 @@
 	position: relative;
 }
 
+// Override some very specific theme styles.
+.post-type-page .editor-styles-wrapper .template-block .fse-template-part {
+	padding-left: 0;
+	padding-right: 0;
+}
+
 .template__block-container {
 	&.is-hovered {
 		cursor: pointer;
@@ -37,13 +43,6 @@
 	.block-editor-block-list__breadcrumb,
 	.block-editor-block-list__block-edit::before {
 		display: none;
-	}
-
-	@media ( min-width: 600px ) {
-		.block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] {
-			margin-left: 14px;
-			margin-right: 14px;
-		}
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -33,6 +33,32 @@
 		}
 	}
 
+	.block-editor-block-list__layout {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit {
+		margin-right: 0;
+		margin-left: 0;
+	}
+
+	.block-editor-block-list__block[data-align=wide] > .block-editor-block-list__block-edit {
+		margin-right: 14px;
+		margin-left: 14px;
+	}
+
+	@media( max-width: 1200px ) {
+		// Try to ensure that normally-aligned blocks work properly.
+		.wp-block:not( [data-align=full] ):not( [data-align=wide] ) {
+			max-width: 580px;
+
+		}
+		.is-sidebar-opened .wp-block:not( [data-align=full] ):not( [data-align=wide] ) {
+			max-width: 400px;
+		}
+	}
+
 	// Remove the 50vh bottom padding that looks off with the FSE frame.
 	.editor-writing-flow__click-redirect {
 		display: none;


### PR DESCRIPTION
With the latest Gutenberg updates, there have been some changes to the editor styles ([#](https://github.com/WordPress/gutenberg/pull/17877)). Essentially, this means that Gutenberg dislikes our frame/margin around the border of the editor much more than it did previously. I have tried to work around that as much as I can in this PR. It's not perfect, but I think it's a big improvement. Mobile styles aren't quite perfect, but they aren't that great in Gutenberg either.

#### Changes proposed in this Pull Request

| Breakpoint | Before | After  |
| ---- | ------------- |-------------|
| Desktop | <img width="1187" alt="Screen Shot 2019-11-18 at 4 08 27 PM" src="https://user-images.githubusercontent.com/6265975/69104746-37d19480-0a1e-11ea-9348-3049b6a0188f.png"> | <img width="1019" alt="Screen Shot 2019-11-18 at 4 07 02 PM" src="https://user-images.githubusercontent.com/6265975/69104757-415afc80-0a1e-11ea-9fe5-395f247c1de7.png">|
| Tablet | <img width="580" alt="Screen Shot 2019-11-18 at 4 08 38 PM" src="https://user-images.githubusercontent.com/6265975/69104770-5041af00-0a1e-11ea-9c16-19dcfbc04dbc.png"> | <img width="560" alt="Screen Shot 2019-11-18 at 4 07 16 PM" src="https://user-images.githubusercontent.com/6265975/69104782-58015380-0a1e-11ea-9647-da960589f559.png"> |
| Smaller tablet | <img width="471" alt="Screen Shot 2019-11-18 at 4 08 47 PM" src="https://user-images.githubusercontent.com/6265975/69104830-79fad600-0a1e-11ea-86f0-69005989c59d.png"> | <img width="454" alt="Screen Shot 2019-11-18 at 4 07 32 PM" src="https://user-images.githubusercontent.com/6265975/69104834-80894d80-0a1e-11ea-8ae7-2ab9ad0140ad.png"> |
| Mobile | <img width="339" alt="Screen Shot 2019-11-18 at 4 17 04 PM" src="https://user-images.githubusercontent.com/6265975/69105021-fe4d5900-0a1e-11ea-8a4c-cb9798d5148c.png"> | <img width="327" alt="Screen Shot 2019-11-18 at 4 17 26 PM" src="https://user-images.githubusercontent.com/6265975/69105027-02797680-0a1f-11ea-863d-0e09e9978895.png"> |


#### Testing instructions
1. Pull these changes (local environment is fine) and try different layouts in the page and template part editors.
2. Try the changes at different breakpoints
3. Verify that the styles look better than before. 

If you have any tips for how to fix some of the mobile styling, please let me know 😬

Fixes #37686 
