### PR TITLE
[reCaptcha v3]: Don't block users from signing up if recaptcha…

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -78,13 +78,17 @@ class PasswordlessSignupForm extends Component {
 			form,
 		} );
 
-		const recaptchaToken =
-			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
-				? await recordGoogleRecaptchaAction(
-						this.state.recaptchaClientId,
-						'calypso/signup/formSubmit'
-				  )
-				: undefined;
+		const shouldRecordRecaptchaAction =
+			typeof this.props.recaptchaClientId === 'number' &&
+			'onboarding' === this.props.flowName &&
+			'show' === abtest( 'userStepRecaptcha' );
+
+		const recaptchaToken = shouldRecordRecaptchaAction
+			? await recordGoogleRecaptchaAction(
+					this.props.recaptchaClientId,
+					'calypso/signup/formSubmit'
+			  )
+			: undefined;
 
 		try {
 			const response = await wpcom.undocumented().usersNew(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't block user signup if Google script fails to load
  * Remove `isLoadingRecaptcha` state that disabled the form submit button
  * Check whether `recaptchaClientId` before recording action
* Fix recording `calypso/signup/formSubmit` action on passwordless form
  * In `passwordless.jsx`, get the client id from props instead of state. There never was a `this.state.recaptchaClientId`
* Fixed blocking lint warnings about JSDoc

I also want to log when recaptcha isn't loaded in time, but will come up with another PR for that.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test blocking the Google script I used a the ScriptBlock extension. After navigating to `/start/user` for the first time you need to click the extension's icon in the top-right to allow `calypso.localhost` and `wordpress.com` scripts before the page will load correctly.
https://chrome.google.com/webstore/detail/scriptblock/hcdjknjpbnhdoabbngpmfekaecnpajba?hl=en

When testing filter the network tab by `users/new` and check the `g-recaptcha-response` param is sent when it's supposed to be.

Cases to test:
1. **Passwordless** signup **with** recaptcha **with** 3rd party script allowed
2. **Passwordless** signup **without** recaptcha **with** 3rd party script allowed
3. **Passwordful** signup **with** recaptcha **with** 3rd party script allowed
4. **Passwordful** signup **without** recaptcha **with** 3rd party script allowed
5. **Passwordless** signup **with** recaptcha **without** 3rd party script allowed
6. **Passwordful** signup **with** recaptcha **without** 3rd party script allowed
