### PR TITLE
WooCommerce Services: Fix rates endpoint compatibility.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/get-rates.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/get-rates.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { mapValues } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import * as api from 'woocommerce/woocommerce-services/api';
@@ -23,7 +28,7 @@ export default ( orderId, siteId, dispatch, origin, destination, packages ) => {
 		const setSuccess = json => {
 			dispatch( {
 				type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_RATES,
-				rates: json.rates,
+				rates: mapValues( json.rates, pckg => ( 'rates' in pckg ? pckg : pckg.default ) ),
 				requestData,
 				siteId,
 				orderId,


### PR DESCRIPTION
Fixes #37638 

Provides compatibility with updated WCS extension API in versions >= 1.22.0

Prior to 1.22.0, the WCS extension rate API returned rates directly under each package. `1.22.0` includes the "default" rates along with "signature_required" and "adult_signature_required" rates: 
<img width="756" alt="image" src="https://user-images.githubusercontent.com/6209518/69173104-f7bcf100-0ab3-11ea-8405-c545b2e10075.png">


Testing: 
 - Get rates for different package types (single and multi-package orders):
     - with WCS < 1.22.0
     - with WCS >= 1.22.0