### PR TITLE
Plans: Adjust plan features title

### DIFF
--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -106,7 +106,7 @@
 }
 
 .current-plan__header-purchase-info-wrapper.card.is-compact {
-	margin: 24px -32px -32px;
+	margin: 24px -32px -14px;
 	display: flex;
 	flex-direction: column;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust spacing of plan features title

<table>
<tr>
<td>Before:
<br><br>

![#37657-before](https://user-images.githubusercontent.com/3323310/69123289-8e4cda80-0ad3-11ea-9698-511cc7e7f69c.png)

</td>
<td>After:
<br><br>

![#37657-after](https://user-images.githubusercontent.com/3323310/69123300-9442bb80-0ad3-11ea-98ad-dbe65adcd6dd.png)

</td>
</tr>
</table>

#### Testing instructions

* Go to `/plans/my-plan/`
* The headlines `Personal plan features`, `Premium plan features`, `Business plan features` and `eCommerce plan features` use the same space above and below the headline, see attached screenshots above.

Fixes #37657
