### PR TITLE
[reCaptcha v3]: Record when recaptcha didn't load

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -82,19 +82,22 @@ class PasswordlessSignupForm extends Component {
 		const isRecaptchaABTest =
 			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' );
 
-		const recaptchaToken =
-			isRecaptchaABTest && isRecaptchaLoaded
-				? await recordGoogleRecaptchaAction(
-						this.props.recaptchaClientId,
-						'calypso/signup/formSubmit'
-				  )
-				: undefined;
-
+		let recaptchaToken = undefined;
 		let recaptchaError = undefined;
-		if ( isRecaptchaABTest && ! isRecaptchaLoaded ) {
-			recaptchaError = 'recaptcha_didnt_load';
-		} else if ( isRecaptchaABTest && isRecaptchaLoaded && ! recaptchaToken ) {
-			recaptchaError = 'recaptcha_failed';
+
+		if ( isRecaptchaABTest ) {
+			if ( isRecaptchaLoaded ) {
+				recaptchaToken = await recordGoogleRecaptchaAction(
+					this.props.recaptchaClientId,
+					'calypso/signup/formSubmit'
+				);
+
+				if ( ! recaptchaToken ) {
+					recaptchaError = 'recaptcha_failed';
+				}
+			} else {
+				recaptchaError = 'recaptcha_didnt_load';
+			}
 		}
 
 		try {

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -90,13 +90,18 @@ class PasswordlessSignupForm extends Component {
 				  )
 				: undefined;
 
+		let recaptchaError = undefined;
+		if ( isRecaptchaABTest && ! isRecaptchaLoaded ) {
+			recaptchaError = 'recaptcha_didnt_load';
+		} else if ( isRecaptchaABTest && isRecaptchaLoaded && ! recaptchaToken ) {
+			recaptchaError = 'recaptcha_failed';
+		}
+
 		try {
 			const response = await wpcom.undocumented().usersNew(
 				{
 					email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
-					'g-recaptcha-didnt-load': ( isRecaptchaABTest && ! isRecaptchaLoaded ) || undefined,
-					'g-recaptcha-failed':
-						( isRecaptchaABTest && isRecaptchaLoaded && ! recaptchaToken ) || undefined,
+					'g-recaptcha-error': recaptchaError,
 					'g-recaptcha-response': recaptchaToken || undefined,
 					is_passwordless: true,
 					signup_flow_name: this.props.flowName,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -375,7 +375,18 @@ export function launchSiteApi( callback, dependencies ) {
 export function createAccount(
 	callback,
 	dependencies,
-	{ userData, flowName, queryArgs, service, access_token, id_token, oauth2Signup, recaptchaToken },
+	{
+		userData,
+		flowName,
+		queryArgs,
+		service,
+		access_token,
+		id_token,
+		oauth2Signup,
+		recaptchaDidntLoad,
+		recaptchaFailed,
+		recaptchaToken,
+	},
 	reduxStore
 ) {
 	const state = reduxStore.getState();
@@ -443,6 +454,8 @@ export function createAccount(
 							oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
 					  }
 					: null,
+				recaptchaDidntLoad ? { 'g-recaptcha-didnt-load': true } : null,
+				recaptchaFailed ? { 'g-recaptcha-failed': true } : null,
 				recaptchaToken ? { 'g-recaptcha-response': recaptchaToken } : null
 			),
 			( error, response ) => {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -454,8 +454,8 @@ export function createAccount(
 							oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
 					  }
 					: null,
-				recaptchaDidntLoad ? { 'g-recaptcha-didnt-load': true } : null,
-				recaptchaFailed ? { 'g-recaptcha-failed': true } : null,
+				recaptchaDidntLoad ? { 'g-recaptcha-error': 'recaptcha_didnt_load' } : null,
+				recaptchaFailed ? { 'g-recaptcha-error': 'recaptcha_failed' } : null,
 				recaptchaToken ? { 'g-recaptcha-response': recaptchaToken } : null
 			),
 			( error, response ) => {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -208,20 +208,22 @@ export class UserStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
 
-		const shouldRecordRecaptchaAction =
-			typeof this.state.recaptchaClientId === 'number' &&
-			'onboarding' === this.props.flowName &&
-			'show' === abtest( 'userStepRecaptcha' );
+		const isRecaptchaLoaded = typeof this.state.recaptchaClientId === 'number';
+		const isRecaptchaABTest =
+			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' );
 
-		const recaptchaPromise = shouldRecordRecaptchaAction
-			? recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' )
-			: Promise.resolve();
+		const recaptchaPromise =
+			isRecaptchaABTest && isRecaptchaLoaded
+				? recordGoogleRecaptchaAction( this.state.recaptchaClientId, 'calypso/signup/formSubmit' )
+				: Promise.resolve();
 
 		recaptchaPromise.then( token => {
 			this.submit( {
 				userData,
 				form: formWithoutPassword,
 				queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
+				recaptchaDidntLoad: isRecaptchaABTest && ! isRecaptchaLoaded,
+				recaptchaFailed: isRecaptchaABTest && isRecaptchaLoaded && ! token,
 				recaptchaToken: token || undefined,
 			} );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Users can fail record a reCaptcha action, either due to network issues or because of an explicit blocker. This change logs when a user fails to log an action for any reason.

There are two failure modes that are recorded. Either they signed up before there was time to record an action (we don't block signup if the Google script hasn't loaded yet) or it could fail after the script has loaded.

p1574111111309800-slack-CJEQFAAJU

#### Testing instructions

Apply D35741-code

To check the client sends the correct parameters filter the network tab by `users/new`. To check for the track events are correct you can watch the live view for `wpcom_recaptcha_response_verified` events. Adding server logging might be faster though.

To test blocking the Google script I used a the ScriptBlock extension. After navigating to `/start/user` for the first time you need to click the extension's icon in the top-right to allow `calypso.localhost` and `wordpress.com` scripts before the page will load correctly.
https://chrome.google.com/webstore/detail/scriptblock/hcdjknjpbnhdoabbngpmfekaecnpajba?hl=en

To test the script load timeout I needed to wait ~40s. You'll know it's timed out because there's a `Timeout` error in the console and this black text appears at the bottom of the screen: `Could not connect to the reCAPTCHA service. Please check your internet connection and reload to get a reCAPTCHA challenge.`

Looks like a lot of test cases, but there's only 6 signups to test.

Cases to test:
- Passwordless
  - With 3rd party script blocked
    - Complete signup before script loads
      - API request includes `g-recaptcha-error=recaptcha_didnt_load`
      - Track event includes `recaptcha_error=recaptcha_didnt_load`
    - Complete signup after script load timeout
      - API request includes `g-recaptcha-error=recaptcha_failed`
      - Track event includes `recaptcha_error=recaptcha_failed`
  - With 3rd party script allowed
    - Complete signup
      - API request includes `g-recaptcha-response=XXXX`
      - Track event includes `recaptcha_score` and `recaptcha_likely_good`
- Passwordful
  - With 3rd party script blocked
    - Complete signup before script loads
      - API request includes `g-recaptcha-error=recaptcha_didnt_load`
      - Track event includes `recaptcha_error=recaptcha_didnt_load`
    - Complete signup after script load timeout
      - API request includes `g-recaptcha-error=recaptcha_failed`
      - Track event includes `recaptcha_error=recaptcha_error`
  - With 3rd party script allowed
    - Complete signup
      - API request includes `g-recaptcha-response=XXXX`
      - Track event includes `recaptcha_score` and `recaptcha_likely_good`