### PR TITLE
Gutenboarding: Add isLoadingDomainSuggestions selector

### DIFF
--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -33,7 +33,7 @@ export const getDomainSuggestions = (
  *
  * @param state Store state
  * @param queryObject Normalized object representing the query
- * @return suggestions
+ * @returns suggestions
  */
 export const __internalGetDomainSuggestions = (
 	state: State,
@@ -53,7 +53,7 @@ export const __internalGetDomainSuggestions = (
  *
  * @param search       Domain search string
  * @param queryOptions Optional paramaters for the query
- * @return Normalized query object
+ * @returns Normalized query object
  */
 function normalizeDomainSuggestionQuery(
 	search: string,

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -26,6 +26,18 @@ export const getDomainSuggestions = (
 	return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
 };
 
+export const isLoadingDomainSuggestions = (
+	state: State,
+	search: string,
+	options: DomainSuggestionSelectorOptions = {}
+) => {
+	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
+
+	return select( 'core/data' ).isResolving( STORE_KEY, '__internalGetDomainSuggestions', [
+		normalizedQuery,
+	] );
+};
+
 /**
  * Do not use this selector. It is for internal use.
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add isLoadingDomainSuggestions selector
This will come in handy to show loading placeholders in the domains picker.

#### Testing instructions

- Go to http://calypso.localhost:3000/gutenboarding
- Clear all fields in the intent gathering step (might not be possible with the vertical, might need to choose something random there)
- In your browser console, create a Live Expression (that's the Eye icon in the console's top bar) with the following content:

```
wp.data.select('automattic/domains/suggestions').isLoadingDomainSuggestions( 'Roasting Beans', { include_wordpressdotcom: true, vertical: 'p13v1' } )
```

- Now, in the intent gathering, pick 'Cafe' as vertical (that's `p13v1`), and enter 'Roasting Beans' as site title.
- Note the Live Expression briefly evaluates to `true`, and then falls back to `false`.

![is-resolving](https://user-images.githubusercontent.com/96308/69130473-c99ed780-0ada-11ea-9bfc-edc03e90aae8.gif)
