### PR TITLE
Plans: Display product+plan overlap notice for inferior features

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -18,7 +18,7 @@ import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
-import { planHasFeature } from 'lib/plans';
+import { planHasFeature, planHasSuperiorFeature } from 'lib/plans';
 import { PRODUCT_SHORT_NAMES } from 'lib/products-values/constants';
 
 class ProductPlanOverlapNotices extends Component {
@@ -55,11 +55,13 @@ class ProductPlanOverlapNotices extends Component {
 			return false;
 		}
 
-		// Does the current plan include the current product as a feature?
+		// Does the current plan include the current product as a feature, or have a superior version of it?
 		return some(
 			products,
 			productSlug =>
-				productSlug === currentProductSlug && planHasFeature( currentPlanSlug, productSlug )
+				productSlug === currentProductSlug &&
+				( planHasFeature( currentPlanSlug, productSlug ) ||
+					planHasSuperiorFeature( currentPlanSlug, productSlug ) )
 		);
 	}
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -78,9 +78,9 @@ export function getPlanClass( planKey ) {
  *
  * Collects features for a plan by calling all possible feature methods for the plan.
  *
- * @param   {Object|String} plan    Plan object or plan name.
- * @param   {String}        feature Feature name.
- * @returns {Boolean}               Whether the specified plan has the specified feature.
+ * @param   {object|string} plan    Plan object or plan name.
+ * @param   {string}        feature Feature name.
+ * @returns {boolean}               Whether the specified plan has the specified feature.
  */
 export function planHasFeature( plan, feature ) {
 	const planConstantObj = getPlan( plan );
@@ -102,6 +102,19 @@ export function planHasFeature( plan, feature ) {
 	);
 
 	return includes( allFeatures, feature );
+}
+
+/**
+ * Determines if a plan has a superior version of a specific feature.
+ *
+ * @param   {object|string} plan    Plan object or plan name.
+ * @param   {string}        feature Feature name.
+ * @returns {boolean}               Whether the specified plan has a superior version of a feature.
+ */
+export function planHasSuperiorFeature( plan, feature ) {
+	const planConstantObj = getPlan( plan );
+
+	return includes( planConstantObj.getInferiorHiddenFeatures(), feature );
 }
 
 export function shouldFetchSitePlans( sitePlans, selectedSite ) {
@@ -150,8 +163,8 @@ export function filterPlansBySiteAndProps(
  * Returns the monthly slug which corresponds to the provided yearly slug or "" if the slug is
  * not a recognized or cannot be converted.
  *
- * @param  {String} planSlug Slug to convert to monthly.
- * @return {String}          Monthly version slug or "" if the slug could not be converted.
+ * @param  {string} planSlug Slug to convert to monthly.
+ * @returns {string}          Monthly version slug or "" if the slug could not be converted.
  */
 export function getMonthlyPlanByYearly( planSlug ) {
 	return findFirstSimilarPlanKey( planSlug, { term: TERM_MONTHLY } ) || '';
@@ -161,8 +174,8 @@ export function getMonthlyPlanByYearly( planSlug ) {
  * Returns the yearly slug which corresponds to the provided monthly slug or "" if the slug is
  * not a recognized or cannot be converted.
  *
- * @param  {String} planSlug Slug to convert to yearly.
- * @return {String}          Yearly version slug or "" if the slug could not be converted.
+ * @param  {string} planSlug Slug to convert to yearly.
+ * @returns {string}          Yearly version slug or "" if the slug could not be converted.
  */
 export function getYearlyPlanByMonthly( planSlug ) {
 	return findFirstSimilarPlanKey( planSlug, { term: TERM_ANNUALLY } ) || '';
@@ -172,8 +185,8 @@ export function getYearlyPlanByMonthly( planSlug ) {
  * Returns the biennial slug which corresponds to the provided slug or "" if the slug is
  * not a recognized or cannot be converted.
  *
- * @param  {String} planSlug Slug to convert to biennial.
- * @return {String}          Biennial version slug or "" if the slug could not be converted.
+ * @param  {string} planSlug Slug to convert to biennial.
+ * @returns {string}          Biennial version slug or "" if the slug could not be converted.
  */
 export function getBiennialPlan( planSlug ) {
 	return findFirstSimilarPlanKey( planSlug, { term: TERM_BIENNIALLY } ) || '';
@@ -187,9 +200,9 @@ export function getBiennialPlan( planSlug ) {
  *     planLevelsMatch( PRO_YEARLY, PRO_MONTHLY ) => true
  *     planLevelsMatch( PRO_YEARLY, PERSONAL_YEARLY ) => false
  *
- * @param  {String}  planSlugA One of the plan slugs to compare
- * @param  {String}  planSlugB One of the plan slugs to compare
- * @return {Boolean}           Whether the plan "types" match regardless of interval
+ * @param  {string}  planSlugA One of the plan slugs to compare
+ * @param  {string}  planSlugB One of the plan slugs to compare
+ * @returns {boolean}           Whether the plan "types" match regardless of interval
  */
 export function planLevelsMatch( planSlugA, planSlugB ) {
 	const planA = getPlan( planSlugA );
@@ -266,7 +279,7 @@ export function isJetpackFreePlan( planSlug ) {
  *
  * @param {string|object} planKey Source plan to compare to
  * @param {object} diff Properties that should differ in matched plan. @see planMatches
- * @return {string|undefined} Matched plan
+ * @returns {string|undefined} Matched plan
  */
 export function findFirstSimilarPlanKey( planKey, diff ) {
 	return findSimilarPlansKeys( planKey, diff )[ 0 ];
@@ -285,7 +298,7 @@ export function findFirstSimilarPlanKey( planKey, diff ) {
  *
  * @param {string|object} planKey Source plan to compare to
  * @param {object} diff Properties that should differ in matched plan. @see planMatches
- * @return {string[]} Matched plans keys
+ * @returns {string[]} Matched plans keys
  */
 export function findSimilarPlansKeys( planKey, diff = {} ) {
 	const plan = getPlan( planKey );
@@ -308,7 +321,7 @@ export function findSimilarPlansKeys( planKey, diff = {} ) {
  * [PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS, PLAN_BUSINESS_2_YEARS]
  *
  * @param {object} query @see planMatches
- * @return {string[]} Matched plans keys
+ * @returns {string[]} Matched plans keys
  */
 export function findPlansKeys( query = {} ) {
 	const plans = getPlans();
@@ -329,7 +342,7 @@ export function findPlansKeys( query = {} ) {
  *
  * @param {string|object} planKey Plan to match
  * @param {object} query Properties that should match
- * @return {bool} Does `planKey` match?
+ * @returns {boolean} Does `planKey` match?
  */
 export function planMatches( planKey, query = {} ) {
 	const acceptedKeys = [ 'type', 'group', 'term' ];

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -66,6 +66,7 @@ const getPlanBloggerDetails = () => ( {
 	],
 	// Features not displayed but used for checking plan abilities
 	getHiddenFeatures: () => [ constants.FEATURE_AUDIO_UPLOADS ],
+	getInferiorHiddenFeatures: () => [],
 } );
 
 const getPlanPersonalDetails = () => ( {
@@ -121,6 +122,7 @@ const getPlanPersonalDetails = () => ( {
 	],
 	// Features not displayed but used for checking plan abilities
 	getHiddenFeatures: () => [ constants.FEATURE_AUDIO_UPLOADS ],
+	getInferiorHiddenFeatures: () => [],
 } );
 
 const getPlanEcommerceDetails = () => ( {
@@ -210,6 +212,7 @@ const getPlanEcommerceDetails = () => ( {
 		constants.FEATURE_GOOGLE_MY_BUSINESS,
 		constants.FEATURE_UPLOAD_THEMES_PLUGINS,
 	],
+	getInferiorHiddenFeatures: () => [],
 } );
 
 const getPlanPremiumDetails = () => ( {
@@ -280,6 +283,7 @@ const getPlanPremiumDetails = () => ( {
 	],
 	// Features not displayed but used for checking plan abilities
 	getHiddenFeatures: () => [ constants.FEATURE_AUDIO_UPLOADS ],
+	getInferiorHiddenFeatures: () => [],
 } );
 
 const getPlanBusinessDetails = () => ( {
@@ -363,6 +367,7 @@ const getPlanBusinessDetails = () => ( {
 		constants.FEATURE_GOOGLE_MY_BUSINESS,
 		constants.FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 	],
+	getInferiorHiddenFeatures: () => [],
 } );
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
@@ -723,6 +728,7 @@ export const PLANS_LIST = {
 			constants.FEATURE_JETPACK_BACKUP_DAILY,
 			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		],
+		getInferiorHiddenFeatures: () => [],
 	},
 
 	[ constants.PLAN_JETPACK_PREMIUM_MONTHLY ]: {
@@ -785,6 +791,7 @@ export const PLANS_LIST = {
 			constants.FEATURE_JETPACK_BACKUP_DAILY,
 			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		],
+		getInferiorHiddenFeatures: () => [],
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL ]: {
@@ -830,6 +837,7 @@ export const PLANS_LIST = {
 			constants.FEATURE_JETPACK_BACKUP_DAILY,
 			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		],
+		getInferiorHiddenFeatures: () => [],
 	},
 
 	[ constants.PLAN_JETPACK_PERSONAL_MONTHLY ]: {
@@ -874,6 +882,7 @@ export const PLANS_LIST = {
 			constants.FEATURE_JETPACK_BACKUP_DAILY,
 			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		],
+		getInferiorHiddenFeatures: () => [],
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS ]: {
@@ -938,6 +947,10 @@ export const PLANS_LIST = {
 			constants.FEATURE_JETPACK_BACKUP_REALTIME,
 			constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 		],
+		getInferiorHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_DAILY,
+			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+		],
 	},
 
 	[ constants.PLAN_JETPACK_BUSINESS_MONTHLY ]: {
@@ -1000,6 +1013,10 @@ export const PLANS_LIST = {
 		getHiddenFeatures: () => [
 			constants.FEATURE_JETPACK_BACKUP_REALTIME,
 			constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
+		],
+		getInferiorHiddenFeatures: () => [
+			constants.FEATURE_JETPACK_BACKUP_DAILY,
+			constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		],
 	},
 };

--- a/client/lib/plans/test/plan-lookups.js
+++ b/client/lib/plans/test/plan-lookups.js
@@ -10,6 +10,8 @@ import {
 	FEATURE_ALL_PERSONAL_FEATURES,
 	FEATURE_AUDIO_UPLOADS,
 	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_JETPACK_BACKUP_DAILY,
+	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_VIDEO_UPLOADS,
 	GROUP_JETPACK,
 	GROUP_WPCOM,
@@ -66,6 +68,7 @@ import {
 	getMonthlyPlanByYearly,
 	getYearlyPlanByMonthly,
 	planHasFeature,
+	planHasSuperiorFeature,
 } from '../index';
 
 describe( 'isFreePlan', () => {
@@ -866,5 +869,28 @@ describe( 'planHasFeature', () => {
 
 	test( 'should return false when a plan does not have a feature', () => {
 		expect( planHasFeature( PLAN_PERSONAL, FEATURE_VIDEO_UPLOADS ) ).to.be.false;
+	} );
+} );
+
+describe( 'planHasSuperiorFeature', () => {
+	test( 'should return true when a yearly plan has a superior feature', () => {
+		expect( planHasSuperiorFeature( PLAN_JETPACK_BUSINESS, FEATURE_JETPACK_BACKUP_DAILY ) ).to.be
+			.true;
+	} );
+
+	test( 'should return true when a monthly plan has a superior feature', () => {
+		expect( planHasSuperiorFeature( PLAN_JETPACK_BUSINESS_MONTHLY, FEATURE_JETPACK_BACKUP_DAILY ) )
+			.to.be.true;
+	} );
+
+	test( 'should return false when a yearly plan does not have a superior feature', () => {
+		expect( planHasSuperiorFeature( PLAN_JETPACK_BUSINESS, FEATURE_JETPACK_BACKUP_REALTIME ) ).to.be
+			.false;
+	} );
+
+	test( 'should return false when a monthly plan does not have a superior feature', () => {
+		expect(
+			planHasSuperiorFeature( PLAN_JETPACK_BUSINESS_MONTHLY, FEATURE_JETPACK_BACKUP_REALTIME )
+		).to.be.false;
 	} );
 } );


### PR DESCRIPTION
Currently, we display a warning when the user has a product and a plan that includes that product as a feature. However, if the plan includes a more superior version of that feature, we incorrectly don't display this warning. This PR fixes that by introducing the concept of "inferior features", utility to check against them and using that utility in the `ProductPlanOverlapNotices` block.

#### Changes proposed in this Pull Request

* Plans: Add support for inferior features to plan objects
* Plans: Introduce `planHasSuperiorFeature` utility function, fix any ESLint warnings in that file.
* Plans: Add tests for `planHasSuperiorFeature`
* Blocks: Display overlap notice for current plan with current inferior product in `ProductPlanOverlapNotices`

#### Preview
![](https://cldup.com/_S0WCfWzb6.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site slug.
* Get a daily backup product.
* Get a Premium plan.
* Verify you can see the overlap notice just like before.
* Upgrade to Professional plan.
* Verify you can see the overlap notice as shown on the screenshot.
* Verify you don't see the overlap notice if you only have a plan or a product.
