### PR TITLE
Fix inconsitent upsell nudge for free plan site

### DIFF
--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -7,21 +7,25 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
+import getSiteDomain from 'state/sites/selectors/get-site-domain';
 
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site
  *
- * @param {Object} state Global state tree
- * @param {Number} siteId Site ID
- * @return {?Boolean} True if the user can participate in the free to paid upsell
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {?boolean} True if the user can participate in the free to paid upsell
  */
 const isEligibleForFreeToPaidUpsell = ( state, siteId ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const siteIsVipSite = isVipSite( state, siteId );
+	const siteHasCustomMappedDomain =
+		siteHasMappedDomain &&
+		! /(\.home\.blog|\.wordpress\.com)$/.test( getSiteDomain( state, siteId ) );
 
-	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && ! siteIsVipSite;
+	return userCanManageOptions && ! siteHasCustomMappedDomain && siteIsOnFreePlan && ! siteIsVipSite;
 };
 
 export default isEligibleForFreeToPaidUpsell;

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -7,7 +7,6 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
-import getSiteDomain from 'state/sites/selectors/get-site-domain';
 
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site
@@ -21,11 +20,8 @@ const isEligibleForFreeToPaidUpsell = ( state, siteId ) => {
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const siteIsVipSite = isVipSite( state, siteId );
-	const siteHasCustomMappedDomain =
-		siteHasMappedDomain &&
-		! /(\.home\.blog|\.wordpress\.com)$/.test( getSiteDomain( state, siteId ) );
 
-	return userCanManageOptions && ! siteHasCustomMappedDomain && siteIsOnFreePlan && ! siteIsVipSite;
+	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && ! siteIsVipSite;
 };
 
 export default isEligibleForFreeToPaidUpsell;

--- a/client/state/selectors/is-mapped-domain-site.js
+++ b/client/state/selectors/is-mapped-domain-site.js
@@ -2,27 +2,32 @@
  * External dependencies
  */
 
-import { get } from 'lodash';
+import { get, some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getRawSite from 'state/selectors/get-raw-site';
+import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 
 /**
  * Returns true if site is a mapped domain site, false if the site is not,
  * or null if the site is unknown.
  *
- * @param {Object} state Global state tree
- * @param {Number} siteId Site ID
- * @return {?Boolean} Whether site is a mapped domain site
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {?boolean} Whether site is a mapped domain site
  */
 export default function isMappedDomainSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
+	const domains = getDomainsBySiteId( state, siteId );
 
-	if ( ! site ) {
+	if ( ! site || 0 === domains.length ) {
 		return null;
 	}
 
-	return get( site, 'options.is_mapped_domain', false );
+	return (
+		get( site, 'options.is_mapped_domain', false ) &&
+		some( domains, ( { isWPCOMDomain } ) => ! isWPCOMDomain )
+	);
 }

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -11,13 +11,11 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
-import getSiteDomain from 'state/sites/selectors/get-site-domain';
 
 jest.mock( 'state/selectors/can-current-user', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
-jest.mock( 'state/sites/selectors/get-site-domain', () => require( 'sinon' ).stub() );
 
 describe( 'isEligibleForFreeToPaidUpsell', () => {
 	const state = 'state';
@@ -28,7 +26,6 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
 		isVipSite.withArgs( state, siteId ).returns( false );
-		getSiteDomain.withArgs( state, siteId ).returns( 'test.home.blog' );
 	};
 
 	test( 'should return false when user can not manage options', () => {
@@ -37,17 +34,10 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
 	} );
 
-	test( 'should return false when site has custom mapped domain', () => {
+	test( 'should return false when site has mapped domain', () => {
 		meetAllConditions();
 		isMappedDomainSite.withArgs( state, siteId ).returns( true );
-		getSiteDomain.withArgs( state, siteId ).returns( 'testingdomain.com' );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
-	} );
-
-	test( 'should return true when site has mapped .home.blog domain', () => {
-		meetAllConditions();
-		isMappedDomainSite.withArgs( state, siteId ).returns( true );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.true;
 	} );
 
 	test( 'should return false when site is not on a free plan', () => {

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -11,11 +11,13 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
+import getSiteDomain from 'state/sites/selectors/get-site-domain';
 
 jest.mock( 'state/selectors/can-current-user', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
+jest.mock( 'state/sites/selectors/get-site-domain', () => require( 'sinon' ).stub() );
 
 describe( 'isEligibleForFreeToPaidUpsell', () => {
 	const state = 'state';
@@ -26,6 +28,7 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
 		isVipSite.withArgs( state, siteId ).returns( false );
+		getSiteDomain.withArgs( state, siteId ).returns( 'test.home.blog' );
 	};
 
 	test( 'should return false when user can not manage options', () => {
@@ -34,10 +37,17 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
 	} );
 
-	test( 'should return false when site has mapped domain', () => {
+	test( 'should return false when site has custom mapped domain', () => {
 		meetAllConditions();
 		isMappedDomainSite.withArgs( state, siteId ).returns( true );
+		getSiteDomain.withArgs( state, siteId ).returns( 'testingdomain.com' );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
+	} );
+
+	test( 'should return true when site has mapped .home.blog domain', () => {
+		meetAllConditions();
+		isMappedDomainSite.withArgs( state, siteId ).returns( true );
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.true;
 	} );
 
 	test( 'should return false when site is not on a free plan', () => {

--- a/client/state/selectors/test/is-mapped-domain-site.js
+++ b/client/state/selectors/test/is-mapped-domain-site.js
@@ -10,12 +10,47 @@ import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 
 describe( '#isMappedDomainSite()', () => {
 	const siteId = 77203074;
+	const sites = {
+		items: {
+			[ siteId ]: {
+				ID: siteId,
+				URL: 'https://example.wordpress.com',
+				options: {
+					is_mapped_domain: false,
+				},
+			},
+		},
+		domains: {
+			items: {
+				[ siteId ]: {
+					isWPCOMDomain: true,
+				},
+			},
+		},
+	};
 
 	test( 'should return null if the site is unknown', () => {
 		const result = isMappedDomainSite(
 			{
 				sites: {
+					...sites,
 					items: {},
+				},
+			},
+			siteId
+		);
+
+		expect( result ).to.be.null;
+	} );
+
+	test( 'should return null if no domain is found', () => {
+		const result = isMappedDomainSite(
+			{
+				sites: {
+					...sites,
+					domains: {
+						items: {},
+					},
 				},
 			},
 			siteId
@@ -28,6 +63,7 @@ describe( '#isMappedDomainSite()', () => {
 		const result = isMappedDomainSite(
 			{
 				sites: {
+					...sites,
 					items: {
 						[ siteId ]: {
 							ID: siteId,
@@ -49,6 +85,7 @@ describe( '#isMappedDomainSite()', () => {
 		const result = isMappedDomainSite(
 			{
 				sites: {
+					...sites,
 					items: {
 						[ siteId ]: {
 							ID: siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes inconsistent upsell nudges for free plan sites. See pbm1bU-3f-p2 for more detail.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new `blog` type website with `.home.blog` subdomain and free plan.
* You should be able to see the "Free domain with a plan" upsell nudge in the sidebar instead of "Upgrade your site and save".

![붙여넣은_이미지_2019__11__19__오후_7_39](https://user-images.githubusercontent.com/212034/69139730-76da1580-0b04-11ea-8fb2-5826f207eca7.png)
![붙여넣은_이미지_2019__11__19__오후_7_40](https://user-images.githubusercontent.com/212034/69139832-ab4dd180-0b04-11ea-9a5d-7e6d9cfa97dc.png)

