### PR TITLE
Classic Editor: migrate GalleryPreviewShortcode to ES6 class component

### DIFF
--- a/client/post-editor/media-modal/gallery/preview-shortcode.jsx
+++ b/client/post-editor/media-modal/gallery/preview-shortcode.jsx
@@ -4,7 +4,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { some } from 'lodash';
 import classNames from 'classnames';
 
@@ -14,42 +13,43 @@ import classNames from 'classnames';
 import { generateGalleryShortcode } from 'lib/media/utils';
 import GalleryShortcode from 'components/gallery-shortcode';
 
-export default createReactClass( {
-	displayName: 'EditorMediaModalGalleryPreviewShortcode',
-
-	propTypes: {
+export default class EditorMediaModalGalleryPreviewShortcode extends React.Component {
+	static propTypes = {
 		siteId: PropTypes.number,
 		settings: PropTypes.object,
-	},
+	};
 
-	getInitialState() {
-		return {
-			isLoading: true,
-			shortcode: generateGalleryShortcode( this.props.settings ),
-		};
-	},
+	state = {
+		isLoading: true,
+		shortcode: generateGalleryShortcode( this.props.settings ),
+	};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	isMounted = false;
+
+	static getDerivedStateFromProps( nextProps, prevState ) {
 		const shortcode = generateGalleryShortcode( nextProps.settings );
-		if ( this.state.shortcode === shortcode ) {
+		if ( prevState.shortcode === shortcode ) {
+			return null;
+		}
+
+		return { isLoading: true, shortcode };
+	}
+
+	componentDidMount() {
+		this.isMounted = true;
+	}
+
+	componentWillUnmount() {
+		this.isMounted = false;
+	}
+
+	setLoaded = () => {
+		if ( ! this.isMounted ) {
 			return;
 		}
 
-		this.setState( {
-			isLoading: true,
-			shortcode,
-		} );
-	},
-
-	setLoaded() {
-		if ( ! this.isMounted() ) {
-			return;
-		}
-
-		this.setState( {
-			isLoading: false,
-		} );
-	},
+		this.setState( { isLoading: false } );
+	};
 
 	render() {
 		const { siteId, settings } = this.props;
@@ -65,5 +65,5 @@ export default createReactClass( {
 				</GalleryShortcode>
 			</div>
 		);
-	},
-} );
+	}
+}


### PR DESCRIPTION
Migrates the Gallery Shortcode Preview in Classic Editor away from `createReactClass` to
the more modern ES6 class. The codemod previously missed it because of the `this.isMounted()`
method usage.

**How to test:**
- open a post in Classic Editor
- click "Add Media" in the toolbar
- select two or more images in the Media Modal so that you start creating a gallery rather than insert a single image
- start modifying the gallery options in the gallery UI (see screenshot below)
- verify that on each option change, the gallery preview first shows a "loading" state for a moment, and then updates itself with the up-to-date preview

<img width="963" alt="Screenshot 2019-11-19 at 11 40 40" src="https://user-images.githubusercontent.com/664258/69140401-bed84880-0ac2-11ea-8630-6925502e528d.png">
