### PR TITLE
Activity Log: Fixes js error when a plugin update doesn't include a version

### DIFF
--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -87,7 +87,7 @@ export function getPlugins( state, siteIds, pluginFilter ) {
 export function getPluginsWithUpdates( state, siteIds ) {
 	return filter( getPlugins( state, siteIds ), _filters.updates ).map( plugin => ( {
 		...plugin,
-		version: plugin.update && plugin.update.new_version,
+		version: plugin?.update?.new_version,
 		type: 'plugin',
 	} ) );
 }

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -87,7 +87,7 @@ export function getPlugins( state, siteIds, pluginFilter ) {
 export function getPluginsWithUpdates( state, siteIds ) {
 	return filter( getPlugins( state, siteIds ), _filters.updates ).map( plugin => ( {
 		...plugin,
-		version: plugin.update.new_version,
+		version: plugin.update && plugin.update.new_version,
 		type: 'plugin',
 	} ) );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove JS WSOF when a plugin update doesn't have a new version when asking about it on the activity log.

Related to this issue p9F6qB-4om-p2

#### Testing instructions
* update your sandbox so that the new_version is not passed to the frontend in the api call.
* Notice that the activity log doesn't break. 
