### PR TITLE
Login: encode the username before sending it in /auth-options request path

### DIFF
--- a/client/state/data-layer/wpcom/users/auth-options/index.js
+++ b/client/state/data-layer/wpcom/users/auth-options/index.js
@@ -21,7 +21,7 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 export const getAuthAccountType = action =>
 	http(
 		{
-			path: `/users/${ action.usernameOrEmail }/auth-options`,
+			path: `/users/${ encodeURIComponent( action.usernameOrEmail ) }/auth-options`,
 			method: 'GET',
 			apiVersion: '1.1',
 			retryPolicy: noRetry(),


### PR DESCRIPTION
Fixes a bug where entering username `foo/bar` would cause a REST request to path `/users/foo/bar/auth-options` which doesn't exist. The correct approach is to encode it and escape the (back)slash. Then the request path becomes `/users/foo%2Fbar/auth-options` and the REST server can handle that.

Backslashes (`foo\bar`) in request URL get translated to forward slashes by the browser's XHR code, so the request will be the same: `.../foo/bar/...`.

Fixes #30381.

**How to test:**
Follow the reproduction steps in #30381 and verify that slashes and backslashes in username don't crash the `/auth-options` endpoint. The username is encoded and the server returns auth options for the username or fails with "User not found".

Note that the `/auth-options` endpoint sanitizes the username by removing most silly characters. Therefore, entering `foo/bar` returns auth options for user `foobar`, which can be surprising.