### PR TITLE
Docs: link TypeScript docs from Calypso devdocs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Consistent coding style makes the code so much easier to read. Here are ours:
 
 * [All Coding Guidelines](../docs/coding-guidelines.md)
 	- [JavaScript](../docs/coding-guidelines/javascript.md)
-    - [TypeScript](../docs/coding-guidelines/typescript.md)
+	- [TypeScript](../docs/coding-guidelines/typescript.md)
 	- [CSS/Sass](../docs/coding-guidelines/css.md)
 	- [HTML](../docs/coding-guidelines/html.md)
 	- [React Components](../docs/components.md)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,6 +58,7 @@ Consistent coding style makes the code so much easier to read. Here are ours:
 
 * [All Coding Guidelines](../docs/coding-guidelines.md)
 	- [JavaScript](../docs/coding-guidelines/javascript.md)
+    - [TypeScript](../docs/coding-guidelines/typescript.md)
 	- [CSS/Sass](../docs/coding-guidelines/css.md)
 	- [HTML](../docs/coding-guidelines/html.md)
 	- [React Components](../docs/components.md)

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -8,6 +8,7 @@ Our coding guidelines are based on the standards adopted by the WordPress core p
 - [HTML](coding-guidelines/html.md)
 - [Sass/CSS](coding-guidelines/css.md)
 - [JavaScript](coding-guidelines/javascript.md)
+- [TypeScript](coding-guidelines/typescript.md)
 
 ### General Rules
 


### PR DESCRIPTION
#### Testing instructions
TypeScript docs should be accessible from the following pages: 
http://calypso.localhost:3000/devdocs/.github/CONTRIBUTING.md
http://calypso.localhost:3000/devdocs/docs/coding-guidelines.md
