### PR TITLE
CI: Remove prepare from wait-calypso-live job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,6 +545,9 @@ jobs:
               echo 'PRs from external authors cannot run on calypso.live'
               exit 1
             fi
+      - restore_cache: *restore-git-cache
+      - checkout
+      # Don't bother updating the git cache here, it would be the second time in the workflow
       - run:
           name: Wait for calypso.live build
           command: ./test/e2e/scripts/wait-for-running-branch.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,6 @@ jobs:
               echo 'PRs from external authors cannot run on calypso.live'
               exit 1
             fi
-      - prepare
       - run:
           name: Wait for calypso.live build
           command: ./test/e2e/scripts/wait-for-running-branch.sh


### PR DESCRIPTION
The `wait-calypso-live` job does not require anything from the `prepare` set of steps. Remove this to save time, notably skip attaching the workspace.

#### Testing instructions

CircleCI workflow works as expected (`wait-calypso-live` job correctly waits for the correct calypso.live build).