### PR TITLE
Tsconfig: Exclude more things

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,18 +24,21 @@
 	},
 	"include": [ "client", "server" ],
 	"exclude": [
-		"public",
-		"node_modules",
-		"**/node_modules/*",
-		"build",
-		"**/build/*",
 		"**/build-module/*",
 		"**/build-style/*",
+		"**/build/*",
 		"**/dist/*",
+		"**/node_modules/*",
+		"apps",
+		"build",
 		"cached-results.json",
-		"stats.json",
-		"server/bundlers/assets-*.json",
-		"server/devdocs/search-index.js"
+		"packages",
+		"public",
+		"server/bundler/assets*.json",
+		"server/devdocs/components-usage-stats.json",
+		"server/devdocs/proptypes-index.json",
+		"server/devdocs/search-index.js",
+		"stats.json"
 	],
 	"types": [ "webpack-env" ]
 }


### PR DESCRIPTION
Add exclude rules to tsconfig.
Some based on .gitignore contents
Also add `apps` and `packages` directories which should be treated as external (like `node_modules`).

May help with tsserver startup speed 🤞 

Some prompts in VSCode about excluding large files prompted me to try this.

#### Testing instructions

Should have no impact given our setup.