### PR TITLE
Gutenboarding: Debounce search input

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -13,6 +13,7 @@ import DomainPicker from './list';
 import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { isFilledFormValue } from '../../stores/onboard/types';
+import { useDebounce } from 'use-debounce';
 
 import './style.scss';
 
@@ -27,11 +28,10 @@ const DomainPickerButton: FunctionComponent = () => {
 	// Without user search, we can provide recommendations based on title + vertical
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 
-	let search = domainSearch.trim();
-	if ( ! search && isFilledFormValue( siteTitle ) ) {
-		search = siteTitle;
-	}
-
+	// Debounce changes to input at 200ms
+	const [ debouncedDomainSearch ] = useDebounce( domainSearch.trim(), 200 );
+	const search =
+		! debouncedDomainSearch && isFilledFormValue( siteTitle ) ? debouncedDomainSearch : siteTitle;
 	const suggestions = useSelect(
 		select => {
 			if ( search ) {

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -36,7 +36,7 @@ const DomainPickerButton: FunctionComponent = () => {
 	 *
 	 * @see https://stackoverflow.com/a/44755058/1432801
 	 */
-	const inputDebounce = 200;
+	const inputDebounce = 400;
 	const [ debouncedDomainSearch ] = useDebounce( domainSearch.trim(), inputDebounce );
 	const search =
 		! debouncedDomainSearch && isFilledFormValue( siteTitle ) ? siteTitle : debouncedDomainSearch;

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -28,10 +28,18 @@ const DomainPickerButton: FunctionComponent = () => {
 	// Without user search, we can provide recommendations based on title + vertical
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 
-	// Debounce changes to input at 200ms
-	const [ debouncedDomainSearch ] = useDebounce( domainSearch.trim(), 200 );
+	/**
+	 * Debounce our input + HTTP dependent select changes
+	 *
+	 * Rapidly changing input generates excessive HTTP requests.
+	 * It also leads to jarring UI changes.
+	 *
+	 * @see https://stackoverflow.com/a/44755058/1432801
+	 */
+	const inputDebounce = 200;
+	const [ debouncedDomainSearch ] = useDebounce( domainSearch.trim(), inputDebounce );
 	const search =
-		! debouncedDomainSearch && isFilledFormValue( siteTitle ) ? debouncedDomainSearch : siteTitle;
+		! debouncedDomainSearch && isFilledFormValue( siteTitle ) ? siteTitle : debouncedDomainSearch;
 	const suggestions = useSelect(
 		select => {
 			if ( search ) {

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -37,9 +37,15 @@ const DomainPickerButton: FunctionComponent = () => {
 	 * @see https://stackoverflow.com/a/44755058/1432801
 	 */
 	const inputDebounce = 400;
-	const [ debouncedDomainSearch ] = useDebounce( domainSearch.trim(), inputDebounce );
-	const search =
-		! debouncedDomainSearch && isFilledFormValue( siteTitle ) ? siteTitle : debouncedDomainSearch;
+	const [ search ] = useDebounce(
+		// Use trimmed domainSearch if non-empty
+		domainSearch.trim() ||
+			// Otherwise use a filled form value
+			( isFilledFormValue( siteTitle ) && siteTitle ) ||
+			// Otherwise use empty string
+			'',
+		inputDebounce
+	);
 	const suggestions = useSelect(
 		select => {
 			if ( search ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27753,6 +27753,11 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
+		"use-debounce": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.1.0.tgz",
+			"integrity": "sha512-DEf3L/ZKkOSTARk/DHlC6KAAJKwMqpck8Zx06SM2Wr+LfU1TzhO8hZRzB/qbpSQqREYWQes24n1q9doeTMqF4g=="
+		},
 		"use-subscription": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
 		"tracekit": "0.4.5",
 		"twemoji": "11.2.0",
 		"url": "0.11.0",
+		"use-debounce": "3.1.0",
 		"use-subscription": "1.2.0",
 		"utility-types": "3.9.0",
 		"uuid": "3.3.3",


### PR DESCRIPTION
Debounces the search input changing the selector. Reduces HTTP traffic and jarring, rapid UI changes.

CC: @Automattic/team-calypso for thoughts. This adds [`use-debounce`](https://github.com/xnimorz/use-debounce) dependency. As far as I can tell, the first third-party (not Facebook) hook-only lib.

#### Testing instructions

* `/gutenboarding`
* Watch network traffic to suggestions endpoint
* Change the domain search.
* Traffic should reflect debounced input changes.
