### PR TITLE
ProductCard: Add analytics to manage subscription button

### DIFF
--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import ProductCardAction from './action';
 import ProductCardPriceGroup from './price-group';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { managePurchase } from 'me/purchases/paths';
 
 /**
@@ -20,75 +22,85 @@ import { managePurchase } from 'me/purchases/paths';
  */
 import './style.scss';
 
-const ProductCard = ( {
-	billingTimeFrame,
-	children,
-	currencyCode,
-	description,
-	discountedPrice,
-	fullPrice,
-	isCurrent,
-	isPlaceholder,
-	purchase,
-	subtitle,
-	title,
-} ) => {
-	const translate = useTranslate();
-	const cardClassNames = classNames( 'product-card', {
-		'is-placeholder': isPlaceholder,
-		'is-purchased': !! purchase,
-	} );
+export class ProductCard extends Component {
+	static propTypes = {
+		billingTimeFrame: PropTypes.string,
+		currencyCode: PropTypes.string,
+		description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+		discountedPrice: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.arrayOf( PropTypes.number ),
+		] ),
+		fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+		isCurrent: PropTypes.bool,
+		isPlaceholder: PropTypes.bool,
+		purchase: PropTypes.object,
+		subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+	};
 
-	return (
-		<Card className={ cardClassNames }>
-			<div className="product-card__header">
-				{ title && (
-					<div className="product-card__header-primary">
-						{ purchase && <Gridicon icon="checkmark" size={ 18 } /> }
-						<h3 className="product-card__title">{ title }</h3>
+	handleManagePurchase( purchase ) {
+		return () => {
+			this.props.recordTracksEvent( 'calypso_manage_purchase_click', {
+				slug: purchase.productSlug,
+			} );
+		};
+	}
+	render() {
+		const {
+			billingTimeFrame,
+			children,
+			currencyCode,
+			description,
+			discountedPrice,
+			fullPrice,
+			isCurrent,
+			isPlaceholder,
+			purchase,
+			subtitle,
+			title,
+			translate,
+		} = this.props;
+		const cardClassNames = classNames( 'product-card', {
+			'is-placeholder': isPlaceholder,
+			'is-purchased': !! purchase,
+		} );
+
+		return (
+			<Card className={ cardClassNames }>
+				<div className="product-card__header">
+					{ title && (
+						<div className="product-card__header-primary">
+							{ purchase && <Gridicon icon="checkmark" size={ 18 } /> }
+							<h3 className="product-card__title">{ title }</h3>
+						</div>
+					) }
+					<div className="product-card__header-secondary">
+						{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
+						{ ! purchase && (
+							<ProductCardPriceGroup
+								billingTimeFrame={ billingTimeFrame }
+								currencyCode={ currencyCode }
+								discountedPrice={ discountedPrice }
+								fullPrice={ fullPrice }
+							/>
+						) }
 					</div>
-				) }
-				<div className="product-card__header-secondary">
-					{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
-					{ ! purchase && (
-						<ProductCardPriceGroup
-							billingTimeFrame={ billingTimeFrame }
-							currencyCode={ currencyCode }
-							discountedPrice={ discountedPrice }
-							fullPrice={ fullPrice }
+				</div>
+				<div className="product-card__description">
+					{ description && <p>{ description }</p> }
+					{ purchase && isCurrent && (
+						<ProductCardAction
+							href={ managePurchase( purchase.domain, purchase.id ) }
+							label={ translate( 'Manage Subscription' ) }
+							primary={ false }
 						/>
 					) }
 				</div>
-			</div>
-			<div className="product-card__description">
-				{ description && <p>{ description }</p> }
-				{ purchase && isCurrent && (
-					<ProductCardAction
-						href={ managePurchase( purchase.domain, purchase.id ) }
-						label={ translate( 'Manage Subscription' ) }
-						primary={ false }
-					/>
-				) }
-			</div>
-			{ children }
-		</Card>
-	);
-};
+				{ children }
+			</Card>
+		);
+	}
+}
 
-ProductCard.propTypes = {
-	billingTimeFrame: PropTypes.string,
-	currencyCode: PropTypes.string,
-	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
-	discountedPrice: PropTypes.oneOfType( [
-		PropTypes.number,
-		PropTypes.arrayOf( PropTypes.number ),
-	] ),
-	fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
-	isCurrent: PropTypes.bool,
-	isPlaceholder: PropTypes.bool,
-	purchase: PropTypes.object,
-	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
-	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
-};
-
-export default ProductCard;
+export default connect( null, { recordTracksEvent } )( localize( ProductCard ) );

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -4,18 +4,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
+import { managePurchase } from 'me/purchases/paths';
 import ProductCardAction from './action';
 import ProductCardPriceGroup from './price-group';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { managePurchase } from 'me/purchases/paths';
 
 /**
  * Style dependencies

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -42,7 +42,7 @@ export class ProductCard extends Component {
 	handleManagePurchase( purchase ) {
 		return () => {
 			this.props.recordTracksEvent( 'calypso_manage_purchase_click', {
-				slug: purchase.productSlug,
+				plan: purchase.productSlug,
 			} );
 		};
 	}
@@ -91,6 +91,7 @@ export class ProductCard extends Component {
 					{ description && <p>{ description }</p> }
 					{ purchase && isCurrent && (
 						<ProductCardAction
+							onClick={ this.handleManagePurchase( purchase ) }
 							href={ managePurchase( purchase.domain, purchase.id ) }
 							label={ translate( 'Manage Subscription' ) }
 							primary={ false }

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -22,7 +22,7 @@ import { managePurchase } from 'me/purchases/paths';
  */
 import './style.scss';
 
-export class ProductCard extends Component {
+class ProductCard extends Component {
 	static propTypes = {
 		billingTimeFrame: PropTypes.string,
 		currencyCode: PropTypes.string,
@@ -39,13 +39,14 @@ export class ProductCard extends Component {
 		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 	};
 
-	handleManagePurchase( purchase ) {
+	handleManagePurchase( productSlug ) {
 		return () => {
 			this.props.recordTracksEvent( 'calypso_manage_purchase_click', {
-				plan: purchase.productSlug,
+				slug: productSlug,
 			} );
 		};
 	}
+
 	render() {
 		const {
 			billingTimeFrame,
@@ -91,7 +92,7 @@ export class ProductCard extends Component {
 					{ description && <p>{ description }</p> }
 					{ purchase && isCurrent && (
 						<ProductCardAction
-							onClick={ this.handleManagePurchase( purchase ) }
+							onClick={ this.handleManagePurchase( purchase.productSlug ) }
 							href={ managePurchase( purchase.domain, purchase.id ) }
 							label={ translate( 'Manage Subscription' ) }
 							primary={ false }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In this PR we are adding an analytics event to the manege subscription event. 

#### Testing instructions
* Buy a product or plan. 
* Click on the new manage subscription button. 
![Screen Shot 2019-11-19 at 3 27 29 PM](https://user-images.githubusercontent.com/115071/69154915-27362280-0ae1-11ea-8a94-bbcc1c8a8ab6.png)

Notice the new on click event. 
Currently it should contain 
![Screen Shot 2019-11-19 at 3 28 51 PM](https://user-images.githubusercontent.com/115071/69155046-5482d080-0ae1-11ea-955e-76e54f2d5881.png)

