### PR TITLE
Composite checkout: Fix payment logo layout for ie11

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -10,6 +10,7 @@ import { StripeHookProvider, useStripe } from '../../lib/stripe';
 import { useLineItems, useCheckoutHandlers } from '../../public-api';
 import { useLocalize } from '../../lib/localize';
 import PaymentRequestButton from '../../components/payment-request-button';
+import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 export function createApplePayMethod( { registerStore, fetchStripeConfiguration } ) {
 	const actions = {
@@ -75,7 +76,9 @@ export function ApplePayLabel() {
 	return (
 		<React.Fragment>
 			<span>{ localize( 'Apple Pay' ) }</span>
-			<ApplePayIcon className="apple-pay__logo payment-logos" fill="black" />
+			<PaymentMethodLogos className="apple-pay__logo payment-logos">
+				<ApplePayIcon fill="black" />
+			</PaymentMethodLogos>
 		</React.Fragment>
 	);
 }

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -13,6 +13,7 @@ import joinClasses from '../../lib/join-classes';
 import { useSelect, useLineItems, renderDisplayValueMarkdown } from '../../public-api';
 import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
 import CreditCardFields from './credit-card-fields';
+import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 export function createCreditCardMethod() {
 	return {
@@ -101,17 +102,13 @@ function CreditCardLogos( className ) {
 	//TODO: Determine which logos to show
 
 	return (
-		<LogoWrapper className={ joinClasses( [ className, 'payment-logos' ] ) }>
+		<PaymentMethodLogos className={ joinClasses( [ className, 'payment-logos' ] ) }>
 			<VisaLogo />
 			<MastercardLogo />
 			<AmexLogo />
-		</LogoWrapper>
+		</PaymentMethodLogos>
 	);
 }
-
-const LogoWrapper = styled.span`
-	display: flex;
-`;
 
 function submitCreditCardPayment() {
 	alert( 'Thank you!' );

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -11,6 +11,7 @@ import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
 import { useDispatch, useSelect } from '../../lib/registry';
 import { useCheckoutHandlers, useCheckoutRedirects, useLineItems } from '../../public-api';
+import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 export function createPayPalMethod( { registerStore, makePayPalExpressRequest } ) {
 	registerStore( 'paypal', {
@@ -94,7 +95,9 @@ export function PaypalLabel() {
 	return (
 		<React.Fragment>
 			<span>{ localize( 'Paypal' ) }</span>
-			<PaypalLogo className="paypal__logo payment-logos" />
+			<PaymentMethodLogos className="paypal__logo payment-logos">
+				<PaypalLogo />
+			</PaymentMethodLogos>
 		</React.Fragment>
 	);
 }

--- a/packages/composite-checkout/src/lib/styled-components/payment-method-logos.js
+++ b/packages/composite-checkout/src/lib/styled-components/payment-method-logos.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const PaymentMethodLogos = styled.span`
+	flex: 1;
+	text-align: right;
+	transform: translateY( 2px );
+
+	svg {
+		display: inline-block;
+	}
+`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a layout issue in ie11. The flex property `justify-content: space-between;` is not recognized in ie so I found a different way to deliver the same outcome. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/69164995-df060880-0abe-11ea-9558-22f2a5681a3a.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/69164802-a403d500-0abe-11ea-8bf9-eca9410328c7.png)

#### Testing instructions
* Get checkout up and running on your local machine.
* If you have a virtualbox, or anyway to test in IE, visit checkout with IE.
* Check other browsers to make sure nothing looks different.
