### PR TITLE
Full Site Editing: Remove SiteCredit requires and settings registration

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -51,7 +51,6 @@ function dangerously_load_full_site_editing_files() {
 	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/site-description/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/site-title/index.php';
-	require_once __DIR__ . '/full-site-editing/blocks/site-credit/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/template/index.php';
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-rest-templates-controller.php';
@@ -163,7 +162,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_posts_list_block' );
  */
 function load_starter_page_templates() {
 	// We don't want the user to choose a template when copying a post.
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 	if ( isset( $_GET['jetpack-copy'] ) ) {
 		return;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -65,8 +65,6 @@ class Full_Site_Editing {
 
 		$this->theme_slug           = $this->normalize_theme_slug( get_stylesheet() );
 		$this->wp_template_inserter = new WP_Template_Inserter( $this->theme_slug );
-
-		$this->register_footer_credit_setting();
 	}
 
 	/**
@@ -159,8 +157,6 @@ class Full_Site_Editing {
 				'closeButtonLabel'    => $this->get_close_button_label(),
 				'closeButtonUrl'      => esc_url( $this->get_close_button_url() ),
 				'editTemplateBaseUrl' => esc_url( $this->get_edit_template_base_url() ),
-				'footerCreditOptions' => get_footer_credit_options(),
-				'defaultCreditOption' => get_default_footer_credit_option(),
 			)
 		);
 


### PR DESCRIPTION
This is an alternative approach to #37683

Instead of adding more requires to a block not production-ready yet, I've removed its other usages.

Eventually, when the `SiteCredit` block is ready, we can refer to this PR to see what needs to be added back.

#### Changes proposed in this Pull Request

* Fix a possible error where a function was undefined.

#### Testing instructions

* Make sure FSE loads locally with no issues.