### PR TITLE
G Suite: Fix placeholders and events on Email page

### DIFF
--- a/client/components/data/store-connection/index.jsx
+++ b/client/components/data/store-connection/index.jsx
@@ -8,7 +8,7 @@ import { isEqual } from 'lodash';
 
 class StoreConnection extends React.Component {
 	static propTypes = {
-		component: PropTypes.func,
+		component: PropTypes.elementType,
 		getStateFromStores: PropTypes.func.isRequired,
 		isDataLoading: PropTypes.func,
 		loadingPlaceholder: PropTypes.func,

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -23,7 +23,8 @@ import {
 } from 'lib/gsuite';
 import { getEligibleEmailForwardingDomain } from 'lib/domains/email-forwarding';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
-import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
+import hasLoadedGSuiteUsers from 'state/selectors/has-loaded-gsuite-users';
+import { getDecoratedSiteDomains, hasLoadedSiteDomains } from 'state/sites/domains/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuitePurchaseCta from 'my-sites/email/gsuite-purchase-cta';
 import GSuiteUsersCard from 'my-sites/email/email-management/gsuite-users-card';
@@ -53,7 +54,8 @@ class EmailManagement extends React.Component {
 	static propTypes = {
 		domains: PropTypes.array.isRequired,
 		gsuiteUsers: PropTypes.array,
-		isRequestingDomains: PropTypes.bool.isRequired,
+		hasGSuiteUsersLoaded: PropTypes.bool.isRequired,
+		hasSiteDomainsLoaded: PropTypes.bool.isRequired,
 		selectedSiteId: PropTypes.number.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
 		selectedDomainName: PropTypes.string,
@@ -99,9 +101,9 @@ class EmailManagement extends React.Component {
 	}
 
 	content() {
-		const { domains, gsuiteUsers, isRequestingDomains, selectedDomainName } = this.props;
+		const { domains, hasGSuiteUsersLoaded, hasSiteDomainsLoaded, selectedDomainName } = this.props;
 
-		if ( isRequestingDomains || ! gsuiteUsers ) {
+		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded ) {
 			return <Placeholder />;
 		}
 
@@ -214,6 +216,7 @@ class EmailManagement extends React.Component {
 		return (
 			<Fragment>
 				<GSuitePurchaseCta domainName={ gsuiteDomainName } />
+
 				{ emailForwardingDomain && this.addEmailForwardingCard( emailForwardingDomain ) }
 			</Fragment>
 		);
@@ -247,7 +250,8 @@ export default connect( state => {
 	return {
 		domains: getDecoratedSiteDomains( state, selectedSiteId ),
 		gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
-		isRequestingDomains: isRequestingSiteDomains( state, selectedSiteId ),
+		hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
+		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	};

--- a/client/state/gsuite-users/reducer.js
+++ b/client/state/gsuite-users/reducer.js
@@ -16,14 +16,14 @@ import { usersSchema } from './schema';
 
 export const usersReducer = withSchemaValidation( usersSchema, ( state = null, action ) => {
 	switch ( action.type ) {
-		case GSUITE_USERS_REQUEST:
-			return null;
 		case GSUITE_USERS_REQUEST_FAILURE:
 			return null;
+
 		case GSUITE_USERS_REQUEST_SUCCESS: {
 			const {
 				response: { accounts },
 			} = action;
+
 			return accounts;
 		}
 	}
@@ -35,8 +35,10 @@ export const requestErrorReducer = withoutPersistence( ( state = false, action )
 	switch ( action.type ) {
 		case GSUITE_USERS_REQUEST:
 			return false;
+
 		case GSUITE_USERS_REQUEST_FAILURE:
 			return true;
+
 		case GSUITE_USERS_REQUEST_SUCCESS:
 			return false;
 	}
@@ -48,8 +50,10 @@ export const requestingReducer = withoutPersistence( ( state = false, action ) =
 	switch ( action.type ) {
 		case GSUITE_USERS_REQUEST:
 			return true;
+
 		case GSUITE_USERS_REQUEST_FAILURE:
 			return false;
+
 		case GSUITE_USERS_REQUEST_SUCCESS:
 			return false;
 	}

--- a/client/state/selectors/has-loaded-gsuite-users.js
+++ b/client/state/selectors/has-loaded-gsuite-users.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Determines whether the list of G Suite users for the specified site has loaded.
+ *
+ * @param {Object} state - global state tree
+ * @param {Number} siteId - identifier of the site
+ * @return {Boolean} true if the list of G Suite users has loaded, false otherwise
+ */
+export default function hasLoadedGSuiteUsers( state, siteId ) {
+	return get( state, [ 'gsuiteUsers', siteId, 'users' ], null ) !== null;
+}

--- a/client/state/selectors/has-loaded-gsuite-users.js
+++ b/client/state/selectors/has-loaded-gsuite-users.js
@@ -6,9 +6,9 @@ import { get } from 'lodash';
 /**
  * Determines whether the list of G Suite users for the specified site has loaded.
  *
- * @param {Object} state - global state tree
- * @param {Number} siteId - identifier of the site
- * @return {Boolean} true if the list of G Suite users has loaded, false otherwise
+ * @param {object} state - global state tree
+ * @param {number} siteId - identifier of the site
+ * @returns {boolean} true if the list of G Suite users has loaded, false otherwise
  */
 export default function hasLoadedGSuiteUsers( state, siteId ) {
 	return get( state, [ 'gsuiteUsers', siteId, 'users' ], null ) !== null;

--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { moment } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,6 +43,17 @@ export const getDomainsBySite = ( state, site ) => {
 	}
 
 	return getDomainsBySiteId( state, site.ID );
+};
+
+/**
+ * Determines whether the list of domains for the specified site has loaded.
+ *
+ * @param {Object} state - global state tree
+ * @param {Number} siteId - identifier of the site
+ * @return {Boolean} true if the list of domains has loaded, false otherwise
+ */
+export const hasLoadedSiteDomains = ( state, siteId ) => {
+	return has( state, [ 'sites', 'domains', 'items', siteId ] );
 };
 
 /**

--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -14,12 +14,11 @@ import treeSelect from '@automattic/tree-select';
 const EMPTY_SITE_DOMAINS = Object.freeze( [] );
 
 /**
- * Return site domains getting from state object and
- * the given siteId
+ * Returns the list of site domains for the specified site identifier.
  *
- * @param {Object} state - current state object
- * @param {Number} siteId - site identificator
- * @return {Array} site domains
+ * @param {object} state - global state tree
+ * @param {number} siteId - identifier of the site
+ * @returns {Array} the list of domains
  */
 export const getDomainsBySiteId = ( state, siteId ) => {
 	if ( ! siteId ) {
@@ -30,12 +29,11 @@ export const getDomainsBySiteId = ( state, siteId ) => {
 };
 
 /**
- * Return site domains getting from state object and
- * the given site object
+ * Returns the list of site domains for the specified site.
  *
- * @param {Object} state - current state object
- * @param {Object} site - site object
- * @return {Array} site domains
+ * @param {object} state - global state tree
+ * @param {object} site - site object
+ * @returns {Array} the list of domains
  */
 export const getDomainsBySite = ( state, site ) => {
 	if ( ! site ) {
@@ -48,20 +46,20 @@ export const getDomainsBySite = ( state, site ) => {
 /**
  * Determines whether the list of domains for the specified site has loaded.
  *
- * @param {Object} state - global state tree
- * @param {Number} siteId - identifier of the site
- * @return {Boolean} true if the list of domains has loaded, false otherwise
+ * @param {object} state - global state tree
+ * @param {number} siteId - identifier of the site
+ * @returns {boolean} true if the list of domains has loaded, false otherwise
  */
 export const hasLoadedSiteDomains = ( state, siteId ) => {
 	return has( state, [ 'sites', 'domains', 'items', siteId ] );
 };
 
 /**
- * Return requesting state for the given site
+ * Determines whether the list of domains is being requested via the API.
  *
- * @param {Object} state - current state object
- * @param {Number} siteId - site identifier
- * @return {Boolean} is site-domains requesting?
+ * @param {object} state - global state tree
+ * @param {number} siteId - identifier of the site
+ * @returns {boolean} true if the list of domains is being requested, false otherwise
  */
 export const isRequestingSiteDomains = ( state, siteId ) => {
 	return state.sites.domains.requesting[ siteId ] || false;
@@ -72,11 +70,12 @@ export const isUpdatingDomainPrivacy = ( state, siteId, domain ) => {
 };
 
 /**
- * Returns decorated site domains with objects we don't want to store in Redux state tree.
+ * Returns the list of domains for the specified site with additional properties. This approach is used to avoid storing
+ * those extra objects in the Redux state tree.
  *
- * @param  {Object}  state  global state
- * @param  {Number}  siteId the site id
- * @return {?Object}        decorated site domains
+ * @param  {object} state - global state tree
+ * @param  {number} siteId - identifier of the site
+ * @returns {?object} the list of site domains decorated
  */
 export const getDecoratedSiteDomains = treeSelect(
 	( state, siteId ) => [ getDomainsBySiteId( state, siteId ) ],


### PR DESCRIPTION
This pull request updates the [`Email` page](https://wordpress.com/email) to only show placeholders when the data required to display that page **has not already been retrieved** from the API:

![screenshot](https://user-images.githubusercontent.com/594356/69164196-d11cab80-0aef-11ea-82ba-f3f73b380504.png)

Navigating to this page indeed triggers requests to retrieve the list of domains and the list of G Suite users. However, if this data is already available from the global state tree, there is no reason not to use it while retrieving fresher data. This should help with making the user interface more responsive:

![screenshot](https://user-images.githubusercontent.com/594356/69165582-1b069100-0af2-11ea-84e5-585e6495551e.png)

This pull request also fixes a `calypso_email_gsuite_purchase_cta_view` Tracks event that would be triggered twice when navigating back to this `Email` page. Revisiting when to display placeholders is actually how I managed to fix that issue (previously the `GSuitePurchaseCta` component would be mounted when navigating back, then unmounted when the API requests are initiated, then mounted again when the API would respond).

#### Testing instructions

1. Run `git checkout fix/gsuite-email-page-placeholders-and-events` and start your server
2. Open the [`Home` page](http://calypso.localhost:3000/home)
3. Enable logging by running the following command in your browser's console:
```javascript
localStorage.setItem( 'debug', 'calypso:analytics:*' )
```
4. Reload the page, and navigates to the [`Email` page](http://calypso.localhost:3000/email)
5. Assert that placeholders are only displayed once
6. Assert that only one `calypso_email_gsuite_purchase_cta_view` event was fired
7. Browse some other parts of Calypso, then navigate back to the `Email` page
8. Repeat steps #5 and #6