### PR TITLE
Plans: Preserve site context for the Jetpack Backup landing page link

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -45,6 +45,7 @@ The following props can be passed to the Product Selector block:
 	* `title`: ( string ) Product title.
 	* `description`: ( string ) Product description.
 	* `id`: ( string ) Product ID.
+	* `landingPageUrl`: ( string ) URL of the landing page for more information about the product.
 	* `options`: ( object ) Product options. Each option has the billing interval as a key, and the value is an array with corresponding product slugs. Example:
 		```
 		options: {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -12,12 +12,14 @@ import { recordTracksEvent } from 'state/analytics/actions';
 /**
  * Internal dependencies
  */
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import ProductCard from 'components/product-card';
 import ProductCardAction from 'components/product-card/action';
 import ProductCardOptions from 'components/product-card/options';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
+import { addQueryArgs } from 'lib/route';
 import { extractProductSlugs, filterByProductSlugs } from './utils';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -168,6 +170,7 @@ export class ProductSelector extends Component {
 	}
 
 	getDescriptionByProduct( product ) {
+		const { selectedSiteSlug, translate } = this.props;
 		const { description, optionDescriptions } = product;
 		const purchase = this.getPurchaseByProduct( product );
 
@@ -182,8 +185,29 @@ export class ProductSelector extends Component {
 			return optionDescriptions[ planProductSlug ];
 		}
 
-		// Default product description
-		return description;
+		// If we have a site in this context, add it to the landing page URL.
+		let linkUrl = 'https://jetpack.com/upgrade/backup/';
+		if ( selectedSiteSlug ) {
+			linkUrl = addQueryArgs( { site: selectedSiteSlug }, linkUrl );
+		}
+
+		// Default product description, with a link to the landing page appended to it.
+		return (
+			<Fragment>
+				{ description }{ ' ' }
+				<ExternalLinkWithTracking
+					href={ linkUrl }
+					tracksEventName="calypso_plan_link_click"
+					tracksEventProps={ {
+						link_location: 'product_jetpack_backup_description',
+						link_slug: 'which-one-do-i-need',
+					} }
+					icon
+				>
+					{ translate( 'Which one do I need?' ) }
+				</ExternalLinkWithTracking>
+			</Fragment>
+		);
 	}
 
 	getProductName( product, productSlug ) {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -41,6 +41,7 @@ export class ProductSelector extends Component {
 				title: PropTypes.string,
 				id: PropTypes.string,
 				description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+				landingPageUrl: PropTypes.string,
 				options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
 				optionDescriptions: PropTypes.objectOf(
 					PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] )
@@ -185,8 +186,13 @@ export class ProductSelector extends Component {
 			return optionDescriptions[ planProductSlug ];
 		}
 
+		// Default product description, without a landing page link.
+		let linkUrl = product.landingPageUrl;
+		if ( ! linkUrl ) {
+			return description;
+		}
+
 		// If we have a site in this context, add it to the landing page URL.
-		let linkUrl = 'https://jetpack.com/upgrade/backup/';
 		if ( selectedSiteSlug ) {
 			linkUrl = addQueryArgs( { site: selectedSiteSlug }, linkUrl );
 		}

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -102,6 +102,7 @@ export const JETPACK_PRODUCTS = [
 		title: translate( 'Jetpack Backup' ),
 		description: PRODUCT_JETPACK_BACKUP_DESCRIPTION,
 		id: PRODUCT_JETPACK_BACKUP,
+		landingPageUrl: 'https://jetpack.com/upgrade/backup/',
 		options: {
 			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
 			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -4,11 +4,6 @@
 import React, { Fragment } from 'react';
 import { translate } from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
-
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
@@ -70,22 +65,7 @@ export const JETPACK_PRODUCT_DISPLAY_NAMES = {
 };
 
 export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = translate(
-	'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
-	{
-		components: {
-			a: (
-				<ExternalLinkWithTracking
-					href="https://jetpack.com/upgrade/backup/"
-					tracksEventName="calypso_plan_link_click"
-					tracksEventProps={ {
-						link_location: 'product_jetpack_backup_description',
-						link_slug: 'which-one-do-i-need',
-					} }
-					icon
-				/>
-			),
-		},
-	}
+	'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
 );
 export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = translate(
 	'{{strong}}Looking for more?{{/strong}} With Real-time backups, we save as you edit and you’ll get unlimited backup archives.',


### PR DESCRIPTION
Currently, regardless of whether we have a site context or not, the "Which one do I need?" link will always redirect to the remote site without a site context. This PR updates this so we preserve the site context by adding a `site` query argument to the landing page URL.

To achieve this, we introduce a new `landingPageUrl` prop to each product, and use that in the `ProductSelector` component.

#### Changes proposed in this Pull Request

* Products: Keep default description clear of links and link components.
* Blocks: Append backup link to default product description
* Products: Move landing page URL to its own product prop

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site without any plan or product purchased.
* Verify that the "Which one do I need?" link leads to https://jetpack.com/upgrade/backup/?site=`:site` where `:site` is the site slug.
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify that the link still leads to just `https://jetpack.com/upgrade/backup/`
