### PR TITLE
Plans: Add a second billing interval selector

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -30,6 +30,11 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
 import { withLocalizedMoment } from 'components/localized-moment';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class ProductSelector extends Component {
 	static propTypes = {
 		basePlansPath: PropTypes.string,

--- a/client/blocks/product-selector/style.scss
+++ b/client/blocks/product-selector/style.scss
@@ -1,0 +1,3 @@
+.product-selector {
+	margin-bottom: 40px;
+}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -86,7 +86,7 @@ export class PlansFeaturesMain extends Component {
 		 * This ensures that Happychat groups are correct in case we switch sites while on the plans
 		 * page, for example between a Jetpack and Simple site.
 		 *
-		 * @TODO: When happychat correctly handles site switching, remove selectHappychatSiteId action.
+		 * TODO: When happychat correctly handles site switching, remove selectHappychatSiteId action.
 		 */
 		const { siteId } = this.props;
 		const { siteId: prevSiteId } = prevProps;
@@ -429,7 +429,7 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { basePlansPath, intervalType, translate } = this.props;
+		const { basePlansPath, intervalType, plansWithScroll, translate } = this.props;
 
 		return (
 			<div className="plans-features-main__group is-narrow">
@@ -445,6 +445,8 @@ export class PlansFeaturesMain extends Component {
 					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }
 				/>
+
+				{ ! plansWithScroll && this.renderToggle() }
 			</div>
 		);
 	}


### PR DESCRIPTION
Currently, when Jetpack Backups purchase section is available, the billing interval selector is a bit far from the plans. So, as suggested by @gravityrail, this PR is adding a second billing interval selector navigation above the plans section.

While I'm not super happy about this solution, I'm happy to go ahead with it if y'all agree it makes things better.

#### Changes proposed in this Pull Request

* Plans: Add a second billing interval selector

#### Preview

Plans page - before:
![](https://cldup.com/7-dWX3ei4J.png)

Plans page - after:
![](https://cldup.com/AXU6nQ9pU6.png)

Jetpack connect landing page - before:
![](https://cldup.com/fkb6K1_JH3.png)

Jetpack connect landing page - after:
![](https://cldup.com/yn-TVC3mb8.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site.
* Verify the new nav appears, and it works and looks well.
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify the new nav appears, and it works and looks well.
* Go to http://calypso.localhost:3000/plans/:site?flags=-plans/jetpack-backup where `:site` is a Jetpack site (this emulates production, where Jetpack Backups is disabled).
* Verify the plans page is unchanged.
* Go to http://calypso.localhost:3000/jetpack/connect/store?flags=-plans/jetpack-backup (this emulates production, where Jetpack Backups is disabled).
* Verify the Jetpack connect landing page is unchanged.
