### PR TITLE
composite-checkout: Inject steps as arguments

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/checkout.jsx
+++ b/packages/composite-checkout-wpcom/src/components/checkout.jsx
@@ -112,7 +112,10 @@ export function WPCOMCheckout( { useShoppingCart, availablePaymentMethods, regis
 			hasStepNumber: true,
 			titleContent: <OrderReviewTitle />,
 			activeStepContent: <ReviewContent />,
-			isCompleteCallback: () => true,
+			isCompleteCallback: ( { activeStep } ) => {
+				const isActive = activeStep.id === 'order-review';
+				return isActive;
+			},
 		},
 	];
 

--- a/packages/composite-checkout-wpcom/src/components/checkout.jsx
+++ b/packages/composite-checkout-wpcom/src/components/checkout.jsx
@@ -3,7 +3,16 @@
  */
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Checkout, CheckoutProvider, WPCheckoutOrderSummary } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+import {
+	Checkout,
+	CheckoutProvider,
+	WPCheckoutOrderSummary,
+	getDefaultPaymentMethodStep,
+	WPCheckoutOrderSummaryTitle,
+	useActiveStep,
+	WPContactForm,
+} from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -25,8 +34,21 @@ const handleCheckoutEvent = select => () => {
 	alert( `handleCheckoutEvent: ${ select }` );
 };
 
+const ContactFormTitle = () => {
+	const translate = useTranslate();
+	const currentStep = useActiveStep();
+	const isActive = currentStep.id === 'payment-method';
+	return isActive ? translate( 'Billing details' ) : translate( 'Enter your billing details' );
+};
+
+const OrderReviewTitle = () => {
+	const translate = useTranslate();
+	return translate( 'Review your order' );
+};
+
 // This is the parent component which would be included on a host page
 export function WPCOMCheckout( { useShoppingCart, availablePaymentMethods, registry } ) {
+	const translate = useTranslate();
 	const { itemsWithTax, total, deleteItem, changePlanLength } = useShoppingCart();
 
 	const { select, subscribe } = registry;
@@ -44,6 +66,56 @@ export function WPCOMCheckout( { useShoppingCart, availablePaymentMethods, regis
 		/>
 	);
 
+	// TODO: should we memoize this?
+	const steps = [
+		{
+			id: 'order-summary',
+			className: 'checkout__order-summary-step',
+			hasStepNumber: false,
+			titleContent: <WPCheckoutOrderSummaryTitle />,
+			completeStepContent: <WPCheckoutOrderSummary />,
+			isCompleteCallback: () => true,
+		},
+		{
+			...getDefaultPaymentMethodStep(),
+			getEditButtonAriaLabel: () => translate( 'Edit the payment method' ),
+			getNextStepButtonAriaLabel: () => translate( 'Continue with the selected payment method' ),
+		},
+		{
+			id: 'contact-form',
+			className: 'checkout__billing-details-step',
+			hasStepNumber: true,
+			titleContent: <ContactFormTitle />,
+			activeStepContent: <WPContactForm isComplete={ false } isActive={ true } />,
+			completeStepContent: <WPContactForm summary isComplete={ true } isActive={ false } />,
+			isCompleteCallback: ( { paymentData } ) => {
+				// TODO: Make sure the form is complete
+				const { billing = {} } = paymentData;
+				if ( ! billing.country ) {
+					return false;
+				}
+				return true;
+			},
+			isEditableCallback: ( { paymentData } ) => {
+				// TODO: Return true if the form is empty
+				if ( paymentData.billing ) {
+					return true;
+				}
+				return false;
+			},
+			getEditButtonAriaLabel: () => translate( 'Edit the billing details' ),
+			getNextStepButtonAriaLabel: () => translate( 'Continue with the entered billing details' ),
+		},
+		{
+			id: 'order-review',
+			className: 'checkout__review-order-step',
+			hasStepNumber: true,
+			titleContent: <OrderReviewTitle />,
+			activeStepContent: <ReviewContent />,
+			isCompleteCallback: () => true,
+		},
+	];
+
 	return (
 		<CheckoutProvider
 			locale={ 'en-us' }
@@ -56,7 +128,7 @@ export function WPCOMCheckout( { useShoppingCart, availablePaymentMethods, regis
 			paymentMethods={ availablePaymentMethods }
 			registry={ registry }
 		>
-			<Checkout OrderSummary={ WPCheckoutOrderSummary } ReviewContent={ ReviewContent } />
+			<Checkout steps={ steps } />
 		</CheckoutProvider>
 	);
 }

--- a/packages/composite-checkout-wpcom/src/components/checkout.jsx
+++ b/packages/composite-checkout-wpcom/src/components/checkout.jsx
@@ -10,7 +10,7 @@ import {
 	WPCheckoutOrderSummary,
 	getDefaultPaymentMethodStep,
 	WPCheckoutOrderSummaryTitle,
-	useActiveStep,
+	useIsStepActive,
 	WPContactForm,
 } from '@automattic/composite-checkout';
 
@@ -36,8 +36,7 @@ const handleCheckoutEvent = select => () => {
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();
-	const currentStep = useActiveStep();
-	const isActive = currentStep.id === 'payment-method';
+	const isActive = useIsStepActive();
 	return isActive ? translate( 'Billing details' ) : translate( 'Enter your billing details' );
 };
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -76,7 +76,7 @@ All properties except for `id` are optional.
 - `activeStepContent?: React.ReactNode`. Displays as the content of the step when it is active. It is also displayed when the step is inactive but is hidden by CSS.
 - `incompleteStepContent?: React.ReactNode`. Displays as the content of the step when it is inactive and incomplete as defined by the `isCompleteCallback`. It is also displayed when the step is active but is hidden by CSS.
 - `completeStepContent?: React.ReactNode`. Displays as the content of the step when it is inactive and complete as defined by the `isCompleteCallback`. It is also displayed when the step is active but is hidden by CSS.
-- `isCompleteCallback?: ({paymentData: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning false.
+- `isCompleteCallback?: ({paymentData: object, activeStep: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning false.
 - `isEditableCallback?: ({paymentData: object}) => boolean`. Used to determine if an inactive step should display an "Edit" button. Default is a function returning false.
 - `getEditButtonAriaLabel?: () => string`. Used to fill in the `aria-label` attribute for the "Edit" button if one exists.
 - `getNextStepButtonAriaLabel?: () => string`. Used to fill in the `aria-label` attribute for the "Continue" button if one exists.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -10,14 +10,14 @@ A set of React components, custom Hooks, and helper functions that together can 
 
 This package provides a context provider, `CheckoutProvider`, and a default component, `Checkout`, which creates a checkout form.
 
-The form has two steps:
+The form has two default steps:
 
 1. Payment method
 2. Review order
 
-The steps can be customized using various props, including adding additional steps.
+These steps can be customized or replaced, and additional steps can be added.
 
-For more detailed customization, it's possible to build a custom form using the other components exported by this package.
+It's also possible to build an entirely custom form using the other components exported by this package.
 
 ### Select payment method
 
@@ -31,18 +31,6 @@ The review step presents a simple list of line items and a total, followed by a 
 
 ![review order step](https://raw.githubusercontent.com/Automattic/wp-calypso/add/wp-checkout-component/packages/composite-checkout/doc-asset/review-step.png 'Review Order Step')
 
-### Customization slots
-
-Some content can be overridden using "customization slots" passed as props to the `Checkout` component. Each of these is a React element type (a component class or function) which will be rendered by `Checkout` in a particular place. The slot components can access all the custom hooks in the package and will also be passed props appropriate to that component; see each customization slot for details about what props are provided.
-
-The `ReviewContent` slot replaces the content of the Review order step.
-
-`UpSell` is a section at the bottom of the form.
-
-`OrderSummary` is a block of content at the top of the form styled to look like a completed step.
-
-`ContactSlot` is a step displayed between the payment method and review order steps.
-
 ### Submitting the form
 
 When the payment button is pressed, the form data will be validated and submitted in a way appropriate to the payment method. If there is a problem with either validation or submission, or if the payment method's service returns an error, the `onFailure` prop on `Checkout` will be called with an object describing the error.
@@ -51,84 +39,51 @@ If the payment method succeeds, the `onSuccess` prop will be called instead. It'
 
 Some payment methods may require a redirect to an external site. If that occurs, the `failureRedirectUrl` and `successRedirectUrl` props on `Checkout` will be used instead of the `onFailure` and `onSuccess` callbacks. All four props are required.
 
-## Example
+### Steps
 
-Here is a very simple example of using the `Checkout` component with default options. Its review section is very basic and line items cannot be removed or added. For a more detailed example, see the file `demo/index.js`.
+The `Checkout` component accepts an optional `steps` prop which is an array of Step objects. Each Step is an object with properties that include both React elements to display at certain times as well as metadata about how the step should be displayed. Here's an example step:
 
 ```js
-import React, { useState } from 'react';
-import { Checkout } from '@automattic/composite-checkout';
-import { formatValueForCurrency } from 'composite-checkout/wpcom';
-
-const initialItems = [
-	{
-		label: 'WordPress.com Personal Plan',
-		id: 'wpcom-personal',
-		type: 'plan',
-		amount: { currency: 'USD', value: 6000, displayValue: '$60' },
+{
+	id: 'payment-method',
+	className: 'checkout__payment-methods-step',
+	hasStepNumber: true,
+	titleContent: <CheckoutPaymentMethodsTitle />,
+	activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
+	incompleteStepContent: null,
+	completeStepContent: <CheckoutPaymentMethods summary isComplete={ true } />,
+	isCompleteCallback: ( { paymentData } ) => {
+		const { billing = {} } = paymentData;
+		if ( ! billing.country ) {
+			return false;
+		}
+		return true;
 	},
-	{
-		label: 'Domain registration',
-		subLabel: 'example.com',
-		id: 'wpcom-domain',
-		type: 'domain',
-		amount: { currency: 'USD', value: 0, displayValue: '~~$17~~ 0' },
+	isEditableCallback: ( { paymentData } ) => {
+		return ( paymentData.billing ) ? true : false;
 	},
-];
-
-// These are used only for non-redirect payment methods
-const onSuccess = () => console.log( 'Payment succeeded!' );
-const onFailure = error => console.error( 'There was a problem with your payment', error );
-
-// These are used only for redirect payment methods
-const successRedirectUrl = window.location.href;
-const failureRedirectUrl = window.location.href;
-
-async function makePayPalExpressRequest() {
-	return 'https://paypal.com';
+	getEditButtonAriaLabel: () => translate( 'Edit the payment method' ),
+	getNextStepButtonAriaLabel: () => translate( 'Continue with the selected payment method' ),
 }
+````
 
-const paypalMethod = createPayPalMethod( { makePayPalExpressRequest } );
+All properties except for `id` are optional.
 
-// This is the parent component which would be included on a host page
-export default function MyCheckout() {
-	const { items, total } = useShoppingCart();
+- `id: string`. A unique ID for the step.
+- `className?: string`. Displayed on the step wrapper.
+- `hasStepNumber?: boolean`. If false, the step will not have a number displayed and will never be made active. Can be used for informational blocks. Defaults to false.
+- `titleContent?: React.ReactNode`. Displays as the title of the step. This can be be variable based on form status by using hooks like `useActiveStep()` to see if the step is active.
+- `activeStepContent?: React.ReactNode`. Displays as the content of the step when it is active. It is also displayed when the step is inactive but is hidden by CSS.
+- `incompleteStepContent?: React.ReactNode`. Displays as the content of the step when it is inactive and incomplete as defined by the `isCompleteCallback`. It is also displayed when the step is active but is hidden by CSS.
+- `completeStepContent?: React.ReactNode`. Displays as the content of the step when it is inactive and complete as defined by the `isCompleteCallback`. It is also displayed when the step is active but is hidden by CSS.
+- `isCompleteCallback?: ({paymentData: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning false.
+- `isEditableCallback?: ({paymentData: object}) => boolean`. Used to determine if an inactive step should display an "Edit" button. Default is a function returning false.
+- `getEditButtonAriaLabel?: () => string`. Used to fill in the `aria-label` attribute for the "Edit" button if one exists.
+- `getNextStepButtonAriaLabel?: () => string`. Used to fill in the `aria-label` attribute for the "Continue" button if one exists.
 
-	return (
-		<CheckoutProvider
-			locale={ 'US' }
-			items={ items }
-			total={ total }
-			onSuccess={ onSuccess }
-			onFailure={ onFailure }
-			successRedirectUrl={ successRedirectUrl }
-			failureRedirectUrl={ failureRedirectUrl }
-			paymentMethods={ [ paypalMethod ] }
-		>
-			<Checkout />
-		</CheckoutProvider>
-	);
-}
+## Example
 
-// This is a very simple shopping cart manager which can calculate totals
-function useShoppingCart() {
-	const [ items ] = useState( initialItems );
-
-	// The total must be calculated outside checkout and need not be related to line items
-	const lineItemTotal = items.reduce( ( sum, item ) => sum + item.amount.value, 0 );
-	const currency = items.reduce( ( lastCurrency, item ) => item.amount.currency, 'USD' );
-	const total = {
-		label: 'Total',
-		amount: {
-			currency,
-			value: lineItemTotal,
-			displayValue: formatValueForCurrency( currency, lineItemTotal ),
-		},
-	};
-
-	return { items, total };
-}
-```
+See the file `demo/index.js`.
 
 ## Styles and Themes
 
@@ -183,10 +138,9 @@ While the `Checkout` component takes care of most everything, there are many sit
 The main component in this package. It has the following props.
 
 - availablePaymentMethods: array
-- ReviewContent: component
-- UpSell: component
-- OrderSummary: component
-- ContactSlot: component
+- steps: array
+
+See the [Steps](#steps) section above for more details.
 
 ### CheckoutNextStepButton
 
@@ -215,7 +169,7 @@ It has the following props.
 
 The line items must be passed to `Checkout` using the required `items` array prop. Each item is an object of the form `{ label: string, subLabel: string, id: string, type: string, amount: { currency: string, value: int, displayValue: string } }`. All the properties are required except for `subLabel`, and `id` must be unique. The `type` property is not used internally but can be used to organize the line items.
 
-If any event in a customization slot causes the line items to change (for example, deleting something during the review step), the `items` array should not be mutated. It is incumbent on the parent component to create a modified line item list and then update `Checkout`.
+If any event in the form causes the line items to change (for example, deleting something during the review step), the `items` array should not be mutated. It is incumbent on the parent component to create a modified line item list and then update `Checkout`.
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
 
@@ -235,7 +189,7 @@ Each of the steps in the checkout flow will be rendered by one of these. Renders
 
 Each should include in its `children` a `CheckoutNextStepButton` if there is a following step.
 
-If a step has the `onEdit` prop, it will include an "Edit" link when `isComplete` is true which will call the `onEdit` prop function. The parent component is responsible for using this to toggle the component's state in an appropriate way (perhaps by setting `isActive` to true). The parent should also modify the URL so that the state is serialized somehow in the URL (this allows the "Back" button to work in an expected way when collapsing and expanding steps).
+If a step has the `onEdit` prop, it will include an "Edit" link which will call the `onEdit` prop function. The parent component is responsible for using this to toggle the component's state in an appropriate way. The parent should also modify the URL so that the state is serialized somehow in the URL (this allows the "Back" button to work in an expected way when collapsing and expanding steps).
 
 ### useAllPaymentMethods()
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -193,7 +193,10 @@ const steps = [
 		hasStepNumber: true,
 		titleContent: <OrderReviewTitle />,
 		activeStepContent: <WPCheckoutOrderReview />,
-		isCompleteCallback: () => true,
+		isCompleteCallback: ( { activeStep } ) => {
+			const isActive = activeStep.id === 'order-review';
+			return isActive;
+		},
 	},
 ];
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -14,7 +14,7 @@ import {
 	createPayPalMethod,
 	createApplePayMethod,
 	createCreditCardMethod,
-	useActiveStep,
+	useIsStepActive,
 	getDefaultPaymentMethodStep,
 	WPCheckoutOrderSummary,
 	WPCheckoutOrderSummaryTitle,
@@ -138,9 +138,8 @@ const hostTranslate = text => text;
 
 const ContactFormTitle = () => {
 	const localize = useLocalize();
-	const currentStep = useActiveStep();
-	const isActive = currentStep.id === 'payment-method';
-	return isActive ? localize( 'Billing details' ) : localize( 'Enter your billing details' );
+	const isActive = useIsStepActive();
+	return isActive ? localize( 'Enter your billing details' ) : localize( 'Billing details' );
 };
 
 const OrderReviewTitle = () => {

--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -12,6 +12,7 @@ export default function Button( {
 	className,
 	fullWidth,
 	children,
+	...props
 } ) {
 	return (
 		<CallToAction
@@ -21,6 +22,7 @@ export default function Button( {
 			onClick={ onClick }
 			className={ className }
 			fullWidth={ fullWidth }
+			{ ...props }
 		>
 			{ children }
 		</CallToAction>

--- a/packages/composite-checkout/src/components/checkout-next-step-button.js
+++ b/packages/composite-checkout/src/components/checkout-next-step-button.js
@@ -8,9 +8,9 @@ import React from 'react';
  */
 import Button from './button';
 
-export default function CheckoutNextStepButton( { value, onClick, ariaLabel } ) {
+export default function CheckoutNextStepButton( { value, onClick, ariaLabel, ...props } ) {
 	return (
-		<Button onClick={ onClick } buttonState="primary" aria-label={ ariaLabel }>
+		<Button onClick={ onClick } buttonState="primary" aria-label={ ariaLabel } { ...props }>
 			{ value }
 		</Button>
 	);

--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -7,7 +7,8 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { useLineItems } from '../public-api';
+import { useLineItems, useTotal, renderDisplayValueMarkdown } from '../public-api';
+import { useLocalize } from '../lib/localize';
 
 export default function CheckoutOrderSummary() {
 	const [ items ] = useLineItems();
@@ -30,4 +31,26 @@ const ProductListItem = styled.li`
 	margin: 0;
 	padding: 0;
 	list-style-type: none;
+`;
+
+export function CheckoutOrderSummaryTitle() {
+	const localize = useLocalize();
+	const total = useTotal();
+	return (
+		<CheckoutSummaryTitle>
+			<span>{ localize( 'You are all set to check out' ) }</span>
+			<CheckoutSummaryTotal>
+				{ renderDisplayValueMarkdown( total.amount.displayValue ) }
+			</CheckoutSummaryTotal>
+		</CheckoutSummaryTitle>
+	);
+}
+
+const CheckoutSummaryTitle = styled.span`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const CheckoutSummaryTotal = styled.span`
+	font-weight: ${props => props.theme.weights.bold};
 `;

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -11,7 +11,12 @@ import styled from '@emotion/styled';
 import joinClasses from '../lib/join-classes';
 import RadioButton from './radio-button';
 import { useLocalize } from '../lib/localize';
-import { useAllPaymentMethods } from '../public-api';
+import {
+	useAllPaymentMethods,
+	usePaymentMethod,
+	usePaymentMethodId,
+	useActiveStep,
+} from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 
 export default function CheckoutPaymentMethods( {
@@ -19,11 +24,11 @@ export default function CheckoutPaymentMethods( {
 	isComplete,
 	className,
 	availablePaymentMethods,
-	paymentMethod,
-	onChange,
 } ) {
 	const localize = useLocalize();
 
+	const paymentMethod = usePaymentMethod();
+	const [ , setPaymentMethod ] = usePaymentMethodId();
 	const paymentMethods = useAllPaymentMethods();
 	const paymentMethodsToDisplay = availablePaymentMethods
 		? paymentMethods.filter( method => availablePaymentMethods.includes( method.id ) )
@@ -63,7 +68,7 @@ export default function CheckoutPaymentMethods( {
 						<PaymentMethod
 							{ ...method }
 							checked={ paymentMethod.id === method.id }
-							onClick={ onChange }
+							onClick={ setPaymentMethod }
 							ariaLabel={ method.getAriaLabel( localize ) }
 						/>
 					</CheckoutErrorBoundary>
@@ -76,11 +81,8 @@ export default function CheckoutPaymentMethods( {
 CheckoutPaymentMethods.propTypes = {
 	summary: PropTypes.bool,
 	isComplete: PropTypes.bool.isRequired,
-	isActive: PropTypes.bool.isRequired,
 	className: PropTypes.string,
 	availablePaymentMethods: PropTypes.arrayOf( PropTypes.string ),
-	paymentMethod: PropTypes.object,
-	onChange: PropTypes.func.isRequired,
 };
 
 export function CheckoutPaymentMethodsTitle() {

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -83,6 +83,13 @@ CheckoutPaymentMethods.propTypes = {
 	onChange: PropTypes.func.isRequired,
 };
 
+export function CheckoutPaymentMethodsTitle() {
+	const localize = useLocalize();
+	const currentStep = useActiveStep();
+	const isActive = currentStep.id === 'payment-method';
+	return isActive ? localize( 'Pick a payment method' ) : localize( 'Payment method' );
+}
+
 function PaymentMethod( {
 	id,
 	LabelComponent,

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -15,7 +15,7 @@ import {
 	useAllPaymentMethods,
 	usePaymentMethod,
 	usePaymentMethodId,
-	useActiveStep,
+	useIsStepActive,
 } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 
@@ -87,8 +87,7 @@ CheckoutPaymentMethods.propTypes = {
 
 export function CheckoutPaymentMethodsTitle() {
 	const localize = useLocalize();
-	const currentStep = useActiveStep();
-	const isActive = currentStep.id === 'payment-method';
+	const isActive = useIsStepActive();
 	return isActive ? localize( 'Pick a payment method' ) : localize( 'Payment method' );
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -14,6 +14,12 @@ import { LocalizeProvider } from '../lib/localize';
 import { LineItemsProvider } from '../lib/line-items';
 import { RegistryProvider, createRegistry } from '../lib/registry';
 import defaultTheme from '../theme';
+import {
+	validateArg,
+	validateTotal,
+	validateLineItems,
+	validatePaymentMethods,
+} from '../lib/validation';
 
 export const CheckoutProvider = props => {
 	const {
@@ -117,57 +123,6 @@ function PaymentMethodWrapperProvider( { children, wrappers } ) {
 	return wrappers.reduce( ( whole, Wrapper ) => {
 		return <Wrapper>{ whole }</Wrapper>;
 	}, children );
-}
-
-function validateArg( value, errorMessage ) {
-	if ( value === null || value === undefined ) {
-		throw new Error( errorMessage );
-	}
-}
-
-function validatePaymentMethods( paymentMethods ) {
-	paymentMethods.map( validatePaymentMethod );
-}
-
-function validatePaymentMethod( {
-	id,
-	LabelComponent,
-	SubmitButtonComponent,
-	SummaryComponent,
-	getAriaLabel,
-} ) {
-	validateArg( id, 'Invalid payment method; missing id property' );
-	validateArg( LabelComponent, `Invalid payment method '${ id }'; missing LabelComponent` );
-	validateArg(
-		SubmitButtonComponent,
-		`Invalid payment method '${ id }'; missing SubmitButtonComponent`
-	);
-	validateArg( SummaryComponent, `Invalid payment method '${ id }'; missing SummaryComponent` );
-	validateArg( getAriaLabel, `Invalid payment method '${ id }'; missing getAriaLabel` );
-}
-
-function validateLineItems( items ) {
-	items.map( validateLineItem );
-}
-
-function validateTotal( { label, amount } ) {
-	validateArg( label, `Invalid total; missing label property` );
-	validateArg( amount, `Invalid total; missing amount property` );
-	validateAmount( 'total', amount );
-}
-
-function validateLineItem( { id, label, amount, type } ) {
-	validateArg( id, 'Invalid line item; missing id property' );
-	validateArg( label, `Invalid line item '${ id }'; missing label property` );
-	validateArg( type, `Invalid line item '${ id }'; missing type property` );
-	validateArg( amount, `Invalid line item '${ id }'; missing amount property` );
-	validateAmount( id, amount );
-}
-
-function validateAmount( id, { currency, value, displayValue } ) {
-	validateArg( currency, `Invalid line item '${ id }'; missing amount.currency property` );
-	validateArg( value, `Invalid line item '${ id }'; missing amount.value property` );
-	validateArg( displayValue, `Invalid line item '${ id }'; missing amount.displayValue property` );
 }
 
 export const useCheckoutHandlers = () => {

--- a/packages/composite-checkout/src/components/checkout-review-order.js
+++ b/packages/composite-checkout/src/components/checkout-review-order.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
  */
 import joinClasses from '../lib/join-classes';
 import { useLineItems, renderDisplayValueMarkdown } from '../public-api';
+import { useLocalize } from '../lib/localize';
 import {
 	OrderReviewLineItems,
 	OrderReviewTotal,

--- a/packages/composite-checkout/src/components/checkout-review-order.js
+++ b/packages/composite-checkout/src/components/checkout-review-order.js
@@ -30,8 +30,12 @@ export default function CheckoutReviewOrder( { className } ) {
 	);
 }
 
+export function CheckoutReviewOrderTitle() {
+	const localize = useLocalize();
+	return localize( 'Review your order' );
+}
+
 CheckoutReviewOrder.propTypes = {
-	isActive: PropTypes.bool.isRequired,
 	className: PropTypes.string,
 };
 

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -60,7 +60,7 @@ export default function CheckoutStep( {
 
 CheckoutStep.propTypes = {
 	className: PropTypes.string,
-	stepNumber: PropTypes.number.isRequired,
+	stepNumber: PropTypes.number,
 	title: PropTypes.node.isRequired,
 	finalStep: PropTypes.bool,
 	stepSummary: PropTypes.node,
@@ -88,7 +88,7 @@ function CheckoutStepHeader( {
 			className={ joinClasses( [ className, 'checkout-step__header' ] ) }
 		>
 			<Stepper isComplete={ isComplete } isActive={ isActive }>
-				{ stepNumber }
+				{ stepNumber || '•' }
 			</Stepper>
 			<StepTitle
 				className="checkout-step__title"
@@ -113,7 +113,7 @@ function CheckoutStepHeader( {
 
 CheckoutStepHeader.propTypes = {
 	className: PropTypes.string,
-	stepNumber: PropTypes.number.isRequired,
+	stepNumber: PropTypes.number,
 	title: PropTypes.node.isRequired,
 	isActive: PropTypes.bool,
 	isComplete: PropTypes.bool,

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -122,11 +122,11 @@ CheckoutStepHeader.propTypes = {
 
 function Stepper( { isComplete, isActive, className, children } ) {
 	// Prevent showing complete stepper when active
-	isComplete = isActive ? false : isComplete;
+	const isCompleteAndInactive = isActive ? false : isComplete;
 	return (
 		<StepNumberOuterWrapper className={ joinClasses( [ className, 'checkout-step__stepper' ] ) }>
-			<StepNumberInnerWrapper isComplete={ isComplete }>
-				<StepNumber isComplete={ isComplete } isActive={ isActive }>
+			<StepNumberInnerWrapper isComplete={ isCompleteAndInactive }>
+				<StepNumber isComplete={ isCompleteAndInactive } isActive={ isActive }>
 					{ children }
 				</StepNumber>
 				<StepNumberCompleted>

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -79,7 +79,7 @@ function CheckoutStepHeader( {
 	editButtonAriaLabel,
 } ) {
 	const localize = useLocalize();
-	const shouldShowEditButton = onEdit && isComplete && ! isActive;
+	const shouldShowEditButton = !! onEdit;
 
 	return (
 		<StepHeader

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -121,6 +121,8 @@ CheckoutStepHeader.propTypes = {
 };
 
 function Stepper( { isComplete, isActive, className, children } ) {
+	// Prevent showing complete stepper when active
+	isComplete = isActive ? false : isComplete;
 	return (
 		<StepNumberOuterWrapper className={ joinClasses( [ className, 'checkout-step__stepper' ] ) }>
 			<StepNumberInnerWrapper isComplete={ isComplete }>

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -23,6 +23,7 @@ export default function CheckoutStep( {
 	finalStep,
 	stepSummary,
 	stepContent,
+	editButtonAriaLabel,
 } ) {
 	const classNames = [
 		className,
@@ -43,6 +44,7 @@ export default function CheckoutStep( {
 				isActive={ isActive }
 				isComplete={ isComplete }
 				onEdit={ onEdit }
+				editButtonAriaLabel={ editButtonAriaLabel }
 			/>
 			<StepContent className="checkout-step__content" isVisible={ isActive }>
 				{ stepContent }

--- a/packages/composite-checkout/src/components/checkout-submit-button.js
+++ b/packages/composite-checkout/src/components/checkout-submit-button.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -10,7 +9,7 @@ import PropTypes from 'prop-types';
 import joinClasses from '../lib/join-classes';
 import { usePaymentMethod } from '../public-api';
 
-export default function CheckoutSubmitButton( { className, isActive } ) {
+export default function CheckoutSubmitButton( { className, disabled } ) {
 	const paymentMethod = usePaymentMethod();
 	if ( ! paymentMethod ) {
 		return null;
@@ -18,12 +17,7 @@ export default function CheckoutSubmitButton( { className, isActive } ) {
 	const { SubmitButtonComponent } = paymentMethod;
 	return (
 		<div className={ joinClasses( [ className, 'checkout-submit-button' ] ) }>
-			<SubmitButtonComponent isActive={ isActive } />
+			<SubmitButtonComponent disabled={ disabled } />
 		</div>
 	);
 }
-
-CheckoutSubmitButton.propTypes = {
-	isActive: PropTypes.bool.isRequired,
-	className: PropTypes.string,
-};

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
@@ -9,17 +9,16 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import joinClasses from '../lib/join-classes';
-import { useLocalize } from '../lib/localize';
+import { useLocalize, sprintf } from '../lib/localize';
 import CheckoutStep from './checkout-step';
-import CheckoutPaymentMethods from './checkout-payment-methods';
-import { usePaymentMethod, usePaymentMethodId } from '../lib/payment-methods';
 import CheckoutNextStepButton from './checkout-next-step-button';
-import CheckoutReviewOrder from './checkout-review-order';
 import CheckoutSubmitButton from './checkout-submit-button';
 import { useSelect, useDispatch, useRegisterStore } from '../lib/registry';
 import CheckoutErrorBoundary from './checkout-error-boundary';
-import CheckoutOrderSummary from './checkout-order-summary';
-import { useTotal, renderDisplayValueMarkdown } from '../public-api';
+import { useActiveStep, ActiveStepProvider } from '../lib/active-step';
+import CheckoutOrderSummary, { CheckoutOrderSummaryTitle } from './checkout-order-summary';
+import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review-order';
+import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
 
 function useRegisterCheckoutStore() {
 	useRegisterStore( 'checkout', {
@@ -54,69 +53,69 @@ function useRegisterCheckoutStore() {
 	} );
 }
 
-export default function Checkout( {
-	availablePaymentMethods,
-	ReviewContent,
-	UpSell,
-	OrderSummary,
-	ContactSlot,
-	className,
-} ) {
+export default function Checkout( { steps, className } ) {
 	useRegisterCheckoutStore();
 	const localize = useLocalize();
+
+	// stepNumber is the displayed number of the active step, not its index
 	const stepNumber = useSelect( select => select( 'checkout' ).getStepNumber() );
 	const { changeStep } = useDispatch( 'checkout' );
+	steps = steps || makeDefaultSteps();
+
+	// Assign step numbers to all steps with numbers
+	const annotatedSteps = useMemo( () => {
+		let numberedStepNumber = 0;
+		return steps.map( ( step, index ) => {
+			numberedStepNumber = step.hasStepNumber ? numberedStepNumber + 1 : numberedStepNumber;
+			return step.hasStepNumber
+				? { ...step, stepNumber: numberedStepNumber, stepIndex: index }
+				: step;
+		} );
+	}, [ steps ] );
+
+	if ( annotatedSteps.length < 1 ) {
+		throw new Error( 'No steps found' );
+	}
+
+	const activeStep = annotatedSteps.find( step => step.stepNumber === stepNumber );
+	if ( ! activeStep ) {
+		throw new Error( 'There is no active step' );
+	}
+
+	const nextStep = annotatedSteps.find( ( step, index ) => {
+		return index > activeStep.stepIndex && step.hasStepNumber;
+	} );
+	const isThereAnotherNumberedStep = nextStep && nextStep.hasStepNumber;
 
 	return (
 		<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
 			<MainContent className={ joinClasses( [ className, 'checkout__content' ] ) }>
-				<OrderSummaryStep OrderSummary={ OrderSummary || CheckoutOrderSummary } />
-
-				<CheckoutErrorBoundary
-					errorMessage={ localize( 'There was a problem with the payment method form.' ) }
-				>
-					<PaymentMethodsStep
-						stepNumber={ 1 }
-						availablePaymentMethods={ availablePaymentMethods }
-						onComplete={ () => changeStep( 2 ) }
-						onEdit={ () => changeStep( 1 ) }
-						isActive={ stepNumber === 1 }
-						isComplete={ stepNumber > 1 }
-					/>
-				</CheckoutErrorBoundary>
-				{ ContactSlot && (
-					<CheckoutErrorBoundary
-						errorMessage={ localize( 'There was a problem with the billing contact form.' ) }
-					>
-						<BillingDetailsStep
-							stepNumber={ 2 }
-							onComplete={ () => changeStep( 3 ) }
-							onEdit={ () => changeStep( 2 ) }
-							isActive={ stepNumber === 2 }
-							isComplete={ stepNumber > 2 }
-							ContactSlot={ ContactSlot }
+				<ActiveStepProvider step={ activeStep }>
+					{ annotatedSteps.map( step => (
+						<CheckoutStepContainer
+							{ ...step }
+							key={ step.id }
+							stepNumber={ step.stepNumber || null }
+							shouldShowNextButton={
+								step.hasStepNumber && step.id === activeStep.id && isThereAnotherNumberedStep
+							}
+							goToNextStep={ () => changeStep( nextStep.stepNumber ) }
+							onEdit={
+								step.isEditableCallback && step.isEditableCallback()
+									? () => changeStep( step.stepNumber )
+									: null
+							}
 						/>
-					</CheckoutErrorBoundary>
-				) }
-				<CheckoutErrorBoundary
-					errorMessage={ localize( 'There was a problem with the review form.' ) }
-				>
-					<ReviewOrderStep
-						stepNumber={ ContactSlot ? 3 : 2 }
-						isActive={ stepNumber === ( ContactSlot ? 3 : 2 ) }
-						isComplete={ stepNumber > ( ContactSlot ? 3 : 2 ) }
-						ReviewContent={ ReviewContent }
-					/>
-				</CheckoutErrorBoundary>
+					) ) }
+				</ActiveStepProvider>
+
 				<CheckoutWrapper>
 					<CheckoutErrorBoundary
 						errorMessage={ localize( 'There was a problem with the submit button.' ) }
 					>
-						<CheckoutSubmitButton isActive={ stepNumber === ( ContactSlot ? 3 : 2 ) } />
+						<CheckoutSubmitButton isActive={ ! isThereAnotherNumberedStep } />
 					</CheckoutErrorBoundary>
 				</CheckoutWrapper>
-
-				{ UpSell && <UpSell /> }
 			</MainContent>
 		</Container>
 	);
@@ -124,12 +123,58 @@ export default function Checkout( {
 
 Checkout.propTypes = {
 	className: PropTypes.string,
-	availablePaymentMethods: PropTypes.arrayOf( PropTypes.string ),
-	ReviewContent: PropTypes.elementType,
-	UpSell: PropTypes.elementType,
-	OrderSummary: PropTypes.elementType,
-	ContactSlot: PropTypes.elementType,
+	steps: PropTypes.array,
 };
+
+function CheckoutStepContainer( {
+	id,
+	titleContent,
+	className,
+	activeStepContent,
+	incompleteStepContent,
+	completeStepContent,
+	isCompleteCallback,
+	stepNumber,
+	shouldShowNextButton,
+	goToNextStep,
+	getNextStepButtonLabel,
+	onEdit,
+	getEditButtonAriaLabel,
+} ) {
+	const localize = useLocalize();
+	const currentStep = useActiveStep();
+	const isActive = currentStep.id === id;
+	const isComplete = isCompleteCallback();
+
+	return (
+		<CheckoutErrorBoundary
+			errorMessage={ sprintf( localize( 'There was a problem with the step "%s".' ), id ) }
+		>
+			<CheckoutStep
+				className={ className }
+				isActive={ isActive }
+				isComplete={ isComplete }
+				stepNumber={ stepNumber }
+				title={ titleContent }
+				onEdit={ ! isActive && isComplete ? onEdit : null }
+				editButtonAriaLabel={ getEditButtonAriaLabel && getEditButtonAriaLabel( localize ) }
+				stepContent={
+					<React.Fragment>
+						{ activeStepContent }
+						{ shouldShowNextButton && (
+							<CheckoutNextStepButton
+								value={ localize( 'Continue' ) }
+								onClick={ goToNextStep }
+								ariaLabel={ getNextStepButtonLabel && getNextStepButtonLabel( localize ) }
+							/>
+						) }
+					</React.Fragment>
+				}
+				stepSummary={ isComplete ? completeStepContent : incompleteStepContent }
+			/>
+		</CheckoutErrorBoundary>
+	);
+}
 
 const Container = styled.div`
 	*:focus {
@@ -155,176 +200,40 @@ const CheckoutWrapper = styled.div`
 	padding: 24px;
 `;
 
-function OrderSummaryStep( { OrderSummary } ) {
-	const localize = useLocalize();
-	const total = useTotal();
-
-	return (
-		<CheckoutStep
-			isActive={ false }
-			isComplete={ true }
-			stepNumber={ 0 }
-			title={
-				<CheckoutSummaryTitle>
-					<span>{ localize( 'You are all set to check out' ) }</span>
-					<CheckoutSummaryTotal>
-						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
-					</CheckoutSummaryTotal>
-				</CheckoutSummaryTitle>
-			}
-			stepSummary={ <OrderSummary /> }
-		/>
-	);
+function makeDefaultSteps() {
+	return [
+		{
+			id: 'order-summary',
+			className: 'checkout__order-summary-step',
+			hasStepNumber: false,
+			titleContent: <CheckoutOrderSummaryTitle />,
+			activeStepContent: null,
+			incompleteStepContent: null,
+			completeStepContent: <CheckoutOrderSummary />,
+			isCompleteCallback: () => true,
+		},
+		{
+			id: 'payment-method',
+			className: 'checkout__payment-methods-step',
+			hasStepNumber: true,
+			titleContent: <CheckoutPaymentMethodsTitle />,
+			activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
+			incompleteStepContent: null,
+			completeStepContent: <CheckoutPaymentMethods summary isComplete={ true } />,
+			isCompleteCallback: () => true,
+			isEditableCallback: () => true,
+			getEditButtonAriaLabel: localize => localize( 'Edit the payment method' ),
+			getNextStepButtonLabel: localize => localize( 'Continue with the selected payment method' ),
+		},
+		{
+			id: 'order-review',
+			className: 'checkout__review-order-step',
+			hasStepNumber: true,
+			titleContent: <CheckoutReviewOrderTitle />,
+			activeStepContent: <CheckoutReviewOrder />,
+			incompleteStepContent: null,
+			completeStepContent: null,
+			isCompleteCallback: () => true,
+		},
+	];
 }
-
-OrderSummaryStep.propTypes = {
-	OrderSummary: PropTypes.elementType,
-};
-
-const CheckoutSummaryTitle = styled.span`
-	display: flex;
-	justify-content: space-between;
-`;
-
-const CheckoutSummaryTotal = styled.span`
-	font-weight: ${props => props.theme.weights.bold};
-`;
-
-function PaymentMethodsStep( {
-	stepNumber,
-	onEdit,
-	onComplete,
-	isActive,
-	isComplete,
-	availablePaymentMethods,
-} ) {
-	const localize = useLocalize();
-	const paymentMethod = usePaymentMethod();
-	const [ , setPaymentMethod ] = usePaymentMethodId();
-
-	return (
-		<CheckoutStep
-			className="checkout__payment-methods-step"
-			isActive={ isActive }
-			isComplete={ isComplete }
-			stepNumber={ stepNumber }
-			title={ isComplete ? localize( 'Payment method' ) : localize( 'Pick a payment method' ) }
-			onEdit={ onEdit }
-			editButtonAriaLabel={ localize( 'Edit the payment method' ) }
-			stepContent={
-				<React.Fragment>
-					<CheckoutPaymentMethods
-						isActive={ isActive }
-						isComplete={ isComplete }
-						availablePaymentMethods={ availablePaymentMethods }
-						onChange={ setPaymentMethod }
-						paymentMethod={ paymentMethod }
-					/>
-
-					<CheckoutNextStepButton
-						value={ localize( 'Continue' ) }
-						onClick={ onComplete }
-						ariaLabel={ localize( 'Continue with the selected payment method' ) }
-					/>
-				</React.Fragment>
-			}
-			stepSummary={
-				<CheckoutPaymentMethods
-					summary
-					isActive={ isActive }
-					isComplete={ isComplete }
-					availablePaymentMethods={ availablePaymentMethods }
-					onChange={ setPaymentMethod }
-					paymentMethod={ paymentMethod }
-				/>
-			}
-		/>
-	);
-}
-
-PaymentMethodsStep.propTypes = {
-	stepNumber: PropTypes.number.isRequired,
-	onComplete: PropTypes.func.isRequired,
-	onEdit: PropTypes.func.isRequired,
-	isActive: PropTypes.bool.isRequired,
-	isComplete: PropTypes.bool.isRequired,
-	availablePaymentMethods: PropTypes.arrayOf( PropTypes.string ),
-};
-
-function BillingDetailsStep( {
-	stepNumber,
-	isActive,
-	isComplete,
-	onComplete,
-	onEdit,
-	ContactSlot,
-} ) {
-	const localize = useLocalize();
-	const paymentMethod = usePaymentMethod();
-	if ( ! paymentMethod ) {
-		throw new Error( 'Cannot render Billing details without a payment method' );
-	}
-
-	return (
-		<CheckoutStep
-			className="checkout__billing-details-step"
-			isActive={ isActive }
-			isComplete={ isComplete }
-			stepNumber={ stepNumber }
-			title={
-				isComplete ? localize( 'Billing details' ) : localize( 'Enter your billing details' )
-			}
-			onEdit={ onEdit }
-			editButtonAriaLabel={ localize( 'Edit the billing details' ) }
-			stepContent={
-				<React.Fragment>
-					<ContactSlot isActive={ isActive } isComplete={ isComplete } />
-					<CheckoutNextStepButton
-						value={ localize( 'Continue' ) }
-						onClick={ onComplete }
-						ariaLabel={ localize( 'Continue with the entered billing details' ) }
-					/>
-				</React.Fragment>
-			}
-			stepSummary={ <ContactSlot summary isActive={ isActive } isComplete={ isComplete } /> }
-		/>
-	);
-}
-
-BillingDetailsStep.propTypes = {
-	stepNumber: PropTypes.number.isRequired,
-	onEdit: PropTypes.func.isRequired,
-	onComplete: PropTypes.func.isRequired,
-	isActive: PropTypes.bool.isRequired,
-	isComplete: PropTypes.bool.isRequired,
-	ContactSlot: PropTypes.elementType.isRequired,
-};
-
-function ReviewOrderStep( { stepNumber, isActive, isComplete, ReviewContent } ) {
-	const localize = useLocalize();
-
-	return (
-		<CheckoutStep
-			finalStep
-			className="checkout__review-order-step"
-			isActive={ isActive }
-			isComplete={ isComplete }
-			stepNumber={ stepNumber }
-			title={ localize( 'Review your order' ) }
-			stepContent={
-				ReviewContent ? (
-					<ReviewContent isActive={ isActive } />
-				) : (
-					<CheckoutReviewOrder isActive={ isActive } />
-				)
-			}
-		/>
-	);
-}
-
-ReviewOrderStep.propTypes = {
-	isActive: PropTypes.bool.isRequired,
-	isComplete: PropTypes.bool.isRequired,
-	stepNumber: PropTypes.number.isRequired,
-	ReviewContent: PropTypes.elementType,
-};

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -115,7 +115,10 @@ export default function Checkout( { steps, className } ) {
 							}
 							goToNextStep={ () => changeStep( nextStep.stepNumber ) }
 							onEdit={
-								step.isEditableCallback && step.isEditableCallback()
+								step.id !== activeStep.id &&
+								step.hasStepNumber &&
+								step.isEditableCallback &&
+								step.isEditableCallback( { paymentData } )
 									? () => changeStep( step.stepNumber )
 									: null
 							}
@@ -171,7 +174,7 @@ function CheckoutStepContainer( {
 				isComplete={ isComplete }
 				stepNumber={ stepNumber }
 				title={ titleContent || '' }
-				onEdit={ ! isActive && isComplete ? onEdit : null }
+				onEdit={ onEdit }
 				editButtonAriaLabel={ getEditButtonAriaLabel && getEditButtonAriaLabel() }
 				stepContent={
 					<React.Fragment>

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -13,7 +13,12 @@ import { useLocalize, sprintf } from '../lib/localize';
 import CheckoutStep from './checkout-step';
 import CheckoutNextStepButton from './checkout-next-step-button';
 import CheckoutSubmitButton from './checkout-submit-button';
-import { usePrimarySelect, usePrimaryDispatch, useRegisterPrimaryStore } from '../lib/registry';
+import {
+	usePrimarySelect,
+	usePrimaryDispatch,
+	useRegisterPrimaryStore,
+	usePaymentData,
+} from '../lib/registry';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { useActiveStep, ActiveStepProvider } from '../lib/active-step';
 import CheckoutOrderSummary, { CheckoutOrderSummaryTitle } from './checkout-order-summary';
@@ -143,8 +148,9 @@ function CheckoutStepContainer( {
 } ) {
 	const localize = useLocalize();
 	const currentStep = useActiveStep();
+	const [ paymentData ] = usePaymentData();
 	const isActive = currentStep.id === id;
-	const isComplete = isCompleteCallback();
+	const isComplete = !! isCompleteCallback( { paymentData } );
 
 	return (
 		<CheckoutErrorBoundary

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -13,7 +13,7 @@ import { useLocalize, sprintf } from '../lib/localize';
 import CheckoutStep from './checkout-step';
 import CheckoutNextStepButton from './checkout-next-step-button';
 import CheckoutSubmitButton from './checkout-submit-button';
-import { useSelect, useDispatch, useRegisterStore } from '../lib/registry';
+import { usePrimarySelect, usePrimaryDispatch, useRegisterPrimaryStore } from '../lib/registry';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { useActiveStep, ActiveStepProvider } from '../lib/active-step';
 import CheckoutOrderSummary, { CheckoutOrderSummaryTitle } from './checkout-order-summary';
@@ -21,7 +21,7 @@ import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review
 import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
 
 function useRegisterCheckoutStore() {
-	useRegisterStore( 'checkout', {
+	useRegisterPrimaryStore( {
 		reducer( state = { stepNumber: 1, paymentData: {} }, action ) {
 			switch ( action.type ) {
 				case 'STEP_NUMBER_SET':
@@ -58,8 +58,8 @@ export default function Checkout( { steps, className } ) {
 	const localize = useLocalize();
 
 	// stepNumber is the displayed number of the active step, not its index
-	const stepNumber = useSelect( select => select( 'checkout' ).getStepNumber() );
-	const { changeStep } = useDispatch( 'checkout' );
+	const stepNumber = usePrimarySelect( select => select().getStepNumber() );
+	const { changeStep } = usePrimaryDispatch();
 	steps = steps || makeDefaultSteps();
 
 	// Assign step numbers to all steps with numbers

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
@@ -73,19 +73,15 @@ export default function Checkout( { steps, className } ) {
 	validateSteps( steps );
 
 	// Assign step numbers to all steps with numbers
-	const annotatedSteps = useMemo( () => {
-		let numberedStepNumber = 0;
-		return steps.map( ( step, index ) => {
-			numberedStepNumber = step.hasStepNumber ? numberedStepNumber + 1 : numberedStepNumber;
-			return {
-				...step,
-				stepNumber: step.hasStepNumber ? numberedStepNumber : null,
-				stepIndex: index,
-				isComplete: !! step.isCompleteCallback && step.isCompleteCallback( { paymentData } ),
-			};
-		} );
-	}, [ steps, paymentData ] );
-
+	let numberedStepNumber = 0;
+	let annotatedSteps = steps.map( ( step, index ) => {
+		numberedStepNumber = step.hasStepNumber ? numberedStepNumber + 1 : numberedStepNumber;
+		return {
+			...step,
+			stepNumber: step.hasStepNumber ? numberedStepNumber : null,
+			stepIndex: index,
+		};
+	} );
 	if ( annotatedSteps.length < 1 ) {
 		throw new Error( 'No steps found' );
 	}
@@ -94,6 +90,15 @@ export default function Checkout( { steps, className } ) {
 	if ( ! activeStep ) {
 		throw new Error( 'There is no active step' );
 	}
+
+	// Assign isComplete separately so we can provide the activeStep
+	annotatedSteps = annotatedSteps.map( step => {
+		return {
+			...step,
+			isComplete:
+				!! step.isCompleteCallback && step.isCompleteCallback( { paymentData, activeStep } ),
+		};
+	} );
 
 	const nextStep = annotatedSteps.find( ( step, index ) => {
 		return index > activeStep.stepIndex && step.hasStepNumber;

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -172,6 +172,7 @@ function CheckoutStepContainer( {
 								value={ localize( 'Continue' ) }
 								onClick={ goToNextStep }
 								ariaLabel={ getNextStepButtonLabel && getNextStepButtonLabel( localize ) }
+								disabled={ ! isComplete }
 							/>
 						) }
 					</React.Fragment>

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -20,7 +20,7 @@ import {
 	usePaymentData,
 } from '../lib/registry';
 import CheckoutErrorBoundary from './checkout-error-boundary';
-import { useActiveStep, ActiveStepProvider } from '../lib/active-step';
+import { useActiveStep, ActiveStepProvider, RenderedStepProvider } from '../lib/active-step';
 import {
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
@@ -173,29 +173,31 @@ function CheckoutStepContainer( {
 		<CheckoutErrorBoundary
 			errorMessage={ sprintf( localize( 'There was a problem with the step "%s".' ), id ) }
 		>
-			<CheckoutStep
-				className={ className }
-				isActive={ isActive }
-				isComplete={ isComplete }
-				stepNumber={ stepNumber }
-				title={ titleContent || '' }
-				onEdit={ onEdit }
-				editButtonAriaLabel={ getEditButtonAriaLabel && getEditButtonAriaLabel() }
-				stepContent={
-					<React.Fragment>
-						{ activeStepContent }
-						{ shouldShowNextButton && (
-							<CheckoutNextStepButton
-								value={ localize( 'Continue' ) }
-								onClick={ goToNextStep }
-								ariaLabel={ getNextStepButtonAriaLabel && getNextStepButtonAriaLabel() }
-								disabled={ ! isComplete }
-							/>
-						) }
-					</React.Fragment>
-				}
-				stepSummary={ isComplete ? completeStepContent : incompleteStepContent }
-			/>
+			<RenderedStepProvider stepId={ id }>
+				<CheckoutStep
+					className={ className }
+					isActive={ isActive }
+					isComplete={ isComplete }
+					stepNumber={ stepNumber }
+					title={ titleContent || '' }
+					onEdit={ onEdit }
+					editButtonAriaLabel={ getEditButtonAriaLabel && getEditButtonAriaLabel() }
+					stepContent={
+						<React.Fragment>
+							{ activeStepContent }
+							{ shouldShowNextButton && (
+								<CheckoutNextStepButton
+									value={ localize( 'Continue' ) }
+									onClick={ goToNextStep }
+									ariaLabel={ getNextStepButtonAriaLabel && getNextStepButtonAriaLabel() }
+									disabled={ ! isComplete }
+								/>
+							) }
+						</React.Fragment>
+					}
+					stepSummary={ isComplete ? completeStepContent : incompleteStepContent }
+				/>
+			</RenderedStepProvider>
 		</CheckoutErrorBoundary>
 	);
 }

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -81,7 +81,7 @@ export default function Checkout( { steps, className } ) {
 				...step,
 				stepNumber: step.hasStepNumber ? numberedStepNumber : null,
 				stepIndex: index,
-				isComplete: !! step.isCompleteCallback( { paymentData } ),
+				isComplete: !! step.isCompleteCallback && step.isCompleteCallback( { paymentData } ),
 			};
 		} );
 	}, [ steps, paymentData ] );

--- a/packages/composite-checkout/src/components/default-steps.js
+++ b/packages/composite-checkout/src/components/default-steps.js
@@ -51,6 +51,9 @@ export function getDefaultOrderReviewStep() {
 		activeStepContent: <CheckoutReviewOrder />,
 		incompleteStepContent: null,
 		completeStepContent: null,
-		isCompleteCallback: () => true,
+		isCompleteCallback: ( { activeStep } ) => {
+			const isActive = activeStep.id === 'order-review';
+			return isActive;
+		},
 	};
 }

--- a/packages/composite-checkout/src/components/default-steps.js
+++ b/packages/composite-checkout/src/components/default-steps.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CheckoutOrderSummary, { CheckoutOrderSummaryTitle } from './checkout-order-summary';
+import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review-order';
+import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
+
+export function getDefaultOrderSummaryStep() {
+	return {
+		id: 'order-summary',
+		className: 'checkout__order-summary-step',
+		hasStepNumber: false,
+		titleContent: <CheckoutOrderSummaryTitle />,
+		activeStepContent: null,
+		incompleteStepContent: null,
+		completeStepContent: <CheckoutOrderSummary />,
+		isCompleteCallback: () => true,
+	};
+}
+
+export function getDefaultPaymentMethodStep() {
+	return {
+		id: 'payment-method',
+		className: 'checkout__payment-methods-step',
+		hasStepNumber: true,
+		titleContent: <CheckoutPaymentMethodsTitle />,
+		activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
+		incompleteStepContent: null,
+		completeStepContent: <CheckoutPaymentMethods summary isComplete={ true } />,
+		isCompleteCallback: () => true, // TODO: make sure any required fields in the selected payment method are complete
+		isEditableCallback: () => true,
+		// These cannot be translated because they are not inside a component and
+		// we don't know if they are being created by the package or the host page.
+		// They can be replaced by the consumer to get translation.
+		getEditButtonAriaLabel: () => 'Edit the payment method',
+		getNextStepButtonAriaLabel: () => 'Continue with the selected payment method',
+	};
+}
+
+export function getDefaultOrderReviewStep() {
+	return {
+		id: 'order-review',
+		className: 'checkout__review-order-step',
+		hasStepNumber: true,
+		titleContent: <CheckoutReviewOrderTitle />,
+		activeStepContent: <CheckoutReviewOrder />,
+		incompleteStepContent: null,
+		completeStepContent: null,
+		isCompleteCallback: () => true,
+	};
+}

--- a/packages/composite-checkout/src/lib/active-step.js
+++ b/packages/composite-checkout/src/lib/active-step.js
@@ -19,3 +19,18 @@ export const useActiveStep = () => {
 	}
 	return step;
 };
+
+const RenderedStepContext = createContext();
+
+export const RenderedStepProvider = ( { stepId, children } ) => (
+	<RenderedStepContext.Provider value={ stepId }>{ children }</RenderedStepContext.Provider>
+);
+
+export const useIsStepActive = () => {
+	const stepId = useContext( RenderedStepContext );
+	const activeStep = useActiveStep();
+	if ( ! stepId ) {
+		throw new Error( 'useIsStepActive can only be used inside an RenderedStepProvider' );
+	}
+	return stepId === activeStep.id;
+};

--- a/packages/composite-checkout/src/lib/active-step.js
+++ b/packages/composite-checkout/src/lib/active-step.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React, { createContext, useContext } from 'react';
+
+const ActiveStepContext = createContext();
+
+export const ActiveStepProvider = ( { step, children } ) => {
+	if ( ! step ) {
+		throw new Error( 'ActiveStepProvider requires a step object' );
+	}
+	return <ActiveStepContext.Provider value={ step }>{ children }</ActiveStepContext.Provider>;
+};
+
+export const useActiveStep = () => {
+	const step = useContext( ActiveStepContext );
+	if ( ! step ) {
+		throw new Error( 'useActiveStep can only be used inside an ActiveStepProvider' );
+	}
+	return step;
+};

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card-fields.js
@@ -12,13 +12,12 @@ import GridRow from '../../components/grid-row';
 import { useLocalize } from '../localize';
 import { AmexLogo, VisaLogo, MastercardLogo } from '../../components/payment-logos';
 import { LeftColumn, RightColumn } from '../styled-components/ie-fallback';
-import { usePrimarySelect, usePrimaryDispatch } from '../../public-api';
+import { usePaymentData } from '../../public-api';
 
 export default function CreditCardFields( { disabled } ) {
 	const localize = useLocalize();
 	const [ paymentIcon, setPaymentIcon ] = useState( <LockIcon /> );
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
-	const { updatePaymentData } = usePrimaryDispatch();
+	const [ paymentData, updatePaymentData ] = usePaymentData();
 	const currentCreditCardData = paymentData.creditCard || {};
 	const updateCreditCard = ( key, value ) =>
 		updatePaymentData( 'creditCard', { ...currentCreditCardData, [ key ]: value } );

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card-fields.js
@@ -11,14 +11,14 @@ import Field from '../../components/field';
 import GridRow from '../../components/grid-row';
 import { useLocalize } from '../localize';
 import { AmexLogo, VisaLogo, MastercardLogo } from '../../components/payment-logos';
-import { useSelect, useDispatch } from '../../public-api';
 import { LeftColumn, RightColumn } from '../styled-components/ie-fallback';
+import { usePrimarySelect, usePrimaryDispatch } from '../../public-api';
 
 export default function CreditCardFields( { disabled } ) {
 	const localize = useLocalize();
 	const [ paymentIcon, setPaymentIcon ] = useState( <LockIcon /> );
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
-	const { updatePaymentData } = useDispatch( 'checkout' );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const { updatePaymentData } = usePrimaryDispatch();
 	const currentCreditCardData = paymentData.creditCard || {};
 	const updateCreditCard = ( key, value ) =>
 		updatePaymentData( 'creditCard', { ...currentCreditCardData, [ key ]: value } );

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import Button from '../../components/button';
 import { useLocalize, sprintf } from '../../lib/localize';
 import joinClasses from '../../lib/join-classes';
-import { usePrimarySelect, useLineItems, renderDisplayValueMarkdown } from '../../public-api';
+import { usePaymentData, useLineItems, renderDisplayValueMarkdown } from '../../public-api';
 import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
 import CreditCardFields from './credit-card-fields';
 
@@ -51,7 +51,7 @@ export function CreditCardSubmitButton() {
 
 export function CreditCardSummary( { id } ) {
 	const localize = useLocalize();
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const [ paymentData ] = usePaymentData();
 
 	let PaymentLogo = null;
 

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import Button from '../../components/button';
 import { useLocalize, sprintf } from '../../lib/localize';
 import joinClasses from '../../lib/join-classes';
-import { useSelect, useLineItems, renderDisplayValueMarkdown } from '../../public-api';
+import { usePrimarySelect, useLineItems, renderDisplayValueMarkdown } from '../../public-api';
 import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
 import CreditCardFields from './credit-card-fields';
 
@@ -51,7 +51,7 @@ export function CreditCardSubmitButton() {
 
 export function CreditCardSummary( { id } ) {
 	const localize = useLocalize();
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
 
 	let PaymentLogo = null;
 

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -9,7 +9,7 @@ import styled from '@emotion/styled';
  */
 import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
-import { useDispatch, useSelect, usePrimarySelect } from '../../lib/registry';
+import { useDispatch, useSelect, usePaymentData } from '../../lib/registry';
 import { useCheckoutHandlers, useCheckoutRedirects, useLineItems } from '../../public-api';
 
 export function createPayPalMethod( { registerStore, makePayPalExpressRequest } ) {
@@ -103,7 +103,7 @@ export function PaypalSubmitButton() {
 	const { submitPaypalPayment } = useDispatch( 'paypal' );
 	const [ items ] = useLineItems();
 	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const [ paymentData ] = usePaymentData();
 	const { billing = {} } = paymentData;
 	useTransactionStatusHandler();
 	const onClick = () =>

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -9,7 +9,7 @@ import styled from '@emotion/styled';
  */
 import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
-import { useDispatch, useSelect } from '../../lib/registry';
+import { useDispatch, useSelect, usePrimarySelect } from '../../lib/registry';
 import { useCheckoutHandlers, useCheckoutRedirects, useLineItems } from '../../public-api';
 
 export function createPayPalMethod( { registerStore, makePayPalExpressRequest } ) {
@@ -103,7 +103,7 @@ export function PaypalSubmitButton() {
 	const { submitPaypalPayment } = useDispatch( 'paypal' );
 	const [ items ] = useLineItems();
 	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
 	const { billing = {} } = paymentData;
 	useTransactionStatusHandler();
 	const onClick = () =>

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -21,7 +21,7 @@ import {
 } from '../stripe';
 import {
 	useSelect,
-	usePrimarySelect,
+	usePaymentData,
 	useDispatch,
 	useCheckoutHandlers,
 	useLineItems,
@@ -554,7 +554,7 @@ function StripePayButton() {
 	const transactionError = useSelect( select => select( 'stripe' ).getTransactionError() );
 	const transactionAuthData = useSelect( select => select( 'stripe' ).getTransactionAuthData() );
 	const { beginStripeTransaction } = useDispatch( 'stripe' );
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const [ paymentData ] = usePaymentData();
 	const { billing = {}, domains = {} } = paymentData;
 
 	useEffect( () => {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -21,6 +21,7 @@ import {
 } from '../stripe';
 import {
 	useSelect,
+	usePrimarySelect,
 	useDispatch,
 	useCheckoutHandlers,
 	useLineItems,
@@ -553,7 +554,7 @@ function StripePayButton() {
 	const transactionError = useSelect( select => select( 'stripe' ).getTransactionError() );
 	const transactionAuthData = useSelect( select => select( 'stripe' ).getTransactionAuthData() );
 	const { beginStripeTransaction } = useDispatch( 'stripe' );
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
 	const { billing = {}, domains = {} } = paymentData;
 
 	useEffect( () => {

--- a/packages/composite-checkout/src/lib/registry.js
+++ b/packages/composite-checkout/src/lib/registry.js
@@ -17,3 +17,17 @@ export function useRegisterStore( id, store ) {
 	const { registerStore } = useRegistry();
 	useConstructor( () => registerStore( id, store ) );
 }
+
+const primaryStoreId = 'checkout';
+
+export function useRegisterPrimaryStore( store ) {
+	return useRegisterStore( primaryStoreId, store );
+}
+
+export function usePrimarySelect( callback ) {
+	return useSelect( select => callback( select.bind( null, primaryStoreId ) ) );
+}
+
+export function usePrimaryDispatch() {
+	return useDispatch( primaryStoreId );
+}

--- a/packages/composite-checkout/src/lib/registry.js
+++ b/packages/composite-checkout/src/lib/registry.js
@@ -31,3 +31,9 @@ export function usePrimarySelect( callback ) {
 export function usePrimaryDispatch() {
 	return useDispatch( primaryStoreId );
 }
+
+export function usePaymentData() {
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const { updatePaymentData } = usePrimaryDispatch();
+	return [ paymentData, updatePaymentData ];
+}

--- a/packages/composite-checkout/src/lib/validation.js
+++ b/packages/composite-checkout/src/lib/validation.js
@@ -1,0 +1,64 @@
+export function validateArg( value, errorMessage ) {
+	if ( value === null || value === undefined ) {
+		throw new Error( errorMessage );
+	}
+}
+
+export function validateArgIfUndefined( value, errorMessage ) {
+	if ( value === undefined ) {
+		throw new Error( errorMessage );
+	}
+}
+
+export function validatePaymentMethods( paymentMethods ) {
+	paymentMethods.map( validatePaymentMethod );
+}
+
+export function validatePaymentMethod( {
+	id,
+	LabelComponent,
+	SubmitButtonComponent,
+	SummaryComponent,
+	getAriaLabel,
+} ) {
+	validateArg( id, 'Invalid payment method; missing id property' );
+	validateArg( LabelComponent, `Invalid payment method '${ id }'; missing LabelComponent` );
+	validateArg(
+		SubmitButtonComponent,
+		`Invalid payment method '${ id }'; missing SubmitButtonComponent`
+	);
+	validateArg( SummaryComponent, `Invalid payment method '${ id }'; missing SummaryComponent` );
+	validateArg( getAriaLabel, `Invalid payment method '${ id }'; missing getAriaLabel` );
+}
+
+export function validateLineItems( items ) {
+	items.map( validateLineItem );
+}
+
+export function validateTotal( { label, amount } ) {
+	validateArg( label, `Invalid total; missing label property` );
+	validateArg( amount, `Invalid total; missing amount property` );
+	validateAmount( 'total', amount );
+}
+
+export function validateLineItem( { id, label, amount, type } ) {
+	validateArg( id, 'Invalid line item; missing id property' );
+	validateArg( label, `Invalid line item '${ id }'; missing label property` );
+	validateArg( type, `Invalid line item '${ id }'; missing type property` );
+	validateArg( amount, `Invalid line item '${ id }'; missing amount property` );
+	validateAmount( id, amount );
+}
+
+export function validateAmount( id, { currency, value, displayValue } ) {
+	validateArg( currency, `Invalid line item '${ id }'; missing amount.currency property` );
+	validateArg( value, `Invalid line item '${ id }'; missing amount.value property` );
+	validateArg( displayValue, `Invalid line item '${ id }'; missing amount.displayValue property` );
+}
+
+export function validateSteps( steps ) {
+	steps.map( validateStep );
+}
+
+export function validateStep( { id } ) {
+	validateArg( id, `Invalid step; missing id` );
+}

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -24,15 +24,26 @@ import {
 	useSelect,
 	useDispatch,
 } from './lib/registry';
-import { WPCheckoutOrderSummary, WPCheckoutOrderReview, WPContactForm } from './wpcom/index'; // TODO: remove this
+import {
+	WPCheckoutOrderSummary,
+	WPCheckoutOrderSummaryTitle,
+	WPCheckoutOrderReview,
+	WPContactForm,
+} from './wpcom/index'; // TODO: remove this
 import { createStripeMethod } from './lib/payment-methods/stripe-credit-card-fields';
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createCreditCardMethod } from './lib/payment-methods/credit-card';
+import { useActiveStep } from './lib/active-step';
+import CheckoutOrderSummary, {
+	CheckoutOrderSummaryTitle,
+} from './components/checkout-order-summary';
 
 // Re-export the public API
 export {
 	Checkout,
+	CheckoutOrderSummary,
+	CheckoutOrderSummaryTitle,
 	CheckoutPaymentMethods,
 	CheckoutProvider,
 	CheckoutStep,
@@ -41,6 +52,7 @@ export {
 	OrderReviewTotal,
 	WPCheckoutOrderReview,
 	WPCheckoutOrderSummary,
+	WPCheckoutOrderSummaryTitle,
 	WPContactForm,
 	createApplePayMethod,
 	createCreditCardMethod,
@@ -48,6 +60,7 @@ export {
 	createRegistry,
 	createStripeMethod,
 	renderDisplayValueMarkdown,
+	useActiveStep,
 	useAllPaymentMethods,
 	useCheckoutHandlers,
 	useCheckoutRedirects,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -20,6 +20,7 @@ import { useLineItems, useTotal, useHasDomainsInCart } from './lib/line-items';
 import {
 	createRegistry,
 	useDispatch,
+	usePaymentData,
 	usePrimaryDispatch,
 	usePrimarySelect,
 	useRegisterStore,
@@ -69,6 +70,7 @@ export {
 	useDispatch,
 	useHasDomainsInCart,
 	useLineItems,
+	usePaymentData,
 	usePaymentMethod,
 	usePaymentMethodId,
 	usePrimaryDispatch,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -19,10 +19,12 @@ import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './li
 import { useLineItems, useTotal, useHasDomainsInCart } from './lib/line-items';
 import {
 	createRegistry,
-	useRegistry,
-	useRegisterStore,
-	useSelect,
 	useDispatch,
+	usePrimaryDispatch,
+	usePrimarySelect,
+	useRegisterStore,
+	useRegistry,
+	useSelect,
 } from './lib/registry';
 import {
 	WPCheckoutOrderSummary,
@@ -69,6 +71,8 @@ export {
 	useLineItems,
 	usePaymentMethod,
 	usePaymentMethodId,
+	usePrimaryDispatch,
+	usePrimarySelect,
 	useRegisterStore,
 	useRegistry,
 	useSelect,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -37,7 +37,7 @@ import { createStripeMethod } from './lib/payment-methods/stripe-credit-card-fie
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createCreditCardMethod } from './lib/payment-methods/credit-card';
-import { useActiveStep } from './lib/active-step';
+import { useActiveStep, useIsStepActive } from './lib/active-step';
 import CheckoutOrderSummary, {
 	CheckoutOrderSummaryTitle,
 } from './components/checkout-order-summary';
@@ -77,6 +77,7 @@ export {
 	useCheckoutRedirects,
 	useDispatch,
 	useHasDomainsInCart,
+	useIsStepActive,
 	useLineItems,
 	usePaymentData,
 	usePaymentMethod,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -41,6 +41,11 @@ import { useActiveStep } from './lib/active-step';
 import CheckoutOrderSummary, {
 	CheckoutOrderSummaryTitle,
 } from './components/checkout-order-summary';
+import {
+	getDefaultOrderSummaryStep,
+	getDefaultPaymentMethodStep,
+	getDefaultOrderReviewStep,
+} from './components/default-steps';
 
 // Re-export the public API
 export {
@@ -62,6 +67,9 @@ export {
 	createPayPalMethod,
 	createRegistry,
 	createStripeMethod,
+	getDefaultOrderReviewStep,
+	getDefaultOrderSummaryStep,
+	getDefaultPaymentMethodStep,
 	renderDisplayValueMarkdown,
 	useActiveStep,
 	useAllPaymentMethods,

--- a/packages/composite-checkout/src/wpcom/index.js
+++ b/packages/composite-checkout/src/wpcom/index.js
@@ -2,7 +2,12 @@
  * Internal dependencies
  */
 import WPCheckoutOrderReview from './wp-checkout-order-review';
-import WPCheckoutOrderSummary from './wp-checkout-order-summary';
+import WPCheckoutOrderSummary, { WPCheckoutOrderSummaryTitle } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 
-export { WPCheckoutOrderReview, WPCheckoutOrderSummary, WPContactForm };
+export {
+	WPCheckoutOrderReview,
+	WPCheckoutOrderSummary,
+	WPCheckoutOrderSummaryTitle,
+	WPContactForm,
+};

--- a/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
+++ b/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
@@ -11,12 +11,12 @@ import styled from '@emotion/styled';
 import joinClasses from './join-classes';
 import Coupon from './coupon';
 import WPTermsAndConditions from './wp-terms-and-conditions';
-import { useLineItems } from '../public-api';
 import {
 	WPOrderReviewLineItems,
 	WPOrderReviewTotal,
 	WPOrderReviewSection,
 } from './wp-order-review-line-items';
+import { useLineItems } from '../public-api';
 
 export default function WPCheckoutOrderReview( { className } ) {
 	const [ items, total ] = useLineItems();
@@ -44,7 +44,6 @@ export default function WPCheckoutOrderReview( { className } ) {
 }
 
 WPCheckoutOrderReview.propTypes = {
-	isActive: PropTypes.bool.isRequired,
 	summary: PropTypes.bool,
 	className: PropTypes.string,
 };

--- a/packages/composite-checkout/src/wpcom/wp-checkout-order-summary.js
+++ b/packages/composite-checkout/src/wpcom/wp-checkout-order-summary.js
@@ -8,7 +8,7 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { useLocalize } from '../lib/localize'; // TODO: remove this
-import { useLineItems } from '../public-api';
+import { useLineItems, useTotal, renderDisplayValueMarkdown } from '../public-api';
 import Button from './button';
 import Coupon from './coupon';
 
@@ -50,6 +50,28 @@ export default function WPCheckoutOrderSummary() {
 		</React.Fragment>
 	);
 }
+
+export function WPCheckoutOrderSummaryTitle() {
+	const localize = useLocalize();
+	const total = useTotal();
+	return (
+		<CheckoutSummaryTitle>
+			<span>{ localize( 'You are all set to check out' ) }</span>
+			<CheckoutSummaryTotal>
+				{ renderDisplayValueMarkdown( total.amount.displayValue ) }
+			</CheckoutSummaryTotal>
+		</CheckoutSummaryTitle>
+	);
+}
+
+const CheckoutSummaryTitle = styled.span`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const CheckoutSummaryTotal = styled.span`
+	font-weight: ${props => props.theme.weights.bold};
+`;
 
 const SummaryContent = styled.div`
 	@media ( ${props => props.theme.breakpoints.smallPhoneUp} ) {

--- a/packages/composite-checkout/src/wpcom/wp-contact-form.js
+++ b/packages/composite-checkout/src/wpcom/wp-contact-form.js
@@ -8,7 +8,7 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { usePrimarySelect, usePrimaryDispatch, useHasDomainsInCart } from '../public-api';
+import { useHasDomainsInCart, usePaymentData } from '../public-api';
 import Field from './field';
 import GridRow from './grid-row';
 // TODO: remove or replace all the below imports as they are not in wpcom
@@ -22,8 +22,7 @@ import { LeftColumn, RightColumn } from '../lib/styled-components/ie-fallback';
 
 export default function WPContactForm( { summary, isComplete, isActive } ) {
 	const isDomainFieldsVisible = useHasDomainsInCart();
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
-	const { updatePaymentData } = usePrimaryDispatch();
+	const [ paymentData, updatePaymentData ] = usePaymentData();
 	const { isDomainContactSame = true } = paymentData;
 
 	if ( summary && isComplete ) {
@@ -163,8 +162,7 @@ const DomainRegistrationCheckbox = styled.input`
 
 function AddressFields( { fieldType } ) {
 	const localize = useLocalize();
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
-	const { updatePaymentData } = usePrimaryDispatch();
+	const [ paymentData, updatePaymentData ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updateLocationData = ( key, value ) =>
 		updatePaymentData( fieldType, { ...currentLocationData, [ key ]: value } );
@@ -277,8 +275,7 @@ function isStateorProvince() {
 
 function PhoneNumberField( { fieldType } ) {
 	const localize = useLocalize();
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
-	const { updatePaymentData } = usePrimaryDispatch();
+	const [ paymentData, updatePaymentData ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updateLocationData = ( key, value ) =>
 		updatePaymentData( fieldType, { ...currentLocationData, [ key ]: value } );
@@ -306,8 +303,7 @@ PhoneNumberField.propTypes = {
 function VatIdField() {
 	const localize = useLocalize();
 	const fieldType = 'billing';
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
-	const { updatePaymentData } = usePrimaryDispatch();
+	const [ paymentData, updatePaymentData ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updateLocationData = ( key, value ) =>
 		updatePaymentData( fieldType, { ...currentLocationData, [ key ]: value } );
@@ -327,8 +323,7 @@ function VatIdField() {
 
 function TaxFields( { fieldType } ) {
 	const localize = useLocalize();
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
-	const { updatePaymentData } = usePrimaryDispatch();
+	const [ paymentData, updatePaymentData ] = usePaymentData();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	// TODO: add field validation; at least to see if a required field is set
 	const updateLocationData = ( key, value ) =>
@@ -431,7 +426,7 @@ const DomainContactFieldsDescription = styled.p`
 
 function ContactFormSummary() {
 	const localize = useLocalize();
-	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const [ paymentData ] = usePaymentData();
 	const { billing = {}, domains = {}, isDomainContactSame = true } = paymentData;
 
 	//Check if paymentData is empty

--- a/packages/composite-checkout/src/wpcom/wp-contact-form.js
+++ b/packages/composite-checkout/src/wpcom/wp-contact-form.js
@@ -330,6 +330,7 @@ function TaxFields( { fieldType } ) {
 	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
 	const { updatePaymentData } = useDispatch( 'checkout' );
 	const currentLocationData = paymentData[ fieldType ] || {};
+	// TODO: add field validation; at least to see if a required field is set
 	const updateLocationData = ( key, value ) =>
 		updatePaymentData( fieldType, { ...currentLocationData, [ key ]: value } );
 

--- a/packages/composite-checkout/src/wpcom/wp-contact-form.js
+++ b/packages/composite-checkout/src/wpcom/wp-contact-form.js
@@ -8,7 +8,7 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { useSelect, useDispatch, useHasDomainsInCart } from '../public-api';
+import { usePrimarySelect, usePrimaryDispatch, useHasDomainsInCart } from '../public-api';
 import Field from './field';
 import GridRow from './grid-row';
 // TODO: remove or replace all the below imports as they are not in wpcom
@@ -22,8 +22,8 @@ import { LeftColumn, RightColumn } from '../lib/styled-components/ie-fallback';
 
 export default function WPContactForm( { summary, isComplete, isActive } ) {
 	const isDomainFieldsVisible = useHasDomainsInCart();
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
-	const { updatePaymentData } = useDispatch( 'checkout' );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const { updatePaymentData } = usePrimaryDispatch();
 	const { isDomainContactSame = true } = paymentData;
 
 	if ( summary && isComplete ) {
@@ -163,8 +163,8 @@ const DomainRegistrationCheckbox = styled.input`
 
 function AddressFields( { fieldType } ) {
 	const localize = useLocalize();
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
-	const { updatePaymentData } = useDispatch( 'checkout' );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const { updatePaymentData } = usePrimaryDispatch();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updateLocationData = ( key, value ) =>
 		updatePaymentData( fieldType, { ...currentLocationData, [ key ]: value } );
@@ -277,8 +277,8 @@ function isStateorProvince() {
 
 function PhoneNumberField( { fieldType } ) {
 	const localize = useLocalize();
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
-	const { updatePaymentData } = useDispatch( 'checkout' );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const { updatePaymentData } = usePrimaryDispatch();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updateLocationData = ( key, value ) =>
 		updatePaymentData( fieldType, { ...currentLocationData, [ key ]: value } );
@@ -306,8 +306,8 @@ PhoneNumberField.propTypes = {
 function VatIdField() {
 	const localize = useLocalize();
 	const fieldType = 'billing';
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
-	const { updatePaymentData } = useDispatch( 'checkout' );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const { updatePaymentData } = usePrimaryDispatch();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	const updateLocationData = ( key, value ) =>
 		updatePaymentData( fieldType, { ...currentLocationData, [ key ]: value } );
@@ -327,8 +327,8 @@ function VatIdField() {
 
 function TaxFields( { fieldType } ) {
 	const localize = useLocalize();
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
-	const { updatePaymentData } = useDispatch( 'checkout' );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
+	const { updatePaymentData } = usePrimaryDispatch();
 	const currentLocationData = paymentData[ fieldType ] || {};
 	// TODO: add field validation; at least to see if a required field is set
 	const updateLocationData = ( key, value ) =>
@@ -431,7 +431,7 @@ const DomainContactFieldsDescription = styled.p`
 
 function ContactFormSummary() {
 	const localize = useLocalize();
-	const paymentData = useSelect( select => select( 'checkout' ).getPaymentData() );
+	const paymentData = usePrimarySelect( select => select().getPaymentData() );
 	const { billing = {}, domains = {}, isDomainContactSame = true } = paymentData;
 
 	//Check if paymentData is empty

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -5,7 +5,13 @@ require( '@babel/polyfill' );
  * External dependencies
  */
 import React from 'react';
-import { render, getAllByLabelText, fireEvent } from '@testing-library/react';
+import {
+	render,
+	getAllByLabelText as getAllByLabelTextInNode,
+	getByText as getByTextInNode,
+	queryByText as queryByTextInNode,
+	fireEvent,
+} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 /**
@@ -18,259 +24,145 @@ import {
 	useDispatch,
 	createRegistry,
 	useRegisterStore,
+	usePaymentData,
 } from '../../src/public-api';
 
 const noop = () => {};
 
 describe( 'Checkout', () => {
-	describe( 'using the default registry', function() {
-		let MyCheckout;
-		const mockMethod = createMockMethod();
-		const { items, total } = createMockItems();
-
-		beforeEach( () => {
-			MyCheckout = () => (
-				<CheckoutProvider
-					locale="en-us"
-					items={ items }
-					total={ total }
-					onSuccess={ noop }
-					onFailure={ noop }
-					successRedirectUrl="#"
-					failureRedirectUrl="#"
-					paymentMethods={ [ mockMethod ] }
-				>
-					<Checkout />
-				</CheckoutProvider>
-			);
-		} );
-
-		it( 'renders the line items and the total', () => {
-			const { container } = render( <MyCheckout /> );
-
-			// Product line items show the correct price
-			getAllByLabelText( container, items[ 0 ].label ).map( element =>
-				expect( element ).toHaveTextContent( items[ 0 ].amount.displayValue )
-			);
-			getAllByLabelText( container, items[ 1 ].label ).map( element =>
-				expect( element ).toHaveTextContent( items[ 1 ].amount.displayValue )
-			);
-
-			// All elements labeled 'Total' show the expected price
-			getAllByLabelText( container, total.label ).map( element =>
-				expect( element ).toHaveTextContent( total.amount.displayValue )
-			);
-		} );
-
-		it( 'renders the payment method LabelComponent', () => {
-			const { getAllByText } = render( <MyCheckout /> );
-			expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
-		} );
-
-		it( 'renders the payment method PaymentMethodComponent', () => {
-			const { getByTestId } = render( <MyCheckout /> );
-			const activeComponent = getByTestId( 'mock-payment-form' );
-			expect( activeComponent ).toHaveTextContent( 'Cardholder Name' );
-		} );
-
-		it( 'renders the review step', () => {
-			const { getAllByText } = render( <MyCheckout /> );
-			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
-		} );
-
-		it( 'renders the payment method SubmitButtonComponent', () => {
-			const { getByText } = render( <MyCheckout /> );
-			expect( getByText( 'Pay Please' ) ).toBeTruthy();
-		} );
-	} );
-
-	describe( 'using a custom registry', function() {
-		let MyCheckout;
-		const mockMethod = createMockMethod();
-		const { items, total } = createMockItems();
-
-		beforeEach( () => {
-			const registry = createRegistry();
-			MyCheckout = ( { ContactSlot, UpSell, OrderSummary, ReviewContent } ) => (
-				<CheckoutProvider
-					locale="en-us"
-					items={ items }
-					total={ total }
-					onSuccess={ noop }
-					onFailure={ noop }
-					successRedirectUrl="#"
-					failureRedirectUrl="#"
-					paymentMethods={ [ mockMethod ] }
-					registry={ registry }
-				>
-					<Checkout
-						ContactSlot={ ContactSlot }
-						UpSell={ UpSell }
-						OrderSummary={ OrderSummary }
-						ReviewContent={ ReviewContent }
-					/>
-				</CheckoutProvider>
-			);
-		} );
-
-		it( 'renders the line items and the total', () => {
-			const { container } = render( <MyCheckout /> );
-
-			// Product line items show the correct price
-			getAllByLabelText( container, items[ 0 ].label ).map( element =>
-				expect( element ).toHaveTextContent( items[ 0 ].amount.displayValue )
-			);
-			getAllByLabelText( container, items[ 1 ].label ).map( element =>
-				expect( element ).toHaveTextContent( items[ 1 ].amount.displayValue )
-			);
-
-			// All elements labeled 'Total' show the expected price
-			getAllByLabelText( container, total.label ).map( element =>
-				expect( element ).toHaveTextContent( total.amount.displayValue )
-			);
-		} );
-
-		it( 'renders the payment method LabelComponent', () => {
-			const { getAllByText } = render( <MyCheckout /> );
-			expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
-		} );
-
-		it( 'renders the payment method PaymentMethodComponent', () => {
-			const { getByTestId } = render( <MyCheckout /> );
-			const activeComponent = getByTestId( 'mock-payment-form' );
-			expect( activeComponent ).toHaveTextContent( 'Cardholder Name' );
-		} );
-
-		it( 'renders the review step', () => {
-			const { getAllByText } = render( <MyCheckout /> );
-			expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
-			expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
-			expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
-		} );
-
-		it( 'renders the payment method SubmitButtonComponent', () => {
-			const { getByText } = render( <MyCheckout /> );
-			expect( getByText( 'Pay Please' ) ).toBeTruthy();
-		} );
-
-		it( 'renders the ReviewContent if provided', () => {
-			const { getByText } = render(
-				<MyCheckout ReviewContent={ () => <div>Some Review Text</div> } />
-			);
-			expect( getByText( 'Some Review Text' ) ).toBeTruthy();
-		} );
-
-		it( 'renders the OrderSummary if provided', () => {
-			const { getByText } = render(
-				<MyCheckout OrderSummary={ () => <div>Some OrderSummary Text</div> } />
-			);
-			expect( getByText( 'Some OrderSummary Text' ) ).toBeTruthy();
-		} );
-
-		it( 'renders the UpSell if provided', () => {
-			const { getByText } = render( <MyCheckout UpSell={ () => <div>Some Upsell Text</div> } /> );
-			expect( getByText( 'Some Upsell Text' ) ).toBeTruthy();
-		} );
-
-		it( 'renders the ContactSlot if provided', () => {
-			const { getByText } = render(
-				<MyCheckout ContactSlot={ ( { summary } ) => summary || <div>Some Contact Form</div> } />
-			);
-			expect( getByText( 'Some Contact Form' ) ).toBeTruthy();
-		} );
-	} );
-
-	describe( 'before clicking a button', function() {
-		let container;
-
-		beforeEach( () => {
+	describe( 'using the default steps', function() {
+		describe( 'using the default registry', function() {
+			let MyCheckout;
 			const mockMethod = createMockMethod();
 			const { items, total } = createMockItems();
-			const MyCheckout = () => (
-				<CheckoutProvider
-					locale="en-us"
-					items={ items }
-					total={ total }
-					onSuccess={ noop }
-					onFailure={ noop }
-					successRedirectUrl="#"
-					failureRedirectUrl="#"
-					paymentMethods={ [ mockMethod ] }
-				>
-					<Checkout />
-				</CheckoutProvider>
-			);
-			const renderResult = render( <MyCheckout /> );
-			container = renderResult.container;
+
+			beforeEach( () => {
+				MyCheckout = () => (
+					<CheckoutProvider
+						locale="en-us"
+						items={ items }
+						total={ total }
+						onSuccess={ noop }
+						onFailure={ noop }
+						successRedirectUrl="#"
+						failureRedirectUrl="#"
+						paymentMethods={ [ mockMethod ] }
+					>
+						<Checkout />
+					</CheckoutProvider>
+				);
+			} );
+
+			it( 'renders the line items and the total', () => {
+				const { container } = render( <MyCheckout /> );
+
+				// Product line items show the correct price
+				getAllByLabelTextInNode( container, items[ 0 ].label ).map( element =>
+					expect( element ).toHaveTextContent( items[ 0 ].amount.displayValue )
+				);
+				getAllByLabelTextInNode( container, items[ 1 ].label ).map( element =>
+					expect( element ).toHaveTextContent( items[ 1 ].amount.displayValue )
+				);
+
+				// All elements labeled 'Total' show the expected price
+				getAllByLabelTextInNode( container, total.label ).map( element =>
+					expect( element ).toHaveTextContent( total.amount.displayValue )
+				);
+			} );
+
+			it( 'renders the payment method LabelComponent', () => {
+				const { getAllByText } = render( <MyCheckout /> );
+				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
+			} );
+
+			it( 'renders the payment method PaymentMethodComponent', () => {
+				const { getByTestId } = render( <MyCheckout /> );
+				const activeComponent = getByTestId( 'mock-payment-form' );
+				expect( activeComponent ).toHaveTextContent( 'Cardholder Name' );
+			} );
+
+			it( 'renders the review step', () => {
+				const { getAllByText } = render( <MyCheckout /> );
+				expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
+				expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
+				expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
+				expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
+			} );
+
+			it( 'renders the payment method SubmitButtonComponent', () => {
+				const { getByText } = render( <MyCheckout /> );
+				expect( getByText( 'Pay Please' ) ).toBeTruthy();
+			} );
 		} );
 
-		it( 'makes the payment method step active', () => {
-			const activeSteps = container.querySelectorAll( '.checkout-step--is-active' );
-			expect( activeSteps ).toHaveLength( 1 );
-			expect( activeSteps[ 0 ] ).toHaveTextContent( 'Pick a payment method' );
-		} );
-
-		it( 'makes the payment method step visible', () => {
-			const firstStep = container.querySelector( '.checkout__payment-methods-step' );
-			const firstStepContent = firstStep.querySelector( '.checkout-step__content' );
-			expect( firstStepContent ).toHaveStyle( 'display: block' );
-		} );
-
-		it( 'makes the review step invisible', () => {
-			const reviewStep = container.querySelector( '.checkout__review-order-step' );
-			expect( reviewStep ).toHaveTextContent( 'Review your order' );
-			const reviewStepContent = reviewStep.querySelector( '.checkout-step__content' );
-			expect( reviewStepContent ).toHaveStyle( 'display: none' );
-		} );
-	} );
-
-	describe( 'when clicking continue from the payment method step', function() {
-		let container;
-
-		beforeEach( () => {
+		describe( 'using a custom registry', function() {
+			let MyCheckout;
 			const mockMethod = createMockMethod();
 			const { items, total } = createMockItems();
-			const MyCheckout = () => (
-				<CheckoutProvider
-					locale="en-us"
-					items={ items }
-					total={ total }
-					onSuccess={ noop }
-					onFailure={ noop }
-					successRedirectUrl="#"
-					failureRedirectUrl="#"
-					paymentMethods={ [ mockMethod ] }
-				>
-					<Checkout />
-				</CheckoutProvider>
-			);
-			const renderResult = render( <MyCheckout /> );
-			container = renderResult.container;
-			const firstStepContinue = renderResult.getAllByText( 'Continue' )[ 0 ];
-			fireEvent.click( firstStepContinue );
+
+			beforeEach( () => {
+				const registry = createRegistry();
+				MyCheckout = () => (
+					<CheckoutProvider
+						locale="en-us"
+						items={ items }
+						total={ total }
+						onSuccess={ noop }
+						onFailure={ noop }
+						successRedirectUrl="#"
+						failureRedirectUrl="#"
+						paymentMethods={ [ mockMethod ] }
+						registry={ registry }
+					>
+						<Checkout />
+					</CheckoutProvider>
+				);
+			} );
+
+			it( 'renders the line items and the total', () => {
+				const { container } = render( <MyCheckout /> );
+
+				// Product line items show the correct price
+				getAllByLabelTextInNode( container, items[ 0 ].label ).map( element =>
+					expect( element ).toHaveTextContent( items[ 0 ].amount.displayValue )
+				);
+				getAllByLabelTextInNode( container, items[ 1 ].label ).map( element =>
+					expect( element ).toHaveTextContent( items[ 1 ].amount.displayValue )
+				);
+
+				// All elements labeled 'Total' show the expected price
+				getAllByLabelTextInNode( container, total.label ).map( element =>
+					expect( element ).toHaveTextContent( total.amount.displayValue )
+				);
+			} );
+
+			it( 'renders the payment method LabelComponent', () => {
+				const { getAllByText } = render( <MyCheckout /> );
+				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
+			} );
+
+			it( 'renders the payment method PaymentMethodComponent', () => {
+				const { getByTestId } = render( <MyCheckout /> );
+				const activeComponent = getByTestId( 'mock-payment-form' );
+				expect( activeComponent ).toHaveTextContent( 'Cardholder Name' );
+			} );
+
+			it( 'renders the review step', () => {
+				const { getAllByText } = render( <MyCheckout /> );
+				expect( getAllByText( items[ 0 ].label ) ).toHaveLength( 2 );
+				expect( getAllByText( items[ 0 ].amount.displayValue ) ).toHaveLength( 1 );
+				expect( getAllByText( items[ 1 ].label ) ).toHaveLength( 2 );
+				expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
+			} );
+
+			it( 'renders the payment method SubmitButtonComponent', () => {
+				const { getByText } = render( <MyCheckout /> );
+				expect( getByText( 'Pay Please' ) ).toBeTruthy();
+			} );
 		} );
 
-		it( 'makes the first step invisible', () => {
-			const firstStep = container.querySelector( '.checkout__payment-methods-step' );
-			const firstStepContent = firstStep.querySelector( '.checkout-step__content' );
-			expect( firstStepContent ).toHaveStyle( 'display: none' );
-		} );
-
-		it( 'makes the review step visible', () => {
-			const reviewStep = container.querySelector( '.checkout__review-order-step' );
-			const reviewStepContent = reviewStep.querySelector( '.checkout-step__content' );
-			expect( reviewStepContent ).toHaveStyle( 'display: block' );
-		} );
-	} );
-
-	describe( 'with a ContactSlot', function() {
 		describe( 'before clicking a button', function() {
 			let container;
-			const ContactForm = ( { summary } ) => summary || <div>Contact Form Here</div>;
 
 			beforeEach( () => {
 				const mockMethod = createMockMethod();
@@ -286,35 +178,35 @@ describe( 'Checkout', () => {
 						failureRedirectUrl="#"
 						paymentMethods={ [ mockMethod ] }
 					>
-						<Checkout ContactSlot={ ContactForm } />
+						<Checkout />
 					</CheckoutProvider>
 				);
 				const renderResult = render( <MyCheckout /> );
 				container = renderResult.container;
 			} );
 
-			it( 'makes the first step visible', () => {
+			it( 'makes the payment method step active', () => {
+				const activeSteps = container.querySelectorAll( '.checkout-step--is-active' );
+				expect( activeSteps ).toHaveLength( 1 );
+				expect( activeSteps[ 0 ] ).toHaveTextContent( 'Pick a payment method' );
+			} );
+
+			it( 'makes the payment method step visible', () => {
 				const firstStep = container.querySelector( '.checkout__payment-methods-step' );
 				const firstStepContent = firstStep.querySelector( '.checkout-step__content' );
 				expect( firstStepContent ).toHaveStyle( 'display: block' );
 			} );
 
-			it( 'makes the contact step invisible', () => {
-				const contactStep = container.querySelector( '.checkout__billing-details-step' );
-				const contactStepContent = contactStep.querySelector( '.checkout-step__content' );
-				expect( contactStepContent ).toHaveStyle( 'display: none' );
-			} );
-
 			it( 'makes the review step invisible', () => {
 				const reviewStep = container.querySelector( '.checkout__review-order-step' );
+				expect( reviewStep ).toHaveTextContent( 'Review your order' );
 				const reviewStepContent = reviewStep.querySelector( '.checkout-step__content' );
 				expect( reviewStepContent ).toHaveStyle( 'display: none' );
 			} );
 		} );
 
 		describe( 'when clicking continue from the payment method step', function() {
-			let renderResult;
-			const ContactForm = ( { summary } ) => summary || <div>Contact Form Here</div>;
+			let container;
 
 			beforeEach( () => {
 				const mockMethod = createMockMethod();
@@ -330,37 +222,235 @@ describe( 'Checkout', () => {
 						failureRedirectUrl="#"
 						paymentMethods={ [ mockMethod ] }
 					>
-						<Checkout ContactSlot={ ContactForm } />
+						<Checkout />
 					</CheckoutProvider>
 				);
-				renderResult = render( <MyCheckout /> );
+				const renderResult = render( <MyCheckout /> );
+				container = renderResult.container;
 				const firstStepContinue = renderResult.getAllByText( 'Continue' )[ 0 ];
 				fireEvent.click( firstStepContinue );
 			} );
 
 			it( 'makes the first step invisible', () => {
-				const firstStep = renderResult.container.querySelector( '.checkout__payment-methods-step' );
+				const firstStep = container.querySelector( '.checkout__payment-methods-step' );
 				const firstStepContent = firstStep.querySelector( '.checkout-step__content' );
 				expect( firstStepContent ).toHaveStyle( 'display: none' );
 			} );
 
-			it( 'makes the contact step visible', () => {
-				const contactStep = renderResult.container.querySelector(
-					'.checkout__billing-details-step'
-				);
-				const contactStepContent = contactStep.querySelector( '.checkout-step__content' );
-				expect( contactStepContent ).toHaveStyle( 'display: block' );
-			} );
-
-			it( 'displays the contact form', () => {
-				expect( renderResult.getByText( 'Contact Form Here' ) ).toBeTruthy();
-			} );
-
-			it( 'makes the review step invisible', () => {
-				const reviewStep = renderResult.container.querySelector( '.checkout__review-order-step' );
+			it( 'makes the review step visible', () => {
+				const reviewStep = container.querySelector( '.checkout__review-order-step' );
 				const reviewStepContent = reviewStep.querySelector( '.checkout-step__content' );
-				expect( reviewStepContent ).toHaveStyle( 'display: none' );
+				expect( reviewStepContent ).toHaveStyle( 'display: block' );
 			} );
+		} );
+	} );
+
+	describe( 'with custom steps', function() {
+		let MyCheckout;
+		const mockMethod = createMockMethod();
+		const { items, total } = createMockItems();
+		const steps = createMockSteps();
+
+		beforeEach( () => {
+			MyCheckout = props => (
+				<CheckoutProvider
+					locale="en-us"
+					items={ items }
+					total={ total }
+					onSuccess={ noop }
+					onFailure={ noop }
+					successRedirectUrl="#"
+					failureRedirectUrl="#"
+					paymentMethods={ [ mockMethod ] }
+				>
+					<Checkout steps={ props.steps || steps } />
+				</CheckoutProvider>
+			);
+		} );
+
+		it( 'renders the step className', () => {
+			const { container } = render( <MyCheckout /> );
+			expect( container.querySelector( '.' + steps[ 0 ].className ) ).toBeTruthy();
+			expect( container.querySelector( '.' + steps[ 1 ].className ) ).toBeTruthy();
+			expect( container.querySelector( '.' + steps[ 2 ].className ) ).toBeTruthy();
+			expect( container.querySelector( '.' + steps[ 3 ].className ) ).toBeTruthy();
+		} );
+
+		it( 'renders the step titleContent', () => {
+			const { getByText } = render( <MyCheckout /> );
+			expect( getByText( 'Custom Step - Summary Title' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Contact Title' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Review Title' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Incomplete Title' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the step activeStepContent always', () => {
+			const { getByText } = render( <MyCheckout /> );
+			expect( getByText( 'Custom Step - Summary Active' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Contact Active' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Review Active' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Incomplete Active' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the activeStepContent as visible when active', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 1 ].className );
+			const content = step.querySelector( '.checkout-step__content' );
+			expect( content ).toHaveStyle( 'display: block' );
+		} );
+
+		it( 'renders the activeStepContent as invisible when inactive', () => {
+			const { container } = render( <MyCheckout /> );
+			let step = container.querySelector( '.' + steps[ 0 ].className );
+			let content = step.querySelector( '.checkout-step__content' );
+			expect( content ).toHaveStyle( 'display: none' );
+			step = container.querySelector( '.' + steps[ 2 ].className );
+			content = step.querySelector( '.checkout-step__content' );
+			expect( content ).toHaveStyle( 'display: none' );
+		} );
+
+		it( 'renders the step completeStepContent always for complete steps', () => {
+			const { getByText, queryByText } = render( <MyCheckout /> );
+			expect( getByText( 'Custom Step - Summary Complete' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Contact Complete' ) ).toBeInTheDocument();
+			expect( getByText( 'Custom Step - Review Complete' ) ).toBeInTheDocument();
+			expect( queryByText( 'Custom Step - Incomplete Complete' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders the step incompleteStepContent always for incomplete steps', () => {
+			const { getByText } = render( <MyCheckout /> );
+			expect( getByText( 'Custom Step - Incomplete Incomplete' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the completeStepContent or incompleteStepContent as visible when inactive', () => {
+			const { container } = render( <MyCheckout /> );
+			let step = container.querySelector( '.' + steps[ 0 ].className );
+			let content = step.querySelector( '.checkout-step__summary' );
+			expect( content ).toHaveStyle( 'display: block' );
+			step = container.querySelector( '.' + steps[ 2 ].className );
+			content = step.querySelector( '.checkout-step__summary' );
+			expect( content ).toHaveStyle( 'display: block' );
+			step = container.querySelector( '.' + steps[ 3 ].className );
+			content = step.querySelector( '.checkout-step__summary' );
+			expect( content ).toHaveStyle( 'display: block' );
+		} );
+
+		it( 'renders the completeStepContent as invisible when active', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 1 ].className );
+			const content = step.querySelector( '.checkout-step__summary' );
+			expect( content ).toHaveStyle( 'display: none' );
+		} );
+
+		it( 'renders the continue button for the active step', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 1 ].className );
+			expect( getByTextInNode( step, 'Continue' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not render the continue button for a step without a number', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 0 ].className );
+			expect( queryByTextInNode( step, 'Continue' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'does not render the continue button for an inactive step', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 2 ].className );
+			expect( queryByTextInNode( step, 'Continue' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders the continue button disabled if the step is active and incomplete', () => {
+			const { container } = render(
+				<MyCheckout steps={ [ steps[ 0 ], steps[ 4 ], steps[ 1 ] ] } />
+			);
+			const step = container.querySelector( '.' + steps[ 4 ].className );
+			expect( getByTextInNode( step, 'Continue' ) ).toBeDisabled();
+		} );
+
+		it( 'renders the continue button enabled if the step is active and complete', () => {
+			const { container, getByLabelText } = render(
+				<MyCheckout steps={ [ steps[ 0 ], steps[ 4 ], steps[ 1 ] ] } />
+			);
+
+			fireEvent.change( getByLabelText( 'User Name' ), { target: { value: 'Lyra' } } );
+			const step = container.querySelector( '.' + steps[ 4 ].className );
+			expect( getByTextInNode( step, 'Continue' ) ).not.toBeDisabled();
+		} );
+
+		it( 'does not render the edit button for steps without a number', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 0 ].className );
+			expect( queryByTextInNode( step, 'Edit' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'does not render the edit button for the active step', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 1 ].className );
+			expect( queryByTextInNode( step, 'Edit' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders the edit button for editable steps with a higher index than the active step', () => {
+			const { container } = render( <MyCheckout /> );
+			const step = container.querySelector( '.' + steps[ 2 ].className );
+			expect( queryByTextInNode( step, 'Edit' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not render the edit button for ineditable steps with a lower index than the active step', () => {
+			const { container, getAllByText } = render(
+				<MyCheckout steps={ [ steps[ 0 ], steps[ 5 ], steps[ 1 ] ] } />
+			);
+			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
+			fireEvent.click( firstStepContinue );
+			const step = container.querySelector( '.' + steps[ 5 ].className );
+			expect( queryByTextInNode( step, 'Edit' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders the edit button for editable steps with a lower index than the active step', () => {
+			const { container, getAllByText } = render( <MyCheckout /> );
+			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
+			fireEvent.click( firstStepContinue );
+			const step = container.querySelector( '.' + steps[ 1 ].className );
+			expect( getByTextInNode( step, 'Edit' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the edit button for inactive steps which start as ineditable but which change', () => {
+			const { container, getByLabelText } = render(
+				<MyCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 4 ] ] } />
+			);
+			const step = container.querySelector( '.' + steps[ 4 ].className );
+			expect( queryByTextInNode( step, 'Edit' ) ).not.toBeInTheDocument();
+			fireEvent.change( getByLabelText( 'User Name' ), { target: { value: 'Lyra' } } );
+			expect( getByTextInNode( step, 'Edit' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the payment method SubmitButtonComponent', () => {
+			const { getByText } = render( <MyCheckout /> );
+			expect( getByText( 'Pay Please' ) ).toBeTruthy();
+		} );
+
+		it( 'renders the payment method SubmitButtonComponent disabled if any steps are incomplete and the last step is not active', () => {
+			const { getByText } = render(
+				<MyCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 2 ] ] } />
+			);
+			expect( getByText( 'Pay Please' ) ).toBeDisabled();
+		} );
+
+		it( 'renders the payment method SubmitButtonComponent disabled if any steps are incomplete and the last step is active', () => {
+			const { getByText } = render( <MyCheckout steps={ [ steps[ 0 ], steps[ 3 ] ] } /> );
+			expect( getByText( 'Pay Please' ) ).toBeDisabled();
+		} );
+
+		it( 'renders the payment method SubmitButtonComponent disabled if all steps are complete but the last step is not active', () => {
+			const { getByText } = render(
+				<MyCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 2 ] ] } />
+			);
+			expect( getByText( 'Pay Please' ) ).toBeDisabled();
+		} );
+
+		it( 'renders the payment method SubmitButtonComponent active if all steps are complete and the last step is active', () => {
+			const { getByText } = render( <MyCheckout steps={ [ steps[ 0 ], steps[ 1 ] ] } /> );
+			expect( getByText( 'Pay Please' ) ).not.toBeDisabled();
 		} );
 	} );
 } );
@@ -370,7 +460,7 @@ function createMockMethod() {
 		id: 'mock',
 		LabelComponent: () => <span data-testid="mock-label">Mock Label</span>,
 		PaymentMethodComponent: MockPaymentForm,
-		SubmitButtonComponent: () => <button>Pay Please</button>,
+		SubmitButtonComponent: props => <button { ...props }>Pay Please</button>,
 		SummaryComponent: () => 'Mock Method',
 		getAriaLabel: () => 'Mock Method',
 	};
@@ -430,4 +520,105 @@ function createMockItems() {
 		amount: { currency: 'USD', value: 17500, displayValue: '$175' },
 	};
 	return { items, total };
+}
+
+function createMockSteps() {
+	return [
+		{
+			id: 'custom-summary-step',
+			className: 'custom-summary-step-class',
+			hasStepNumber: false,
+			titleContent: <span>Custom Step - Summary Title</span>,
+			activeStepContent: <span>Custom Step - Summary Active</span>,
+			incompleteStepContent: <span>Custom Step - Summary Incomplete</span>,
+			completeStepContent: <span>Custom Step - Summary Complete</span>,
+			isCompleteCallback: () => true,
+			isEditableCallback: () => true,
+			getEditButtonAriaLabel: () => 'Custom Step - Summary edit button label',
+			getNextStepButtonAriaLabel: () => 'Custom Step - Summary next button label',
+		},
+		{
+			id: 'custom-contact-step',
+			className: 'custom-contact-step-class',
+			hasStepNumber: true,
+			titleContent: <span>Custom Step - Contact Title</span>,
+			activeStepContent: <span>Custom Step - Contact Active</span>,
+			incompleteStepContent: <span>Custom Step - Contact Incomplete</span>,
+			completeStepContent: <span>Custom Step - Contact Complete</span>,
+			isCompleteCallback: () => true,
+			isEditableCallback: () => true,
+			getEditButtonAriaLabel: () => 'Custom Step - Contact edit button label',
+			getNextStepButtonAriaLabel: () => 'Custom Step - Contact next button label',
+		},
+		{
+			id: 'custom-review-step',
+			className: 'custom-review-step-class',
+			hasStepNumber: true,
+			titleContent: <span>Custom Step - Review Title</span>,
+			activeStepContent: <span>Custom Step - Review Active</span>,
+			incompleteStepContent: <span>Custom Step - Review Incomplete</span>,
+			completeStepContent: <span>Custom Step - Review Complete</span>,
+			isCompleteCallback: () => true,
+			isEditableCallback: () => true,
+			getEditButtonAriaLabel: () => 'Custom Step - Review edit button label',
+			getNextStepButtonAriaLabel: () => 'Custom Step - Review next button label',
+		},
+		{
+			id: 'custom-incomplete-step',
+			className: 'custom-incomplete-step-class',
+			hasStepNumber: true,
+			titleContent: <span>Custom Step - Incomplete Title</span>,
+			activeStepContent: <span>Custom Step - Incomplete Active</span>,
+			incompleteStepContent: <span>Custom Step - Incomplete Incomplete</span>,
+			completeStepContent: <span>Custom Step - Incomplete Complete</span>,
+			isCompleteCallback: () => false,
+			isEditableCallback: () => true,
+			getEditButtonAriaLabel: () => 'Custom Step - Incomplete edit button label',
+			getNextStepButtonAriaLabel: () => 'Custom Step - Incomplete next button label',
+		},
+		{
+			id: 'custom-possibly-complete-step',
+			className: 'custom-possibly-complete-step-class',
+			hasStepNumber: true,
+			titleContent: <span>Custom Step - Possibly Complete Title</span>,
+			activeStepContent: <StepWithEditableField />,
+			incompleteStepContent: <span>Custom Step - Possibly Complete Incomplete</span>,
+			completeStepContent: <span>Custom Step - Possibly Complete Complete</span>,
+			isCompleteCallback: ( { paymentData } ) => {
+				return paymentData.userName && paymentData.userName.length > 0 ? true : false;
+			},
+			isEditableCallback: ( { paymentData } ) => {
+				return !! paymentData.userName;
+			},
+			getEditButtonAriaLabel: () => 'Custom Step - Incomplete edit button label',
+			getNextStepButtonAriaLabel: () => 'Custom Step - Incomplete next button label',
+		},
+		{
+			id: 'custom-uneditable-step',
+			className: 'custom-uneditable-step-class',
+			hasStepNumber: true,
+			titleContent: <span>Custom Step - Uneditable Title</span>,
+			activeStepContent: <span>Custom Step - Uneditable Active</span>,
+			incompleteStepContent: <span>Custom Step - Uneditable Incomplete</span>,
+			completeStepContent: <span>Custom Step - Uneditable Complete</span>,
+			isCompleteCallback: () => true,
+			isEditableCallback: () => false,
+			getEditButtonAriaLabel: () => 'Custom Step - Uneditable edit button label',
+			getNextStepButtonAriaLabel: () => 'Custom Step - Uneditable next button label',
+		},
+	];
+}
+
+function StepWithEditableField() {
+	const [ paymentData, setPaymentData ] = usePaymentData();
+	const onChange = event => {
+		setPaymentData( 'userName', event.target.value );
+	};
+	const value = paymentData.userName || '';
+	return (
+		<div>
+			<label htmlFor="username-field">User Name</label>
+			<input id="username-field" type="text" value={ value } onChange={ onChange } />
+		</div>
+	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A great deal of the `Checkout` form is now provided by customization slots, including the first step (`OrderSummary`), the contact form (`ContactSlot`), and the last step (`ReviewContent`). This is appropriate, but it does highlight an evolving need: the host page wants to control the contents of the form more directly. Using slots means that we have to expect every situation that the host page might want to do and add a slot for it. There is nothing wrong with this approach but it restricts what can be done without changing the checkout component itself.

This PR modifies the `Checkout` component so that instead of taking a series of components that it injects into slots in the steps, it takes an array of _steps_ to display. 

Each _step_ is an object with a particular schema that includes both components and meta-data about the step's behavior. This is similar to how payment methods work now. And just like payment methods, we can provide some steps as constructor functions from within the package; notably the Payment Methods step is likely to be required for every form. The form then connects those steps with "continue" buttons and displays each step when appropriate.

This also helps to address a different issue: it was never very clear what props were being injected into a slotted component and how they were supposed to be used. `summary`, `isActive`, `isComplete` were all used in various combinations that the components had to understand and render correctly. Since each step now has a full object, each version of the step can be a separate component with a clearly defined role (or the same component with different props, but that is up to the author of that component and isn't baked into the system as it was with the slots). The roles represent the original three states of a step and use the properties `activeStepContent`, `incompleteStepContent`, and `completeStepContent`.

The step object also can reference various functions. Most importantly, the `isCompleteCallback` property creates a defined place to perform validation for a step in order to determine if that step is complete.

Finally, some steps are actually just informational blocks and should never be active (eg: the `OrderSummary` slot in the current form). Giving these steps a number is awkward and could cause problems if we ever want one between other numbered steps. With this change, these steps can set the property `hasStepNumber` to false, and they will not be counted in the step numbering system nor will it be possible to make them active.

Here's an example of a step object:

```js
{
	id: 'payment-method',
	className: 'checkout__payment-methods-step',
	hasStepNumber: true,
	titleContent: <CheckoutPaymentMethodsTitle />,
	activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
	incompleteStepContent: null,
	completeStepContent: <CheckoutPaymentMethods summary isComplete={ true } />,
	isCompleteCallback: ( { paymentData } ) => {
		const { billing = {} } = paymentData;
		if ( ! billing.country ) {
			return false;
		}
		return true;
	},
	isEditableCallback: ( { paymentData } ) => {
		return ( paymentData.billing ) ? true : false;
	},
	getEditButtonAriaLabel: () => translate( 'Edit the payment method' ),
	getNextStepButtonAriaLabel: () => translate( 'Continue with the selected payment method' ),
},
```

#### Testing instructions

- Add a file called `packages/composite-checkout/demo/private.js` and inside it put the following: `export const stripeKey = 'TEST KEY HERE'`;
- Run `npm run composite-checkout-demo`.
- Verify that the form works as expected.
- Run calypso with the `composite-checkout-wpcom` flag and verify that the form works as expected there as well.

Note that this PR adds a bunch of tests to verify the behavior of steps. This is actually another big benefit to this strategy; it gives us the ability to more easily write tests for the behaviors of various steps.