### PR TITLE
Update Jetpack Backup credentials nudge banner

### DIFF
--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -27,9 +27,13 @@ class JetpackBackupCredsBanner extends Component {
 
 	render() {
 		const { event, isJetpack, rewindState, siteId, siteSlug, translate } = this.props;
+
+		if ( ! isJetpack ) {
+			return null;
+		}
 		return (
 			<Fragment>
-				{ siteId && isJetpack && <QueryRewindState siteId={ siteId } /> }
+				{ siteId && <QueryRewindState siteId={ siteId } /> }
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
 						event={ event }

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -17,8 +17,8 @@ import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 
 class JetpackBackupCredsBanner extends Component {
 	static propTypes = {
-		// Banner location, passed to tracks event, single word to follow tracks naming conventions.
-		location: PropTypes.string.isRequired,
+		// Tracks event name on click
+		event: PropTypes.string.isRequired,
 		// Connected props
 		siteId: PropTypes.number,
 		rewindState: PropTypes.object,
@@ -26,9 +26,7 @@ class JetpackBackupCredsBanner extends Component {
 	};
 
 	render() {
-		const { isJetpack, rewindState, siteId, siteSlug, translate } = this.props;
-		const location = this.props.location || 'nolocation';
-		const event = `calpyso_jetpack_backup_credential_banner_${ location }_click`;
+		const { event, isJetpack, rewindState, siteId, siteSlug, translate } = this.props;
 		return (
 			<Fragment>
 				{ siteId && isJetpack && <QueryRewindState siteId={ siteId } /> }

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -19,10 +19,14 @@ class JetpackBackupCredsBanner extends Component {
 	static propTypes = {
 		// Banner location, passed to tracks event, single word to follow tracks naming conventions.
 		location: PropTypes.string.isRequired,
+		// Connected props
+		siteId: PropTypes.number,
+		rewindState: PropTypes.object,
+		siteSlug: PropTypes.string,
 	};
 
 	render() {
-		const { isJetpack, rewindState, siteId, slug, translate } = this.props;
+		const { isJetpack, rewindState, siteId, siteSlug, translate } = this.props;
 		const location = this.props.location || 'nolocation';
 		const event = `calpyso_jetpack_backup_credential_banner_${ location }_click`;
 		return (
@@ -34,8 +38,8 @@ class JetpackBackupCredsBanner extends Component {
 						icon="history"
 						href={
 							rewindState.canAutoconfigure
-								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
-								: `/settings/security/${ slug }`
+								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
+								: `/settings/security/${ siteSlug }`
 						}
 						title={ translate( 'Add your server credentials' ) }
 						description={ translate(
@@ -55,6 +59,6 @@ export default connect( state => {
 		isJetpack: isJetpackSite( state, siteId ),
 		siteId,
 		rewindState: getRewindState( state, siteId ),
-		slug: getSiteSlug( state, siteId ),
+		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( localize( JetpackBackupCredsBanner ) );

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -15,16 +16,21 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 
 class JetpackBackupCredsBanner extends Component {
+	static propTypes = {
+		// Banner location, passed to tracks event, single word to follow tracks naming conventions.
+		location: PropTypes.string.isRequired,
+	};
+
 	render() {
 		const { isJetpack, rewindState, siteId, slug, translate } = this.props;
-
+		const location = this.props.location || 'nolocation';
+		const event = `calpyso_jetpack_backup_credential_banner_${ location }_click`;
 		return (
-			// TODO: prop for tracks event
-			// TODO: link to settings for creds entry
 			<Fragment>
 				{ siteId && isJetpack && <QueryRewindState siteId={ siteId } /> }
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
+						event={ event }
 						icon="history"
 						href={
 							rewindState.canAutoconfigure

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -29,7 +29,7 @@ class JetpackBackupCredsBanner extends Component {
 						href={
 							rewindState.canAutoconfigure
 								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
-								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
+								: `/settings/security/${ slug }`
 						}
 						title={ translate( 'Add site credentials' ) }
 						description={ translate(

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -31,9 +31,9 @@ class JetpackBackupCredsBanner extends Component {
 								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
 								: `/settings/security/${ slug }`
 						}
-						title={ translate( 'Add site credentials' ) }
+						title={ translate( 'Add your server credentials' ) }
 						description={ translate(
-							'Backups and security scans require access to your site to work properly.'
+							"Enter your site's server credentials to set up site restores from your backups."
 						) }
 					/>
 				) }

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -20,9 +20,12 @@ class JetpackBackupCredsBanner extends Component {
 		// Tracks event name on click
 		event: PropTypes.string.isRequired,
 		// Connected props
-		siteId: PropTypes.number,
+		isJetpack: PropTypes.bool,
 		rewindState: PropTypes.object,
+		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
+		// From localize()
+		translate: PropTypes.function,
 	};
 
 	render() {

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Banner from 'components/banner';
+import getRewindState from 'state/selectors/get-rewind-state';
+import QueryRewindState from 'components/data/query-rewind-state';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+
+class JetpackBackupCredsBanner extends Component {
+	render() {
+		const { isJetpack, rewindState, siteId, slug, translate } = this.props;
+
+		return (
+			// TODO: prop for tracks event
+			// TODO: link to settings for creds entry
+			<Fragment>
+				{ siteId && isJetpack && <QueryRewindState siteId={ siteId } /> }
+				{ 'awaitingCredentials' === rewindState.state && (
+					<Banner
+						icon="history"
+						href={
+							rewindState.canAutoconfigure
+								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
+								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
+						}
+						title={ translate( 'Add site credentials' ) }
+						description={ translate(
+							'Backups and security scans require access to your site to work properly.'
+						) }
+					/>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		isJetpack: isJetpackSite( state, siteId ),
+		siteId,
+		rewindState: getRewindState( state, siteId ),
+		slug: getSiteSlug( state, siteId ),
+	};
+} )( localize( JetpackBackupCredsBanner ) );

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -425,7 +425,7 @@ class ActivityLog extends Component {
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
-				<JetpackBackupCredsBanner location={ 'activitylog' } />
+				<JetpackBackupCredsBanner event={ 'activity-backup-credentials' } />
 				{ 'provisioning' === rewindState.state && (
 					<Banner
 						icon="history"

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -27,6 +27,7 @@ import UpgradeBanner from '../activity-log-banner/upgrade-banner';
 import IntroBanner from '../activity-log-banner/intro-banner';
 import { isFreePlan } from 'lib/plans';
 import { isJetpackBackup } from 'lib/products-values';
+import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -141,6 +142,7 @@ class ActivityLog extends Component {
 
 	/**
 	 * Close Restore, Backup, or Transfer confirmation dialog.
+	 *
 	 * @param {string} type Type of dialog to close.
 	 */
 	handleCloseDialog = type => {
@@ -160,7 +162,7 @@ class ActivityLog extends Component {
 	 * times need to be formatted for display to ensure all times are displayed as site times.
 	 *
 	 * @param   {object} date Moment to adjust.
-	 * @returns {Moment}      Moment adjusted for site timezone or gmtOffset.
+	 * @returns {object}      Moment adjusted for site timezone or gmtOffset.
 	 */
 	applySiteOffset = date => {
 		const { timezone, gmtOffset } = this.props;
@@ -213,7 +215,8 @@ class ActivityLog extends Component {
 
 	/**
 	 * Display the status of the operation currently being performed.
-	 * @param   {integer} siteId         Id of the site where the operation is performed.
+	 *
+	 * @param   {number} siteId         Id of the site where the operation is performed.
 	 * @param   {object}  actionProgress Current status of operation performed.
 	 * @param   {string}  action         Action type. Allows to set the right text without waiting for data.
 	 * @returns {object}                 Card showing progress.
@@ -247,7 +250,8 @@ class ActivityLog extends Component {
 
 	/**
 	 * Display a success or error card based on the last status of operation.
-	 * @param   {integer} siteId   Id of the site where the operation was performed.
+	 *
+	 * @param   {number} siteId   Id of the site where the operation was performed.
 	 * @param   {object}  progress Last status of operation.
 	 * @returns {object}           Card showing success or error.
 	 */
@@ -363,7 +367,6 @@ class ActivityLog extends Component {
 			rewindState,
 			siteId,
 			siteHasNoLog,
-			slug,
 			translate,
 			isAtomic,
 			isJetpack,
@@ -422,20 +425,7 @@ class ActivityLog extends Component {
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
-				{ 'awaitingCredentials' === rewindState.state && ! siteHasNoLog && (
-					<Banner
-						icon="history"
-						href={
-							rewindState.canAutoconfigure
-								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
-								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
-						}
-						title={ translate( 'Add site credentials' ) }
-						description={ translate(
-							'Backups and security scans require access to your site to work properly.'
-						) }
-					/>
-				) }
+				<JetpackBackupCredsBanner />
 				{ 'provisioning' === rewindState.state && (
 					<Banner
 						icon="history"

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -425,7 +425,7 @@ class ActivityLog extends Component {
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
-				<JetpackBackupCredsBanner />
+				<JetpackBackupCredsBanner location={ 'activitylog' } />
 				{ 'provisioning' === rewindState.state && (
 					<Banner
 						icon="history"

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -415,6 +415,8 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 
+				<JetpackBackupCredsBanner event={ 'activity-backup-credentials' } />
+
 				<FormattedHeader
 					className="activity-log__page-heading"
 					headerText={ translate( 'Activity' ) }
@@ -425,7 +427,6 @@ class ActivityLog extends Component {
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
-				<JetpackBackupCredsBanner event={ 'activity-backup-credentials' } />
 				{ 'provisioning' === rewindState.state && (
 					<Banner
 						icon="history"

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import GeneralSettings from './section-general';
+import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import JetpackDevModeNotice from './jetpack-dev-mode-notice';
 import Main from 'components/main';
 import QueryProductsList from 'components/data/query-products-list';
@@ -28,6 +29,7 @@ import './style.scss';
 const SiteSettingsComponent = ( { siteId, translate } ) => {
 	return (
 		<Main className="site-settings">
+			<JetpackBackupCredsBanner location={ 'settings' } />
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<QueryProductsList />
 			<QuerySitePurchases siteId={ siteId } />

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -29,7 +29,7 @@ import './style.scss';
 const SiteSettingsComponent = ( { siteId, translate } ) => {
 	return (
 		<Main className="site-settings">
-			<JetpackBackupCredsBanner location={ 'settings' } />
+			<JetpackBackupCredsBanner event={ 'settings-backup-credentials' } />
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<QueryProductsList />
 			<QuerySitePurchases siteId={ siteId } />

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -8,11 +8,13 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import GeneralForm from 'my-sites/site-settings/form-general';
+import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import SiteTools from './site-tools';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const SiteSettingsGeneral = ( { site } ) => (
 	<div className="site-settings__main general-settings">
+		<JetpackBackupCredsBanner location={ 'settings' } />
 		<GeneralForm site={ site } />
 		<SiteTools />
 	</div>

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -8,13 +8,11 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import GeneralForm from 'my-sites/site-settings/form-general';
-import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import SiteTools from './site-tools';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const SiteSettingsGeneral = ( { site } ) => (
 	<div className="site-settings__main general-settings">
-		<JetpackBackupCredsBanner location={ 'settings' } />
 		<GeneralForm site={ site } />
 		<SiteTools />
 	</div>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -157,7 +157,7 @@ class StatsSite extends Component {
 					title={ `Stats > ${ titlecase( period ) }` }
 				/>
 				<PrivacyPolicyBanner />
-				<JetpackBackupCredsBanner location={ 'stats' } />
+				<JetpackBackupCredsBanner event={ 'stats-backup-credentials' } />
 				<SidebarNavigation />
 				<FormattedHeader
 					className="stats__section-header"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -26,6 +26,7 @@ import titlecase from 'to-title-case';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import StatsBanners from './stats-banners';
 import StickyPanel from 'components/sticky-panel';
+import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
@@ -156,6 +157,7 @@ class StatsSite extends Component {
 					title={ `Stats > ${ titlecase( period ) }` }
 				/>
 				<PrivacyPolicyBanner />
+				<JetpackBackupCredsBanner location={ 'stats' } />
 				<SidebarNavigation />
 				<FormattedHeader
 					className="stats__section-header"


### PR DESCRIPTION
## Changes proposed in this Pull Request

- [x] Update banner text now that backups can proceed without credentials.
- [x] Display banner in Stats and Settings pages as well as Activity Log.
- [x] Add a tracks event so we can see which banners are most effective.
- [x] Link to the Settings screen instead of the dedicated credentials entry flow.
- [x] Move banner to very top of Activity Log screen


## Before

<img width="978" alt="Screenshot 2019-11-25 at 13 47 53" src="https://user-images.githubusercontent.com/7767559/69545748-4b36af80-0f8a-11ea-8ed8-af7b52160c0e.png">


## After

<img width="970" alt="Screenshot 2019-11-25 at 13 47 10" src="https://user-images.githubusercontent.com/7767559/69545758-4eca3680-0f8a-11ea-9e84-acf088a54f67.png">

<img width="789" alt="Screenshot 2019-11-22 at 14 45 33" src="https://user-images.githubusercontent.com/7767559/69435077-cacc4080-0d36-11ea-8730-9455c0c8f7d0.png">

<img width="959" alt="Screenshot 2019-11-19 at 21 21 41" src="https://user-images.githubusercontent.com/7767559/69187556-b90a5380-0b12-11ea-9b37-aba375be2433.png">


## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new jurassic ninja site.
* Connect Jetpack and purchase one of the new backup-only products.
* Go to the Activity Log, Settings (general), and Stats pages for the new site on this branch.

**EXPECTED**:
* You should see the new wording on the banner.
* The banner should link to the security settings page showing a form to enter site credentials.
* After credential entry, the banner should disappear.




