### PR TITLE
Fix mobile margin on the Jetpack + WooCommerce connection flow

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -905,6 +905,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			svg > g {
 				transform: translateX( 25% );
 			}
+
+			@include breakpoint( '<660px' ) {
+				margin-top: 0;
+			}
 		}
 
 		.jetpack-header {


### PR DESCRIPTION
There's a margin added to the normal Jetpack logo on mobile views. This PR removes it when used on the new WooCommerce Onboarding + Jetpack flow.

Before

<img width="475" alt="Screen Shot 2019-11-19 at 1 51 20 PM" src="https://user-images.githubusercontent.com/689165/69176555-ed125400-0ad3-11ea-905e-3c3a921ecb9b.png">

After

<img width="580" alt="Screen Shot 2019-11-19 at 1 54 10 PM" src="https://user-images.githubusercontent.com/689165/69176633-1632e480-0ad4-11ea-8f50-a4a98dc90cde.png">

#### Testing instructions

This flow is reachable through WooCommerce Admin. 

* Install WooCommerce
* Install WooCommerce Admin from GitHub
* Enable `WP_DEBUG`
* Go to `WooCommerce > Settings > Help > Setup Wizard` and connect via the Jetpack flow
* Shrink your screen below 660 and notice the margin is gone
