### PR TITLE
Use theme slug if is front page and did not have slug

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -105,6 +105,28 @@ function get_theme_slug() {
 }
 
 /**
+ * Returns a normalized slug for the current theme.
+ *
+ * In some cases, the theme is located in a subfolder like `pub/maywood`. Use
+ * this function to get the slug without the prefix.
+ *
+ * @param string $theme_slug The raw theme_slug to normalize.
+ * @return string Theme slug.
+ */
+function normalize_theme_slug( $theme_slug ) {
+	// Normalize the theme slug.
+	if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
+		$theme_slug = substr( $theme_slug, 4 );
+	}
+
+	if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
+		$theme_slug = substr( $theme_slug, 0, -6 );
+	}
+
+	return $theme_slug;
+}
+
+/**
  * Whether or not the site is eligible for FSE.
  * This is essentially a feature gate to disable FSE
  * on some sites which could theoretically otherwise use it.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -177,7 +177,7 @@ class Starter_Page_Templates {
 				'vertical'        => $vertical,
 				'segment'         => $segment,
 				'screenAction'    => $screen->action,
-				'theme'           => get_stylesheet(),
+				'theme'           => normalize_theme_slug( get_stylesheet() ),
 				// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 				'isFrontPage'     => isset( $_GET['post'] ) && get_option( 'page_on_front' ) === $_GET['post'],
 			]

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -17,7 +17,7 @@ import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
 /* eslint-enable import/no-extraneous-dependencies */
 
-const { theme } = starterPageTemplatesConfig;
+const { theme, isFrontPage } = starterPageTemplatesConfig;
 
 class SidebarModalOpener extends Component {
 	state = {
@@ -39,7 +39,7 @@ class SidebarModalOpener extends Component {
 		// Try to match the homepage of the theme. Note that as folks transition
 		// to using the slug-based version of the homepage (e.g. "shawburn"), the
 		// slug will work normally without going through this check.
-		if ( lastTemplateUsedSlug === 'home' ) {
+		if ( ! lastTemplateUsedSlug && isFrontPage ) {
 			lastTemplateUsedSlug = theme;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Use theme slug if the current page is the front page and there is no previously selected template

### Testing
1. Sandbox a URL you are about to create through the horizon FSE flow
2. create the fse site
3. edit the homepage
4. in the document sidebar, make sure the layout matches the current theme (e.g. maywood)
5. Previously it would have defaulted to "blank"

<img width="1856" alt="Screen Shot 2019-11-19 at 11 23 42 AM" src="https://user-images.githubusercontent.com/6265975/69179132-df52d380-0abf-11ea-8227-d980a9d84bbe.png">
