### PR TITLE
Starter Page Templates: Only overwrite the page title if the layout is not one of the homepage layouts

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -111,9 +111,12 @@ class PageTemplateModal extends Component {
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 		this.props.saveTemplateChoice( slug );
 
+		const isHomepageTemplate = find( this.props.templates, { slug, category: 'home' } );
+
 		// Load content.
 		const blocks = this.getBlocksByTemplateSlug( slug );
-		const title = this.getTitleByTemplateSlug( slug );
+		// Only overwrite the page title if the template is not one of the Homepage Layouts
+		const title = isHomepageTemplate ? null : this.getTitleByTemplateSlug( slug );
 
 		// Skip inserting if there's nothing to insert.
 		if ( ! blocks || ! blocks.length ) {
@@ -356,7 +359,9 @@ export const PageTemplatesPlugin = compose(
 			},
 			insertTemplate: ( title, blocks ) => {
 				// Set post title.
-				editorDispatcher.editPost( { title } );
+				if ( title ) {
+					editorDispatcher.editPost( { title } );
+				}
 
 				// Replace blocks.
 				const postContentBlock = ownProps.postContentBlock;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When picking a layout in the Starter Page Template selector, both the page's content and title are overwritten by the layout's.
This won't work anymore now that we have a list of homepage layouts titled after their theme, especially because the front page title is hidden and so there isn't any place to modify the front page title anymore.

* Prevent homepage layouts to overwrite the current page title when selected.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an FSE site edit a page, make note of its title, and change its layout.
* Select an homepage layout (e.g. Shawburn).
* Make sure the page title is NOT changed.
* Change the layout again.
* Select a "regular" layout (e.g. About).
* Make sure the page title has changed to About.