### PR TITLE
Gutenboarding: Improve domains popover

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -68,7 +68,6 @@ export function Gutenboard() {
 										</ObserveTyping>
 									</WritingFlow>
 								</div>
-								<Popover.Slot />
 							</div>
 							<div>
 								<SettingsSidebar isActive={ isEditorSidebarOpened } />
@@ -78,6 +77,7 @@ export function Gutenboard() {
 					</div>
 				</DropZoneProvider>
 			</SlotFillProvider>
+			<Popover.Slot />
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
Fixes the popover positioning by moving its slot.

## Screens

### Before
<img width="520" alt="Screen Shot 2019-11-19 at 21 35 43" src="https://user-images.githubusercontent.com/841763/69186451-d2ae9980-0b18-11ea-9185-05474e9772ab.png">

### After
<img width="520" alt="Screen Shot 2019-11-19 at 21 34 32" src="https://user-images.githubusercontent.com/841763/69186460-d7734d80-0b18-11ea-9013-b907c404287c.png">

## Test

Visit `/gutenboarding` and confirm the popover is correctly positioned above the header.