### PR TITLE
AppsBadge: Load styles with webpack

### DIFF
--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -16,6 +16,11 @@ import { getLocaleSlug } from 'lib/i18n-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import TranslatableString from 'components/translatable/proptype';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 // the locale slugs for each stores' image paths follow different rules
 // therefore we have to perform some trickery in getLocaleSlug()
 const APP_STORE_BADGE_URLS = {

--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -19,7 +19,7 @@ import TranslatableString from 'components/translatable/proptype';
 /**
  * Style dependencies
  */
-import './style.scss';
+import './apps-badge.scss';
 
 // the locale slugs for each stores' image paths follow different rules
 // therefore we have to perform some trickery in getLocaleSlug()

--- a/client/blocks/get-apps/apps-badge.scss
+++ b/client/blocks/get-apps/apps-badge.scss
@@ -6,15 +6,14 @@
 		width: auto;
 	}
 
-	&.android-app-badge {
-		img {
-			max-height: 59px;
-			margin-top: 0;
-			margin-bottom: 0;
-			margin-right: 0;
-		}
-		& + .ios-app-badge img {
-			margin-left: 0;
-		}
+	&.android-app-badge img {
+		max-height: 59px;
+		margin-top: 0;
+		margin-bottom: 0;
+		margin-right: 0;
+	}
+
+	&.ios-app-badge img {
+		margin-left: 0;
 	}
 }

--- a/client/blocks/get-apps/apps-badge.scss
+++ b/client/blocks/get-apps/apps-badge.scss
@@ -1,0 +1,20 @@
+.get-apps__app-badge {
+	display: inline-block;
+	img {
+		max-height: 41px;
+		margin: 9px 0;
+		width: auto;
+	}
+
+	&.android-app-badge {
+		img {
+			max-height: 59px;
+			margin-top: 0;
+			margin-bottom: 0;
+			margin-right: 0;
+		}
+		& + .ios-app-badge img {
+			margin-left: 0;
+		}
+	}
+}

--- a/client/blocks/get-apps/apps-badge.scss
+++ b/client/blocks/get-apps/apps-badge.scss
@@ -1,5 +1,6 @@
 .get-apps__app-badge {
 	display: inline-block;
+
 	img {
 		max-height: 41px;
 		margin: 9px 0;
@@ -7,13 +8,7 @@
 	}
 
 	&.android-app-badge img {
-		max-height: 59px;
-		margin-top: 0;
-		margin-bottom: 0;
-		margin-right: 0;
-	}
-
-	&.ios-app-badge img {
+		max-height: 60px;
 		margin-left: 0;
 	}
 }

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -194,24 +194,3 @@
 		margin-left: 24px;
 	}
 }
-
-.get-apps__app-badge {
-	display: inline-block;
-	img {
-		max-height: 41px;
-		margin: 9px 0;
-		width: auto;
-	}
-
-	&.android-app-badge {
-		img {
-			max-height: 59px;
-			margin-top: 0;
-			margin-bottom: 0;
-			margin-right: 0;
-		}
-		& + .ios-app-badge img {
-			margin-left: 0;
-		}
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I noticed this visual bug on Customer Home while I was working on it:
<img width="386" alt="Screen Shot 2019-11-19 at 9 02 44 AM" src="https://user-images.githubusercontent.com/2124984/69188336-5309d600-0aea-11ea-95ca-53919272e014.png">

* The styles for AppsBadge weren't enqueued, probably because they're only imported within the parent component, GetApps.

* This PR imports the stylesheet within `AppsBadge` so the styles are correctly applied regardless of where the component is shown. The fix should look like this:
<img width="423" alt="Screen Shot 2019-11-19 at 4 29 39 PM" src="https://user-images.githubusercontent.com/2124984/69188351-5ac97a80-0aea-11ea-8310-0891ab2e70e6.png">

* I believe this duplicates the stylesheet when viewing `GetApps`. Is that a concern? Is it worth it to split each of these components' styles into separate stylesheets?

#### Testing instructions

* Switch to this PR and navigate to /me/get-apps
* Make sure the app badges display properly at all screen sizes.
