### PR TITLE
Migration: Update the design for the site-selection and confirmation screens

### DIFF
--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -29,3 +29,45 @@
 		text-decoration: underline;
 	}
 }
+
+.migrate__sites {
+	display: flex;
+	border-top: 1px solid var( --color-neutral-10 );
+	border-bottom: 1px solid var( --color-neutral-10 );
+	margin-bottom: 16px;
+
+	.site__content {
+		padding-left: 0;
+		padding-right: 0;
+	}
+}
+
+.migrate__sites-arrow {
+	display: flex;
+	color: var( --color-neutral-10 );
+	padding: 20px 40px 20px 0;
+	@include breakpoint( '>1040px' ) {
+		padding-right: 64px;
+	}
+	@include breakpoint( '<480px' ) {
+		padding-right: 16px;
+	}
+}
+
+.migrate__list {
+	margin: 16px 0 32px;
+	li {
+		list-style-type: none;
+		line-height: 30px;
+		font-size: 14px;
+	}
+}
+
+.migrate__checkmark {
+	color: var( --color-success );
+	margin-right: 16px;
+}
+
+.migrate__cancel {
+	margin-left: 16px;
+}

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -4,6 +4,28 @@
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
-.migrate__source-site, .migrate__confirmation, .migrate__status {
+.migrate__source-site, .migrate__confirmation, .migrate__status, .migrate__explain {
 	margin-bottom: 16px;
+}
+
+.migrate__card {
+	.site__content, .site-selector__hidden-sites-message {
+		border-bottom: 1px solid var( --color-neutral-10 );
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.site-selector .search {
+		margin: 0;
+	}
+}
+
+.migrate__card-footer {
+	color: var( --color-neutral-40 );
+	font-size: 13px;
+
+	a {
+		color: var( --color-neutral-40 );
+		text-decoration: underline;
+	}
 }


### PR DESCRIPTION
Note: This change is behind a feature-flag and is part of an in-progress larger project. This PR is intentionally incomplete. For context, see pbkcP4-8-p2.

Updates the designs for the site-selection and site-confirmation screens of migration.

#### Changes proposed in this Pull Request

![image](https://user-images.githubusercontent.com/363749/69371847-414d3d80-0c66-11ea-8c76-ccbb366967d9.png)

![image](https://user-images.githubusercontent.com/363749/69371965-75c0f980-0c66-11ea-9632-6444070c0724.png)

Note: the site-names / addresses have been partially-removed from the screenshots

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this pull request and run Calypso locally, or view it on calypso.live with the flag `tools/migrate.`
* Viewing calypso.localhost:3000/migrate/, you should see a `SiteSelector` component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another `SiteSelector` component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.

