### PR TITLE
Gutenboarding: Rework header and domainpicker structure

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -69,8 +69,10 @@ const DomainPickerButton: FunctionComponent = () => {
 	return (
 		<>
 			<Button
-				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
+				aria-expanded={ isDomainPopoverVisible }
+				aria-haspopup="menu"
 				aria-pressed={ isDomainPopoverVisible }
+				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 			>
 				{ /* This empty span gives us a good place to anchor our popover */ }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useState, useRef } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { head, partition } from 'lodash';
@@ -22,8 +22,6 @@ import { useDebounce } from 'use-debounce';
 import './style.scss';
 
 const DomainPickerButton: FunctionComponent = () => {
-	const popoverAnchor = useRef< HTMLElement >();
-
 	// User can search for a domain
 	const [ domainSearch, setDomainSearch ] = useState( '' );
 
@@ -75,13 +73,11 @@ const DomainPickerButton: FunctionComponent = () => {
 				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 			>
-				{ /* This empty span gives us a good place to anchor our popover */ }
-				<span ref={ popoverAnchor } />
 				{ head( freeDomainSuggestions )?.domain_name ?? '\u00a0' }
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
-				<Popover anchorRect={ popoverAnchor.current?.getBoundingClientRect() }>
+				<Popover>
 					<DomainPicker
 						domainSearch={ domainSearch }
 						setDomainSearch={ setDomainSearch }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useState } from 'react';
-import { __ as NO__ } from '@wordpress/i18n';
-import { Button, Popover } from '@wordpress/components';
+import React, { FunctionComponent, useState, useRef } from 'react';
+import { Button, Popover, Dashicon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { head, partition } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -22,6 +22,8 @@ import { useDebounce } from 'use-debounce';
 import './style.scss';
 
 const DomainPickerButton: FunctionComponent = () => {
+	const popoverAnchor = useRef< HTMLElement >();
+
 	// User can search for a domain
 	const [ domainSearch, setDomainSearch ] = useState( '' );
 
@@ -40,7 +42,7 @@ const DomainPickerButton: FunctionComponent = () => {
 	 *
 	 * @see https://stackoverflow.com/a/44755058/1432801
 	 */
-	const inputDebounce = 400;
+	const inputDebounce = 300;
 	const [ search ] = useDebounce(
 		// Use trimmed domainSearch if non-empty
 		domainSearch.trim() ||
@@ -65,20 +67,19 @@ const DomainPickerButton: FunctionComponent = () => {
 	const [ freeDomainSuggestions, paidDomainSuggestions ] = partition( suggestions, 'is_free' );
 
 	return (
-		<Button
-			className="domain-picker__button"
-			onClick={ () => setDomainPopoverVisibility( s => ! s ) }
-		>
-			<div className="domain-picker__site-title">
-				{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
-			</div>
-			<div>{ head( freeDomainSuggestions )?.domain_name }</div>
+		<>
+			<Button
+				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
+				aria-pressed={ isDomainPopoverVisible }
+				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
+			>
+				{ /* This empty span gives us a good place to anchor our popover */ }
+				<span ref={ popoverAnchor } />
+				{ head( freeDomainSuggestions )?.domain_name ?? '\u00a0' }
+				<Dashicon icon="arrow-down-alt2" />
+			</Button>
 			{ isDomainPopoverVisible && (
-				<Popover
-					/* Prevent interaction in the domain picker from affecting the popover */
-					onClick={ e => e.stopPropagation() }
-					onKeyDown={ e => e.stopPropagation() }
-				>
+				<Popover anchorRect={ popoverAnchor.current?.getBoundingClientRect() }>
 					<DomainPicker
 						domainSearch={ domainSearch }
 						setDomainSearch={ setDomainSearch }
@@ -86,7 +87,7 @@ const DomainPickerButton: FunctionComponent = () => {
 					/>
 				</Popover>
 			) }
-		</Button>
+		</>
 	);
 };
 

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -1,11 +1,11 @@
 .domain-picker__button {
-	display: block;
-	margin-left: 20px;
-	text-align: left;
-}
-
-.domain-picker__site-title {
-	font-weight: bold;
+	.dashicon {
+		margin-left: 0.5em;
+		transition: transform 180ms ease-in-out;
+	}
+	&.is-open .dashicon {
+		transform: rotate( 180deg );
+	}
 }
 
 .domain-picker__choose-domain-header,

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -7,7 +7,6 @@ import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keyc
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
 import { isEmpty } from 'lodash';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -40,24 +39,24 @@ const Header: FunctionComponent< Props > = ( { isEditorSidebarOpened, toggleGene
 			aria-label={ NO__( 'Top bar' ) }
 			tabIndex={ -1 }
 		>
-			<HeaderSection>
-				<HeaderGroup>
+			<div className="gutenboarding__header-section">
+				<div className="gutenboarding__header-group">
 					<Icon icon="wordpress-alt" color="#066188" />
-				</HeaderGroup>
-				<HeaderGroup>
+				</div>
+				<div className="gutenboarding__header-group">
 					<div className="gutenboarding__site-title">
 						{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
 					</div>
 					<DomainPickerButton />
-				</HeaderGroup>
-			</HeaderSection>
-			<HeaderSection>
-				<HeaderGroup>
+				</div>
+			</div>
+			<div className="gutenboarding__header-section">
+				<div className="gutenboarding__header-group">
 					<Button isPrimary isLarge disabled={ isEmpty( siteVertical ) }>
 						{ NO__( 'Next' ) }
 					</Button>
-				</HeaderGroup>
-				<HeaderGroup>
+				</div>
+				<div className="gutenboarding__header-group">
 					<IconButton
 						aria-expanded={ isEditorSidebarOpened }
 						aria-haspopup="menu"
@@ -68,18 +67,11 @@ const Header: FunctionComponent< Props > = ( { isEditorSidebarOpened, toggleGene
 						onClick={ toggleGeneralSidebar }
 						shortcut={ toggleSidebarShortcut }
 					/>
-				</HeaderGroup>
-			</HeaderSection>
+				</div>
+			</div>
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
-
-const HeaderGroup: FunctionComponent< { className?: string } > = ( { children, className } ) => (
-	<div className={ classnames( 'gutenboarding__header-group', className ) }>{ children }</div>
-);
-const HeaderSection: FunctionComponent< { className?: string } > = ( { children, className } ) => (
-	<div className={ classnames( 'gutenboarding__header-section', className ) }>{ children }</div>
-);
 
 export default Header;

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -59,11 +59,13 @@ const Header: FunctionComponent< Props > = ( { isEditorSidebarOpened, toggleGene
 				</HeaderGroup>
 				<HeaderGroup>
 					<IconButton
+						aria-expanded={ isEditorSidebarOpened }
+						aria-haspopup="menu"
+						aria-pressed={ isEditorSidebarOpened }
 						icon="admin-generic"
+						isToggled={ isEditorSidebarOpened }
 						label={ NO__( 'Site block settings' ) }
 						onClick={ toggleGeneralSidebar }
-						isToggled={ isEditorSidebarOpened }
-						aria-expanded={ isEditorSidebarOpened }
 						shortcut={ toggleSidebarShortcut }
 					/>
 				</HeaderGroup>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -5,8 +5,9 @@ import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Icon, IconButton } from '@wordpress/components';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { isEmpty } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -29,7 +30,7 @@ interface Props {
 }
 
 export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
-	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
+	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -39,30 +40,42 @@ export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }:
 			aria-label={ NO__( 'Top bar' ) }
 			tabIndex={ -1 }
 		>
-			<div className="gutenboarding__header-site">
-				<Icon icon="wordpress-alt" color="#066188" />
-				<DomainPickerButton />
-			</div>
-			<div
-				aria-label={ NO__( 'Document tools' ) }
-				aria-orientation="horizontal"
-				className="gutenboarding__header-toolbar"
-				role="toolbar"
-			></div>
-			<div className="gutenboarding__header-actions">
-				<Button isPrimary isLarge disabled={ isEmpty( siteVertical ) }>
-					{ NO__( 'Next' ) }
-				</Button>
-				<IconButton
-					icon="admin-generic"
-					label={ NO__( 'Site block settings' ) }
-					onClick={ toggleGeneralSidebar }
-					isToggled={ isEditorSidebarOpened }
-					aria-expanded={ isEditorSidebarOpened }
-					shortcut={ toggleSidebarShortcut }
-				/>
-			</div>
+			<HeaderSection>
+				<HeaderGroup>
+					<Icon icon="wordpress-alt" color="#066188" />
+				</HeaderGroup>
+				<HeaderGroup>
+					<div className="gutenboarding__site-title">
+						{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
+					</div>
+					<DomainPickerButton />
+				</HeaderGroup>
+			</HeaderSection>
+			<HeaderSection>
+				<HeaderGroup>
+					<Button isPrimary isLarge disabled={ isEmpty( siteVertical ) }>
+						{ NO__( 'Next' ) }
+					</Button>
+				</HeaderGroup>
+				<HeaderGroup>
+					<IconButton
+						icon="admin-generic"
+						label={ NO__( 'Site block settings' ) }
+						onClick={ toggleGeneralSidebar }
+						isToggled={ isEditorSidebarOpened }
+						aria-expanded={ isEditorSidebarOpened }
+						shortcut={ toggleSidebarShortcut }
+					/>
+				</HeaderGroup>
+			</HeaderSection>
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
+
+const HeaderGroup: FunctionComponent< { className?: string } > = ( { children, className } ) => (
+	<div className={ classnames( 'gutenboarding__header-group', className ) }>{ children }</div>
+);
+const HeaderSection: FunctionComponent< { className?: string } > = ( { children, className } ) => (
+	<div className={ classnames( 'gutenboarding__header-section', className ) }>{ children }</div>
+);

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -69,7 +69,10 @@ const Header: FunctionComponent< Props > = ( { isEditorSidebarOpened, toggleGene
 						isToggled={ isEditorSidebarOpened }
 						label={ NO__( 'Site block settings' ) }
 						onClick={ toggleGeneralSidebar }
-						shortcut={ toggleSidebarShortcut }
+						shortcut={
+							/* @TODO: this shortcut based on Gutenberg doesn't seem to be handled at this time. */
+							toggleSidebarShortcut
+						}
 					/>
 				</div>
 			</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -6,7 +6,6 @@ import { Button, Icon, IconButton } from '@wordpress/components';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +13,7 @@ import { isEmpty } from 'lodash';
 import { STORE_KEY } from '../../stores/onboard';
 import './style.scss';
 import { DomainPickerButton } from '../domain-picker';
+import { isFilledFormValue } from '../../stores/onboard/types';
 
 // Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
 // to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
@@ -52,7 +52,11 @@ const Header: FunctionComponent< Props > = ( { isEditorSidebarOpened, toggleGene
 			</div>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Button isPrimary isLarge disabled={ isEmpty( siteVertical ) }>
+					<Button
+						isPrimary
+						isLarge
+						disabled={ isFilledFormValue( siteVertical ) || ! siteVertical }
+					>
 						{ NO__( 'Next' ) }
 					</Button>
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -29,7 +29,7 @@ interface Props {
 	toggleGeneralSidebar: () => void;
 }
 
-export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }: Props ) {
+const Header: FunctionComponent< Props > = ( { isEditorSidebarOpened, toggleGeneralSidebar } ) => {
 	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -71,7 +71,7 @@ export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }:
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
-}
+};
 
 const HeaderGroup: FunctionComponent< { className?: string } > = ( { children, className } ) => (
 	<div className={ classnames( 'gutenboarding__header-group', className ) }>{ children }</div>
@@ -79,3 +79,5 @@ const HeaderGroup: FunctionComponent< { className?: string } > = ( { children, c
 const HeaderSection: FunctionComponent< { className?: string } > = ( { children, className } ) => (
 	<div className={ classnames( 'gutenboarding__header-section', className ) }>{ children }</div>
 );
+
+export default Header;

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -23,12 +23,21 @@
 	}
 }
 
-.gutenboarding__header-site {
+.gutenboarding__header-section {
 	display: flex;
-	flex-direction: row;
-	margin-left: 20px;
-	font-size: 14px;
 	align-items: center;
+}
+
+.gutenboarding__header-group {
+	display: flex;
+	flex-direction: column;
+	margin: 10px;
+	font-size: 14px;
+	align-items: flex-start;
+}
+
+.gutenboarding__site-title {
+	font-weight: bold;
 }
 
 .gutenboarding__header-actions {


### PR DESCRIPTION
Refactor header and domain picker structure.

This should provide some accessibility and valid HTML improvements.

- DomainPicker button doesn't contain interactive elements
- Adds aria-* props
- Simplifies and standardized Header structure:
  Header > HeaderSection > HeaderGroup (currently `div.gutenboarding__header*`)

See #37736 for fixed z-positioning of the Popover.

#### Testing instructions

* `/gutenboarding` works and displays well

Fixes #
