### PR TITLE
SPT: Update the preview responsive styles

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -339,6 +339,14 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		display: none;
 	}
 
+	@media screen and ( min-width: 660px ) {
+		&.is-blank-preview {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+	}
+
 	position: fixed;
 	top: 111px;
 	bottom: 24px;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -71,10 +71,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     left: 0;
     right: 0;
     bottom: 0;
-    transform: none;
     max-width: none;
     max-height: none;
     background-color: #eeeeee;
+    transform: translateZ(0);
 }
 
 .page-template-modal .components-modal__header-heading-container {
@@ -293,11 +293,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 .page-template-modal__form {
 	@media screen and ( min-width: 660px ) {
-		max-width: 20%;
+		width: 20%;
 	}
 
 	@media screen and ( min-width: 783px ) {
-		max-width: 30%;
+		width: 30%;
 	}
 }
 
@@ -335,6 +335,19 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 // Template Selector Preview
 .template-selector-preview {
+	display: flex;
+  	position: fixed;
+  	top: 111px;
+	bottom: 25px;
+	left: calc( 20% + 30px );
+	width: calc( 80% - 50px );
+	background: $template-selector-empty-background;
+	border-radius: 4px;
+	overflow-x: hidden;
+	overflow-y: auto;
+	border: solid 2px $template-selector-border-color;
+	border-radius: 6px;
+
 	@media screen and ( max-width: 659px ) {
 		display: none;
 	}
@@ -347,16 +360,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 	}
 
-	position: fixed;
-	top: 111px;
-	bottom: 24px;
-	width: calc( 70% - 75px );
-	margin-left: calc( 30% + 25px );
-	background: $template-selector-empty-background;
-	border-radius: 4px;
-	overflow-x: hidden;
-	overflow-y: auto;
-	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
+	@media screen and ( min-width: 783px ) {
+		width: calc( 70% - 50px );
+		left: calc( 30% + 30px );
+	}
 
 	.edit-post-visual-editor {
 		margin: 0;
@@ -398,21 +405,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 body:not( .is-fullscreen-mode ) {
 	.template-selector-preview {
-		@media screen and ( min-width: 783px ) {
-			width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
-		}
-
-		@media screen and ( min-width: 961px ) {
-			width: calc( 70% - #{$wp-org-sidebar-full } );
-		}
-	}
-	@media screen and ( min-width: 783px ) {
-		&.folded .template-selector-preview {
-			width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
-		}
-		&:not( .folded ):not( .auto-fold ) .template-selector-preview {
-			width: calc( 70% - #{$wp-org-sidebar-full } );
-		}
+		bottom: 50px;
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -74,7 +74,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     max-width: none;
     max-height: none;
     background-color: #eeeeee;
-    transform: translateZ(0);
+    transform: translateZ( 0 );
 }
 
 .page-template-modal .components-modal__header-heading-container {
@@ -342,7 +342,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	left: calc( 20% + 30px );
 	width: calc( 80% - 50px );
 	background: $template-selector-empty-background;
-	border-radius: 4px;
 	overflow-x: hidden;
 	overflow-y: auto;
 	border: solid 2px $template-selector-border-color;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -24,12 +24,6 @@ $template-large-preview-title-height: 120px;
 $wp-org-sidebar-reduced: 36px;
 $wp-org-sidebar-full: 160px;
 
-// Preview positioning
-$preview-max-width: 960px;
-$preview-right-margin: 24px;
-$preview-left-sidebar-reduced: calc( 30% + #{$wp-org-sidebar-reduced} );
-$preview-left-sidebar-full: calc( 30% + #{$wp-org-sidebar-full} );
-
 // Modal Overlay
 .page-template-modal-screen-overlay {
 	animation: none;
@@ -345,33 +339,13 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		display: none;
 	}
 
-	@media screen and ( min-width: 783px ) {
-		width: calc( 70% - 50px );
-	}
-
-	@media screen and ( min-width: 660px ) {
-		&.is-blank-preview {
-			align-items: center;
-			display: flex;
-			justify-content: center;
-		}
-	}
-
-	@media screen and ( min-width: 1648px ) {
-		right: unset;
-		left: calc( #{$preview-left-sidebar-full} + ( 100vw - #{$preview-left-sidebar-full} - #{$preview-max-width} - #{$preview-right-margin} ) / 2 );
-		body.folded & {
-			left: calc( #{$preview-left-sidebar-reduced} + ( 100vw - #{$preview-left-sidebar-reduced} - #{$preview-max-width} - #{$preview-right-margin} ) / 2 );
-		}
-	}
-
 	position: fixed;
 	top: 111px;
 	bottom: 24px;
-	right: $preview-right-margin;
-	width: calc( 80% - 50px );
+	width: calc( 70% - 75px );
+	margin-left: calc( 30% + 25px );
 	background: $template-selector-empty-background;
-	border-radius: 2px;
+	border-radius: 4px;
 	overflow-x: hidden;
 	overflow-y: auto;
 	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
@@ -444,7 +418,6 @@ body:not( .is-fullscreen-mode ) {
 // Tweak styles which are inside of the preview container.
 .block-editor-block-preview__container,
 .template-selector-preview {
-	max-width: $preview-max-width;
 
 	.editor-styles-wrapper {
 		.wp-block {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the preview so that it always is consistently aligned with the left and right edge, no matter what size the viewport is. The preview is scaled depending on the viewport size, so any width preview works well. This makes it feel more like an app and visually consistent.

Before:

<img width="1744" alt="Screen Shot 2019-11-19 at 6 05 15 PM" src="https://user-images.githubusercontent.com/1464705/69202742-5d7e9c80-0af7-11ea-8299-65d1e9bf9711.png">

After:

<img width="1760" alt="Screen Shot 2019-11-19 at 6 04 45 PM" src="https://user-images.githubusercontent.com/1464705/69202748-62435080-0af7-11ea-8910-f811cd753d9f.png">

#### Testing instructions

* Checkout the branch, and try resizing the window. The preview pane should expand to fill the width of the modal, minus the space for the preview thumbnails and never move away from the left edge.
