### PR TITLE
Add new sftp-phpmyadmin feature flag

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -19,6 +19,7 @@ import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosti
 import SFTPCard from './sftp-card';
 import PhpMyAdminCard from './phpmyadmin-card';
 import DataLossWarning from './data-loss-warning';
+import { isEnabled } from 'config';
 
 /**
  * Style dependencies
@@ -29,6 +30,17 @@ const Hosting = ( { translate, isDisabled, canViewAtomicHosting } ) => {
 	if ( ! canViewAtomicHosting ) {
 		return null;
 	}
+
+	const sftpPhpMyAdminFeatures = isEnabled( 'hosting/sftp-phpmyadmin' ) ? (
+		<>
+			<div className="hosting__cards">
+				<SFTPCard disabled={ isDisabled } />
+				<PhpMyAdminCard disabled={ isDisabled } />
+			</div>
+			{ ! isDisabled && <DataLossWarning /> }
+		</>
+	) : null;
+
 	return (
 		<Main className="hosting is-wide-layout">
 			<PageViewTracker path="/hosting-admin/:site" title="SFTP & MySQL" />
@@ -44,11 +56,7 @@ const Hosting = ( { translate, isDisabled, canViewAtomicHosting } ) => {
 					disableHref
 				/>
 			) }
-			<div className="hosting__cards">
-				<SFTPCard disabled={ isDisabled } />
-				<PhpMyAdminCard disabled={ isDisabled } />
-			</div>
-			{ ! isDisabled && <DataLossWarning /> }
+			{ sftpPhpMyAdminFeatures }
 		</Main>
 	);
 };

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -17,11 +17,11 @@ import isSiteOnAtomicPlan from 'state/selectors/is-site-on-atomic-plan';
  * TODO: this selector should be backed by an API response instead
  * Returns true if hosting section should be viewable
  *
- * @param  {Object}  state  Global state tree
- * @return {?Boolean}        Whether site can display the atomic hosting section
+ * @param  {object}  state  Global state tree
+ * @returns {?boolean}        Whether site can display the atomic hosting section
  */
 export default function canSiteViewAtomicHosting( state ) {
-	if ( ! isEnabled( 'hosting' ) ) {
+	if ( ! isEnabled( 'hosting/sftp-phpmyadmin' ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -21,7 +21,7 @@ import isSiteOnAtomicPlan from 'state/selectors/is-site-on-atomic-plan';
  * @returns {?boolean}        Whether site can display the atomic hosting section
  */
 export default function canSiteViewAtomicHosting( state ) {
-	if ( ! isEnabled( 'hosting/sftp-phpmyadmin' ) ) {
+	if ( ! isEnabled( 'hosting' ) ) {
 		return false;
 	}
 

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -37,6 +37,7 @@
 		"help/courses": true,
 		"hosting": false,
 		"hosting/non-atomic-support": false,
+		"hosting/sftp-phpmyadmin": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/personalPlan": true,

--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"help/courses": true,
 		"hosting": true,
 		"hosting/non-atomic-support": true,
+		"hosting/sftp-phpmyadmin": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -43,6 +43,7 @@
 		"help/courses": true,
 		"hosting": true,
 		"hosting/non-atomic-support": false,
+		"hosting/sftp-phpmyadmin": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,

--- a/config/production.json
+++ b/config/production.json
@@ -39,6 +39,7 @@
 		"help/courses": true,
 		"hosting": false,
 		"hosting/non-atomic-support": false,
+		"hosting/sftp-phpmyadmin": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": false,
 		"jetpack/concierge-sessions": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,6 +41,7 @@
 		"help/courses": true,
 		"hosting": false,
 		"hosting/non-atomic-support": false,
+		"hosting/sftp-phpmyadmin": false,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,

--- a/config/test.json
+++ b/config/test.json
@@ -42,6 +42,7 @@
 		"help": true,
 		"hosting": false,
 		"hosting/non-atomic-support": false,
+		"hosting/sftp-phpmyadmin": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/site-questions": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"help/courses": true,
 		"hosting": false,
 		"hosting/non-atomic-support": false,
+		"hosting/sftp-phpmyadmin": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a separate sftp-phpmyadmin feature flag so other hosting features can be pushed out independently 

#### Testing instructions

* Check out this PR and check that you can still see the sftp/mysql feature in local dev env
* Restart with `DISABLE_FEATURES=hosting/sftp-phpmyadmin npm start` and verify the the related content does not render in the section
* Restart with `DISABLE_FEATURES=hosting/sftp-phpmyadmin,hosting npm start` and verify the sidebar section does not render

Fixes #37746
