### PR TITLE
Keep Calypso alive while navigating to template parts

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -572,7 +572,7 @@ function handleCloseEditor( calypsoPort ) {
 	$( '#editor' ).on( 'click', '.edit-post-fullscreen-mode-close__toolbar a', e => {
 		e.preventDefault();
 
-		const { port1, port2 } = new MessageChannel();
+		const { port2 } = new MessageChannel();
 		calypsoPort.postMessage(
 			{
 				action: 'closeEditor',
@@ -582,15 +582,6 @@ function handleCloseEditor( calypsoPort ) {
 			},
 			[ port2 ]
 		);
-
-		// We only want to navigate back if the client tells us to.
-		// We need to give it a chance to set if the post is dirty
-		// before we can navigate away.
-		port1.onmessage = ( { data } ) => {
-			port1.close(); // We only want to recieve this once.
-			// data is the URL to which we go back:
-			window.open( data, '_top' );
-		};
 	} );
 }
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -94,6 +94,7 @@ enum EditorActions {
 	ConversionRequest = 'triggerConversionRequest',
 	OpenCustomizer = 'openCustomizer',
 	GetTemplateEditorUrl = 'getTemplateEditorUrl',
+	OpenTemplatePart = 'openTemplatePart',
 	GetCloseButtonUrl = 'getCloseButtonUrl',
 	LogError = 'logError',
 }
@@ -113,7 +114,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	conversionPort: MessagePort | null = null;
 	mediaSelectPort: MessagePort | null = null;
 	revisionsPort: MessagePort | null = null;
-	templatePorts: [ T.PostId, MessagePort ][] = [];
 	successfulIframeLoad = false;
 
 	componentDidMount() {
@@ -231,11 +231,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				//set postId on state.ui.editor.postId, so components like editor revisions can read from it
 				this.props.startEditingPost( siteId, postId );
 			}
-
-			// Update the edit template part links with the ID of the FSE parent page.
-			this.templatePorts.forEach( ( [ templateId ] ) => {
-				this.sendTemplateEditorUrl( templateId );
-			} );
 		}
 
 		if ( EditorActions.TrashPost === action ) {
@@ -270,19 +265,10 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.openCustomizer( autofocus, unsavedChanges );
 		}
 
-		if ( EditorActions.GetTemplateEditorUrl === action ) {
-			const { templateId } = payload;
-			if ( ! templateId ) {
-				return;
-			}
-			// Update the port if it already exists, otherwise add it:
-			const existingPort = this.templatePorts.findIndex( template => template[ 0 ] === templateId );
-			if ( existingPort >= 0 ) {
-				this.templatePorts[ existingPort ] = [ templateId, ports[ 0 ] ];
-			} else {
-				this.templatePorts.push( [ templateId, ports[ 0 ] ] );
-			}
-			this.sendTemplateEditorUrl( templateId );
+		if ( EditorActions.OpenTemplatePart === action ) {
+			const { templatePartId, unsavedChanges } = payload;
+			const templatePartUrl = this.getTemplateEditorUrl( templatePartId );
+			this.navigate( templatePartUrl, unsavedChanges );
 		}
 
 		if ( EditorActions.GetCloseButtonUrl === action ) {
@@ -321,29 +307,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			show_on_front: 'page',
 			page_on_front: editedPostId,
 		} );
-	};
-
-	onCloseEditor = ( hasUnsavedChanges: boolean, messagePort: MessagePort ) => {
-		const { closeUrl } = this.props;
-
-		if ( hasUnsavedChanges ) {
-			this.props.markChanged();
-		} else {
-			this.props.markSaved();
-		}
-
-		if ( this.shouldDoServerBackNav() ) {
-			messagePort.postMessage( `${ window.location.origin }${ closeUrl }` );
-		} else {
-			this.props.navigate( closeUrl );
-		}
-	};
-
-	// If we are on a template part and have a parent page
-	// ID, we want to do a server nav back to that page.
-	shouldDoServerBackNav = () => {
-		const { fseParentPageId, postType } = this.props;
-		return null != fseParentPageId && 'wp_template_part' === postType;
 	};
 
 	loadRevision = ( {
@@ -482,12 +445,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				customizerUrl
 			);
 		}
-		if ( unsavedChanges ) {
-			this.props.markChanged();
-		} else {
-			this.props.markSaved();
-		}
-		this.props.navigate( customizerUrl );
+		this.navigate( customizerUrl, unsavedChanges );
 	};
 
 	getTemplateEditorUrl = ( templateId: T.PostId ) => {
@@ -505,7 +463,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		const { markChanged, markSaved } = this.props;
 		unsavedChanges ? markChanged() : markSaved();
 		this.props.navigate( navUrl );
-	}
+	};
 
 	handleConversionResponse = ( confirmed: boolean ) => {
 		this.setState( { isConversionPromptVisible: false } );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -246,7 +246,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 		if ( EditorActions.CloseEditor === action || EditorActions.GoToAllPosts === action ) {
 			const { unsavedChanges = false } = payload;
-			this.onCloseEditor( unsavedChanges, ports[ 0 ] );
+			this.navigate( this.props.closeUrl, unsavedChanges );
 		}
 
 		if ( EditorActions.OpenRevisions === action ) {
@@ -501,13 +501,11 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		return templateEditorUrl;
 	};
 
-	sendTemplateEditorUrl = ( templateId: T.PostId ) => {
-		const templateEditorUrl = this.getTemplateEditorUrl( templateId );
-		const port = this.templatePorts.find(
-			( [ portTemplateId ] ) => portTemplateId === templateId
-		)[ 1 ];
-		port.postMessage( `${ window.location.origin }${ templateEditorUrl }` );
-	};
+	navigate = ( navUrl: string, unsavedChanges: boolean ) => {
+		const { markChanged, markSaved } = this.props;
+		unsavedChanges ? markChanged() : markSaved();
+		this.props.navigate( navUrl );
+	}
 
 	handleConversionResponse = ( confirmed: boolean ) => {
 		this.setState( { isConversionPromptVisible: false } );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -172,6 +172,7 @@ export const post = ( context, next ) => {
 
 	context.primary = (
 		<CalypsoifyIframe
+			key={ postId }
 			postId={ postId }
 			postType={ postType }
 			duplicatePostId={ duplicatePostId }


### PR DESCRIPTION
### Goals
1. Stop destroying the calypso navigation context when we navigate to/from the template part. This caused a bug where you would always be taken back to the "all pages" list, even if you started elsewhere, like customer home. This happened as long as you went into the template editor.
2. Improve performance. We are no longer loading all of calypso every time we transition between the page editor and template parts, just the stuff inside the iFrame.
3. A great accidental result here is that it should be more obvious what the code does, and simpler to work on in the future.

### Changes proposed in this Pull Request
* Add a `key` prop to the Iframe so that it resets if we start editing a different post.
* Remove code which updates the hrefs of the header/footer links.
* Remove code which does a server-side navigation if navigating to/from template pats.
* Introduce a handler which, on clicking "edit header/footer", sends a message to the Calypso code, which does a client-side navigation to/from the template part.

#### Testing instructions
1. Pull this and build it on calypso.localhost
2. Sync the latest and greatest FSE changes to your sandbox.
2. Sync the bridge server code (D35795-code) and sandbox `widgets.wp.com`
3. Navigate between the page editor and the template part editor and smoke test that everything works properly (especially making sure the URL in the browser nav bar matches the editor you are looking at).
4. Test creating pages/posts.
5. Test navigation in the post editor without FSE.

#### Test back button
1. From customer home on a site with FSE, try clicking "add a page"
<img width="757" alt="Screen Shot 2019-11-22 at 2 34 53 PM" src="https://user-images.githubusercontent.com/6265975/69465184-4927e300-0d35-11ea-8230-8384e364bcc4.png">

2. Choose a layout and publish the page
3. Edit the header.
4. Click the template part back button
5. Click the page back button. (it should be like "< Home" if you synced FSE)
6. You should end up at customer home.

Fixes #37840