### PR TITLE
Use passwordless signup in test-fse flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -186,12 +186,12 @@ class SignupForm extends Component {
 		return userExistsError;
 	}
 
-	/***
+	/**
 	 * If the step is invalid because we had an error that the user exists,
 	 * we should prompt user with a request to connect his social account
 	 * to his existing WPCOM account
 	 *
-	 * @param {Object} props react component props that has step info
+	 * @param {object} props react component props that has step info
 	 */
 	maybeRedirectToSocialConnect( props ) {
 		const userExistsError = this.getUserExistsError( props );
@@ -956,8 +956,8 @@ class SignupForm extends Component {
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
 		if (
-			this.props.flowName === 'onboarding' &&
-			'passwordless' === abtest( 'passwordlessSignup' )
+			this.props.flowName === 'test-fse' ||
+			( this.props.flowName === 'onboarding' && 'passwordless' === abtest( 'passwordlessSignup' ) )
 		) {
 			const logInUrl = config.isEnabled( 'login/native-login-links' )
 				? this.getLoginLink()

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -229,7 +229,7 @@ export default class SignupFlowController {
 	/**
 	 * Returns a list of the dependencies provided in the flow configuration.
 	 *
-	 * @return {array} a list of dependency names
+	 * @returns {Array} a list of dependency names
 	 */
 	_getFlowProvidesDependencies() {
 		return flatMap(
@@ -307,9 +307,10 @@ export default class SignupFlowController {
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
 		if (
-			'onboarding' === this._flowName &&
-			get( step, 'isPasswordlessSignupForm' ) &&
-			'passwordless' === abtest( 'passwordlessSignup' )
+			( 'test-fse' === this._flowName && get( step, 'isPasswordlessSignupForm' ) ) ||
+			( 'onboarding' === this._flowName &&
+				get( step, 'isPasswordlessSignupForm' ) &&
+				'passwordless' === abtest( 'passwordlessSignup' ) )
 		) {
 			this._processingSteps.delete( step.stepName );
 			analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -33,7 +33,6 @@ import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { resetSignup, updateDependencies } from 'state/signup/actions';
 import { completeSignupStep, invalidateStep, processStep } from 'state/signup/progress/actions';
-import { abtest } from 'lib/abtest';
 
 interface Dependencies {
 	[ other: string ]: any;
@@ -302,16 +301,12 @@ export default class SignupFlowController {
 		/*
 			AB Test: passwordlessSignup
 
-			`isPasswordlessSignupForm` in this check is for the `onboarding` flow.
+			`isPasswordlessSignupForm` is set by the PasswordlessSignupForm.
 
-			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
+			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow.
+			For passwordless signups, the API call has already occurred in the PasswordlessSignupForm, so here it is skipped.
 		*/
-		if (
-			( 'test-fse' === this._flowName && get( step, 'isPasswordlessSignupForm' ) ) ||
-			( 'onboarding' === this._flowName &&
-				get( step, 'isPasswordlessSignupForm' ) &&
-				'passwordless' === abtest( 'passwordlessSignup' ) )
-		) {
+		if ( get( step, 'isPasswordlessSignupForm' ) ) {
 			this._processingSteps.delete( step.stepName );
 			analytics.tracks.recordEvent( 'calypso_signup_actions_complete_step', {
 				step: step.stepName,


### PR DESCRIPTION
This PR is split out from #37565 

Update the `test-fse` signup flow to use the passwordless signup form instead of the default form for the `user` step.

#### Changes proposed in this Pull Request

* Updates the `test-fse` flow to use the passwordless signup form by:
  - Checking for the `test-fse` flow name in the SignupForm component
* Removes A/B test and flow name checks from the `isPasswordlessSignupForm` step property check in the flow controller. This ensures that if a passwordless signup form has been submitted, the `apiFunction` call will definitely be skipped in the flow controller's `_processStep` method — this way we can safely use the passwordless signup outside of the `onboarding` flow and A/B tests where we choose to, without accidentally breaking the flow controller.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before each of the following steps, ensure you are logged out / in an Incognito window:

1. Ensure standard signup experience from `/start` _passwordful_ works as normal and create a new site
2. Go to `/start` and select the `passwordless` variant of the `passwordlessSignup` A/B test. Create a passwordless account and complete site creation.
3. Go to `/start/test-fse` and you should be presented with the passwordless signup step. Complete the signup flow and a new account and site should be created as expected.
