### PR TITLE
Allow passwordless signup to work for sandboxed signups

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -134,7 +134,7 @@ class PasswordlessSignupForm extends Component {
 		analytics.identifyUser( { ID: userId, username, email: this.state.email } );
 
 		this.submitStep( {
-			username: response.username,
+			username,
 			bearer_token: response.bearer_token,
 		} );
 	};

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -655,24 +655,6 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 }
 
 /**
- * Creates a user account using an email only and logs them in immediately.
- * It differs from `createPasswordlessUser` in that we don't require a verification step before the user can continue with onboarding.
- * Returns the dependencies for the step.
- *
- * @param {Function} callback API callback function
- * @param {object}   data     An object sent via POST to WPCOM API with the following values: `email`
- */
-export function createUserAccountFromEmailAddress( callback, { email } ) {
-	wpcom
-		.undocumented()
-		.createUserAccountFromEmailAddress( { email }, null )
-		.then( response =>
-			callback( null, { username: response.username, bearer_token: response.token.access_token } )
-		)
-		.catch( err => callback( err ) );
-}
-
-/**
  * Creates a user account and sends the user a verification code via email to confirm the account.
  * Returns the dependencies for the step.
  *

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1412,26 +1412,6 @@ Undocumented.prototype.usersEmailNew = function( query, fn ) {
 };
 
 /**
- * Sign up for a new user account and login immediately
- * Onboard a new user
- *
- * @param {object} query - an object with the following values: email
- * @param {Function} fn - Function to invoke when request is complete
- */
-Undocumented.prototype.createUserAccountFromEmailAddress = function( query, fn ) {
-	debug( '/users/email/onboard' );
-
-	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( query );
-
-	const args = {
-		path: '/users/email/onboard',
-		body: query,
-	};
-	return this.wpcom.req.post( args, fn );
-};
-
-/**
  * Verify a new passwordless user account
  *
  * @param {object} query - an object with the following values: email, code


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow passwordless signup to use sandboxed signups by saving the user step with the `signup_sandbox_username` if it exists in the response from the server
* Remove no-longer used `createUserAccountFromEmailAddress` functions (no longer needed due to: https://github.com/Automattic/wp-calypso/pull/37502

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Sandboxed signups

* Set sandbox to use sandboxed signups with an existing account
* Go to `/start` and select the `passwordless` variant of the `passwordlessSignup` A/B test
* Complete signup and create a site
* The site should be created (and not stuck on the `Awesome...` loading screen)
* The site should be added to your existing user account

---

##### Unsandboxed signups

* Ensure that you are not sandboxed
* Go to `/start` and select the `passwordless` variant of the `passwordlessSignup` A/B test
* Complete signup and create a site
* The site should be created (and not stuck on the `Awesome...` loading screen)
* The site should be added to a new user account as expected