### PR TITLE
People Management: Update message under`Invite User` option to make it more clear

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -342,7 +342,7 @@ class InvitePeople extends React.Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'If the user has an existing WordPress.com account, add their username. Otherwise, add their Email ID to send them an invite. You can add up to 10 people at a time.'
+									'If the user has an existing WordPress.com account, add their username. Otherwise, add their email address to send them an invite. You can add up to 10 people at a time.'
 								) }
 							</FormSettingExplanation>
 						</div>

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -342,7 +342,7 @@ class InvitePeople extends React.Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'Enter up to 10 WordPress.com usernames or email addresses at a time.'
+									'If the user has an existing WordPress.com account, add their username. Otherwise, add their Email ID to send them an invite. You can add up to 10 people at a time.'
 								) }
 							</FormSettingExplanation>
 						</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the message a user sees when inviting other users to their site.

<table>
<tr>
<td>Before:
<br><br>

![36842-before](https://user-images.githubusercontent.com/3323310/69226791-561cc900-0bb3-11ea-88a8-98276d1f96fd.png)

</td>
<td>After:
<br><br>

![36842-after](https://user-images.githubusercontent.com/3323310/69226797-5917b980-0bb3-11ea-8fc3-a6b792384095.png)

</td>
</tr>
</table>

#### Testing instructions

* Go to https://wordpress.com/people/new/{SITE}

Fixes #36842 
