### PR TITLE
e2e: Double timeout waiting for gutenberg editor

### DIFF
--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -104,6 +104,9 @@ export default class LoginFlow {
 		usingGutenberg = false,
 		{ useFreshLogin = false } = {}
 	) {
+		if ( usingGutenberg ) {
+			this.timeout( 40000 );
+		}
 		if (
 			siteURL ||
 			( host !== 'WPCOM' && this.account.legacyAccountName !== 'jetpackConnectUser' )


### PR DESCRIPTION
We've been observing test failures timeout waiting for the Gutenberg editor. Increase timeout.