### PR TITLE
Gutenboarding: Implement shortcut locally, drop @wordpress/edit-post

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -3,9 +3,9 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Icon, IconButton } from '@wordpress/components';
+import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 import React from 'react';
-import shortcuts from '@wordpress/edit-post/build-module/keyboard-shortcuts';
 import { isEmpty } from 'lodash';
 
 /**
@@ -14,6 +14,14 @@ import { isEmpty } from 'lodash';
 import { STORE_KEY } from '../../stores/onboard';
 import './style.scss';
 import { DomainPickerButton } from '../domain-picker';
+
+// Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
+// to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
+const toggleSidebarShortcut = {
+	raw: rawShortcut.primaryShift( ',' ),
+	display: displayShortcut.primaryShift( ',' ),
+	ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
+};
 
 interface Props {
 	isEditorSidebarOpened: boolean;
@@ -51,7 +59,7 @@ export default function Header( { isEditorSidebarOpened, toggleGeneralSidebar }:
 					onClick={ toggleGeneralSidebar }
 					isToggled={ isEditorSidebarOpened }
 					aria-expanded={ isEditorSidebarOpened }
-					shortcut={ shortcuts.toggleSidebar }
+					shortcut={ toggleSidebarShortcut }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Gutenboarding: Implement shortcut info locally, drop `@wordpress/edit-post`

Should decrease bundle size, since we no longer depend on `@wordpress/edit-post`.

#### Testing instructions

- Go to `http://calypso.localhost:3000/gutenboarding`
- _In theory_, you should be able to type `,` (comma) to toggle the sidebar. However, this has never worked so it's not a regression :grimacing: Let's keep this one small and iterate to implement that kind of behavior.

Edit: This component might be relevant for a follow-up PR that implements the actual shortcut: https://developer.wordpress.org/block-editor/components/keyboard-shortcuts/
