### PR TITLE
Gutenboarding: Localize verticals API

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -98,10 +98,12 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 	];
 
 	const suggestions = ! inputValue.length
-		? popular.map( label => ( {
-				...verticals.find( vertical => vertical.label.includes( label ) ),
-				category: NO__( 'Popular' ),
-		  } ) )
+		? popular
+				.map( label => ( {
+					...verticals.find( vertical => vertical.label.includes( label ) ),
+					category: NO__( 'Popular' ),
+				} ) )
+				.filter( x => Object.prototype.hasOwnProperty.call( x, 'label' ) )
 		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
 
 	const label = NO__( 'My site is about' );

--- a/client/landing/gutenboarding/stores/onboard/resolvers.ts
+++ b/client/landing/gutenboarding/stores/onboard/resolvers.ts
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
  */
 import { receiveVerticals } from './actions';
+import { getLanguage } from 'lib/i18n-utils';
 
 /**
  * Fetch verticals from the verticals endpoint.
@@ -21,7 +23,24 @@ import { receiveVerticals } from './actions';
  */
 export function* getVerticals() {
 	const url = 'https://public-api.wordpress.com/wpcom/v2/verticals';
-	const verticals = yield apiFetch( { url } );
+	let locale;
+	if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
+		for ( const langSlug of navigator.languages ) {
+			const language = getLanguage( langSlug.toLowerCase() );
+			if ( language ) {
+				locale = language.langSlug;
+				break;
+			}
+		}
+	}
+
+	let localeQueryParam;
+	if ( locale && locale !== 'en' ) {
+		// v2 api request
+		localeQueryParam = { _locale: locale };
+	}
+
+	const verticals = yield apiFetch( { url: addQueryArgs( url, localeQueryParam ) } );
 
 	// @TODO: validate and normalize verticals?
 


### PR DESCRIPTION
Partially implementing: #37630 

Get localized verticals result based on browser locale.

#### Testing instructions

Go to http://calypso.localhost:3000/gutenboarding while having different languages set as primary in the browser and search for verticals.

Spanish:
![Screenshot 2019-11-20 at 12 29 52](https://user-images.githubusercontent.com/14192054/69231896-9cadfb80-0b92-11ea-8675-58a38a04da7a.png)

German:
![Screenshot 2019-11-20 at 12 12 15](https://user-images.githubusercontent.com/14192054/69231916-a6cffa00-0b92-11ea-8741-bde682aea9c8.png)

#### Follow up

- extract or use an alternative for `getLanguage` which is now imported from `lib/i18n-utils`
- get details of an existing user session if available 
