### PR TITLE
Gutenboarding: Persist empty form values

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 enum ActionType {
 	RECEIVE_VERTICALS = 'RECEIVE_VERTICALS',
@@ -24,10 +24,10 @@ export interface SiteVertical {
 	id: string;
 }
 
-export const EMPTY_FORM_VALUE = Object.freeze( {} );
+export const EMPTY_FORM_VALUE = Object.freeze( { __EFV__: '__EFV__' } );
 export type FormValue< T > = T | typeof EMPTY_FORM_VALUE;
 export function isFilledFormValue< T >( value: FormValue< T > ): value is T {
-	return value !== EMPTY_FORM_VALUE && ! isEmpty( value );
+	return value !== EMPTY_FORM_VALUE && ! isShallowEqual( value, EMPTY_FORM_VALUE );
 }
 
 /**

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
 enum ActionType {
 	RECEIVE_VERTICALS = 'RECEIVE_VERTICALS',
 	RESET_SITE_TYPE = 'RESET_SITE_TYPE',
@@ -22,7 +27,7 @@ export interface SiteVertical {
 export const EMPTY_FORM_VALUE = Object.freeze( {} );
 export type FormValue< T > = T | typeof EMPTY_FORM_VALUE;
 export function isFilledFormValue< T >( value: FormValue< T > ): value is T {
-	return value !== EMPTY_FORM_VALUE;
+	return value !== EMPTY_FORM_VALUE && ! isEmpty( value );
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3685,6 +3685,12 @@
 			"integrity": "sha512-YD/Zh/rof9gAypXXKpfKHOe8w4+deohqwC04q9dt01AyZwSviOFY8mfpa+0gR4t1eyZiYKI8g/Gv6D2ccmYs9g==",
 			"dev": true
 		},
+		"@types/wordpress__is-shallow-equal": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__is-shallow-equal/-/wordpress__is-shallow-equal-1.4.0.tgz",
+			"integrity": "sha512-UsmnPfa2LzzQmLqOTVo0WPc4eWHYkIxcxKk6u8y9tymCfo/6zzDK34gAP2r/BQDcgJPO0h8h5KAtcbAXf+bOFg==",
+			"dev": true
+		},
 		"@types/wordpress__keycodes": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@types/wordpress__keycodes/-/wordpress__keycodes-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"@wordpress/element": "2.9.0",
 		"@wordpress/format-library": "1.10.0",
 		"@wordpress/i18n": "3.7.0",
+		"@wordpress/is-shallow-equal": "1.6.1",
 		"@wordpress/keycodes": "2.7.0",
 		"@wordpress/notices": "1.9.0",
 		"@wordpress/nux": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -327,6 +327,7 @@
 		"@types/wordpress__editor": "9.4.1",
 		"@types/wordpress__element": "2.4.0",
 		"@types/wordpress__i18n": "3.4.0",
+		"@types/wordpress__is-shallow-equal": "1.4.0",
 		"@types/wordpress__keycodes": "2.3.0",
 		"@types/wordpress__url": "2.3.0",
 		"@typescript-eslint/eslint-plugin": "2.7.0",


### PR DESCRIPTION
Value coming from persist is different than `EMPTY_FORM_VALUE` so it isn't considered 'empty'.

#### Changes proposed in this Pull Request

- Add `isEmpty` check to isFilledFormValue.

#### Testing instructions

**Before**:
![Screenshot 2019-11-20 at 12 47 47](https://user-images.githubusercontent.com/14192054/69232641-24e0d080-0b94-11ea-9721-4046c0ac9f2f.png)

**After**:
![Screenshot 2019-11-20 at 12 47 51](https://user-images.githubusercontent.com/14192054/69232655-28745780-0b94-11ea-8262-a5ebeea968c9.png)

#### Alternatives

- find a way to persist only values that are not empty
