### PR TITLE
Gutenboarding: Add Keyboard Shortcut to Toggle Sidebar

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -3,7 +3,6 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Icon, IconButton } from '@wordpress/components';
-import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
 
@@ -15,20 +14,23 @@ import './style.scss';
 import { DomainPickerButton } from '../domain-picker';
 import { isFilledFormValue } from '../../stores/onboard/types';
 
-// Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
-// to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
-const toggleSidebarShortcut = {
-	raw: rawShortcut.primaryShift( ',' ),
-	display: displayShortcut.primaryShift( ',' ),
-	ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
-};
-
 interface Props {
 	isEditorSidebarOpened: boolean;
 	toggleGeneralSidebar: () => void;
+	toggleSidebarShortcut: KeyboardShortcut;
 }
 
-const Header: FunctionComponent< Props > = ( { isEditorSidebarOpened, toggleGeneralSidebar } ) => {
+interface KeyboardShortcut {
+	raw: string;
+	display: string;
+	ariaLabel: string;
+}
+
+const Header: FunctionComponent< Props > = ( {
+	isEditorSidebarOpened,
+	toggleGeneralSidebar,
+	toggleSidebarShortcut,
+} ) => {
 	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -71,10 +71,7 @@ const Header: FunctionComponent< Props > = ( {
 						isToggled={ isEditorSidebarOpened }
 						label={ NO__( 'Site block settings' ) }
 						onClick={ toggleGeneralSidebar }
-						shortcut={
-							/* @TODO: this shortcut based on Gutenberg doesn't seem to be handled at this time. */
-							toggleSidebarShortcut
-						}
+						shortcut={ toggleSidebarShortcut }
 					/>
 				</div>
 			</div>

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -48,9 +48,7 @@ const onboardingBlock = createBlock( name, {} );
 export function Gutenboard() {
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );
 
-	function toggleGeneralSidebar() {
-		updateIsEditorSidebarOpened( ! isEditorSidebarOpened );
-	}
+	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -9,7 +9,12 @@ import {
 	WritingFlow,
 	ObserveTyping,
 } from '@wordpress/block-editor';
-import { Popover, SlotFillProvider, DropZoneProvider } from '@wordpress/components';
+import {
+	Popover,
+	SlotFillProvider,
+	DropZoneProvider,
+	KeyboardShortcuts,
+} from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
 import classnames from 'classnames';
@@ -48,6 +53,12 @@ export function Gutenboard() {
 							'is-sidebar-opened': isEditorSidebarOpened,
 						} ) }
 					>
+						<KeyboardShortcuts
+							bindGlobal
+							shortcuts={ {
+								'mod+shift+,': toggleGeneralSidebar,
+							} }
+						/>
 						<Header
 							isEditorSidebarOpened={ isEditorSidebarOpened }
 							toggleGeneralSidebar={ toggleGeneralSidebar }

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -16,6 +16,7 @@ import {
 	KeyboardShortcuts,
 } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
+import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useState } from 'react';
@@ -31,6 +32,14 @@ import SettingsSidebar from './components/settings-sidebar';
 import './stores/domain-suggestions';
 import './stores/onboard';
 import './style.scss';
+
+// Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
+// to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
+const toggleSidebarShortcut = {
+	raw: rawShortcut.primaryShift( ',' ),
+	display: displayShortcut.primaryShift( ',' ),
+	ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
+};
 
 registerBlockType( name, settings );
 
@@ -56,12 +65,13 @@ export function Gutenboard() {
 						<KeyboardShortcuts
 							bindGlobal
 							shortcuts={ {
-								'mod+shift+,': toggleGeneralSidebar,
+								[ toggleSidebarShortcut.raw ]: toggleGeneralSidebar,
 							} }
 						/>
 						<Header
 							isEditorSidebarOpened={ isEditorSidebarOpened }
 							toggleGeneralSidebar={ toggleGeneralSidebar }
+							toggleSidebarShortcut={ toggleSidebarShortcut }
 						/>
 						<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
 							<div className="edit-post-layout__content">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Gutenboarding: Add Keyboard Shortcut to Toggle Sidebar

Follow-up from #37754. Use the [`<KeyboardShortcuts />` component](https://developer.wordpress.org/block-editor/components/keyboard-shortcuts/) to implement this.

#### Testing instructions

- Go to `http://calypso.localhost:3000/gutenboarding`
- Type <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> on non-Mac) to toggle the sidebar. 

#### Known issues

Shortcut only works to display the sidebar but doesn't hide it :confused: 

#### Questions

Is this a good place for the `<KeyboardShortcuts />` component? Should it go somewhere else?

#### Follow-up

Remove `BlockEditorKeyboardShortcuts` since those are block-editor specific (insert/remove blocks, select all), which doesn't make sense for Gutenboarding.