### PR TITLE
Gutenboarding: Remove BlockEditorKeyboardShortcuts

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -4,7 +4,6 @@
 import '@wordpress/editor'; // This shouldn't be necessary
 import { __ } from '@wordpress/i18n';
 import {
-	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
 	WritingFlow,
@@ -55,7 +54,6 @@ export function Gutenboard() {
 						/>
 						<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
 							<div className="edit-post-layout__content">
-								<BlockEditorKeyboardShortcuts />
 								<div
 									className="edit-post-visual-editor editor-styles-wrapper"
 									role="region"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove [`<BlockEditorKeyboardShortcuts />`](https://github.com/WordPress/gutenberg/blob/39f568faf2e62c57736bb80d7088a996eb067944/packages/block-editor/src/components/block-editor-keyboard-shortcuts/index.js) since those are block-editor specific (insert/remove blocks, select all), which doesn't make sense for Gutenboarding.

Props @simison 

Follow-up from #37758

#### Testing instructions

http://calypso.localhost:3000/gutenboarding still works?
