### PR TITLE
Match ProductCard title size to other titles and improve header layout

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -20,6 +20,7 @@
 
 	@include breakpoint( '>660px' ) {
 		display: flex;
+		flex-flow: row wrap;
 		align-items: baseline;
 	}
 }
@@ -38,7 +39,7 @@
 .product-card__header-primary {
 	display: flex;
 	padding-top: 16px;
-	padding-bottom: 8px;
+	padding-bottom: 4px;
 
 	@include breakpoint( '>480px' ) {
 		padding-top: 24px;
@@ -46,8 +47,7 @@
 
 	@include breakpoint( '>660px' ) {
 		flex-grow: 1;
-		padding-top: 12px;
-		padding-bottom: 0;
+		padding-top: 16px;
 	}
 
 	.gridicon {
@@ -71,16 +71,22 @@
 	}
 
 	@include breakpoint( '>660px' ) {
-		padding-bottom: 12px;
+		padding-bottom: 16px;
+	}
+
+	.is-purchased & {
+		@include breakpoint( '>660px' ) {
+			padding-left: 40px;
+		}
 	}
 }
 
 .product-card__title {
-	font-size: 22px;
+	font-size: 20px;
 	line-height: 24px;
 
-	@include breakpoint( '>660px' ) {
-		font-size: 17px;
+	@include breakpoint( '>960px' ) {
+		font-size: 22px;
 	}
 
 	em,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the `ProductCard` title size to 20px on small screens and 22px on large screens to match plan titles size in the grid below.
* In case the product name and price group in header don't fit in a single line, break into two lines gracefully. 

**Before**
![Screen Shot on 2019-11-20 at 14-34-05](https://user-images.githubusercontent.com/478735/69243259-fb7b7100-0ba2-11ea-9700-cfd7bcb1c350.png)

**After**
![Screen Shot on 2019-11-20 at 14-34-45](https://user-images.githubusercontent.com/478735/69243263-fdddcb00-0ba2-11ea-837d-561fda86a484.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/devdocs/design/product-card
* Confirm that the product name (card title) matches the size of plan titles found in plans grid (http://calypso.localhost:3000/plans/)
* Confirm that the price group moves to a second line in the header if there's not enough horizontal space (e.g. resize the window)

Fixes n/a
