### PR TITLE
Change links color in the product card to match other links on the page

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -1,14 +1,3 @@
-// Placeholder selectors
-%product-card-link-plain {
-	color: var( --color-link-light );
-
-	&:hover,
-	&:focus,
-	&:active {
-		color: var( --color-link-dark );
-	}
-}
-
 // Header
 .product-card__header {
 	margin: -16px -16px 16px;
@@ -104,10 +93,6 @@
 	line-height: 20px;
 	font-style: italic;
 	color: var( --color-text-subtle );
-
-	a {
-		@extend %product-card-link-plain;
-	}
 }
 
 // Price group
@@ -203,10 +188,6 @@
 	font-size: 14px;
 	line-height: 20px;
 	color: var( --color-text-subtle );
-
-	a:not( .button ) {
-		@extend %product-card-link-plain;
-	}
 
 	p:last-child {
 		margin: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change links color in the product card to match other links on the page

**Before**
![Screen Shot on 2019-11-20 at 14-37-32](https://user-images.githubusercontent.com/478735/69243610-b99efa80-0ba3-11ea-8df4-00c60d047c80.png)

**After**
![Screen Shot on 2019-11-20 at 14-38-02](https://user-images.githubusercontent.com/478735/69243617-bc99eb00-0ba3-11ea-9658-96c1fae7d10f.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/devdocs/design/product-card
* Confirm that the link colors match other link colors in Calypso (should be `color: #2271b1;; var( --color-link );`).

Fixes n/a
