### PR TITLE
StatsBanners: Make primary button display conditional

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -111,7 +111,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 						<div className="google-my-business-stats-nudge__button-row">
 							<Button
 								href={ `/google-my-business/${ this.props.siteSlug }` }
-								primary
+								primary={ this.props.primaryButton }
 								onClick={ this.onStartNowClick }
 							>
 								{ this.props.translate( 'Start Now' ) }

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -119,7 +119,11 @@ class GSuiteStatsNudge extends Component {
 							</p>
 						}
 						<div className="gsuite-stats-nudge__button-row">
-							<Button href={ url } primary onClick={ this.onStartNowClick }>
+							<Button
+								href={ url }
+								primary={ this.props.primaryButton }
+								onClick={ this.onStartNowClick }
+							>
 								{ translate( 'Get G Suite' ) }
 							</Button>
 						</div>

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -92,7 +92,7 @@ class UpworkBanner extends PureComponent {
 						"We've partnered with Upwork, a network of freelancers with a huge pool of WordPress experts. They know their stuff and they're waiting to help you build your dream site."
 					) }
 				</p>
-				<Button className="upwork-banner__cta" compact primary>
+				<Button className="upwork-banner__cta" compact primary={ this.props.primaryButton }>
 					{ translate( 'Find your expert' ) }
 				</Button>
 				<Button className="upwork-banner__close" onClick={ this.onDismissClick }>

--- a/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
+++ b/client/blocks/upwork-banner/test/__snapshots__/index.js.snap
@@ -25,7 +25,7 @@ exports[`UpworkBanner renders correctly 1`] = `
     We've partnered with Upwork, a network of freelancers with a huge pool of WordPress experts. They know their stuff and they're waiting to help you build your dream site.
   </p>
   <button
-    className="button upwork-banner__cta is-compact is-primary"
+    className="button upwork-banner__cta is-compact"
     type="button"
   >
     Find your expert

--- a/client/blocks/upwork-stats-nudge/index.js
+++ b/client/blocks/upwork-stats-nudge/index.js
@@ -113,7 +113,7 @@ class UpworkStatsNudge extends Component {
 						<div className="upwork-stats-nudge__button-row">
 							<Button
 								href={ '/experts/upwork?source=stat-banner' }
-								primary
+								primary={ this.props.primaryButton }
 								onClick={ this.onStartNowClick }
 								target="_blank"
 								rel="noopener noreferrer"

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -222,7 +222,14 @@ class Home extends Component {
 	}
 
 	render() {
-		const { translate, canUserUseCustomerHome, siteSlug, siteId } = this.props;
+		const {
+			translate,
+			canUserUseCustomerHome,
+			siteSlug,
+			siteId,
+			isChecklistComplete,
+			siteIsUnlaunched,
+		} = this.props;
 
 		if ( ! canUserUseCustomerHome ) {
 			const title = translate( 'This page is not available on this site.' );
@@ -242,7 +249,11 @@ class Home extends Component {
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				<SidebarNavigation />
 				{ this.renderCustomerHomeHeader() }
-				<StatsBanners siteId={ siteId } slug={ siteSlug } />
+				<StatsBanners
+					siteId={ siteId }
+					slug={ siteSlug }
+					primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }
+				/>
 				{ renderChecklistCompleteBanner && (
 					<Banner
 						dismissPreferenceName="checklist-complete"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -169,7 +169,9 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<div id="my-stats-content">
-					{ ! isCustomerHomeEnabled && <StatsBanners siteId={ siteId } slug={ slug } /> }
+					{ ! isCustomerHomeEnabled && (
+						<StatsBanners siteId={ siteId } slug={ slug } primaryButton={ true } />
+					) }
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
 						activeLegend={ this.state.activeLegend }

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -63,27 +63,35 @@ class StatsBanners extends Component {
 	}
 
 	renderGoogleMyBusinessBanner() {
-		const { isGoogleMyBusinessStatsNudgeVisible, siteId, slug } = this.props;
+		const { isGoogleMyBusinessStatsNudgeVisible, siteId, slug, primaryButton } = this.props;
 
 		return (
 			<GoogleMyBusinessStatsNudge
 				siteSlug={ slug }
 				siteId={ siteId }
 				visible={ isGoogleMyBusinessStatsNudgeVisible }
+				primaryButton={ primaryButton }
 			/>
 		);
 	}
 
 	renderGSuiteBanner() {
-		const { gsuiteDomainName, siteId, slug } = this.props;
+		const { gsuiteDomainName, siteId, slug, primaryButton } = this.props;
 
-		return <GSuiteStatsNudge siteSlug={ slug } siteId={ siteId } domainSlug={ gsuiteDomainName } />;
+		return (
+			<GSuiteStatsNudge
+				siteSlug={ slug }
+				siteId={ siteId }
+				domainSlug={ gsuiteDomainName }
+				primaryButton={ primaryButton }
+			/>
+		);
 	}
 
 	renderUpworkBanner() {
-		const { siteId, slug } = this.props;
+		const { siteId, slug, primaryButton } = this.props;
 
-		return <UpworkStatsNudge siteSlug={ slug } siteId={ siteId } />;
+		return <UpworkStatsNudge siteSlug={ slug } siteId={ siteId } primaryButton={ primaryButton } />;
 	}
 
 	showGoogleMyBusinessBanner() {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Avoid showing multiple primary actions on Customer Home by adding a `primaryButton` prop to the `StatsBanners` component. This applies to Gsuite, Google My Business, and Upwork upsells.
* Only show `StatsBanners` with primary buttons if a site has a complete checklist and is launched.
* Always show primary buttons when `StatsBanners` are shown on the Stats page.

**Before**
<img width="1140" alt="69248488-3d83c300-0b61-11ea-8f1e-5542d5e0e191" src="https://user-images.githubusercontent.com/2124984/69250116-176c1c00-0b7d-11ea-9f3f-6c610a9adcea.png">

**After**

<img width="1094" alt="Screen Shot 2019-11-20 at 9 57 59 AM" src="https://user-images.githubusercontent.com/2124984/69250104-10450e00-0b7d-11ea-8836-ef05864c393b.png">

#### Testing instructions

* Switch to this PR and start a new account through `/start/`
* Finish signup and checking out. You should be brought to Customer Home. The only primary action should be on the Checklist (button reading "Start").

Fixes #37767
