### PR TITLE
Composite checkout: add delete buttons to review

### DIFF
--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -100,7 +100,7 @@ function getBoxShadowHover( props ) {
 }
 
 function getBorderWeight( { buttonState } ) {
-	return buttonState === 'text-button' ? '0' : '1px';
+	return buttonState === 'text-button' || buttonState === 'borderless' ? '0' : '1px';
 }
 
 function getRollOverColor( { buttonState, buttonType, theme } ) {
@@ -119,6 +119,8 @@ function getRollOverColor( { buttonState, buttonType, theme } ) {
 		case 'disabled':
 			return colors.disabledPaymentButtons;
 		case 'text-button':
+			return 'none';
+		case 'borderless':
 			return 'none';
 		default:
 			return colors.highlight;

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -112,7 +112,8 @@ const CheckoutModalContent = styled.div`
 	background: ${props => props.theme.colors.surface};
 	display: block;
 	width: 100%;
-	max-width: 300px;
+	max-width: 350px;
+	border: 1px solid ${props => props.theme.colors.borderColorLight};
 	padding: 32px;
 	animation: ${animateIn} 0.2s 0.1s ease-out;
 	animation-fill-mode: backwards;

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -151,7 +151,7 @@ function preventClose( event ) {
 
 function useModalScreen( isVisible, closeModal ) {
 	useEffect( () => {
-		document.body.style = isVisible ? 'overflow: hidden' : 'overflow: scroll';
+		document.body.style.cssText = isVisible ? 'overflow: hidden' : 'overflow: scroll';
 		const keyPressHandler = makeHandleKeyPress( closeModal );
 		if ( isVisible ) {
 			document.addEventListener( 'keydown', keyPressHandler, false );

--- a/packages/composite-checkout/src/theme.js
+++ b/packages/composite-checkout/src/theme.js
@@ -30,7 +30,7 @@ const theme = {
 		textColorOnDarkBackground: swatches.white,
 		paypalGold: '#F0C443',
 		paypalGoldHover: '#FFB900',
-		modalBackground: 'rgba( 0,0,0,0.4 )',
+		modalBackground: 'rgba( 255,255,255,0.9 )',
 		disabledField: swatches.gray0,
 		placeHolderTextColor: swatches.gray30,
 	},

--- a/packages/composite-checkout/src/wpcom/button.js
+++ b/packages/composite-checkout/src/wpcom/button.js
@@ -100,7 +100,7 @@ function getBoxShadowHover( props ) {
 }
 
 function getBorderWeight( { buttonState } ) {
-	return buttonState === 'text-button' ? '0' : '1px';
+	return buttonState === 'text-button' || buttonState === 'borderless' ? '0' : '1px';
 }
 
 function getRollOverColor( { buttonState, buttonType, theme } ) {
@@ -119,6 +119,8 @@ function getRollOverColor( { buttonState, buttonType, theme } ) {
 		case 'disabled':
 			return colors.disabledPaymentButtons;
 		case 'text-button':
+			return 'none';
+		case 'borderless':
 			return 'none';
 		default:
 			return colors.highlight;

--- a/packages/composite-checkout/src/wpcom/coupon.js
+++ b/packages/composite-checkout/src/wpcom/coupon.js
@@ -80,7 +80,6 @@ const CouponWrapper = styled.form`
 	margin: ${props => props.marginTop} 0 0 0;
 	padding-top: 0;
 	position: relative;
-	width: 100%;
 `;
 
 const ApplyButton = styled( Button )`

--- a/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
+++ b/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
@@ -11,7 +11,12 @@ import styled from '@emotion/styled';
 import joinClasses from './join-classes';
 import Coupon from './coupon';
 import WPTermsAndConditions from './wp-terms-and-conditions';
-import { useLineItems, renderDisplayValueMarkdown, OrderReviewLineItems, OrderReviewTotal, OrderReviewSection } from '../public-api';
+import { useLineItems, renderDisplayValueMarkdown } from '../public-api';
+import {
+	OrderReviewLineItems,
+	OrderReviewTotal,
+	OrderReviewSection,
+} from './wp-order-review-line-items';
 
 export default function WPCheckoutOrderReview( { className } ) {
 	const [ items, total ] = useLineItems();
@@ -20,13 +25,17 @@ export default function WPCheckoutOrderReview( { className } ) {
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
 			<OrderReviewSection>
-				<OrderReviewLineItems items={ items } />
+				<OrderReviewLineItems
+					items={ items }
+					hasDeleteButtons={ true }
+					removeProduct={ removeProductFromCart }
+				/>
 			</OrderReviewSection>
 
 			<CouponField id="order-review-coupon" isCouponFieldVisible={ true } />
 
 			<OrderReviewSection>
-				<OrderReviewTotal total={ total } />
+				<OrderReviewTotal total={ total } hasDeleteButtons={ true } />
 			</OrderReviewSection>
 
 			<WPTermsAndConditions />
@@ -40,8 +49,13 @@ WPCheckoutOrderReview.propTypes = {
 	className: PropTypes.string,
 };
 
+function removeProductFromCart( id ) {
+	// TODO: Replace with code to remove product and also show notification saying the product has bene removed.
+	alert( id );
+}
+
 const CouponField = styled( Coupon )`
-	margin: 24px 0;
+	margin: 24px 30px 24px 0;
 	padding-bottom: 24px;
 	border-bottom: 1px solid ${props => props.theme.colors.borderColorLight};
 `;

--- a/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
+++ b/packages/composite-checkout/src/wpcom/wp-checkout-order-review.js
@@ -11,11 +11,11 @@ import styled from '@emotion/styled';
 import joinClasses from './join-classes';
 import Coupon from './coupon';
 import WPTermsAndConditions from './wp-terms-and-conditions';
-import { useLineItems, renderDisplayValueMarkdown } from '../public-api';
+import { useLineItems } from '../public-api';
 import {
-	OrderReviewLineItems,
-	OrderReviewTotal,
-	OrderReviewSection,
+	WPOrderReviewLineItems,
+	WPOrderReviewTotal,
+	WPOrderReviewSection,
 } from './wp-order-review-line-items';
 
 export default function WPCheckoutOrderReview( { className } ) {
@@ -24,19 +24,19 @@ export default function WPCheckoutOrderReview( { className } ) {
 	//TODO: tie the coupon field visibility based on whether there is a coupon in the cart
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
-			<OrderReviewSection>
-				<OrderReviewLineItems
+			<WPOrderReviewSection>
+				<WPOrderReviewLineItems
 					items={ items }
 					hasDeleteButtons={ true }
 					removeProduct={ removeProductFromCart }
 				/>
-			</OrderReviewSection>
+			</WPOrderReviewSection>
 
 			<CouponField id="order-review-coupon" isCouponFieldVisible={ true } />
 
-			<OrderReviewSection>
-				<OrderReviewTotal total={ total } hasDeleteButtons={ true } />
-			</OrderReviewSection>
+			<WPOrderReviewSection>
+				<WPOrderReviewTotal total={ total } hasDeleteButtons={ true } />
+			</WPOrderReviewSection>
 
 			<WPTermsAndConditions />
 		</div>
@@ -59,22 +59,3 @@ const CouponField = styled( Coupon )`
 	padding-bottom: 24px;
 	border-bottom: 1px solid ${props => props.theme.colors.borderColorLight};
 `;
-
-function LineItem( { item, className } ) {
-	return (
-		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
-			<span>•</span>
-			<span>{ item.label }</span>
-			<span>{ renderDisplayValueMarkdown( item.amount.displayValue ) }</span>
-		</div>
-	);
-}
-
-LineItem.propTypes = {
-	item: PropTypes.shape( {
-		label: PropTypes.string,
-		amount: PropTypes.shape( {
-			displayValue: PropTypes.string,
-		} ),
-	} ),
-};

--- a/packages/composite-checkout/src/wpcom/wp-order-review-line-items.js
+++ b/packages/composite-checkout/src/wpcom/wp-order-review-line-items.js
@@ -14,7 +14,7 @@ import { useLocalize } from '../lib/localize';
 import Button from './button';
 import CheckoutModal from '../components/checkout-modal';
 
-export function OrderReviewSection( { children, className } ) {
+export function WPOrderReviewSection( { children, className } ) {
 	return (
 		<OrderReviewSectionArea className={ joinClasses( [ className, 'order-review-section' ] ) }>
 			{ children }
@@ -22,7 +22,7 @@ export function OrderReviewSection( { children, className } ) {
 	);
 }
 
-OrderReviewSection.propTypes = {
+WPOrderReviewSection.propTypes = {
 	className: PropTypes.string,
 };
 
@@ -30,7 +30,7 @@ const OrderReviewSectionArea = styled.div`
 	margin-bottom: 16px;
 `;
 
-function LineItem( { item, className, hasDeleteButtons, removeProduct } ) {
+function WPLineItem( { item, className, hasDeleteButtons, removeProduct } ) {
 	const localize = useLocalize();
 	const hasDomainsInCart = useHasDomainsInCart();
 	const itemSpanId = `checkout-line-item-${ item.id }`;
@@ -72,7 +72,7 @@ function LineItem( { item, className, hasDeleteButtons, removeProduct } ) {
 	);
 }
 
-LineItem.propTypes = {
+WPLineItem.propTypes = {
 	className: PropTypes.string,
 	total: PropTypes.bool,
 	isSummaryVisible: PropTypes.bool,
@@ -86,7 +86,7 @@ LineItem.propTypes = {
 	} ),
 };
 
-const LineItemUI = styled( LineItem )`
+const LineItemUI = styled( WPLineItem )`
 	display: flex;
 	justify-content: space-between;
 	font-weight: ${( { theme, total } ) => ( total ? theme.weights.bold : theme.weights.normal )};
@@ -154,7 +154,7 @@ function DeleteIcon( { uniqueID } ) {
 	);
 }
 
-export function OrderReviewTotal( { total, className } ) {
+export function WPOrderReviewTotal( { total, className } ) {
 	return (
 		<div className={ joinClasses( [ className, 'order-review-total' ] ) }>
 			<LineItemUI total item={ total } />
@@ -162,7 +162,7 @@ export function OrderReviewTotal( { total, className } ) {
 	);
 }
 
-export function OrderReviewLineItems( {
+export function WPOrderReviewLineItems( {
 	items,
 	className,
 	isSummaryVisible,
@@ -184,7 +184,7 @@ export function OrderReviewLineItems( {
 	);
 }
 
-OrderReviewLineItems.propTypes = {
+WPOrderReviewLineItems.propTypes = {
 	className: PropTypes.string,
 	isSummaryVisible: PropTypes.bool,
 	hasDeleteButtons: PropTypes.bool,

--- a/packages/composite-checkout/src/wpcom/wp-order-review-line-items.js
+++ b/packages/composite-checkout/src/wpcom/wp-order-review-line-items.js
@@ -1,0 +1,233 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import joinClasses from '../lib/join-classes';
+import { renderDisplayValueMarkdown, useHasDomainsInCart } from '../public-api';
+import { useLocalize } from '../lib/localize';
+import Button from './button';
+import CheckoutModal from '../components/checkout-modal';
+
+export function OrderReviewSection( { children, className } ) {
+	return (
+		<OrderReviewSectionArea className={ joinClasses( [ className, 'order-review-section' ] ) }>
+			{ children }
+		</OrderReviewSectionArea>
+	);
+}
+
+OrderReviewSection.propTypes = {
+	className: PropTypes.string,
+};
+
+const OrderReviewSectionArea = styled.div`
+	margin-bottom: 16px;
+`;
+
+function LineItem( { item, className, hasDeleteButtons, removeProduct } ) {
+	const localize = useLocalize();
+	const hasDomainsInCart = useHasDomainsInCart();
+	const itemSpanId = `checkout-line-item-${ item.id }`;
+	const deleteButtonId = `checkout-delete-button-${ item.id }`;
+	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const modalCopy = returnModalCopy( item.type, localize, hasDomainsInCart );
+
+	return (
+		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
+			<span id={ itemSpanId }>{ item.label }</span>
+			<span aria-labelledby={ itemSpanId }>
+				{ renderDisplayValueMarkdown( item.amount.displayValue ) }
+			</span>
+			{ hasDeleteButtons && (
+				<React.Fragment>
+					<DeleteButton
+						buttonState="borderless"
+						onClick={ () => {
+							setIsModalVisible( true );
+						} }
+					>
+						<DeleteIcon uniqueID={ deleteButtonId } />
+					</DeleteButton>
+
+					<CheckoutModal
+						isVisible={ isModalVisible }
+						closeModal={ () => {
+							setIsModalVisible( false );
+						} }
+						primaryAction={ () => {
+							removeProduct( item.id );
+						} }
+						title={ modalCopy.title }
+						copy={ modalCopy.description }
+					/>
+				</React.Fragment>
+			) }
+		</div>
+	);
+}
+
+LineItem.propTypes = {
+	className: PropTypes.string,
+	total: PropTypes.bool,
+	isSummaryVisible: PropTypes.bool,
+	hasDeleteButtons: PropTypes.bool,
+	removeProduct: PropTypes.func,
+	item: PropTypes.shape( {
+		label: PropTypes.string,
+		amount: PropTypes.shape( {
+			displayValue: PropTypes.string,
+		} ),
+	} ),
+};
+
+const LineItemUI = styled( LineItem )`
+	display: flex;
+	justify-content: space-between;
+	font-weight: ${( { theme, total } ) => ( total ? theme.weights.bold : theme.weights.normal )};
+	color: ${( { theme, total } ) => ( total ? theme.colors.textColorDark : 'inherit' )};
+	font-size: ${( { total } ) => ( total ? '1.2em' : '1em' )};
+	padding: ${( { total, isSummaryVisible } ) => ( isSummaryVisible || total ? 0 : '24px 0' )};
+	border-bottom: ${( { theme, total, isSummaryVisible } ) =>
+		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
+	position: relative;
+	margin-right: 30px;
+
+	:first-of-type {
+		padding-top: 10px;
+	}
+
+	:first-of-type button {
+		top: -4px;
+	}
+`;
+
+const DeleteButton = styled( Button )`
+	position: absolute;
+	padding: 10px;
+	right: -50px;
+	top: 10px;
+
+	:hover rect {
+		fill: ${props => props.theme.colors.error};
+	}
+`;
+
+function DeleteIcon( { uniqueID } ) {
+	const localize = useLocalize();
+
+	return (
+		<svg
+			width="25"
+			height="24"
+			viewBox="0 0 25 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-labelledby={ uniqueID }
+		>
+			<title id={ uniqueID }>{ localize( 'Delete' ) }</title>
+			<mask
+				id="trashIcon"
+				mask-type="alpha"
+				maskUnits="userSpaceOnUse"
+				x="5"
+				y="3"
+				width="15"
+				height="18"
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M15.4456 3L16.4456 4H19.9456V6H5.94557V4H9.44557L10.4456 3H15.4456ZM6.94557 19C6.94557 20.1 7.84557 21 8.94557 21H16.9456C18.0456 21 18.9456 20.1 18.9456 19V7H6.94557V19ZM8.94557 9H16.9456V19H8.94557V9Z"
+					fill="white"
+				/>
+			</mask>
+			<g mask="url(#trashIcon)">
+				<rect x="0.945572" width="24" height="24" fill="#8E9196" />
+			</g>
+		</svg>
+	);
+}
+
+export function OrderReviewTotal( { total, className } ) {
+	return (
+		<div className={ joinClasses( [ className, 'order-review-total' ] ) }>
+			<LineItemUI total item={ total } />
+		</div>
+	);
+}
+
+export function OrderReviewLineItems( {
+	items,
+	className,
+	isSummaryVisible,
+	hasDeleteButtons,
+	removeProduct,
+} ) {
+	return (
+		<div className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
+			{ items.map( item => (
+				<LineItemUI
+					isSummaryVisible={ isSummaryVisible }
+					key={ item.id }
+					item={ item }
+					hasDeleteButtons={ hasDeleteButtons }
+					removeProduct={ removeProduct }
+				/>
+			) ) }
+		</div>
+	);
+}
+
+OrderReviewLineItems.propTypes = {
+	className: PropTypes.string,
+	isSummaryVisible: PropTypes.bool,
+	hasDeleteButtons: PropTypes.bool,
+	removeProduct: PropTypes.func,
+	items: PropTypes.arrayOf(
+		PropTypes.shape( {
+			label: PropTypes.string,
+			amount: PropTypes.shape( {
+				displayValue: PropTypes.string,
+			} ),
+		} )
+	),
+};
+
+function returnModalCopy( product, localize, hasDomainsInCart ) {
+	const modalCopy = {};
+	const productType = product === 'plan' && hasDomainsInCart ? 'plan with dependencies' : product;
+
+	switch ( productType ) {
+		case 'plan with dependencies':
+			modalCopy.title = localize( 'You are about to remove your plan from the cart' );
+			modalCopy.description = localize(
+				'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since your other product(s) depend on your plan to be purchased, they will also be removed from the cart and we will take you back to your site.'
+			);
+			break;
+		case 'plan':
+			modalCopy.title = localize( 'You are about to remove your plan from the cart' );
+			modalCopy.description = localize(
+				'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. We will then take you back to your site.'
+			);
+			break;
+		case 'domain':
+			modalCopy.title = localize( 'You are about to remove your domain from the cart' );
+			modalCopy.description = localize(
+				'When you press Continue, we will remove your domain from the cart and you will have no claim for the domain name you picked.'
+			);
+			break;
+		default:
+			modalCopy.title = localize( 'You are about to remove your product from the cart' );
+			modalCopy.description = localize(
+				'When you press Continue, we will remove your product from the cart and your site will continue to run without it.'
+			);
+	}
+
+	return modalCopy;
+}

--- a/packages/composite-checkout/src/wpcom/wp-terms-and-conditions.js
+++ b/packages/composite-checkout/src/wpcom/wp-terms-and-conditions.js
@@ -87,7 +87,7 @@ export default function WPTermsAndConditions() {
 
 const TermsAndConditionsWrapper = styled.div`
 	padding: 24px 0 0;
-	margin: 24px 0 8px;
+	margin: 24px 30px 8px 0;
 	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
 `;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a delete button to the WPcom review section. Since I tailored the review section so much for wpcom, I duplicated and baseline and added my code to a new wpcom specific file.

![remove](https://user-images.githubusercontent.com/6981253/69250612-fce67280-0b7d-11ea-954f-5645e9c0ca34.gif)
 

#### Testing instructions

* Get checkout up and running with these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Proceed to the review step of checkout and remove a product from the cart. 
