### PR TITLE
Blocks: Fix missing prices in ProductCard

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -495,12 +495,14 @@ export class ProductSelector extends Component {
 						planLink: <a href={ `/plans/my-plan/${ selectedSiteSlug }` } />,
 					},
 				} );
-			}
-			if ( hasProductPurchase ) {
-				billingTimeFrame = this.getBillingTimeFrameLabel();
-				fullPrice = this.getProductOptionFullPrice( selectedProductSlug );
-				discountedPrice = this.getProductOptionDiscountedPrice( selectedProductSlug );
+			} else {
 				subtitle = this.getSubtitleByProduct( product );
+
+				if ( ! hasProductPurchase ) {
+					billingTimeFrame = this.getBillingTimeFrameLabel();
+					fullPrice = this.getProductOptionFullPrice( selectedProductSlug );
+					discountedPrice = this.getProductOptionDiscountedPrice( selectedProductSlug );
+				}
 			}
 
 			return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Blocks: Fix missing prices in ProductCard when on a free plan without a Backup product.

#### Preview

Before:
![](https://cldup.com/B6cj89kROp.png)

After:
![](https://cldup.com/6GbcVpVdeG.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site with a Free plan and no backup product.
* Verify you can see the right prices on the top right side of the card.
* Buy a product. 
* Verify you can see the "Purchased on {DATE}" in that same area of the card.
* Buy a plan and cancel the product. 
* Verify you can see the "Included in {PLAN NAME}" in that same area of the card.
