### PR TITLE
Composite checkout: add focus states for IE

### DIFF
--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -133,7 +133,7 @@ Checkout.propTypes = {
 
 const Container = styled.div`
 	*:focus {
-		outline: ${props => props.theme.colors.outline} auto 5px;
+		outline: ${props => props.theme.colors.outline} solid 2px;
 	}
 `;
 

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -115,7 +115,7 @@ const Input = styled.input`
 
 	:focus {
 		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
-			auto 5px !important;
+			solid 2px !important;
 	}
 
 	::-webkit-inner-spin-button,

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -151,7 +151,7 @@ function getGrayscaleValue( { checked } ) {
 
 function getOutline( { isFocused, theme } ) {
 	if ( isFocused ) {
-		return theme.colors.outline + ' auto 5px';
+		return theme.colors.outline + ' solid 2px';
 	}
 	return '0';
 }

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -387,11 +387,11 @@ const StripeFieldWrapper = styled.span`
 	}
 
 	.StripeElement--focus {
-		outline: ${props => props.theme.colors.outline} auto 5px;
+		outline: ${props => props.theme.colors.outline} solid 2px;
 	}
 
 	.StripeElement--focus.StripeElement--invalid {
-		outline: ${props => props.theme.colors.error} auto 5px;
+		outline: ${props => props.theme.colors.error} solid 2px;
 	}
 `;
 

--- a/packages/composite-checkout/src/wpcom/field.js
+++ b/packages/composite-checkout/src/wpcom/field.js
@@ -115,7 +115,7 @@ const Input = styled.input`
 
 	:focus {
 		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
-			auto 5px !important;
+			solid 2px !important;
 	}
 
 	::-webkit-inner-spin-button,

--- a/packages/composite-checkout/src/wpcom/wp-contact-form.js
+++ b/packages/composite-checkout/src/wpcom/wp-contact-form.js
@@ -157,7 +157,7 @@ const DomainRegistrationCheckbox = styled.input`
 	}
 
 	:focus + label:before {
-		outline: ${props => props.theme.colors.outline} auto 5px;
+		outline: ${props => props.theme.colors.outline} solid 2px;
 	}
 `;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds focus states for ie because for some reason, ie doesn't understand the `auto` value for the `outline-style` property. 

#### Testing instructions
Check on IE if you can but also test other browsers too.

* Get checkout up and running with these instructions: https://github.com/Automattic/wp-calypso/pull/37013
*  Tab through the interface
