### PR TITLE
Signup: provide the default business content for user testing

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -187,6 +187,11 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		newSiteParams.options.nux_import_from_url = getNuxUrlInputValue( state );
 	}
 
+	// Provide the default business starter content for the FSE user testing flow.
+	if ( 'test-fse' === lastKnownFlow ) {
+		newSiteParams.options.site_segment = 1;
+	}
+
 	if ( isEligibleForPageBuilder( siteSegment, flowToCheck ) && shouldEnterPageBuilder() ) {
 		newSiteParams.options.in_page_builder = true;
 	}


### PR DESCRIPTION
Since the `test-fse` flow is without a site segment step, the newly created sites use the default theme headstart annotations, which include secondary pages and assigned menus, breaking the functionality of FSE.

This passes a default "business" segment value to the sites/new endpoint for the `test-fse` flow, forcing the new site into the single-page starter content.

**To test:**
- visit `start/test-fse/`
- create a site
- verify that the new site has the Maywood theme assigned with the default business starter content (a cover image block with "Welcome! What can we do for you?", followed by media+text blocks)