### PR TITLE
Checklist/Starter Page Templates: Automatically open the layout selector when updating the homepage the checklist

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 0.15
+ * Version: 0.15.1
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -20,7 +20,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '0.15' );
+define( 'PLUGIN_VERSION', '0.15.1' );
 
 // Themes which are supported by Full Site Editing (not the same as the SPT themes).
 const SUPPORTED_THEMES = [ 'maywood' ];

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, codebykat, copons, dmsnell, ge
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.3
-Stable tag: 0.15
+Stable tag: 0.15.1
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -41,6 +41,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 0.15.1 =
+
+* Always open the layout selector if the `?new-homepage` query argument exists.
 
 = 0.15 =
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -176,7 +176,8 @@ class Starter_Page_Templates {
 				'templates'       => array_merge( $default_templates, $vertical_templates ),
 				'vertical'        => $vertical,
 				'segment'         => $segment,
-				'screenAction'    => $screen->action,
+				// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+				'screenAction'    => isset( $_GET['new-homepage'] ) ? 'add' : $screen->action,
 				'theme'           => normalize_theme_slug( get_stylesheet() ),
 				// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 				'isFrontPage'     => isset( $_GET['post'] ) && get_option( 'page_on_front' ) === $_GET['post'],

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"description": "Plugin for full site editing with the block editor.",
 	"sideEffects": true,
 	"repository": {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -634,7 +634,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 const mapStateToProps = (
 	state,
-	{ postId, postType, duplicatePostId, fseParentPageId }: Props
+	{ postId, postType, duplicatePostId, fseParentPageId, creatingNewHomepage }: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
@@ -652,6 +652,7 @@ const mapStateToProps = (
 		'jetpack-copy': duplicatePostId,
 		origin: window.location.origin,
 		'environment-id': config( 'env_id' ),
+		'new-homepage': creatingNewHomepage,
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -9,7 +9,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { getPostsForQuery } from 'state/posts/selectors';
 import getEditorUrl from 'state/selectors/get-editor-url';
-import { getSiteOption } from 'state/sites/selectors';
+import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
 import createSelector from 'lib/create-selector';
 import { isEnabled } from 'config';
 
@@ -42,13 +42,12 @@ export default createSelector(
 		const posts = getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY );
 		const firstPostID = get( find( posts, { type: 'post' } ), [ 0, 'ID' ] );
 		const contactPageUrl = getPageEditorUrl( state, siteId, getContactPage( posts ) );
-		const frontPageUrl = getPageEditorUrl(
-			state,
-			siteId,
-			getSiteOption( state, siteId, 'page_on_front' )
-		);
+		const frontPageUrl = getFrontPageEditorUrl( state, siteId );
+
 		const updateHomepageUrl = isEnabled( 'checklist-homepage-template-select' )
-			? addQueryArgs( getEditorUrl( state, siteId, null, 'page' ), { 'new-homepage': 1 } )
+			? addQueryArgs( frontPageUrl || getEditorUrl( state, siteId, null, 'page' ), {
+					'new-homepage': 1,
+			  } )
 			: frontPageUrl;
 
 		return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the `checklist-homepage-template-select` is enabled, always pass `?new-homepage=1` to the editor when creating or updating a front page via the Checklist.
Then pass the query arg through to the Gutenframe.

* In the Starter Page Templates plugin, if `?new-homepage` exists, open the layout selector modal when entering the page editor (which is the same behaviour as when _creating_ a page).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR, build Calypso, and pre-sandbox a new site.
* Sync the FSE change to the sandbox. Since it's a PHP change, it's enough to just copy the file. E.g.
`cp -R wp-calypso/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php  sandbox/wp-content/plugins/full-site-editing-plugin/0.15/starter-page-templates/class-starter-page-templates.php`
* Launch the Horizon flow: https://horizon.wordpress.com/start/test-fse
* Once landing in the Checklist, change the URL to use the dev environment. E.g. `http://calypso.localhost:3000/home/test-site.wordpress.com`.
* Click on the Start button in the checklist.
* Make sure you've opened the pre-existing homepage (the URL should contain a post ID, otherwise it would be creating a new page).
* Make sure the layout selector is open.
* Somehow smoke test for regressions.