### PR TITLE
G Suite: Update price component to support discount

### DIFF
--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -15,22 +15,11 @@ import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
  */
 import './style.scss';
 
-const GSuitePrice = ( { cost, currencyCode, showMonthlyPrice } ) => {
+const GSuitePrice = ( { cost, currencyCode } ) => {
 	const translate = useTranslate();
 
 	const annualPrice = cost && currencyCode ? getAnnualPrice( cost, currencyCode ) : '-';
 	const monthlyPrice = cost && currencyCode ? getMonthlyPrice( cost, currencyCode ) : '-';
-
-	const renderPerUserPerYear = () => {
-		return translate( '{{strong}}%(price)s{{/strong}} per user / year', {
-			components: {
-				strong: <strong />,
-			},
-			args: {
-				price: annualPrice,
-			},
-		} );
-	};
 
 	const renderPerUserPerMonth = () => {
 		return translate( '{{strong}}%(price)s{{/strong}} per user / month', {
@@ -46,17 +35,16 @@ const GSuitePrice = ( { cost, currencyCode, showMonthlyPrice } ) => {
 	return (
 		<div className="gsuite-price">
 			<h4 className="gsuite-price__price-per-user">
-				<span>{ showMonthlyPrice ? renderPerUserPerMonth() : renderPerUserPerYear() }</span>
+				<span>{ renderPerUserPerMonth() }</span>
 			</h4>
-			{ showMonthlyPrice && (
-				<h5 className="gsuite-price__annual-price">
-					{ translate( '%(price)s billed yearly', {
-						args: {
-							price: annualPrice,
-						},
-					} ) }
-				</h5>
-			) }
+
+			<h5 className="gsuite-price__annual-price">
+				{ translate( '%(price)s billed yearly', {
+					args: {
+						price: annualPrice,
+					},
+				} ) }
+			</h5>
 		</div>
 	);
 };
@@ -64,11 +52,6 @@ const GSuitePrice = ( { cost, currencyCode, showMonthlyPrice } ) => {
 GSuitePrice.propTypes = {
 	cost: PropTypes.number,
 	currencyCode: PropTypes.string,
-	showMonthlyPrice: PropTypes.bool.isRequired,
-};
-
-GSuitePrice.defaultProps = {
-	showMonthlyPrice: false,
 };
 
 export default GSuitePrice;

--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -15,27 +15,26 @@ import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
  */
 import './style.scss';
 
-const GSuitePrice = ( { cost, currencyCode } ) => {
+const GSuitePrice = ( { currencyCode, product } ) => {
 	const translate = useTranslate();
 
+	const cost = product?.cost ?? null;
 	const annualPrice = cost && currencyCode ? getAnnualPrice( cost, currencyCode ) : '-';
 	const monthlyPrice = cost && currencyCode ? getMonthlyPrice( cost, currencyCode ) : '-';
-
-	const renderPerUserPerMonth = () => {
-		return translate( '{{strong}}%(price)s{{/strong}} per user / month', {
-			components: {
-				strong: <strong />,
-			},
-			args: {
-				price: monthlyPrice,
-			},
-		} );
-	};
 
 	return (
 		<div className="gsuite-price">
 			<h4 className="gsuite-price__price-per-user">
-				<span>{ renderPerUserPerMonth() }</span>
+				<span>
+					{ translate( '{{strong}}%(price)s{{/strong}} per user / month', {
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							price: monthlyPrice,
+						},
+					} ) }
+				</span>
 			</h4>
 
 			<h5 className="gsuite-price__annual-price">
@@ -50,8 +49,8 @@ const GSuitePrice = ( { cost, currencyCode } ) => {
 };
 
 GSuitePrice.propTypes = {
-	cost: PropTypes.number,
 	currencyCode: PropTypes.string,
+	product: PropTypes.object,
 };
 
 export default GSuitePrice;

--- a/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GSuitePrice it renders GSuitePrice with monthly prices 1`] = `
+exports[`GSuitePrice renders correctly 1`] = `
 <div
   className="gsuite-price"
 >
@@ -9,7 +9,7 @@ exports[`GSuitePrice it renders GSuitePrice with monthly prices 1`] = `
   >
     <span>
       <strong>
-        $12
+        €6,40
       </strong>
        per user / month
     </span>
@@ -17,24 +17,7 @@ exports[`GSuitePrice it renders GSuitePrice with monthly prices 1`] = `
   <h5
     className="gsuite-price__annual-price"
   >
-    $144 billed yearly
+    €76 billed yearly
   </h5>
-</div>
-`;
-
-exports[`GSuitePrice it renders GSuitePrice without monthly prices 1`] = `
-<div
-  className="gsuite-price"
->
-  <h4
-    className="gsuite-price__price-per-user"
-  >
-    <span>
-      <strong>
-        $72
-      </strong>
-       per user / year
-    </span>
-  </h4>
 </div>
 `;

--- a/client/components/gsuite/gsuite-price/test/index.js
+++ b/client/components/gsuite/gsuite-price/test/index.js
@@ -10,15 +10,48 @@ import renderer from 'react-test-renderer';
 import GSuitePrice from '../';
 
 describe( 'GSuitePrice', () => {
-	test( 'it renders GSuitePrice without monthly prices', () => {
-		const tree = renderer.create( <GSuitePrice cost={ 72 } currencyCode={ 'USD' } /> ).toJSON();
-		expect( tree ).toMatchSnapshot();
-	} );
+	const product = {
+		product_id: 69,
+		product_name: 'G Suite',
+		product_slug: 'gapps',
+		description: '',
+		cost: 76,
+		available: true,
+		prices: {
+			USD: 72,
+			AUD: 102,
+			CAD: 96,
+			EUR: 76,
+			GBP: 65,
+			JPY: 8200,
+			BRL: 288,
+			ILS: 264,
+			INR: 5040,
+			MXN: 1404,
+			NZD: 104.4,
+			RUB: 4680,
+			SEK: 792,
+			HUF: 23400,
+			CHF: 72,
+			CZK: 1728,
+			DKK: 522,
+			HKD: 576,
+			NOK: 720,
+			PHP: 3960,
+			PLN: 288,
+			SGD: 108,
+			TWD: 2304,
+			THB: 2520,
+			TRY: 396
+		},
+		is_domain_registration: false,
+		cost_display: '€76.00',
+		currency_code: 'EUR'
+	};
 
-	test( 'it renders GSuitePrice with monthly prices', () => {
-		const tree = renderer
-			.create( <GSuitePrice cost={ 144 } currencyCode={ 'USD' } /> )
-			.toJSON();
+	test( 'renders correctly', () => {
+		const tree = renderer.create( <GSuitePrice product={ product } currencyCode={ 'EUR' } /> ).toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/gsuite/gsuite-price/test/index.js
+++ b/client/components/gsuite/gsuite-price/test/index.js
@@ -17,7 +17,7 @@ describe( 'GSuitePrice', () => {
 
 	test( 'it renders GSuitePrice with monthly prices', () => {
 		const tree = renderer
-			.create( <GSuitePrice cost={ 144 } currencyCode={ 'USD' } showMonthlyPrice /> )
+			.create( <GSuitePrice cost={ 144 } currencyCode={ 'USD' } /> )
 			.toJSON();
 		expect( tree ).toMatchSnapshot();
 	} );

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
@@ -14,9 +14,7 @@ import CompactCard from 'components/card/compact';
 import { areAllUsersValid, getItemsForCart, newUsers } from 'lib/gsuite/new-users';
 import GSuiteUpsellProductDetails from './product-details';
 import GSuiteNewUserList from 'components/gsuite/gsuite-new-user-list';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import QueryProducts from 'components/data/query-products-list';
-import { getProductCost } from 'state/products-list/selectors';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 /**
@@ -25,10 +23,8 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
 import './style.scss';
 
 const GSuiteUpsellCard = ( {
-	currencyCode,
 	domain,
-	gSuiteCost,
-	gSuiteProductSlug,
+	productSlug,
 	onAddEmailClick,
 	onSkipClick,
 	recordTracksEvent,
@@ -59,7 +55,7 @@ const GSuiteUpsellCard = ( {
 		recordClickEvent( `calypso_checkout_gsuite_upgrade_add_email_button_click` );
 
 		if ( canContinue ) {
-			onAddEmailClick( getItemsForCart( [ domain ], gSuiteProductSlug, users ) );
+			onAddEmailClick( getItemsForCart( [ domain ], productSlug, users ) );
 		}
 	};
 
@@ -105,9 +101,7 @@ const GSuiteUpsellCard = ( {
 			<CompactCard>
 				<GSuiteUpsellProductDetails
 					domain={ domain }
-					cost={ gSuiteCost }
-					currencyCode={ currencyCode }
-					plan={ gSuiteProductSlug }
+					productSlug={ productSlug }
 				/>
 
 				<GSuiteNewUserList
@@ -138,18 +132,12 @@ const GSuiteUpsellCard = ( {
 };
 
 GSuiteUpsellCard.propTypes = {
-	currencyCode: PropTypes.string,
 	domain: PropTypes.string.isRequired,
-	gSuiteCost: PropTypes.number,
-	gSuiteProductSlug: PropTypes.oneOf( [ 'gapps', 'gapps_unlimited' ] ),
+	productSlug: PropTypes.oneOf( [ 'gapps', 'gapps_unlimited' ] ),
 	onAddEmailClick: PropTypes.func.isRequired,
 	onSkipClick: PropTypes.func.isRequired,
 };
 
-export default connect(
-	( state, { gSuiteProductSlug } ) => ( {
-		currencyCode: getCurrentUserCurrencyCode( state ),
-		gSuiteCost: getProductCost( state, gSuiteProductSlug ),
-	} ),
-	{ recordTracksEvent: recordTracksEventAction }
-)( GSuiteUpsellCard );
+export default connect( null, {
+	recordTracksEvent: recordTracksEventAction
+} )( GSuiteUpsellCard );

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
@@ -8,10 +9,12 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getProductBySlug } from 'state/products-list/selectors';
 import GSuitePrice from 'components/gsuite/gsuite-price';
 import GSuiteCompactFeatures from 'components/gsuite/gsuite-features/compact';
 
-function GSuiteUpsellProductDetails( { currencyCode, cost, domain, plan } ) {
+function GSuiteUpsellProductDetails( { currencyCode, domain, product, productSlug } ) {
 	const translate = useTranslate();
 
 	return (
@@ -29,19 +32,24 @@ function GSuiteUpsellProductDetails( { currencyCode, cost, domain, plan } ) {
 					) }
 				</p>
 
-				<GSuitePrice cost={ cost } currencyCode={ currencyCode } />
+				<GSuitePrice product={ product } currencyCode={ currencyCode } />
 			</div>
 
-			<GSuiteCompactFeatures domainName={ domain } productSlug={ plan } type={ 'list' } />
+			<GSuiteCompactFeatures domainName={ domain } productSlug={ productSlug } type={ 'list' } />
 		</div>
 	);
 }
 
 GSuiteUpsellProductDetails.propTypes = {
 	currencyCode: PropTypes.string,
-	cost: PropTypes.number,
 	domain: PropTypes.string.isRequired,
-	plan: PropTypes.string.isRequired,
+	product: PropTypes.object,
+	productSlug: PropTypes.oneOf( [ 'gapps', 'gapps_unlimited' ] ),
 };
 
-export default GSuiteUpsellProductDetails;
+export default connect(
+	( state, { productSlug } ) => ( {
+		currencyCode: getCurrentUserCurrencyCode( state ),
+		product: getProductBySlug( state, productSlug ),
+	} )
+)( GSuiteUpsellProductDetails );

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
@@ -29,7 +29,7 @@ function GSuiteUpsellProductDetails( { currencyCode, cost, domain, plan } ) {
 					) }
 				</p>
 
-				<GSuitePrice cost={ cost } currencyCode={ currencyCode } showMonthlyPrice />
+				<GSuitePrice cost={ cost } currencyCode={ currencyCode } />
 			</div>
 
 			<GSuiteCompactFeatures domainName={ domain } productSlug={ plan } type={ 'list' } />

--- a/client/components/upgrades/gsuite/index.jsx
+++ b/client/components/upgrades/gsuite/index.jsx
@@ -46,7 +46,7 @@ const GSuiteUpgrade = ( { cart, domain, selectedSiteSlug } ) => {
 
 			<GSuiteUpsellCard
 				domain={ domain }
-				gSuiteProductSlug={ 'gapps' }
+				productSlug={ 'gapps' }
 				onSkipClick={ handleSkipClick }
 				onAddEmailClick={ handleAddEmailClick }
 			/>

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -86,7 +86,7 @@ export class GSuiteNudge extends React.Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<GSuiteUpsellCard
 					domain={ this.props.domain }
-					gSuiteProductSlug={ 'gapps' }
+					productSlug={ 'gapps' }
 					onSkipClick={ this.handleSkipClick }
 					onAddEmailClick={ this.handleAddEmailClick }
 				/>

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -16,7 +16,7 @@ import CompactCard from 'components/card/compact';
 import { emailManagementNewGSuiteAccount } from 'my-sites/email/paths';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getProductCost } from 'state/products-list/selectors';
+import { getProductBySlug } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuiteFeatures from 'components/gsuite/gsuite-features';
 import GSuiteLearnMore from 'components/gsuite/gsuite-learn-more';
@@ -32,7 +32,7 @@ import './style.scss';
 export const GSuitePurchaseCta = ( {
 	currencyCode,
 	domainName,
-	gsuiteBasicCost,
+	product,
 	recordTracksEvent: recordEvent,
 	selectedSiteSlug,
 } ) => {
@@ -90,7 +90,7 @@ export const GSuitePurchaseCta = ( {
 					</p>
 
 					<div>
-						<GSuitePrice cost={ gsuiteBasicCost } currencyCode={ currencyCode } />
+						<GSuitePrice product={ product } currencyCode={ currencyCode } />
 
 						{ upgradeAvailable && (
 							<Button
@@ -122,15 +122,15 @@ export const GSuitePurchaseCta = ( {
 GSuitePurchaseCta.propTypes = {
 	currencyCode: PropTypes.string,
 	domainName: PropTypes.string.isRequired,
-	gsuiteBasicCost: PropTypes.number,
+	product: PropTypes.object,
 	recordTracksEvent: PropTypes.func.isRequired,
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
 
 export default connect(
 	state => ( {
-		gsuiteBasicCost: getProductCost( state, 'gapps' ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
+		product: getProductBySlug( state, 'gapps' ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{ recordTracksEvent }

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -90,7 +90,7 @@ export const GSuitePurchaseCta = ( {
 					</p>
 
 					<div>
-						<GSuitePrice cost={ gsuiteBasicCost } currencyCode={ currencyCode } showMonthlyPrice />
+						<GSuitePrice cost={ gsuiteBasicCost } currencyCode={ currencyCode } />
 
 						{ upgradeAvailable && (
 							<Button

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
+exports[`GSuitePurchaseCta renders correctly 1`] = `
 <EmailVerificationGate
   noticeStatus="is-info"
   noticeText="You must verify your email to purchase G Suite."
@@ -44,7 +44,7 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
           >
             <span>
               <strong>
-                $6
+                €6,40
               </strong>
                per user / month
             </span>
@@ -52,7 +52,7 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
           <h5
             className="gsuite-price__annual-price"
           >
-            $72 billed yearly
+            €76 billed yearly
           </h5>
         </div>
         <button

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -17,18 +17,58 @@ jest.mock( 'my-sites/email/gsuite-purchase-cta/sku-info', () => 'GSuitePurchaseC
 jest.mock( 'components/data/query-products-list', () => 'QueryProductsList' );
 
 describe( 'GSuitePurchaseCta', () => {
-	test( 'it renders GSuitePurchaseCta', () => {
+	test( 'renders correctly', () => {
+		const product = {
+			product_id: 69,
+			product_name: 'G Suite',
+			product_slug: 'gapps',
+			description: '',
+			cost: 76,
+			available: true,
+			prices: {
+				USD: 72,
+				AUD: 102,
+				CAD: 96,
+				EUR: 76,
+				GBP: 65,
+				JPY: 8200,
+				BRL: 288,
+				ILS: 264,
+				INR: 5040,
+				MXN: 1404,
+				NZD: 104.4,
+				RUB: 4680,
+				SEK: 792,
+				HUF: 23400,
+				CHF: 72,
+				CZK: 1728,
+				DKK: 522,
+				HKD: 576,
+				NOK: 720,
+				PHP: 3960,
+				PLN: 288,
+				SGD: 108,
+				TWD: 2304,
+				THB: 2520,
+				TRY: 396
+			},
+			is_domain_registration: false,
+			cost_display: '€76.00',
+			currency_code: 'EUR'
+		};
+
 		const tree = renderer
 			.create(
 				<GSuitePurchaseCta
-					currencyCode={ 'USD' }
+					currencyCode={ 'EUR' }
 					domainName={ 'test.com' }
-					gsuiteBasicCost={ 72 }
+					product={ product }
 					recordTracksEvent={ noop }
 					selectedSiteSlug={ 'test.wordpress.com' }
 				/>
 			)
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 } );

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -27,14 +27,26 @@ export function getAvailableProductsList( state ) {
 }
 
 /**
- * Returns the display price of a product
+ * Retrieves the product with the specified slug.
  *
- * @param {Object} state The Redux state tree
- * @param {string} productSlug The internal product slug, eg 'jetpack_premium'
- * @return {string} The display price formatted in the user's currency, eg "A$29.00"
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {?object} the corresponding product, or null if not found
+ */
+export function getProductBySlug( state, productSlug ) {
+	return get( state, [ 'productsList', 'items', productSlug ], null );
+}
+
+/**
+ * Returns the display price of the specified product.
+ *
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {?string} the display price formatted in the user's currency (eg 'A$29.00'), or null otherwise
  */
 export function getProductDisplayCost( state, productSlug ) {
-	const product = state.productsList.items[ productSlug ];
+	const product = getProductBySlug( state, productSlug );
+
 	if ( ! product ) {
 		return null;
 	}
@@ -43,14 +55,15 @@ export function getProductDisplayCost( state, productSlug ) {
 }
 
 /**
- * Returns the price of a product
+ * Returns the price of the specified product.
  *
- * @param {Object} state The Redux state tree
- * @param {string} productSlug The internal product slug, eg 'jetpack_premium'
- * @return {number} The price formatted in the user's currency, eg 29.15
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {?number} the price formatted in the user's currency (e.g. '29.15'), or null otherwise
  */
 export function getProductCost( state, productSlug ) {
-	const product = state.productsList.items[ productSlug ];
+	const product = getProductBySlug( state, productSlug );
+
 	if ( ! product ) {
 		return null;
 	}
@@ -61,11 +74,11 @@ export function getProductCost( state, productSlug ) {
 /**
  * Computes a price based on plan slug/constant, including any discounts available.
  *
- * @param {Object} state Current redux state
- * @param {Number} siteId Site ID to consider
- * @param {Object} planObject Plan object returned by getPlan() from lib/plans
+ * @param {object} state Current redux state
+ * @param {number} siteId Site ID to consider
+ * @param {object} planObject Plan object returned by getPlan() from lib/plans
  * @param {boolean} isMonthly Flag - should return a monthly price?
- * @return {Number} Requested price
+ * @returns {number} Requested price
  */
 export const getPlanPrice = ( state, siteId, planObject, isMonthly ) => {
 	return (
@@ -78,8 +91,8 @@ export const getPlanPrice = ( state, siteId, planObject, isMonthly ) => {
  * Computes a plan object and a related product object based on plan slug/constant
  *
  * @param {Array[]} products A list of products
- * @param {String} planSlug Plan constant/slug
- * @return {Object} Object with a related plan and product objects
+ * @param {string} planSlug Plan constant/slug
+ * @returns {object} Object with a related plan and product objects
  */
 export const planSlugToPlanProduct = ( products, planSlug ) => {
 	const plan = getPlan( planSlug );
@@ -94,12 +107,12 @@ export const planSlugToPlanProduct = ( products, planSlug ) => {
 /**
  * Computes a full and monthly price for a given plan, based on it's slug/constant
  *
- * @param {Object} state Current redux state
- * @param {Number} siteId Site ID to consider
- * @param {Object} planObject Plan object returned by getPlan() from lib/plans
- * @param {Number} credits The number of free credits in cart
- * @param {Object} couponDiscounts Absolute values of any discounts coming from a discount coupon
- * @return {Object} Object with a full and monthly price
+ * @param {object} state Current redux state
+ * @param {number} siteId Site ID to consider
+ * @param {object} planObject Plan object returned by getPlan() from lib/plans
+ * @param {number} credits The number of free credits in cart
+ * @param {object} couponDiscounts Absolute values of any discounts coming from a discount coupon
+ * @returns {object} Object with a full and monthly price
  */
 export const computeFullAndMonthlyPricesForPlan = (
 	state,
@@ -125,12 +138,12 @@ export const computeFullAndMonthlyPricesForPlan = (
  * Turns a list of plan slugs into a list of plan objects, corresponding
  * products, and their full and monthly prices
  *
- * @param {Object} state Current redux state
- * @param {Number} siteId Site ID to consider
- * @param {String[]} planSlugs Plans constants
- * @param {Number} credits The number of free credits in cart
- * @param {Object} couponDiscounts Absolute values of any discounts coming from a discount coupon
- * @return {Array} A list of objects as described above
+ * @param {object} state Current redux state
+ * @param {number} siteId Site ID to consider
+ * @param {string[]} planSlugs Plans constants
+ * @param {number} credits The number of free credits in cart
+ * @param {object} couponDiscounts Absolute values of any discounts coming from a discount coupon
+ * @returns {Array} A list of objects as described above
  */
 export const computeProductsWithPrices = ( state, siteId, planSlugs, credits, couponDiscounts ) => {
 	const products = getProductsList( state );


### PR DESCRIPTION
This pull request is a preliminary step to adding discount support for G Suite. It removes the option to display yearly prices that was introduced to A/B test monthly versus yearly prices. Since we know that we want to display both now, there is no need to keep that code around.

This pull request also introduces a new selector to retrieve a store product by slug. Finally, it refactors G Suite components to simplify the data that is passed down the components tree, and updates the component in charge of displaying prices to accept a product instead of just a cost. In the future, this product will contain the necessary information to display the discount.

#### Testing instructions

1. Run `git checkout add/gsuite-discount-support` and start your server, or open a [live branch](https://calypso.live/?branch=add/gsuite-discount-support)
2. Log in to an account that has a site with G Suite
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Assert that the price displayed is correct
5. Navigate to the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
6. Select any domain in order to be redirected to the Upsell page
7. Assert that the price displayed is correct
8. Log out, then [sign up](http://calypso.localhost:3000/start) for a new account
9. Select a plan with a domain during signup in order to be presented with the Upsell page
10. Assert that the price displayed is correct