### PR TITLE
Ads Stats: Fix Formatted Header Alignment

### DIFF
--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -151,7 +151,7 @@ class WordAds extends Component {
 				<FormattedHeader
 					className="wordads__section-header"
 					headerText={ translate( 'Stats and Insights' ) }
-					leftAlign
+					align="left"
 				/>
 				{ ! canAccessAds && (
 					<EmptyContent


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I think this is just a typo introduced in #37343, but the Formatted Header for ads stats is centred, which is an odd jump when clicking through the stats labels.

#### Testing instructions

Visit `/stats/ads/day/site` on a WordAds site.

**Before:**
<img width="950" alt="Screenshot 2019-11-20 at 17 05 42" src="https://user-images.githubusercontent.com/43215253/69260772-523f7580-0bb8-11ea-9526-f3c3c0b1b7c0.png">

**After:**
<img width="969" alt="Screenshot 2019-11-20 at 17 05 32" src="https://user-images.githubusercontent.com/43215253/69260797-5bc8dd80-0bb8-11ea-8a92-9403a8ecfee7.png">

cc @danhauk 
