### PR TITLE
Update prettier and lockfile in e2e tests

### DIFF
--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -34,124 +34,154 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
-			"integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+			"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
 			"requires": {
-				"@babel/types": "^7.3.2",
+				"@babel/types": "^7.7.2",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.10",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
+			"integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.0.tgz",
+			"integrity": "sha512-Cd8r8zs4RKDwMG/92lpZcnn5WPQ3LAMQbCw42oqUh4s7vsSN5ANUZjMel0OOnxDLq57hoDDbai+ryygYfCTOsw==",
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-explode-assignable-expression": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			}
+		},
+		"@babel/helper-builder-react-jsx": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz",
+			"integrity": "sha512-LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==",
+			"requires": {
+				"@babel/types": "^7.7.0",
+				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
-			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.0.tgz",
+			"integrity": "sha512-Su0Mdq7uSSWGZayGMMQ+z6lnL00mMCnGAbO/R0ZO9odIdB/WNU/VfQKqMQU0fdIsxQYbRjDM4BixIa93SQIpvw==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-hoist-variables": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.0.tgz",
+			"integrity": "sha512-MZiB5qvTWoyiFOgootmRSDV1udjIqJW/8lmxgzKq6oDqxdmHUjeP2ZUOmgHdYjmUVNABqRrHjYAYRvj8Eox/UA==",
+			"requires": {
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-member-expression-to-functions": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz",
+			"integrity": "sha512-pAil/ZixjTlrzNpjx+l/C/wJk002Wo7XbbZ8oujH/AoJ3Juv0iN/UTcPUHXKMFLqsfS0Hy6Aow8M31brUYBlQQ==",
+			"requires": {
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
-			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.0.tgz",
+			"integrity": "sha512-kPKWPb0dMpZi+ov1hJiwse9dWweZsz3V9rP4KdytnX1E7z3cTNmFGglwklzFPuqIcHLIY3bgKSs4vkwXXdflQA==",
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"lodash": "^4.17.10"
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/types": "^7.7.0",
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.0.tgz",
+			"integrity": "sha512-CDs26w2shdD1urNUAji2RJXyBFCaR+iBEGnFz3l7maizMkQe3saVw9WtjG1tz8CwbjvlFnaSLVhgnu1SWaherg==",
 			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+			"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-get-function-arity": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+			"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
-			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.0.tgz",
+			"integrity": "sha512-LUe/92NqsDAkJjjCEWkNe+/PcpnisvnqdlRe19FahVapa4jndeuJ+FBiTX1rcAKWKcJGE+C3Q3tuEuxkSmCEiQ==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.0.tgz",
+			"integrity": "sha512-QaCZLO2RtBcmvO/ekOLp8p7R5X2JriKRizeDpm5ChATAFWrrYDcDxPuCIBXKyBjY+i1vYSdcUTMIb8psfxHDPA==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
+			"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz",
+			"integrity": "sha512-rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/template": "^7.2.2",
-				"@babel/types": "^7.2.2",
-				"lodash": "^4.17.10"
+				"@babel/helper-module-imports": "^7.7.0",
+				"@babel/helper-simple-access": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0",
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz",
+			"integrity": "sha512-48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -160,78 +190,78 @@
 			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz",
+			"integrity": "sha512-pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-wrap-function": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "^7.7.0",
+				"@babel/helper-wrap-function": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
-			"integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.0.tgz",
+			"integrity": "sha512-5ALYEul5V8xNdxEeWvRsBzLMxQksT7MaStpxjJf9KsnLxpAKBtfw5NeMKZJSYDa0lKdOcy0g+JT/f5mPSulUgg==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.0.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.2.3",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-member-expression-to-functions": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz",
+			"integrity": "sha512-AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==",
 			"requires": {
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/template": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+			"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
+			"integrity": "sha512-sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==",
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.2.0"
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
-			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+			"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
 			"requires": {
-				"@babel/template": "^7.1.2",
-				"@babel/traverse": "^7.1.5",
-				"@babel/types": "^7.3.0"
+				"@babel/template": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -239,18 +269,46 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
-			"integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ=="
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+			"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.0.tgz",
+			"integrity": "sha512-ot/EZVvf3mXtZq0Pd0+tSOfGWMizqmOohXmNZg6LNFjHOV+wOPv7BvVYh8oPR8LhpIP3ye8nNooKL50YRWxpYA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/helper-remap-async-to-generator": "^7.7.0",
 				"@babel/plugin-syntax-async-generators": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
+			"integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.5.5",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-proposal-decorators": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.6.0.tgz",
+			"integrity": "sha512-ZSyYw9trQI50sES6YxREXKu+4b7MAg6Qx2cvyDDYjP2Hpzd3FleOUwC9cqn1+za8d0A2ZU8SHujxFao956efUg==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.6.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-decorators": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.0.tgz",
+			"integrity": "sha512-7poL3Xi+QFPC7sGAzEIbXUyYzGJwbc2+gSD0AkiC5k52kH2cqHdqxm5hNFfLW3cRSTcx9bN0Fl7/6zWcLLnKAQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
@@ -263,9 +321,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
-			"integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+			"integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -281,13 +339,12 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
-			"integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.0.tgz",
+			"integrity": "sha512-mk34H+hp7kRBWJOOAR0ZMGCydgKMD4iN9TpDRp3IIcbunltxEY89XSimc6WbtSLCDrwcdy/EEw7h5CFCzxTchw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.2.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -298,10 +355,42 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-decorators": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
+			"integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-flow": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.0.tgz",
+			"integrity": "sha512-vQMV07p+L+jZeUnvX3pEJ9EiXGCjB5CTTvsirFD9rpEuATnoAvLBLoYbw1v5tyn3d2XxSuvEKi8cV3KqYUa0vQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-syntax-json-strings": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
 			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -322,6 +411,22 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.0.tgz",
+			"integrity": "sha512-hi8FUNiFIY1fnUI2n1ViB1DR0R4QeK4iHcTlW6aJkrPoTdb8Rf1EMQ6GT3f67DDkYyWgew9DFoOZ6gOoEsdzTA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+			"integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-arrow-functions": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
@@ -331,13 +436,13 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
-			"integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.0.tgz",
+			"integrity": "sha512-vLI2EFLVvRBL3d8roAMqtVY0Bm9C1QzLkdS57hiKrjUBSqsQYrBsMCeOg/0KK7B0eK9V71J5mWcha9yyoI2tZw==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0"
+				"@babel/helper-remap-async-to-generator": "^7.7.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
@@ -349,26 +454,26 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
-			"integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+			"integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
-			"integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.0.tgz",
+			"integrity": "sha512-/b3cKIZwGeUesZheU9jNYcwrEA7f/Bo4IdPmvp7oHgvks2majB5BoT5byAql44fiNQYOPzhk2w8DbgfuafkMoA==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.1.0",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-annotate-as-pure": "^7.7.0",
+				"@babel/helper-define-map": "^7.7.0",
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-optimise-call-expression": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
 				"globals": "^11.1.0"
 			}
 		},
@@ -381,27 +486,26 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
-			"integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-			"integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.0.tgz",
+			"integrity": "sha512-3QQlF7hSBnSuM1hQ0pS3pmAbWLax/uGNCbPBND9y+oJ4Y776jsyujG2k0Sn2Aj2a0QwVOiOFL5QVPA7spjvzSA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-			"integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+			"integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -415,20 +519,29 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-flow-strip-types": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz",
+			"integrity": "sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-flow": "^7.2.0"
+			}
+		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
-			"integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
-			"integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.0.tgz",
+			"integrity": "sha512-P5HKu0d9+CzZxP5jcrWdpe7ZlFDe24bmqP6a6X8BHEBl/eizAsY8K6LX8LASZL0Jxdjm5eEfzp+FIrxCm/p8bA==",
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-function-name": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -440,84 +553,158 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-transform-modules-amd": {
+		"@babel/plugin-transform-member-expression-literals": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-			"integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-			"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+			"integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0"
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.0.tgz",
+			"integrity": "sha512-KEMyWNNWnjOom8vR/1+d+Ocz/mILZG/eyHHO06OuBQ2aNhxT62fr4y6fGOplRx+CxCSp3IFwesL8WdINfY/3kg==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.7.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz",
-			"integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.0.tgz",
+			"integrity": "sha512-ZAuFgYjJzDNv77AjXRqzQGlQl4HdUM6j296ee4fwKVZfhDR9LAGxfvXjBkb06gNETPnN0sLqRm9Gxg4wZH6dXg==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-hoist-variables": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.0.tgz",
+			"integrity": "sha512-u7eBA03zmUswQ9LQ7Qw0/ieC1pcAkbp5OQatbWUzY1PaBccvuJXUkYzoN1g7cqp7dbTu6Dp9bXyalBvD04AANA==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz",
-			"integrity": "sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.0.tgz",
+			"integrity": "sha512-+SicSJoKouPctL+j1pqktRVCgy+xAch1hWWTMy13j0IflnyNjaoskj+DwRQFimHbLqO3sq2oN2CXMvXq3Bgapg==",
 			"requires": {
-				"regexp-tree": "^0.1.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
-			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+			"integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0"
+				"@babel/helper-replace-supers": "^7.5.5"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz",
-			"integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
 			"requires": {
-				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-call-delegate": "^7.4.4",
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
-			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
 			"requires": {
-				"regenerator-transform": "^0.13.3"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-react-display-name": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz",
+			"integrity": "sha512-mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==",
+			"requires": {
+				"@babel/helper-builder-react-jsx": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-self": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+			"integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-source": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+			"integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.0.tgz",
+			"integrity": "sha512-AXmvnC+0wuj/cFkkS/HFHIojxH3ffSXE+ttulrqWjZZRaUOonfJc60e1wSNT4rV8tIunvu/R3wCp71/tLAa9xg==",
+			"requires": {
+				"regenerator-transform": "^0.14.0"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
+			"integrity": "sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -529,9 +716,9 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+			"integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -546,9 +733,9 @@
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
-			"integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -562,14 +749,23 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
-			"integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+		"@babel/plugin-transform-typescript": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.2.tgz",
+			"integrity": "sha512-UWhDaJRqdPUtdK1s0sKYdoRuqK0NepjZto2UZltvuCgMoMZmdjhgz5hcRokie/3aYEaSz3xvusyoayVaq4PjRg==",
 			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.7.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/plugin-syntax-typescript": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.0.tgz",
+			"integrity": "sha512-RrThb0gdrNwFAqEAAx9OWgtx6ICK69x7i9tCnMdVrxQwSDp/Abu9DXFU5Hh16VP33Rmxh04+NGW28NsIkFvFKA==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/preset-env": {
@@ -622,6 +818,27 @@
 				"semver": "^5.3.0"
 			}
 		},
+		"@babel/preset-react": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.0.tgz",
+			"integrity": "sha512-IXXgSUYBPHUGhUkH+89TR6faMcBtuMW0h5OHbMuVbL3/5wK2g6a2M2BBpkLa+Kw0sAHiZ9dNVgqJMDP/O4GRBA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.7.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
+			}
+		},
+		"@babel/preset-typescript": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.6.0.tgz",
+			"integrity": "sha512-4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-transform-typescript": "^7.6.0"
+			}
+		},
 		"@babel/register": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
@@ -645,40 +862,45 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+			"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.2.2",
-				"@babel/types": "^7.2.2"
+				"@babel/parser": "^7.7.0",
+				"@babel/types": "^7.7.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+			"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.2.2",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/parser": "^7.2.3",
-				"@babel/types": "^7.2.2",
+				"@babel/code-frame": "^7.5.5",
+				"@babel/generator": "^7.7.2",
+				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-split-export-declaration": "^7.7.0",
+				"@babel/parser": "^7.7.2",
+				"@babel/types": "^7.7.2",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
-			"integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+			"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.13",
 				"to-fast-properties": "^2.0.0"
 			}
+		},
+		"@csstools/convert-colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
+			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
 		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",
@@ -760,9 +982,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "10.12.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.23.tgz",
-			"integrity": "sha512-EKhb5NveQ3NlW5EV7B0VRtDKwUfVey8LuJRl9pp5iW0se87/ZqLjG0PMf2MCzPXAJYWZN5Ltg7pHIAf9/Dm1tQ=="
+			"version": "12.12.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
+			"integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ=="
 		},
 		"@xmpp/client-core": {
 			"version": "0.3.0",
@@ -892,50 +1114,44 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
 			"requires": {
-				"mime-types": "~2.1.18",
-				"negotiator": "0.6.1"
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
 			}
 		},
 		"acorn": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-			"integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw=="
-		},
-		"acorn-dynamic-import": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+			"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
 		},
 		"acorn-jsx": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
 			"dev": true
 		},
 		"acorn-node": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.6.2.tgz",
-			"integrity": "sha512-rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+			"integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
 			"requires": {
-				"acorn": "^6.0.2",
-				"acorn-dynamic-import": "^4.0.0",
-				"acorn-walk": "^6.1.0",
-				"xtend": "^4.0.1"
+				"acorn": "^7.0.0",
+				"acorn-walk": "^7.0.0",
+				"xtend": "^4.0.2"
 			}
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
+			"integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg=="
 		},
 		"address": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
+			"integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA=="
 		},
 		"after": {
 			"version": "0.8.2",
@@ -943,17 +1159,17 @@
 			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
 		},
 		"agent-base": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
 		},
 		"ajv": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
-			"integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -993,9 +1209,9 @@
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -1003,107 +1219,6 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
 				"color-convert": "^1.9.0"
-			}
-		},
-		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"optional": true,
-			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"optional": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"optional": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"optional": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"optional": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"optional": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"optional": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"optional": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"optional": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				}
 			}
 		},
 		"argparse": {
@@ -1141,11 +1256,6 @@
 			"resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
 			"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
 		},
-		"array-filter": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
-		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -1155,16 +1265,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
-		"array-map": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
-		},
-		"array-reduce": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
 		},
 		"array-slice": {
 			"version": "1.1.0",
@@ -1228,10 +1328,11 @@
 			}
 		},
 		"assert": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
 			"requires": {
+				"object-assign": "^4.1.1",
 				"util": "0.10.3"
 			},
 			"dependencies": {
@@ -1271,16 +1372,10 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
-		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-			"optional": true
-		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -1293,27 +1388,17 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"autoprefixer": {
-			"version": "6.7.7",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+			"version": "9.7.2",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.2.tgz",
+			"integrity": "sha512-LCAfcdej1182uVvPOZnytbq61AhnOZ/4JelDaJGDeNwewyU1AMaNthcHsyz1NRjTmd2FkurMckLWfkHg3Z//KA==",
 			"requires": {
-				"browserslist": "^1.7.6",
-				"caniuse-db": "^1.0.30000634",
+				"browserslist": "^4.7.3",
+				"caniuse-lite": "^1.0.30001010",
+				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^5.2.16",
-				"postcss-value-parser": "^3.2.3"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
-					}
-				}
+				"postcss": "^7.0.23",
+				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"aws-sign2": {
@@ -1326,57 +1411,42 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
-		"babel-cli": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
-			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-polyfill": "^6.26.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"chokidar": "^1.6.1",
-				"commander": "^2.11.0",
-				"convert-source-map": "^1.5.0",
-				"fs-readdir-recursive": "^1.0.0",
-				"glob": "^7.1.2",
-				"lodash": "^4.17.4",
-				"output-file-sync": "^1.1.2",
-				"path-is-absolute": "^1.0.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6",
-				"v8flags": "^2.1.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-				},
-				"v8flags": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-					"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-					"requires": {
-						"user-home": "^1.1.1"
-					}
-				}
-			}
-		},
 		"babel-code-frame": {
-			"version": "7.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
-			"integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "^2.0.0",
+				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"js-tokens": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -1406,43 +1476,6 @@
 				"source-map": "^0.5.7"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"babel-code-frame": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
-					}
-				},
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1450,11 +1483,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 				},
 				"json5": {
 					"version": "0.5.1",
@@ -1465,19 +1493,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -1517,132 +1532,6 @@
 				}
 			}
 		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-builder-react-jsx": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
-			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
-			}
-		},
-		"babel-helper-call-delegate": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-define-map": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-get-function-arity": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-hoist-variables": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-optimise-call-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-replace-supers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
 		"babel-helpers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
@@ -1660,580 +1549,178 @@
 				"babel-runtime": "^6.22.0"
 			}
 		},
-		"babel-plugin-check-es2015-constants": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"object.assign": "^4.1.0"
 			}
 		},
-		"babel-plugin-syntax-async-functions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-		},
-		"babel-plugin-syntax-class-properties": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-		},
-		"babel-plugin-syntax-flow": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
-		},
-		"babel-plugin-syntax-jsx": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+		"babel-plugin-macros": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
+			"integrity": "sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-class-properties": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.22.0.tgz",
-			"integrity": "sha1-qnj4E0SVx94GwJcRi6BhhE4dwdg=",
-			"requires": {
-				"babel-helper-function-name": "^6.22.0",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-arrow-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoped-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoping": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-plugin-transform-es2015-classes": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-computed-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-destructuring": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-duplicate-keys": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-for-of": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-amd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-systemjs": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-umd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-object-super": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-parameters": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-shorthand-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-spread": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-template-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-typeof-symbol": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"@babel/runtime": "^7.4.2",
+				"cosmiconfig": "^5.2.0",
+				"resolve": "^1.10.0"
 			},
 			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-				},
-				"regexpu-core": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-					"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+				"@babel/runtime": {
+					"version": "7.7.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+					"integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
 					"requires": {
-						"regenerate": "^1.2.1",
-						"regjsgen": "^0.2.0",
-						"regjsparser": "^0.1.4"
+						"regenerator-runtime": "^0.13.2"
 					}
 				},
-				"regjsgen": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-				},
-				"regjsparser": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-					"requires": {
-						"jsesc": "~0.5.0"
-					}
-				}
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-flow-strip-types": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-object-rest-spread": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.22.0.tgz",
-			"integrity": "sha1-HUGbVeaNLk9kpf8zc71n1zyOg7w=",
-			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-constant-elements": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.22.0.tgz",
-			"integrity": "sha1-SvRW+A0oPovgDwDxKFI1Te+gjuE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-display-name": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.22.0.tgz",
-			"integrity": "sha1-SFVrfdTD/pfRyUO81U/D8lYcGBc=",
-			"requires": {
-				"babel-helper-builder-react-jsx": "^6.22.0",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-self": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-source": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-regenerator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"requires": {
-				"regenerator-transform": "^0.10.0"
-			},
-			"dependencies": {
-				"regenerator-transform": {
-					"version": "0.10.1",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-					"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-					"requires": {
-						"babel-runtime": "^6.18.0",
-						"babel-types": "^6.19.0",
-						"private": "^0.1.6"
-					}
-				}
-			}
-		},
-		"babel-plugin-transform-runtime": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.22.0.tgz",
-			"integrity": "sha1-EJaNdgu/ZRckMIHux3jhD6goVRw=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-polyfill": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
-			},
-			"dependencies": {
 				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 				}
 			}
 		},
-		"babel-preset-env": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.2.1.tgz",
-			"integrity": "sha1-ZZF49U33SnR2X3lr5NKQtb7rP18=",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.3.13",
-				"babel-plugin-syntax-trailing-function-commas": "^6.13.0",
-				"babel-plugin-transform-async-to-generator": "^6.8.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
-				"babel-plugin-transform-es2015-block-scoping": "^6.6.0",
-				"babel-plugin-transform-es2015-classes": "^6.6.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.3.13",
-				"babel-plugin-transform-es2015-destructuring": "^6.6.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.6.0",
-				"babel-plugin-transform-es2015-for-of": "^6.6.0",
-				"babel-plugin-transform-es2015-function-name": "^6.3.13",
-				"babel-plugin-transform-es2015-literals": "^6.3.13",
-				"babel-plugin-transform-es2015-modules-amd": "^6.8.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.6.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.12.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.12.0",
-				"babel-plugin-transform-es2015-object-super": "^6.3.13",
-				"babel-plugin-transform-es2015-parameters": "^6.6.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
-				"babel-plugin-transform-es2015-spread": "^6.3.13",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
-				"babel-plugin-transform-es2015-template-literals": "^6.6.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
-				"babel-plugin-transform-exponentiation-operator": "^6.8.0",
-				"babel-plugin-transform-regenerator": "^6.6.0",
-				"browserslist": "^1.4.0",
-				"electron-to-chromium": "^1.1.0",
-				"invariant": "^2.2.2"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
-					}
-				}
-			}
-		},
-		"babel-preset-es2015": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-				"babel-plugin-transform-es2015-classes": "^6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-				"babel-plugin-transform-es2015-for-of": "^6.22.0",
-				"babel-plugin-transform-es2015-function-name": "^6.24.1",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-				"babel-plugin-transform-es2015-object-super": "^6.24.1",
-				"babel-plugin-transform-es2015-parameters": "^6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-				"babel-plugin-transform-regenerator": "^6.24.1"
-			}
-		},
-		"babel-preset-react": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.22.0.tgz",
-			"integrity": "sha1-e8l+LXPuxLmA+2tOTgiE6BzNwWU=",
-			"requires": {
-				"babel-plugin-syntax-flow": "^6.3.13",
-				"babel-plugin-syntax-jsx": "^6.3.13",
-				"babel-plugin-transform-flow-strip-types": "^6.22.0",
-				"babel-plugin-transform-react-display-name": "^6.22.0",
-				"babel-plugin-transform-react-jsx": "^6.22.0",
-				"babel-plugin-transform-react-jsx-self": "^6.22.0",
-				"babel-plugin-transform-react-jsx-source": "^6.22.0"
-			}
+		"babel-plugin-transform-react-remove-prop-types": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
 		},
 		"babel-preset-react-app": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-2.2.0.tgz",
-			"integrity": "sha1-MUO88xYEn3i1+dBCL9eCLKRxXKQ=",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.2.tgz",
+			"integrity": "sha512-aXD+CTH8Chn8sNJr4tO/trWKqe5sSE4hdO76j9fhVezJSzmpWYWUSc5JoPmdSxADwef5kQFNGKXd433vvkd2VQ==",
 			"requires": {
-				"babel-plugin-transform-class-properties": "6.22.0",
-				"babel-plugin-transform-object-rest-spread": "6.22.0",
-				"babel-plugin-transform-react-constant-elements": "6.22.0",
-				"babel-plugin-transform-react-jsx": "6.22.0",
-				"babel-plugin-transform-react-jsx-self": "6.22.0",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-plugin-transform-regenerator": "6.22.0",
-				"babel-plugin-transform-runtime": "6.22.0",
-				"babel-preset-env": "1.2.1",
-				"babel-preset-react": "6.22.0",
-				"babel-runtime": "6.22.0"
+				"@babel/core": "7.6.0",
+				"@babel/plugin-proposal-class-properties": "7.5.5",
+				"@babel/plugin-proposal-decorators": "7.6.0",
+				"@babel/plugin-proposal-object-rest-spread": "7.5.5",
+				"@babel/plugin-syntax-dynamic-import": "7.2.0",
+				"@babel/plugin-transform-destructuring": "7.6.0",
+				"@babel/plugin-transform-flow-strip-types": "7.4.4",
+				"@babel/plugin-transform-react-display-name": "7.2.0",
+				"@babel/plugin-transform-runtime": "7.6.0",
+				"@babel/preset-env": "7.6.0",
+				"@babel/preset-react": "7.0.0",
+				"@babel/preset-typescript": "7.6.0",
+				"@babel/runtime": "7.6.0",
+				"babel-plugin-dynamic-import-node": "2.3.0",
+				"babel-plugin-macros": "2.6.1",
+				"babel-plugin-transform-react-remove-prop-types": "0.4.24"
 			},
 			"dependencies": {
-				"babel-plugin-transform-regenerator": {
-					"version": "6.22.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
-					"integrity": "sha1-ZXQFk6MZxEUiFXU41pC4QJRhfqY=",
+				"@babel/core": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+					"integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
 					"requires": {
-						"regenerator-transform": "0.9.8"
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.6.0",
+						"@babel/helpers": "^7.6.0",
+						"@babel/parser": "^7.6.0",
+						"@babel/template": "^7.6.0",
+						"@babel/traverse": "^7.6.0",
+						"@babel/types": "^7.6.0",
+						"convert-source-map": "^1.1.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.13",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
 					}
 				},
-				"babel-runtime": {
-					"version": "6.22.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-					"integrity": "sha1-HPi0rGfHek3bDbKuH3TeUqxMphE=",
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+					"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
 					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.10.0"
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
+					"integrity": "sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+						"@babel/plugin-proposal-dynamic-import": "^7.5.0",
+						"@babel/plugin-proposal-json-strings": "^7.2.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.2.0",
+						"@babel/plugin-syntax-json-strings": "^7.2.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-transform-arrow-functions": "^7.2.0",
+						"@babel/plugin-transform-async-to-generator": "^7.5.0",
+						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+						"@babel/plugin-transform-block-scoping": "^7.6.0",
+						"@babel/plugin-transform-classes": "^7.5.5",
+						"@babel/plugin-transform-computed-properties": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.6.0",
+						"@babel/plugin-transform-dotall-regex": "^7.4.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.5.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+						"@babel/plugin-transform-for-of": "^7.4.4",
+						"@babel/plugin-transform-function-name": "^7.4.4",
+						"@babel/plugin-transform-literals": "^7.2.0",
+						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+						"@babel/plugin-transform-modules-amd": "^7.5.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.6.0",
+						"@babel/plugin-transform-modules-systemjs": "^7.5.0",
+						"@babel/plugin-transform-modules-umd": "^7.2.0",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
+						"@babel/plugin-transform-new-target": "^7.4.4",
+						"@babel/plugin-transform-object-super": "^7.5.5",
+						"@babel/plugin-transform-parameters": "^7.4.4",
+						"@babel/plugin-transform-property-literals": "^7.2.0",
+						"@babel/plugin-transform-regenerator": "^7.4.5",
+						"@babel/plugin-transform-reserved-words": "^7.2.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+						"@babel/plugin-transform-spread": "^7.2.0",
+						"@babel/plugin-transform-sticky-regex": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.4.4",
+						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+						"@babel/plugin-transform-unicode-regex": "^7.4.4",
+						"@babel/types": "^7.6.0",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.1.1",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
+					}
+				},
+				"@babel/preset-react": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
+					"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-transform-react-display-name": "^7.0.0",
+						"@babel/plugin-transform-react-jsx": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-self": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-source": "^7.0.0"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+					"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
 					}
 				},
 				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-				},
-				"regenerator-transform": {
-					"version": "0.9.8",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
-					"integrity": "sha1-D4i7K8A5Mt23trcxLmgHjwECbWw=",
-					"requires": {
-						"babel-runtime": "^6.18.0",
-						"babel-types": "^6.19.0",
-						"private": "^0.1.6"
-					}
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 				}
 			}
 		},
@@ -2296,13 +1783,6 @@
 				"babel-types": "^6.26.0",
 				"babylon": "^6.18.0",
 				"lodash": "^4.17.4"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-				}
 			}
 		},
 		"babel-traverse": {
@@ -2321,43 +1801,6 @@
 				"lodash": "^4.17.4"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"babel-code-frame": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
-					}
-				},
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2371,28 +1814,10 @@
 					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
 					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -2415,28 +1840,19 @@
 			}
 		},
 		"babelify": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-			"integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-			"requires": {
-				"babel-core": "^6.0.14",
-				"object-assign": "^4.0.0"
-			}
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+			"integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg=="
 		},
 		"babylon": {
-			"version": "7.0.0-beta.34",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.34.tgz",
-			"integrity": "sha512-ribEzWEhWKKjY+1FdKCryo+HiN/1idPjUB8vyR5Yf221MtGzCd5+7OwPvWvYHerHHC2eJLr6MhvumbTocXGY7Q=="
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"backo2": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
 			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-		},
-		"bail": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -2504,14 +1920,14 @@
 			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"base64id": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -2529,12 +1945,6 @@
 				"callsite": "1.0.0"
 			}
 		},
-		"binary-extensions": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
-			"optional": true
-		},
 		"bitwise-xor": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/bitwise-xor/-/bitwise-xor-0.0.0.tgz",
@@ -2546,9 +1956,9 @@
 			"integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
 		},
 		"bluebird": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -2556,20 +1966,20 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
-			"version": "1.18.3",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
 			"requires": {
-				"bytes": "3.0.0",
+				"bytes": "3.1.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
-				"http-errors": "~1.6.3",
-				"iconv-lite": "0.4.23",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
 				"on-finished": "~2.3.0",
-				"qs": "6.5.2",
-				"raw-body": "2.3.3",
-				"type-is": "~1.6.16"
+				"qs": "6.7.0",
+				"raw-body": "2.4.0",
+				"type-is": "~1.6.17"
 			},
 			"dependencies": {
 				"debug": {
@@ -2580,18 +1990,15 @@
 						"ms": "2.0.0"
 					}
 				},
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 				}
 			}
 		},
@@ -2678,9 +2085,9 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"browserify": {
-			"version": "16.2.3",
-			"resolved": "https://registry.npmjs.org/browserify/-/browserify-16.2.3.tgz",
-			"integrity": "sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==",
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.0.tgz",
+			"integrity": "sha512-6bfI3cl76YLAnCZ75AGu/XPOsqUhRyc0F/olGIJeCxtfxF2HvPKEcmjU9M8oAPxl4uBY1U7Nry33Q6koV3f2iw==",
 			"requires": {
 				"JSONStream": "^1.0.3",
 				"assert": "^1.4.0",
@@ -2719,7 +2126,7 @@
 				"shasum": "^1.0.0",
 				"shell-quote": "^1.6.1",
 				"stream-browserify": "^2.0.0",
-				"stream-http": "^2.0.0",
+				"stream-http": "^3.0.0",
 				"string_decoder": "^1.1.1",
 				"subarg": "^1.0.0",
 				"syntax-error": "^1.1.1",
@@ -2805,19 +2212,19 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
-			"integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.3.tgz",
+			"integrity": "sha512-jWvmhqYpx+9EZm/FxcZSbUZyDEvDTLDi3nSAKbzEkyWvtI0mNSmUosey+5awDW1RUlrgXbQb5A6qY1xQH9U6MQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000929",
-				"electron-to-chromium": "^1.3.103",
-				"node-releases": "^1.1.3"
+				"caniuse-lite": "^1.0.30001010",
+				"electron-to-chromium": "^1.3.306",
+				"node-releases": "^1.1.40"
 			}
 		},
 		"buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+			"integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4"
@@ -2849,14 +2256,14 @@
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"bulma": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/bulma/-/bulma-0.3.2.tgz",
-			"integrity": "sha1-LB+mra8qMfR6FCwRhW8tsnvGOMk="
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/bulma/-/bulma-0.8.0.tgz",
+			"integrity": "sha512-nhf3rGyiZh/VM7FrSJ/5KeLlfaFkXz0nYcXriynfPH4vVpnxnqyEwaNGdNCVzHyyCA3cHgkQAMpdF/SFbFGZfA=="
 		},
 		"bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
 		"cache-base": {
 			"version": "1.0.1",
@@ -2879,21 +2286,36 @@
 			"resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
 			"integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg=="
 		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"requires": {
+				"callsites": "^2.0.0"
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"requires": {
+				"caller-callsite": "^2.0.0"
+			}
+		},
 		"callsite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
 			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
 		},
 		"callsites": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
-			"dev": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camelcase": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
@@ -2902,51 +2324,12 @@
 			"requires": {
 				"camelcase": "^2.0.0",
 				"map-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				}
 			}
-		},
-		"caniuse-api": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-			"requires": {
-				"browserslist": "^1.3.6",
-				"caniuse-db": "^1.0.30000529",
-				"lodash.memoize": "^4.1.2",
-				"lodash.uniq": "^4.5.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
-					}
-				},
-				"lodash.memoize": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-					"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-				}
-			}
-		},
-		"caniuse-db": {
-			"version": "1.0.30000935",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000935.tgz",
-			"integrity": "sha512-HFqvW9MZZcWD02F3J2GV2ggQyIXiDr7DRPlOWSKVIihu8J1dtsYFqtMjmFqiYamfOmY4NHyn7xFaWAHBtFWgjQ=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000935",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz",
-			"integrity": "sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ=="
+			"version": "1.0.30001011",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001011.tgz",
+			"integrity": "sha512-h+Eqyn/YA6o6ZTqpS86PyRmNWOs1r54EBDcd2NTwwfsXQ8re1B38SnB+p2RKF8OUsyEIjeDU8XGec1RGO/wYCg=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -2979,60 +2362,11 @@
 				"supports-color": "^5.3.0"
 			}
 		},
-		"character-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
-		},
-		"character-entities-legacy": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
-		},
-		"character-reference-invalid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
-		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"optional": true,
-			"requires": {
-				"anymatch": "^1.3.0",
-				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"optional": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
-			}
 		},
 		"chromedriver": {
 			"version": "77.0.0",
@@ -3077,11 +2411,6 @@
 			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
 			"dev": true
 		},
-		"cjk-regex": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/cjk-regex/-/cjk-regex-1.0.2.tgz",
-			"integrity": "sha512-NwSMtwULPLk8Ka9DEUcoFXhMRnV/bpyKDnoyDiVw/Qy5przhvHTvXLcsKaOmx13o8J4XEsPVT1baoCUj5zQs3w=="
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3112,9 +2441,9 @@
 			},
 			"dependencies": {
 				"commander": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				}
 			}
 		},
@@ -3156,13 +2485,6 @@
 				"es6-iterator": "^2.0.3",
 				"memoizee": "^0.4.14",
 				"timers-ext": "^0.1.5"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				}
 			}
 		},
 		"cli-cursor": {
@@ -3174,16 +2496,6 @@
 				"restore-cursor": "^2.0.0"
 			}
 		},
-		"cli-table3": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-			"integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
-			"requires": {
-				"colors": "^1.1.2",
-				"object-assign": "^4.1.0",
-				"string-width": "^2.1.1"
-			}
-		},
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -3191,19 +2503,19 @@
 			"dev": true
 		},
 		"cliui": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
+				"wordwrap": "0.0.2"
 			}
 		},
 		"clone": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
 		"co": {
 			"version": "4.6.0",
@@ -3220,11 +2532,6 @@
 			"resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
 			"integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4="
 		},
-		"collapse-white-space": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
-		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3232,16 +2539,6 @@
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
-			}
-		},
-		"color": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-			"requires": {
-				"clone": "^1.0.2",
-				"color-convert": "^1.3.0",
-				"color-string": "^0.3.0"
 			}
 		},
 		"color-convert": {
@@ -3257,18 +2554,10 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"color-string": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"requires": {
-				"color-name": "^1.0.0"
-			}
-		},
 		"colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
 		},
 		"combine-source-map": {
 			"version": "0.8.0",
@@ -3289,9 +2578,9 @@
 			}
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -3317,9 +2606,9 @@
 			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
 		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"component-inherit": {
 			"version": "0.0.3",
@@ -3390,12 +2679,9 @@
 			}
 		},
 		"console-browserify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"requires": {
-				"date-now": "^0.1.4"
-			}
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3403,9 +2689,12 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
 		},
 		"content-disposition": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
 		},
 		"content-type": {
 			"version": "1.0.4",
@@ -3413,17 +2702,17 @@
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"convert-source-map": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
 		},
 		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
@@ -3436,9 +2725,25 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-			"integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+		},
+		"core-js-compat": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.1.tgz",
+			"integrity": "sha512-YdeJI26gLc0CQJ9asLE5obEgBz2I0+CIgnoTbS2T0d5IPQw/OCgCIFR527RmpduxjrB3gSEHoGOCTq9sigOyfw==",
+			"requires": {
+				"browserslist": "^4.7.2",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -3446,38 +2751,14 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-			"integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
 			"requires": {
+				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
-				"parse-json": "^3.0.0",
-				"require-from-string": "^2.0.1"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				},
-				"js-yaml": {
-					"version": "3.12.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-					"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-					"integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
-					"requires": {
-						"error-ex": "^1.3.1"
-					}
-				}
+				"js-yaml": "^3.13.1",
+				"parse-json": "^4.0.0"
 			}
 		},
 		"create-ecdh": {
@@ -3514,26 +2795,25 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"create-react-class": {
-			"version": "15.6.3",
-			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-			"requires": {
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
-			}
-		},
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
 			"requires": {
 				"nice-try": "^1.0.4",
 				"path-key": "^2.0.1",
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				}
 			}
 		},
 		"cryptiles": {
@@ -3562,31 +2842,40 @@
 				"randomfill": "^1.0.3"
 			}
 		},
-		"css-color-function": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.3.tgz",
-			"integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
+		"css-blank-pseudo": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
+			"integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
 			"requires": {
-				"balanced-match": "0.1.0",
-				"color": "^0.11.0",
-				"debug": "^3.1.0",
-				"rgb": "~0.1.0"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-					"integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"postcss": "^7.0.5"
 			}
+		},
+		"css-has-pseudo": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
+			"integrity": "sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==",
+			"requires": {
+				"postcss": "^7.0.6",
+				"postcss-selector-parser": "^5.0.0-rc.4"
+			}
+		},
+		"css-prefers-color-scheme": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+			"integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
+			"requires": {
+				"postcss": "^7.0.5"
+			}
+		},
+		"cssdb": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
+			"integrity": "sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ=="
+		},
+		"cssesc": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+			"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
 		},
 		"ctype": {
 			"version": "0.5.3",
@@ -3603,12 +2892,18 @@
 			}
 		},
 		"d": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
 			"requires": {
-				"es5-ext": "^0.10.9"
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
 			}
+		},
+		"dash-ast": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+			"integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA=="
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -3618,20 +2913,10 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"dashify": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dashify/-/dashify-0.2.2.tgz",
-			"integrity": "sha1-agdBWgHJH69KMuONnfunH2HLIP4="
-		},
 		"date-fns": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
 			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
-		},
-		"date-now": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"dateformat": {
 			"version": "1.0.12",
@@ -3673,6 +2958,14 @@
 				"for-own": "^0.1.3",
 				"is-extendable": "^0.1.1",
 				"lazy-cache": "^0.2.3"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"requires": {
+				"object-keys": "^1.0.12"
 			}
 		},
 		"define-property": {
@@ -3749,20 +3042,20 @@
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"deps-sort": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
-			"integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+			"integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
 			"requires": {
 				"JSONStream": "^1.0.3",
-				"shasum": "^1.0.0",
+				"shasum-object": "^1.0.0",
 				"subarg": "^1.0.0",
 				"through2": "^2.0.0"
 			}
 		},
 		"des.js": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
 			"requires": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
@@ -3785,11 +3078,6 @@
 			"requires": {
 				"repeating": "^2.0.0"
 			}
-		},
-		"detect-newline": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
 		},
 		"detect-port": {
 			"version": "1.3.0",
@@ -3887,44 +3175,20 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"editorconfig": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.14.2.tgz",
-			"integrity": "sha512-tghjvKwo1gakrhFiZWlbo5ILWAfnuOu1JFztW0li+vzbnInN0CMZuF4F0T/Pnn9UWpT7Mr1aFTWdHVuxiR9K9A==",
-			"requires": {
-				"bluebird": "^3.0.5",
-				"commander": "^2.9.0",
-				"lru-cache": "^3.2.0",
-				"semver": "^5.1.0",
-				"sigmund": "^1.0.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-				}
-			}
-		},
-		"editorconfig-to-prettier": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.0.6.tgz",
-			"integrity": "sha512-Ysw+hBdwhPFruYmLapKRm7Or5XgMzhasbqu4AN07V2l/AkqpgooWm2xtTQPzTD6S0tq54A+WbSxNt6qmsO3hoA=="
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.113",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
-			"integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g=="
+			"version": "1.3.307",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.307.tgz",
+			"integrity": "sha512-01rTsAqHwf3D2X6NtlUvzB2hxDj67kiTVIO5GWdFb2unA0QvFvrjyrtc993ByRLF+surlr+9AvJdD0UYs5HzwA=="
 		},
 		"elliptic": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -3936,9 +3200,10 @@
 			}
 		},
 		"emoji-regex": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -3954,58 +3219,50 @@
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"requires": {
 				"once": "^1.4.0"
 			}
 		},
 		"engine.io": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
-			"integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.0.tgz",
+			"integrity": "sha512-XCyYVWzcHnK5cMz7G4VTu2W7zJS7SM1QkcelghyIk/FmobWBtXE7fwhBusEKvCSqc3bMh8fNFMlUkCKTFRxH2w==",
 			"requires": {
 				"accepts": "~1.3.4",
-				"base64id": "1.0.0",
+				"base64id": "2.0.0",
 				"cookie": "0.3.1",
-				"debug": "~3.1.0",
-				"engine.io-parser": "~2.1.0",
-				"ws": "~6.1.0"
+				"debug": "~4.1.0",
+				"engine.io-parser": "~2.2.0",
+				"ws": "^7.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				"cookie": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+					"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
 				},
 				"ws": {
-					"version": "6.1.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
-					"integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
+					"integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
 					"requires": {
-						"async-limiter": "~1.0.0"
+						"async-limiter": "^1.0.0"
 					}
 				}
 			}
 		},
 		"engine.io-client": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
-			"integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
+			"integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
 			"requires": {
 				"component-emitter": "1.2.1",
 				"component-inherit": "0.0.3",
-				"debug": "~3.1.0",
-				"engine.io-parser": "~2.1.1",
+				"debug": "~4.1.0",
+				"engine.io-parser": "~2.2.0",
 				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
 				"parseqs": "0.0.5",
@@ -4015,23 +3272,15 @@
 				"yeast": "0.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 				},
 				"ws": {
-					"version": "6.1.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
-					"integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
+					"version": "6.1.4",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+					"integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
 					"requires": {
 						"async-limiter": "~1.0.0"
 					}
@@ -4039,9 +3288,9 @@
 			}
 		},
 		"engine.io-parser": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
-			"integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+			"integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
 			"requires": {
 				"after": "0.8.2",
 				"arraybuffer.slice": "~0.0.7",
@@ -4058,14 +3307,41 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"es-abstract": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.0",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-inspect": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"string.prototype.trimleft": "^2.1.0",
+				"string.prototype.trimright": "^2.1.0"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
 		"es5-ext": {
-			"version": "0.10.47",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
-			"integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
+			"version": "0.10.52",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
+			"integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
 			"requires": {
 				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
+				"es6-symbol": "~3.1.2",
+				"next-tick": "~1.0.0"
 			}
 		},
 		"es6-iterator": {
@@ -4079,9 +3355,9 @@
 			}
 		},
 		"es6-promise": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
@@ -4092,22 +3368,22 @@
 			}
 		},
 		"es6-symbol": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
 			}
 		},
 		"es6-weak-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
 			"requires": {
 				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-iterator": "^2.0.1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
 				"es6-symbol": "^3.1.1"
 			}
 		},
@@ -4222,36 +3498,45 @@
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
 				"eslint-scope": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
 					}
 				},
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
-				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.12.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-					"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+				"import-fresh": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
 					"dev": true,
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -4267,15 +3552,18 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-			"dev": true
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.1.0"
+			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 			"dev": true
 		},
 		"esm": {
@@ -4284,14 +3572,22 @@
 			"integrity": "sha512-r6v4kFfezz5/Qo6Q5ThaNPPUi7a2E3J4ZWxFuohhxJRAa6X7hg6Ca7GRPaixsi5ALcokhif/04Ys4zAxab4Edw=="
 		},
 		"espree": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-			"integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+			"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.2",
+				"acorn": "^6.0.7",
 				"acorn-jsx": "^5.0.0",
 				"eslint-visitor-keys": "^1.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -4318,15 +3614,15 @@
 			}
 		},
 		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -4362,17 +3658,46 @@
 			}
 		},
 		"execa": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+			"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+			"dev": true,
 			"requires": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"dev": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				}
 			}
 		},
 		"exit": {
@@ -4425,57 +3750,6 @@
 				}
 			}
 		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"optional": true,
-			"requires": {
-				"fill-range": "^2.1.0"
-			},
-			"dependencies": {
-				"fill-range": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"optional": true,
-					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^3.0.0",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
-					}
-				},
-				"is-number": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"optional": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"optional": true,
-					"requires": {
-						"isarray": "1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"optional": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
-		},
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -4485,38 +3759,38 @@
 			}
 		},
 		"express": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "~1.3.7",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.18.3",
-				"content-disposition": "0.5.2",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
 				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
+				"cookie": "0.4.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
+				"finalhandler": "~1.1.2",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"parseurl": "~1.3.3",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.4",
-				"qs": "6.5.2",
-				"range-parser": "~1.2.0",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
 				"safe-buffer": "5.1.2",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
 			},
@@ -4533,6 +3807,26 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+				}
+			}
+		},
+		"ext": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
+			"integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
+			"requires": {
+				"type": "^2.0.0"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
 				}
 			}
 		},
@@ -4561,9 +3855,9 @@
 			}
 		},
 		"external-editor": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
 			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
@@ -4688,34 +3982,10 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"fault": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
-			"integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
-			"requires": {
-				"format": "^0.2.2"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-				}
-			}
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
 		},
 		"fd-slicer": {
 			"version": "1.0.1",
@@ -4749,12 +4019,6 @@
 				"object-assign": "^4.0.1"
 			}
 		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"optional": true
-		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -4777,16 +4041,16 @@
 			}
 		},
 		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
@@ -4816,11 +4080,11 @@
 			}
 		},
 		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"findup-sync": {
@@ -4846,9 +4110,9 @@
 			}
 		},
 		"fined": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-			"integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+			"integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
 			"requires": {
 				"expand-tilde": "^2.0.2",
 				"is-plain-object": "^2.0.3",
@@ -4872,17 +4136,23 @@
 				"graceful-fs": "^4.1.2",
 				"rimraf": "~2.6.2",
 				"write": "^0.2.1"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
-		},
-		"flow-parser": {
-			"version": "0.59.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.59.0.tgz",
-			"integrity": "sha1-9uvK5h/6GH5CCZnUDOCoAfObJjU="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+			"integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -4912,11 +4182,6 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"format": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
-		},
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -4945,496 +4210,10 @@
 				"rimraf": "^2.2.8"
 			}
 		},
-		"fs-readdir-recursive": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
-			"optional": true,
-			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
-				},
-				"minipass": {
-					"version": "2.3.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.2.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.2.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.10.3",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.5",
-					"bundled": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.2.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"yallist": {
-					"version": "3.0.3",
-					"bundled": true,
-					"optional": true
-				}
-			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -5473,12 +4252,10 @@
 			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
 		},
 		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"requires": {
-				"pump": "^3.0.0"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -5499,9 +4276,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5509,59 +4286,6 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"optional": true,
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"optional": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
-			}
-		},
-		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"optional": true,
-			"requires": {
-				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"optional": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
 			}
 		},
 		"global-modules": {
@@ -5587,9 +4311,9 @@
 			}
 		},
 		"globals": {
-			"version": "11.10.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-			"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ=="
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
 		"globby": {
 			"version": "6.1.0",
@@ -5611,22 +4335,14 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-		},
-		"graphql": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
-			"integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
-			"requires": {
-				"iterall": "^1.1.0"
-			}
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -5634,9 +4350,9 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"grunt": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
-			"integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
+			"integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
 			"requires": {
 				"coffeescript": "~1.10.0",
 				"dateformat": "~1.0.12",
@@ -5649,7 +4365,7 @@
 				"grunt-legacy-log": "~2.0.0",
 				"grunt-legacy-util": "~1.1.1",
 				"iconv-lite": "~0.4.13",
-				"js-yaml": "~3.5.2",
+				"js-yaml": "~3.13.0",
 				"minimatch": "~3.0.2",
 				"mkdirp": "~0.5.1",
 				"nopt": "~3.0.6",
@@ -5685,6 +4401,29 @@
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
 					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "7.1.6",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
+					}
 				}
 			}
 		},
@@ -5736,13 +4475,6 @@
 				"grunt-legacy-log-utils": "~2.0.0",
 				"hooker": "~0.2.3",
 				"lodash": "~4.17.5"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-				}
 			}
 		},
 		"grunt-legacy-log-utils": {
@@ -5778,11 +4510,6 @@
 				"object-assign": "^4.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -5798,27 +4525,6 @@
 						"has-ansi": "^2.0.0",
 						"strip-ansi": "^3.0.0",
 						"supports-color": "^2.0.0"
-					}
-				},
-				"npm-run-path": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-					"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-					"requires": {
-						"path-key": "^1.0.0"
-					}
-				},
-				"path-key": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-					"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -5856,13 +4562,6 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				}
 			}
 		},
 		"has-binary2": {
@@ -5889,6 +4588,11 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"has-symbols": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -5991,9 +4695,9 @@
 			}
 		},
 		"hoek": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-			"integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+			"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
 		},
 		"home-or-tmp": {
 			"version": "3.0.0",
@@ -6001,9 +4705,9 @@
 			"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
 		},
 		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
@@ -6014,9 +4718,9 @@
 			"integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
 		},
 		"hosted-git-info": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
 		},
 		"html-minify": {
 			"version": "0.3.2",
@@ -6062,14 +4766,22 @@
 			}
 		},
 		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				}
 			}
 		},
 		"http-response-object": {
@@ -6088,9 +4800,9 @@
 			}
 		},
 		"http_ece": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.0.5.tgz",
-			"integrity": "sha1-tgZg+q8UIVEC0Uk+pyDc2StTNy8=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.1.0.tgz",
+			"integrity": "sha512-bptAfCDdPJxOs5zYSe7Y3lpr772s1G346R4Td5LgRUeCwIGpCGDUTJxRrhTNcAXbx37spge0kWEIH7QAYWNTlA==",
 			"requires": {
 				"urlsafe-base64": "~1.0.0"
 			}
@@ -6101,11 +4813,11 @@
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"https-proxy-agent": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"requires": {
-				"agent-base": "^4.1.0",
+				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
 			},
 			"dependencies": {
@@ -6146,64 +4858,6 @@
 						"parse-json": "^4.0.0",
 						"require-from-string": "^2.0.1"
 					}
-				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
-				},
-				"execa": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.12.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-					"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
 				}
 			}
 		},
@@ -6216,14 +4870,15 @@
 			}
 		},
 		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"ignore": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true
 		},
 		"immediate": {
 			"version": "3.0.6",
@@ -6231,13 +4886,12 @@
 			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"import-fresh": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-			"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
-			"dev": true,
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
 			"requires": {
-				"parent-module": "^1.0.0",
-				"resolve-from": "^4.0.0"
+				"caller-path": "^2.0.0",
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -6274,9 +4928,9 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -6292,9 +4946,9 @@
 			}
 		},
 		"inquirer": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-			"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
@@ -6303,28 +4957,63 @@
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^2.0.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.12",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
 				"string-width": "^2.1.0",
-				"strip-ansi": "^5.0.0",
+				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
-				"strip-ansi": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -6360,9 +5049,9 @@
 			}
 		},
 		"invert-kv": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ip-regex": {
 			"version": "2.1.0",
@@ -6370,9 +5059,9 @@
 			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
 		},
 		"ipaddr.js": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
 		"is-absolute": {
 			"version": "1.0.0",
@@ -6401,38 +5090,20 @@
 				}
 			}
 		},
-		"is-alphabetical": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
-		},
-		"is-alphanumerical": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
-			}
-		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
-		"is-binary-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"optional": true,
-			"requires": {
-				"binary-extensions": "^1.0.0"
-			}
-		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
 		"is-ci": {
 			"version": "1.2.1",
@@ -6461,10 +5132,10 @@
 				}
 			}
 		},
-		"is-decimal": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -6488,21 +5159,6 @@
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"optional": true
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"optional": true,
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -6522,9 +5178,12 @@
 			}
 		},
 		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
 		},
 		"is-glob": {
 			"version": "3.1.0",
@@ -6533,11 +5192,6 @@
 			"requires": {
 				"is-extglob": "^2.1.0"
 			}
-		},
-		"is-hexadecimal": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -6586,11 +5240,6 @@
 				"path-is-inside": "^1.0.2"
 			}
 		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6599,22 +5248,18 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"optional": true
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"optional": true
-		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "^1.0.1"
+			}
 		},
 		"is-relative": {
 			"version": "1.0.0",
@@ -6628,6 +5273,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -6652,20 +5305,10 @@
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
-		"is-whitespace-character": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-		},
-		"is-word-character": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
-			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA=="
 		},
 		"is2": {
 			"version": "2.0.1",
@@ -6687,63 +5330,15 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
-		"isnumeric": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
-			"integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ="
-		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
-			}
-		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
-		"iterall": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-			"integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
-		},
-		"jest-docblock": {
-			"version": "21.3.0-beta.11",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.3.0-beta.11.tgz",
-			"integrity": "sha512-sxSwZUm7JyCO8dverup5g/OKJhjYRrBdgEdezIO1qAmMGWuza7ewovpfDmxp+JLvlm0i2WRFKUQNNIMGmPGTVg==",
-			"requires": {
-				"detect-newline": "^2.1.0"
-			}
-		},
-		"jest-get-type": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-			"integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q=="
-		},
-		"jest-validate": {
-			"version": "21.1.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.1.0.tgz",
-			"integrity": "sha512-xS0cyErNWpsLFlGkn/b87pk/Mv7J+mCTs8hQ4KmtOIIoM1sHYobXII8AtkoN8FC7E3+Ptxjo+/3xWk6LK1dKcw==",
-			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^21.0.2",
-				"leven": "^2.1.0",
-				"pretty-format": "^21.1.0"
-			}
-		},
-		"js-base64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
 		},
 		"js-levenshtein": {
 			"version": "1.1.6",
@@ -6756,12 +5351,19 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-			"integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"requires": {
-				"argparse": "^1.0.2",
-				"esprima": "^2.6.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				}
 			}
 		},
 		"jsbn": {
@@ -6809,9 +5411,9 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
 			"requires": {
 				"minimist": "^1.2.0"
 			}
@@ -6873,20 +5475,12 @@
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 		},
 		"labeled-stream-splicer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
-			"integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+			"integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
 			"requires": {
 				"inherits": "^2.0.1",
-				"isarray": "^2.0.4",
 				"stream-splicer": "^2.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
-					"integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA=="
-				}
 			}
 		},
 		"lazy-cache": {
@@ -6895,17 +5489,12 @@
 			"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
 		},
 		"lcid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "^2.0.0"
+				"invert-kv": "^1.0.0"
 			}
-		},
-		"leven": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -6965,18 +5554,18 @@
 			}
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "^3.0.0",
+				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.14",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -7010,16 +5599,6 @@
 				"lodash._reinterpolate": "^3.0.0"
 			}
 		},
-		"lodash.unescape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
-		},
-		"lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-		},
 		"long": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
@@ -7048,11 +5627,13 @@
 			}
 		},
 		"lru-cache": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-			"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.1"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"lru-queue": {
@@ -7064,11 +5645,11 @@
 			}
 		},
 		"ltx": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.1.tgz",
-			"integrity": "sha512-l4H1FS9I6IVqwvIpUHsSgyxE6t2jP7qd/2MeVG1UhmVK6vlHsQpfm2KNUcbdImeE0ai04vl1qTCF4CPCJqhknQ==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
+			"integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
 			"requires": {
-				"inherits": "^2.0.1"
+				"inherits": "^2.0.4"
 			}
 		},
 		"mailosaur": {
@@ -7210,14 +5791,6 @@
 				"kind-of": "^6.0.2"
 			}
 		},
-		"map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"requires": {
-				"p-defer": "^1.0.0"
-			}
-		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -7244,16 +5817,6 @@
 				"yargs": "^3.15.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -7264,62 +5827,10 @@
 						"wrap-ansi": "^2.0.0"
 					}
 				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
 				"window-size": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
 					"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				},
 				"yargs": {
 					"version": "3.32.0",
@@ -7337,22 +5848,6 @@
 				}
 			}
 		},
-		"markdown-escapes": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
-		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
-		},
-		"math-random": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
-			"optional": true
-		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -7367,16 +5862,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"mem": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
-			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^1.0.0",
-				"p-is-promise": "^2.0.0"
-			}
 		},
 		"memoizee": {
 			"version": "0.4.14",
@@ -7450,27 +5935,28 @@
 			}
 		},
 		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
 		},
 		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"version": "2.1.25",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.42.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
@@ -7496,9 +5982,9 @@
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -7594,13 +6080,13 @@
 			"integrity": "sha512-KZvpMJTqzLZw3mOb+EEuYi4YZS41C9iTnb7skVFRxHjUd1OYbl64tCMSmpdIRM9LnwIrSOaRfPtNpF5msgv6Eg=="
 		},
 		"module-deps": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.0.tgz",
-			"integrity": "sha512-hKPmO06so6bL/ZvqVNVqdTVO8UAYsi3tQWlCa+z9KuWhoN4KDQtb5hcqQQv58qYiDE21wIvnttZEPiDgEbpwbA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.1.tgz",
+			"integrity": "sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==",
 			"requires": {
 				"JSONStream": "^1.0.3",
 				"browser-resolve": "^1.7.0",
-				"cached-path-relative": "^1.0.0",
+				"cached-path-relative": "^1.0.2",
 				"concat-stream": "~1.6.0",
 				"defined": "^1.0.0",
 				"detective": "^5.0.2",
@@ -7616,9 +6102,9 @@
 			}
 		},
 		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"mustache": {
 			"version": "2.3.2",
@@ -7630,12 +6116,6 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
-		},
-		"nan": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -7683,9 +6163,9 @@
 			}
 		},
 		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"next-tick": {
 			"version": "1.0.0",
@@ -7695,7 +6175,8 @@
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -7712,11 +6193,18 @@
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
 		},
 		"node-releases": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.7.tgz",
-			"integrity": "sha512-bKdrwaqJUPHqlCzDD7so/R+Nk0jGv9a11ZhLrD9f6i947qGLrGAhU3OxRENa19QQmwzGy/g6zCDEuLGDO8HPvA==",
+			"version": "1.1.40",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
+			"integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
 			"requires": {
-				"semver": "^5.3.0"
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"node-slack-upload": {
@@ -7737,9 +6225,9 @@
 			}
 		},
 		"node-watch": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.4.1.tgz",
-			"integrity": "sha1-0JR9VKmV+RE120BWtocixtfDIq0="
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.3.tgz",
+			"integrity": "sha512-InVPsg51EemnMVH3fvrrSVgqVBMlksZ/mK7ZDWx/NuWdNQi28wcVJX1/BP38alraPFXbRi9jZ35OfK4Ra7l8Bg=="
 		},
 		"nopt": {
 			"version": "3.0.6",
@@ -7760,31 +6248,22 @@
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
-		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"optional": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
-		},
 		"normalize-range": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
 		},
 		"normalize.css": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-5.0.0.tgz",
-			"integrity": "sha1-fOyHXOgXilMzxN6Ato6pwYudfDc="
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+			"integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
 		},
 		"npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+			"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "^1.0.0"
 			}
 		},
 		"num2fraction": {
@@ -7840,12 +6319,33 @@
 				}
 			}
 		},
+		"object-inspect": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
 				"isobject": "^3.0.0"
+			}
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"object.defaults": {
@@ -7869,6 +6369,15 @@
 				}
 			}
 		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
 		"object.map": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -7886,16 +6395,6 @@
 						"for-in": "^1.0.1"
 					}
 				}
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"optional": true,
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -7922,11 +6421,6 @@
 				"wrappy": "1"
 			}
 		},
-		"onecolor": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
-			"integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ="
-		},
 		"onetime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -7937,25 +6431,17 @@
 			}
 		},
 		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
 			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
+				"fast-levenshtein": "~2.0.6",
 				"levn": "~0.3.0",
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
-			},
-			"dependencies": {
-				"wordwrap": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-					"dev": true
-				}
+				"word-wrap": "~1.2.3"
 			}
 		},
 		"os-browserify": {
@@ -7969,13 +6455,11 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
+				"lcid": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -7992,45 +6476,26 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
-		"output-file-sync": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-			"requires": {
-				"graceful-fs": "^4.1.4",
-				"mkdirp": "^0.5.1",
-				"object-assign": "^4.1.0"
-			}
-		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-		},
-		"p-is-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
 		},
 		"p-limit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"requires": {
-				"p-try": "^2.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -8039,9 +6504,9 @@
 			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
 		},
 		"p-try": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"pad-stream": {
 			"version": "1.2.0",
@@ -8056,17 +6521,25 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
-			"integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
 		},
 		"parent-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+					"dev": true
+				}
 			}
 		},
 		"parents": {
@@ -8078,9 +6551,9 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
-			"integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -8088,19 +6561,6 @@
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
-			}
-		},
-		"parse-entities": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
-			"integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"parse-filepath": {
@@ -8111,35 +6571,6 @@
 				"is-absolute": "^1.0.0",
 				"map-cache": "^0.2.0",
 				"path-root": "^0.1.1"
-			}
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"optional": true,
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"optional": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
 			}
 		},
 		"parse-json": {
@@ -8161,14 +6592,6 @@
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
-		"parse5": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"parseqs": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
@@ -8186,9 +6609,9 @@
 			}
 		},
 		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -8216,9 +6639,9 @@
 			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+			"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -8297,32 +6720,11 @@
 			}
 		},
 		"pirates": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
-			"integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
-			}
-		},
-		"pixrem": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
-			"integrity": "sha1-MNG6+0w73Ojpu0vVahOYVhkyDDQ=",
-			"requires": {
-				"browserslist": "^1.0.0",
-				"postcss": "^5.0.0",
-				"reduce-css-calc": "^1.2.7"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
-					}
-				}
 			}
 		},
 		"pkg-dir": {
@@ -8331,55 +6733,6 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"requires": {
 				"find-up": "^2.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-				}
-			}
-		},
-		"pleeease-filters": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-3.0.1.tgz",
-			"integrity": "sha1-Tf4OjxBGYTUXxktyi8gGCKfr8i8=",
-			"requires": {
-				"onecolor": "~2.4.0",
-				"postcss": "^5.0.4"
 			}
 		},
 		"plur": {
@@ -8456,11 +6809,11 @@
 			},
 			"dependencies": {
 				"async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"requires": {
-						"lodash": "^4.17.10"
+						"lodash": "^4.17.14"
 					}
 				}
 			}
@@ -8471,516 +6824,346 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
-			"version": "5.2.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+			"integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
 			"requires": {
-				"chalk": "^1.1.3",
-				"js-base64": "^2.1.9",
-				"source-map": "^0.5.6",
-				"supports-color": "^3.2.3"
+				"chalk": "^2.4.2",
+				"source-map": "^0.6.1",
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "^3.0.0"
 					}
-				}
-			}
-		},
-		"postcss-apply": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.3.0.tgz",
-			"integrity": "sha1-ovN8W9+ogeTBX08kXsDNlt0ucNU=",
-			"requires": {
-				"balanced-match": "^0.4.1",
-				"postcss": "^5.0.21"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
 				}
 			}
 		},
 		"postcss-attribute-case-insensitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
-			"integrity": "sha1-zrc3d+EGFn6yM/GTjJvZ8uaXMI0=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
+			"integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
 			"requires": {
-				"postcss": "^5.1.1",
-				"postcss-selector-parser": "^2.2.0"
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0"
 			}
 		},
-		"postcss-calc": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-			"requires": {
-				"postcss": "^5.0.2",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-css-calc": "^1.2.6"
-			}
-		},
-		"postcss-color-function": {
+		"postcss-color-functional-notation": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-2.0.1.tgz",
-			"integrity": "sha1-mtIm9VDop8f4uKd4YFRbbdf1UkE=",
+			"resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
+			"integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
 			"requires": {
-				"css-color-function": "^1.2.0",
-				"postcss": "^5.0.4",
-				"postcss-message-helpers": "^2.0.0",
-				"postcss-value-parser": "^3.3.0"
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			}
 		},
 		"postcss-color-gray": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.1.tgz",
-			"integrity": "sha1-dEMu3mbdg7HRNjVlxos3bhj/Z3A=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
+			"integrity": "sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==",
 			"requires": {
-				"color": "^0.11.3",
-				"postcss": "^5.0.4",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-function-call": "^1.0.1"
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.5",
+				"postcss-values-parser": "^2.0.0"
 			}
 		},
 		"postcss-color-hex-alpha": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
-			"integrity": "sha1-RP1uyt5mAoZIyIHLZQTNy/3GzQk=",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+			"integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
 			"requires": {
-				"color": "^0.10.1",
-				"postcss": "^5.0.4",
-				"postcss-message-helpers": "^2.0.0"
-			},
-			"dependencies": {
-				"color": {
-					"version": "0.10.1",
-					"resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
-					"integrity": "sha1-wEGI34KiCd3rzOzazT7DIPGTc58=",
-					"requires": {
-						"color-convert": "^0.5.3",
-						"color-string": "^0.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "0.5.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-					"integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-				}
+				"postcss": "^7.0.14",
+				"postcss-values-parser": "^2.0.1"
 			}
 		},
-		"postcss-color-hsl": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-1.0.5.tgz",
-			"integrity": "sha1-9Tuxw0gxDOMHrYnjGBqGRzi15oc=",
+		"postcss-color-mod-function": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
+			"integrity": "sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==",
 			"requires": {
-				"postcss": "^5.2.0",
-				"postcss-value-parser": "^3.3.0",
-				"units-css": "^0.4.0"
-			}
-		},
-		"postcss-color-hwb": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-2.0.1.tgz",
-			"integrity": "sha1-1jr6+bcMtZX5AKKcn+V78qMvq+w=",
-			"requires": {
-				"color": "^0.11.4",
-				"postcss": "^5.0.4",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-function-call": "^1.0.1"
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			}
 		},
 		"postcss-color-rebeccapurple": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.1.tgz",
-			"integrity": "sha1-dMZETny7fYVhO19yht96SRYIRRw=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
+			"integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
 			"requires": {
-				"color": "^0.11.4",
-				"postcss": "^5.0.4"
-			}
-		},
-		"postcss-color-rgb": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-1.1.4.tgz",
-			"integrity": "sha1-8pJD4i6OjBNDRHQJI3LUzmBb6Lw=",
-			"requires": {
-				"postcss": "^5.2.0",
-				"postcss-value-parser": "^3.3.0"
-			}
-		},
-		"postcss-color-rgba-fallback": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-2.2.0.tgz",
-			"integrity": "sha1-bSlJG+WZCpMXPUfnx29YELCUAro=",
-			"requires": {
-				"postcss": "^5.0.0",
-				"postcss-value-parser": "^3.0.2",
-				"rgb-hex": "^1.0.0"
-			}
-		},
-		"postcss-cssnext": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-2.11.0.tgz",
-			"integrity": "sha1-MeaPAB5AlgTacDtm3hS4uMjJ8rE=",
-			"requires": {
-				"autoprefixer": "^6.0.2",
-				"caniuse-api": "^1.5.3",
-				"chalk": "^1.1.1",
-				"pixrem": "^3.0.0",
-				"pleeease-filters": "^3.0.0",
-				"postcss": "^5.0.4",
-				"postcss-apply": "^0.3.0",
-				"postcss-attribute-case-insensitive": "^1.0.1",
-				"postcss-calc": "^5.0.0",
-				"postcss-color-function": "^2.0.0",
-				"postcss-color-gray": "^3.0.0",
-				"postcss-color-hex-alpha": "^2.0.0",
-				"postcss-color-hsl": "^1.0.5",
-				"postcss-color-hwb": "^2.0.0",
-				"postcss-color-rebeccapurple": "^2.0.0",
-				"postcss-color-rgb": "^1.1.4",
-				"postcss-color-rgba-fallback": "^2.0.0",
-				"postcss-custom-media": "^5.0.0",
-				"postcss-custom-properties": "^5.0.0",
-				"postcss-custom-selectors": "^3.0.0",
-				"postcss-font-family-system-ui": "^1.0.1",
-				"postcss-font-variant": "^2.0.0",
-				"postcss-image-set-polyfill": "^0.3.3",
-				"postcss-initial": "^1.3.1",
-				"postcss-media-minmax": "^2.1.0",
-				"postcss-nesting": "^2.0.5",
-				"postcss-pseudo-class-any-link": "^1.0.0",
-				"postcss-pseudoelements": "^3.0.0",
-				"postcss-replace-overflow-wrap": "^1.0.0",
-				"postcss-selector-matches": "^2.0.0",
-				"postcss-selector-not": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			}
 		},
 		"postcss-custom-media": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz",
-			"integrity": "sha1-E40loYS/LrVN4S1VpsAcMKnYvYE=",
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+			"integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
 			"requires": {
-				"postcss": "^5.0.0"
+				"postcss": "^7.0.14"
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-5.0.2.tgz",
-			"integrity": "sha1-lxnXjy2pz59TgQrrwj1GVhMKzrE=",
+			"version": "8.0.11",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+			"integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
 			"requires": {
-				"balanced-match": "^0.4.2",
-				"postcss": "^5.0.0"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
+				"postcss": "^7.0.17",
+				"postcss-values-parser": "^2.0.1"
 			}
 		},
 		"postcss-custom-selectors": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
-			"integrity": "sha1-j4Ekn17Qeo0JF89qOf5bBWt/lqw=",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
+			"integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
 			"requires": {
-				"balanced-match": "^0.2.0",
-				"postcss": "^5.0.0",
-				"postcss-selector-matches": "^2.0.0"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-					"integrity": "sha1-e8ZYtL7WHu5CStdPdfXD4sTfPMc="
-				}
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
 			}
 		},
-		"postcss-font-family-system-ui": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-1.0.2.tgz",
-			"integrity": "sha1-PhpeP7fjHl6ecUOcyw6AFFVpJ8c=",
+		"postcss-dir-pseudo-class": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
+			"integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
 			"requires": {
-				"lodash": "^4.17.4",
-				"postcss": "^5.2.12",
-				"postcss-value-parser": "^3.3.0"
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
+			}
+		},
+		"postcss-double-position-gradients": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
+			"integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
+			"requires": {
+				"postcss": "^7.0.5",
+				"postcss-values-parser": "^2.0.0"
+			}
+		},
+		"postcss-env-function": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
+			"integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			}
+		},
+		"postcss-focus-visible": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
+			"integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-focus-within": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
+			"integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
+			"requires": {
+				"postcss": "^7.0.2"
 			}
 		},
 		"postcss-font-variant": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz",
-			"integrity": "sha1-fKKRA/WfoCyjrOLKIrL3VoU9Tvg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
+			"integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "^7.0.2"
 			}
 		},
-		"postcss-image-set-polyfill": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
-			"integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
+		"postcss-gap-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
+			"integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
 			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-media-query-parser": "^0.2.3"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-image-set-function": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
+			"integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			}
 		},
 		"postcss-initial": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-1.5.3.tgz",
-			"integrity": "sha1-IMPpHJaCLdsb7UlQjbltVrrDd9A=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.2.tgz",
+			"integrity": "sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==",
 			"requires": {
-				"lodash.template": "^4.2.4",
-				"postcss": "^5.0.19"
+				"lodash.template": "^4.5.0",
+				"postcss": "^7.0.2"
 			}
 		},
-		"postcss-less": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.3.tgz",
-			"integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
+		"postcss-lab-function": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
+			"integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
 			"requires": {
-				"postcss": "^5.2.16"
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			}
+		},
+		"postcss-logical": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
+			"integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
+			"requires": {
+				"postcss": "^7.0.2"
 			}
 		},
 		"postcss-media-minmax": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz",
-			"integrity": "sha1-RExc+JJqteT9iiUJ6Sl+dRZJzfg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
+			"integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "^7.0.2"
 			}
 		},
-		"postcss-media-query-parser": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
-		},
-		"postcss-message-helpers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
-		},
 		"postcss-nesting": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz",
-			"integrity": "sha1-lKa2pO9wf77CCof+5clXdZtOAc8=",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.1.tgz",
+			"integrity": "sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==",
 			"requires": {
-				"postcss": "^5.0.19"
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-overflow-shorthand": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
+			"integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-page-break": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
+			"integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-place": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
+			"integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			}
+		},
+		"postcss-preset-env": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
+			"integrity": "sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==",
+			"requires": {
+				"autoprefixer": "^9.6.1",
+				"browserslist": "^4.6.4",
+				"caniuse-lite": "^1.0.30000981",
+				"css-blank-pseudo": "^0.1.4",
+				"css-has-pseudo": "^0.10.0",
+				"css-prefers-color-scheme": "^3.1.1",
+				"cssdb": "^4.4.0",
+				"postcss": "^7.0.17",
+				"postcss-attribute-case-insensitive": "^4.0.1",
+				"postcss-color-functional-notation": "^2.0.1",
+				"postcss-color-gray": "^5.0.0",
+				"postcss-color-hex-alpha": "^5.0.3",
+				"postcss-color-mod-function": "^3.0.3",
+				"postcss-color-rebeccapurple": "^4.0.1",
+				"postcss-custom-media": "^7.0.8",
+				"postcss-custom-properties": "^8.0.11",
+				"postcss-custom-selectors": "^5.1.2",
+				"postcss-dir-pseudo-class": "^5.0.0",
+				"postcss-double-position-gradients": "^1.0.0",
+				"postcss-env-function": "^2.0.2",
+				"postcss-focus-visible": "^4.0.0",
+				"postcss-focus-within": "^3.0.0",
+				"postcss-font-variant": "^4.0.0",
+				"postcss-gap-properties": "^2.0.0",
+				"postcss-image-set-function": "^3.0.1",
+				"postcss-initial": "^3.0.0",
+				"postcss-lab-function": "^2.0.1",
+				"postcss-logical": "^3.0.0",
+				"postcss-media-minmax": "^4.0.0",
+				"postcss-nesting": "^7.0.0",
+				"postcss-overflow-shorthand": "^2.0.0",
+				"postcss-page-break": "^2.0.0",
+				"postcss-place": "^4.0.1",
+				"postcss-pseudo-class-any-link": "^6.0.0",
+				"postcss-replace-overflow-wrap": "^3.0.0",
+				"postcss-selector-matches": "^4.0.0",
+				"postcss-selector-not": "^4.0.0"
 			}
 		},
 		"postcss-pseudo-class-any-link": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
-			"integrity": "sha1-kDI5GWQB0zX+c6x1YYb6YuaTryY=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
+			"integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
 			"requires": {
-				"postcss": "^5.0.3",
-				"postcss-selector-parser": "^1.1.4"
-			},
-			"dependencies": {
-				"postcss-selector-parser": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
-					"integrity": "sha1-0u4Z33pk+O8hwacchvfUg1yIwoE=",
-					"requires": {
-						"flatten": "^1.0.2",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				}
-			}
-		},
-		"postcss-pseudoelements": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-3.0.0.tgz",
-			"integrity": "sha1-bGghd8eQC6BTtt8X+MWQKEx7i7w=",
-			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
 			}
 		},
 		"postcss-replace-overflow-wrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-1.0.0.tgz",
-			"integrity": "sha1-8KA7Meq5Y2ppNr/SEOKu8bQ0pkM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
+			"integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
 			"requires": {
-				"postcss": "^5.0.16"
-			}
-		},
-		"postcss-scss": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.2.tgz",
-			"integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
-			"requires": {
-				"postcss": "^6.0.3"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
+				"postcss": "^7.0.2"
 			}
 		},
 		"postcss-selector-matches": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.5.tgz",
-			"integrity": "sha1-+g9Dvle2jneqTNEYBwI0kqExAn8=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
+			"integrity": "sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==",
 			"requires": {
-				"balanced-match": "^0.4.2",
-				"postcss": "^5.0.0"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
+				"balanced-match": "^1.0.0",
+				"postcss": "^7.0.2"
 			}
 		},
 		"postcss-selector-not": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
-			"integrity": "sha1-xzrSGj91I0vuf+4mnhVP1qhpeY0=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
+			"integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
 			"requires": {
-				"balanced-match": "^0.2.0",
-				"postcss": "^5.0.0"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-					"integrity": "sha1-e8ZYtL7WHu5CStdPdfXD4sTfPMc="
-				}
+				"balanced-match": "^1.0.0",
+				"postcss": "^7.0.2"
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+			"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 			"requires": {
-				"flatten": "^1.0.2",
+				"cssesc": "^2.0.0",
 				"indexes-of": "^1.0.1",
 				"uniq": "^1.0.1"
 			}
 		},
 		"postcss-value-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+			"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
 		},
 		"postcss-values-parser": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.3.1.tgz",
-			"integrity": "sha512-chFn9CnFAAUpQ3cwrxvVjKB8c0y6BfONv6eapndJoTXJ3h8fr1uAiue8lGP3rUIpBI2KgJGdgCVk9KNvXh0n6A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+			"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 			"requires": {
 				"flatten": "^1.0.2",
 				"indexes-of": "^1.0.1",
@@ -8993,118 +7176,10 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"optional": true
-		},
 		"prettier": {
-			"version": "github:automattic/calypso-prettier#503d7779e8e95f0ea0d6dc55056db41c16835cb1",
-			"from": "github:automattic/calypso-prettier#503d7779",
-			"requires": {
-				"babel-code-frame": "7.0.0-beta.3",
-				"babylon": "7.0.0-beta.34",
-				"camelcase": "4.1.0",
-				"chalk": "2.1.0",
-				"cjk-regex": "1.0.2",
-				"cosmiconfig": "3.1.0",
-				"dashify": "0.2.2",
-				"diff": "3.2.0",
-				"editorconfig": "0.14.2",
-				"editorconfig-to-prettier": "0.0.6",
-				"emoji-regex": "6.5.1",
-				"escape-string-regexp": "1.0.5",
-				"esutils": "2.0.2",
-				"flow-parser": "0.59.0",
-				"get-stream": "3.0.0",
-				"globby": "6.1.0",
-				"graphql": "0.10.5",
-				"ignore": "3.3.7",
-				"jest-docblock": "21.3.0-beta.11",
-				"jest-validate": "21.1.0",
-				"leven": "2.1.0",
-				"mem": "1.1.0",
-				"minimatch": "3.0.4",
-				"minimist": "1.2.0",
-				"parse5": "3.0.3",
-				"path-root": "0.1.1",
-				"postcss-less": "1.1.3",
-				"postcss-media-query-parser": "0.2.3",
-				"postcss-scss": "1.0.2",
-				"postcss-selector-parser": "2.2.3",
-				"postcss-values-parser": "1.3.1",
-				"remark-frontmatter": "1.1.0",
-				"remark-parse": "4.0.0",
-				"semver": "5.4.1",
-				"string-width": "2.1.1",
-				"typescript": "2.6.2",
-				"typescript-eslint-parser": "9.0.1",
-				"unicode-regex": "1.0.1",
-				"unified": "6.1.6"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-				},
-				"mem": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"requires": {
-						"has-flag": "^2.0.0"
-					}
-				}
-			}
-		},
-		"pretty-format": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-			"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
-			}
+			"version": "npm:wp-prettier@1.19.1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
 		},
 		"pretty-ms": {
 			"version": "2.1.0",
@@ -9127,9 +7202,9 @@
 			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 		},
 		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -9146,12 +7221,13 @@
 			}
 		},
 		"prop-types": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
 			"requires": {
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
 			}
 		},
 		"protobufjs": {
@@ -9174,6 +7250,11 @@
 				"long": "^4.0.0"
 			},
 			"dependencies": {
+				"@types/node": {
+					"version": "10.17.5",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
+					"integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
+				},
 				"long": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -9182,23 +7263,24 @@
 			}
 		},
 		"proxy-addr": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.8.0"
+				"ipaddr.js": "1.9.0"
 			}
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -9214,9 +7296,9 @@
 			}
 		},
 		"pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -9230,17 +7312,6 @@
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
 				"pump": "^2.0.0"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
 			}
 		},
 		"punycode": {
@@ -9255,9 +7326,9 @@
 			"dev": true
 		},
 		"push-receiver": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/push-receiver/-/push-receiver-2.0.2.tgz",
-			"integrity": "sha512-L7e+0F6lt2Mp3ZQjtY8oiFd3DxWSGDLly4zTpoq5YsyHloDnyu9dzbfc5GSZ52xYO9JXgwWSKdRMi8AKpmR3lQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/push-receiver/-/push-receiver-2.1.0.tgz",
+			"integrity": "sha512-l9e6ccSLZ3adyjDQGYMCVNdaEaLQQkGPl0OnWbh0wM3/u1gACHoBLx9IBaIaQpfXvMvVy+vQxN4JxBaL6PUfZA==",
 			"requires": {
 				"http_ece": "^1.0.5",
 				"long": "^3.2.0",
@@ -9288,29 +7359,10 @@
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
-		"randomatic": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"optional": true,
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"optional": true
-				}
-			}
-		},
 		"randombytes": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -9325,53 +7377,46 @@
 			}
 		},
 		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
 		"raw-body": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
 			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.3",
-				"iconv-lite": "0.4.23",
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				}
 			}
 		},
 		"react": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-			"integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
 			"requires": {
-				"create-react-class": "^15.6.0",
-				"fbjs": "^0.8.9",
 				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.0",
-				"prop-types": "^15.5.10"
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
 			}
 		},
 		"react-dom": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-			"integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+			"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
 			"requires": {
-				"fbjs": "^0.8.9",
 				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.0",
-				"prop-types": "^15.5.10"
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.18.0"
 			}
+		},
+		"react-is": {
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
 		},
 		"read-only-stream": {
 			"version": "2.0.0",
@@ -9486,17 +7531,6 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"readdirp": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-			"optional": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
-			}
-		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -9522,47 +7556,15 @@
 				"strip-indent": "^1.0.1"
 			}
 		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"requires": {
-				"balanced-match": "^0.4.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
-			}
-		},
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerate-unicode-properties": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
@@ -9573,20 +7575,11 @@
 			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regenerator-transform": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-			"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+			"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
 			"requires": {
 				"private": "^0.1.6"
-			}
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"optional": true,
-			"requires": {
-				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -9598,16 +7591,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexp-tree": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.1.tgz",
-			"integrity": "sha512-HwRjOquc9QOwKTgbxvZTcddS5mlNlwePMQ3NFL8broajMLD5CXDAqas8Y5yxJH5QtZp5iRor3YCILd5pz71Cgw==",
-			"requires": {
-				"cli-table3": "^0.5.0",
-				"colors": "^1.1.2",
-				"yargs": "^12.0.5"
-			}
-		},
 		"regexpp": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -9615,22 +7598,22 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
-			"integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
 			"requires": {
 				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^7.0.0",
+				"regenerate-unicode-properties": "^8.1.0",
 				"regjsgen": "^0.5.0",
 				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.0.2"
+				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
 		},
 		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
 		},
 		"regjsparser": {
 			"version": "0.6.0",
@@ -9646,43 +7629,6 @@
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
-		},
-		"remark-frontmatter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.1.0.tgz",
-			"integrity": "sha512-mLbYtwP9w1L9TA8dX+I/HyDF5lCpa0dmYvvW9Io+zUPpqEZ49QMKWb0hSpunpLVA+Squy0SowzSzjHVPbxWq1g==",
-			"requires": {
-				"fault": "^1.0.1",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-parse": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
-			"integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
-			"requires": {
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^1.0.2",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^1.0.0",
-				"vfile-location": "^2.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"optional": true
 		},
 		"repeat-element": {
 			"version": "1.1.3",
@@ -9701,11 +7647,6 @@
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
 			"version": "2.88.0",
@@ -9735,22 +7676,22 @@
 			}
 		},
 		"request-promise": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-			"integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+			"integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
 			"requires": {
 				"bluebird": "^3.5.0",
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"request-promise-core": "1.1.3",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "^4.17.15"
 			}
 		},
 		"require-directory": {
@@ -9761,7 +7702,8 @@
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
@@ -9769,9 +7711,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -9786,10 +7728,9 @@
 			}
 		},
 		"resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -9811,16 +7752,6 @@
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
-		"rgb": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
-			"integrity": "sha1-vieykej+/+rBvZlylyG/pA/AN7U="
-		},
-		"rgb-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-1.0.0.tgz",
-			"integrity": "sha1-v6+M2c2RZLWibXHrTxWgllMks8E="
-		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -9830,9 +7761,9 @@
 			}
 		},
 		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -9880,9 +7811,9 @@
 			"integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc="
 		},
 		"rxjs": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-			"integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -9953,6 +7884,15 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
+		"scheduler": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+			"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
+		},
 		"selenium-webdriver": {
 			"version": "4.0.0-alpha.4",
 			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.4.tgz",
@@ -9965,14 +7905,14 @@
 			}
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
 			"requires": {
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
@@ -9981,12 +7921,12 @@
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
 				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -9995,24 +7935,31 @@
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
 						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+						}
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
 			}
 		},
 		"set-blocking": {
@@ -10026,9 +7973,9 @@
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -10046,15 +7993,10 @@
 				}
 			}
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
 		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -10074,10 +8016,19 @@
 				"sha.js": "~2.4.4"
 			}
 		},
+		"shasum-object": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz",
+			"integrity": "sha512-Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==",
+			"requires": {
+				"fast-safe-stringify": "^2.0.7"
+			}
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -10085,23 +8036,13 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"shell-quote": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-			"requires": {
-				"array-filter": "~0.0.0",
-				"array-map": "~0.0.0",
-				"array-reduce": "~0.0.0",
-				"jsonify": "~0.0.0"
-			}
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -10136,12 +8077,20 @@
 				"ansi-styles": "^3.2.0",
 				"astral-regex": "^1.0.0",
 				"is-fullwidth-code-point": "^2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				}
 			}
 		},
 		"slugify": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
-			"integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw=="
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
+			"integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -10271,16 +8220,16 @@
 			}
 		},
 		"socket.io": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
-			"integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
+			"integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
 			"requires": {
 				"debug": "~4.1.0",
-				"engine.io": "~3.3.1",
+				"engine.io": "~3.4.0",
 				"has-binary2": "~1.0.2",
 				"socket.io-adapter": "~1.1.0",
-				"socket.io-client": "2.2.0",
-				"socket.io-parser": "~3.3.0"
+				"socket.io-client": "2.3.0",
+				"socket.io-parser": "~3.4.0"
 			}
 		},
 		"socket.io-adapter": {
@@ -10289,16 +8238,16 @@
 			"integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
 		},
 		"socket.io-client": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
-			"integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+			"integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
 			"requires": {
 				"backo2": "1.0.2",
 				"base64-arraybuffer": "0.1.5",
 				"component-bind": "1.0.0",
 				"component-emitter": "1.2.1",
-				"debug": "~3.1.0",
-				"engine.io-client": "~3.3.1",
+				"debug": "~4.1.0",
+				"engine.io-client": "~3.4.0",
 				"has-binary2": "~1.0.2",
 				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
@@ -10309,38 +8258,10 @@
 				"to-array": "0.1.4"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
-		"socket.io-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-			"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
-			"requires": {
-				"component-emitter": "1.2.1",
-				"debug": "~3.1.0",
-				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 				},
 				"isarray": {
 					"version": "2.0.1",
@@ -10351,6 +8272,48 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"socket.io-parser": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+					"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+					"requires": {
+						"component-emitter": "1.2.1",
+						"debug": "~3.1.0",
+						"isarray": "2.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				}
+			}
+		},
+		"socket.io-parser": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
+			"integrity": "sha512-/G/VOI+3DBp0+DJKW4KesGnQkQPFmUCbA/oO2QGT6CWxU7hLGWqU3tyuzeSK/dqcyeHsQg1vTe9jiZI8GU9SCQ==",
+			"requires": {
+				"component-emitter": "1.2.1",
+				"debug": "~4.1.0",
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
 				}
 			}
 		},
@@ -10372,9 +8335,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.10",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-			"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -10421,9 +8384,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
 		"speakeasy": {
 			"version": "2.0.0",
@@ -10551,11 +8514,6 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
-		"state-toggle": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
-		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -10576,9 +8534,9 @@
 			}
 		},
 		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -10604,15 +8562,26 @@
 			}
 		},
 		"stream-http": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
+			"integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.6",
-				"to-arraybuffer": "^1.0.0",
+				"readable-stream": "^3.0.6",
 				"xtend": "^4.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"stream-shift": {
@@ -10621,21 +8590,40 @@
 			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 		},
 		"stream-splicer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
-			"integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+			"integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.2"
 			}
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
+			}
+		},
+		"string.prototype.trimleft": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string_decoder": {
@@ -10647,11 +8635,11 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "^3.0.0"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -10662,7 +8650,8 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"strip-indent": {
 			"version": "1.0.1",
@@ -10715,15 +8704,49 @@
 			}
 		},
 		"table": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.2.2.tgz",
-			"integrity": "sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.6.1",
-				"lodash": "^4.17.11",
-				"slice-ansi": "^2.0.0",
-				"string-width": "^2.1.1"
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"tcp-port-used": {
@@ -10755,11 +8778,6 @@
 				"yargs": "^7.0.2"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -10774,63 +8792,6 @@
 						"strip-ansi": "^3.0.1",
 						"wrap-ansi": "^2.0.0"
 					}
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				},
 				"yargs": {
 					"version": "7.1.0",
@@ -10850,14 +8811,6 @@
 						"which-module": "^1.0.0",
 						"y18n": "^3.2.1",
 						"yargs-parser": "^5.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-					"requires": {
-						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -10885,17 +8838,12 @@
 				"yargs": "6.5.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
 				"async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"requires": {
-						"lodash": "^4.17.10"
+						"lodash": "^4.17.14"
 					}
 				},
 				"camelcase": {
@@ -10913,67 +8861,10 @@
 						"wrap-ansi": "^2.0.0"
 					}
 				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
 				"window-size": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
 					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				},
 				"yargs": {
 					"version": "6.5.0",
@@ -11007,71 +8898,20 @@
 			}
 		},
 		"testarmada-magellan-local-executor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/testarmada-magellan-local-executor/-/testarmada-magellan-local-executor-2.0.0.tgz",
-			"integrity": "sha1-LtNzPkX/jw9cU1hpMYbNHZjuv24=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/testarmada-magellan-local-executor/-/testarmada-magellan-local-executor-2.0.3.tgz",
+			"integrity": "sha512-E5Kt5WqwtJVTbFTO96VMtcexWi511qdxe5yPP9mQ0WYokh6rJW1EpOUR59wlBQWnFdEXd6NMjT4ggb84mBZRtA==",
 			"requires": {
-				"babel-cli": "^6.18.0",
-				"babel-eslint": "^7.1.1",
-				"babel-preset-es2015": "^6.18.0",
 				"cli-color": "^1.1.0",
 				"lodash": "^4.17.4",
 				"testarmada-logger": "^1.1.1",
 				"yargs": "^6.6.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"babel-code-frame": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
-					}
-				},
-				"babel-eslint": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-					"integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
-					"requires": {
-						"babel-code-frame": "^6.22.0",
-						"babel-traverse": "^6.23.1",
-						"babel-types": "^6.23.0",
-						"babylon": "^6.17.0"
-					}
-				},
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -11082,73 +8922,6 @@
 						"strip-ansi": "^3.0.1",
 						"wrap-ansi": "^2.0.0"
 					}
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				},
 				"yargs": {
 					"version": "6.6.0",
@@ -11252,9 +9025,9 @@
 			}
 		},
 		"titlecase": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/titlecase/-/titlecase-1.1.2.tgz",
-			"integrity": "sha1-eBE9EQgIa4MmMxoyR96o9aSeqFM="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/titlecase/-/titlecase-1.1.3.tgz",
+			"integrity": "sha512-pQX4oiemzjBEELPqgK4WE+q0yhAqjp/yzusGtlSJsOuiDys0RQxggepYmo0BuegIDppYS3b3cpdegRwkpyN3hw=="
 		},
 		"tmp": {
 			"version": "0.0.30",
@@ -11268,11 +9041,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
 			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
-		},
-		"to-arraybuffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
@@ -11317,6 +9085,11 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+		},
 		"tough-cookie": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -11338,11 +9111,6 @@
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
 			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
 		},
-		"trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -11353,16 +9121,6 @@
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
-		"trim-trailing-lines": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
-		},
-		"trough": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
-			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw=="
-		},
 		"truncate-utf8-bytes": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -11372,9 +9130,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
 		"tty-browserify": {
@@ -11395,6 +9153,11 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
+		"type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -11405,44 +9168,18 @@
 			}
 		},
 		"type-is": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "~2.1.18"
+				"mime-types": "~2.1.24"
 			}
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-		},
-		"typescript": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-			"integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
-		},
-		"typescript-eslint-parser": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-9.0.1.tgz",
-			"integrity": "sha512-w1jqotvnhLtLukD9H3gQPAlbD0kLf7ZkoQGwiwSIshKIlzRL7i0OY9Y7VIdE1xtytZXThg678eomxMZ1rZXGVQ==",
-			"requires": {
-				"lodash.unescape": "4.0.1",
-				"semver": "5.4.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-				}
-			}
-		},
-		"ua-parser-js": {
-			"version": "0.7.19",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
 		},
 		"uglify-js": {
 			"version": "2.6.4",
@@ -11459,32 +9196,6 @@
 					"version": "0.2.10",
 					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
 					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-				},
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-				},
-				"cliui": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
-						"wordwrap": "0.0.2"
-					}
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
 				}
 			}
 		},
@@ -11494,9 +9205,9 @@
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
 		},
 		"uglifycss": {
-			"version": "0.0.25",
-			"resolved": "https://registry.npmjs.org/uglifycss/-/uglifycss-0.0.25.tgz",
-			"integrity": "sha1-vqcr9JeerO8TowLPR7LRrz80QZc="
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/uglifycss/-/uglifycss-0.0.29.tgz",
+			"integrity": "sha512-J2SQ2QLjiknNGbNdScaNZsXgmMGI0kYNrXaDlr4obnPW9ni1jljb1NeEVWAiTgZ8z+EBWP2ozfT9vpy03rjlMQ=="
 		},
 		"ultron": {
 			"version": "1.1.1",
@@ -11514,11 +9225,12 @@
 			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
 		},
 		"undeclared-identifiers": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz",
-			"integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+			"integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
 			"requires": {
 				"acorn-node": "^1.3.0",
+				"dash-ast": "^1.0.0",
 				"get-assigned-identifiers": "^1.2.0",
 				"simple-concat": "^1.0.0",
 				"xtend": "^4.0.1"
@@ -11531,15 +9243,6 @@
 			"requires": {
 				"sprintf-js": "^1.0.3",
 				"util-deprecate": "^1.0.2"
-			}
-		},
-		"unherit": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"xtend": "^4.0.1"
 			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
@@ -11557,64 +9260,24 @@
 			}
 		},
 		"unicode-match-property-value-ecmascript": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
 		},
 		"unicode-property-aliases-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
-		},
-		"unicode-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-1.0.1.tgz",
-			"integrity": "sha1-+BngUBkdW5VhozmljdO5CV7ZSzU="
-		},
-		"unified": {
-			"version": "6.1.6",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
-			"integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
-			"requires": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-plain-obj": "^1.1.0",
-				"trough": "^1.0.0",
-				"vfile": "^2.0.0",
-				"x-is-function": "^1.0.4",
-				"x-is-string": "^0.1.0"
-			}
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"uniq": {
@@ -11622,48 +9285,10 @@
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
 			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
 		},
-		"unist-util-is": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
-		},
-		"unist-util-remove-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
-			"requires": {
-				"unist-util-visit": "^1.1.0"
-			}
-		},
-		"unist-util-stringify-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
-		},
-		"unist-util-visit": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-			"integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
-			"requires": {
-				"unist-util-visit-parents": "^2.0.0"
-			}
-		},
-		"unist-util-visit-parents": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-			"integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
-			"requires": {
-				"unist-util-is": "^2.1.2"
-			}
-		},
-		"units-css": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
-			"integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
-			"requires": {
-				"isnumeric": "^0.2.0",
-				"viewport-dimensions": "^0.2.0"
-			}
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -11671,9 +9296,9 @@
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unquoted-property-validator": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unquoted-property-validator/-/unquoted-property-validator-1.0.2.tgz",
-			"integrity": "sha512-LokWcfN2q9UnQTTIpRkTZNsLVVO2KaXeO3oUMQ7JShGhMdO8P+zN1MfrPMf1IwR/Cyh283lGaxbRcNGyq2IXYQ=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unquoted-property-validator/-/unquoted-property-validator-1.1.0.tgz",
+			"integrity": "sha512-ZWeQoYZ7HN8DCLeaowNv2GvZIXqJptKB1uUWd08ZYc1qAmJt8tXh9nck26aoYmhJtE3jCjDqdqEfUTqcJ0R7bw=="
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -11750,11 +9375,6 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
-		"user-home": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
-		},
 		"utf8-byte-length": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
@@ -11766,6 +9386,13 @@
 			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
 			"requires": {
 				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				}
 			}
 		},
 		"util-deprecate": {
@@ -11773,20 +9400,29 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
 		"utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 		},
 		"v8flags": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
-			"integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+			"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
@@ -11815,44 +9451,10 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
-		"vfile": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-			"requires": {
-				"is-buffer": "^1.1.4",
-				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^1.0.0",
-				"vfile-message": "^1.0.0"
-			}
-		},
-		"vfile-location": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
-			"integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w=="
-		},
-		"vfile-message": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-			"requires": {
-				"unist-util-stringify-position": "^1.1.1"
-			}
-		},
-		"viewport-dimensions": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
-			"integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w="
-		},
 		"vm-browserify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-			"integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
 		},
 		"which": {
 			"version": "1.3.1",
@@ -11863,14 +9465,20 @@
 			}
 		},
 		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 		},
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
 		},
 		"wordwrap": {
 			"version": "0.0.2",
@@ -11884,39 +9492,6 @@
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
 			}
 		},
 		"wrappy": {
@@ -11943,16 +9518,6 @@
 				"ultron": "~1.1.0"
 			}
 		},
-		"x-is-function": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
-			"integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4="
-		},
-		"x-is-string": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
-		},
 		"xml-mapping": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/xml-mapping/-/xml-mapping-1.0.3.tgz",
@@ -11968,12 +9533,13 @@
 			"integrity": "sha1-t28dWRwWomNOvbcDx729D9aBkGU="
 		},
 		"xml2js": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"version": "0.4.22",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+			"integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
 			"requires": {
 				"sax": ">=0.6.0",
-				"xmlbuilder": "~9.0.1"
+				"util.promisify": "~1.0.0",
+				"xmlbuilder": "~11.0.0"
 			}
 		},
 		"xml2js-parser": {
@@ -11993,9 +9559,9 @@
 			}
 		},
 		"xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
 		},
 		"xmlhttprequest-ssl": {
 			"version": "1.5.5",
@@ -12012,128 +9578,159 @@
 			}
 		},
 		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"xunit-viewer": {
-			"version": "5.1.8",
-			"resolved": "https://registry.npmjs.org/xunit-viewer/-/xunit-viewer-5.1.8.tgz",
-			"integrity": "sha512-T8cW+6eZrY1k2CCur0lue35i98/pgHZzVopF/4Zq+sCr+3bJD1/5Xv7hVqln++vYnp7Mb+0yGEXa8ahbzJb0xA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/xunit-viewer/-/xunit-viewer-5.2.0.tgz",
+			"integrity": "sha512-PLjppr8fWpvLo2b+0vXiZfCdITeS2a13MdHqDzXouxrQ/DJq0RjmOyiIv7tgK3vxLspIq0rnpivFjo14QUMv3A==",
 			"requires": {
-				"babel-core": "^6.23.1",
-				"babel-preset-react-app": "^2.1.1",
-				"babelify": "^7.3.0",
-				"browserify": "^16.2.3",
-				"bulma": "^0.3.2",
-				"chalk": "^1.1.3",
-				"detect-port": "^1.1.0",
-				"express": "^4.15.2",
-				"fs-extra": "^2.0.0",
+				"@babel/preset-env": "^7.6.3",
+				"@babel/preset-react": "^7.6.3",
+				"babel-core": "^6.26.3",
+				"babel-preset-react-app": "^9.0.2",
+				"babelify": "^10.0.0",
+				"browserify": "^16.5.0",
+				"bulma": "^0.8.0",
+				"chalk": "^2.4.2",
+				"clone": "^2.1.2",
+				"detect-port": "^1.3.0",
+				"express": "^4.17.1",
+				"fs-extra": "^8.1.0",
 				"fuzzysearch": "^1.0.3",
-				"mustache": "^2.3.0",
-				"node-watch": "^0.4.1",
-				"normalize.css": "^5.0.0",
-				"postcss": "^5.2.15",
-				"postcss-cssnext": "^2.9.0",
-				"promise": "^7.1.1",
-				"react": "^15.4.2",
-				"react-dom": "^15.4.2",
-				"recursive-readdir": "^2.1.1",
-				"socket.io": "^2.1.1",
-				"titlecase": "^1.1.2",
-				"uglify-js": "^2.8.7",
-				"uglifycss": "^0.0.25",
-				"uuid": "^3.0.1",
+				"mustache": "^3.1.0",
+				"node-watch": "^0.6.3",
+				"normalize.css": "^8.0.1",
+				"postcss": "^7.0.18",
+				"postcss-preset-env": "^6.7.0",
+				"promise": "^8.0.3",
+				"react": "^16.10.2",
+				"react-dom": "^16.10.2",
+				"recursive-readdir": "^2.2.2",
+				"socket.io": "^2.3.0",
+				"titlecase": "^1.1.3",
+				"uglify-js": "^3.6.1",
+				"uglifycss": "^0.0.29",
+				"uuid": "^3.3.3",
 				"xml2js-parser": "^1.1.1"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+				"@babel/preset-env": {
+					"version": "7.7.1",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.1.tgz",
+					"integrity": "sha512-/93SWhi3PxcVTDpSqC+Dp4YxUu3qZ4m7I76k0w73wYfn7bGVuRIO4QUz95aJksbS+AD1/mT1Ie7rbkT0wSplaA==",
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"@babel/helper-module-imports": "^7.7.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.7.0",
+						"@babel/plugin-proposal-dynamic-import": "^7.7.0",
+						"@babel/plugin-proposal-json-strings": "^7.2.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.7.0",
+						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.2.0",
+						"@babel/plugin-syntax-json-strings": "^7.2.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-syntax-top-level-await": "^7.7.0",
+						"@babel/plugin-transform-arrow-functions": "^7.2.0",
+						"@babel/plugin-transform-async-to-generator": "^7.7.0",
+						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+						"@babel/plugin-transform-block-scoping": "^7.6.3",
+						"@babel/plugin-transform-classes": "^7.7.0",
+						"@babel/plugin-transform-computed-properties": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.6.0",
+						"@babel/plugin-transform-dotall-regex": "^7.7.0",
+						"@babel/plugin-transform-duplicate-keys": "^7.5.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+						"@babel/plugin-transform-for-of": "^7.4.4",
+						"@babel/plugin-transform-function-name": "^7.7.0",
+						"@babel/plugin-transform-literals": "^7.2.0",
+						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+						"@babel/plugin-transform-modules-amd": "^7.5.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.7.0",
+						"@babel/plugin-transform-modules-systemjs": "^7.7.0",
+						"@babel/plugin-transform-modules-umd": "^7.7.0",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.0",
+						"@babel/plugin-transform-new-target": "^7.4.4",
+						"@babel/plugin-transform-object-super": "^7.5.5",
+						"@babel/plugin-transform-parameters": "^7.4.4",
+						"@babel/plugin-transform-property-literals": "^7.2.0",
+						"@babel/plugin-transform-regenerator": "^7.7.0",
+						"@babel/plugin-transform-reserved-words": "^7.2.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+						"@babel/plugin-transform-spread": "^7.6.2",
+						"@babel/plugin-transform-sticky-regex": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.4.4",
+						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+						"@babel/plugin-transform-unicode-regex": "^7.7.0",
+						"@babel/types": "^7.7.1",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.1.1",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
 					}
 				},
-				"cliui": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
-						"wordwrap": "0.0.2"
-					}
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				},
 				"fs-extra": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0"
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"graceful-fs": "^4.1.6"
 					}
 				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				"mustache": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/mustache/-/mustache-3.1.0.tgz",
+					"integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ=="
+				},
+				"promise": {
+					"version": "8.0.3",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+					"integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
+					"requires": {
+						"asap": "~2.0.6"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"uglify-js": {
-					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"version": "3.6.9",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+					"integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
 					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
-					}
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
+						"commander": "~2.20.3",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -12142,31 +9739,36 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^3.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^11.1.1"
+				"camelcase": "^1.0.2",
+				"cliui": "^2.1.0",
+				"decamelize": "^1.0.0",
+				"window-size": "0.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+				}
 			}
 		},
 		"yargs-parser": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
+				"camelcase": "^3.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				}
 			}
 		},
 		"yauzl": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -49,7 +49,7 @@
 		"mocha-steps": "^1.1.0",
 		"node-slack-upload": "1.2.1",
 		"png-itxt": "1.3.0",
-		"prettier": "github:automattic/calypso-prettier#503d7779",
+		"prettier": "npm:wp-prettier@1.19.1",
 		"push-receiver": "^2.0.0",
 		"request-promise": "^4.2.2",
 		"sanitize-filename": "1.6.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move to the npm hosted wp-prettier via an npm alias
* Regenerate the lockfile

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* e2e tests should still work

Rebuilding the lock was a bit odd. I had to remove the root `node_modules` before it would generate a sane lockfile...
