### PR TITLE
Customer Home: Don't show Launch Site card when needsEmailVerification

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -50,7 +50,7 @@ import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
 import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 
@@ -274,6 +274,7 @@ class Home extends Component {
 			displayChecklist,
 			isAtomic,
 			isChecklistComplete,
+			needsEmailVerification,
 			translate,
 			customizeUrl,
 			checklistMode,
@@ -400,7 +401,7 @@ class Home extends Component {
 					) }
 				</div>
 				<div className="customer-home__layout-col customer-home__layout-col-right">
-					{ siteIsUnlaunched && (
+					{ siteIsUnlaunched && ! needsEmailVerification && (
 						<Card className="customer-home__launch-button">
 							<CardHeading>{ translate( 'Site Privacy' ) }</CardHeading>
 							<h6 className="customer-home__card-subheader">
@@ -566,6 +567,7 @@ const connectHome = connect(
 			hasChecklistData,
 			isChecklistComplete,
 			isAtomic,
+			needsEmailVerification: ! isCurrentUserEmailVerified( state ),
 			isStaticHomePage: 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 			siteHasPaidPlan: isSiteOnPaidPlan( state, siteId ),
 			isNewlyCreatedSite: isNewSite( state, siteId ),


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="1069" alt="Screen Shot 2019-11-20 at 2 46 04 PM" src="https://user-images.githubusercontent.com/1587282/69272367-8872fa00-0ba4-11ea-864a-2abf5a3b8166.png">|<img width="1064" alt="Screen Shot 2019-11-20 at 2 46 12 PM" src="https://user-images.githubusercontent.com/1587282/69272390-90329e80-0ba4-11ea-9ae3-2c6e09e50abe.png">|


#### Changes proposed in this Pull Request

* Select `isCurrentUserEmailVerified` (inverted) from state into component prop: `needsEmailVerification`
* When `needsEmailVerification`, don't render the `.customer-home__launch-button` Card.

#### Testing instructions

* Run this branch
* Visit `/home` for a new site for a new user with an unverified email address
* You should not see the Launch Site button card or able to launch your site via the Customer Home UI

#### Reported

p1574275842326800-slack-CCS1W9QVA
