### PR TITLE
Dependencies: Consolidate on @wordpress/is-shallow-equal

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1147,32 +1147,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/gaearon/react-pure-render
-```text
-The MIT License (MIT)
-
-Copyright (c) 2015 Dan Abramov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
-
 ### https://github.com/sindresorhus/srcset
 ```text
 The MIT License (MIT)

--- a/client/components/data/query-media/index.jsx
+++ b/client/components/data/query-media/index.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import shallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import { connect } from 'react-redux';
 
 /**
@@ -39,7 +39,7 @@ class QueryMedia extends Component {
 		if (
 			this.props.siteId === prevProps.siteId &&
 			this.props.mediaId === prevProps.mediaId &&
-			shallowEqual( this.props.query, prevProps.query )
+			isShallowEqual( this.props.query, prevProps.query )
 		) {
 			return;
 		}

--- a/client/components/data/query-media/index.jsx
+++ b/client/components/data/query-media/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import shallowEqual from 'react-pure-render/shallowEqual';
+import shallowEqual from '@wordpress/is-shallow-equal';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-post-revision-authors/index.jsx
+++ b/client/components/data/query-post-revision-authors/index.jsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import shallowEqual from 'react-pure-render/shallowEqual';
+import shallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/client/components/data/query-post-revision-authors/index.jsx
+++ b/client/components/data/query-post-revision-authors/index.jsx
@@ -4,7 +4,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import shallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ class QueryPostRevisionAuthors extends Component {
 
 	componentDidUpdate( prevProps ) {
 		if (
-			shallowEqual( this.props.userIds, prevProps.userIds ) &&
+			isShallowEqual( this.props.userIds, prevProps.userIds ) &&
 			this.props.siteId === prevProps.siteId
 		) {
 			return;

--- a/client/components/data/query-posts/index.jsx
+++ b/client/components/data/query-posts/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Component } from 'react';
-import shallowEqual from 'react-pure-render/shallowEqual';
+import shallowEqual from '@wordpress/is-shallow-equal';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import debug from 'debug';

--- a/client/components/data/query-posts/index.jsx
+++ b/client/components/data/query-posts/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Component } from 'react';
-import shallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import debug from 'debug';
@@ -27,7 +27,7 @@ class QueryPosts extends Component {
 		if (
 			this.props.siteId === nextProps.siteId &&
 			this.props.postId === nextProps.postId &&
-			shallowEqual( this.props.query, nextProps.query )
+			isShallowEqual( this.props.query, nextProps.query )
 		) {
 			return;
 		}

--- a/client/components/data/query-site-stats/index.jsx
+++ b/client/components/data/query-site-stats/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import shallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import { defer } from 'lodash';
 
 /**
@@ -24,7 +24,7 @@ class QuerySiteStats extends Component {
 		if (
 			this.props.siteId === prevProps.siteId &&
 			this.props.statType === prevProps.statType &&
-			shallowEqual( this.props.query, prevProps.query )
+			isShallowEqual( this.props.query, prevProps.query )
 		) {
 			return;
 		}

--- a/client/components/data/query-site-stats/index.jsx
+++ b/client/components/data/query-site-stats/index.jsx
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import shallowEqual from 'react-pure-render/shallowEqual';
-
+import shallowEqual from '@wordpress/is-shallow-equal';
 import { defer } from 'lodash';
 
 /**

--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import shallowEqual from 'react-pure-render/shallowEqual';
+import shallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import shallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ class QueryTerms extends Component {
 		if (
 			this.props.siteId === nextProps.siteId &&
 			this.props.taxonomy === nextProps.taxonomy &&
-			shallowEqual( this.props.query, nextProps.query )
+			isShallowEqual( this.props.query, nextProps.query )
 		) {
 			return;
 		}

--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce, forEach } from 'lodash';
-import shallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -88,7 +88,7 @@ export default class SignupSitePreviewIframe extends Component {
 
 		if (
 			this.props.content.body !== nextProps.content.body ||
-			! shallowEqual( this.props.content.params, nextProps.content.params )
+			! isShallowEqual( this.props.content.params, nextProps.content.params )
 		) {
 			this.setContentParams( nextProps.content.params );
 		}

--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce, forEach } from 'lodash';
-import shallowEqual from 'react-pure-render/shallowEqual';
+import shallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -26,9 +26,9 @@ const VALID_ARG_TYPES = [ 'number', 'boolean', 'string' ];
  * state, which is the basis upon which memoize cache is cleared. Should return
  * a value or array of values to be shallowly compared for strict equality.
  *
- * @type   {Function}
- * @param  {Object}    state Current state object
- * @return {(Array|*)}       Value(s) to be shallow compared
+ * @type    {Function}
+ * @param   {object}    state Current state object
+ * @returns {(Array|*)}       Value(s) to be shallow compared
  */
 const DEFAULT_GET_DEPENDANTS = state => state;
 
@@ -62,8 +62,8 @@ const DEFAULT_GET_CACHE_KEY = ( () => {
  * Given an array of getDependants functions, returns a single function which,
  * when called, returns an array of mapped results from those functions.
  *
- * @param  {Function[]} dependants Array of getDependants
- * @return {Function}              Function mapping getDependants results
+ * @param   {Function[]} dependants Array of getDependants
+ * @returns {Function}              Function mapping getDependants results
  */
 const makeSelectorFromArray = dependants => ( state, ...args ) =>
 	dependants.map( dependant => dependant( state, ...args ) );
@@ -75,8 +75,8 @@ const makeSelectorFromArray = dependants => ( state, ...args ) =>
  * @param  {Function|Function[]} getDependants Function(s) describing dependent
  *                                             state, or an array of dependent
  *                                             state selectors
- * @param  {Function}            getCacheKey   Function generating cache key
- * @return {Function}                          Memoized selector
+ * @param   {Function}            getCacheKey   Function generating cache key
+ * @returns {Function}                          Memoized selector
  */
 export default function createSelector(
 	selector,

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { memoize, includes } from 'lodash';
-import shallowEqual from 'react-pure-render/shallowEqual';
+import shallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { memoize, includes } from 'lodash';
-import shallowEqual from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -97,7 +97,7 @@ export default function createSelector(
 				currentDependants = [ currentDependants ];
 			}
 
-			if ( lastDependants && ! shallowEqual( currentDependants, lastDependants ) ) {
+			if ( lastDependants && ! isShallowEqual( currentDependants, lastDependants ) ) {
 				memoizedSelector.cache.clear();
 			}
 

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -13,7 +13,7 @@ import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
 import ListGap from 'reader/list-gap';
 import CrossPost from './x-post';
-import { shallowEquals } from 'reader/utils';
+import shallowEquals from '@wordpress/is-shallow-equal';
 import RecommendedPosts from './recommended-posts';
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
 import PostBlocked from 'blocks/reader-post-card/blocked';

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -13,7 +13,7 @@ import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
 import ListGap from 'reader/list-gap';
 import CrossPost from './x-post';
-import shallowEquals from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import RecommendedPosts from './recommended-posts';
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
 import PostBlocked from 'blocks/reader-post-card/blocked';
@@ -36,7 +36,7 @@ class PostLifecycle extends React.Component {
 		const currentPropsToCompare = omit( this.props, 'handleClick' );
 		const nextPropsToCompare = omit( nextProps, 'handleClick' );
 
-		return ! shallowEquals( currentPropsToCompare, nextPropsToCompare );
+		return ! isShallowEqual( currentPropsToCompare, nextPropsToCompare );
 	}
 
 	render() {

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import page from 'page';
-import { every } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -92,9 +91,6 @@ export function showFullPost( { post, replaceHistory, comments } ) {
 		page[ method ]( `/read/blogs/${ post.site_ID }/posts/${ post.ID }${ hashtag }${ query }` );
 	}
 }
-
-export const shallowEquals = ( o1, o2 ) =>
-	every( Object.keys( o1 ), key => o1[ key ] === o2[ key ] );
 
 export function getStreamType( streamKey ) {
 	const indexOfColon = streamKey.indexOf( ':' );

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -40,7 +40,7 @@ export function showSelectedPost( { replaceHistory, postKey, comments } ) {
 
 	// normal
 	let mappedPost;
-	if ( !! postKey.feedId ) {
+	if ( postKey.feedId ) {
 		mappedPost = {
 			feed_ID: postKey.feedId,
 			feed_item_ID: postKey.postId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23179,11 +23179,6 @@
 				"prop-types": "^15.5.8"
 			}
 		},
-		"react-pure-render": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/react-pure-render/-/react-pure-render-1.0.2.tgz",
-			"integrity": "sha1-nYqSjH8sN1E8LQZOV7Pjw1bp+rs="
-		},
 		"react-redux": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
 		"react-lazily-render": "1.1.0",
 		"react-live": "1.12.0",
 		"react-modal": "3.8.1",
-		"react-pure-render": "1.0.2",
 		"react-redux": "7.1.3",
 		"react-stripe-elements": "4.0.0",
 		"react-transition-group": "2.5.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove unmaintained [`react-pure-render`](https://github.com/gaearon/react-pure-render) which was only used for shallow compare.
Replace functionality with `@wordpress/is-shallow-equal`.
Replace home-grown function with `@wordpress/is-shallow-equal`.

* Props @razvanpapadopol for spotting (https://github.com/Automattic/wp-calypso/pull/37757/files#r348539613)

#### Testing instructions

* There are no expected functional changes.
