### PR TITLE
Gutenboarding: Add more domain picker UI

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { TextControl, Panel, PanelBody, PanelRow } from '@wordpress/components';
+import { Button, Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
 import { __ as NO__ } from '@wordpress/i18n';
 
 /**
@@ -23,11 +23,23 @@ const DomainPicker: FunctionComponent< Props > = ( {
 } ) => {
 	const label = NO__( 'Search for a domain' );
 
+	const handleDomainPick = suggestion => () => {
+		// eslint-disable-next-line no-console
+		console.log( 'Picked domain: %o', suggestion );
+	};
+
+	const handleHasDomain = () => {
+		// eslint-disable-next-line no-console
+		console.log( 'Already has a domain.' );
+	};
+
 	return (
 		<Panel className="domain-picker">
 			<PanelBody>
-				<PanelRow>
-					<h3 className="domain-picker__choose-domain-header">{ NO__( 'Choose a new domain' ) }</h3>
+				<PanelRow className="domain-picker__panel-row">
+					<div className="domain-picker__choose-domain-header">
+						{ NO__( 'Choose a new domain' ) }
+					</div>
 					<TextControl
 						hideLabelFromVision
 						label={ label }
@@ -37,16 +49,28 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					/>
 				</PanelRow>
 
+				<hr />
+
 				{ suggestions?.length ? (
-					<PanelRow>
-						<h3 className="domain-picker__recommended-header">{ NO__( 'Recommended' ) }</h3>
-						<ul>
-							{ suggestions.map( ( { domain_name } ) => (
-								<li key={ domain_name }>{ domain_name }</li>
-							) ) }
-						</ul>
+					<PanelRow className="domain-picker__panel-row">
+						<div className="domain-picker__recommended-header">{ NO__( 'Recommended' ) }</div>
+						{ suggestions.map( suggestion => (
+							<Button
+								onClick={ handleDomainPick( suggestion ) }
+								className="domain-picker__suggestion-item"
+								key={ suggestion.domain_name }
+							>
+								<div className="domain-picker__suggestion-item-name">
+									{ suggestion.domain_name }
+								</div>
+								<div className="domain-picker__suggestion-action">{ NO__( 'Upgrade' ) }</div>
+							</Button>
+						) ) }
 					</PanelRow>
 				) : null }
+				<PanelRow className="domain-picker__has-domain domain-picker__panel-row">
+					<Button onClick={ handleHasDomain }>{ NO__( 'I already have a domain' ) }</Button>
+				</PanelRow>
 			</PanelBody>
 		</Panel>
 	);

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -2,7 +2,14 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { Button, Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
+import {
+	Button,
+	HorizontalRule,
+	Panel,
+	PanelBody,
+	PanelRow,
+	TextControl,
+} from '@wordpress/components';
 import { __ as NO__ } from '@wordpress/i18n';
 
 /**
@@ -49,7 +56,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					/>
 				</PanelRow>
 
-				<hr />
+				<HorizontalRule className="domain-picker__divider" />
 
 				{ suggestions?.length ? (
 					<PanelRow className="domain-picker__panel-row">

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -67,10 +67,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								className="domain-picker__suggestion-item"
 								key={ suggestion.domain_name }
 							>
-								<div className="domain-picker__suggestion-item-name">
+								<span className="domain-picker__suggestion-item-name">
 									{ suggestion.domain_name }
-								</div>
-								<div className="domain-picker__suggestion-action">{ NO__( 'Upgrade' ) }</div>
+								</span>
+								<span className="domain-picker__suggestion-action">{ NO__( 'Upgrade' ) }</span>
 							</Button>
 						) ) }
 					</PanelRow>

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -41,6 +41,6 @@
 	}
 }
 
-.domain-picker hr {
-	margin-top: 16px;
+.domain-picker__divider {
+	margin-top: 20px;
 }

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -1,3 +1,5 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+
 .domain-picker__button {
 	.dashicon {
 		margin-left: 0.5em;
@@ -8,14 +10,31 @@
 	}
 }
 
-.domain-picker__choose-domain-header,
+.domain-picker__choose-domain-header {
+	font-weight: bold;
+	text-align: center;
+}
 .domain-picker__recommended-header {
 	font-weight: bold;
 }
 
-.domain-picker {
-	.components-panel__row {
-		flex-direction: column;
-		align-items: stretch;
+.domain-picker__panel-row {
+	flex-direction: column;
+	align-items: stretch;
+}
+
+.domain-picker__suggestion-item {
+	display: flex;
+	justify-content: space-between;
+}
+
+.domain-picker__suggestion-action {
+	color: $blue-medium-highlight;
+}
+
+.domain-picker__has-domain {
+	align-items: center;
+	.components-button {
+		color: $blue-medium-highlight;
 	}
 }

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -13,6 +13,7 @@
 .domain-picker__choose-domain-header {
 	font-weight: bold;
 	text-align: center;
+	margin-bottom: 20px;
 }
 .domain-picker__recommended-header {
 	font-weight: bold;
@@ -26,15 +27,20 @@
 .domain-picker__suggestion-item {
 	display: flex;
 	justify-content: space-between;
+	margin-top: 18px;
 }
 
 .domain-picker__suggestion-action {
-	color: $blue-medium-highlight;
+	color: var( --studio-blue-40 );
 }
 
 .domain-picker__has-domain {
 	align-items: center;
 	.components-button {
-		color: $blue-medium-highlight;
+		color: var( --studio-blue-30 );
 	}
+}
+
+.domain-picker hr {
+	margin-top: 16px;
 }


### PR DESCRIPTION
Continues work on the domain picker UI according to paObgF-H3-p2

<img width="357" alt="Screen Shot 2019-11-21 at 00 24 57" src="https://user-images.githubusercontent.com/841763/69287239-d6fcb480-0bf5-11ea-95aa-0cac110e47af.png">

UI only, no interaction has been added or modified.

## Testing

Visit `/gutenboarding` and see how the domain picker looks and behaves.