### PR TITLE
Checklist: Remove checklist dismiss actions

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -1,4 +1,4 @@
-$task-left-padding: 24px;
+$task-left-padding: 55px;
 $task-right-padding: 50px;
 $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
@@ -54,10 +54,9 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		left: 24px;
 		width: 16px;
 		height: 16px;
-		border: 2px solid var( --color-neutral-10 );
+		border: 2px solid var( --color-neutral-5 );
 		border-radius: 16px;
 		background: var( --color-surface );
-		z-index: 2;
 
 		.gridicons-checkmark {
 			display: none;
@@ -66,6 +65,34 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 			top: -1px;
 			left: 1px;
 		}
+
+		&.is-disabled,
+		&.is-disabled:focus,
+		&.is-disabled:hover,
+		&.is-disabled:active {
+			border: 2px solid var( --color-neutral-10 );
+			background: var( --color-surface );
+			cursor: default;
+		}
+	}
+
+	.spinner {
+		display: none;
+		position: absolute;
+		top: 17px;
+		left: 24px;
+	}
+
+	.checklist__task-warning-background {
+		display: block;
+		position: absolute;
+		top: -1px;
+		left: 0;
+		width: 18px;
+		height: 18px;
+		border-radius: 16px;
+		background: var( --color-surface );
+		cursor: pointer;
 	}
 
 	.checklist__task-title {
@@ -86,7 +113,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 		.checklist__toggle-icon {
 			position: absolute;
-			right: 18px;
+			right: 12px;
 			top: 16px;
 			fill: var( --color-neutral-light );
 			transition: $chevron-animation;
@@ -161,15 +188,10 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 			font-weight: 600;
 			font-size: 14px;
 			padding-top: 8px;
-			padding-left: 62px;
 
 			.checklist__toggle-icon {
 				top: 8px;
 			}
-		}
-
-		.checklist__task-content {
-			padding-left: 62px;
 		}
 
 		.gridicons-checkmark {

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -1,4 +1,4 @@
-$task-left-padding: 55px;
+$task-left-padding: 24px;
 $task-right-padding: 50px;
 $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
@@ -57,7 +57,6 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		border: 2px solid var( --color-neutral-10 );
 		border-radius: 16px;
 		background: var( --color-surface );
-		cursor: pointer;
 		z-index: 2;
 
 		.gridicons-checkmark {
@@ -67,49 +66,6 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 			top: -1px;
 			left: 1px;
 		}
-
-		&:hover,
-		&:focus {
-			background: var( --color-success );
-			border-color: var( --color-success );
-
-			.gridicons-checkmark {
-				display: block;
-			}
-		}
-
-		&:active {
-			background: var( --color-accent );
-			border-color: var( --color-accent );
-		}
-
-		&.is-disabled,
-		&.is-disabled:focus,
-		&.is-disabled:hover,
-		&.is-disabled:active {
-			border: 2px solid var( --color-neutral-10 );
-			background: var( --color-surface );
-			cursor: default;
-		}
-	}
-
-	.spinner {
-		display: none;
-		position: absolute;
-		top: 17px;
-		left: 24px;
-	}
-
-	.checklist__task-warning-background {
-		display: block;
-		position: absolute;
-		top: -1px;
-		left: 0;
-		width: 18px;
-		height: 18px;
-		border-radius: 16px;
-		background: var( --color-surface );
-		cursor: pointer;
 	}
 
 	.checklist__task-title {
@@ -130,7 +86,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 		.checklist__toggle-icon {
 			position: absolute;
-			right: 12px;
+			right: 18px;
 			top: 16px;
 			fill: var( --color-neutral-light );
 			transition: $chevron-animation;
@@ -205,10 +161,15 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 			font-weight: 600;
 			font-size: 14px;
 			padding-top: 8px;
+			padding-left: 62px;
 
 			.checklist__toggle-icon {
 				top: 8px;
 			}
+		}
+
+		.checklist__task-content {
+			padding-left: 62px;
 		}
 
 		.gridicons-checkmark {

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,6 +14,7 @@ import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import Notice from 'components/notice';
 import ScreenReaderText from 'components/screen-reader-text';
+import Spinner from 'components/spinner';
 
 class Task extends PureComponent {
 	static propTypes = {
@@ -50,18 +51,73 @@ class Task extends PureComponent {
 	}
 
 	renderCheckmarkIcon() {
-		const { completed, translate } = this.props;
+		const { completed, disableIcon, inProgress, isWarning, translate } = this.props;
+		const onDismiss = ! completed ? this.props.onDismiss : undefined;
+
+		if ( inProgress ) {
+			return (
+				<Fragment>
+					<ScreenReaderText>{ translate( 'In progress' ) }</ScreenReaderText>
+					{ this.renderGridicon() }
+				</Fragment>
+			);
+		}
+
+		if ( disableIcon ) {
+			return (
+				<div className="checklist__task-icon is-disabled">
+					<ScreenReaderText>{ translate( 'Waiting to complete' ) }</ScreenReaderText>
+				</div>
+			);
+		}
+
+		if ( onDismiss ) {
+			return (
+				<div className="checklist__task-icon">
+					<ScreenReaderText>
+						{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
+					</ScreenReaderText>
+					{ this.renderGridicon() }
+				</div>
+			);
+		}
 
 		if ( completed ) {
 			return (
 				<div className="checklist__task-icon">
 					<ScreenReaderText>{ translate( 'Complete' ) }</ScreenReaderText>
-					<Gridicon icon={ 'checkmark' } size={ 18 } />
+					{ this.renderGridicon() }
+				</div>
+			);
+		}
+
+		if ( isWarning ) {
+			return (
+				<div>
+					<ScreenReaderText>{ translate( 'Warning' ) }</ScreenReaderText>
+					{ this.renderGridicon() }
 				</div>
 			);
 		}
 
 		return null;
+	}
+
+	renderGridicon() {
+		if ( this.props.inProgress ) {
+			return <Spinner size={ 20 } />;
+		}
+
+		if ( this.props.isWarning ) {
+			return (
+				<div>
+					<div className="checklist__task-warning-background" />
+					<Gridicon icon={ 'notice-outline' } size={ 24 } />
+				</div>
+			);
+		}
+
+		return <Gridicon icon={ 'checkmark' } size={ 18 } />;
 	}
 
 	render() {

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import PropTypes from 'prop-types';
-import React, { Fragment, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,10 +12,8 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
-import Focusable from 'components/focusable';
 import Notice from 'components/notice';
 import ScreenReaderText from 'components/screen-reader-text';
-import Spinner from 'components/spinner';
 
 class Task extends PureComponent {
 	static propTypes = {
@@ -52,77 +50,18 @@ class Task extends PureComponent {
 	}
 
 	renderCheckmarkIcon() {
-		const { completed, disableIcon, inProgress, isWarning, translate } = this.props;
-		const onDismiss = ! completed ? this.props.onDismiss : undefined;
-
-		if ( inProgress ) {
-			return (
-				<Fragment>
-					<ScreenReaderText>{ translate( 'In progress' ) }</ScreenReaderText>
-					{ this.renderGridicon() }
-				</Fragment>
-			);
-		}
-
-		if ( disableIcon ) {
-			return (
-				<div className="checklist__task-icon is-disabled">
-					<ScreenReaderText>{ translate( 'Waiting to complete' ) }</ScreenReaderText>
-				</div>
-			);
-		}
-
-		if ( onDismiss ) {
-			return (
-				<Focusable
-					className="checklist__task-icon"
-					onClick={ onDismiss }
-					aria-pressed={ completed ? 'true' : 'false' }
-				>
-					<ScreenReaderText>
-						{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
-					</ScreenReaderText>
-					{ this.renderGridicon() }
-				</Focusable>
-			);
-		}
+		const { completed, translate } = this.props;
 
 		if ( completed ) {
 			return (
 				<div className="checklist__task-icon">
 					<ScreenReaderText>{ translate( 'Complete' ) }</ScreenReaderText>
-					{ this.renderGridicon() }
-				</div>
-			);
-		}
-
-		if ( isWarning ) {
-			return (
-				<div>
-					<ScreenReaderText>{ translate( 'Warning' ) }</ScreenReaderText>
-					{ this.renderGridicon() }
+					<Gridicon icon={ 'checkmark' } size={ 18 } />
 				</div>
 			);
 		}
 
 		return null;
-	}
-
-	renderGridicon() {
-		if ( this.props.inProgress ) {
-			return <Spinner size={ 20 } />;
-		}
-
-		if ( this.props.isWarning ) {
-			return (
-				<div>
-					<div className="checklist__task-warning-background" />
-					<Gridicon icon={ 'notice-outline' } size={ 24 } />
-				</div>
-			);
-		}
-
-		return <Gridicon icon={ 'checkmark' } size={ 18 } />;
 	}
 
 	render() {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -137,16 +137,6 @@ class WpcomChecklistComponent extends PureComponent {
 		}
 	};
 
-	handleLaunchTaskDismiss = taskId => () => {
-		const { siteId } = this.props;
-
-		if ( taskId ) {
-			this.props.requestSiteChecklistTaskUpdate( siteId, taskId );
-			this.trackTaskDismiss( taskId );
-			this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId );
-		}
-	};
-
 	trackTaskDismiss = taskId => {
 		if ( taskId ) {
 			this.props.recordTracksEvent( 'calypso_checklist_task_dismiss', {
@@ -674,7 +664,7 @@ class WpcomChecklistComponent extends PureComponent {
 				isButtonDisabled={ disabled }
 				noticeText={ noticeText }
 				onClick={ this.handleLaunchSite }
-				onDismiss={ this.handleLaunchTaskDismiss( task.id ) }
+				onDismiss={ this.handleTaskDismiss( task.id ) }
 				showSkip={ false }
 				title={ translate( 'Launch your site' ) }
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* User testing has shown the ability to "complete" a task using the checklist circles doesn't work as expected and leads to confusion, since it doesn't actually complete the task. It's easy to click these accidentally, dismissing the checklist task without the ability to get it back. 
* This PR removes the focusable component from the checkboxes and styles them with a slightly lighter border, making them a visual decoration rather than a button.
* This does not appear to affect the Jetpack checklist on the Plans -> My Plan page, but it should be tested again to make sure.

**Before**

<img width="641" alt="Screen Shot 2019-11-20 at 6 22 54 PM" src="https://user-images.githubusercontent.com/2124984/69287686-1eb71800-0bc5-11ea-90e5-20f3ae51b5d5.png">

**After**

<img width="648" alt="Screen Shot 2019-11-20 at 6 40 33 PM" src="https://user-images.githubusercontent.com/2124984/69287719-460de500-0bc5-11ea-82fb-4a8aa95e2f76.png">


#### Testing instructions

* Switch to this PR, start a new site from `/start/test-fse`
* Finish signup and land on Customer Home
* Note the checklist; you should not be able to click on the checklist circles to dismiss tasks. Only clicking on the primary action button should complete the task.
