### PR TITLE
Paste to link functionality: remove feature flag and ship to production

### DIFF
--- a/client/blocks/comments/form-textarea.jsx
+++ b/client/blocks/comments/form-textarea.jsx
@@ -28,10 +28,8 @@ const PostCommentFormTextarea = React.forwardRef( ( props, ref ) => (
 ) );
 /* eslint-enable jsx-a11y/no-autofocus */
 
-let component = PostCommentFormTextarea;
-if ( isEnabled( 'reader/paste-to-link' ) ) {
-	component = withPasteToLink( component );
-}
+let component = withPasteToLink( PostCommentFormTextarea );
+
 if ( isEnabled( 'reader/user-mention-suggestions' ) ) {
 	component = withUserMentions( component );
 }

--- a/client/lib/paste-to-link/index.jsx
+++ b/client/lib/paste-to-link/index.jsx
@@ -14,7 +14,7 @@ import { resemblesUrl } from 'lib/url';
  * If the clipboard contains a URL and some text is selected, pasting will wrap the selected text
  * in an <a> element with the href set to the URL in the clipboard.
  *
- * @example: withPasteToLink( Component )
+ * @example withPasteToLink( Component )
  * @param {object} WrappedComponent - React component to wrap
  * @returns {object} Enhanced component
  */
@@ -37,7 +37,8 @@ export default WrappedComponent => {
 			const clipboardText = event.clipboardData && event.clipboardData.getData( 'text/plain' );
 			const node = this.textareaRef.current;
 
-			// If we have a URL in the clipboard and a current selection, pass the URL to insertLink to wrap in an <a> element
+			// If we have a URL in the clipboard and a current selection, pass the URL to insertLink
+			// to wrap in an <a> element
 			if (
 				clipboardText &&
 				clipboardText.length > 0 &&

--- a/config/development.json
+++ b/config/development.json
@@ -139,7 +139,6 @@
 		"reader": true,
 		"reader/comment-polling": true,
 		"reader/full-errors": true,
-		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
 		"resume-editing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -98,7 +98,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/test.json
+++ b/config/test.json
@@ -85,7 +85,6 @@
 		"publicize-preview": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,7 +113,6 @@
 		"publicize-preview": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
 		"resume-editing": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #25113 we added paste-to-link functionality to the comments component.

Paste-to-Link is a higher-order component (HOC) that adds special paste behaviour to the wrapped component.

If the clipboard contains a URL and some text is selected, pasting will wrap the selected text in an
<a> element with the href set to the URL in the clipboard.

This functionality was launched as far as staging for internal users but not released to production.

This PR removes the feature flag and launches it for everyone.

#### Testing instructions

Open a Reader full post like:

http://calypso.localhost:3000/read/feeds/82926118/posts/1864180970

Copy a URL to your clipboard, type and highlight some text in the comments, and then paste.

Ensure that:
- @ user mentions still work
- copying a non-URL to your clipboard does not change the regular paste behaviour
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

