### PR TITLE
Update support.js to add Domain Mapping support guide link to a specific section.

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -69,6 +69,7 @@ export const MANAGE_PURCHASES_FAQ_CANCELLING = `${ root }/manage-purchases/#FAQ-
 export const MAP_EXISTING_DOMAIN = `${ root }/domains/map-existing-domain`;
 export const MAP_EXISTING_DOMAIN_UPDATE_DNS = `${ root }/domains/map-existing-domain#2-ask-your-domain-provider-to-update-your-dns-settings`;
 export const MAP_SUBDOMAIN = `${ root }/domains/map-subdomain`;
+export const MAP_SUBDOMAIN_CHANGE_NAME_SERVERS = `${ root }domains/map-existing-domain/#change-your-domains-name-servers`;
 export const MEDIA = `${ root }/media`;
 export const PUBLICIZE = `${ root }/publicize`;
 export const PUBLIC_VS_PRIVATE = `${ root }/domains/register-domain/#public-versus-private-registration-and-gdpr`;


### PR DESCRIPTION
I need to add this specific link because I need to use it to fix this GitHub issue: https://github.com/Automattic/wp-calypso/issues/37811 

This is the Support guide link: MAP_SUBDOMAIN_CHANGE_NAME_SERVERS: https://en.support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers which I have added. 
