### PR TITLE
Fix error updating cell widths on plans step in narrow viewports (e.g 320px)

### DIFF
--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -186,7 +186,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 			do {
 				visibleCount--;
 				cellWidth = ( vpw * ( 1 - SIDE_PANE_RATIO * 2 ) ) / visibleCount - borderSpacing;
-			} while ( cellWidth < MIN_CELL_WIDTH );
+			} while ( cellWidth < MIN_CELL_WIDTH && visibleCount > 1 );
 
 			paneWidth = SIDE_PANE_RATIO * vpw;
 			scrollerWidth = ( cellWidth + borderSpacing ) * planCount + borderSpacing;


### PR DESCRIPTION
On narrow viewports where the calculated cell width of the plan cards would be lower than the minimum cell width, the cell width would be calculated against a zero visible count resulting in a divide by zero, resulting in a cellWidth of Infinity, which threw an error and rendered the plans step incorrectly (screenshot below).

This change only runs the cellWidth calculation while the visible count is at least 1, fixing the error on narrow viewports.

Example devices at narrow 320px widths include iPhone 5 / SE. Larger screenwidths, where the cell width was greater than the minimum cell width don't have the same issue.

#### Changes proposed in this Pull Request

* In `computeStyleVars` only recalculate the `cellWidth` with a `visibleCount` of at least 1.

#### Before

![image](https://user-images.githubusercontent.com/14988353/69317291-c0ef0280-0c8e-11ea-8a62-199b1a942f4e.png)

#### After

![image](https://user-images.githubusercontent.com/14988353/69317352-e976fc80-0c8e-11ea-8953-548c9f63ca06.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your device viewport to 320px / iphone 5 / SE resolution
* Complete signup from `/start` and at the plans step the card should be rendered correctly
* The plan step should continue to render correctly at other resolutions
* Double-check the e-commerce signup flow where only two cards are presented in the plans step — does it still look okay?

Issue was reported in: https://github.com/Automattic/wp-calypso/pull/37554
