### PR TITLE
Create a hideSidebar action to disable sidebar for certain routes

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -29,7 +29,7 @@ import { addQueryArgs, externalRedirect, sectionify } from 'lib/route';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath, getPathParts } from 'lib/i18n-utils';
 import switchLocale from 'lib/i18n-utils/switch-locale';
-import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
+import { hideMasterbar, showMasterbar, hideSidebar } from 'state/ui/actions';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { login } from 'lib/paths';
 import { parseAuthorizationQuery } from './utils';
@@ -57,8 +57,7 @@ const analyticsPageTitleByType = {
 	pro: 'Jetpack Install Pro',
 };
 
-const removeSidebar = context =>
-	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+const removeSidebar = context => context.store.dispatch( hideSidebar() );
 
 const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 	const planSlugs = {
@@ -323,9 +322,8 @@ export function siteTopic( context, next ) {
  * and switches to that locale if the user is logged out.
  * If the user is logged in we remove the fragment and defer to the user's settings.
  *
- * @param {Object} context -- Middleware context
+ * @param {object} context -- Middleware context
  * @param {Function} next -- Call next middleware in chain
- * @returns {Undefined} next()
  */
 export function setLoggedOutLocale( context, next ) {
 	const isLoggedIn = !! getCurrentUserId( context.store.getState() );

--- a/client/jetpack-onboarding/controller.js
+++ b/client/jetpack-onboarding/controller.js
@@ -7,14 +7,10 @@ import React from 'react';
  * Internal Dependencies
  */
 import JetpackOnboardingMain from './main';
-import { setSection } from 'state/ui/actions';
-
-const removeSidebar = context => {
-	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
-};
+import { hideSidebar } from 'state/ui/actions';
 
 export const onboarding = ( context, next ) => {
-	removeSidebar( context );
+	hideSidebar( context );
 
 	// We validate siteSlug inside the component
 	context.primary = (

--- a/client/jetpack-onboarding/controller.js
+++ b/client/jetpack-onboarding/controller.js
@@ -10,7 +10,7 @@ import JetpackOnboardingMain from './main';
 import { hideSidebar } from 'state/ui/actions';
 
 export const onboarding = ( context, next ) => {
-	hideSidebar( context );
+	context.store.dispatch( hideSidebar() );
 
 	// We validate siteSlug inside the component
 	context.primary = (

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-
-import { omit } from 'lodash';
 import React from 'react';
-import { setSection } from 'state/ui/actions';
 
 /**
  * Internal Dependencies
@@ -13,21 +10,12 @@ import MainComponent from './main';
 
 export default {
 	unsubscribe( context, next ) {
-		// We don't need the sidebar here.
-		context.store.dispatch(
-			setSection(
-				{ name: 'me' },
-				{
-					hasSidebar: false,
-				}
-			)
-		);
-
+		const { email, category, hmac, ...rest } = context.query;
 		context.primary = React.createElement( MainComponent, {
-			email: context.query.email,
-			category: context.query.category,
-			hmac: context.query.hmac,
-			context: omit( context.query, [ 'email', 'category', 'hmac' ] ),
+			email,
+			category,
+			hmac,
+			context: rest,
 		} );
 		next();
 	},

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -96,12 +96,7 @@ function createNavigation( context ) {
 }
 
 function removeSidebar( context ) {
-	context.store.dispatch(
-		setSection( {
-			group: 'sites',
-			secondary: false,
-		} )
-	);
+	context.store.dispatch( setSection( { group: 'sites', secondary: false } ) );
 }
 
 function renderEmptySites( context ) {
@@ -444,8 +439,8 @@ export function navigation( context, next ) {
 /**
  * Middleware that adds the site selector screen to the layout.
  *
- * @param {object} context -- Middleware context
- * @param {function} next -- Call next middleware in chain
+ * @param {object} context Middleware context
+ * @param {Function} next Call next middleware in chain
  */
 export function sites( context, next ) {
 	if ( context.query.verified === '1' ) {
@@ -457,12 +452,7 @@ export function sites( context, next ) {
 	}
 
 	context.store.dispatch( setLayoutFocus( 'content' ) );
-	context.store.dispatch(
-		setSection( {
-			group: 'sites',
-			secondary: false,
-		} )
-	);
+	removeSidebar( context );
 
 	context.primary = createSitesComponent( context );
 	next();

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -13,7 +13,7 @@ import i18n from 'i18n-calypso';
  */
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InviteAccept from 'my-sites/invites/invite-accept';
-import { setSection } from 'state/ui/actions';
+import { hideSidebar } from 'state/ui/actions';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
 import _user from 'lib/user';
@@ -46,7 +46,7 @@ export function acceptInvite( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) );
 
-	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+	context.store.dispatch( hideSidebar() );
 
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -17,8 +17,8 @@ import PluginListComponent from './main';
 import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
 import PluginUpload from './plugin-upload';
-import { setSection } from 'state/ui/actions';
-import { getSelectedSite, getSection } from 'state/ui/selectors';
+import { hideSidebar } from 'state/ui/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 import getSelectedOrAllSitesWithPlugins from 'state/selectors/get-selected-or-all-sites-with-plugins';
 
 /**
@@ -115,10 +115,7 @@ function renderPluginWarnings( context ) {
 }
 
 function renderProvisionPlugins( context ) {
-	const state = context.store.getState();
-	const section = getSection( state );
-
-	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
+	context.store.dispatch( hideSidebar() );
 
 	context.primary = React.createElement( PlanSetup, {
 		whitelist: context.query.only || false,

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -21,7 +21,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isVipSite from 'state/selectors/is-vip-site';
-import { setSection } from 'state/ui/actions';
+import { hideSidebar } from 'state/ui/actions';
 
 function canDeleteSite( state, siteId ) {
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
@@ -66,14 +66,14 @@ export function deleteSite( context, next ) {
 }
 
 export function disconnectSite( context, next ) {
-	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+	context.store.dispatch( hideSidebar() );
 	context.primary = <DisconnectSite reason={ context.params.reason } />;
 	next();
 }
 
 export function disconnectSiteConfirm( context, next ) {
 	const { reason, text } = context.query;
-	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+	context.store.dispatch( hideSidebar() );
 	context.primary = <ConfirmDisconnection reason={ reason } text={ text } />;
 	next();
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -277,7 +277,9 @@ const sections = [
 		name: 'mailing-lists',
 		paths: [ '/mailing-lists/unsubscribe' ],
 		module: 'mailing-lists',
+		secondary: false,
 		enableLoggedOut: true,
+		group: 'me',
 	},
 	{
 		name: 'feature-upsell',

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -15,15 +15,15 @@ import 'state/data-layer/wpcom/sites/jitm';
  * Re-exports
  */
 export { default as setRoute } from './set-route';
-export { setSection } from '../section/actions';
+export { setSection, hideSidebar } from '../section/actions';
 export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
 
 /**
  * Returns an action object to be used in signalling that a site has been set
  * as selected.
  *
- * @param  {Number} siteId Site ID
- * @return {Object}        Action object
+ * @param {number} siteId Site ID
+ * @returns {object} Action object
  */
 export function setSelectedSiteId( siteId ) {
 	return {
@@ -36,7 +36,7 @@ export function setSelectedSiteId( siteId ) {
  * Returns an action object to be used in signalling that all sites have been
  * set as selected.
  *
- * @return {Object}        Action object
+ * @returns {object} Action object
  */
 export function setAllSitesSelected() {
 	return {
@@ -55,7 +55,7 @@ export function setPreviewShowing( isShowing ) {
 /**
  * Sets ui state to toggle the notifications panel
  *
- * @returns {Object} An action object
+ * @returns {object} An action object
  */
 export const toggleNotificationsPanel = () => {
 	return {
@@ -66,16 +66,17 @@ export const toggleNotificationsPanel = () => {
 /**
  * Returns an action object signalling navigation to the given path.
  *
- * @param  {String} path Navigation path
- * @return {Object}      Action object
+ * @param  {string} path Navigation path
+ * @returns {object}      Action object
  */
 export const navigate = path => ( { type: NAVIGATE, path } );
 
 /**
  * Replaces the current url and modifies the browser history entry. Equivalent to window.replaceHistory
- * @param  {String} path Navigation path
- * @param  {Boolean} saveContext true if we should save the current page.js context
- * @return {Object}      Action object
+ *
+ * @param {string} path Navigation path
+ * @param {boolean} saveContext true if we should save the current page.js context
+ * @returns {object} Action object
  */
 export const replaceHistory = ( path, saveContext ) => ( {
 	type: HISTORY_REPLACE,

--- a/client/state/ui/section/actions.js
+++ b/client/state/ui/section/actions.js
@@ -15,3 +15,10 @@ export function setSection( section, options = {} ) {
 
 	return action;
 }
+
+export function hideSidebar() {
+	return {
+		type: SECTION_SET,
+		hasSidebar: false,
+	};
+}


### PR DESCRIPTION
This patch is inspired by @Aurorum's work in #37688 and their attempts to hide the sidebar in the `/me/account/closed` route 🙂 

There are many routes that want to hide the sidebar even if the section that owns the route has `secondary: true` in its section definition. To disable the sidebar for a certain route, we usually dispatch the `setSection` action in a weird form:
```js
setSection( null, { hasSidebar: false } )
```
The goal is to set only the `state.ui.hasSidebar` flag in state and leave `state.ui.section` unchanged.

This patch introduces a more developer-friendly action creator: `hideSidebar()` and uses it across Calypso.

There are some special cases where we want to set the section name, too: in the `siteSelection` handler, where we force section name to `sites` when showing special "no sites" UI, and also in Concierge Upsell UI.

The change in `client/mailing-list` is also a bit special: here I'm updating the `mailing-lists` section definition to make the dispatches in the route handler redundant.

There are several drive-by fixes of JSDoc comments (suggested by ESLint), hope they don't make the patch too confusing.