### PR TITLE
Reader: Replace shouldComponentUpdate with react-redux option

### DIFF
--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -22,7 +22,7 @@ import CombinedCard from 'blocks/reader-combined-card';
 import EmptySearchRecommendedPost from './empty-search-recommended-post';
 import { getPostByKey } from 'state/reader/posts/selectors';
 import QueryReaderPost from 'components/data/query-reader-post';
-import compareProps from 'lib/compareProps';
+import compareProps from 'lib/compare-props';
 
 class PostLifecycle extends React.Component {
 	static propTypes = {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -13,7 +13,6 @@ import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
 import ListGap from 'reader/list-gap';
 import CrossPost from './x-post';
-import isShallowEqual from '@wordpress/is-shallow-equal';
 import RecommendedPosts from './recommended-posts';
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
 import PostBlocked from 'blocks/reader-post-card/blocked';
@@ -23,6 +22,7 @@ import CombinedCard from 'blocks/reader-combined-card';
 import EmptySearchRecommendedPost from './empty-search-recommended-post';
 import { getPostByKey } from 'state/reader/posts/selectors';
 import QueryReaderPost from 'components/data/query-reader-post';
+import compareProps from 'lib/compareProps';
 
 class PostLifecycle extends React.Component {
 	static propTypes = {
@@ -31,13 +31,6 @@ class PostLifecycle extends React.Component {
 		handleClick: PropTypes.func,
 		recStreamKey: PropTypes.string,
 	};
-
-	shouldComponentUpdate( nextProps ) {
-		const currentPropsToCompare = omit( this.props, 'handleClick' );
-		const nextPropsToCompare = omit( nextProps, 'handleClick' );
-
-		return ! isShallowEqual( currentPropsToCompare, nextPropsToCompare );
-	}
 
 	render() {
 		const { post, postKey, followSource, isSelected, recsStreamKey, streamKey } = this.props;
@@ -104,6 +97,11 @@ class PostLifecycle extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => ( {
-	post: getPostByKey( state, ownProps.postKey ),
-} ) )( PostLifecycle );
+export default connect(
+	( state, ownProps ) => ( {
+		post: getPostByKey( state, ownProps.postKey ),
+	} ),
+	null,
+	null,
+	{ areOwnPropsEqual: compareProps( { ignore: [ 'handleClick' ] } ) }
+)( PostLifecycle );


### PR DESCRIPTION
via https://github.com/Automattic/wp-calypso/pull/37804#discussion_r348965248

#### Changes proposed in this Pull Request

* Replace shouldComponentUpdate with react-redux `areOwnPropsEqual` option.

#### Testing instructions

* No behavioral changes
* Ensure the reader stream does not have increased rerenders