### PR TITLE
Gutenboarding: Close DomainPicker by default

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -25,9 +25,7 @@ const DomainPickerButton: FunctionComponent = () => {
 	// User can search for a domain
 	const [ domainSearch, setDomainSearch ] = useState( '' );
 
-	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState(
-		true /* @TODO: should be `false` by default, true for dev */
-	);
+	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
 
 	// Without user search, we can provide recommendations based on title + vertical
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Close it by default, this is what production behavior will be.

#### Testing instructions

* Visit `/gutenboarding`
* Is the DomainPicker closed to start? It opens on click?