### PR TITLE
Gutenboarding: Separate DomainPicker and onboarding concerns

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -4,18 +4,12 @@
 import React, { FunctionComponent, useState } from 'react';
 import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Popover, Dashicon } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
-import { useDebounce } from 'use-debounce';
 
 /**
  * Internal dependencies
  */
 import DomainPicker from './list';
-import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
-import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { isFilledFormValue } from '../../stores/onboard/types';
-import { selectorDebounce } from '../../constants';
 
 /**
  * Style dependencies
@@ -23,34 +17,7 @@ import { selectorDebounce } from '../../constants';
 import './style.scss';
 
 const DomainPickerButton: FunctionComponent = ( { children } ) => {
-	// User can search for a domain
-	const [ domainSearch, setDomainSearch ] = useState( '' );
-
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
-
-	// Without user search, we can provide recommendations based on title + vertical
-	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
-
-	const [ search ] = useDebounce(
-		// Use trimmed domainSearch if non-empty
-		domainSearch.trim() ||
-			// Otherwise use a filled form value
-			( isFilledFormValue( siteTitle ) && siteTitle ) ||
-			// Otherwise use empty string
-			'',
-		selectorDebounce
-	);
-	const suggestions = useSelect(
-		select => {
-			if ( search ) {
-				return select( DOMAIN_STORE ).getDomainSuggestions(
-					search,
-					isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
-				);
-			}
-		},
-		[ search, siteVertical ]
-	);
 
 	return (
 		<>
@@ -66,11 +33,7 @@ const DomainPickerButton: FunctionComponent = ( { children } ) => {
 			</Button>
 			{ isDomainPopoverVisible && (
 				<Popover>
-					<DomainPicker
-						domainSearch={ domainSearch }
-						setDomainSearch={ setDomainSearch }
-						suggestions={ suggestions }
-					/>
+					<DomainPicker />
 				</Popover>
 			) }
 		</>

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useState } from 'react';
-import { __ as NO__ } from '@wordpress/i18n';
+import React, { ComponentPropsWithoutRef, FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
 import classnames from 'classnames';
 
@@ -16,7 +15,21 @@ import DomainPicker from './list';
  */
 import './style.scss';
 
-const DomainPickerButton: FunctionComponent = ( { children } ) => {
+interface Props {
+	/**
+	 * Term to search when no user input is provided.
+	 */
+	defaultQuery?: ComponentPropsWithoutRef< typeof DomainPicker >[ 'defaultQuery' ];
+
+	/**
+	 * Additional parameters for the domain suggestions query.
+	 *
+	 * @see DomainPicker for defaults
+	 */
+	queryParameters?: ComponentPropsWithoutRef< typeof DomainPicker >[ 'queryParameters' ];
+}
+
+const DomainPickerButton: FunctionComponent< Props > = ( { children, ...domainPickerProps } ) => {
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
 
 	return (
@@ -33,7 +46,7 @@ const DomainPickerButton: FunctionComponent = ( { children } ) => {
 			</Button>
 			{ isDomainPopoverVisible && (
 				<Popover>
-					<DomainPicker />
+					<DomainPicker { ...domainPickerProps } />
 				</Popover>
 			) }
 		</>

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -15,19 +15,7 @@ import DomainPicker from './list';
  */
 import './style.scss';
 
-interface Props {
-	/**
-	 * Term to search when no user input is provided.
-	 */
-	defaultQuery?: ComponentPropsWithoutRef< typeof DomainPicker >[ 'defaultQuery' ];
-
-	/**
-	 * Additional parameters for the domain suggestions query.
-	 *
-	 * @see DomainPicker for defaults
-	 */
-	queryParameters?: ComponentPropsWithoutRef< typeof DomainPicker >[ 'queryParameters' ];
-}
+type Props = ComponentPropsWithoutRef< typeof DomainPicker >;
 
 const DomainPickerButton: FunctionComponent< Props > = ( { children, ...domainPickerProps } ) => {
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -44,10 +44,11 @@ const DomainPicker: FunctionComponent = () => {
 	const suggestions = useSelect(
 		select => {
 			if ( search ) {
-				return select( DOMAIN_STORE ).getDomainSuggestions(
-					search,
-					isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
-				);
+				return select( DOMAIN_STORE ).getDomainSuggestions( search, {
+					include_wordpressdotcom: true,
+					quantity: 4,
+					...( isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined ),
+				} );
 			}
 		},
 		[ search, siteVertical ]

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -3,7 +3,7 @@
 .domain-picker__button {
 	.dashicon {
 		margin-left: 0.5em;
-		transition: transform 120ms ease-in-out;
+		transition: transform 100ms ease-in-out;
 	}
 	&.is-open .dashicon {
 		transform: rotate( 180deg );

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -3,7 +3,7 @@
 .domain-picker__button {
 	.dashicon {
 		margin-left: 0.5em;
-		transition: transform 180ms ease-in-out;
+		transition: transform 120ms ease-in-out;
 	}
 	&.is-open .dashicon {
 		transform: rotate( 180deg );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -86,7 +86,7 @@ const Header: FunctionComponent< Props > = ( {
 					<div className="gutenboarding__site-title">
 						{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
 					</div>
-					<DomainPickerButton>{ domainText ?? NO__( 'Choose a domain' ) }</DomainPickerButton>
+					{ domainText && <DomainPickerButton>{ domainText }</DomainPickerButton> }
 				</div>
 			</div>
 			<div className="gutenboarding__header-section">

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -57,8 +57,7 @@ const Header: FunctionComponent< Props > = ( {
 				return;
 			}
 			return select( DOMAIN_STORE ).getDomainSuggestions( domainSearch, {
-				include_wordpressdotcom: true,
-				quantity: 1,
+				only_wordpressdotcom: true,
 				...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
 			} )?.[ 0 ];
 		},

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -65,8 +65,9 @@ const Header: FunctionComponent< Props > = ( {
 		[ domainSearch, siteVertical ]
 	);
 
+	// Update domainText only when we have a replacement.
 	useEffect( () => {
-		setDomainText( domain ?? freeDomainSuggestion?.domain_name );
+		setDomainText( current => domain ?? freeDomainSuggestion?.domain_name ?? current );
 	}, [ domain, freeDomainSuggestion ] );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -41,12 +41,11 @@ const Header: FunctionComponent< Props > = ( {
 	);
 
 	const [ domainSearch ] = useDebounce(
-		domain
-			? // If we know a domain, do not search.
-			  null
-			: isFilledFormValue( siteTitle )
-			? // If we have a siteTitle, use it.
-			  siteTitle
+		// eslint-disable-next-line no-nested-ternary
+		domain // If we know a domain, do not search.
+			? null
+			: isFilledFormValue( siteTitle ) // If we have a siteTitle, use it.
+			? siteTitle
 			: // Otherwise, do not search.
 			  null,
 		selectorDebounce
@@ -57,7 +56,9 @@ const Header: FunctionComponent< Props > = ( {
 				return;
 			}
 			return select( DOMAIN_STORE ).getDomainSuggestions( domainSearch, {
-				only_wordpressdotcom: true,
+				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
+				include_wordpressdotcom: true,
+				quantity: 1,
 				...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
 			} )?.[ 0 ];
 		},
@@ -85,7 +86,16 @@ const Header: FunctionComponent< Props > = ( {
 					<div className="gutenboarding__site-title">
 						{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
 					</div>
-					{ domainText && <DomainPickerButton>{ domainText }</DomainPickerButton> }
+					{ domainText && (
+						<DomainPickerButton
+							defaultQuery={ isFilledFormValue( siteTitle ) ? siteTitle : undefined }
+							queryParameters={
+								isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
+							}
+						>
+							{ domainText }
+						</DomainPickerButton>
+					) }
 				</div>
 			</div>
 			<div className="gutenboarding__header-section">

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -13,6 +13,7 @@ import { useDebounce } from 'use-debounce';
 import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import './style.scss';
+import { DomainName } from '../../stores/domain-suggestions/types';
 import { DomainPickerButton } from '../domain-picker';
 import { isFilledFormValue } from '../../stores/onboard/types';
 import { selectorDebounce } from '../../constants';
@@ -34,7 +35,7 @@ const Header: FunctionComponent< Props > = ( {
 	toggleGeneralSidebar,
 	toggleSidebarShortcut,
 } ) => {
-	const [ domainText, setDomainText ] = useState< string | null >( null );
+	const [ domainText, setDomainText ] = useState< DomainName >( '' );
 
 	const { domain, siteTitle, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Debounce our input + HTTP dependent select changes
+ *
+ * Rapidly changing input generates excessive HTTP requests.
+ * It also leads to jarring UI changes.
+ *
+ * @see https://stackoverflow.com/a/44755058/1432801
+ */
+export const selectorDebounce = 300;

--- a/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/selectors.ts
@@ -73,7 +73,9 @@ function normalizeDomainSuggestionQuery(
 ): DomainSuggestionQuery {
 	return {
 		// Defaults
-		include_wordpressdotcom: false,
+		include_wordpressdotcom: queryOptions.only_wordpressdotcom || false,
+		include_dotblogsubdomain: ! queryOptions.only_wordpressdotcom || false,
+		only_wordpressdotcom: false,
 		quantity: 5,
 		vendor: 'variation2_front',
 

--- a/client/landing/gutenboarding/stores/domain-suggestions/types.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/types.ts
@@ -3,17 +3,42 @@ enum ActionType {
 }
 export { ActionType };
 
-// See client/state/domains/suggestions/actions.js#requestDomainsSuggestions
 export interface DomainSuggestionQuery {
 	/**
-	 * Domain query
+	 * True to include .blog subdomain suggestions
+	 *
+	 * @example
+	 * example.photo.blog
+	 */
+	include_dotblogsubdomain?: true;
+
+	/**
+	 * True to include WordPress.com subdomain suggestions
+	 *
+	 * @example
+	 * example.wordpress.com
+	 */
+	include_wordpressdotcom?: true;
+
+	/**
+	 * True to only provide a wordpress.com subdomain
+	 *
+	 * @example
+	 * example.wordpress.com
+	 */
+	only_wordpressdotcom?: true;
+
+	/**
+	 * Desired number of results
+	 */
+	quantity?: number;
+
+	/**
+	 * Domain search term
 	 */
 	query: string;
 
-	/**
-	 * Number of results
-	 */
-	quantity: number;
+	recommendation_context?: string;
 
 	/**
 	 * Vendor
@@ -21,18 +46,7 @@ export interface DomainSuggestionQuery {
 	vendor: string;
 
 	/**
-	 * True to include WordPress.com subdomain suggestions
-	 */
-	include_wordpressdotcom: boolean;
-	include_dotblogsubdomain: boolean;
-
-	// @FIXME: Obviates some others?
-	only_wordpressdotcom: boolean;
-
-	recommendation_context?: string;
-
-	/**
-	 * The site vertical
+	 * The vertical id or slug
 	 */
 	vertical?: string;
 }

--- a/client/landing/gutenboarding/stores/domain-suggestions/types.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/types.ts
@@ -24,6 +24,10 @@ export interface DomainSuggestionQuery {
 	 * True to include WordPress.com subdomain suggestions
 	 */
 	include_wordpressdotcom: boolean;
+	include_dotblogsubdomain: boolean;
+
+	// @FIXME: Obviates some others?
+	only_wordpressdotcom: boolean;
 
 	recommendation_context?: string;
 

--- a/client/landing/gutenboarding/stores/domain-suggestions/types.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/types.ts
@@ -10,7 +10,7 @@ export interface DomainSuggestionQuery {
 	 * @example
 	 * example.photo.blog
 	 */
-	include_dotblogsubdomain?: true;
+	include_dotblogsubdomain: boolean;
 
 	/**
 	 * True to include WordPress.com subdomain suggestions
@@ -18,7 +18,7 @@ export interface DomainSuggestionQuery {
 	 * @example
 	 * example.wordpress.com
 	 */
-	include_wordpressdotcom?: true;
+	include_wordpressdotcom: boolean;
 
 	/**
 	 * True to only provide a wordpress.com subdomain
@@ -26,12 +26,12 @@ export interface DomainSuggestionQuery {
 	 * @example
 	 * example.wordpress.com
 	 */
-	only_wordpressdotcom?: true;
+	only_wordpressdotcom: boolean;
 
 	/**
 	 * Desired number of results
 	 */
-	quantity?: number;
+	quantity: number;
 
 	/**
 	 * Domain search term


### PR DESCRIPTION
- Reorganize the domain picker internals, the selection happens closer to where it's required.
- Isolate the DomainPicker from onboarding store.
- The contents of the DomainPicker button is now passed as `children`.
- Only show the domain picker if we have a domain already selected or a site title.

## Testing
- `/gutenboarding` domains picker works well
- Domains picker appears when appropriate (have site title) and responds to changes to site title appropriately
- Domains picker searches correctly when a term is entered.