### PR TITLE
Gutenboarding: domain picker display free and paid domains

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -4,7 +4,6 @@
 import React, { FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { head, partition } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -60,8 +59,6 @@ const DomainPickerButton: FunctionComponent = () => {
 		[ search, siteVertical ]
 	);
 
-	const [ freeDomainSuggestions, paidDomainSuggestions ] = partition( suggestions, 'is_free' );
-
 	return (
 		<>
 			<Button
@@ -71,7 +68,7 @@ const DomainPickerButton: FunctionComponent = () => {
 				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 			>
-				{ head( freeDomainSuggestions )?.domain_name ?? '\u00a0' }
+				Choose a domain
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
@@ -79,7 +76,7 @@ const DomainPickerButton: FunctionComponent = () => {
 					<DomainPicker
 						domainSearch={ domainSearch }
 						setDomainSearch={ setDomainSearch }
-						suggestions={ paidDomainSuggestions }
+						suggestions={ suggestions }
 					/>
 				</Popover>
 			) }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -68,7 +68,7 @@ const DomainPickerButton: FunctionComponent = () => {
 				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 			>
-				Choose a domain
+				{ NO__( 'Choose a domain' ) }
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -31,8 +31,13 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const label = NO__( 'Search for a domain' );
 
 	const handleDomainPick = suggestion => () => {
-		// eslint-disable-next-line no-console
-		console.log( 'Picked domain: %o', suggestion );
+		if ( suggestion.is_free ) {
+			// eslint-disable-next-line no-console
+			console.log( 'Picked free domain: %o', suggestion );
+		} else {
+			// eslint-disable-next-line no-console
+			console.log( 'Picked paid domain: %o', suggestion );
+		}
 	};
 
 	const handleHasDomain = () => {
@@ -70,7 +75,18 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								<span className="domain-picker__suggestion-item-name">
 									{ suggestion.domain_name }
 								</span>
-								<span className="domain-picker__suggestion-action">{ NO__( 'Upgrade' ) }</span>
+								{ suggestion.is_free ? (
+									<span className="domain-picker__suggestion-action">{ NO__( 'Select' ) }</span>
+								) : (
+									<a
+										className="domain-picker__suggestion-action"
+										href={ `http://wordpress.com/start/domain?new=${ suggestion.domain_name }` }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ NO__( 'Upgrade' ) }
+									</a>
+								) }
 							</Button>
 						) ) }
 					</PanelRow>

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -32,6 +32,8 @@
 
 .domain-picker__suggestion-action {
 	color: var( --studio-blue-40 );
+	text-decoration: none;
+	margin-left: 20px;
 }
 
 .domain-picker__has-domain {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* use 'Select' as link text for free domain
* 'Upgrade' link redirects to another flow

![Screenshot 2019-11-21 at 14 35 27](https://user-images.githubusercontent.com/14192054/69338904-d4897180-0c6c-11ea-8c27-ad6837244f15.png)

#### Testing instructions
Visit http://calypso.localhost:3000/gutenboarding and search for a domain.
Clicking on 'Upgrade' link next to a paid domain should open an external page. 
