### PR TITLE
Add a tracks event for the skip button in domain step test

### DIFF
--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -16,8 +16,9 @@ import './style.scss';
 class FreeDomainExplainer extends React.Component {
 	handleClick = () => {
 		const hideFreePlan = true;
+		const tracksEventName = 'calypso_domain_step_skip_to_paid_plans';
 
-		this.props.onSkip( undefined, hideFreePlan );
+		this.props.onSkip( undefined, hideFreePlan, tracksEventName );
 	};
 	render() {
 		return (

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -16,9 +16,8 @@ import './style.scss';
 class FreeDomainExplainer extends React.Component {
 	handleClick = () => {
 		const hideFreePlan = true;
-		const tracksEventName = 'calypso_domain_step_skip_to_paid_plans';
 
-		this.props.onSkip( undefined, hideFreePlan, tracksEventName );
+		this.props.onSkip( undefined, hideFreePlan );
 	};
 	render() {
 		return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -207,9 +207,10 @@ class DomainsStep extends React.Component {
 	};
 
 	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const hideFreePlanTracksProp = this.props.showTestCopy
+		const hideFreePlanTracksProp = this.showTestCopy
 			? { should_hide_free_plan: shouldHideFreePlan }
 			: {};
+
 		const tracksProperties = Object.assign(
 			{
 				section: this.getAnalyticsSection(),
@@ -219,11 +220,9 @@ class DomainsStep extends React.Component {
 			hideFreePlanTracksProp
 		);
 
-		recordTracksEvent( 'calypso_signup_skip_step', tracksProperties );
+		this.props.recordTracksEvent( 'calypso_signup_skip_step', tracksProperties );
 
-		defer( () => {
-			this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
-		} );
+		this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
@@ -711,6 +710,7 @@ export default connect(
 		setDesignType,
 		saveSignupStep,
 		submitSignupStep,
+		recordTracksEvent,
 		fetchUsernameSuggestion,
 		hideSitePreview,
 		showSitePreview,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -206,11 +206,14 @@ class DomainsStep extends React.Component {
 		return `${ repo }/${ themeSlug }`;
 	};
 
-	handleSkip = () => {
-		const domainItem = undefined;
+	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false, tracksEventName ) => {
+		tracksEventName &&
+			recordTracksEvent( tracksEventName, {
+				section: this.getAnalyticsSection(),
+				flow: this.props.flowName,
+			} );
 
-		this.props.submitSignupStep( { stepName: this.props.stepName, domainItem }, { domainItem } );
-		this.props.goToNextStep();
+		this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
@@ -438,7 +441,7 @@ class DomainsStep extends React.Component {
 				showSkipButton={ this.props.showSkipButton }
 				vertical={ this.props.vertical }
 				onSkip={ this.handleSkip }
-				hideFreePlan={ this.submitWithDomain }
+				hideFreePlan={ this.handleSkip }
 			/>
 		);
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -206,12 +206,13 @@ class DomainsStep extends React.Component {
 		return `${ repo }/${ themeSlug }`;
 	};
 
-	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false, tracksEventName ) => {
-		tracksEventName &&
-			recordTracksEvent( tracksEventName, {
-				section: this.getAnalyticsSection(),
-				flow: this.props.flowName,
-			} );
+	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
+		recordTracksEvent( 'calypso_signup_skip_step', {
+			section: this.getAnalyticsSection(),
+			flow: this.props.flowName,
+			step: this.props.stepName,
+			shouldHideFreePlan,
+		} );
 
 		this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -207,12 +207,19 @@ class DomainsStep extends React.Component {
 	};
 
 	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		recordTracksEvent( 'calypso_signup_skip_step', {
-			section: this.getAnalyticsSection(),
-			flow: this.props.flowName,
-			step: this.props.stepName,
-			shouldHideFreePlan,
-		} );
+		const hideFreePlanTracksProp = this.props.showTestCopy
+			? { should_hide_free_plan: shouldHideFreePlan }
+			: {};
+		const tracksProperties = Object.assign(
+			{
+				section: this.getAnalyticsSection(),
+				flow: this.props.flowName,
+				step: this.props.stepName,
+			},
+			hideFreePlanTracksProp
+		);
+
+		recordTracksEvent( 'calypso_signup_skip_step', tracksProperties );
 
 		defer( () => {
 			this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -214,7 +214,9 @@ class DomainsStep extends React.Component {
 			shouldHideFreePlan,
 		} );
 
-		this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
+		defer( () => {
+			this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
+		} );
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For the domain step test introduced by #37546, add a Tracks event for the cta on the free-domain textbox.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start
* Type `localStorage.setItem('debug', 'calypso:analytics:tracks');` in your browser console and refresh page.
* Assign yourself to the variant group in the `domainStepCopyUpdates` A/B test.
* Go through the signup flow. In the domain step, click the "Review our plans to get started >>" link and verify that the Tracks event is fired.
* Verify that you can then complete the signup flow and create a new site.