### PR TITLE
Gutenboarding: Fix DomainName type imports

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { ActionType, DomainName, SiteVertical, Vertical } from './types';
+import { ActionType, SiteVertical, Vertical } from './types';
+import { DomainName } from '../domain-suggestions/types';
 
 export const setDomain = ( domain: DomainName ) => ( {
 	type: ActionType.SET_DOMAIN as const,

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -7,14 +7,8 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	ActionType,
-	DomainName,
-	FormValue,
-	EMPTY_FORM_VALUE,
-	Vertical,
-	SiteVertical,
-} from './types';
+import { ActionType, FormValue, EMPTY_FORM_VALUE, Vertical, SiteVertical } from './types';
+import { DomainName } from '../domain-suggestions/types';
 import * as Actions from './actions';
 
 const domain: Reducer< DomainName | null, ReturnType< typeof Actions[ 'setDomain' ] > > = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Gutenboarding: Fix DomainName type imports

Other options @sirreal and I discussed are:

- Define `DomainName` separately in `client/landing/gutenboarding/stores/onboard/types.ts`, see https://github.com/Automattic/wp-calypso/pull/37820/files#r349096785
- Remove the `DomainName` type alias altogether, just use `string` everywhere

Happy to go with the latter instead of this PR; not a big fan of the former. We can discuss on this PR.

#### Testing instructions

No functional changes, but `npm run typecheck -- --project tsconfig/gutenboarding.json` should produce 2 errors less than on `master`.