### PR TITLE
Composite checkout: screen reader enhancements

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -5,18 +5,12 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { renderDisplayValueMarkdown } from '@automattic/composite-checkout';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, sprintf } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-<<<<<<< HEAD:packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
 import joinClasses from './join-classes';
-=======
-import joinClasses from '../lib/join-classes';
-import { renderDisplayValueMarkdown, useHasDomainsInCart } from '../public-api';
-import { useLocalize, sprintf } from '../lib/localize';
->>>>>>> Add sprintf:packages/composite-checkout/src/wpcom/wp-order-review-line-items.js
 import Button from './button';
 import RadioButton from './radio-button';
 import CheckoutModal from '../components/checkout-modal'; // TODO: remove this
@@ -147,7 +141,7 @@ const TermOptionsItem = styled.li`
 `;
 
 function DeleteIcon( { uniqueID, product } ) {
-	const translate = useLocalize();
+	const translate = useTranslate();
 
 	return (
 		<svg

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -54,7 +54,7 @@ function WPLineItem( { item, className, hasDeleteButtons, removeProduct } ) {
 							setIsModalVisible( true );
 						} }
 					>
-						<DeleteIcon uniqueID={ deleteButtonId } />
+						<DeleteIcon uniqueID={ deleteButtonId } product={ item.label } />
 					</DeleteButton>
 
 					<CheckoutModal
@@ -102,14 +102,6 @@ const LineItemUI = styled( WPLineItem )`
 		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
 	position: relative;
 	margin-right: 30px;
-
-	:first-of-type {
-		padding-top: 10px;
-	}
-
-	:first-of-type button {
-		top: -4px;
-	}
 `;
 
 const ProductTitle = styled.span`
@@ -148,8 +140,8 @@ const TermOptionsItem = styled.li`
 	}
 `;
 
-function DeleteIcon( { uniqueID } ) {
-	const translate = useTranslate();
+function DeleteIcon( { uniqueID, product } ) {
+	const translate = useLocalize();
 
 	return (
 		<svg
@@ -160,7 +152,7 @@ function DeleteIcon( { uniqueID } ) {
 			xmlns="http://www.w3.org/2000/svg"
 			aria-labelledby={ uniqueID }
 		>
-			<title id={ uniqueID }>{ translate( 'Delete' ) }</title>
+			<title id={ uniqueID }>{ translate( 'Remove ' + product + ' from cart' ) }</title>
 			<mask
 				id="trashIcon"
 				mask-type="alpha"
@@ -200,17 +192,18 @@ export function WPOrderReviewLineItems( {
 	removeProduct,
 } ) {
 	return (
-		<div className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
+		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ items.map( item => (
-				<LineItemUI
-					isSummaryVisible={ isSummaryVisible }
-					key={ item.id }
-					item={ item }
-					hasDeleteButtons={ hasDeleteButtons }
-					removeProduct={ removeProduct }
-				/>
+				<WPOrderReviewListItems key={ item.id }>
+					<LineItemUI
+						isSummaryVisible={ isSummaryVisible }
+						item={ item }
+						hasDeleteButtons={ hasDeleteButtons }
+						removeProduct={ removeProduct }
+					/>
+				</WPOrderReviewListItems>
 			) ) }
-		</div>
+		</WPOrderReviewList>
 	);
 }
 
@@ -228,6 +221,18 @@ WPOrderReviewLineItems.propTypes = {
 		} )
 	),
 };
+
+const WPOrderReviewList = styled.ul`
+	margin: -10px 0 0;
+	padding: 0;
+`;
+
+const WPOrderReviewListItems = styled.li`
+	margin: 0;
+	padding: 0;
+	display: block;
+	list-style: none;
+`;
 
 function PlanTermOptions() {
 	const translate = useTranslate();

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -10,7 +10,13 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+<<<<<<< HEAD:packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
 import joinClasses from './join-classes';
+=======
+import joinClasses from '../lib/join-classes';
+import { renderDisplayValueMarkdown, useHasDomainsInCart } from '../public-api';
+import { useLocalize, sprintf } from '../lib/localize';
+>>>>>>> Add sprintf:packages/composite-checkout/src/wpcom/wp-order-review-line-items.js
 import Button from './button';
 import RadioButton from './radio-button';
 import CheckoutModal from '../components/checkout-modal'; // TODO: remove this
@@ -152,7 +158,7 @@ function DeleteIcon( { uniqueID, product } ) {
 			xmlns="http://www.w3.org/2000/svg"
 			aria-labelledby={ uniqueID }
 		>
-			<title id={ uniqueID }>{ translate( 'Remove ' + product + ' from cart' ) }</title>
+			<title id={ uniqueID }>{ sprintf( translate( 'Remove %s from cart' ), product ) }</title>
 			<mask
 				id="trashIcon"
 				mask-type="alpha"

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { renderDisplayValueMarkdown } from '@automattic/composite-checkout';
-import { useTranslate, sprintf } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -152,7 +152,11 @@ function DeleteIcon( { uniqueID, product } ) {
 			xmlns="http://www.w3.org/2000/svg"
 			aria-labelledby={ uniqueID }
 		>
-			<title id={ uniqueID }>{ sprintf( translate( 'Remove %s from cart' ), product ) }</title>
+			<title id={ uniqueID }>
+				{ translate( 'Remove %s from cart', {
+					args: product,
+				} ) }
+			</title>
 			<mask
 				id="trashIcon"
 				mask-type="alpha"

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -88,7 +88,7 @@ function CheckoutStepHeader( {
 			className={ joinClasses( [ className, 'checkout-step__header' ] ) }
 		>
 			<Stepper isComplete={ isComplete } isActive={ isActive }>
-				{ stepNumber || '•' }
+				{ stepNumber || null }
 			</Stepper>
 			<StepTitle
 				className="checkout-step__title"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes some enhancements so that our checkout reads better for screen readers. Here are some of the tweaks:
* Stop rendering the step number if it's 0 so that it reads "You are all set to checkout" vs. "ZERO.. Your are all set to checkout"
* Updated the remove from cart button title so that it reads "Remove [product] from the cart"
* Updated the items in the review step so that they're a list. 

#### Testing instructions
* Get checkout up and running with these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Setup voice commands: https://webaim.org/articles/voiceover
* Walk through the interface with the screen reader.
