### PR TITLE
Store selected domain suggestion

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -3,12 +3,14 @@
  */
 import React, { ComponentPropsWithoutRef, FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import DomainPicker from './list';
+import { STORE_KEY } from '../../stores/onboard';
 
 /**
  * Style dependencies

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -3,14 +3,12 @@
  */
 import React, { ComponentPropsWithoutRef, FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import DomainPicker from './list';
-import { STORE_KEY } from '../../stores/onboard';
 
 /**
  * Style dependencies
@@ -19,8 +17,17 @@ import './style.scss';
 
 type Props = ComponentPropsWithoutRef< typeof DomainPicker >;
 
-const DomainPickerButton: FunctionComponent< Props > = ( { children, ...domainPickerProps } ) => {
+const DomainPickerButton: FunctionComponent< Props > = ( {
+	children,
+	onDomainSelect,
+	...domainPickerProps
+} ) => {
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
+
+	const handleDomainSelect: typeof onDomainSelect = selectedDomain => {
+		setDomainPopoverVisibility( false );
+		onDomainSelect( selectedDomain );
+	};
 
 	return (
 		<>
@@ -36,7 +43,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( { children, ...domainPi
 			</Button>
 			{ isDomainPopoverVisible && (
 				<Popover>
-					<DomainPicker { ...domainPickerProps } />
+					<DomainPicker { ...domainPickerProps } onDomainSelect={ handleDomainSelect } />
 				</Popover>
 			) }
 		</>

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -28,7 +28,9 @@ interface Props {
 	defaultQuery?: string;
 
 	/**
-	 * Event handler to call upon free domain selection
+	 * Callback that will be invoked when a domain is selected.
+	 *
+	 * @param domainSuggestion The selected domain.
 	 */
 	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
 

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -28,12 +28,21 @@ interface Props {
 	defaultQuery?: string;
 
 	/**
+	 * Event handler to call upon free domain selection
+	 */
+	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
+
+	/**
 	 * Additional parameters for the domain suggestions query.
 	 */
 	queryParameters?: Partial< DomainSuggestionQuery >;
 }
 
-const DomainPicker: FunctionComponent< Props > = ( { defaultQuery, queryParameters } ) => {
+const DomainPicker: FunctionComponent< Props > = ( {
+	defaultQuery,
+	onDomainSelect,
+	queryParameters,
+} ) => {
 	const label = NO__( 'Search for a domain' );
 
 	const [ domainSearch, setDomainSearch ] = useState( '' );
@@ -52,16 +61,6 @@ const DomainPicker: FunctionComponent< Props > = ( { defaultQuery, queryParamete
 		},
 		[ search, queryParameters ]
 	);
-
-	const handleDomainPick = ( suggestion: DomainSuggestion ) => () => {
-		if ( suggestion.is_free ) {
-			// eslint-disable-next-line no-console
-			console.log( 'Picked free domain: %o', suggestion );
-		} else {
-			// eslint-disable-next-line no-console
-			console.log( 'Picked paid domain: %o', suggestion );
-		}
-	};
 
 	const handleHasDomain = () => {
 		// eslint-disable-next-line no-console
@@ -91,7 +90,7 @@ const DomainPicker: FunctionComponent< Props > = ( { defaultQuery, queryParamete
 						<div className="domain-picker__recommended-header">{ NO__( 'Recommended' ) }</div>
 						{ suggestions.map( suggestion => (
 							<Button
-								onClick={ handleDomainPick( suggestion ) }
+								onClick={ () => onDomainSelect( suggestion ) }
 								className="domain-picker__suggestion-item"
 								key={ suggestion.domain_name }
 							>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -64,7 +64,7 @@ const Header: FunctionComponent< Props > = ( {
 		[ domainSearch, siteVertical ]
 	);
 
-	const domainText = domain?.domain_name ?? freeDomainSuggestion?.domain_name;
+	const currentDomain = domain ?? freeDomainSuggestion;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -82,7 +82,7 @@ const Header: FunctionComponent< Props > = ( {
 					<div className="gutenboarding__site-title">
 						{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
 					</div>
-					{ domainText && (
+					{ currentDomain && (
 						<DomainPickerButton
 							defaultQuery={ isFilledFormValue( siteTitle ) ? siteTitle : undefined }
 							onDomainSelect={ setDomain }
@@ -90,7 +90,7 @@ const Header: FunctionComponent< Props > = ( {
 								isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
 							}
 						>
-							{ domainText }
+							{ currentDomain?.domain_name }
 						</DomainPickerButton>
 					) }
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -4,7 +4,7 @@
 import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Icon, IconButton } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { useDebounce } from 'use-debounce';
 
 /**
@@ -13,7 +13,6 @@ import { useDebounce } from 'use-debounce';
 import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import './style.scss';
-import { DomainName } from '../../stores/domain-suggestions/types';
 import { DomainPickerButton } from '../domain-picker';
 import { isFilledFormValue } from '../../stores/onboard/types';
 import { selectorDebounce } from '../../constants';
@@ -35,8 +34,6 @@ const Header: FunctionComponent< Props > = ( {
 	toggleGeneralSidebar,
 	toggleSidebarShortcut,
 } ) => {
-	const [ domainText, setDomainText ] = useState< DomainName >( '' );
-
 	const { domain, siteTitle, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
@@ -67,10 +64,7 @@ const Header: FunctionComponent< Props > = ( {
 		[ domainSearch, siteVertical ]
 	);
 
-	// Update domainText only when we have a replacement.
-	useEffect( () => {
-		setDomainText( current => domain?.domain_name ?? freeDomainSuggestion?.domain_name ?? current );
-	}, [ domain, freeDomainSuggestion ] );
+	const domainText = domain?.domain_name ?? freeDomainSuggestion?.domain_name;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -90,7 +90,7 @@ const Header: FunctionComponent< Props > = ( {
 								isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
 							}
 						>
-							{ currentDomain?.domain_name }
+							{ currentDomain.domain_name }
 						</DomainPickerButton>
 					) }
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Icon, IconButton } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 
@@ -40,6 +40,7 @@ const Header: FunctionComponent< Props > = ( {
 	const { domain, siteTitle, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
+	const { setDomain } = useDispatch( ONBOARD_STORE );
 
 	const [ domainSearch ] = useDebounce(
 		// eslint-disable-next-line no-nested-ternary
@@ -68,7 +69,7 @@ const Header: FunctionComponent< Props > = ( {
 
 	// Update domainText only when we have a replacement.
 	useEffect( () => {
-		setDomainText( current => domain ?? freeDomainSuggestion?.domain_name ?? current );
+		setDomainText( current => domain?.domain_name ?? freeDomainSuggestion?.domain_name ?? current );
 	}, [ domain, freeDomainSuggestion ] );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -90,6 +91,7 @@ const Header: FunctionComponent< Props > = ( {
 					{ domainText && (
 						<DomainPickerButton
 							defaultQuery={ isFilledFormValue( siteTitle ) ? siteTitle : undefined }
+							onDomainSelect={ setDomain }
 							queryParameters={
 								isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
 							}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -2,9 +2,9 @@
  * Internal dependencies
  */
 import { ActionType, SiteVertical, Vertical } from './types';
-import { DomainName } from '../domain-suggestions/types';
+import { DomainSuggestion } from '../domain-suggestions/types';
 
-export const setDomain = ( domain: DomainName ) => ( {
+export const setDomain = ( domain: DomainSuggestion ) => ( {
 	type: ActionType.SET_DOMAIN as const,
 	domain,
 } );

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -8,10 +8,10 @@ import { combineReducers } from '@wordpress/data';
  * Internal dependencies
  */
 import { ActionType, FormValue, EMPTY_FORM_VALUE, Vertical, SiteVertical } from './types';
-import { DomainName } from '../domain-suggestions/types';
+import { DomainSuggestion } from '../domain-suggestions/types';
 import * as Actions from './actions';
 
-const domain: Reducer< DomainName | null, ReturnType< typeof Actions[ 'setDomain' ] > > = (
+const domain: Reducer< DomainSuggestion | null, ReturnType< typeof Actions[ 'setDomain' ] > > = (
 	state = null,
 	action
 ) => {


### PR DESCRIPTION
- Add `onDomainSelect` to `DomainPickerButton`
- Modify `domain` onboarding store state to store a DomainSuggestion
- Store selected domain when clicked.
- Display selected `domain` in header.

![domain-picker](https://user-images.githubusercontent.com/841763/69365055-cbf86180-0c93-11ea-8656-063d8ad8c96d.gif)


## Testing
- `/gutenboarding`
- Search for a domain and click on in the list. It should be visible in the header when selected.