### PR TITLE
Checkout: Enable returning customers to pre-upgrade-intended activity

### DIFF
--- a/client/state/selectors/get-checkout-upgrade-intent.js
+++ b/client/state/selectors/get-checkout-upgrade-intent.js
@@ -1,15 +1,9 @@
 /**
- * Internal dependencies
- */
-import { isEnabled } from 'config';
-
-/**
  * Retrieve the "intent" that the client implied prior to upgrading so we can send them to the appropriate route after checkout
  *
  * @param {object} state  Global state tree
  * @returns {string} The intent signaled by the customer for upgrade purposes
  */
 export default function getCheckoutUpgradeIntent( state ) {
-	// This is gated by a config flag while we wait for translations
-	return ( isEnabled( 'checkout-upgrade-intent' ) && state?.ui?.checkout?.upgradeIntent ) || '';
+	return state?.ui?.checkout?.upgradeIntent || '';
 }

--- a/config/development.json
+++ b/config/development.json
@@ -35,7 +35,6 @@
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
 		"checklist-homepage-template-select": true,
-		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,7 +22,6 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"checklist-homepage-template-select": true,
-		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/test.json
+++ b/config/test.json
@@ -31,7 +31,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
-		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -25,7 +25,6 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"checklist-homepage-template-select": true,
-		"checkout-upgrade-intent": true,
 		"code-splitting": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
#37641 added new strings & we don't want to show them untranslated, so it was gated behind a feature flag.

Since both strings are [now showing 16 translations](https://translate.wordpress.com/localci/status/automattic/wp-calypso/update/checkout-thank-you-cta), this change removes that gate & launches the feature!

#### Changes proposed in this Pull Request

* This reverts commit d2aa822949982d85b17d2adaf209908314219c9e.
  * Remove flag `checkout-upgrade-intent`
  * Remove consultation of the flag in the `getCheckoutUpgradeIntent` selector

#### Testing instructions

Follow test plan in #37641

Fixes https://github.com/Automattic/zelda-private/issues/252
