### PR TITLE
Reader: Accented characters and quotes render properly #37829

### DIFF
--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -11,7 +11,6 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
-import ExternalLink from 'components/external-link';
 import { recordPermalinkClick } from 'reader/stats';
 import TimeSince from 'components/time-since';
 import ReaderFullPostHeaderTags from './header-tags';
@@ -44,15 +43,14 @@ const ReaderFullPostHeader = ( { post, referralPost } ) => {
 			{ post.title ? (
 				<AutoDirection>
 					<h1 className="reader-full-post__header-title">
-						<ExternalLink
-							className="reader-full-post__header-title-link"
+						<a
+							className="external-link reader-full-post__header-title-link"
 							href={ externalHref }
 							target="_blank"
-							icon={ false }
 							onClick={ handlePermalinkClick }
-						>
-							{ post.title }
-						</ExternalLink>
+							rel="external noopener noreferrer"
+							dangerouslySetInnerHTML={ { __html: post.title } }
+						></a>
 					</h1>
 				</AutoDirection>
 			) : null }

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -30,7 +30,7 @@ const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpa
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
-							<Emojify>{ post.title }</Emojify>
+							<Emojify dangerouslySetInnerHTML={ { __html: post.title } }></Emojify>
 						</a>
 					</h1>
 				</AutoDirection>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
These are fixes to issue: #37829 
* Fixing reader's component to render post title using same 					**dangerouslySetInnerHTML** that is used to render post content.
#### Testing instructions
- Can someone check if there were no changes in regard to accessibility
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before:
![screenshot-wordpress com-2019 11 22-05_35_33](https://user-images.githubusercontent.com/41870839/69386895-00970800-0cea-11ea-9700-dcd23fcf744f.png)
![screenshot-wordpress com-2019 11 22-05_38_34](https://user-images.githubusercontent.com/41870839/69387003-61bedb80-0cea-11ea-876d-62b2b7ee5ca6.png)

After:
![screenshot-calypso localhost_3000-2019 11 22-05_34_14](https://user-images.githubusercontent.com/41870839/69386867-de9d8580-0ce9-11ea-8645-19353dd111fd.png)
![screenshot-calypso localhost_3000-2019 11 22-05_39_18](https://user-images.githubusercontent.com/41870839/69387031-7c915000-0cea-11ea-93a5-5879dc8f93d7.png)

Fixes #
In the full post reader component, instead of using ExternalLink component in ReaderFullPostHeader component we should use anchor html tag with all the same properties in order to use dangerouslySetHtml which allows us to render all accented characters and quotes properly.
It's working fine in case of Emojify component, since it doesn't have multiple children.