### PR TITLE
Fix back button from creating new pages/posts

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -27,6 +27,7 @@ import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { requestSelectedEditor, setSelectedEditor } from 'state/selected-editor/actions';
 import { getGutenbergEditorUrl } from 'state/selectors/get-gutenberg-editor-url';
 import { shouldLoadGutenberg } from 'state/selectors/should-load-gutenberg';
+import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -192,10 +193,10 @@ async function redirectIfBlockEditor( context, next ) {
 	// pass along parameters, for example press-this
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 	const url = addQueryArgs( context.query, gutenbergUrl );
-	if ( url.startsWith( '/block-editor' ) ) {
-		return page.redirect( url );
+	if ( shouldRedirectGutenberg( state, siteId ) ) {
+		return window.location.replace( url );
 	}
-	return window.location.replace( url );
+	return page.redirect( url );
 }
 
 export default {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -189,9 +189,13 @@ async function redirectIfBlockEditor( context, next ) {
 
 	const postType = determinePostType( context );
 	const postId = getPostID( context );
-	const url = getGutenbergEditorUrl( state, siteId, postId, postType );
 	// pass along parameters, for example press-this
-	return window.location.replace( addQueryArgs( context.query, url ) );
+	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
+	const url = addQueryArgs( context.query, gutenbergUrl );
+	if ( url.startsWith( '/block-editor' ) ) {
+		return page.redirect( url );
+	}
+	return window.location.replace( url );
 }
 
 export default {

--- a/client/state/selectors/get-last-non-editor-route.js
+++ b/client/state/selectors/get-last-non-editor-route.js
@@ -14,14 +14,23 @@ import createSelector from 'lib/create-selector';
  * Get the last non-editor route while ignoring navigation in block editor.
  *
  * @param {object} state  Global state tree
- * @returns {string} The last non block editor route -- empty string if none.
+ * @returns {string} The last non editor route -- empty string if none.
  */
 const getLastNonEditorRoute = createSelector(
 	state => {
 		const previousPath = getPreviousPath( state );
-		const blockEditorPattern = /^\/block-editor/;
+		// Include paths which start in the classic editor because it is common
+		// to redirect from the classic editor to the
 
-		if ( previousPath && ! blockEditorPattern.test( previousPath ) ) {
+		/**
+		 * Include paths which start in the classic editor because it is common
+		 * to redirect from classic to block editor. For example, to create a new
+		 * page, you go to `/page`, which then redirects to `/block-editor/page`.
+		 * Matching page or post handles that case.
+		 */
+		const editorPattern = /^\/(block-editor|page|post)/;
+
+		if ( previousPath && ! editorPattern.test( previousPath ) ) {
 			return previousPath;
 		}
 
@@ -30,7 +39,7 @@ const getLastNonEditorRoute = createSelector(
 			last(
 				dropRightWhile(
 					getRouteHistory( state ),
-					( { path } ) => path && blockEditorPattern.test( path )
+					( { path } ) => path && editorPattern.test( path )
 				)
 			),
 			'path',

--- a/client/state/selectors/get-last-non-editor-route.js
+++ b/client/state/selectors/get-last-non-editor-route.js
@@ -19,8 +19,6 @@ import createSelector from 'lib/create-selector';
 const getLastNonEditorRoute = createSelector(
 	state => {
 		const previousPath = getPreviousPath( state );
-		// Include paths which start in the classic editor because it is common
-		// to redirect from the classic editor to the
 
 		/**
 		 * Include paths which start in the classic editor because it is common


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* If we are trying to access a route like `page`, but need to redirect to `block-editor`, use `page` to handle the redirect so we don't loose the entire Calypso context in the process.
* Add `page` and `posts` as routes to match for the last non-editor route.

#### Testing instructions
0. Run calypso.localhost with this branch.
1. On a site which has customer home, make sure you have completed the entire checklist.
2. Click "Add a page" from customer home.
<img width="1900" alt="Screen Shot 2019-11-21 at 5 33 21 PM" src="https://user-images.githubusercontent.com/6265975/69390712-0b6b8180-0c85-11ea-805f-e265e96ba119.png">

3. It should take you to the block editor. After choosing a page layout, click the back button. It should take you to customer home. **Note: the label will be incorrect, but that will be fixed at the next FSE plugin release**
4. Test the create page flow again, this time clicking the back button from the SPT selector. Make sure it still goes to home before choosing a layout.
4. Also test this for "Write a blog post". It should take you to the block editor, and the back button should go to customer home.

A side effect of this should be slightly better performance as we don't have to reload all of calypso now.

Fixes #37841
