### PR TITLE
chore(formatting): Remove @format pragma from codebase (2)

### DIFF
--- a/client/state/selectors/is-site-on-atomic-plan.js
+++ b/client/state/selectors/is-site-on-atomic-plan.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * Internal dependencies
  */
@@ -9,9 +8,9 @@ import { isEcommercePlan, isBusinessPlan } from 'lib/plans';
  * Returns true if site is on a paid plan that is eligible to be an Atomic site,
  * false if not, or if the site or plan is unknown.
  *
- * @param {Object} state Global state tree
- * @param {Number} siteId Site ID
- * @return {Boolean} Whether site is on an atomic paid plan
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} Whether site is on an atomic paid plan
  */
 const isSiteOnAtomicPlan = ( state, siteId ) => {
 	const currentPlan = getCurrentPlan( state, siteId );

--- a/packages/calypso-codemods/tests/merge-lodash-imports/__snapshots__/codemod.spec.js.snap
+++ b/packages/calypso-codemods/tests/merge-lodash-imports/__snapshots__/codemod.spec.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic.js 1`] = `
-"/* @format */
-import { map, pick, zip } from \\"lodash\\";
+"import { map, pick, zip } from \\"lodash\\";
 
 "
 `;

--- a/packages/calypso-codemods/tests/merge-lodash-imports/basic.js
+++ b/packages/calypso-codemods/tests/merge-lodash-imports/basic.js
@@ -1,4 +1,3 @@
-/* @format */
 import { zip } from 'lodash';
 import { map } from 'lodash';
 import { pick } from 'lodash';

--- a/packages/calypso-codemods/transforms/merge-lodash-imports.js
+++ b/packages/calypso-codemods/transforms/merge-lodash-imports.js
@@ -10,8 +10,6 @@
  * // output
  * import { map, pick, zip } from 'lodash'
  *
- * @format
- *
  * @param file
  * @param api
  * @returns {string}

--- a/packages/calypso-codemods/transforms/modular-lodash-no-more.js
+++ b/packages/calypso-codemods/transforms/modular-lodash-no-more.js
@@ -12,8 +12,6 @@
  * // output
  * import { map as _map } from 'lodash'
  *
- * @format
- *
  * @param file
  * @param api
  * @returns {string}

--- a/packages/calypso-codemods/transforms/modular-lodash-requires-no-more.js
+++ b/packages/calypso-codemods/transforms/modular-lodash-requires-no-more.js
@@ -1,7 +1,3 @@
-/**
- * @format
- */
-
 let j;
 
 const getImports = source => {

--- a/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
+++ b/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
@@ -1,5 +1,3 @@
-/** @format */
-
 module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/37591 where most of these were removed.

#### Changes proposed in this Pull Request
* Remove the last remaining @format pragmas from the codebase
* A couple of jsdoc fixes

#### Testing instructions

* e2es should cover this

