### PR TITLE
Domain step test: define dependency for the ecommerce flow

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -226,7 +226,14 @@ export function generateSteps( {
 		domains: {
 			stepName: 'domains',
 			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+				'shouldHideFreePlan',
+			],
+			optionalDependencies: [ 'shouldHideFreePlan' ],
 			props: {
 				isDomainOnly: false,
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -245,6 +245,7 @@ export function generateSteps( {
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ],
 			props: {
 				isDomainOnly: true,
+				shouldShowDomainTestCopy: false,
 			},
 		},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR builds on top of the domain-copy A/B test introduced as a feature flag in #37546. Check the What next? section in that PR on how to review this and other PRs as part of this A/B test.

* This is a bug fix for the ecommerce flow. The bug is that if in the variant group of the `domainStepCopyUpdates` test, then the following sequence:

selecting Online Store in site type step --> click "Review our plans to get started »" in domain step

gives an error that shouldHideFreePlan dependency is unspecified.

* In https://github.com/Automattic/wp-calypso/pull/37554, we introduced a new signup dependency for the domain step. The fix for this error is to define that dependency for the domain step that is used in the ecommerce-onboarding flow.

* This PR also excludes the domain only flow from the test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and put yourself in the variant variantShowUpdates of the `domainStepCopyUpdates` A/B test
* Select "Online store" as site type.
* In the domain step search results page, click "Review our plans to get started »". You should be able to see the plans page.
* Verify you can then successfully complete signup.

**Test the Domain only flow**

* Go to /start/domain and put yourself in the variant variantShowUpdates of the `domainStepCopyUpdates` A/B test
* The domain step _should not_ show the new copy and UI, and instead retain its original look
* Complete the flow.


**Verify that the A/B test is not automatically assigned**

* Go to /start and without manually assigning yourself to an A/B test, just complete the signup flow.
* In your Browser console, type localstorage.ABTests;. Verify that the domainStepCopyUpdates test is not present in the object. This is because we do not yet want any user getting assigned to the test till all the pieces are deployed.