### PR TITLE
Writing Settings: disable Mobile Theme UI when feature isn't active

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -61,7 +61,7 @@ class SiteSettingsFormWriting extends Component {
 			<form
 				id="site-settings"
 				onSubmit={ handleSubmitForm }
-				className="site-settings__general-settings"
+				className="site-settings__writing-settings"
 			>
 				{ config.isEnabled( 'manage/site-settings/categories' ) && (
 					<div className="site-settings__taxonomies">

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -524,3 +524,16 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	opacity: 0.33;
 	pointer-events: none;
 }
+
+.site-settings__writing-settings {
+	.theme-enhancements__card {
+		.form-fieldset.minileven {
+			&.inactive {
+				p, .form-toggle__label, .support-info {
+					opacity: 0.3;
+					transition: all 0.75s;
+				}
+			}
+		}
+	}
+}

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -289,10 +289,8 @@ class ThemeEnhancements extends Component {
 						<Fragment>
 							{ this.renderJetpackInfiniteScrollSettings() }
 							<hr />
-							<Fragment>
-								{ this.renderMinilevenSettings() }
-								<hr />
-							</Fragment>
+							{ this.renderMinilevenSettings() }
+							<hr />
 							{ this.renderCustomCSSSettings() }
 						</Fragment>
 					) : (

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -228,54 +228,50 @@ class ThemeEnhancements extends Component {
 				>
 					<NoticeAction href={ minilevenSupportUrl }>{ translate( 'Learn more' ) }</NoticeAction>
 				</Notice>
-				{ minilevenModuleActive && (
-					<Fragment>
-						<SupportInfo
-							text={ translate(
-								'Enables a lightweight, mobile-friendly theme ' +
-									'that will be displayed to visitors on mobile devices.'
-							) }
-							link={ minilevenSupportUrl }
-						/>
-						<p>
-							{ translate(
-								'Give your site a fast-loading, streamlined look for mobile devices. Visitors will ' +
-									'still see your regular theme on other screen sizes.'
-							) }
-						</p>
-						<JetpackModuleToggle
-							siteId={ selectedSiteId }
-							moduleSlug="minileven"
-							label={ translate( 'Enable the Jetpack Mobile theme' ) }
-							disabled={ formPending || ! minilevenModuleActive }
-						/>
+				<SupportInfo
+					text={ translate(
+						'Enables a lightweight, mobile-friendly theme ' +
+							'that will be displayed to visitors on mobile devices.'
+					) }
+					link={ minilevenSupportUrl }
+				/>
+				<p>
+					{ translate(
+						'Give your site a fast-loading, streamlined look for mobile devices. Visitors will ' +
+							'still see your regular theme on other screen sizes.'
+					) }
+				</p>
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="minileven"
+					label={ translate( 'Enable the Jetpack Mobile theme' ) }
+					disabled={ formPending || ! minilevenModuleActive }
+				/>
 
-						<div className="theme-enhancements__module-settings site-settings__child-settings">
-							{ this.renderToggle(
-								'wp_mobile_excerpt',
-								! minilevenModuleActive,
-								translate( 'Use excerpts instead of full posts on front page and archive pages' )
-							) }
-							{ this.renderToggle(
-								'wp_mobile_featured_images',
-								! minilevenModuleActive,
-								translate( 'Show featured images' )
-							) }
-							{ this.renderToggle(
-								'wp_mobile_app_promos',
-								! minilevenModuleActive,
-								translate(
-									'Show an ad for the {{link}}WordPress mobile apps{{/link}} in the footer of the mobile theme',
-									{
-										components: {
-											link: <a href="https://apps.wordpress.com/" />,
-										},
-									}
-								)
-							) }
-						</div>
-					</Fragment>
-				) }
+				<div className="theme-enhancements__module-settings site-settings__child-settings">
+					{ this.renderToggle(
+						'wp_mobile_excerpt',
+						! minilevenModuleActive,
+						translate( 'Use excerpts instead of full posts on front page and archive pages' )
+					) }
+					{ this.renderToggle(
+						'wp_mobile_featured_images',
+						! minilevenModuleActive,
+						translate( 'Show featured images' )
+					) }
+					{ this.renderToggle(
+						'wp_mobile_app_promos',
+						! minilevenModuleActive,
+						translate(
+							'Show an ad for the {{link}}WordPress mobile apps{{/link}} in the footer of the mobile theme',
+							{
+								components: {
+									link: <a href="https://apps.wordpress.com/" />,
+								},
+							}
+						)
+					) }
+				</div>
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -224,7 +224,7 @@ class ThemeEnhancements extends Component {
 	}
 
 	render() {
-		const { siteIsJetpack, translate } = this.props;
+		const { minilevenModuleActive, siteIsJetpack, translate } = this.props;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -236,8 +236,12 @@ class ThemeEnhancements extends Component {
 						<Fragment>
 							{ this.renderJetpackInfiniteScrollSettings() }
 							<hr />
-							{ this.renderMinilevenSettings() }
-							<hr />
+							{ minilevenModuleActive && (
+								<Fragment>
+									{ this.renderMinilevenSettings() }
+									<hr />
+								</Fragment>
+							) }
 							{ this.renderCustomCSSSettings() }
 						</Fragment>
 					) : (


### PR DESCRIPTION
Fixes #36404

Matching Jetpack PR: 
https://github.com/Automattic/jetpack/pull/14101

* Internal references:
    - p1HpG7-84F-p2
    - p6TEKc-3iM-p2
    - p6TEKc-3jj-p2
    - p6TEKc-3l7-p2

#### Changes proposed in this Pull Request

The Mobile theme was developed 8 years ago, back when responsive themes weren't a thing. It isn't as useful today, and can even be harmful when one enables it on their site without realizing the consequences, as outlined in https://github.com/Automattic/jetpack/issues/7602.

*****

This PR comes as a first step to deprecate the Mobile Theme feature. We'll start by greying out Mobile Theme Settings from the Writing Settings UI when the feature is not active. Folks that still use the feature can access its settings and disable it. Folks who do not use it cannot turn it on via the UI.

In addition to those changes, we'll display a notice on top of the settings:
- If the Mobile Theme feature is active on your site and if you run Jetpack 8.1 Alpha or newer, we'll show you a notice inviting you to check the look of the site on mobile devices if you did not run the Mobile Theme feature on your site. We can do so via a Google Tool.
- If you run an older version of the Jetpack plugin, or if the Mobile Theme feature is already off on your site, you'll see a generic notice announcing the deprecation.

******

**Module active**

![image](https://user-images.githubusercontent.com/426388/71020599-edb30000-20fc-11ea-90bf-1599508ae642.png)

**Module inactive**

<img width="827" alt="screenshot 2019-12-17 at 18 39 37" src="https://user-images.githubusercontent.com/426388/71020453-a88ece00-20fc-11ea-8eaf-c5e7b11de7a4.png">


#### Testing instructions

* Start from a site running Jetpack 8.1 Alpha.
* Run `yarn docker:wp jetpack module activate minileven` to enable the module on your Jetpack site.
* Go to Manage > Settings > Writing.
* Notice that the Mobile Theme settings are there.
* Notice the notice.
* Click the 2 links to check the support docs as well as the Google checking tool.
* Disable the feature.
* The settings should become grey.