### PR TITLE
Gutenboarding: Close domain picker when unfocused

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -42,7 +42,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
-				<Popover onFocusOutside={ () => setDomainPopoverVisibility( false ) }>
+				<Popover onClose={ () => setDomainPopoverVisibility( false ) }>
 					<DomainPicker { ...domainPickerProps } onDomainSelect={ handleDomainSelect } />
 				</Popover>
 			) }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -42,7 +42,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
-				<Popover>
+				<Popover onFocusOutside={ () => setDomainPopoverVisibility( false ) }>
 					<DomainPicker { ...domainPickerProps } onDomainSelect={ handleDomainSelect } />
 				</Popover>
 			) }

--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { ComponentPropsWithoutRef, FunctionComponent, useState } from 'react';
+import React, { ComponentPropsWithoutRef, createRef, FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
 import classnames from 'classnames';
 
@@ -22,7 +22,17 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	onDomainSelect,
 	...domainPickerProps
 } ) => {
+	const buttonRef = createRef();
+
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
+
+	const handleClose = ( e?: FocusEvent ) => {
+		// Don't collide with button toggling
+		if ( e?.relatedTarget === buttonRef.current ) {
+			return;
+		}
+		setDomainPopoverVisibility( false );
+	};
 
 	const handleDomainSelect: typeof onDomainSelect = selectedDomain => {
 		setDomainPopoverVisibility( false );
@@ -37,12 +47,13 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				aria-pressed={ isDomainPopoverVisible }
 				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
+				ref={ buttonRef }
 			>
 				{ children }
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
-				<Popover onClose={ () => setDomainPopoverVisibility( false ) }>
+				<Popover onClose={ handleClose } onFocusOutside={ handleClose }>
 					<DomainPicker { ...domainPickerProps } onDomainSelect={ handleDomainSelect } />
 				</Popover>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Close the domain picker when it loses focus.

Part of #37856

Todo:
- [x] ~Clicking on the toggle button to close re-opens the popover 🤦‍♂~ props @razvanpapadopol for the tip ✨ 

#### Testing instructions

* `/gutenboarding`
* Enter site title
* Click the DomainPicker to open
* Click outside - it should close
* 🐛 Click the toggle button to open and close - it should close and stay closed

