### PR TITLE
[e2e] Re-enable Sign up test for purchasing .live domain

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -969,7 +969,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe.skip( 'Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow in CAD currency @signup', function() {
+	describe( 'Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow in CAD currency @signup', function() {
 		const siteName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ siteName }.live`;
 		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enable test `Sign up for a site on a business paid plan w/ domain name coming in via /create as business flow in CAD currency`. 

This test was temporarily disabled in https://github.com/Automattic/wp-calypso/pull/37592 because there was an issue with OpenSRS environment (more details here _p2MSmN-7z3-p2_). Now when it's solved test is working again and I'm going to enable it. 


#### Testing instructions

Make sure that the test is passing.
