### PR TITLE
Gutenboarding: Use text cursor for madlibs

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/question/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/question/style.scss
@@ -48,7 +48,7 @@
 	.onboarding-block__question-answered {
 		color: $blue-medium-900;
 		border-bottom: 3px solid transparent;
-		cursor: pointer;
+		cursor: text;
 		margin: 0 0 0 0.2em;
 		transition-property: border-color;
 		transition-duration: 0.3s;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Questions are really text inputs, use the text cursor

##### Screens

###### Before
![before](https://user-images.githubusercontent.com/841763/69423852-84bbb080-0d27-11ea-9324-c8b9634ad5c8.gif)

###### After
![after](https://user-images.githubusercontent.com/841763/69423856-86857400-0d27-11ea-9ffd-68ce69f254b4.gif)

#### Testing instructions

* Test questions as `/gutenboarding`
