### PR TITLE
Fix: Redirect after Business plan purchase fails on the ecommerce flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -206,14 +206,14 @@ export function generateFlows( {
 		// please copy the same changes to ecommerce-onboarding flow too
 		flows.ecommerce = {
 			steps: [ 'user', 'about', 'domains', 'plans' ],
-			destination: getSiteDestination,
+			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2018-01-24',
 		};
 
 		flows[ 'ecommerce-onboarding' ] = {
 			steps: [ 'user', 'site-type', 'domains', 'plans-ecommerce' ],
-			destination: getSiteDestination,
+			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2018-11-21',
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check p1574424650365900-slack-CCS1W9QVA.
* Fixes failed redirect after Business plan purchase on the eCommerce flow
* The issue was that after Business plan purchase via the ecommerce-onboarding flow, the following error shows on console and the page is stuck on the checkout page:

<img width="1643" alt="Screenshot 2019-11-22 at 5 33 36 PM" src="https://user-images.githubusercontent.com/1269602/69426662-bcd8e880-0d53-11ea-8112-48cdd876029d.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Begin at /start
* Select "Online Store" as site type
* Verify you can complete purchase of a Business plan and that you are taken to checklist.