### PR TITLE
Full Site Editing: Fix editor frame after a Gutenberg update

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -22,10 +22,14 @@
 
 .post-type-page, .post-type-wp_template_part {
 	@media ( min-width: 768px ) {
+		// @TODO: remove .edit-post-layout__content when Gutenberg 7.0.0 lands in production
+		.edit-post-layout__content,
 		.edit-post-editor-regions__content {
 			background: #eee;
 		}
 
+		// @TODO: remove .edit-post-layout__content when Gutenberg 7.0.0 lands in production
+		.edit-post-layout__content .edit-post-visual-editor,
 		.edit-post-editor-regions__content .edit-post-visual-editor {
 			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 			flex: none;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -22,11 +22,11 @@
 
 .post-type-page, .post-type-wp_template_part {
 	@media ( min-width: 768px ) {
-		.edit-post-layout__content {
+		.edit-post-editor-regions__content {
 			background: #eee;
 		}
 
-		.edit-post-layout__content .edit-post-visual-editor {
+		.edit-post-editor-regions__content .edit-post-visual-editor {
 			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 			flex: none;
 			margin: 36px 32px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update a block editor editor CSS class name that was changed in a recent Gutenberg update.

Note: this must be deployed **AFTER** Gutenberg 7.0.0 lands on WPCOM (see p7DVsv-7Ks-p2).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This must be tested on a FSE site with an updated Gutenberg, or on Horizon.
* Open the page editor and make sure the FSE frame is visible.
* Add blocks with different widths (regular, wide, full), and check if they adapt to the frame width instead of the full editor width.
* Repeat the previous tests in the template part editor.

Fixes #37837
