### PR TITLE
Fix: Redirect after plan purchase fails in the launch flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -208,14 +208,14 @@ export function generateFlows( {
 			steps: [ 'user', 'about', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
-			lastModified: '2018-01-24',
+			lastModified: '2019-11-22',
 		};
 
 		flows[ 'ecommerce-onboarding' ] = {
 			steps: [ 'user', 'site-type', 'domains', 'plans-ecommerce' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
-			lastModified: '2018-11-21',
+			lastModified: '2019-11-22',
 		};
 	}
 
@@ -257,7 +257,7 @@ export function generateFlows( {
 		destination: getSignupDestination,
 		description: 'A flow to launch a private site.',
 		providesDependenciesInQuery: [ 'siteSlug' ],
-		lastModified: '2019-01-16',
+		lastModified: '2019-11-22',
 		pageTitle: translate( 'Launch your site' ),
 	};
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -254,7 +254,7 @@ export function generateFlows( {
 
 	flows[ 'launch-site' ] = {
 		steps: [ 'domains-launch', 'plans-launch', 'launch' ],
-		destination: getSiteDestination,
+		destination: getSignupDestination,
 		description: 'A flow to launch a private site.',
 		providesDependenciesInQuery: [ 'siteSlug' ],
 		lastModified: '2019-01-16',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a follow up to https://github.com/Automattic/wp-calypso/pull/37862. Read that PR for further details on the issue and the slack convo linked there.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through launch flow
* Purchase a plan
* Verify that you are taken to checklist
