### PR TITLE
Gutenboarding: Increase domain picker size

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/button.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/button.tsx
@@ -1,26 +1,31 @@
 /**
  * External dependencies
  */
-import React, { ComponentPropsWithoutRef, createRef, FunctionComponent, useState } from 'react';
+import React, { createRef, FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import DomainPicker from './list';
+import DomainPicker, { Props as DomainPickerProps } from './list';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-type Props = ComponentPropsWithoutRef< typeof DomainPicker >;
+interface Props extends DomainPickerProps, Button.BaseProps {
+	className?: string;
+}
 
 const DomainPickerButton: FunctionComponent< Props > = ( {
 	children,
+	className,
 	onDomainSelect,
-	...domainPickerProps
+	defaultQuery,
+	queryParameters,
+	...buttonProps
 } ) => {
 	const buttonRef = createRef();
 
@@ -42,19 +47,26 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	return (
 		<>
 			<Button
+				{ ...buttonProps }
 				aria-expanded={ isDomainPopoverVisible }
 				aria-haspopup="menu"
 				aria-pressed={ isDomainPopoverVisible }
-				className={ classnames( 'domain-picker__button', { 'is-open': isDomainPopoverVisible } ) }
+				className={ classnames( 'domain-picker__button', className, {
+					'is-open': isDomainPopoverVisible,
+				} ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 				ref={ buttonRef }
 			>
-				{ children }
+				<span>{ children }</span>
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
 				<Popover onClose={ handleClose } onFocusOutside={ handleClose }>
-					<DomainPicker { ...domainPickerProps } onDomainSelect={ handleDomainSelect } />
+					<DomainPicker
+						defaultQuery={ defaultQuery }
+						onDomainSelect={ handleDomainSelect }
+						queryParameters={ queryParameters }
+					/>
 				</Popover>
 			) }
 		</>

--- a/client/landing/gutenboarding/components/domain-picker/list.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/list.tsx
@@ -21,7 +21,7 @@ import { DomainSuggestion, DomainSuggestionQuery } from '../../stores/domain-sug
 import { STORE_KEY } from '../../stores/domain-suggestions';
 import { selectorDebounce } from '../../constants';
 
-interface Props {
+export interface Props {
 	/**
 	 * Term to search when no user input is provided.
 	 */

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -67,6 +67,12 @@ const Header: FunctionComponent< Props > = ( {
 	const currentDomain = domain ?? freeDomainSuggestion;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	const siteTitleElement = (
+		<span className="gutenboarding__site-title">
+			{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
+		</span>
+	);
+
 	return (
 		<div
 			className="gutenboarding__header"
@@ -88,15 +94,11 @@ const Header: FunctionComponent< Props > = ( {
 								isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
 							}
 						>
-							<span className="gutenboarding__site-title">
-								{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
-							</span>
+							{ siteTitleElement }
 							<span>{ currentDomain.domain_name }</span>
 						</DomainPickerButton>
 					) : (
-						<span className="gutenboarding__site-title">
-							{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
-						</span>
+						siteTitleElement
 					) }
 				</div>
 			</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -79,19 +79,24 @@ const Header: FunctionComponent< Props > = ( {
 					<Icon icon="wordpress-alt" color="#066188" />
 				</div>
 				<div className="gutenboarding__header-group">
-					<div className="gutenboarding__site-title">
-						{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
-					</div>
-					{ currentDomain && (
+					{ currentDomain ? (
 						<DomainPickerButton
+							className="gutenboarding__header-domain-picker-button"
 							defaultQuery={ isFilledFormValue( siteTitle ) ? siteTitle : undefined }
 							onDomainSelect={ setDomain }
 							queryParameters={
 								isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
 							}
 						>
-							{ currentDomain.domain_name }
+							<span className="gutenboarding__site-title">
+								{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
+							</span>
+							<span>{ currentDomain.domain_name }</span>
 						</DomainPickerButton>
+					) : (
+						<span className="gutenboarding__site-title">
+							{ siteTitle ? siteTitle : NO__( 'Create your site' ) }
+						</span>
 					) }
 				</div>
 			</div>

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -36,6 +36,17 @@
 	align-items: flex-start;
 }
 
+.gutenboarding__header-domain-picker-button {
+	> span {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+	> .dashicon {
+		align-self: flex-end;
+	}
+}
+
 .gutenboarding__site-title {
 	font-weight: bold;
 }

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -36,7 +36,21 @@
 	align-items: flex-start;
 }
 
+$padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;
 .gutenboarding__header-domain-picker-button {
+	padding: $padding--gutenboarding__header-domain-picker-button;
+	border-radius: $radius-round-rectangle;
+
+	&:focus,
+	&:hover {
+		box-shadow: 0 0 0 2px $blue-medium-focus;
+		outline: 0;
+	}
+
+	.gutenboarding__site-title {
+		padding: 0;
+	}
+
 	> span {
 		display: flex;
 		flex-direction: column;
@@ -48,6 +62,7 @@
 }
 
 .gutenboarding__site-title {
+	padding: $padding--gutenboarding__header-domain-picker-button;
 	font-weight: bold;
 }
 


### PR DESCRIPTION
Restructure the domain picker button and header to include more and increase the picker size.

Closes #37851

## Screens
### Before
![before](https://user-images.githubusercontent.com/841763/69531599-6eeefb00-0f74-11ea-85ee-6fc3aaecd4ac.gif)

### After
![after](https://user-images.githubusercontent.com/841763/69531610-70b8be80-0f74-11ea-8138-c8bde1015117.gif)

## Testing
Use the domain picker (via mouse and keyboard) at `/gutenboarding`
