### PR TITLE
G Suite: Fix empty page displayed when navigating back to Email page

### DIFF
--- a/client/components/data/query-gsuite-users/index.jsx
+++ b/client/components/data/query-gsuite-users/index.jsx
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import isRequestingGSuiteUsers from 'state/selectors/is-requesting-gsuite-users';
 import { getGSuiteUsers } from 'state/gsuite-users/actions';
+import isRequestingGSuiteUsers from 'state/selectors/is-requesting-gsuite-users';
 
 const QueryGSuiteUsers = ( { siteId, request, isRequesting } ) => {
 	useEffect( () => {
@@ -17,18 +17,19 @@ const QueryGSuiteUsers = ( { siteId, request, isRequesting } ) => {
 			request( siteId );
 		}
 	}, [ siteId, request, isRequesting ] );
+
 	return null;
 };
 
 QueryGSuiteUsers.propTypes = {
+	isRequesting: PropTypes.bool.isRequired,
 	siteId: PropTypes.number.isRequired,
 	request: PropTypes.func.isRequired,
-	isRequesting: PropTypes.bool.isRequired,
 };
 
 export default connect(
 	( state, ownProps ) => ( {
-		isRequesting: isRequestingGSuiteUsers( state, ownProps.siteid ),
+		isRequesting: isRequestingGSuiteUsers( state, ownProps.siteId ),
 	} ),
 	{ request: getGSuiteUsers }
 )( QueryGSuiteUsers );

--- a/client/state/selectors/get-gsuite-users.js
+++ b/client/state/selectors/get-gsuite-users.js
@@ -4,12 +4,12 @@
 import { get } from 'lodash';
 
 /**
- * Retrieve a list of G Suite users for a site
+ * Retrieves the list of G Suite users for the specified site.
  *
- * @param  {Object} state    Global state tree
- * @param  {String} siteId siteId to request G Suite users for
- * @return {Object}        G Suite Users
+ * @param {object} state - global state tree
+ * @param {number} siteId - identifier of the site
+ * @returns {?Array} the list of G Suite users, null otherwise
  */
 export default function getGSuiteUsers( state, siteId ) {
-	return get( state.gsuiteUsers, [ siteId, 'users' ], null );
+	return get( state, [ 'gsuiteUsers', siteId, 'users' ], null );
 }

--- a/client/state/selectors/has-loaded-gsuite-users.js
+++ b/client/state/selectors/has-loaded-gsuite-users.js
@@ -1,15 +1,15 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { get } from 'lodash';
+import getGSuiteUsers from 'state/selectors/get-gsuite-users';
 
 /**
  * Determines whether the list of G Suite users for the specified site has loaded.
  *
  * @param {object} state - global state tree
  * @param {number} siteId - identifier of the site
- * @returns {boolean} true if the list of G Suite users has loaded, false otherwise
+ * @returns {?boolean} true if the list of G Suite users has loaded, false otherwise
  */
 export default function hasLoadedGSuiteUsers( state, siteId ) {
-	return get( state, [ 'gsuiteUsers', siteId, 'users' ], null ) !== null;
+	return getGSuiteUsers( state, siteId ) !== null;
 }

--- a/client/state/selectors/is-requesting-gsuite-users.js
+++ b/client/state/selectors/is-requesting-gsuite-users.js
@@ -4,11 +4,12 @@
 import { get } from 'lodash';
 
 /**
+ * Determines whether the list of G Suite users is being requested.
  *
- * @param  {Object} state  Global state tree
- * @param  {String} siteId the siteId to get domains for
- * @return {Boolean} If the request is in progress
+ * @param {object} state - global state tree
+ * @param {number} siteId - identifier of the site
+ * @returns {?boolean} true if the list of G Suite users is being requested, false otherwise
  */
 export default function isRequestingGSuiteUsers( state, siteId ) {
-	return get( state.gsuiteUsers, [ siteId, 'requesting' ], false );
+	return get( state, [ 'gsuiteUsers', siteId, 'requesting' ], false );
 }


### PR DESCRIPTION
This pull request seeks to fix a race condition with the `Email` page:

![screenshot](https://user-images.githubusercontent.com/594356/69436732-3e277f80-0d42-11ea-9476-8844f3621fe7.png)

It indeed seems that navigating between the `Email` page and the `Domain Settings` page sometimes results in displaying what we call an empty page:

![screenshot](https://user-images.githubusercontent.com/594356/69437049-d1f94b80-0d42-11ea-91ec-e223089df469.png)

This pull requests fixes an invalid property used, and refine some selectors.

#### Testing instructions

1. Run `git checkout fix/gsuite-empty-page` and start your server, or open a [live branch](https://calypso.live/?branch=fix/gsuite-empty-page)
2. Log in to an account that has a site with a domain but without G Suite
3. Open the [`Domains` page](http://calypso.localhost:3000/domains)
4. Click the domain to access the corresponding `Domain Settings` page
5. Click the `Email` option to access the `Email` page for that domain
6. Assert that you are presented with the option to purchase G Suite
7. Navigate back-and-forth several times between the `Domain Settings` page and the `Email` page
8. Assert that you are always presented with the option to purchase G Suite

#### Additional notes

There is a small chance that this issue is a consequence of https://github.com/Automattic/wp-calypso/pull/37724 or https://github.com/Automattic/wp-calypso/pull/37073. I could be totally wrong, but I thought I should mention it.