### PR TITLE
Custom hold component for unlaunched sites: SiteLaunchGate

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -33,6 +33,7 @@ import WarningList from './warning-list';
  * Style dependencies
  */
 import './style.scss';
+import SiteLaunchGate from 'blocks/site-launch-gate';
 
 export const EligibilityWarnings = ( {
 	backUrl,
@@ -116,57 +117,58 @@ export const EligibilityWarnings = ( {
 					title={ translate( 'Custom domain required' ) }
 				/>
 			) }
+			<SiteLaunchGate className="eligibility-warnings__site-launch-gate">
+				{ ( isPlaceholder || listHolds.length > 0 ) && (
+					<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } siteSlug={ siteSlug } />
+				) }
+				{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
-			{ ( isPlaceholder || listHolds.length > 0 ) && (
-				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } siteSlug={ siteSlug } />
-			) }
-			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
+				{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
+					<Card className="eligibility-warnings__no-conflicts">
+						<Gridicon icon="thumbs-up" size={ 24 } />
+						<span>
+							{ translate( 'This site is eligible to install plugins and upload themes.' ) }
+						</span>
+					</Card>
+				) }
 
-			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
-				<Card className="eligibility-warnings__no-conflicts">
-					<Gridicon icon="thumbs-up" size={ 24 } />
-					<span>
-						{ translate( 'This site is eligible to install plugins and upload themes.' ) }
-					</span>
+				<Card className="eligibility-warnings__confirm-box">
+					<div className="eligibility-warnings__confirm-text">
+						{ ! isEligible && (
+							<>
+								{ translate( 'Please clear all issues above to proceed.' ) }
+								&nbsp;
+							</>
+						) }
+						{ isEligible && warnings.length > 0 && (
+							<>
+								{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
+								&nbsp;
+							</>
+						) }
+						{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
+							components: {
+								a: (
+									<a
+										href="https://wordpress.com/help/contact"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</div>
+					<div className="eligibility-warnings__confirm-buttons">
+						<Button href={ backUrl } onClick={ onCancel }>
+							{ translate( 'Cancel' ) }
+						</Button>
+
+						<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
+							{ translate( 'Proceed' ) }
+						</Button>
+					</div>
 				</Card>
-			) }
-
-			<Card className="eligibility-warnings__confirm-box">
-				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && (
-						<>
-							{ translate( 'Please clear all issues above to proceed.' ) }
-							&nbsp;
-						</>
-					) }
-					{ isEligible && warnings.length > 0 && (
-						<>
-							{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
-							&nbsp;
-						</>
-					) }
-					{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
-						components: {
-							a: (
-								<a
-									href="https://wordpress.com/help/contact"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</div>
-				<div className="eligibility-warnings__confirm-buttons">
-					<Button href={ backUrl } onClick={ onCancel }>
-						{ translate( 'Cancel' ) }
-					</Button>
-
-					<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
-						{ translate( 'Proceed' ) }
-					</Button>
-				</div>
-			</Card>
+			</SiteLaunchGate>
 		</div>
 	);
 };

--- a/client/blocks/site-launch-gate/index.tsx
+++ b/client/blocks/site-launch-gate/index.tsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent, SyntheticEvent } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { translate } from 'i18n-calypso';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { localizeUrl } from 'lib/i18n-utils';
+import getSectionName from 'state/ui/selectors/get-section-name';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
+import Card from 'components/card';
+import Button from 'components/button';
+import InlineSupportLink from 'components/inline-support-link';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	className?: string;
+}
+
+const SiteLaunchGate: FunctionComponent< Props > = ( { children, className } ) => {
+	const dispatch = useDispatch();
+	const section = useSelector( getSectionName );
+	const siteId = useSelector( getSelectedSiteId );
+	const isUnlaunched = useSelector( state => isUnlaunchedSite( state, siteId ) );
+
+	if ( ! isUnlaunched ) {
+		return <>{ children }</>;
+	}
+
+	const toContinueText =
+		( section === 'themes' &&
+			translate( 'To continue installing the theme, you must launch your site.' ) ) ||
+		( section === 'plugins' &&
+			translate( 'To continue installing the plugin, you must launch your site.' ) ) ||
+		translate( 'To continue, you must launch your site.' );
+
+	return (
+		<Card className={ classNames( 'site-launch-gate', className ) }>
+			{ toContinueText }
+			<div className="site-launch-gate__actions">
+				<Button
+					primary
+					onClick={ ( e: SyntheticEvent ) => {
+						e.preventDefault();
+						dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId ) );
+					} }
+				>
+					{ translate( 'Launch site' ) }
+				</Button>
+				<InlineSupportLink
+					supportPostId={ 1507 }
+					supportLink={ localizeUrl(
+						'https://en.support.wordpress.com/settings/privacy-settings/'
+					) }
+				/>
+			</div>
+		</Card>
+	);
+};
+
+export default SiteLaunchGate;

--- a/client/blocks/site-launch-gate/style.scss
+++ b/client/blocks/site-launch-gate/style.scss
@@ -1,0 +1,9 @@
+.site-launch-gate .inline-support-link {
+	line-height: 40px;
+	margin-left: 10px;
+	vertical-align: middle;
+}
+
+.site-launch-gate__actions {
+	margin-top: 14px;
+}

--- a/client/state/selectors/is-unlaunched-site.js
+++ b/client/state/selectors/is-unlaunched-site.js
@@ -7,12 +7,12 @@ import getRawSite from 'state/selectors/get-raw-site';
 /**
  * Returns true if the site is unlaunched
  *
- * @param {Object} state Global state tree
- * @param {Object} siteId Site ID
- * @return {Boolean} True if site is unlaunched
+ * @param {object} state Global state tree
+ * @param {number | null} siteId Site ID
+ * @returns {boolean} True if site is unlaunched
  */
 export default function isUnlaunchedSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
 
-	return site && site.launch_status && site.launch_status === 'unlaunched';
+	return site?.launch_status === 'unlaunched';
 }

--- a/client/state/selectors/test/is-unlaunched-site.js
+++ b/client/state/selectors/test/is-unlaunched-site.js
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import isUnlaunchedSite from '../is-unlaunched-site';
+
+describe( 'isUnlaunchedSite()', () => {
+	test( 'should return false when there is no such site', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {},
+					},
+				},
+				222
+			)
+		).toBe( false );
+	} );
+
+	test( 'should return false when site has no launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {},
+						},
+					},
+				},
+				222
+			)
+		).toBe( false );
+	} );
+
+	test( 'should return false when site has non "launched" launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {
+								launch_status: 'launched',
+							},
+						},
+					},
+				},
+				222
+			)
+		).toBe( false );
+	} );
+
+	test( 'should return false when site has non gibberish launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {
+								launch_status: 'gibberish',
+							},
+						},
+					},
+				},
+				222
+			)
+		).toBe( false );
+	} );
+
+	test( 'should return true when site has "unlaunched" launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {
+								launch_status: 'unlaunched',
+							},
+						},
+					},
+				},
+				222
+			)
+		).toBe( true );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Gate the "Eligibility Warning" UI behind a new component, `SiteLaunchGate`
* When the site is unlaunched, `SiteLaunchGate`, prompts to `Launch site` & also includes an `InlineSupportLink` to show the Privacy Settings support document in an overlay
* When the site is already launched (more specifically, when the site is not unlaunched), the `SiteLaunchGate` component just renders its children (the existing "Eligibility Warning" UI)
* Enforce `isUnlaunchedSite`'s return to boolean & fix up JSDoc annotation
* Add tests for the `isUnlaunchedSite` selector

##### Before

![site-launch-gate-before](https://user-images.githubusercontent.com/1587282/69577379-36fbae00-0f9c-11ea-98ba-45fc7a6813af.gif)

##### After

![site-launch-gate-after](https://user-images.githubusercontent.com/1587282/69577418-4844ba80-0f9c-11ea-8c09-ef391915988a.gif)

#### Testing instructions

##### Test the selector change

* Run automated tests: `npm run test-client client/state/selectors/test/is-unlaunched-site.js`
* Search for usages of `isUnlaunchedSite` & make sure there are no dependencies on it returning a non-boolean value (`null`, `undefined`, etc.)
* Ensure the checklist and customer home continue to work as expected

##### Test the new UI

* Create or locate a test site with a Business plan
* Browse to `/plugins`
* Attempt to install a plugin
  * You should see the new UI & be able to launch your site

* Repeat the above & attempt to upload a plugin
* Repeat the above & attempt to install a theme from `/themes`
* Repeat the above & attempt to upload a theme

