### PR TITLE
Composit checkout: fix ie11 stepper issue

### DIFF
--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -183,7 +183,7 @@ const StepNumberInnerWrapper = styled.div`
 `;
 
 const StepNumber = styled.div`
-	background: ${getStepNumberBackgroundColor};
+	background: ${ getStepNumberBackgroundColor };
 	font-weight: normal;
 	width: 27px;
 	height: 27px;
@@ -191,22 +191,26 @@ const StepNumber = styled.div`
 	box-sizing: border-box;
 	text-align: center;
 	border-radius: 50%;
-	color: ${getStepNumberForegroundColor};
+	color: ${ getStepNumberForegroundColor };
 	position: absolute;
 	top: 0;
 	left: 0;
 	backface-visibility: hidden;
-	@media all and ( -ms-high-contrast: none ), ( -ms-high-contrast: active ) {
-		z-index: ${props => ( props.isComplete ? '0' : '1' )};
+	// Reason: needs to not have spaces
+	// prettier-ignore
+	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
+		z-index: ${ props => ( props.isComplete ? '0' : '1' ) };
 	}
 `;
 
 const StepNumberCompleted = styled( StepNumber )`
-	background: ${props => props.theme.colors.success};
+	background: ${ props => props.theme.colors.success };
 	transform: rotateY( 180deg );
-	@media all and ( -ms-high-contrast: none ), ( -ms-high-contrast: active ) {
+	// Reason: needs to not have spaces
+	// prettier-ignore
+	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
 		backface-visibility: visible;
-		z-index: ${props => ( props.isComplete ? '1' : '0' )};
+		z-index: ${ props => ( props.isComplete ? '1' : '0' ) };
 	}
 
 	svg {

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -196,11 +196,18 @@ const StepNumber = styled.div`
 	top: 0;
 	left: 0;
 	backface-visibility: hidden;
+	@media all and ( -ms-high-contrast: none ), ( -ms-high-contrast: active ) {
+		z-index: ${props => ( props.isComplete ? '0' : '1' )};
+	}
 `;
 
 const StepNumberCompleted = styled( StepNumber )`
 	background: ${props => props.theme.colors.success};
 	transform: rotateY( 180deg );
+	@media all and ( -ms-high-contrast: none ), ( -ms-high-contrast: active ) {
+		backface-visibility: visible;
+		z-index: ${props => ( props.isComplete ? '1' : '0' )};
+	}
 
 	svg {
 		margin-top: 4px;

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -196,7 +196,7 @@ const StepNumber = styled.div`
 	top: 0;
 	left: 0;
 	backface-visibility: hidden;
-	// Reason: needs to not have spaces
+	// Reason: The IE media query needs to not have spaces within brackets otherwise ie11 doesn't read them
 	// prettier-ignore
 	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
 		z-index: ${ props => ( props.isComplete ? '0' : '1' ) };
@@ -206,7 +206,7 @@ const StepNumber = styled.div`
 const StepNumberCompleted = styled( StepNumber )`
 	background: ${ props => props.theme.colors.success };
 	transform: rotateY( 180deg );
-	// Reason: needs to not have spaces
+	// Reason: media query needs to not have spaces within brackets otherwise ie11 doesn't read them
 	// prettier-ignore
 	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
 		backface-visibility: visible;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug in ie11 where the stepper numbers and checkmarks were misbehaving. The media queries ensure the code only runs on IE.

**Before**
![image](https://user-images.githubusercontent.com/6981253/69437315-11a73f80-0d11-11ea-911d-22f9016fea04.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/69437293-03f1ba00-0d11-11ea-8063-73d683ea7367.png)


#### Testing instructions
* Get checkout running locally with the following instructions:
* Complete steps and ensure the numbers and checkmarks are showing at the appropriate times — if you can do this on IE11 that's a bonus too :) 