### PR TITLE
Domain step test: Remove domain suggestions from store on skip

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -224,6 +224,31 @@ class DomainsStep extends React.Component {
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
+		const shouldHideFreePlanItem = this.showTestCopy ? { shouldHideFreePlan } : {};
+
+		if ( shouldHideFreePlan ) {
+			let domainItem, isPurchasingItem, siteUrl;
+
+			this.props.submitSignupStep(
+				Object.assign(
+					{
+						stepName: this.props.stepName,
+						domainItem,
+						googleAppsCartItem,
+						isPurchasingItem,
+						siteUrl,
+						stepSectionName: this.props.stepSectionName,
+					},
+					this.getThemeArgs()
+				),
+				Object.assign( { domainItem }, shouldHideFreePlanItem )
+			);
+
+			this.props.goToNextStep();
+
+			return;
+		}
+
 		const suggestion = this.props.step.suggestion;
 
 		const isPurchasingItem = suggestion && Boolean( suggestion.product_slug );
@@ -240,8 +265,6 @@ class DomainsStep extends React.Component {
 					productSlug: suggestion.product_slug,
 			  } )
 			: undefined;
-
-		const shouldHideFreePlanItem = this.showTestCopy ? { shouldHideFreePlan } : {};
 
 		suggestion && this.props.submitDomainStepSelection( suggestion, this.getAnalyticsSection() );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the `domainStepCopyUpdates` test, when in the variant group, the following bug exists:
    - Select a custom domain (you will then be taken to the plans page)
    - Hit the back navigation for the plan page and go back to the domain page
    - Now click the skip option i.e "Review our plans to get started"
    - Now select a paid plan and go to checkout page
    - You will notice the previously selected domain is still in cart.
* The bug is caused because the search suggestions are not cleared when the skip button is clicked. This PR fixes the issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Repeat the steps described above. Verify that the custom domain is not in cart In the checkout page.
* Run through the signup flow in both control group and variant group and verify that the signup completes without any issues.

