### PR TITLE
Remove Jetpack sites from the Free to Paid Upsells

### DIFF
--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -4,10 +4,10 @@
 
 import canCurrentUser from 'state/selectors/can-current-user';
 
+import { isJetpackSite } from 'state/sites/selectors';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
-
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site
  *
@@ -18,10 +18,17 @@ import isVipSite from 'state/selectors/is-vip-site';
 const isEligibleForFreeToPaidUpsell = ( state, siteId ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
+	const siteIsJetpack = isJetpackSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const siteIsVipSite = isVipSite( state, siteId );
 
-	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && ! siteIsVipSite;
+	return (
+		userCanManageOptions &&
+		! siteHasMappedDomain &&
+		siteIsOnFreePlan &&
+		! siteIsVipSite &&
+		! siteIsJetpack
+	);
 };
 
 export default isEligibleForFreeToPaidUpsell;

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -6,13 +6,15 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import isEligibleForFreeToPaidUpsell from '../is-eligible-for-free-to-paid-upsell';
 import canCurrentUser from 'state/selectors/can-current-user';
+import isEligibleForFreeToPaidUpsell from '../is-eligible-for-free-to-paid-upsell';
+import { isJetpackSite } from 'state/sites/selectors';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
 
 jest.mock( 'state/selectors/can-current-user', () => require( 'sinon' ).stub() );
+jest.mock( 'state/sites/selectors', () => ( { isJetpackSite: require( 'sinon' ).stub() } ) );
 jest.mock( 'state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
@@ -23,6 +25,7 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 
 	const meetAllConditions = () => {
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( true );
+		isJetpackSite.withArgs( state, siteId ).returns( false );
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
 		isVipSite.withArgs( state, siteId ).returns( false );
@@ -31,6 +34,12 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 	test( 'should return false when user can not manage options', () => {
 		meetAllConditions();
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( false );
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
+	} );
+
+	test( 'should return false when site is Jetpack', () => {
+		meetAllConditions();
+		isJetpackSite.withArgs( state, siteId ).returns( true );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds Jetpack sites list of sites that are not eligable for free to Paid Upsells. 


#### Testing instructions

* On a Jetpack site do you see the Free Domain upsell?
* Do you still see the upsell on the regular free plan?

