### PR TITLE
Revert "Fix inconsitent upsell nudge for free plan site"

### DIFF
--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -11,9 +11,9 @@ import isVipSite from 'state/selectors/is-vip-site';
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site
  *
- * @param {object} state Global state tree
- * @param {number} siteId Site ID
- * @returns {?boolean} True if the user can participate in the free to paid upsell
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @return {?Boolean} True if the user can participate in the free to paid upsell
  */
 const isEligibleForFreeToPaidUpsell = ( state, siteId ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -11,9 +11,9 @@ import isVipSite from 'state/selectors/is-vip-site';
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site
  *
- * @param {Object} state Global state tree
- * @param {Number} siteId Site ID
- * @return {?Boolean} True if the user can participate in the free to paid upsell
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {?boolean} True if the user can participate in the free to paid upsell
  */
 const isEligibleForFreeToPaidUpsell = ( state, siteId ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );

--- a/client/state/selectors/is-mapped-domain-site.js
+++ b/client/state/selectors/is-mapped-domain-site.js
@@ -2,32 +2,27 @@
  * External dependencies
  */
 
-import { get, some } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getRawSite from 'state/selectors/get-raw-site';
-import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 
 /**
  * Returns true if site is a mapped domain site, false if the site is not,
  * or null if the site is unknown.
  *
- * @param {object} state Global state tree
- * @param {number} siteId Site ID
- * @returns {?boolean} Whether site is a mapped domain site
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @return {?Boolean} Whether site is a mapped domain site
  */
 export default function isMappedDomainSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
-	const domains = getDomainsBySiteId( state, siteId );
 
-	if ( ! site || 0 === domains.length ) {
+	if ( ! site ) {
 		return null;
 	}
 
-	return (
-		get( site, 'options.is_mapped_domain', false ) &&
-		some( domains, ( { isWPCOMDomain } ) => ! isWPCOMDomain )
-	);
+	return get( site, 'options.is_mapped_domain', false );
 }

--- a/client/state/selectors/test/is-mapped-domain-site.js
+++ b/client/state/selectors/test/is-mapped-domain-site.js
@@ -10,47 +10,12 @@ import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 
 describe( '#isMappedDomainSite()', () => {
 	const siteId = 77203074;
-	const sites = {
-		items: {
-			[ siteId ]: {
-				ID: siteId,
-				URL: 'https://example.wordpress.com',
-				options: {
-					is_mapped_domain: false,
-				},
-			},
-		},
-		domains: {
-			items: {
-				[ siteId ]: {
-					isWPCOMDomain: true,
-				},
-			},
-		},
-	};
 
 	test( 'should return null if the site is unknown', () => {
 		const result = isMappedDomainSite(
 			{
 				sites: {
-					...sites,
 					items: {},
-				},
-			},
-			siteId
-		);
-
-		expect( result ).to.be.null;
-	} );
-
-	test( 'should return null if no domain is found', () => {
-		const result = isMappedDomainSite(
-			{
-				sites: {
-					...sites,
-					domains: {
-						items: {},
-					},
 				},
 			},
 			siteId
@@ -63,7 +28,6 @@ describe( '#isMappedDomainSite()', () => {
 		const result = isMappedDomainSite(
 			{
 				sites: {
-					...sites,
 					items: {
 						[ siteId ]: {
 							ID: siteId,
@@ -85,7 +49,6 @@ describe( '#isMappedDomainSite()', () => {
 		const result = isMappedDomainSite(
 			{
 				sites: {
-					...sites,
 					items: {
 						[ siteId ]: {
 							ID: siteId,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#37704

It caused the upsell nudge to show up for Jetpack sites.

### Testing
Jetpack site with just Jetpack Backup -> the upsell is shown, but does not make sense in the context of a Jetpack site.

Related PR: https://github.com/Automattic/wp-calypso/pull/37878

Unfortunately, the tests there are failing and I don't have the bandwidth to figure out now why.
Best option is to revert this change since the effect will be much lower than continuing showing this on a Jetpack sites.