### PR TITLE
Composite checkout: Add disabled button state

### DIFF
--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -190,6 +190,7 @@ function CheckoutStepContainer( {
 									value={ localize( 'Continue' ) }
 									onClick={ goToNextStep }
 									ariaLabel={ getNextStepButtonAriaLabel && getNextStepButtonAriaLabel() }
+									buttonState={ ! isComplete ? 'disabled' : 'primary' }
 									disabled={ ! isComplete }
 								/>
 							) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the disabled appearance to disabled buttons.

**Before**
![image](https://user-images.githubusercontent.com/6981253/69448164-fc88db80-0d25-11ea-94ef-42e1f71f6094.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/69448071-ccd9d380-0d25-11ea-8ad5-a09dbff7c7d2.png)


#### Testing instructions
* Get checkout running locally by following these instructions: https://github.com/Automattic/wp-calypso/pull/37013
* Press continue on the first step, the next continue button should be disabled.
