### PR TITLE
Load all persisted state on boot.

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -14,7 +14,7 @@ import { configureReduxStore, setupMiddlewares, utils } from './common';
 import { setupLocale } from './locale';
 import { createReduxStore } from 'state';
 import initialReducer from 'state/reducer';
-import { getInitialState, persistOnChange } from 'state/initial-state';
+import { getInitialState, persistOnChange, loadAllState } from 'state/initial-state';
 import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
 
@@ -29,7 +29,8 @@ const boot = currentUser => {
 	debug( "Starting Calypso. Let's do this." );
 
 	utils();
-	getInitialState( initialReducer ).then( initialState => {
+	loadAllState().then( () => {
+		const initialState = getInitialState( initialReducer );
 		const reduxStore = createReduxStore( initialState, initialReducer );
 		persistOnChange( reduxStore );
 		setupLocale( currentUser.get(), reduxStore );

--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -7,9 +7,9 @@ import { Reducer, Store } from 'redux';
  * Internal Dependencies
  */
 import { APPLY_STORED_STATE } from 'state/action-types';
-import { getStateFromLocalStorage } from 'state/initial-state';
+import { getStateFromCache } from 'state/initial-state';
 
-const initializations = new Map< string, Promise< void > >();
+const initializations = new Map< string, boolean >();
 const reducers = new Map< string, Reducer >();
 
 function normalizeKey( key: string[] ): string {
@@ -24,12 +24,12 @@ interface WithAddReducer {
 	addReducer: ( keys: string[], subReducer: Reducer & OptionalStorageKey ) => void;
 }
 
-async function initializeState(
+function initializeState(
 	store: Store & WithAddReducer,
 	storageKey: string,
 	reducer: Reducer & OptionalStorageKey
 ) {
-	const storedState = await getStateFromLocalStorage( reducer, storageKey );
+	const storedState = getStateFromCache( reducer, storageKey );
 
 	if ( storedState ) {
 		store.dispatch( { type: APPLY_STORED_STATE, storageKey, storedState } );
@@ -40,12 +40,12 @@ async function initializeState(
 // and loads (asynchronously) and applies the persisted state for it.
 export const addReducerToStore = < T extends Reducer & OptionalStorageKey >(
 	store: Store & WithAddReducer
-) => ( key: string[], reducer: T ): Promise< void > => {
+) => ( key: string[], reducer: T ): void => {
 	const storageKey: string | undefined = reducer.storageKey;
 	const normalizedKey = normalizeKey( key );
 
 	const previousReducer = reducers.get( normalizedKey );
-	let init = initializations.get( normalizedKey );
+	const init = initializations.get( normalizedKey );
 
 	if ( previousReducer && reducer !== previousReducer ) {
 		throw new Error(
@@ -57,14 +57,10 @@ export const addReducerToStore = < T extends Reducer & OptionalStorageKey >(
 		store.addReducer( key, reducer );
 
 		if ( storageKey ) {
-			init = initializeState( store, storageKey, reducer );
-		} else {
-			init = Promise.resolve();
+			initializeState( store, storageKey, reducer );
 		}
 
-		initializations.set( normalizedKey, init );
+		initializations.set( normalizedKey, true );
 		reducers.set( normalizedKey, reducer );
 	}
-
-	return init;
 };

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -278,7 +278,9 @@ function getInitialStoredState( initialReducer ) {
 		}
 	}
 
-	map( storageKeys, loadReducerState );
+	for ( const item of storageKeys ) {
+		loadReducerState( item );
+	}
 
 	return initialStoredState;
 }

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -3,13 +3,13 @@
  */
 
 import debugModule from 'debug';
-import { get, map, pick, throttle } from 'lodash';
+import { map, pick, throttle } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { APPLY_STORED_STATE, SERIALIZE, DESERIALIZE } from 'state/action-types';
-import { getStoredItem, setStoredItem, clearStorage } from 'lib/browser-storage';
+import { getAllStoredItems, setStoredItem, clearStorage } from 'lib/browser-storage';
 import { isSupportSession } from 'lib/user/support-user-interop';
 import config from 'config';
 import User from 'lib/user';
@@ -24,6 +24,15 @@ const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;
 export const SERIALIZE_THROTTLE = 5000;
 export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
+
+/**
+ * In-memory copy of persisted state.
+ *
+ * We load from browser storage into this cache on boot, and initialize state
+ * from it, rather than asynchronously reading from browser storage for every
+ * persisted reducer.
+ */
+let stateCache = {};
 
 function serialize( state, reducer ) {
 	return reducer( state, { type: SERIALIZE } );
@@ -87,8 +96,8 @@ function shouldAddSympathy() {
 // scenario where state data may have been stored without this
 // check being performed.
 function verifyStoredRootState( state ) {
-	const currentUserId = get( user.get(), 'ID', null );
-	const storedUserId = get( state, [ 'currentUser', 'id' ], null );
+	const currentUserId = user.get()?.ID ?? null;
+	const storedUserId = state?.currentUser?.id ?? null;
 
 	if ( currentUserId !== storedUserId ) {
 		debug( `current user ID=${ currentUserId } and state user ID=${ storedUserId } don't match` );
@@ -102,15 +111,29 @@ function verifyStateTimestamp( state ) {
 	return state._timestamp && state._timestamp + MAX_AGE > Date.now();
 }
 
-export async function getStateFromLocalStorage( reducer, subkey, forceLoggedOutUser = false ) {
+export async function loadAllState() {
+	try {
+		const storedState = await getAllStoredItems( /^redux-state-/ );
+		debug( 'fetched stored Redux state from persistent storage', storedState );
+		stateCache = storedState ?? {};
+	} catch ( error ) {
+		debug( 'error while loading stored Redux state:', error );
+	}
+}
+
+export async function clearAllState() {
+	stateCache = {};
+	await clearStorage();
+}
+
+export function getStateFromCache( reducer, subkey, forceLoggedOutUser = false ) {
 	const reduxStateKey = getReduxStateKey( forceLoggedOutUser ) + ( subkey ? ':' + subkey : '' );
 
 	try {
-		const storedState = await getStoredItem( reduxStateKey );
-		debug( 'fetched stored Redux state from persistent storage', storedState );
+		const storedState = stateCache[ reduxStateKey ] ?? null;
 
 		if ( storedState === null ) {
-			debug( 'stored Redux state not found in persistent storage' );
+			debug( 'stored Redux state not found in cache' );
 			return null;
 		}
 
@@ -138,7 +161,7 @@ export async function getStateFromLocalStorage( reducer, subkey, forceLoggedOutU
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
-	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : get( user.get(), 'ID', null ) );
+	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user.get()?.ID ?? null );
 }
 
 function getReduxStateKeyForUserId( userId ) {
@@ -157,16 +180,17 @@ function isValidReduxKeyAndState( key, state ) {
 	// able to force the state in memory to be rebuilt - possibly using
 	// https://stackoverflow.com/questions/35622588/how-to-reset-the-state-of-a-redux-store/35641992#35641992
 	// - without generating any errors. Until then, it must remain in place.)
-	const userId = get( state, [ 'currentUser', 'id' ], null );
+	const userId = state?.currentUser?.id ?? null;
 	return key === getReduxStateKeyForUserId( userId );
 }
 
-function persistentStoreState( reduxStateKey, storageKey, state, _timestamp ) {
+async function persistentStoreState( reduxStateKey, storageKey, state, _timestamp ) {
 	if ( storageKey !== 'root' ) {
 		reduxStateKey += ':' + storageKey;
 	}
 
-	return setStoredItem( reduxStateKey, Object.assign( {}, state, { _timestamp } ) );
+	stateCache[ reduxStateKey ] = { ...state, _timestamp };
+	return await setStoredItem( reduxStateKey, stateCache[ reduxStateKey ] );
 }
 
 export function persistOnChange( reduxStore ) {
@@ -212,13 +236,13 @@ export function persistOnChange( reduxStore ) {
 	reduxStore.subscribe( throttledSaveState );
 }
 
-async function getInitialStoredState( initialReducer ) {
+function getInitialStoredState( initialReducer ) {
 	if ( ! shouldPersist() ) {
 		return null;
 	}
 
 	if ( 'development' === process.env.NODE_ENV ) {
-		window.resetState = () => clearStorage().then( () => location.reload( true ) );
+		window.resetState = () => clearAllState().then( () => window.location.reload( true ) );
 
 		if ( shouldAddSympathy() ) {
 			// eslint-disable-next-line no-console
@@ -227,19 +251,19 @@ async function getInitialStoredState( initialReducer ) {
 				'font-size: 14px; color: red;'
 			);
 
-			clearStorage();
+			clearAllState();
 			return null;
 		}
 	}
 
-	let initialStoredState = await getStateFromLocalStorage( initialReducer );
+	let initialStoredState = getStateFromCache( initialReducer );
 	const storageKeys = [ ...initialReducer.getStorageKeys() ];
 
-	async function loadReducerState( { storageKey, reducer } ) {
-		let storedState = await getStateFromLocalStorage( reducer, storageKey, false );
+	function loadReducerState( { storageKey, reducer } ) {
+		let storedState = getStateFromCache( reducer, storageKey, false );
 
 		if ( ! storedState && storageKey === 'signup' ) {
-			storedState = await getStateFromLocalStorage( reducer, storageKey, true );
+			storedState = getStateFromCache( reducer, storageKey, true );
 			debug( 'fetched signup state from logged out state', storedState );
 		}
 
@@ -252,13 +276,13 @@ async function getInitialStoredState( initialReducer ) {
 		}
 	}
 
-	await Promise.all( map( storageKeys, loadReducerState ) );
+	map( storageKeys, loadReducerState );
 
 	return initialStoredState;
 }
 
-export async function getInitialState( initialReducer ) {
-	const storedState = await getInitialStoredState( initialReducer );
+export function getInitialState( initialReducer ) {
+	const storedState = getInitialStoredState( initialReducer );
 	const serverState = getInitialServerState( initialReducer );
 	return { ...storedState, ...serverState };
 }

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -189,8 +189,10 @@ async function persistentStoreState( reduxStateKey, storageKey, state, _timestam
 		reduxStateKey += ':' + storageKey;
 	}
 
-	stateCache[ reduxStateKey ] = { ...state, _timestamp };
-	return await setStoredItem( reduxStateKey, stateCache[ reduxStateKey ] );
+	const newState = { ...state, _timestamp };
+	const result = await setStoredItem( reduxStateKey, newState );
+	stateCache[ reduxStateKey ] = newState;
+	return result;
 }
 
 export function persistOnChange( reduxStore ) {

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -18,7 +18,13 @@ import { isSupportSession } from 'lib/user/support-user-interop';
 import { SERIALIZE, DESERIALIZE } from 'state/action-types';
 import { createReduxStore } from 'state';
 import initialReducer from 'state/reducer';
-import { getInitialState, persistOnChange, MAX_AGE, SERIALIZE_THROTTLE } from 'state/initial-state';
+import {
+	getInitialState,
+	persistOnChange,
+	loadAllState,
+	MAX_AGE,
+	SERIALIZE_THROTTLE,
+} from 'state/initial-state';
 import { combineReducers, withStorageKey } from 'state/utils';
 import { addReducerToStore } from 'state/add-reducer';
 
@@ -50,16 +56,18 @@ describe( 'initial-state', () => {
 				let state, consoleErrorSpy, getStoredItemSpy;
 
 				const savedState = {
-					currentUser: { id: 123456789 },
-					postTypes: {
-						items: {
-							2916284: {
-								post: { name: 'post', label: 'Posts' },
-								page: { name: 'page', label: 'Pages' },
+					'redux-state-123456789': {
+						currentUser: { id: 123456789 },
+						postTypes: {
+							items: {
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' },
+								},
 							},
 						},
+						_timestamp: Date.now(),
 					},
-					_timestamp: Date.now(),
 				};
 
 				const serverState = { currentUser: { id: 123456789 } };
@@ -68,9 +76,10 @@ describe( 'initial-state', () => {
 					window.initialReduxState = serverState;
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getStoredItem' )
+						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					state = await getInitialState( initialReducer );
+					await loadAllState();
+					state = getInitialState( initialReducer );
 				} );
 
 				afterAll( () => {
@@ -103,16 +112,18 @@ describe( 'initial-state', () => {
 					let state, consoleErrorSpy, getStoredItemSpy;
 
 					const savedState = {
-						currentUser: { id: 123456789 },
-						postTypes: {
-							items: {
-								2916284: {
-									post: { name: 'post', label: 'Posts' },
-									page: { name: 'page', label: 'Pages' },
+						'redux-state-123456789': {
+							currentUser: { id: 123456789 },
+							postTypes: {
+								items: {
+									2916284: {
+										post: { name: 'post', label: 'Posts' },
+										page: { name: 'page', label: 'Pages' },
+									},
 								},
 							},
+							_timestamp: Date.now(),
 						},
-						_timestamp: Date.now(),
 					};
 
 					beforeAll( async () => {
@@ -121,9 +132,10 @@ describe( 'initial-state', () => {
 						window.initialReduxState = { currentUser: { currencyCode: 'USD' } };
 						consoleErrorSpy = jest.spyOn( global.console, 'error' );
 						getStoredItemSpy = jest
-							.spyOn( browserStorage, 'getStoredItem' )
+							.spyOn( browserStorage, 'getAllStoredItems' )
 							.mockResolvedValue( savedState );
-						state = await getInitialState( initialReducer );
+						await loadAllState();
+						state = getInitialState( initialReducer );
 					} );
 
 					afterAll( () => {
@@ -156,16 +168,18 @@ describe( 'initial-state', () => {
 				let state, consoleErrorSpy, getStoredItemSpy;
 
 				const savedState = {
-					currentUser: { id: 123456789 },
-					postTypes: {
-						items: {
-							2916284: {
-								post: { name: 'post', label: 'Posts' },
-								page: { name: 'page', label: 'Pages' },
+					'redux-state-123456789': {
+						currentUser: { id: 123456789 },
+						postTypes: {
+							items: {
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' },
+								},
 							},
 						},
+						_timestamp: Date.now(),
 					},
-					_timestamp: Date.now(),
 				};
 
 				const serverState = {
@@ -183,9 +197,10 @@ describe( 'initial-state', () => {
 					isEnabled.enablePersistRedux();
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getStoredItem' )
+						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					state = await getInitialState( initialReducer );
+					await loadAllState();
+					state = getInitialState( initialReducer );
 				} );
 
 				afterAll( () => {
@@ -216,16 +231,18 @@ describe( 'initial-state', () => {
 				let state, consoleErrorSpy, getStoredItemSpy;
 
 				const savedState = {
-					currentUser: { id: 123456789 },
-					postTypes: {
-						items: {
-							2916284: {
-								post: { name: 'post', label: 'Posts' },
-								page: { name: 'page', label: 'Pages' },
+					'redux-state-123456789': {
+						currentUser: { id: 123456789 },
+						postTypes: {
+							items: {
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' },
+								},
 							},
 						},
+						_timestamp: Date.now() - MAX_AGE - 1,
 					},
-					_timestamp: Date.now() - MAX_AGE - 1,
 				};
 
 				const serverState = {
@@ -243,9 +260,10 @@ describe( 'initial-state', () => {
 					isEnabled.enablePersistRedux();
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getStoredItem' )
+						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					state = await getInitialState( initialReducer );
+					await loadAllState();
+					state = getInitialState( initialReducer );
 				} );
 
 				afterAll( () => {
@@ -276,16 +294,18 @@ describe( 'initial-state', () => {
 				let state, consoleErrorSpy, getStoredItemSpy;
 
 				const savedState = {
-					currentUser: { id: 123456789 },
-					postTypes: {
-						items: {
-							2916284: {
-								post: { name: 'post', label: 'Posts' },
-								page: { name: 'page', label: 'Pages' },
+					'redux-state-123456789': {
+						currentUser: { id: 123456789 },
+						postTypes: {
+							items: {
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' },
+								},
 							},
 						},
+						_timestamp: Date.now(),
 					},
-					_timestamp: Date.now(),
 				};
 
 				const serverState = {};
@@ -295,9 +315,10 @@ describe( 'initial-state', () => {
 					isEnabled.enablePersistRedux();
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getStoredItem' )
+						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					state = await getInitialState( initialReducer );
+					await loadAllState();
+					state = getInitialState( initialReducer );
 				} );
 
 				afterAll( () => {
@@ -313,7 +334,9 @@ describe( 'initial-state', () => {
 
 				test( 'builds state using local forage state', () => {
 					expect( state.currentUser.id ).toBe( 123456789 );
-					expect( state.postTypes.items ).toEqual( savedState.postTypes.items );
+					expect( state.postTypes.items ).toEqual(
+						savedState[ 'redux-state-123456789' ].postTypes.items
+					);
 				} );
 
 				test( 'does not add timestamp to store', () => {
@@ -324,20 +347,23 @@ describe( 'initial-state', () => {
 			describe( 'with invalid persisted data and no initial server data', () => {
 				let state, consoleErrorSpy, getStoredItemSpy;
 
+				const userId = userFactory().get().ID + 1;
 				const savedState = {
-					// Create an invalid state by forcing the user ID
-					// stored in the state to differ from the current
-					// mocked user ID.
-					currentUser: { id: userFactory().get().ID + 1 },
-					postTypes: {
-						items: {
-							2916284: {
-								post: { name: 'post', label: 'Posts' },
-								page: { name: 'page', label: 'Pages' },
+					[ `redux-state-${ userId }` ]: {
+						// Create an invalid state by forcing the user ID
+						// stored in the state to differ from the current
+						// mocked user ID.
+						currentUser: { id: userFactory().get().ID + 1 },
+						postTypes: {
+							items: {
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' },
+								},
 							},
 						},
+						_timestamp: Date.now(),
 					},
-					_timestamp: Date.now(),
 				};
 
 				const serverState = {};
@@ -347,9 +373,10 @@ describe( 'initial-state', () => {
 					isEnabled.enablePersistRedux();
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getStoredItem' )
+						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
-					state = await getInitialState( initialReducer );
+					await loadAllState();
+					state = getInitialState( initialReducer );
 				} );
 
 				afterAll( () => {
@@ -398,10 +425,11 @@ describe( 'initial-state', () => {
 					window.initialReduxState = serverState;
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getStoredItem' )
-						.mockImplementation( key => storedState[ key ] );
+						.spyOn( browserStorage, 'getAllStoredItems' )
+						.mockResolvedValue( storedState );
 
-					state = await getInitialState( initialReducer );
+					await loadAllState();
+					state = getInitialState( initialReducer );
 				} );
 
 				afterAll( () => {
@@ -468,10 +496,11 @@ describe( 'initial-state', () => {
 					window.initialReduxState = serverState;
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getStoredItem' )
-						.mockImplementation( key => storedState[ key ] );
+						.spyOn( browserStorage, 'getAllStoredItems' )
+						.mockResolvedValue( storedState );
 
-					state = await getInitialState( initialReducer );
+					await loadAllState();
+					state = getInitialState( initialReducer );
 				} );
 
 				afterAll( () => {
@@ -526,7 +555,7 @@ describe( 'initial-state', () => {
 		// current mocked user ID).
 		const initialState = { currentUser: { id: 123456789 } };
 
-		beforeEach( () => {
+		beforeEach( async () => {
 			isEnabled.enablePersistRedux();
 			// we use fake timers from Sinon (aka Lolex) because `lodash.throttle` also uses `Date.now()`
 			// and relies on it returning a mocked value. Jest fake timers don't mock `Date`, Lolex does.
@@ -536,7 +565,7 @@ describe( 'initial-state', () => {
 				.mockImplementation( value => Promise.resolve( value ) );
 
 			store = createReduxStore( initialState, reducer );
-			persistOnChange( store );
+			persistOnChange( store, false );
 		} );
 
 		afterEach( () => {
@@ -707,8 +736,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// `lib/browser-storage` mock to return mock IndexedDB state
 		getStoredItemSpy = jest
-			.spyOn( browserStorage, 'getStoredItem' )
-			.mockImplementation( key => storedState[ key ] );
+			.spyOn( browserStorage, 'getAllStoredItems' )
+			.mockResolvedValue( storedState );
 	} );
 
 	afterEach( () => {
@@ -725,7 +754,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		const state = await getInitialState( reducer );
+		await loadAllState();
+		const state = getInitialState( reducer );
 		const store = createReduxStore( state, reducer );
 
 		// verify that state from all storageKey's was loaded
@@ -751,7 +781,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		const state = await getInitialState( reducer );
+		await loadAllState();
+		const state = getInitialState( reducer );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -763,7 +794,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const aReducer = withStorageKey( 'A', withKeyPrefix( 'A' ) );
-		await addReducerToStore( store )( [ 'a' ], aReducer );
+		addReducerToStore( store )( [ 'a' ], aReducer );
 
 		// verify that the Redux store contains the stored state for `A` now
 		expect( store.getState() ).toEqual( {
@@ -784,7 +815,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		const state = await getInitialState( reducer );
+		await loadAllState();
+		const state = getInitialState( reducer );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -796,7 +828,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const cdReducer = withStorageKey( 'CD', withKeyPrefix( 'CD' ) );
-		await addReducerToStore( store )( [ 'c', 'd' ], cdReducer );
+		addReducerToStore( store )( [ 'c', 'd' ], cdReducer );
 
 		// verify that the Redux store contains the stored state for `A` now
 		expect( store.getState() ).toEqual( {
@@ -819,7 +851,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		const state = await getInitialState( reducer );
+		await loadAllState();
+		const state = getInitialState( reducer );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -831,10 +864,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const eReducer = withStorageKey( 'E', withKeyPrefix( 'E' ) );
-		await Promise.all( [
-			addReducerToStore( store )( [ 'e' ], eReducer ),
-			addReducerToStore( store )( [ 'e' ], eReducer ),
-		] );
+		addReducerToStore( store )( [ 'e' ], eReducer );
+		addReducerToStore( store )( [ 'e' ], eReducer );
 
 		// verify that the Redux store contains the stored state for `E` now
 		expect( store.getState() ).toEqual( {
@@ -855,7 +886,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		} );
 
 		// load initial state and create Redux store with it
-		const state = await getInitialState( reducer );
+		await loadAllState();
+		const state = getInitialState( reducer );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -870,10 +902,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		const cReducer = withStorageKey( 'C', withKeyPrefix( 'C' ) );
 
 		expect( () => {
-			Promise.all( [
-				addReducerToStore( store )( [ 'b' ], bReducer ),
-				addReducerToStore( store )( [ 'b' ], cReducer ),
-			] );
+			addReducerToStore( store )( [ 'b' ], bReducer );
+			addReducerToStore( store )( [ 'b' ], cReducer );
 		} ).toThrow();
 	} );
 } );


### PR DESCRIPTION
By loading all persisted state on boot, we can make adding reducers to the store a synchronous process, paving the way for dependency-based reducer injection.

#### Changes proposed in this Pull Request

* Load all persisted state on boot
* Make initial state retrieval for reducers synchronous
* Make reducer injection synchronous
* Update initial state tests

#### Testing instructions

I don't really have any specific testing instructions. This touches all of Calypso state, so take it for a spin and see if anything breaks.
