### PR TITLE
composite-checkout: Add stripe/apple-pay to calypso version

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import { createRegistry, createPayPalMethod } from '@automattic/composite-checkout';
+import {
+	createRegistry,
+	createPayPalMethod,
+	createStripeMethod,
+	createApplePayMethod,
+} from '@automattic/composite-checkout';
 import {
 	WPCOMCheckout,
 	makeShoppingCartHook,
@@ -61,16 +66,65 @@ const useShoppingCart = makeShoppingCartHook(
 	initialCart
 );
 
+async function fetchStripeConfiguration( requestArgs ) {
+	return wpcom.stripeConfiguration( requestArgs );
+}
+
+async function sendStripeTransaction() {
+	// return await wpcom.req.post( '/me/transactions', transaction );
+	return {
+		success: true,
+	};
+}
+
+const stripeMethod = createStripeMethod( {
+	registerStore,
+	fetchStripeConfiguration,
+	sendStripeTransaction,
+} );
+
+const paypalMethod = createPayPalMethod( {
+	registerStore: registerStore,
+	makePayPalExpressRequest: mockPayPalExpressRequest,
+} );
+
+const applePayMethod = isApplePayAvailable()
+	? createApplePayMethod( {
+			registerStore,
+			fetchStripeConfiguration,
+	  } )
+	: null;
+
+export function isApplePayAvailable() {
+	// Our Apple Pay implementation uses the Payment Request API, so check that first.
+	if ( ! window.PaymentRequest ) {
+		return false;
+	}
+
+	// Check if Apple Pay is available. This can be very expensive on certain
+	// Safari versions due to a bug (https://trac.webkit.org/changeset/243447/webkit),
+	// and there is no way it can change during a page request, so cache the
+	// result.
+	if ( typeof isApplePayAvailable.canMakePayments === 'undefined' ) {
+		try {
+			isApplePayAvailable.canMakePayments = Boolean(
+				window.ApplePaySession && window.ApplePaySession.canMakePayments()
+			);
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+			return false;
+		}
+	}
+	return isApplePayAvailable.canMakePayments;
+}
+
+const availablePaymentMethods = [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean );
+
 export default function CompositeCheckoutContainer() {
 	return (
 		<WPCOMCheckout
 			useShoppingCart={ useShoppingCart }
-			availablePaymentMethods={ [
-				createPayPalMethod( {
-					registerStore: registerStore,
-					makePayPalExpressRequest: mockPayPalExpressRequest,
-				} ),
-			] }
+			availablePaymentMethods={ availablePaymentMethods }
 			registry={ registry }
 		/>
 	);

--- a/packages/composite-checkout-wpcom/src/components/checkout.jsx
+++ b/packages/composite-checkout-wpcom/src/components/checkout.jsx
@@ -28,9 +28,8 @@ const successRedirectUrl = window.location.href;
 const failureRedirectUrl = window.location.href;
 
 // Called when the store is changed.
-const handleCheckoutEvent = select => () => {
+const handleCheckoutEvent = () => () => {
 	// TODO: write this
-	alert( `handleCheckoutEvent: ${ select }` );
 };
 
 const ContactFormTitle = () => {

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -21,7 +21,7 @@ It's also possible to build an entirely custom form using the other components e
 
 ### Select payment method
 
-The payment method options displayed on the form are chosen automatically by the component based on the environment, locale, and possibly other factors, but they will include only methods listed in the optional `availablePaymentMethods` array. If the array is not set, no appropriate payment methods will be excluded.
+The payment method options displayed on the form are chosen automatically by the component based on the environment, locale, and possibly other factors.
 
 ![payment method step](https://raw.githubusercontent.com/Automattic/wp-calypso/add/wp-checkout-component/packages/composite-checkout/doc-assets/payment-method-step.png 'Payment Method Step')
 
@@ -137,7 +137,6 @@ While the `Checkout` component takes care of most everything, there are many sit
 
 The main component in this package. It has the following props.
 
-- availablePaymentMethods: array
 - steps: array
 
 See the [Steps](#steps) section above for more details.
@@ -148,7 +147,7 @@ Renders a button to move to the next `CheckoutStep` component. Its `value` prop 
 
 ### CheckoutPaymentMethods
 
-Renders buttons for each payment method that can be used out of the array in the `availablePaymentMethods` prop. The `onChange` callback prop can be used to determine which payment method has been selected. When the `isComplete` prop is true and `isActive` is false, it will display a summary of the current choice.
+Renders buttons for each payment method that can be used. The `onChange` callback prop can be used to determine which payment method has been selected. When the `isComplete` prop is true and `isActive` is false, it will display a summary of the current choice.
 
 ### CheckoutProvider
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -19,20 +19,12 @@ import {
 } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 
-export default function CheckoutPaymentMethods( {
-	summary,
-	isComplete,
-	className,
-	availablePaymentMethods,
-} ) {
+export default function CheckoutPaymentMethods( { summary, isComplete, className } ) {
 	const localize = useLocalize();
 
 	const paymentMethod = usePaymentMethod();
 	const [ , setPaymentMethod ] = usePaymentMethodId();
 	const paymentMethods = useAllPaymentMethods();
-	const paymentMethodsToDisplay = availablePaymentMethods
-		? paymentMethods.filter( method => availablePaymentMethods.includes( method.id ) )
-		: paymentMethods;
 
 	if ( summary && isComplete && paymentMethod ) {
 		return (
@@ -58,7 +50,7 @@ export default function CheckoutPaymentMethods( {
 	return (
 		<div className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }>
 			<RadioButtons>
-				{ paymentMethodsToDisplay.map( method => (
+				{ paymentMethods.map( method => (
 					<CheckoutErrorBoundary
 						key={ method.id }
 						errorMessage={
@@ -82,7 +74,6 @@ CheckoutPaymentMethods.propTypes = {
 	summary: PropTypes.bool,
 	isComplete: PropTypes.bool.isRequired,
 	className: PropTypes.string,
-	availablePaymentMethods: PropTypes.arrayOf( PropTypes.string ),
 };
 
 export function CheckoutPaymentMethodsTitle() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently there's only the Paypal payment method listed in the version of composite-checkout used in Calypso. This adds the Stripe and Apple Pay payment methods as well.

#### Testing instructions

- Run calypso with the `composite-checkout-wpcom` flag and verify that the form works as expected and you see the Stripe payment method. You won't see the Apple Pay one unless you are using Safari.
