### PR TITLE
Composite checkout: Remove ghost markup

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -449,12 +449,11 @@ function ContactFormSummary() {
 		<GridRow>
 			<div>
 				<SummaryDetails>
-					{ billing.firstName ||
-						( billing.lastName && (
-							<SummaryLine>
-								{ billing.firstName } { billing.lastName }
-							</SummaryLine>
-						) ) }
+					{ ( billing.firstName || billing.lastName ) && (
+						<SummaryLine>
+							{ billing.firstName } { billing.lastName }
+						</SummaryLine>
+					) }
 
 					{ billing.email && <SummarySpacerLine>{ billing.email }</SummarySpacerLine> }
 

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -449,19 +449,31 @@ function ContactFormSummary() {
 		<GridRow>
 			<div>
 				<SummaryDetails>
-					<SummaryLine>
-						{ billing.firstName || '' } { billing.lastName || '' }
-					</SummaryLine>
-					<SummarySpacerLine>{ billing.email || '' }</SummarySpacerLine>
-					<SummaryLine>{ billing.address || '' } </SummaryLine>
-					<SummaryLine>
-						{ billing.city && billing.city + ', ' } { billing.state || billing.province || '' }
-					</SummaryLine>
-					<SummaryLine>
-						{ postalCode && postalCode + ', ' }
-						{ billing.country }
-					</SummaryLine>
+					{ billing.firstName ||
+						( billing.lastName && (
+							<SummaryLine>
+								{ billing.firstName } { billing.lastName }
+							</SummaryLine>
+						) ) }
+
+					{ billing.email && <SummarySpacerLine>{ billing.email }</SummarySpacerLine> }
+
+					{ billing.address && <SummaryLine>{ billing.address } </SummaryLine> }
+
+					{ ( billing.city || billing.state || billing.province ) && (
+						<SummaryLine>
+							{ billing.city && billing.city + ', ' } { billing.state || billing.province }
+						</SummaryLine>
+					) }
+
+					{ ( postalCode || billing.country ) && (
+						<SummaryLine>
+							{ postalCode && postalCode + ', ' }
+							{ billing.country }
+						</SummaryLine>
+					) }
 				</SummaryDetails>
+
 				{ ( billing.phoneNumber || ( isElligibleForVat() && billing.vatId ) ) && (
 					<SummaryDetails>
 						<SummaryLine>{ billing.phoneNumber }</SummaryLine>
@@ -474,23 +486,36 @@ function ContactFormSummary() {
 					</SummaryDetails>
 				) }
 			</div>
+
 			{ domains && ! isDomainContactSame && (
 				<div>
 					<SummaryDetails>
-						<SummaryLine>{ domains.firstName + ' ' + domains.lastName }</SummaryLine>
-						<SummarySpacerLine>{ domains.email }</SummarySpacerLine>
-						<SummaryLine>{ domains.address }</SummaryLine>
-						<SummaryLine>
-							{ domains.city && domains.city + ', ' } { domains.state || domains.province }
-						</SummaryLine>
-						<SummaryLine>
-							{ domainPostalCode && domainPostalCode + ', ' } { domains.country }
-						</SummaryLine>
+						{ ( domains.firstName || domains.lastName ) && (
+							<SummaryLine>{ domains.firstName + ' ' + domains.lastName }</SummaryLine>
+						) }
+
+						{ domains.email && <SummarySpacerLine>{ domains.email }</SummarySpacerLine> }
+
+						{ domains.address && <SummaryLine>{ domains.address }</SummaryLine> }
+
+						{ ( domains.city || domains.city || domains.state || domains.province ) && (
+							<SummaryLine>
+								{ domains.city && domains.city + ', ' } { domains.state || domains.province }
+							</SummaryLine>
+						) }
+
+						{ ( domainPostalCode || domains.country ) && (
+							<SummaryLine>
+								{ domainPostalCode && domainPostalCode + ', ' } { domains.country }
+							</SummaryLine>
+						) }
 					</SummaryDetails>
 
-					<SummaryDetails>
-						<SummaryLine>{ domains.phoneNumber }</SummaryLine>
-					</SummaryDetails>
+					{ domains.phoneNumber && (
+						<SummaryDetails>
+							<SummaryLine>{ domains.phoneNumber }</SummaryLine>
+						</SummaryDetails>
+					) }
 				</div>
 			) }
 		</GridRow>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR cleans up some ghost markup showing up in the billing summary. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/69455845-462df200-0d37-11ea-89fb-e7da5704e969.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/69455577-af613580-0d36-11ea-8d8b-e130ec2888ca.png)

#### Testing instructions

* Get calypso running locally and make your way to checkout
* Append the checkout flag (`?flags=composite-checkout-wpcom`) to the end of your url and refresh
* Complete the billing step and ensure no extra markup is showing.
