### PR TITLE
Fix small back button errors

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -1,4 +1,5 @@
 /* global fullSiteEditing */
+/* global calypsoifyGutenberg */
 
 /**
  * External dependencies
@@ -63,7 +64,16 @@ domReady( () => {
 		toolbar.prepend( componentsToolbar );
 
 		// These should go here so that they have any updates that happened while querying for the selector.
-		const { closeButtonLabel, closeButtonUrl } = fullSiteEditing;
+		let { closeButtonLabel, closeButtonUrl } = fullSiteEditing;
+
+		// Use wpcom close button/url if they exist.
+		if ( calypsoifyGutenberg && calypsoifyGutenberg.closeUrl ) {
+			closeButtonUrl = calypsoifyGutenberg.closeUrl;
+		}
+
+		if ( calypsoifyGutenberg && calypsoifyGutenberg.closeButtonLabel ) {
+			closeButtonLabel = calypsoifyGutenberg.closeButtonLabel;
+		}
 
 		// Create custom close button for the template part editor.
 		if ( 'wp_template_part' === editorPostType ) {
@@ -86,7 +96,7 @@ domReady( () => {
 
 		// Create a "normal" close button for the page/post editor.
 		if ( 'page' === editorPostType || 'post' === editorPostType ) {
-			const defaultUrl = `edit.php?post_type=${ editorPostType }`;
+			const defaultUrl = closeButtonUrl || `edit.php?post_type=${ editorPostType }`;
 
 			let defaultLabel = closeButtonLabel || 'Back';
 			if ( 'page' === editorPostType && ! closeButtonLabel ) {

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* global calypsoifyGutenberg */
-/* global fullSiteEditing */
 
 /**
  * External dependencies
@@ -725,7 +724,8 @@ function getCloseButtonUrl( calypsoPort ) {
 	port1.onmessage = ( { data } ) => {
 		const { closeUrl, label } = data;
 		calypsoifyGutenberg.closeUrl = closeUrl;
-		fullSiteEditing.closeButtonLabel = label;
+		calypsoifyGutenberg.closeButtonLabel = label;
+
 		window.wp.hooks.doAction( 'updateCloseButtonOverrides', data );
 	};
 }


### PR DESCRIPTION
I accidentally tried to use the FSE global object when it didn't exist in #37749. This fixes that.

#### Changes proposed in this Pull Request
* Use calypsoify global object instead of FSE object for back label override
* Use default calypsoify globals if they exist instead of the FSE global.

#### Testing instructions
1. Sync the iFrame bridge server to your sandbox and sandbox `widgets.wp.com` as well as your test site.
2. Verify that for a non-FSE site, you see no 'fullSiteEditing is undefined errors' in the console when editing a post/page in gutenberg.
3. For an FSE site, sync these FSE changes to your sandbox and make sure the back button label still matches the page you come from.