### PR TITLE
Signup: remove site title step from FSE testing flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -316,7 +316,7 @@ export function generateFlows( {
 
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
-			steps: [ 'user', 'site-title', 'domains', 'plans' ],
+			steps: [ 'user', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'User testing Signup flow for Full Site Editing',
 			lastModified: '2019-11-19',


### PR DESCRIPTION
Full site editing allows the user to change their site title directly in the editor, making the Signup step irrelevant. This removes the step from the FSE testing flow.

Fixes #37893.

#### Testing instructions

- as a new user, visit `/start/test-fse/`
- Signup steps should be: user, domains, plans
- verify that after signup up, you can edit your site title from the editor
