### PR TITLE
Fix an error where calypsoifyGutenberg global object was undefined

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -1,5 +1,4 @@
 /* global fullSiteEditing */
-/* global calypsoifyGutenberg */
 
 /**
  * External dependencies
@@ -65,6 +64,13 @@ domReady( () => {
 
 		// These should go here so that they have any updates that happened while querying for the selector.
 		let { closeButtonLabel, closeButtonUrl } = fullSiteEditing;
+
+		/**
+		 * We have to reference calypsoifyGutenberg off of the window object
+		 * directly to handle the case where it is undefined. Otherwise, the
+		 * variable declariation itself won't exist, causing a runtime error.
+		 */
+		const { calypsoifyGutenberg } = window;
 
 		// Use wpcom close button/url if they exist.
 		if ( calypsoifyGutenberg && calypsoifyGutenberg.closeUrl ) {


### PR DESCRIPTION
We tried to reference the global declaration even though it was undefined.

To fix, we reference it directly from the window object, which declares the variable and sets its value to undefined. Previously, the entire variable was undefined, causing the runtime error.

Props to @Addison-Stavlo for finding this!

### Testing:
Test that the "Back" button shows up in your local install when editing an FSE page. This bug does not happen with gutenframe since the global object exists there.