### PR TITLE
Layout: More closely tie is-iframe classname to the state

### DIFF
--- a/client/layout/html-is-iframe-classname.tsx
+++ b/client/layout/html-is-iframe-classname.tsx
@@ -35,4 +35,4 @@ const HtmlIsIframeClassname = () => {
 	return null;
 };
 
-export default typeof document === 'object' ? HtmlIsIframeClassname : () => null;
+export default HtmlIsIframeClassname;

--- a/client/layout/html-is-iframe-classname.tsx
+++ b/client/layout/html-is-iframe-classname.tsx
@@ -3,14 +3,11 @@
  */
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import isIframeForHtmlElement from 'state/selectors/is-iframe-for-html-element';
-
-const debug = debugFactory( 'calypso:layout:html-is-iframe-classname' );
 
 const HtmlIsIframeClassname = () => {
 	const isIframe = useSelector( isIframeForHtmlElement );
@@ -19,16 +16,14 @@ const HtmlIsIframeClassname = () => {
 		const htmlNode = document.querySelector( 'html' );
 
 		if ( ! htmlNode ) {
-			debug( 'no html node' );
 			return;
 		}
 
 		if ( isIframe ) {
-			debug( 'adding is-iframe' );
 			htmlNode.classList.add( 'is-iframe' );
 			return () => htmlNode.classList.remove( 'is-iframe' );
 		}
-		debug( 'removing is-iframe' );
+
 		htmlNode.classList.remove( 'is-iframe' );
 	}, [ isIframe ] );
 

--- a/client/layout/html-is-iframe-classname.tsx
+++ b/client/layout/html-is-iframe-classname.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, memo } from 'react';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import debugFactory from 'debug';
 
@@ -12,7 +12,7 @@ import isIframeForHtmlElement from 'state/selectors/is-iframe-for-html-element';
 
 const debug = debugFactory( 'calypso:layout:html-is-iframe-classname' );
 
-const HtmlIsIframeClassname = memo( () => {
+const HtmlIsIframeClassname = () => {
 	const isIframe = useSelector( isIframeForHtmlElement );
 
 	useEffect( () => {
@@ -30,9 +30,9 @@ const HtmlIsIframeClassname = memo( () => {
 			debug( 'removing is-iframe' );
 			htmlNode.classList.remove( 'is-iframe' );
 		}
-	} );
+	}, [ isIframe ] );
 
 	return null;
-} );
+};
 
 export default typeof document === 'object' ? HtmlIsIframeClassname : () => null;

--- a/client/layout/html-is-iframe-classname.tsx
+++ b/client/layout/html-is-iframe-classname.tsx
@@ -20,10 +20,14 @@ const HtmlIsIframeClassname = () => {
 		}
 
 		if ( isIframe ) {
+			// App state dictates the html node should have class `is-iframe`. Add it.
 			htmlNode.classList.add( 'is-iframe' );
+
+			// Remove the CSS class from the html node in the effect cleanup function
 			return () => htmlNode.classList.remove( 'is-iframe' );
 		}
 
+		// App state dictates the html node should not have class `is-iframe`. Remove it.
 		htmlNode.classList.remove( 'is-iframe' );
 	}, [ isIframe ] );
 

--- a/client/layout/html-is-iframe-classname.tsx
+++ b/client/layout/html-is-iframe-classname.tsx
@@ -26,10 +26,10 @@ const HtmlIsIframeClassname = () => {
 		if ( isIframe ) {
 			debug( 'adding is-iframe' );
 			htmlNode.classList.add( 'is-iframe' );
-		} else {
-			debug( 'removing is-iframe' );
-			htmlNode.classList.remove( 'is-iframe' );
+			return () => htmlNode.classList.remove( 'is-iframe' );
 		}
+		debug( 'removing is-iframe' );
+		htmlNode.classList.remove( 'is-iframe' );
 	}, [ isIframe ] );
 
 	return null;

--- a/client/layout/html-is-iframe-classname.tsx
+++ b/client/layout/html-is-iframe-classname.tsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useEffect, memo } from 'react';
+import { useSelector } from 'react-redux';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import isIframeForHtmlElement from 'state/selectors/is-iframe-for-html-element';
+
+const debug = debugFactory( 'calypso:layout:html-is-iframe-classname' );
+
+const HtmlIsIframeClassname = memo( () => {
+	const isIframe = useSelector( isIframeForHtmlElement );
+
+	useEffect( () => {
+		const htmlNode = document.querySelector( 'html' );
+
+		if ( ! htmlNode ) {
+			debug( 'no html node' );
+			return;
+		}
+
+		if ( isIframe ) {
+			debug( 'adding is-iframe' );
+			htmlNode.classList.add( 'is-iframe' );
+		} else {
+			debug( 'removing is-iframe' );
+			htmlNode.classList.remove( 'is-iframe' );
+		}
+	} );
+
+	return null;
+} );
+
+export default typeof document === 'object' ? HtmlIsIframeClassname : () => null;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -14,6 +14,7 @@ import classnames from 'classnames';
 import AsyncLoad from 'components/async-load';
 import MasterbarLoggedIn from 'layout/masterbar/logged-in';
 import GlobalNotices from 'components/global-notices';
+import HtmlIsIframeClassname from 'layout/html-is-iframe-classname';
 import notices from 'notices';
 import config from 'config';
 import OfflineStatus from 'layout/offline-status';
@@ -129,6 +130,7 @@ class Layout extends Component {
 		return (
 			<div className={ sectionClass }>
 				<BodySectionCssClass group={ this.props.sectionGroup } section={ this.props.sectionName } />
+				<HtmlIsIframeClassname />
 				<DocumentHead />
 				<QuerySites primaryAndRecent />
 				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }

--- a/client/state/selectors/is-iframe-for-html-element.js
+++ b/client/state/selectors/is-iframe-for-html-element.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+import getSectionName from 'state/ui/selectors/get-section-name';
+
+const isIframeForHtmlElement = state =>
+	!! ( getSelectedSiteId( state ) && getSectionName( state ) === 'gutenberg-editor' );
+export default isIframeForHtmlElement;

--- a/client/state/selectors/test/is-iframe-for-html-element.js
+++ b/client/state/selectors/test/is-iframe-for-html-element.js
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import isIframeForHtmlElement from '../is-iframe-for-html-element';
+
+describe( 'isIframeForHtmlElement()', () => {
+	test( 'should be true when in `gutenberg-editor` section with a siteId', () => {
+		const state = {
+			ui: {
+				section: {
+					name: 'gutenberg-editor',
+				},
+				selectedSiteId: 1701,
+			},
+		};
+		expect( isIframeForHtmlElement( state ) ).toBe( true );
+	} );
+
+	test( 'should be false when in `gutenberg-editor` section without a siteId', () => {
+		const state = {
+			ui: {
+				section: {
+					name: 'gutenberg-editor',
+				},
+			},
+		};
+		expect( isIframeForHtmlElement( state ) ).toBe( false );
+	} );
+
+	test( 'should be false when in other section', () => {
+		const state = {
+			ui: {
+				section: {
+					name: 'Section 31',
+				},
+				selectedSiteId: 1701,
+			},
+		};
+		expect( isIframeForHtmlElement( state ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* New selector `isIframeForHtmlElement`
* New memoized functional component `HtmlIsIframeClassname` which `useSelect`s the new selector & has a side effect of toggling the presence of the `is-iframe` class on the `html` node.
* Mount the component in the `Layout` render

#### Testing instructions

##### Repro case 1 from the issue:

* Open the block editor: https://wordpress.com/block-editor/post/
  * You should be able to scroll the site picker (It's helpful to use a test user with a lot of sites so you can scroll)
* Select a site to create a new post (It's helpful to choose a site which has a lot of posts that you've authored)
* Click the back arrow in the top left to exit the editor.
  * You should be able to scroll the posts list
* Navigate to other Calypso screens
  * You should be able to scroll

##### Repro case 2 from the issue:

* Select one of your posts in the Reader
* Edit the post from the Reader view
* Update the post
* You should be able to scroll as expected.

##### Confirm the new component updates appropriately:

~~Enter the following in your dev console: `localStorage.setItem('debug', 'calypso:layout:html-is-iframe-classname' )` Repeat the above tests cases & monitor the debug output.~~ (Debug statements removed before merging -- revert 6b0fed7 if you'd like to add them back)

Fixes #35305
