### PR TITLE
Update: index.jsx to improve Domain Mapping message in Calypso dashboard to make it more informative.

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -27,7 +27,7 @@ import {
 	MAP_EXISTING_DOMAIN_UPDATE_DNS,
 	MAP_SUBDOMAIN,
 	SETTING_PRIMARY_DOMAIN,
-	MAP_DOMAIN_CHANGE_NAME_SERVERS
+	MAP_DOMAIN_CHANGE_NAME_SERVERS,
 } from 'lib/url/support';
 import {
 	domainManagementEdit,
@@ -185,11 +185,10 @@ export class DomainWarnings extends React.PureComponent {
 				learnMoreUrl = MAP_SUBDOMAIN;
 			} else {
 				text = translate(
-					"ACTION REQUIRED: Please contact your domain registrar to point {{strong}}%(domainName)s's{{/strong}} name server records to WordPress.com.",
+					"Action required: Please contact your domain registrar to point {{strong}}%(domainName)s's{{/strong}} name server records to WordPress.com.",
 					{
 						components: { strong: <strong /> },
 						args: { domainName: domain.name },
-						context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 					}
 				);
 				learnMoreUrl = MAP_DOMAIN_CHANGE_NAME_SERVERS;

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -23,11 +23,11 @@ import { isSubdomain } from 'lib/domains';
 import {
 	CHANGE_NAME_SERVERS,
 	DOMAINS,
-	DOMAIN_HELPER_PREFIX,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	MAP_EXISTING_DOMAIN_UPDATE_DNS,
 	MAP_SUBDOMAIN,
 	SETTING_PRIMARY_DOMAIN,
+	MAP_DOMAIN_CHANGE_NAME_SERVERS
 } from 'lib/url/support';
 import {
 	domainManagementEdit,
@@ -185,14 +185,14 @@ export class DomainWarnings extends React.PureComponent {
 				learnMoreUrl = MAP_SUBDOMAIN;
 			} else {
 				text = translate(
-					"{{strong}}%(domainName)s's{{/strong}} name server records need to be configured.",
+					"ACTION REQUIRED: Please contact your domain registrar to point {{strong}}%(domainName)s's{{/strong}} name server records to WordPress.com.",
 					{
 						components: { strong: <strong /> },
 						args: { domainName: domain.name },
 						context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 					}
 				);
-				learnMoreUrl = DOMAIN_HELPER_PREFIX + domain.name;
+				learnMoreUrl = MAP_DOMAIN_CHANGE_NAME_SERVERS;
 			}
 		} else {
 			offendingList = (

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -133,7 +133,9 @@ describe( 'index', () => {
 			expect( textContent ).toContain( 'contact your domain registrar' );
 			expect(
 				links.some(
-					link => link.href === 'https://en.support.wordpress.com/domain-helper/?host=1.com'
+					link =>
+						link.href ===
+						'https://en.support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers'
 				)
 			).toBeTruthy();
 		} );

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -130,7 +130,7 @@ describe( 'index', () => {
 				textContent = domNode.textContent,
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			expect( textContent ).toContain( 'name server records need to be configured' );
+			expect( textContent ).toContain( 'contact your domain registrar' );
 			expect(
 				links.some(
 					link => link.href === 'https://en.support.wordpress.com/domain-helper/?host=1.com'


### PR DESCRIPTION
The changes proposed are meant to improve the domain mapping message that we display in Calypso at the moment. It is linked to a guide which doesn't help our users much and they have to contact us. Also improved it to make it clear that there is an action required on their part. This is to try and match the text that we send in the automated email too.

Steps to Test:

- Go to Manage -> Domains -> Add domain and map an existing domain.

**Before Change**: 
Message: 

![image](https://user-images.githubusercontent.com/16509219/69473078-387c7900-0dd8-11ea-8d39-de9f4fbeb358.png)

Linked support guide: https://en.support.wordpress.com/domain-helper/?host=erricgunawan.com

**After change**:
Message:
![image](https://user-images.githubusercontent.com/16509219/69473072-21d62200-0dd8-11ea-80ff-a4d224fc5722.png)

Link to support guide: https://en.support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers




*

Fixes  https://github.com/Automattic/wp-calypso/issues/37811
