### PR TITLE
Hosting: Replace loading spinner with busy button when resetting password

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -58,7 +58,7 @@ const SftpCard = ( {
 	// State for clipboard copy button for both username and password data
 	const [ isCopied, setIsCopied ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const [ isPasswordReset, setPasswordReset ] = useState( false );
+	const [ isPasswordLoading, setPasswordLoading ] = useState( false );
 	const usernameIsCopied = isCopied === 'username';
 	const passwordIsCopied = isCopied === 'password';
 	const urlIsCopied = isCopied === 'url';
@@ -71,7 +71,7 @@ const SftpCard = ( {
 	};
 
 	const resetPassword = () => {
-		setPasswordReset( true );
+		setPasswordLoading( true );
 		resetSftpPassword( siteId, currentUserId );
 	};
 
@@ -91,7 +91,7 @@ const SftpCard = ( {
 	useEffect( () => {
 		if ( username === null || username || password ) {
 			setIsLoading( false );
-			setPasswordReset( false );
+			setPasswordLoading( false );
 		}
 	}, [ username, password ] );
 
@@ -121,8 +121,8 @@ const SftpCard = ( {
 				<span>{ translate( 'You must reset your password to view it.' ) }</span>
 				<Button
 					onClick={ resetPassword }
-					disabled={ isPasswordReset }
-					busy={ isPasswordReset }
+					disabled={ isPasswordLoading }
+					busy={ isPasswordLoading }
 					compact
 				>
 					{ translate( 'Reset Password' ) }

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -58,6 +58,7 @@ const SftpCard = ( {
 	// State for clipboard copy button for both username and password data
 	const [ isCopied, setIsCopied ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isPasswordReset, setPasswordReset ] = useState( false );
 	const usernameIsCopied = isCopied === 'username';
 	const passwordIsCopied = isCopied === 'password';
 	const urlIsCopied = isCopied === 'url';
@@ -70,7 +71,7 @@ const SftpCard = ( {
 	};
 
 	const resetPassword = () => {
-		setIsLoading( true );
+		setPasswordReset( true );
 		resetSftpPassword( siteId, currentUserId );
 	};
 
@@ -90,6 +91,7 @@ const SftpCard = ( {
 	useEffect( () => {
 		if ( username === null || username || password ) {
 			setIsLoading( false );
+			setPasswordReset( false );
 		}
 	}, [ username, password ] );
 
@@ -117,7 +119,12 @@ const SftpCard = ( {
 		return (
 			<>
 				<span>{ translate( 'You must reset your password to view it.' ) }</span>
-				<Button onClick={ resetPassword } disabled={ isLoading } compact>
+				<Button
+					onClick={ resetPassword }
+					disabled={ isPasswordReset }
+					busy={ isPasswordReset }
+					compact
+				>
 					{ translate( 'Reset Password' ) }
 				</Button>
 			</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switches the Reset Password feature to use a busy button prop instead of the loading spinner to indicate busy state

#### Testing instructions

* Apply this PR to your local calyspo dev environment
* Go to hosting section for an eligible Atomic site
* Click the reset password button and check that the busy button indicator shows instead of the loading indicator
* Reload the page and check that the loading indicator still shows when sftp details loading
* Open an Atomic site with no sftp user and click the 'Enable' button, and make sure the loading indicator displays as the new user is loading

Before:

![before](https://user-images.githubusercontent.com/3629020/69503431-774c3380-0f7e-11ea-80ca-f67884b6cfa9.gif)

After:

![after](https://user-images.githubusercontent.com/3629020/69503434-84692280-0f7e-11ea-9098-46cf3e9aa1a8.gif)

The faint grey loading bars don't show in above gif unfortunately, but they are there :-)

Fixes #37580
