### PR TITLE
Hosting: Add contextual inline help

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -9,6 +9,7 @@ import { translate } from 'i18n-calypso';
  */
 import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 import { localizeUrl } from 'lib/i18n-utils';
+import { isEnabled } from 'config';
 
 /**
  * Module variables
@@ -906,7 +907,7 @@ const contextLinksForSection = {
 		},
 	],
 	hosting: [
-		{
+		isEnabled( 'hosting/sftp-phpmyadmin' ) && {
 			link: localizeUrl( 'https://en.support.wordpress.com/sftp/' ),
 			post_id: 159771,
 			title: translate( 'SFTP on WordPress.com' ),
@@ -914,12 +915,20 @@ const contextLinksForSection = {
 				"Access and edit your website's files directly by using an SFTP client."
 			),
 		},
-		{
+		isEnabled( 'hosting/sftp-phpmyadmin' ) && {
 			link: localizeUrl( 'https://en.support.wordpress.com/phpmyadmin-and-mysql/' ),
 			post_id: 159822,
 			title: translate( 'phpMyAdmin and MySQL' ),
 			description: translate(
 				'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/php-version-switching/' ),
+			post_id: 160597,
+			title: translate( 'PHP Version Switching' ),
+			description: translate(
+				'Sites on the Business Plan using custom plugins and/or custom themes and any site on the eCommerce Plan, now have the option to switch PHP versions.'
 			),
 		},
 	],

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -905,6 +905,24 @@ const contextLinksForSection = {
 			),
 		},
 	],
+	hosting: [
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/sftp/' ),
+			post_id: 159771,
+			title: translate( 'SFTP Credentials' ),
+			description: translate(
+				"Access and edit your website's files directly by using an SFTP client."
+			),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/database-access/' ),
+			post_id: 159822,
+			title: translate( 'Database Access' ),
+			description: translate(
+				'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'
+			),
+		},
+	],
 };
 
 /*

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -909,15 +909,15 @@ const contextLinksForSection = {
 		{
 			link: localizeUrl( 'https://en.support.wordpress.com/sftp/' ),
 			post_id: 159771,
-			title: translate( 'SFTP Credentials' ),
+			title: translate( 'SFTP on WordPress.com' ),
 			description: translate(
 				"Access and edit your website's files directly by using an SFTP client."
 			),
 		},
 		{
-			link: localizeUrl( 'https://en.support.wordpress.com/database-access/' ),
+			link: localizeUrl( 'https://en.support.wordpress.com/phpmyadmin-and-mysql/' ),
 			post_id: 159822,
-			title: translate( 'Database Access' ),
+			title: translate( 'phpMyAdmin and MySQL' ),
 			description: translate(
 				'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'
 			),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds some contextual inline help links for the new hosting section

#### Testing instructions

* Checkout this PR and open Hosting Configuration Section for an eligible Atomic site
* Click on the inline help button at bottom right
* Check that the help popup shows links for SFTP Credential and Database Access

Before:
<img width="770" alt="Screen Shot 2019-11-25 at 2 21 28 PM" src="https://user-images.githubusercontent.com/3629020/69505452-e598f200-0f8e-11ea-8884-dddb0ba15fb3.png">

After:
<img width="777" alt="Screen Shot 2019-11-25 at 2 15 57 PM" src="https://user-images.githubusercontent.com/3629020/69505430-cbf7aa80-0f8e-11ea-8616-aa91602c0c4f.png">

Fixes #37899
