### PR TITLE
Fix blank screen on signup form 

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -229,10 +229,11 @@ class SignupForm extends Component {
 		const sanitizedUsername = this.sanitizeUsername( fields.username );
 
 		if ( fields.email !== sanitizedEmail || fields.username !== sanitizedUsername ) {
-			onComplete( {
+			const sanitizedFormValues = Object.assign( fields, {
 				email: sanitizedEmail,
 				username: sanitizedUsername,
 			} );
+			onComplete( sanitizedFormValues );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The signup form can sometimes show a blank screen if the email or username field has an unexpected character.
* This PR fixes the issue reported in https://github.com/Automattic/wp-calypso/issues/37908

Why we see a blank screen:

The sanitize function's onComplete callback expects to be sent all the form values, whereas it is being sent only the email and username field values. Thus the password field gets an `undefined` value, thus giving an error [when the length property is used on an undefined value](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/signup-form/index.jsx#L355).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try the scenarios described in the bug report and verify that none of them lead to a blank screen or console error:
    - email value with a capitalized letter
    - username with a single space
    - username with a disallowed character like `+` or `.`
