### PR TITLE
Recurring Payments: "New" badge in Earn section

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -31,12 +31,13 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	title,
 	image,
 	body,
+	badge,
 	actions,
 } ) => {
 	const cta = get( actions, 'cta', null );
 	const learnMoreLink = get( actions, 'learnMoreLink', null );
 	return (
-		<PromoCard isPrimary={ !! isPrimary } title={ title } image={ image }>
+		<PromoCard isPrimary={ !! isPrimary } title={ title } image={ image } badge={ badge }>
 			<p>{ body }</p>
 			{ cta && <PromoCardCta cta={ cta } learnMoreLink={ learnMoreLink } /> }
 		</PromoCard>

--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -13,6 +13,7 @@ import ActionPanelTitle from 'components/action-panel/title';
 import ActionPanelBody from 'components/action-panel/body';
 import PromoCardCta from './cta';
 import classNames from 'classnames';
+import Badge from 'components/badge';
 
 /**
  * Style dependencies
@@ -29,9 +30,10 @@ export interface Props {
 	image?: Image;
 	title: string | TranslateResult;
 	isPrimary?: boolean;
+	badge: string;
 }
 
-const PromoCard: FunctionComponent< Props > = ( { title, image, isPrimary, children } ) => {
+const PromoCard: FunctionComponent< Props > = ( { title, image, isPrimary, children, badge } ) => {
 	const classes = classNames( {
 		'promo-card': true,
 		'is-primary': isPrimary,
@@ -46,6 +48,7 @@ const PromoCard: FunctionComponent< Props > = ( { title, image, isPrimary, child
 			<ActionPanelBody>
 				<ActionPanelTitle className={ classNames( { 'is-primary': isPrimary } ) }>
 					{ title }
+					{ badge && <Badge className="promo-card__title-badge">{ badge }</Badge> }
 				</ActionPanelTitle>
 				{ isPrimary
 					? React.Children.map( children, child => {

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -50,4 +50,9 @@
 			margin: 0 1em 4px 0;
 		}
 	}
+	.promo-card__title-badge {
+		margin-left: 48px;
+		background-color: var( --color-accent-60 );
+		color: var( --color-text-inverted );
+	}
 }

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -142,7 +142,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			badge: 'New',
+			badge: translate( 'New' ),
 			image: {
 				path: '/calypso/images/earn/recurring.svg',
 			},

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -142,6 +142,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
+			badge: 'New',
 			image: {
 				path: '/calypso/images/earn/recurring.svg',
 			},

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -63,7 +63,7 @@ import {
 	SIDEBAR_SECTION_MANAGE,
 } from './constants';
 import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosting';
-
+import Badge from 'components/badge';
 /**
  * Style dependencies
  */
@@ -229,7 +229,9 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackEarnClick }
 				tipTarget="earn"
 				expandSection={ this.expandToolsSection }
-			/>
+			>
+				<Badge type="info">{ translate( 'New' ) }</Badge>
+			</SidebarItem>
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See previous discussion in p8hgLy-2d2-p2  - per @davemart-in  design:

* Introduce "new" badge to this new feature in Earn sidebar button
* Introduce "new" badge inside the earn section

![Zrzut ekranu 2019-11-25 o 13 18 33](https://user-images.githubusercontent.com/3775068/69540128-36f0b380-0f86-11ea-93bf-2ec0ab249577.png)


#### Testing instructions

* Go to Earn section http://calypso.localhost:3000/earn/
* See fabulous "NEW" badges



