### PR TITLE
Plans: remove sales team widget from Plans page in signup

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -33,37 +33,6 @@ import './style.scss';
 
 export class PlansStep extends Component {
 	componentDidMount() {
-		if (
-			typeof window !== 'undefined' &&
-			window.location &&
-			typeof document !== 'undefined' &&
-			document.createElement &&
-			document.body
-		) {
-			if ( window.location.search ) {
-				// save this so that we can enter debug mode in the widget
-				window.salesteam_initial_search_string = window.location.search;
-			}
-
-			const salesTeamStyles = document.createElement( 'link' );
-			salesTeamStyles.setAttribute(
-				'href',
-				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/css/wpcom-salesteam.css?ver=1'
-			);
-			salesTeamStyles.setAttribute( 'rel', 'stylesheet' );
-			salesTeamStyles.setAttribute( 'type', 'text/css' );
-			salesTeamStyles.setAttribute( 'media', 'all' );
-			document.head.appendChild( salesTeamStyles );
-
-			const salesTeamScript = document.createElement( 'script' );
-			salesTeamScript.setAttribute(
-				'src',
-				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190418'
-			);
-			salesTeamScript.setAttribute( 'defer', true );
-			document.head.appendChild( salesTeamScript );
-		}
-
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
 
@@ -227,8 +196,8 @@ PlansStep.propTypes = {
  * Checks if the domainItem picked in the domain step is a top level .blog domain -
  * we only want to make Blogger plan available if it is.
  *
- * @param {Object} domainItem domainItem object stored in the "choose domain" step
- * @return {bool} is .blog domain registration
+ * @param {object} domainItem domainItem object stored in the "choose domain" step
+ * @returns {boolean} is .blog domain registration
  */
 export const isDotBlogDomainRegistration = domainItem => {
 	if ( ! domainItem ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* removes the Sales Team Widget from the the Plans page in signup

#### Testing instructions

* go through the signup flow
* (especially on the Plans page,) ensure that the Sales Team Widget script and style files are not requested in the Network tab
