### PR TITLE
composite-checkout: Disable submit button when form is incomplete

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/button.js
+++ b/packages/composite-checkout-wpcom/src/components/button.js
@@ -12,6 +12,7 @@ export default function Button( {
 	className,
 	fullWidth,
 	children,
+	...props
 } ) {
 	return (
 		<CallToAction
@@ -21,6 +22,7 @@ export default function Button( {
 			onClick={ onClick }
 			className={ className }
 			fullWidth={ fullWidth }
+			{ ...props }
 		>
 			{ children }
 		</CallToAction>
@@ -72,7 +74,7 @@ const CallToAction = styled.button`
 		color: ${ getTextColor };
 	}
 
-	img {
+	svg {
 		margin-bottom: -1px;
 		transform: translateY(2px);
 		filter: ${ getImageFilter }
@@ -136,9 +138,6 @@ function getRollOverBorderColor( { buttonState, buttonType, theme } ) {
 		case 'secondary':
 			return colors.highlightBorder;
 		case 'disabled':
-			if ( buttonType === 'paypal' ) {
-				return colors.disabledPaymentButtons;
-			}
 			return colors.disabledButtons;
 		default:
 			return colors.borderColorDark;
@@ -195,9 +194,6 @@ function getBorderColor( { buttonType, buttonState, theme } ) {
 		case 'secondary':
 			return colors.highlightBorder;
 		case 'disabled':
-			if ( buttonType === 'paypal' || buttonType === 'apple-pay' ) {
-				return colors.disabledPaymentButtons;
-			}
 			return colors.disabledButtons;
 		default:
 			return colors.borderColor;

--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -74,7 +74,7 @@ const CallToAction = styled.button`
 		color: ${ getTextColor };
 	}
 
-	img {
+	svg {
 		margin-bottom: -1px;
 		transform: translateY(2px);
 		filter: ${ getImageFilter }
@@ -138,9 +138,6 @@ function getRollOverBorderColor( { buttonState, buttonType, theme } ) {
 		case 'secondary':
 			return colors.highlightBorder;
 		case 'disabled':
-			if ( buttonType === 'paypal' ) {
-				return colors.disabledPaymentButtons;
-			}
 			return colors.disabledButtons;
 		default:
 			return colors.borderColorDark;
@@ -197,9 +194,6 @@ function getBorderColor( { buttonType, buttonState, theme } ) {
 		case 'secondary':
 			return colors.highlightBorder;
 		case 'disabled':
-			if ( buttonType === 'paypal' || buttonType === 'apple-pay' ) {
-				return colors.disabledPaymentButtons;
-			}
 			return colors.disabledButtons;
 		default:
 			return colors.borderColor;

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -83,7 +83,7 @@ export function ApplePayLabel() {
 	);
 }
 
-export function ApplePaySubmitButton() {
+export function ApplePaySubmitButton( { disabled } ) {
 	const localize = useLocalize();
 	const { onSuccess } = useCheckoutHandlers();
 	const paymentRequestOptions = usePaymentRequestOptions();
@@ -103,7 +103,14 @@ export function ApplePaySubmitButton() {
 		);
 	}
 
-	return <PaymentRequestButton paymentRequest={ paymentRequest } paymentType="apple-pay" />;
+	return (
+		<PaymentRequestButton
+			disabled={ disabled }
+			disabledReason={ disabled && localize( 'The form is not complete' ) }
+			paymentRequest={ paymentRequest }
+			paymentType="apple-pay"
+		/>
+	);
 }
 
 export function ApplePaySummary() {

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -36,7 +36,7 @@ export function CreditCardLabel() {
 	);
 }
 
-export function CreditCardSubmitButton() {
+export function CreditCardSubmitButton( { disabled } ) {
 	const localize = useLocalize();
 	const [ , total ] = useLineItems();
 	const buttonString = sprintf(
@@ -44,7 +44,12 @@ export function CreditCardSubmitButton() {
 		renderDisplayValueMarkdown( total.amount.displayValue )
 	);
 	return (
-		<Button onClick={ submitCreditCardPayment } buttonState="primary" fullWidth>
+		<Button
+			disabled={ disabled }
+			onClick={ submitCreditCardPayment }
+			buttonState="primary"
+			fullWidth
+		>
 			{ buttonString }
 		</Button>
 	);

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -47,7 +47,7 @@ export function CreditCardSubmitButton( { disabled } ) {
 		<Button
 			disabled={ disabled }
 			onClick={ submitCreditCardPayment }
-			buttonState="primary"
+			buttonState={ disabled ? 'disabled' : 'primary' }
 			fullWidth
 		>
 			{ buttonString }

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -123,7 +123,7 @@ export function PaypalSubmitButton( { disabled } ) {
 		<Button
 			disabled={ disabled }
 			onClick={ onClick }
-			buttonState="primary"
+			buttonState={ disabled ? 'disabled' : 'primary' }
 			buttonType="paypal"
 			fullWidth
 		>

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -102,7 +102,7 @@ export function PaypalLabel() {
 	);
 }
 
-export function PaypalSubmitButton() {
+export function PaypalSubmitButton( { disabled } ) {
 	const { submitPaypalPayment } = useDispatch( 'paypal' );
 	const [ items ] = useLineItems();
 	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
@@ -120,7 +120,13 @@ export function PaypalSubmitButton() {
 			domainDetails: null, // TODO: get this somehow
 		} );
 	return (
-		<Button onClick={ onClick } buttonState="primary" buttonType="paypal" fullWidth>
+		<Button
+			disabled={ disabled }
+			onClick={ onClick }
+			buttonState="primary"
+			buttonType="paypal"
+			fullWidth
+		>
 			{ <ButtonPayPalIcon /> }
 		</Button>
 	);

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -512,7 +512,7 @@ function LockIcon( { className } ) {
 	);
 }
 
-function StripePayButton() {
+function StripePayButton( { disabled } ) {
 	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
 	const { onSuccess, onFailure } = useCheckoutHandlers();
@@ -559,6 +559,7 @@ function StripePayButton() {
 	);
 	return (
 		<Button
+			disabled={ disabled }
 			onClick={ () =>
 				submitStripePayment( {
 					billing,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -574,7 +574,7 @@ function StripePayButton( { disabled } ) {
 					beginStripeTransaction,
 				} )
 			}
-			buttonState="primary"
+			buttonState={ disabled ? 'disabled' : 'primary' }
 			fullWidth
 		>
 			{ buttonString }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the checkout form is incomplete, the payment method's submit button component is passed the `disabled` attribute. However, that attribute was not being used by any of the payment methods. This change passes that attribute along to each payment method's submit button.

#### Testing instructions

- Add a file called `packages/composite-checkout/demo/private.js` and inside it put the following: `export const stripeKey = 'TEST KEY HERE'`;
- Run `npm run composite-checkout-demo`.
- Try clicking the submit button and be sure it is disabled (its UI may not look disabled, but this is a separate issue). Try it with each payment method.
