### PR TITLE
composite-checkout: Fill in demo contact form

### DIFF
--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -132,7 +132,7 @@ const getTotal = items => {
 	};
 };
 
-// TODO: replace this with the host page's translation system
+// Replace this with the host page's translation system
 const useLocalize = () => text => text;
 const hostTranslate = text => text;
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -15,6 +15,7 @@ import {
 	createApplePayMethod,
 	createCreditCardMethod,
 	useIsStepActive,
+	usePaymentData,
 	getDefaultPaymentMethodStep,
 	getDefaultOrderSummaryStep,
 	getDefaultOrderReviewStep,
@@ -140,9 +141,26 @@ const ContactFormTitle = () => {
 	return isActive ? localize( 'Enter your billing details' ) : localize( 'Billing details' );
 };
 
-function ContactForm() {
-	// TODO: define one for this demo
-	return <span>TODO</span>;
+function ContactForm( { summary } ) {
+	const [ paymentData, changePaymentData ] = usePaymentData();
+	const { billing = {} } = paymentData;
+	const { country = '' } = billing;
+	const onChangeCountry = event =>
+		changePaymentData( 'billing', { ...billing, country: event.target.value } );
+	if ( summary ) {
+		return (
+			<div>
+				<div>Country</div>
+				<span>{ country }</span>
+			</div>
+		);
+	}
+	return (
+		<div>
+			<label htmlFor="country">Country</label>
+			<input id="country" type="text" value={ country } onChange={ onChangeCountry } />
+		</div>
+	);
 }
 
 const steps = [
@@ -157,10 +175,9 @@ const steps = [
 		className: 'checkout__billing-details-step',
 		hasStepNumber: true,
 		titleContent: <ContactFormTitle />,
-		activeStepContent: <ContactForm isComplete={ false } isActive={ true } />,
-		completeStepContent: <ContactForm summary isComplete={ true } isActive={ false } />,
+		activeStepContent: <ContactForm />,
+		completeStepContent: <ContactForm summary />,
 		isCompleteCallback: ( { paymentData } ) => {
-			// TODO: Make sure the form is complete
 			const { billing = {} } = paymentData;
 			if ( ! billing.country ) {
 				return false;
@@ -168,7 +185,6 @@ const steps = [
 			return true;
 		},
 		isEditableCallback: ( { paymentData } ) => {
-			// TODO: Return true if the form is empty
 			if ( paymentData.billing ) {
 				return true;
 			}

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -5,6 +5,7 @@ require( '@babel/polyfill' );
  * External dependencies
  */
 import React, { useState, useEffect, useMemo } from 'react';
+import styled from '@emotion/styled';
 import ReactDOM from 'react-dom';
 import {
 	Checkout,
@@ -141,6 +142,37 @@ const ContactFormTitle = () => {
 	return isActive ? localize( 'Enter your billing details' ) : localize( 'Billing details' );
 };
 
+const Label = styled.label`
+	display: block;
+	color: ${props => props.theme.colors.textColor};
+	font-weight: ${props => props.theme.weights.bold};
+	font-size: 14px;
+	margin-bottom: 8px;
+
+	:hover {
+		cursor: ${props => ( props.disabled ? 'default' : 'pointer' )};
+	}
+`;
+
+const Input = styled.input`
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	font-size: 16px;
+	border: 1px solid
+		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
+	padding: 13px 10px 12px 10px;
+
+	:focus {
+		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
+			solid 2px !important;
+	}
+`;
+
+const Form = styled.div`
+	margin-bottom: 0.5em;
+`;
+
 function ContactForm( { summary } ) {
 	const [ paymentData, changePaymentData ] = usePaymentData();
 	const { billing = {} } = paymentData;
@@ -156,10 +188,10 @@ function ContactForm( { summary } ) {
 		);
 	}
 	return (
-		<div>
-			<label htmlFor="country">Country</label>
-			<input id="country" type="text" value={ country } onChange={ onChangeCountry } />
-		</div>
+		<Form>
+			<Label htmlFor="country">Country</Label>
+			<Input id="country" type="text" value={ country } onChange={ onChangeCountry } />
+		</Form>
 	);
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the WPCOM contact form was extracted in #37838, the contact form was left empty. This change adds a basic country field so that the contact form in the demo page works again.

#### Testing instructions

- Add a file called `packages/composite-checkout/demo/private.js` and inside it put the following: `export const stripeKey = 'TEST KEY HERE'`;
- Run `npm run composite-checkout-demo`.
- Verify that the form works as expected, particularly the contact form. The "continue" button should be disabled until the country field is filled in.
