### PR TITLE
G Suite: Add discount support via sales coupons

### DIFF
--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
+import Badge from 'components/badge';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
 
 /**
@@ -79,14 +80,14 @@ const GSuitePrice = ( { currencyCode, product } ) => {
 				</h5>
 
 				{ isDiscounted && (
-					<h6 className="gsuite-price__discounted-price">
+					<Badge type="success">
 						{ translate( '%(price)s for your first year', {
 							args: {
 								price: getAnnualPrice( product.sale_cost, currencyCode ),
 							},
 							comment: "Discounted annual price formatted with the currency (e.g. '$80')"
 						} ) }
-					</h6>
+					</Badge>
 				) }
 			</div>
 		);

--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
@@ -8,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
 
 /**
@@ -15,16 +17,84 @@ import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
  */
 import './style.scss';
 
+/**
+ * Determines whether a discount can be applied to the specified product via a sales coupon.
+ *
+ * @param {object} product - G Suite product
+ * @returns {boolean} - true if a discount can be applied, false otherwise
+ */
+const hasValidDiscount = ( product ) => {
+	if (
+		! product ||
+		! product.sale_cost ||
+		! product.sale_coupon ||
+		! product.sale_coupon.start_date ||
+		! product.sale_coupon.expires
+	) {
+		return false;
+	}
+
+	const currentTime = Date.now();
+	const startDate = new Date( product.sale_coupon.start_date );
+	const endDate = new Date( product.sale_coupon.expires );
+
+	return currentTime >= startDate && currentTime <= endDate;
+};
+
 const GSuitePrice = ( { currencyCode, product } ) => {
 	const translate = useTranslate();
 
 	const cost = product?.cost ?? null;
-	const annualPrice = cost && currencyCode ? getAnnualPrice( cost, currencyCode ) : '-';
-	const monthlyPrice = cost && currencyCode ? getMonthlyPrice( cost, currencyCode ) : '-';
+
+	const annualPrice = getAnnualPrice( cost, currencyCode );
+	const monthlyPrice = getMonthlyPrice( cost, currencyCode );
+
+	if ( abtest( 'gsuitePrice' ) === 'discount' ) {
+		const isDiscounted = hasValidDiscount( product );
+
+		return (
+			<div className="gsuite-price">
+				<h4 className="gsuite-price__monthly-price">
+					{ translate( '{{strong}}%(price)s{{/strong}} per user/month', {
+						args: {
+							price: monthlyPrice,
+						},
+						components: {
+							strong: <strong />,
+						},
+						comment: "Monthly price per user formatted with the currency (e.g. '$8.40')",
+					} ) }
+				</h4>
+
+				<h5 className={ classNames( {
+					'gsuite-price__annual-price': true,
+					'discounted': isDiscounted
+				} ) }>
+					{ translate( '%(price)s billed annually', {
+						args: {
+							price: annualPrice,
+						},
+						comment: "Annual price formatted with the currency (e.g. '$99.99')"
+					} ) }
+				</h5>
+
+				{ isDiscounted && (
+					<h6 className="gsuite-price__discounted-price">
+						{ translate( '%(price)s for your first year', {
+							args: {
+								price: getAnnualPrice( product.sale_cost, currencyCode ),
+							},
+							comment: "Discounted annual price formatted with the currency (e.g. '$80')"
+						} ) }
+					</h6>
+				) }
+			</div>
+		);
+	}
 
 	return (
 		<div className="gsuite-price">
-			<h4 className="gsuite-price__price-per-user">
+			<h4 className="gsuite-price__price-per-user-per-month">
 				<span>
 					{ translate( '{{strong}}%(price)s{{/strong}} per user / month', {
 						components: {
@@ -37,7 +107,7 @@ const GSuitePrice = ( { currencyCode, product } ) => {
 				</span>
 			</h4>
 
-			<h5 className="gsuite-price__annual-price">
+			<h5 className="gsuite-price__price-per-user-per-year">
 				{ translate( '%(price)s billed yearly', {
 					args: {
 						price: annualPrice,

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -1,4 +1,37 @@
-.gsuite-price__price-per-user {
+.gsuite-price__monthly-price {
+	font-size: 18px;
+	font-weight: 500;
+
+	strong {
+		font-size: 24px;
+		font-weight: normal;
+	}
+}
+
+.gsuite-price__annual-price {
+	color: var( --color-text-subtle );
+	display: inline-block;
+	font-size: 12px;
+
+	&.discounted {
+		margin-right: 7px;
+		text-decoration: line-through;
+	}
+}
+
+.gsuite-price__discounted-price {
+	background: var( --color-success );
+	border-radius: 10px;
+	color: var( --color-text-inverted );
+	display: inline-block;
+	font-size: 13px;
+	height: 21px;
+	padding-left: 8px;
+	padding-right: 8px;
+	vertical-align: middle;
+}
+
+.gsuite-price__price-per-user-per-month {
 	strong {
 		color: var( --color-text );
 		font-size: 24px;
@@ -12,7 +45,7 @@
 	}
 }
 
-.gsuite-price__annual-price {
+.gsuite-price__price-per-user-per-year {
 	color: var( --color-text-subtle );
 	font-size: 13px;
 	font-style: italic;

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -11,24 +11,11 @@
 .gsuite-price__annual-price {
 	color: var( --color-text-subtle );
 	display: inline-block;
-	font-size: 12px;
 
 	&.discounted {
 		margin-right: 7px;
 		text-decoration: line-through;
 	}
-}
-
-.gsuite-price__discounted-price {
-	background: var( --color-success );
-	border-radius: 10px;
-	color: var( --color-text-inverted );
-	display: inline-block;
-	font-size: 13px;
-	height: 21px;
-	padding-left: 8px;
-	padding-right: 8px;
-	vertical-align: middle;
 }
 
 .gsuite-price__price-per-user-per-month {

--- a/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`GSuitePrice renders correctly 1`] = `
   className="gsuite-price"
 >
   <h4
-    className="gsuite-price__price-per-user"
+    className="gsuite-price__price-per-user-per-month"
   >
     <span>
       <strong>
@@ -15,7 +15,7 @@ exports[`GSuitePrice renders correctly 1`] = `
     </span>
   </h4>
   <h5
-    className="gsuite-price__annual-price"
+    className="gsuite-price__price-per-user-per-year"
   >
     €76 billed yearly
   </h5>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,4 +123,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	gsuitePrice: {
+		datestamp: '20191125',
+		variations: {
+			discount: 0,
+			control: 100,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import formatCurrency from '@automattic/format-currency';
-import { endsWith, get, includes, some, sortBy } from 'lodash';
+import { endsWith, get, includes, isNumber, isString, some, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -63,13 +63,18 @@ function formatPrice( cost, currencyCode, options = {} ) {
 }
 
 /**
- * Gets the formatted annual cost
+ * Formats the specified yearly price.
  *
- * @param {Number} cost - cost
- * @param {String} currencyCode - currency code to format with
- * @returns {String} - Formatted Annual price
+ * @param {number} cost - yearly cost (e.g. '99.99')
+ * @param {string} currencyCode - code of the currency (e.g. 'USD')
+ * @param {string} defaultValue - value to return when the price can't be determined
+ * @returns {string} - the yearly price formatted (e.g. '$99.99'), otherwise the default value
  */
-function getAnnualPrice( cost, currencyCode ) {
+function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
+	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
+		return defaultValue;
+	}
+
 	return formatPrice( cost, currencyCode );
 }
 
@@ -140,13 +145,18 @@ function getLoginUrlWithTOSRedirect( email, domain ) {
 }
 
 /**
- * Gets the formatted monthly cost
+ * Computes and formats the monthly price from the specified yearly price.
  *
- * @param {Number} cost - cost
- * @param {String} currencyCode - currency code to format with
- * @returns {String} - Formatted Monthly price, rounded to the nearest tenth
+ * @param {number} cost - yearly cost (e.g. '99.99')
+ * @param {string} currencyCode - code of the currency (e.g. 'USD')
+ * @param {string} defaultValue - value to return when the price can't be determined
+ * @returns {string} - the monthly price rounded to the nearest tenth (e.g. '$8.40'), otherwise the default value
  */
-function getMonthlyPrice( cost, currencyCode ) {
+function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
+	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
+		return defaultValue;
+	}
+
 	return formatPrice( cost / 12, currencyCode, { precision: 1 } );
 }
 
@@ -216,7 +226,6 @@ function isGSuiteRestricted() {
 
 export {
 	canDomainAddGSuite,
-	formatPrice,
 	getAnnualPrice,
 	getEligibleGSuiteDomain,
 	getGSuiteSettingsUrl,

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -18,9 +18,9 @@ const GSUITE_LINK_PREFIX = 'https://mail.google.com/a/';
 /**
  * Applies a precision to the cost
  *
- * @param {Number} cost - cost
- * @param {Number} precision - precision to apply to cost
- * @returns {String} - Returns price with applied precision
+ * @param {number} cost - cost
+ * @param {number} precision - precision to apply to cost
+ * @returns {string} - Returns price with applied precision
  */
 function applyPrecision( cost, precision ) {
 	const exponent = Math.pow( 10, precision );
@@ -30,8 +30,8 @@ function applyPrecision( cost, precision ) {
 /**
  * Can a domain add G Suite
  *
- * @param {String} domainName - domainname
- * @returns {Boolean} -Can a domain add G Suite
+ * @param {string} domainName - domainname
+ * @returns {boolean} -Can a domain add G Suite
  */
 function canDomainAddGSuite( domainName ) {
 	const GOOGLE_APPS_INVALID_SUFFIXES = [ '.in', '.wpcomstaging.com' ];
@@ -49,10 +49,10 @@ function canDomainAddGSuite( domainName ) {
 /**
  * Formats price given cost and currency
  *
- * @param {Number} cost - cost
- * @param {String} currencyCode - currency code to format with
- * @param {Object} options - options containing precision
- * @returns {String} - Returns a formatted price
+ * @param {number} cost - cost
+ * @param {string} currencyCode - currency code to format with
+ * @param {object} options - options containing precision
+ * @returns {string} - Returns a formatted price
  */
 function formatPrice( cost, currencyCode, options = {} ) {
 	if ( undefined !== options.precision ) {
@@ -85,9 +85,9 @@ function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
  *   - The primary domain of the site, if eligible
  *   - The first non-primary domain eligible found
  *
- * @param {String} selectedDomainName - domain name for the site currently selected by the user
+ * @param {string} selectedDomainName - domain name for the site currently selected by the user
  * @param {Array} domains - list of domain objects
- * @returns {String} - the name of the first eligible domain found
+ * @returns {string} - the name of the first eligible domain found
  */
 function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 	if ( selectedDomainName && canDomainAddGSuite( selectedDomainName ) ) {
@@ -129,9 +129,9 @@ function getGSuiteSupportedDomains( domains ) {
 /**
  * Creates the Google ToS redirect url given email and domain
  *
- * @param {String} email - email
- * @param {String} domain - domain name
- * @returns {String} - ToS url redirect
+ * @param {string} email - email
+ * @param {string} domain - domain name
+ * @returns {string} - ToS url redirect
  */
 function getLoginUrlWithTOSRedirect( email, domain ) {
 	return (
@@ -163,8 +163,8 @@ function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
 /**
  * Returns G Suite management url
  *
- * @param {String} domainName - domain name
- * @returns {String} - Returns G Suite settings url
+ * @param {string} domainName - domain name
+ * @returns {string} - Returns G Suite settings url
  */
 function getGSuiteSettingsUrl( domainName ) {
 	return GSUITE_LINK_PREFIX + domainName;
@@ -173,8 +173,8 @@ function getGSuiteSettingsUrl( domainName ) {
 /**
  * Given a domain object, does that domain have G Suite with us.
  *
- * @param {Object} domain - domain object
- * @returns {Boolean} - true if the domain is under our management, false otherwise
+ * @param {object} domain - domain object
+ * @returns {boolean} - true if the domain is under our management, false otherwise
  */
 function hasGSuiteWithUs( domain ) {
 	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
@@ -185,8 +185,8 @@ function hasGSuiteWithUs( domain ) {
 /**
  * Given a domain object, does that domain have G Suite with another provider.
  *
- * @param {Object} domain - domain object
- * @returns {Boolean} - true if the domain is with another provider, false otherwise
+ * @param {object} domain - domain object
+ * @returns {boolean} - true if the domain is with another provider, false otherwise
  */
 function hasGSuiteWithAnotherProvider( domain ) {
 	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
@@ -198,7 +198,7 @@ function hasGSuiteWithAnotherProvider( domain ) {
  * Given a list of domains does one of them support G Suite
  *
  * @param {Array} domains - list of domain objects
- * @returns {Boolean} - Does list of domains contain a G Suited supported domain
+ * @returns {boolean} - Does list of domains contain a G Suited supported domain
  */
 function hasGSuiteSupportedDomain( domains ) {
 	return getGSuiteSupportedDomains( domains ).length > 0;
@@ -207,8 +207,8 @@ function hasGSuiteSupportedDomain( domains ) {
 /**
  * Does a domain have pending G Suite Users
  *
- * @param {Object} domain - domain object
- * @returns {Boolean} - Does domain have pending G Suite users
+ * @param {object} domain - domain object
+ * @returns {boolean} - Does domain have pending G Suite users
  */
 function hasPendingGSuiteUsers( domain ) {
 	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
@@ -217,7 +217,7 @@ function hasPendingGSuiteUsers( domain ) {
 /**
  * Is the user G Suite restricted
  *
- * @returns {Boolean} - Is the user G Suite restricted
+ * @returns {boolean} - Is the user G Suite restricted
  */
 function isGSuiteRestricted() {
 	const user = userFactory();

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -3,7 +3,9 @@
  */
 import {
 	canDomainAddGSuite,
+	getAnnualPrice,
 	getEligibleGSuiteDomain,
+	getMonthlyPrice,
 	getGSuiteSupportedDomains,
 	hasGSuiteSupportedDomain,
 	hasGSuiteWithUs,
@@ -33,6 +35,42 @@ describe( 'index', () => {
 
 		test( 'returns false when domain has banned phrase', () => {
 			expect( canDomainAddGSuite( 'foobargoogle.blog' ) ).toEqual( false );
+		} );
+	} );
+
+	describe( '#getAnnualPrice', () => {
+		test( 'returns default value when no parameter provided', () => {
+			expect( getAnnualPrice() ).toEqual( '-' );
+		} );
+
+		test( 'returns default value when only default value provided', () => {
+			expect( getAnnualPrice( null, null, '' ) ).toEqual( '' );
+		} );
+
+		test( 'returns valid monthly price when cost is integer', () => {
+			expect( getAnnualPrice( 120, 'EUR' ) ).toEqual( '€120' );
+		} );
+
+		test( 'returns valid monthly price when cost is float', () => {
+			expect( getAnnualPrice( 99.99, 'USD' ) ).toEqual( '$99.99' );
+		} );
+	} );
+
+	describe( '#getMonthlyPrice', () => {
+		test( 'returns default value when no parameter provided', () => {
+			expect( getMonthlyPrice() ).toEqual( '-' );
+		} );
+
+		test( 'returns default value when only default value provided', () => {
+			expect( getMonthlyPrice( null, null, '/' ) ).toEqual( '/' );
+		} );
+
+		test( 'returns valid monthly price when cost is integer', () => {
+			expect( getMonthlyPrice( 120, 'EUR' ) ).toEqual( '€10' );
+		} );
+
+		test( 'returns valid monthly price when cost is float', () => {
+			expect( getMonthlyPrice( 99.99, 'USD' ) ).toEqual( '$8.40' );
 		} );
 	} );
 

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -36,7 +36,7 @@
 
 	@include breakpoint( '>1040px' ) {
 		flex-basis: 100%;
-		max-width: 400px;
+		max-width: 410px;
 	}
 }
 

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -40,7 +40,7 @@ exports[`GSuitePurchaseCta renders correctly 1`] = `
           className="gsuite-price"
         >
           <h4
-            className="gsuite-price__price-per-user"
+            className="gsuite-price__price-per-user-per-month"
           >
             <span>
               <strong>
@@ -50,7 +50,7 @@ exports[`GSuitePurchaseCta renders correctly 1`] = `
             </span>
           </h4>
           <h5
-            className="gsuite-price__annual-price"
+            className="gsuite-price__price-per-user-per-year"
           >
             €76 billed yearly
           </h5>


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/37776 which adds support for **discounts** provided via **sales coupon** to the G Suite Upsell and `Email` pages. It introduces this feature behind an A/B test that acts as a feature gate, thus allowing us to declare all the strings that need to be translated before deploying the change to all users. Ultimately, the display of the price will be driven by the sales coupon provided by the API, and which is only valid for a certain duration.

Old (control) | New (without discount) | New (with discount)
------ | ----- | -----
![01](https://user-images.githubusercontent.com/594356/69556382-e5a3ec80-0fa4-11ea-8f89-9812d282b6d9.png) | ![02](https://user-images.githubusercontent.com/594356/69556401-ea68a080-0fa4-11ea-8514-5fafc11f3989.png) | ![03](https://user-images.githubusercontent.com/594356/69556402-eb013700-0fa4-11ea-8218-8cf668795ccb.png)

#### Testing instructions

> Note you can select a variation of the `gsuitePrice` A/B test from the development environment badge (see p4TIVU-3pQ-p2 for more information). You will have to apply the server-side patch 231db-pb in order for the API to return a sales coupon for G Suite.

1. Run `git checkout add/gsuite-discount-support` and start your server, or open a [live branch](https://calypso.live/?branch=add/gsuite-discount-support)
2. Log in to an account that has a site without G Suite
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Assert that the pricing block is displayed as in the screenshots above
5. Navigate to the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
6. Select any domain in order to be redirected to the Upsell page
7. Assert that the pricing block is displayed as in the screenshots above
8. Log out, then [sign up](http://calypso.localhost:3000/start) for a new account
9. Select a plan with a domain during signup in order to be presented with the Upsell page
10. Assert that the pricing block is displayed as in the screenshots above

/cc @fditrapani 