### PR TITLE
Config: Enable Jetpack Backups in Production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -85,7 +85,7 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-backup": false,
+		"plans/jetpack-backup": true,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Config: Enable Jetpack Backups in Production

#### Testing instructions

* No testing needed. If you wish, smoke test Jetpack Backups on staging.
