### PR TITLE
My Plan Card: Don't show the icon if we are still displaying the placeholder

### DIFF
--- a/client/my-sites/plans/current-plan/my-plan-card/index.jsx
+++ b/client/my-sites/plans/current-plan/my-plan-card/index.jsx
@@ -26,7 +26,9 @@ const MyPlanCard = ( { action, isError, isPlaceholder, details, product, tagline
 	return (
 		<Card className={ cardClassNames } compact>
 			<div className="my-plan-card__primary">
-				<div className="my-plan-card__icon">{ product && <ProductIcon product={ product } /> }</div>
+				<div className="my-plan-card__icon">
+					{ ! isPlaceholder && product && <ProductIcon product={ product } /> }
+				</div>
 				<div className="my-plan-card__header">
 					{ title && <h2 className="my-plan-card__title">{ title }</h2> }
 					{ tagline && <p className="my-plan-card__tagline">{ tagline }</p> }


### PR DESCRIPTION
Under some conditions the loading of the My Plan Card looks off. This PR fixes it by making sure that we load the whole card before we show the icon.

#### Changes proposed in this Pull Request
Before:

<img width="695" alt="Screen Shot 2019-11-25 at 9 17 46 PM" src="https://user-images.githubusercontent.com/115071/69575190-09c5f480-0fca-11ea-80c9-1dd724452226.png">

After:
<img width="703" alt="Screen Shot 2019-11-25 at 9 17 19 PM" src="https://user-images.githubusercontent.com/115071/69575203-0df21200-0fca-11ea-9a51-14e9f346468f.png">


#### Testing instructions

I tested this by forcing the isPlaceholder on the My Products section to always return true. 
This way I don't have to make meet the condition in a different way. 
