### PR TITLE
Add right/left alignment to nav block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
@@ -24,7 +24,7 @@ registerBlockType( 'a8c/navigation-menu', {
 	icon,
 	category: 'layout',
 	supports: {
-		align: [ 'wide', 'full' ],
+		align: [ 'wide', 'full', 'right', 'left' ],
 		html: false,
 		reusable: false,
 	},

--- a/apps/full-site-editing/package-lock.json
+++ b/apps/full-site-editing/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "0.14.0",
+	"version": "0.15.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
cc @Copons 

Add right/left alignment to the nav block. This lets us put the block beside other blocks.

The theme styles are still rough, but as you can see the nav block shows inline with the social links block. I just had to "align" it right. Otherwise, it is impossible to align the nav block with that block in the editor.

<img width="1919" alt="Screen Shot 2019-11-25 at 7 59 34 PM" src="https://user-images.githubusercontent.com/6265975/69598481-4c81cf80-0fbe-11ea-8e82-3f3894e5f44f.png">
