### PR TITLE
CircleCI: Enforce strict TypeScript typechecking for Gutenboarding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,14 @@ jobs:
           # Report but don't fail the build (`|| exit 0`)
           command: npm run typecheck || exit 0
 
+  typecheck-strict:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - prepare
+      - run:
+          name: TypeScript strict typecheck of individual subprojects
+          command: npm run typecheck -- --project client/landing/gutenboarding
 
   lint-and-translate:
     <<: *defaults
@@ -677,6 +685,9 @@ workflows:
           requires:
             - setup
       - typecheck:
+          requires:
+            - setup
+      - typecheck-strict:
           requires:
             - setup
       - wait-calypso-live:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

CircleCI: Enforce strict TypeScript typechecking for Gutenboarding

#### Testing instructions

CircleCI should be all-green, especially for the `typecheck-strict` task.

/cc @sirreal 