### PR TITLE
Jetpack Checklist: Add My checklist heading

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/header.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/header.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,24 +11,33 @@ import Card from 'components/card';
 import CardHeading from 'components/card-heading';
 
 const JetpackChecklistHeader = ( { isPaidPlan, translate } ) => (
-	<Card compact className="jetpack-checklist__header">
-		<img
-			className="jetpack-checklist__header-illustration"
-			alt=""
-			aria-hidden="true"
-			src="/calypso/images/illustrations/security.svg"
-		/>
-		<div className="jetpack-checklist__header-content">
-			<CardHeading>
-				{ translate( "Let's start by securing your site with a few essential security features" ) }
-			</CardHeading>
-			{ isPaidPlan && (
-				<p>
-					{ translate( 'These security features ensure that your site is secured and backed up.' ) }
-				</p>
-			) }
-		</div>
-	</Card>
+	<Fragment>
+		<Card compact className="jetpack-checklist__top">
+			<strong>{ translate( 'My Checklist' ) }</strong>
+		</Card>
+		<Card compact className="jetpack-checklist__header">
+			<img
+				className="jetpack-checklist__header-illustration"
+				alt=""
+				aria-hidden="true"
+				src="/calypso/images/illustrations/security.svg"
+			/>
+			<div className="jetpack-checklist__header-content">
+				<CardHeading>
+					{ translate(
+						"Let's start by securing your site with a few essential security features"
+					) }
+				</CardHeading>
+				{ isPaidPlan && (
+					<p>
+						{ translate(
+							'These security features ensure that your site is secured and backed up.'
+						) }
+					</p>
+				) }
+			</div>
+		</Card>
+	</Fragment>
 );
 
 export default localize( JetpackChecklistHeader );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -1,3 +1,7 @@
+.jetpack-checklist__top {
+	margin-top: 40px;
+}
+
 .jetpack-checklist {
 	margin-bottom: 80px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update the design of the My plans page to include more padding as per design. 

Before:
<img width="1099" alt="Screen Shot 2019-11-26 at 10 39 41 AM" src="https://user-images.githubusercontent.com/115071/69617795-103f8500-1039-11ea-8bc5-137be8f1f3ae.png">

After:
<img width="797" alt="Screen Shot 2019-11-26 at 10 36 42 AM" src="https://user-images.githubusercontent.com/115071/69617804-146ba280-1039-11ea-8118-18557e0329d6.png">

I force the notice to show up. By faking the error. 

#### Testing instructions

* Visit my plans page for jetpack site. 
* Does everything still look as expected.


