### PR TITLE
Domains: fix removing default WPCOM records when adding custom A record

### DIFF
--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -3,6 +3,7 @@
  */
 import {
 	filter,
+	find,
 	findIndex,
 	matches,
 	negate,
@@ -43,9 +44,9 @@ function isNsRecord( domain ) {
 }
 
 function removeDuplicateWpcomRecords( domain, records ) {
-	const rootARecords = filter( records, isRootARecord( domain ) ),
-		wpcomARecord = find( rootARecords, isWpcomRecord ),
-		customARecord = find( rootARecords, negate( isWpcomRecord ) );
+	const rootARecords = filter( records, isRootARecord( domain ) );
+	const wpcomARecord = find( rootARecords, isWpcomRecord );
+	const customARecord = find( rootARecords, negate( isWpcomRecord ) );
 
 	if ( wpcomARecord && customARecord ) {
 		return without( records, wpcomARecord );


### PR DESCRIPTION
Fixes regression introduced in #37907 where `removeDuplicateWpcomRecords` wouldn't remove default WPCOM A records when adding a custom one. Because we didn't import `find` from Lodash in the module, the function used `window.find` that searches for a string inside the window's HTML 🤦‍♂ Not exactly what we wanted.

As a followup, let's disable the ESLint behavior that allows variable references that are `window` properties.

**How to test:**
Add a custom A record for your domain. Verify that the default A record (_Handled by WordPress.com_) is removed. When removing the custom A record, the default WPCOM record should be added back.