### PR TITLE
Migration: locking interface during active migration

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -24,6 +24,7 @@ import AsyncLoad from 'components/async-load';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
+import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -113,7 +114,7 @@ class MasterbarLoggedIn extends React.Component {
 	}
 
 	render() {
-		const { domainOnlySite, translate, isCheckout } = this.props;
+		const { domainOnlySite, translate, isCheckout, isMigrationInProgress } = this.props;
 
 		if ( isCheckout === true ) {
 			return (
@@ -147,7 +148,7 @@ class MasterbarLoggedIn extends React.Component {
 					<AsyncLoad require="./quick-language-switcher" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
-				{ ! domainOnlySite && (
+				{ ! domainOnlySite && ! isMigrationInProgress && (
 					<Publish
 						isActive={ this.isActive( 'post' ) }
 						className="masterbar__item-new"
@@ -200,6 +201,7 @@ export default connect(
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			user: getCurrentUser( state ),
 			isSupportSession: isSupportSession( state ),
+			isMigrationInProgress: !! isSiteMigrationInProgress( state, siteId ),
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -204,9 +204,9 @@ function onSelectedSiteAvailable( context, basePath ) {
 	const calypsoify = isAtomicSite && config.isEnabled( 'calypsoify/plugins' );
 
 	// If migration is in progress, only /migrate paths should be loaded for the site
-	const isActiveMigration = isSiteMigrationInProgress( state, selectedSite.ID );
+	const isMigrationInProgress = isSiteMigrationInProgress( state, selectedSite.ID );
 
-	if ( isActiveMigration && ! startsWith( context.pathname, '/migrate/' ) ) {
+	if ( isMigrationInProgress && ! startsWith( context.pathname, '/migrate/' ) ) {
 		page.redirect( `/migrate/${ selectedSite.slug }` );
 		return false;
 	}
@@ -448,8 +448,8 @@ export function navigation( context, next ) {
 /**
  * Middleware that adds the site selector screen to the layout.
  *
- * @param {object} context Middleware context
- * @param {Function} next Call next middleware in chain
+ * @param {object} context -- Middleware context
+ * @param {Function} next -- Call next middleware in chain
  */
 export function sites( context, next ) {
 	if ( context.query.verified === '1' ) {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -43,6 +43,7 @@ import formatCurrency from '@automattic/format-currency/src';
 import { getPreference } from 'state/preferences/selectors';
 import { savePreference } from 'state/preferences/actions';
 import { CTA_FREE_TO_PAID } from './constants';
+import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
 
 const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
 
@@ -292,7 +293,7 @@ export class SiteNotice extends React.Component {
 
 	render() {
 		const { site } = this.props;
-		if ( ! site ) {
+		if ( ! site || this.props.isSiteMigrationInProgress ) {
 			return <div className="current-site__notices" />;
 		}
 
@@ -334,6 +335,7 @@ export default connect(
 			isPlanOwner: isCurrentUserCurrentPlanOwner( state, siteId ),
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			domainUpsellNudgeDismissedDate: getPreference( state, DOMAIN_UPSELL_NUDGE_DISMISS_KEY ),
+			isSiteMigrationInProgress: !! isSiteMigrationInProgress( state, siteId ),
 		};
 	},
 	dispatch => {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -292,8 +292,8 @@ export class SiteNotice extends React.Component {
 	}
 
 	render() {
-		const { site } = this.props;
-		if ( ! site || this.props.isSiteMigrationInProgress ) {
+		const { site, isMigrationInProgress } = this.props;
+		if ( ! site || isMigrationInProgress ) {
 			return <div className="current-site__notices" />;
 		}
 
@@ -335,7 +335,7 @@ export default connect(
 			isPlanOwner: isCurrentUserCurrentPlanOwner( state, siteId ),
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			domainUpsellNudgeDismissedDate: getPreference( state, DOMAIN_UPSELL_NUDGE_DISMISS_KEY ),
-			isSiteMigrationInProgress: !! isSiteMigrationInProgress( state, siteId ),
+			isMigrationInProgress: !! isSiteMigrationInProgress( state, siteId ),
 		};
 	},
 	dispatch => {

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -701,7 +701,7 @@ export class MySitesSidebar extends Component {
 			);
 		}
 
-		if ( this.props.isSiteMigrationInProgress ) {
+		if ( this.props.isMigrationInProgress ) {
 			return <SidebarMenu />;
 		}
 
@@ -825,7 +825,7 @@ function mapStateToProps( state ) {
 		isToolsSectionOpen,
 		isManageSectionOpen,
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
-		isSiteMigrationInProgress: !! isSiteMigrationInProgress( state, selectedSiteId ),
+		isMigrationInProgress: !! isSiteMigrationInProgress( state, selectedSiteId ),
 		isVip: isVipSite( state, selectedSiteId ),
 		showCustomizerLink: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
 		siteId,

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -36,6 +36,7 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import hasJetpackSites from 'state/selectors/has-jetpack-sites';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
 import {
 	getCustomizerUrl,
 	getSite,
@@ -700,6 +701,10 @@ export class MySitesSidebar extends Component {
 			);
 		}
 
+		if ( this.props.isSiteMigrationInProgress ) {
+			return <SidebarMenu />;
+		}
+
 		const tools = !! this.tools() || !! this.marketing() || !! this.earn() || !! this.activity();
 		const manage = !! this.upgrades() || !! this.users() || !! this.siteSettings();
 
@@ -820,6 +825,7 @@ function mapStateToProps( state ) {
 		isToolsSectionOpen,
 		isManageSectionOpen,
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
+		isSiteMigrationInProgress: !! isSiteMigrationInProgress( state, selectedSiteId ),
 		isVip: isVipSite( state, selectedSiteId ),
 		showCustomizerLink: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
 		siteId,

--- a/client/state/selectors/is-site-migration-in-progress.js
+++ b/client/state/selectors/is-site-migration-in-progress.js
@@ -13,8 +13,8 @@ import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
  */
 /* eslint-disable */
 export default function isSiteMigrationInProgress( state, siteId ) {
-	const migrationStatus = getSiteMigrationStatus( state, siteId );
+	const site = getRawSite( state, siteId );
 
-	return migrationStatus !== 'inactive';
+	return site && site.migration_status && site.migration_status === 'migrating';
 }
 /* eslint-enable */

--- a/client/state/selectors/is-site-migration-in-progress.js
+++ b/client/state/selectors/is-site-migration-in-progress.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * Internal dependencies
  */
 
@@ -15,6 +20,14 @@ import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 export default function isSiteMigrationInProgress( state, siteId ) {
 	const site = getRawSite( state, siteId );
 
-	return site && site.migration_status && site.migration_status === 'migrating';
+	if ( null === site ) {
+		return false;
+	}
+
+	return (
+		site &&
+		site.migration_status &&
+		includes( [ 'backing-up', 'restoring' ], site.migration_status )
+	);
 }
 /* eslint-enable */

--- a/client/state/selectors/is-site-migration-in-progress.js
+++ b/client/state/selectors/is-site-migration-in-progress.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 
@@ -18,16 +13,8 @@ import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
  */
 /* eslint-disable */
 export default function isSiteMigrationInProgress( state, siteId ) {
-	const site = getRawSite( state, siteId );
+	const migrationStatus = getSiteMigrationStatus( state, siteId );
 
-	if ( null === site ) {
-		return false;
-	}
-
-	return (
-		site &&
-		site.migration_status &&
-		includes( [ 'backing-up', 'restoring' ], site.migration_status )
-	);
+	return migrationStatus !== 'inactive';
 }
 /* eslint-enable */

--- a/client/state/selectors/is-site-migration-in-progress.js
+++ b/client/state/selectors/is-site-migration-in-progress.js
@@ -4,6 +4,7 @@
 
 import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 
+/* eslint-disable */
 /**
  * Returns true if the site is the target of an active migration
  *
@@ -16,3 +17,4 @@ export default function isSiteMigrationInProgress( state, siteId ) {
 
 	return migrationStatus !== 'inactive';
 }
+/* eslint-enable */

--- a/client/state/selectors/is-site-migration-in-progress.js
+++ b/client/state/selectors/is-site-migration-in-progress.js
@@ -4,7 +4,6 @@
 
 import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 
-/* eslint-disable */
 /**
  * Returns true if the site is the target of an active migration
  *
@@ -12,6 +11,7 @@ import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
  * @param {object} siteId Site ID
  * @returns {boolean} True if site is the target of an active migration
  */
+/* eslint-disable */
 export default function isSiteMigrationInProgress( state, siteId ) {
 	const migrationStatus = getSiteMigrationStatus( state, siteId );
 

--- a/client/state/selectors/is-site-migration-in-progress.js
+++ b/client/state/selectors/is-site-migration-in-progress.js
@@ -11,10 +11,8 @@ import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
  * @param {object} siteId Site ID
  * @returns {boolean} True if site is the target of an active migration
  */
-/* eslint-disable */
 export default function isSiteMigrationInProgress( state, siteId ) {
 	const migrationStatus = getSiteMigrationStatus( state, siteId );
 
 	return migrationStatus !== 'inactive';
 }
-/* eslint-enable */


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* While a migration is in progress, we want to prevent the user making any change to the target site to avoid unexpected results.
* When the current site has a `migration_status` state indicating a migration is in progress, this change hides all links in the sidebar, suppresses sidebar upgrade notifications, and hides the "Write" button in the Masterbar.

<img width="1381" alt="image" src="https://user-images.githubusercontent.com/1647564/71107594-49db5a00-21b9-11ea-8902-8fe49aec99a3.png">


#### Testing instructions

* Run D35642-code on your sandbox.
* Do a migration. While the migration is going on, the sidebar should be blanked out and the Write button should not appear.
* The default layout should only be restored when you acknowledge completion of the migration by clicking the "Start over" button on the finish page.
