### PR TITLE
ESLint: disable browser global, allow only window and document

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,13 +64,17 @@ module.exports = {
 		),
 	],
 	env: {
-		browser: true,
 		jest: true,
 		// mocha is only still on because we have not finished porting all of our tests to jest's syntax
 		mocha: true,
 		node: true,
 	},
 	globals: {
+		// allow the browser globals. ESLint's `browser` env is too permissive and allows referencing
+		// directly hundreds of properties that are available on `window` and `document`. That
+		// frequently caused bugs where we used an undefined variable and ESLint didn't warn us.
+		window: true,
+		document: true,
 		// this is our custom function that's transformed by babel into either a dynamic import or a normal require
 		asyncRequire: true,
 		// this is the SHA of the current commit. Injected at boot in a script tag.

--- a/client/state/happychat/selectors/get-happychat-userinfo.js
+++ b/client/state/happychat/selectors/get-happychat-userinfo.js
@@ -17,25 +17,21 @@ export default state => ( { site, howCanWeHelp, howYouFeel } ) => {
 		localDateTime: moment().format( 'h:mm a, MMMM Do YYYY' ),
 	};
 
-	// add screen size
-	if ( 'object' === typeof screen ) {
+	if ( typeof window !== 'undefined' ) {
+		// add screen size
 		info.screenSize = {
-			width: screen.width,
-			height: screen.height,
+			width: window.screen.width,
+			height: window.screen.height,
 		};
-	}
 
-	// add browser size
-	if ( 'object' === typeof window ) {
+		// add browser size
 		info.browserSize = {
 			width: window.innerWidth,
 			height: window.innerHeight,
 		};
-	}
 
-	// add user agent
-	if ( 'object' === typeof navigator ) {
-		info.userAgent = navigator.userAgent;
+		// add user agent
+		info.userAgent = window.navigator.userAgent;
 	}
 
 	const geoLocation = getGeoLocation( state );

--- a/client/state/happychat/selectors/test/get-happychat-userinfo.js
+++ b/client/state/happychat/selectors/test/get-happychat-userinfo.js
@@ -19,28 +19,18 @@ describe( 'HAPPYCHAT_IO_SEND_MESSAGE_USERINFO action', () => {
 		},
 	};
 
-	const previousWindow = global.window;
-	const previousScreen = global.screen;
-	const previousNavigator = global.navigator;
-
 	beforeAll( () => {
 		global.window = {
 			innerWidth: 'windowInnerWidth',
 			innerHeight: 'windowInnerHeight',
+			screen: {
+				width: 'screenWidth',
+				height: 'screenHeight',
+			},
+			navigator: {
+				userAgent: 'navigatorUserAgent',
+			},
 		};
-		global.screen = {
-			width: 'screenWidth',
-			height: 'screenHeight',
-		};
-		global.navigator = {
-			userAgent: 'navigatorUserAgent',
-		};
-	} );
-
-	afterAll( () => {
-		global.window = previousWindow;
-		global.screen = previousScreen;
-		global.navigator = previousNavigator;
 	} );
 
 	test( 'should send relevant browser information to the connection', () => {


### PR DESCRIPTION
Our current ESLint config defines that the JS sources use the `browser` environment, which means that the [700+ globals](https://github.com/sindresorhus/globals/blob/master/globals.json#L227) that are defined on `window` and `document` can be directly referenced and the `no-undef` rule won't complain.

That can lead to some nasty bugs like #37949, where we forgot to import the `find` function from `lodash` and [window.find](https://developer.mozilla.org/en-US/docs/Web/API/Window/find) was called instead, with completely different results of course.

I've seen another instance some time ago, where an undefined `status` variable wasn't reported either.

This PR removes the `browser` env and defines just the two `window` and `document` globals. That's inline with what Gutenberg does.

The second commit fix one (of many) instance where the global references need fixing.