### PR TITLE
Open Global Styles to every site with theme support

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -235,9 +235,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_starter_page_templates' );
  * Load Global Styles plugin.
  */
 function load_global_styles() {
-	if ( is_site_eligible_for_full_site_editing() ) {
-		require_once __DIR__ . '/global-styles/class-global-styles.php';
-	}
+	require_once __DIR__ . '/global-styles/class-global-styles.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
 


### PR DESCRIPTION
This PR makes Global Styles available to all sites whose theme supports it (at the moment, all of Template-First Themes).

In https://github.com/Automattic/wp-calypso/pull/36288 we introduced Global Styles, a way to customize fonts from the block editor. Although it doesn't depend on FSE, it was gated as such (to people whose site was eligible for FSE) as a way to soft-launch and test the waters. Testing didn't surface any issues, so this can now be opened.

## Testing

* Copy the modified file to your sandbox within the latest version of the FSE plugin.
* Sandboxed, load a site whose [theme supports global styles](https://wordpress.com/themes/filter/global-styles) - hint: any of the Template-First Themes.
* Open the block editor and verify that the Global Styles button is shown in the top-right.
* Open the Global Style sidebar and check that it works as expected.
* Switch to a theme that doesn't support Global Styles and verify that the sidebar isn't available.
