### PR TITLE
Components: Fix requesting state in QuerySitePurchases

### DIFF
--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -14,7 +14,7 @@ import { fetchSitePurchases } from 'state/purchases/actions';
 
 class QuerySitePurchases extends Component {
 	requestSitePurchases( props = this.props ) {
-		if ( props.siteId ) {
+		if ( props.siteId && ! props.requesting ) {
 			this.props.fetchSitePurchases( props.siteId );
 		}
 	}
@@ -24,9 +24,10 @@ class QuerySitePurchases extends Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.requesting || ! nextProps.siteId || this.props.siteId === nextProps.siteId ) {
+		if ( this.props.siteId === nextProps.siteId ) {
 			return;
 		}
+
 		this.requestSitePurchases( nextProps );
 	}
 


### PR DESCRIPTION
Currently, in the `QuerySitePurchases` we'll check if the site purchases are being requested, but only when we switch the site. This means that we don't check when we mount, and this results in a new request on every mount. Currently, on the plans page, we have 3. This PR fixes the check so it happens in both cases.

#### Changes proposed in this Pull Request

* Components: Fix requesting state in QuerySitePurchases

#### Testing instructions

* Checkout this branch.
* Open your network tab.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site.
* Verify you get 1 request to the site purchases, and not 3.
* Switch to another site.
* Verify you get 1 request to the site purchases for that site ID.