### PR TITLE
My Plans: Rename Products => Solutions

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -218,7 +218,7 @@ class PurchasesListing extends Component {
 		return (
 			<Fragment>
 				<Card compact>
-					<strong>{ translate( 'My Products' ) }</strong>
+					<strong>{ translate( 'My Solutions' ) }</strong>
 				</Card>
 				{ productPurchases.map( purchase => (
 					<MyPlanCard


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Before:
<img width="508" alt="Screen Shot 2019-11-26 at 2 25 26 PM" src="https://user-images.githubusercontent.com/115071/69637297-a9ca5f00-1058-11ea-9d29-20ae090c4399.png">

After:
<img width="425" alt="Screen Shot 2019-11-26 at 2 25 36 PM" src="https://user-images.githubusercontent.com/115071/69637276-9fa86080-1058-11ea-85c7-14ff66514744.png">

#### Testing instructions

Visit my plans page for a jetpack site that has the backup product. 