### PR TITLE
Sidebar: Remove Plan name from Plan menu item for Jetpack sites

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -407,6 +407,9 @@ export class MySitesSidebar extends Component {
 			} );
 		}
 
+		// Hide the plan name only for Jetpack sites that are not Atomic or VIP.
+		const displayPlanName = ! ( isJetpack && ! isAtomicSite && ! isVip );
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className={ linkClass } data-tip-target={ tipTarget }>
@@ -415,7 +418,7 @@ export class MySitesSidebar extends Component {
 					<span className="menu-link-text" data-e2e-sidebar="Plan">
 						{ translate( 'Plan', { context: 'noun' } ) }
 					</span>
-					{ ! ( isJetpack && ! isAtomicSite && ! isVip ) && (
+					{ displayPlanName && (
 						<span className="sidebar__menu-link-secondary-text">{ planName }</span>
 					) }
 				</a>

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -363,7 +363,15 @@ export class MySitesSidebar extends Component {
 	}
 
 	plan() {
-		const { path, site, translate, canUserManageOptions } = this.props;
+		const {
+			canUserManageOptions,
+			isAtomicSite,
+			isJetpack,
+			isVip,
+			path,
+			site,
+			translate,
+		} = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -407,7 +415,9 @@ export class MySitesSidebar extends Component {
 					<span className="menu-link-text" data-e2e-sidebar="Plan">
 						{ translate( 'Plan', { context: 'noun' } ) }
 					</span>
-					<span className="sidebar__menu-link-secondary-text">{ planName }</span>
+					{ ! ( isJetpack && ! isAtomicSite && ! isVip ) && (
+						<span className="sidebar__menu-link-secondary-text">{ planName }</span>
+					) }
 				</a>
 			</li>
 		);


### PR DESCRIPTION
This PR is removing the plan name from the Plan sidebar menu item for Jetpack sites, as suggested by @eeeeevon13. It's being removed because it no longer makes sense for users with a combination of products and plans.

#### Changes proposed in this Pull Request

* Sidebar: Remove Plan name from Plan menu item for Jetpack sites

#### Preview

Before:
![](https://cldup.com/yaZ4tHx2tz.png)

After:
![](https://cldup.com/7hr3NI4-Mq.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site slug.
* Verify the plan name no longer appears.
* Do the same for an Atomic, VIP or WP.com simple site.
* Verify you can see the plan names.
