### PR TITLE
Enable checklist-driven domain verification for FSE sites

### DIFF
--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -3,26 +3,21 @@
  */
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import { useDispatch, connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { requestSiteChecklist } from 'state/checklist/actions';
-import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
-export function QuerySiteChecklist( { siteId, isSiteUsingFSE } ) {
+export default function QuerySiteChecklist( { siteId } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( requestSiteChecklist( siteId, isSiteUsingFSE ) );
-	}, [ dispatch, siteId, isSiteUsingFSE ] );
+		dispatch( requestSiteChecklist( siteId ) );
+	}, [ dispatch, siteId ] );
 
 	return null;
 }
 
 QuerySiteChecklist.propTypes = { siteId: PropTypes.number.isRequired };
-
-export default connect( ( state, { siteId } ) => ( {
-	isSiteUsingFSE: isSiteUsingFullSiteEditing( state, siteId ),
-} ) )( QuerySiteChecklist );

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -16,7 +16,7 @@ export function QuerySiteChecklist( { siteId, isSiteUsingFSE } ) {
 
 	useEffect( () => {
 		dispatch( requestSiteChecklist( siteId, isSiteUsingFSE ) );
-	}, [ dispatch, siteId ] );
+	}, [ dispatch, siteId, isSiteUsingFSE ] );
 
 	return null;
 }

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -3,19 +3,23 @@
  */
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { requestSiteChecklist } from 'state/checklist/actions';
+import isSiteEligibleForFullSiteEditing from 'state/selectors/is-site-eligible-for-full-site-editing';
 
 export default function QuerySiteChecklist( { siteId } ) {
 	const dispatch = useDispatch();
+	const isSiteEligibleForFSE = useSelector( state =>
+		isSiteEligibleForFullSiteEditing( state, siteId )
+	);
 
 	useEffect( () => {
-		dispatch( requestSiteChecklist( siteId ) );
-	}, [ dispatch, siteId ] );
+		dispatch( requestSiteChecklist( siteId, isSiteEligibleForFSE ) );
+	}, [ dispatch, siteId, isSiteEligibleForFSE ] );
 
 	return null;
 }

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -3,21 +3,26 @@
  */
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { requestSiteChecklist } from 'state/checklist/actions';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
-export default function QuerySiteChecklist( { siteId } ) {
+export function QuerySiteChecklist( { siteId, isSiteUsingFSE } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( requestSiteChecklist( siteId ) );
+		dispatch( requestSiteChecklist( siteId, isSiteUsingFSE ) );
 	}, [ dispatch, siteId ] );
 
 	return null;
 }
 
 QuerySiteChecklist.propTypes = { siteId: PropTypes.number.isRequired };
+
+export default connect( ( state, { siteId } ) => ( {
+	isSiteUsingFSE: isSiteUsingFullSiteEditing( state, siteId ),
+} ) )( QuerySiteChecklist );

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -16,6 +16,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import isSiteEligibleForFullSiteEditing from 'state/selectors/is-site-eligible-for-full-site-editing';
 
 const ruleWhiteList = [
 	'unverifiedDomainsCanManage',
@@ -37,6 +38,7 @@ const CurrentSiteDomainWarnings = ( {
 	isJetpack,
 	selectedSite,
 	siteIsUnlaunched,
+	isSiteEligibleForFSE,
 } ) => {
 	if ( ! selectedSite || ( isJetpack && ! isAtomic ) ) {
 		// Simple and Atomic sites. Not Jetpack sites.
@@ -52,6 +54,7 @@ const CurrentSiteDomainWarnings = ( {
 				selectedSite={ selectedSite }
 				domains={ domains }
 				ruleWhiteList={ ruleWhiteList }
+				isSiteEligibleForFSE={ isSiteEligibleForFSE }
 				siteIsUnlaunched={ siteIsUnlaunched }
 			/>
 		</div>
@@ -61,6 +64,7 @@ const CurrentSiteDomainWarnings = ( {
 CurrentSiteDomainWarnings.propTypes = {
 	domains: PropTypes.array,
 	isJetpack: PropTypes.bool,
+	isSiteEligibleForFSE: PropTypes.bool,
 	selectedSite: PropTypes.object,
 };
 
@@ -73,5 +77,6 @@ export default connect( state => {
 		isAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		selectedSite: getSelectedSite( state ),
 		siteIsUnlaunched: isUnlaunchedSite( state, selectedSiteId ),
+		isSiteEligibleForFSE: isSiteEligibleForFullSiteEditing( state, selectedSiteId ),
 	};
 } )( CurrentSiteDomainWarnings );

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -16,7 +16,6 @@ import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 const ruleWhiteList = [
 	'unverifiedDomainsCanManage',
@@ -38,7 +37,6 @@ const CurrentSiteDomainWarnings = ( {
 	isJetpack,
 	selectedSite,
 	siteIsUnlaunched,
-	isSiteUsingFSE,
 } ) => {
 	if ( ! selectedSite || ( isJetpack && ! isAtomic ) ) {
 		// Simple and Atomic sites. Not Jetpack sites.
@@ -54,7 +52,6 @@ const CurrentSiteDomainWarnings = ( {
 				selectedSite={ selectedSite }
 				domains={ domains }
 				ruleWhiteList={ ruleWhiteList }
-				isSiteUsingFSE={ isSiteUsingFSE }
 				siteIsUnlaunched={ siteIsUnlaunched }
 			/>
 		</div>
@@ -77,6 +74,5 @@ export default connect( state => {
 		isAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		selectedSite: getSelectedSite( state ),
 		siteIsUnlaunched: isUnlaunchedSite( state, selectedSiteId ),
-		isSiteUsingFSE: isSiteUsingFullSiteEditing( state, selectedSiteId ),
 	};
 } )( CurrentSiteDomainWarnings );

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -61,7 +61,6 @@ const CurrentSiteDomainWarnings = ( {
 CurrentSiteDomainWarnings.propTypes = {
 	domains: PropTypes.array,
 	isJetpack: PropTypes.bool,
-	isSiteUsingFSE: PropTypes.bool,
 	selectedSite: PropTypes.object,
 };
 

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -16,6 +16,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 const ruleWhiteList = [
 	'unverifiedDomainsCanManage',
@@ -37,6 +38,7 @@ const CurrentSiteDomainWarnings = ( {
 	isJetpack,
 	selectedSite,
 	siteIsUnlaunched,
+	isSiteUsingFSE,
 } ) => {
 	if ( ! selectedSite || ( isJetpack && ! isAtomic ) ) {
 		// Simple and Atomic sites. Not Jetpack sites.
@@ -52,6 +54,7 @@ const CurrentSiteDomainWarnings = ( {
 				selectedSite={ selectedSite }
 				domains={ domains }
 				ruleWhiteList={ ruleWhiteList }
+				isSiteUsingFSE={ isSiteUsingFSE }
 				siteIsUnlaunched={ siteIsUnlaunched }
 			/>
 		</div>
@@ -61,6 +64,7 @@ const CurrentSiteDomainWarnings = ( {
 CurrentSiteDomainWarnings.propTypes = {
 	domains: PropTypes.array,
 	isJetpack: PropTypes.bool,
+	isSiteUsingFSE: PropTypes.bool,
 	selectedSite: PropTypes.object,
 };
 
@@ -73,5 +77,6 @@ export default connect( state => {
 		isAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		selectedSite: getSelectedSite( state ),
 		siteIsUnlaunched: isUnlaunchedSite( state, selectedSiteId ),
+		isSiteUsingFSE: isSiteUsingFullSiteEditing( state, selectedSiteId ),
 	};
 } )( CurrentSiteDomainWarnings );

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -635,7 +635,7 @@ export class DomainWarnings extends React.PureComponent {
 					.add( 2, 'days' )
 					.isAfter()
 		);
-		if ( this.props.siteIsUnlaunched && isWithinTwoDays ) {
+		if ( this.props.isSiteEligibleForFSE && this.props.siteIsUnlaunched && isWithinTwoDays ) {
 			// Customer Home nudges this on unlaunched sites.
 			// After two days let's re-display the nudge
 			return;

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -636,11 +635,7 @@ export class DomainWarnings extends React.PureComponent {
 					.add( 2, 'days' )
 					.isAfter()
 		);
-		if (
-			config.isEnabled( 'experience/domain-verification-in-checklist' ) &&
-			this.props.siteIsUnlaunched &&
-			isWithinTwoDays
-		) {
+		if ( this.props.isSiteUsingFSE && this.props.siteIsUnlaunched && isWithinTwoDays ) {
 			// Customer Home nudges this on unlaunched sites.
 			// After two days let's re-display the nudge
 			return;

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -635,7 +635,7 @@ export class DomainWarnings extends React.PureComponent {
 					.add( 2, 'days' )
 					.isAfter()
 		);
-		if ( this.props.isSiteUsingFSE && this.props.siteIsUnlaunched && isWithinTwoDays ) {
+		if ( this.props.siteIsUnlaunched && isWithinTwoDays ) {
 			// Customer Home nudges this on unlaunched sites.
 			// After two days let's re-display the nudge
 			return;

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -255,7 +255,7 @@ describe( 'index', () => {
 	} );
 
 	describe( 'verification nudge', () => {
-		test( 'should not show any verification nudge for any unverified domains younger than 2 days if site has FSE enabled', () => {
+		test( 'should not show any verification nudge for any unverified domains younger than 2 days', () => {
 			const props = {
 				translate: identity,
 				domains: [
@@ -279,7 +279,6 @@ describe( 'index', () => {
 					},
 				],
 				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
-				isSiteUsingFSE: true,
 				siteIsUnlaunched: true,
 				moment,
 			};

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -255,6 +255,52 @@ describe( 'index', () => {
 	} );
 
 	describe( 'verification nudge', () => {
+		test( 'should not show any verification nudge for any unverified domains younger than 2 days if site has FSE enabled', () => {
+			const props = {
+				translate: identity,
+				domains: [
+					{
+						name: 'blog.example.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: true,
+						isPendingIcannVerification: true,
+						registrationDate: moment()
+							.subtract( 1, 'days' )
+							.toISOString(),
+					},
+					{
+						name: 'mygroovysite.com',
+						type: domainTypes.REGISTERED,
+						currentUserCanManage: true,
+						isPendingIcannVerification: true,
+						registrationDate: moment()
+							.subtract( 1, 'days' )
+							.toISOString(),
+					},
+				],
+				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
+				isSiteUsingFSE: true,
+				siteIsUnlaunched: true,
+				moment,
+			};
+			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+
+			const domNode = ReactDom.findDOMNode( component ),
+				textContent = domNode.textContent,
+				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+
+			expect( textContent ).not.toContain( 'Please verify ownership of domains' );
+			expect(
+				links.some( link =>
+					link.href.endsWith( '/domains/manage/blog.example.com/edit/blog.example.com' )
+				)
+			).toBeFalsy();
+			expect(
+				links.some( link =>
+					link.href.endsWith( '/domains/manage/mygroovysite.com/edit/blog.example.com' )
+				)
+			).toBeFalsy();
+		} );
 		test( 'should show a verification nudge with weak message for any unverified domains younger than 2 days', () => {
 			const props = {
 				translate: identity,

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -255,7 +255,7 @@ describe( 'index', () => {
 	} );
 
 	describe( 'verification nudge', () => {
-		test( 'should not show any verification nudge for any unverified domains younger than 2 days', () => {
+		test( 'should not show any verification nudge for any unverified domains younger than 2 days if site is FSE eligible', () => {
 			const props = {
 				translate: identity,
 				domains: [
@@ -279,6 +279,7 @@ describe( 'index', () => {
 					},
 				],
 				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
+				isSiteEligibleForFSE: true,
 				siteIsUnlaunched: true,
 				moment,
 			};

--- a/client/state/checklist/actions.js
+++ b/client/state/checklist/actions.js
@@ -28,11 +28,13 @@ export function receiveSiteChecklist( siteId, checklist ) {
  * Action creator function: SITE_CHECKLIST_REQUEST
  *
  * @param {string} siteId for the checklist
+ * @param {boolean} isSiteEligibleForFSE whether or not the site is eligible for Full Site Editing
  * @returns {object} action object
  */
-export const requestSiteChecklist = siteId => ( {
+export const requestSiteChecklist = ( siteId, isSiteEligibleForFSE = false ) => ( {
 	type: SITE_CHECKLIST_REQUEST,
 	siteId,
+	isSiteEligibleForFSE,
 	meta: {
 		dataLayer: {
 			trackRequest: true,

--- a/client/state/checklist/actions.js
+++ b/client/state/checklist/actions.js
@@ -30,9 +30,10 @@ export function receiveSiteChecklist( siteId, checklist ) {
  * @param {String} siteId for the checklist
  * @return {Object} action object
  */
-export const requestSiteChecklist = siteId => ( {
+export const requestSiteChecklist = ( siteId, isSiteUsingFSE = false ) => ( {
 	type: SITE_CHECKLIST_REQUEST,
 	siteId,
+	isSiteUsingFSE,
 	meta: {
 		dataLayer: {
 			trackRequest: true,

--- a/client/state/checklist/actions.js
+++ b/client/state/checklist/actions.js
@@ -12,9 +12,9 @@ import 'state/data-layer/wpcom/checklist';
 /**
  * Action creator function: SITE_CHECKLIST_RECEIVE
  *
- * @param {String} siteId for the checklist
- * @param {Object} checklist the new checklist state
- * @return {Object} action object
+ * @param {string} siteId for the checklist
+ * @param {object} checklist the new checklist state
+ * @returns {object} action object
  */
 export function receiveSiteChecklist( siteId, checklist ) {
 	return {
@@ -27,8 +27,9 @@ export function receiveSiteChecklist( siteId, checklist ) {
 /**
  * Action creator function: SITE_CHECKLIST_REQUEST
  *
- * @param {String} siteId for the checklist
- * @return {Object} action object
+ * @param {string} siteId for the checklist
+ * @param {boolean} isSiteUsingFSE whether or not the site uses full site editing
+ * @returns {object} action object
  */
 export const requestSiteChecklist = ( siteId, isSiteUsingFSE = false ) => ( {
 	type: SITE_CHECKLIST_REQUEST,
@@ -44,9 +45,9 @@ export const requestSiteChecklist = ( siteId, isSiteUsingFSE = false ) => ( {
 /**
  * Action creator function: SITE_CHECKLIST_TASK_UPDATE
  *
- * @param {String} siteId for the checklist
- * @param {String} taskId for the task
- * @return {Object} action object
+ * @param {string} siteId for the checklist
+ * @param {string} taskId for the task
+ * @returns {object} action object
  */
 export const requestSiteChecklistTaskUpdate = ( siteId, taskId ) => ( {
 	type: SITE_CHECKLIST_TASK_UPDATE,

--- a/client/state/checklist/actions.js
+++ b/client/state/checklist/actions.js
@@ -28,13 +28,11 @@ export function receiveSiteChecklist( siteId, checklist ) {
  * Action creator function: SITE_CHECKLIST_REQUEST
  *
  * @param {string} siteId for the checklist
- * @param {boolean} isSiteUsingFSE whether or not the site uses full site editing
  * @returns {object} action object
  */
-export const requestSiteChecklist = ( siteId, isSiteUsingFSE = false ) => ( {
+export const requestSiteChecklist = siteId => ( {
 	type: SITE_CHECKLIST_REQUEST,
 	siteId,
-	isSiteUsingFSE,
 	meta: {
 		dataLayer: {
 			trackRequest: true,

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -6,7 +6,6 @@ import { get, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -27,9 +26,7 @@ export const fetchChecklist = action =>
 			apiNamespace: 'rest/v1.1',
 			query: {
 				http_envelope: 1,
-				with_domain_verification: config.isEnabled( 'experience/domain-verification-in-checklist' )
-					? 1
-					: 0,
+				with_domain_verification: action.isSiteUsingFSE ? 1 : 0,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -26,7 +26,7 @@ export const fetchChecklist = action =>
 			apiNamespace: 'rest/v1.1',
 			query: {
 				http_envelope: 1,
-				with_domain_verification: action.isSiteUsingFSE ? 1 : 0,
+				with_domain_verification: 1,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -26,7 +26,7 @@ export const fetchChecklist = action =>
 			apiNamespace: 'rest/v1.1',
 			query: {
 				http_envelope: 1,
-				with_domain_verification: 1,
+				with_domain_verification: action.isSiteEligibleForFSE ? 1 : 0,
 			},
 		},
 		action

--- a/client/state/selectors/is-site-eligible-for-full-site-editing.js
+++ b/client/state/selectors/is-site-eligible-for-full-site-editing.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+
+/**
+ * Checks if a site is eligible for the Full Site Editing experience
+ *
+ * @param {object} state  Global state tree
+ * @param {object} siteId Site ID
+ * @returns {boolean} True if the site is eligible for Full Site Editing, otherwise false
+ */
+export default function isSiteEligibleForFullSiteEditing( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	return get( site, 'is_fse_eligible', false );
+}

--- a/client/state/selectors/test/is-site-eligible-for-full-site-editing.js
+++ b/client/state/selectors/test/is-site-eligible-for-full-site-editing.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import isSiteEligibleForFullSiteEditing from '../is-site-eligible-for-full-site-editing';
+
+function getSitesState( siteData = {} ) {
+	return {
+		sites: {
+			items: {
+				123: {
+					...siteData,
+				},
+			},
+		},
+	};
+}
+
+describe( 'isSiteUsingFullSiteEditing', () => {
+	test( 'returns false if site does not exist', () => {
+		const state = { sites: { items: {} } };
+		const isFSE = isSiteEligibleForFullSiteEditing( state, 1 );
+		expect( isFSE ).toBe( false );
+	} );
+
+	test( 'returns true if site exists, has is_fse_eligble set to true', () => {
+		const state = getSitesState( { is_fse_eligible: true } );
+		const isFSE = isSiteEligibleForFullSiteEditing( state, 123 );
+		expect( isFSE ).toBe( true );
+	} );
+
+	test( 'returns false if site exists, has is_fse_eligible set to false', () => {
+		const state = getSitesState( { is_fse_eligible: false } );
+		const isFSE = isSiteEligibleForFullSiteEditing( state, 123 );
+		expect( isFSE ).toBe( false );
+	} );
+
+	test( 'returns false if site exists, but has no is_fse_eligible prop', () => {
+		const state = getSitesState();
+		const isFSE = isSiteEligibleForFullSiteEditing( state, 123 );
+		expect( isFSE ).toBe( false );
+	} );
+} );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -16,6 +16,7 @@ export const SITE_REQUEST_FIELDS = [
 	'lang',
 	'launch_status',
 	'is_fse_active',
+	'is_fse_eligible',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/config/development.json
+++ b/config/development.json
@@ -55,7 +55,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"experience/domain-verification-in-checklist": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,7 +30,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"experience/domain-verification-in-checklist": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of https://github.com/Automattic/wp-calypso/issues/37867

Replaces horizon feature flag check with FSE flag check for conditionally showing the domain verification checklist step and hiding the domain verification nudge from the sidebar.

Original Pull Request where horizon flag was introduced https://github.com/Automattic/wp-calypso/pull/37510

#### Changes proposed

* Gate the checklist-driven domain verification behind a check for a new `is_fse_eligible` flag (implemented in D36164-code ) so that the FSE check is correct immediately after signup
* Remove `experience/domain-verification-in-checklist` config flag checks

#### Testing instructions

See https://github.com/Automattic/wp-calypso/pull/37510

Test for FSE and non-FSE users

##### Non-FSE site

A site created through the main onboarding flow where a domain is purchased will have the domain verification nudge at the left-hand side:

![image](https://user-images.githubusercontent.com/14988353/69844032-6d983800-12be-11ea-8400-9feb03cd27e9.png)

##### FSE site

An FSE site, e.g. one created via the `test-fse` flow where a domain is purchased, will not show the domain verification nudge at the left-hand side (within two days of purchase), and will display a checklist item for domain verification:

![image](https://user-images.githubusercontent.com/14988353/69844100-c10a8600-12be-11ea-83ee-2573b3b0f2a0.png)


