### PR TITLE
Jetpack Connect: Hide Backup landing page links

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -171,7 +171,7 @@ export class ProductSelector extends Component {
 	}
 
 	getDescriptionByProduct( product ) {
-		const { selectedSiteSlug, translate } = this.props;
+		const { basePlansPath, selectedSiteSlug, translate } = this.props;
 		const { description, optionDescriptions } = product;
 		const purchase = this.getPurchaseByProduct( product );
 
@@ -188,7 +188,7 @@ export class ProductSelector extends Component {
 
 		// Default product description, without a landing page link.
 		let linkUrl = product.landingPageUrl;
-		if ( ! linkUrl ) {
+		if ( ! linkUrl || !! basePlansPath ) {
 			return description;
 		}
 


### PR DESCRIPTION
This PR removes the link to the Jetpack Backup landing page on the Jetpack Connect page.

#### Changes proposed in this Pull Request

* Jetpack Connect: Hide Backup landing page links

#### Preview

Before:
![](https://cldup.com/CjbH5FXvbH.png)

After:
![](https://cldup.com/tY8Vtx44qH.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify you no longer see the link.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site on a free plan without any backup products purchased.
* Verify you can still see the link.
