### PR TITLE
JetpackBackupCredsBanner: fixup proptypes

### DIFF
--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -25,7 +25,7 @@ class JetpackBackupCredsBanner extends Component {
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 		// From localize()
-		translate: PropTypes.function,
+		translate: PropTypes.func,
 	};
 
 	render() {


### PR DESCRIPTION
Fixup prop types of `JetpackBackupCredsBanner` introduced in #37730. `PropTypes.function` is not a valid prop type. The right one is `PropTypes.func`.

Fixes a React console warning about prop type being `undefined` rather than having one of the supported values.