### PR TITLE
Enable template picker for users with FSE enabled (instead of restricting that to horizon)

### DIFF
--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -11,7 +11,7 @@ import { getPostsForQuery } from 'state/posts/selectors';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
 import createSelector from 'lib/create-selector';
-import { isEnabled } from 'config';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 export const FIRST_TEN_SITE_POSTS_QUERY = { type: 'any', number: 10, order_by: 'ID', order: 'ASC' };
 
@@ -44,7 +44,7 @@ export default createSelector(
 		const contactPageUrl = getPageEditorUrl( state, siteId, getContactPage( posts ) );
 		const frontPageUrl = getFrontPageEditorUrl( state, siteId );
 
-		const updateHomepageUrl = isEnabled( 'checklist-homepage-template-select' )
+		const updateHomepageUrl = isSiteUsingFullSiteEditing( state, siteId )
 			? addQueryArgs( frontPageUrl || getEditorUrl( state, siteId, null, 'page' ), {
 					'new-homepage': 1,
 			  } )

--- a/config/development.json
+++ b/config/development.json
@@ -34,7 +34,6 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
-		"checklist-homepage-template-select": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,7 +21,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"checklist-homepage-template-select": true,
 		"code-splitting": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,6 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"checklist-homepage-template-select": true,
 		"code-splitting": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of https://github.com/Automattic/wp-calypso/issues/37867

Replaces horizon feature flag check with FSE flag check

Original Pull Request where horizon flag was introduced https://github.com/Automattic/wp-calypso/pull/37458

#### Testing instructions

See https://github.com/Automattic/wp-calypso/pull/37458

Test for FSE and non-FSE users

