### PR TITLE
Domains: fixup initial state of the DNS reducer

### DIFF
--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -170,7 +170,7 @@ function findDnsIndex( records, record ) {
 	return findIndex( records, matchingFields );
 }
 
-export default function reducer( state = initialState, action ) {
+export default function reducer( state = {}, action ) {
 	switch ( action.type ) {
 		case DOMAINS_DNS_FETCH:
 			state = updateDomainState( state, action.domainName, {


### PR DESCRIPTION
The initial state of the reducer should be `{}` rather than the `initialState` value.
The state is keyed by domain name. It's the values that correspond to these keys that
should use the `initialState` constant.
