### PR TITLE
Add isSecondary attribute to Formatted Header

### DIFF
--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -26,3 +26,4 @@ render() {
 * `headerText` (`string`) - The main header text
 * `subHeaderText` (`node`) - Sub header text (optional)
 * `compactOnMobile` (`bool`) - Display a compact header on small screens (optional)
+* `isSecondary` (`bool`) - Use the H2 element instead of the H1 (optional)

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -16,7 +16,15 @@ import { preventWidows } from 'lib/formatting';
  */
 import './style.scss';
 
-function FormattedHeader( { id, headerText, subHeaderText, className, compactOnMobile, align } ) {
+function FormattedHeader( {
+	id,
+	headerText,
+	subHeaderText,
+	className,
+	compactOnMobile,
+	align,
+	isSecondary,
+} ) {
 	const classes = classNames( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
 		'is-compact-on-mobile': compactOnMobile,
@@ -26,7 +34,12 @@ function FormattedHeader( { id, headerText, subHeaderText, className, compactOnM
 
 	return (
 		<header id={ id } className={ classes }>
-			<h1 className="formatted-header__title">{ preventWidows( headerText, 2 ) }</h1>
+			{ ! isSecondary && (
+				<h1 className="formatted-header__title">{ preventWidows( headerText, 2 ) }</h1>
+			) }
+			{ isSecondary && (
+				<h2 className="formatted-header__title">{ preventWidows( headerText, 2 ) }</h2>
+			) }
 			{ subHeaderText && (
 				<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>
 			) }
@@ -38,6 +51,7 @@ FormattedHeader.propTypes = {
 	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
 	compactOnMobile: PropTypes.bool,
+	isSecondary: PropTypes.bool,
 	align: PropTypes.string,
 };
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -160,6 +160,7 @@ export class PlansFeaturesMain extends Component {
 							'Get everything your site needs, in one package — so you can focus on your business.'
 						) }
 						compactOnMobile
+						isSecondary
 					/>
 				) }
 				<PlanFeatures
@@ -437,6 +438,7 @@ export class PlansFeaturesMain extends Component {
 					headerText={ translate( 'Solutions' ) }
 					subHeaderText={ translate( 'Just need backups? Learn about add-on solutions.' ) }
 					compactOnMobile
+					isSecondary
 				/>
 				<ProductPlanOverlapNotices plans={ JETPACK_PLANS } products={ JETPACK_BACKUP_PRODUCTS } />
 				<ProductSelector


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes the formatted header on the plans page by adding the isSecondary attribute. Which lets us set the html of the component to be an H2 instead of an H1. 

This lets us use the H2 tag on pages that already have the H1 tag. 

No visual change should be present on that page.

#### Testing instructions
Go to the plans page. Using the web inspector notice that the Plans and Solutions are now rendered using the H2 tag.

