### PR TITLE
Update Renovate: Limit TinyMCE to v4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,10 @@
 		{
 			"packagePatterns": [ "^webpack" ],
 			"prPriority": 1
+		},
+		{
+			"packageName": "tinymce",
+			"allowedVersions": "^4"
 		}
 	],
 	"statusCheckVerify": true,


### PR DESCRIPTION
This matches core and our classic editor

See https://core.trac.wordpress.org/ticket/47218

Closes #33416
