### PR TITLE
Make the Free plan tagline on My Plan page dependant on Backup product

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -641,10 +641,24 @@ export const PLANS_LIST = {
 		getAudience: () => i18n.translate( 'Best for students' ),
 		getProductId: () => 2002,
 		getStoreSlug: () => constants.PLAN_JETPACK_FREE,
-		getTagline: () =>
-			i18n.translate(
-				'Upgrade your site to access additional features, including spam protection, backups, and priority support.'
-			),
+		getTagline: feature => {
+			switch ( feature ) {
+				case constants.FEATURE_JETPACK_BACKUP_DAILY:
+				case constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY:
+					return i18n.translate(
+						'Upgrade your site to access additional features, including spam protection, real-time backups, and priority support.'
+					);
+				case constants.FEATURE_JETPACK_BACKUP_REALTIME:
+				case constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY:
+					return i18n.translate(
+						'Upgrade your site to access additional features, including spam protection, and priority support.'
+					);
+				default:
+					return i18n.translate(
+						'Upgrade your site to access additional features, including spam protection, backups, and priority support.'
+					);
+			}
+		},
 		getDescription: () =>
 			i18n.translate(
 				'The features most needed by WordPress sites' +

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -5,7 +5,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { invoke, isEmpty } from 'lodash';
+import { find, invoke, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -80,6 +80,13 @@ class PurchasesListing extends Component {
 		return product.expiryMoment < moment().add( 30, 'days' );
 	}
 
+	getJetpackBackup() {
+		return (
+			find( this.props.purchases, purchase => purchase.active && isJetpackBackup( purchase ) ) ??
+			null
+		);
+	}
+
 	getTitle( purchase ) {
 		const { currentPlanSlug } = this.props;
 
@@ -102,10 +109,12 @@ class PurchasesListing extends Component {
 			return getJetpackProductTagline( purchase );
 		}
 
+		const jetpackBackup = this.getJetpackBackup();
+
 		if ( currentPlanSlug ) {
 			const planObject = getPlan( currentPlanSlug );
 			return (
-				planObject.getTagline?.() ??
+				planObject.getTagline?.( jetpackBackup?.productSlug ) ??
 				translate(
 					'Unlock the full potential of your site with all the features included in your plan.'
 				)
@@ -205,11 +214,10 @@ class PurchasesListing extends Component {
 	}
 
 	renderProducts() {
-		const { purchases, translate } = this.props;
+		const { translate } = this.props;
 
-		const productPurchases = purchases.filter(
-			purchase => purchase.active && isJetpackBackup( purchase )
-		);
+		// Get all products and filter out falsy items.
+		const productPurchases = [ this.getJetpackBackup() ].filter( Boolean );
 
 		if ( isEmpty( productPurchases ) ) {
 			return null;

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -80,7 +80,7 @@ class PurchasesListing extends Component {
 		return product.expiryMoment < moment().add( 30, 'days' );
 	}
 
-	getJetpackBackup() {
+	getJetpackBackupPurchase() {
 		return (
 			find( this.props.purchases, purchase => purchase.active && isJetpackBackup( purchase ) ) ??
 			null
@@ -109,12 +109,12 @@ class PurchasesListing extends Component {
 			return getJetpackProductTagline( purchase );
 		}
 
-		const jetpackBackup = this.getJetpackBackup();
+		const jetpackBackupPurchase = this.getJetpackBackupPurchase();
 
 		if ( currentPlanSlug ) {
 			const planObject = getPlan( currentPlanSlug );
 			return (
-				planObject.getTagline?.( jetpackBackup?.productSlug ) ??
+				planObject.getTagline?.( jetpackBackupPurchase?.productSlug ) ??
 				translate(
 					'Unlock the full potential of your site with all the features included in your plan.'
 				)
@@ -217,7 +217,7 @@ class PurchasesListing extends Component {
 		const { translate } = this.props;
 
 		// Get all products and filter out falsy items.
-		const productPurchases = [ this.getJetpackBackup() ].filter( Boolean );
+		const productPurchases = [ this.getJetpackBackupPurchase() ].filter( Boolean );
 
 		if ( isEmpty( productPurchases ) ) {
 			return null;


### PR DESCRIPTION
The Free plan tagline on My Plan page is always the same - no matter if the user already purchased one of the Jetpack Backup options. This can be confusing since the default tagline prompts the user to purchase a paid plan in order to get backups while the user might already have a separate Jetpack Backup product.

This PR resolves this issue. The Free plan tagline is now different depending if the user has one of the Jetpack Backup options or no additional product.

**Before**
<img width="845" alt="Screenshot 2019-11-26 at 16 48 12" src="https://user-images.githubusercontent.com/478735/69648962-93c69980-106c-11ea-89a0-d8ec0391f3ab.png">

**After - without Jetpack Backup**
<img width="846" alt="Screenshot 2019-11-26 at 16 30 50" src="https://user-images.githubusercontent.com/478735/69649004-9f19c500-106c-11ea-8887-002fc0101e9b.png">

**After - with Jetpack Backup Daily**
<img width="847" alt="Screenshot 2019-11-26 at 16 17 14" src="https://user-images.githubusercontent.com/478735/69649032-a93bc380-106c-11ea-857c-ee710d52e2ee.png">
 
**After - with Jetpack Backup Real-Time**
<img width="847" alt="Screenshot 2019-11-26 at 16 30 06" src="https://user-images.githubusercontent.com/478735/69649045-b22c9500-106c-11ea-92cd-3e19770204a7.png">

#### Changes proposed in this Pull Request

* Make the Free plan tagline on My Plan page dependant on Backup product

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/plans/my-plan and select a Jetpack site on the Free plan
* Confirm that the tagline is correct depending if you have no Jetpack Backup, Backup Daily or Backup Real-Time.

Fixes n/a