### PR TITLE
composite-checkout-wpcom: Switch composite-checkout dependency to file path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -278,6 +278,30 @@
 				"react-stripe-elements": "^5.1.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"i18n-calypso": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-4.0.0.tgz",
+					"integrity": "sha512-L1oMtViG/LtwWqGcLfA6FJN+ililsA6r/fPJswxvND8waJAWRONZEDmmjojs6MKratJ1E6cnFjTifiC75zuHHQ==",
+					"requires": {
+						"debug": "^3.2.6",
+						"events": "^3.0.0",
+						"hash.js": "^1.1.5",
+						"interpolate-components": "^1.1.1",
+						"jed": "^1.1.1",
+						"lodash": "^4.17.11",
+						"lru": "^3.1.0",
+						"moment": "^2.24.0",
+						"react": "^16.8.3"
+					}
+				},
 				"react-stripe-elements": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16996,8 +16996,8 @@
 			"dev": true
 		},
 		"mini-css-extract-plugin-with-rtl": {
-			"version": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
-			"from": "mini-css-extract-plugin-with-rtl@github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
+			"version": "github:Automattic/mini-css-extract-plugin-with-rtl#f48ce03f385390257bdacbfec4759d38df983361",
+			"from": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
 				"file-loader": "4.2.0",
 				"jest-config": "24.9.0",
 				"jest-enzyme": "7.1.2",
-				"mini-css-extract-plugin-with-rtl": "mini-css-extract-plugin-with-rtl@github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
 				"node-sass": "4.13.0",
 				"postcss-custom-properties": "9.0.2",
 				"postcss-loader": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,7 +267,7 @@
 		"@automattic/composite-checkout-wpcom": {
 			"version": "file:packages/composite-checkout-wpcom",
 			"requires": {
-				"@automattic/composite-checkout": "^1.0.0",
+				"@automattic/composite-checkout": "file:packages/composite-checkout",
 				"@emotion/core": "10.0.22",
 				"@emotion/styled": "10.0.23",
 				"@wordpress/data": "^4.9.2",

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -37,7 +37,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/composite-checkout-wpcom#readme",
 	"dependencies": {
-		"@automattic/composite-checkout": "^1.0.0",
+		"@automattic/composite-checkout": "file:../composite-checkout",
 		"@emotion/core": "10.0.22",
 		"@emotion/styled": "10.0.23",
 		"@wordpress/data": "^4.9.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #37099 a new package, `composite-checkout-wpcom`, was added. The package has a dependency on the `composite-checkout` package. That package is private and should have been referenced by a local `file:` path rather than its version so that npm doesn't try to look for it in the registry.

This PR updates the dependency to use the file path instead.

#### Testing instructions

Run `npm run distclean` and then `npm install` and be sure the install completes.