### PR TITLE
G Suite: Display discount in shopping cart

### DIFF
--- a/client/components/gsuite/gsuite-features/index.jsx
+++ b/client/components/gsuite/gsuite-features/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'lib/gsuite/constants';
 import GSuiteSingleFeature from './single-feature';
 
 /**
@@ -21,20 +22,21 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 	const getStorageText = () => {
 		if ( compact ) {
 			return undefined;
-		} else if ( 'gapps' === productSlug ) {
+		} else if ( GSUITE_BASIC_SLUG === productSlug ) {
 			return translate( 'Get 30GB of storage for all your files synced across devices.' );
-		} else if ( 'gapps_unlimited' === productSlug ) {
+		} else if ( GSUITE_BUSINESS_SLUG === productSlug ) {
 			return translate( 'Get unlimited storage for all your files synced across devices.' );
 		}
+
 		return translate( 'Get 30GB or unlimited storage for all your files synced across devices.' );
 	};
 
 	const getStorageTitle = () => {
 		if ( ! compact ) {
 			return translate( 'Keep all your files secure' );
-		} else if ( 'gapps' === productSlug ) {
+		} else if ( GSUITE_BASIC_SLUG === productSlug ) {
 			return translate( '30GB of cloud storage' );
-		} else if ( 'gapps_unlimited' === productSlug ) {
+		} else if ( GSUITE_BUSINESS_SLUG === productSlug ) {
 			return translate( 'Unlimited cloud storage (or 1TB per user if fewer than 5 users)' );
 		}
 

--- a/client/components/gsuite/gsuite-features/test/compact.js
+++ b/client/components/gsuite/gsuite-features/test/compact.js
@@ -7,22 +7,25 @@ import renderer from 'react-test-renderer';
 /**
  * Internal dependencies
  */
+import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'lib/gsuite/constants';
 import GSuiteCompactFeatures from '../compact';
 
 describe( 'GSuiteCompactFeatures', () => {
 	test( 'it renders GSuiteCompactFeatures with basic plan', () => {
 		const tree = renderer
-			.create( <GSuiteCompactFeatures domainName={ 'testing123.com' } productSlug={ 'gapps' } /> )
+			.create( <GSuiteCompactFeatures domainName={ 'testing123.com' } productSlug={ GSUITE_BASIC_SLUG } /> )
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuiteCompactFeatures with business plan', () => {
 		const tree = renderer
 			.create(
-				<GSuiteCompactFeatures domainName={ 'testing123.com' } productSlug={ 'gapps_unlimited' } />
+				<GSuiteCompactFeatures domainName={ 'testing123.com' } productSlug={ GSUITE_BUSINESS_SLUG } />
 			)
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 
@@ -30,6 +33,7 @@ describe( 'GSuiteCompactFeatures', () => {
 		const tree = renderer
 			.create( <GSuiteCompactFeatures domainName={ 'testing123.com' } /> )
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 
@@ -38,11 +42,12 @@ describe( 'GSuiteCompactFeatures', () => {
 			.create(
 				<GSuiteCompactFeatures
 					domainName={ 'testing123.com' }
-					productSlug={ 'gapps' }
+					productSlug={ GSUITE_BASIC_SLUG }
 					type={ 'list' }
 				/>
 			)
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/gsuite/gsuite-features/test/index.js
+++ b/client/components/gsuite/gsuite-features/test/index.js
@@ -7,36 +7,41 @@ import renderer from 'react-test-renderer';
 /**
  * Internal dependencies
  */
+import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'lib/gsuite/constants';
 import GSuiteFeatures from '../';
 
 describe( 'GSuiteFeatures', () => {
 	test( 'it renders GSuiteFeatures with basic plan', () => {
 		const tree = renderer
-			.create( <GSuiteFeatures domainName={ 'testing123.com' } productSlug={ 'gapps' } /> )
+			.create( <GSuiteFeatures domainName={ 'testing123.com' } productSlug={ GSUITE_BASIC_SLUG } /> )
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuiteFeatures with business plan', () => {
 		const tree = renderer
 			.create(
-				<GSuiteFeatures domainName={ 'testing123.com' } productSlug={ 'gapps_unlimited' } />
+				<GSuiteFeatures domainName={ 'testing123.com' } productSlug={ GSUITE_BUSINESS_SLUG } />
 			)
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuiteFeatures without a productSlug', () => {
 		const tree = renderer.create( <GSuiteFeatures domainName={ 'testing123.com' } /> ).toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuiteFeatures in a list', () => {
 		const tree = renderer
 			.create(
-				<GSuiteFeatures domainName={ 'testing123.com' } productSlug={ 'gapps' } type={ 'list' } />
+				<GSuiteFeatures domainName={ 'testing123.com' } productSlug={ GSUITE_BASIC_SLUG } type={ 'list' } />
 			)
 			.toJSON();
+
 		expect( tree ).toMatchSnapshot();
 	} );
 } );

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
@@ -14,6 +14,7 @@ import CompactCard from 'components/card/compact';
 import { areAllUsersValid, getItemsForCart, newUsers } from 'lib/gsuite/new-users';
 import GSuiteUpsellProductDetails from './product-details';
 import GSuiteNewUserList from 'components/gsuite/gsuite-new-user-list';
+import { GSUITE_SLUG_PROP_TYPES } from 'lib/gsuite/constants';
 import QueryProducts from 'components/data/query-products-list';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
@@ -133,7 +134,7 @@ const GSuiteUpsellCard = ( {
 
 GSuiteUpsellCard.propTypes = {
 	domain: PropTypes.string.isRequired,
-	productSlug: PropTypes.oneOf( [ 'gapps', 'gapps_unlimited' ] ),
+	productSlug: GSUITE_SLUG_PROP_TYPES,
 	onAddEmailClick: PropTypes.func.isRequired,
 	onSkipClick: PropTypes.func.isRequired,
 };

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
@@ -13,6 +13,7 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductBySlug } from 'state/products-list/selectors';
 import GSuitePrice from 'components/gsuite/gsuite-price';
 import GSuiteCompactFeatures from 'components/gsuite/gsuite-features/compact';
+import { GSUITE_SLUG_PROP_TYPES } from 'lib/gsuite/constants';
 
 function GSuiteUpsellProductDetails( { currencyCode, domain, product, productSlug } ) {
 	const translate = useTranslate();
@@ -44,7 +45,7 @@ GSuiteUpsellProductDetails.propTypes = {
 	currencyCode: PropTypes.string,
 	domain: PropTypes.string.isRequired,
 	product: PropTypes.object,
-	productSlug: PropTypes.oneOf( [ 'gapps', 'gapps_unlimited' ] ),
+	productSlug: GSUITE_SLUG_PROP_TYPES,
 };
 
 export default connect(

--- a/client/components/upgrades/gsuite/index.jsx
+++ b/client/components/upgrades/gsuite/index.jsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { addItems } from 'lib/cart/actions';
 import { hasDomainInCart } from 'lib/cart-values/cart-items';
+import { GSUITE_BASIC_SLUG } from 'lib/gsuite/constants';
 import GSuiteUpsellCard from './gsuite-upsell-card';
 import HeaderCake from 'components/header-cake';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
@@ -18,6 +19,7 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 const GSuiteUpgrade = ( { cart, domain, selectedSiteSlug } ) => {
 	const handleAddEmailClick = cartItems => {
 		addItems( cartItems );
+
 		page( `/checkout/${ selectedSiteSlug }` );
 	};
 
@@ -46,7 +48,7 @@ const GSuiteUpgrade = ( { cart, domain, selectedSiteSlug } ) => {
 
 			<GSuiteUpsellCard
 				domain={ domain }
-				productSlug={ 'gapps' }
+				productSlug={ GSUITE_BASIC_SLUG }
 				onSkipClick={ handleSkipClick }
 				onAddEmailClick={ handleAddEmailClick }
 			/>

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -24,6 +24,7 @@ import emailValidator from 'email-validator';
 /**
  * Internal dependencies
  */
+import { GSUITE_BASIC_SLUG, GSUITE_EXTRA_LICENSE_SLUG } from 'lib/gsuite/constants';
 import {
 	formatProduct,
 	getDomain,
@@ -673,14 +674,14 @@ export function getGoogleApps( cart ) {
 }
 
 export function googleApps( properties ) {
-	const productSlug = properties.product_slug || 'gapps',
+	const productSlug = properties.product_slug || GSUITE_BASIC_SLUG,
 		item = domainItem( productSlug, properties.meta ? properties.meta : properties.domain );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }
 
 export function googleAppsExtraLicenses( properties ) {
-	const item = domainItem( 'gapps_extra_license', properties.domain, properties.source );
+	const item = domainItem( GSUITE_EXTRA_LICENSE_SLUG, properties.domain, properties.source );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }

--- a/client/lib/gsuite/constants.js
+++ b/client/lib/gsuite/constants.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+export const GSUITE_BASIC_SLUG         = 'gapps';
+export const GSUITE_BUSINESS_SLUG      = 'gapps_unlimited';
+export const GSUITE_EXTRA_LICENSE_SLUG = 'gapps_extra_license';
+
+export const GSUITE_SLUG_PROP_TYPES = PropTypes.oneOf( [ GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG ] );
+
+export const GSUITE_LINK_PREFIX = 'https://mail.google.com/a/';

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -7,13 +7,14 @@ import { endsWith, get, includes, isNumber, isString, some, sortBy } from 'lodas
 /**
  * Internal dependencies
  */
+import {
+	GSUITE_BASIC_SLUG,
+	GSUITE_BUSINESS_SLUG,
+	GSUITE_EXTRA_LICENSE_SLUG,
+	GSUITE_LINK_PREFIX
+} from 'lib/gsuite/constants';
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import userFactory from 'lib/user';
-
-/**
- * Constants
- */
-const GSUITE_LINK_PREFIX = 'https://mail.google.com/a/';
 
 /**
  * Applies a precision to the cost
@@ -215,12 +216,43 @@ function hasPendingGSuiteUsers( domain ) {
 }
 
 /**
+ * Determines whether the specified product slug is for G Suite Basic or Business.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to G Suite Basic or Business, false otherwise
+ */
+function isGSuiteProductSlug( productSlug ) {
+	return [ GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG ].includes( productSlug );
+}
+
+/**
+ * Determines whether the specified product slug is for a G Suite extra license.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to an extra license, false otherwise
+ */
+function isGSuiteExtraLicenseProductSlug( productSlug ) {
+	return productSlug === GSUITE_EXTRA_LICENSE_SLUG;
+}
+
+/**
+ * Determines whether the specified product slug refers to any type of G Suite product.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to any G Suite product, false otherwise
+ */
+function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
+	return isGSuiteProductSlug( productSlug ) || isGSuiteExtraLicenseProductSlug( productSlug );
+}
+
+/**
  * Is the user G Suite restricted
  *
  * @returns {boolean} - Is the user G Suite restricted
  */
 function isGSuiteRestricted() {
 	const user = userFactory();
+
 	return ! get( user.get(), 'is_valid_google_apps_country', false );
 }
 
@@ -236,5 +268,8 @@ export {
 	hasGSuiteWithAnotherProvider,
 	hasGSuiteWithUs,
 	hasPendingGSuiteUsers,
+	isGSuiteExtraLicenseProductSlug,
+	isGSuiteOrExtraLicenseProductSlug,
+	isGSuiteProductSlug,
 	isGSuiteRestricted,
 };

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -392,7 +392,7 @@ export function getProductClass( productSlug ) {
  * Get Jetpack product display name based on the product purchase object.
  *
  * @param   product {object}             Product purchase object
- * @returns         {string|HTMLElement} Product display name
+ * @returns         {string|object} Product display name
  */
 export function getJetpackProductDisplayName( product ) {
 	product = formatProduct( product );
@@ -405,7 +405,7 @@ export function getJetpackProductDisplayName( product ) {
  * Get Jetpack product tagline based on the product purchase object.
  *
  * @param   product {object}             Product purchase object
- * @returns         {string|HTMLElement} Product tagline
+ * @returns         {string|object} Product tagline
  */
 export function getJetpackProductTagline( product ) {
 	product = formatProduct( product );

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -6,6 +6,7 @@ import { assign, difference, get, includes, isEmpty, pick } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isGSuiteOrExtraLicenseProductSlug } from 'lib/gsuite';
 import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
@@ -447,11 +448,7 @@ export function isGoogleApps( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return (
-		'gapps' === product.product_slug ||
-		'gapps_unlimited' === product.product_slug ||
-		'gapps_extra_license' === product.product_slug
-	);
+	return isGSuiteOrExtraLicenseProductSlug( product.product_slug );
 }
 
 export function isGuidedTransfer( product ) {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -45,7 +45,7 @@ export class CartItem extends React.Component {
 	};
 
 	price() {
-		const { cartItem, translate } = this.props;
+		const { cart, cartItem, translate } = this.props;
 
 		if ( typeof cartItem.cost === 'undefined' ) {
 			return translate( 'Loading price' );
@@ -66,21 +66,25 @@ export class CartItem extends React.Component {
 		}
 
 		if ( isGSuiteProductSlug( cartItem.product_slug ) ) {
-			const { cost_before_coupon: costBeforeCoupon } = cartItem;
+			const {
+				cost_before_coupon: costBeforeCoupon,
+				is_sale_coupon_applied: isSaleCouponApplied,
+			} = cartItem;
+			const { is_coupon_applied: isCouponApplied } = cart;
 
-			if ( costBeforeCoupon ) {
+			if ( isSaleCouponApplied ) {
 				return (
 					<div className="cart__gsuite-discount">
-						<span className="cart__gsuite-discount-regular-price">
-							{ costBeforeCoupon }
-						</span>
+						<span className="cart__gsuite-discount-regular-price">{ costBeforeCoupon }</span>
 
 						<span className="cart__gsuite-discount-discounted-price">
 							{ cost } { cartItem.currency }
 						</span>
 
 						<span className="cart__gsuite-discount-text">
-							{ translate( 'Discount for first year' ) }
+							{ isCouponApplied
+								? translate( 'Multiple discounts' )
+								: translate( 'Discount for first year' ) }
 						</span>
 					</div>
 				);

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -24,6 +24,7 @@ import {
 	isBundled,
 	isDomainProduct,
 } from 'lib/products-values';
+import { isGSuiteProductSlug } from 'lib/gsuite';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'lib/gsuite/constants';
@@ -62,6 +63,28 @@ export class CartItem extends React.Component {
 
 		if ( 0 === cost ) {
 			return <span className="cart__free-text">{ translate( 'Free' ) }</span>;
+		}
+
+		if ( isGSuiteProductSlug( cartItem.product_slug ) ) {
+			const { cost_before_coupon: costBeforeCoupon } = cartItem;
+
+			if ( costBeforeCoupon ) {
+				return (
+					<div className="cart__gsuite-discount">
+						<span className="cart__gsuite-discount-regular-price">
+							{ costBeforeCoupon }
+						</span>
+
+						<span className="cart__gsuite-discount-discounted-price">
+							{ cost } { cartItem.currency }
+						</span>
+
+						<span className="cart__gsuite-discount-text">
+							{ translate( 'Discount for first year' ) }
+						</span>
+					</div>
+				);
+			}
 		}
 
 		return translate( '%(cost)s %(currency)s', {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -70,9 +70,10 @@ export class CartItem extends React.Component {
 				cost_before_coupon: costBeforeCoupon,
 				is_sale_coupon_applied: isSaleCouponApplied,
 			} = cartItem;
-			const { is_coupon_applied: isCouponApplied } = cart;
 
 			if ( isSaleCouponApplied ) {
+				const { is_coupon_applied: isCouponApplied } = cart;
+
 				return (
 					<div className="cart__gsuite-discount">
 						<span className="cart__gsuite-discount-regular-price">{ costBeforeCoupon }</span>
@@ -83,7 +84,7 @@ export class CartItem extends React.Component {
 
 						<span className="cart__gsuite-discount-text">
 							{ isCouponApplied
-								? translate( 'Multiple discounts' )
+								? translate( 'Discounts applied' )
 								: translate( 'Discount for first year' ) }
 						</span>
 					</div>

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -26,6 +26,7 @@ import {
 } from 'lib/products-values';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
+import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'lib/gsuite/constants';
 import { removeItem } from 'lib/cart/actions';
 import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
@@ -274,8 +275,8 @@ export class CartItem extends React.Component {
 			return cartItem.product_name;
 		} else if ( cartItem.volume === 1 ) {
 			switch ( cartItem.product_slug ) {
-				case 'gapps':
-				case 'gapps_unlimited':
+				case GSUITE_BASIC_SLUG:
+				case GSUITE_BUSINESS_SLUG:
 					return translate( '%(productName)s (1 User)', {
 						args: {
 							productName: cartItem.product_name,
@@ -287,8 +288,8 @@ export class CartItem extends React.Component {
 			}
 		} else {
 			switch ( cartItem.product_slug ) {
-				case 'gapps':
-				case 'gapps_unlimited':
+				case GSUITE_BASIC_SLUG:
+				case GSUITE_BUSINESS_SLUG:
 					return translate(
 						'%(productName)s (%(volume)s User)',
 						'%(productName)s (%(volume)s Users)',

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -69,6 +69,21 @@
 			padding-left: 0;
 		}
 
+		.cart__gsuite-discount {
+			.cart__gsuite-discount-regular-price {
+				text-decoration: line-through;
+			}
+
+			.cart__gsuite-discount-discounted-price {
+				padding-left: 4px;
+			}
+
+			.cart__gsuite-discount-text {
+				color: var( --color-success );
+				padding-left: 8px;
+			}
+		}
+
 		.product-monthly-price {
 			color: var( --color-text-subtle );
 			display: block;

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -72,10 +72,6 @@
 		.cart__gsuite-discount {
 			.cart__gsuite-discount-regular-price {
 				text-decoration: line-through;
-
-				&:empty + .cart__gsuite-discount-discounted-price {
-					padding-left: 0;
-				}
 			}
 
 			.cart__gsuite-discount-discounted-price {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -72,6 +72,10 @@
 		.cart__gsuite-discount {
 			.cart__gsuite-discount-regular-price {
 				text-decoration: line-through;
+
+				&:empty + .cart__gsuite-discount-discounted-price {
+					padding-left: 0;
+				}
 			}
 
 			.cart__gsuite-discount-discounted-price {

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -12,6 +12,7 @@ import page from 'page';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
+import { GSUITE_BASIC_SLUG } from 'lib/gsuite/constants';
 import GSuiteUpsellCard from 'components/upgrades/gsuite/gsuite-upsell-card';
 import Main from 'components/main';
 import QuerySites from 'components/data/query-sites';
@@ -81,7 +82,7 @@ export class GSuiteNudge extends React.Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<GSuiteUpsellCard
 					domain={ this.props.domain }
-					productSlug={ 'gapps' }
+					productSlug={ GSUITE_BASIC_SLUG }
 					onSkipClick={ this.handleSkipClick }
 					onAddEmailClick={ this.handleAddEmailClick }
 				/>

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -32,6 +32,7 @@ import {
 	validateAgainstExistingUsers,
 } from 'lib/gsuite/new-users';
 import { getSelectedSite } from 'state/ui/selectors';
+import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from 'lib/gsuite/constants';
 import GSuiteNewUserList from 'components/gsuite/gsuite-new-user-list';
 import Main from 'components/main';
 import Notice from 'components/notice';
@@ -77,7 +78,7 @@ class GSuiteAddUsers extends React.Component {
 
 		if ( canContinue ) {
 			addItems(
-				getItemsForCart( domains, 'business' === planType ? 'gapps_unlimited' : 'gapps', users )
+				getItemsForCart( domains, 'business' === planType ? GSUITE_BUSINESS_SLUG : GSUITE_BASIC_SLUG, users )
 			);
 			page( '/checkout/' + selectedSite.slug );
 		}

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -18,6 +18,7 @@ import EmailVerificationGate from 'components/email-verification/email-verificat
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductBySlug } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { GSUITE_BASIC_SLUG } from 'lib/gsuite/constants';
 import GSuiteFeatures from 'components/gsuite/gsuite-features';
 import GSuiteLearnMore from 'components/gsuite/gsuite-learn-more';
 import GSuitePrice from 'components/gsuite/gsuite-price';
@@ -112,7 +113,8 @@ export const GSuitePurchaseCta = ( {
 			</CompactCard>
 
 			<CompactCard className="gsuite-purchase-cta__info">
-				<GSuiteFeatures domainName={ domainName } productSlug={ 'gapps' } />
+				<GSuiteFeatures domainName={ domainName } productSlug={ GSUITE_BASIC_SLUG } />
+
 				<GSuiteLearnMore onLearnMoreClick={ handleLearnMoreClick } />
 			</CompactCard>
 		</EmailVerificationGate>
@@ -130,7 +132,7 @@ GSuitePurchaseCta.propTypes = {
 export default connect(
 	state => ( {
 		currencyCode: getCurrentUserCurrencyCode( state ),
-		product: getProductBySlug( state, 'gapps' ),
+		product: getProductBySlug( state, GSUITE_BASIC_SLUG ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{ recordTracksEvent }


### PR DESCRIPTION
This pull request displays and formats the price in the shopping cart when a G Suite discount is applied. It also displays a short text next to the price:

Popup | Checkout 
------ | -----
![02](https://user-images.githubusercontent.com/594356/69654672-721de000-1075-11ea-8b26-b412dec1d88a.png) | ![screenshot](https://user-images.githubusercontent.com/594356/69654680-7649fd80-1075-11ea-980d-d592543c6e63.png)

Finally, it introduces constants to avoid referring to slugs directly, and to take ease future refactoring.

#### Testing instructions

1. Apply 2332e-pb to your sandbox to simulate a discount to the frontend
2. Apply D36169-code to to your sandbox to help differentiate between different discounts.
3. Point `public-api.wordpress.com` to your sandbox
4. Run `git checkout add/gsuite-discount-shopping-cart` and start your development server
5. Log in to an account that has a site without G Suite
6. Open the [`Email` page](http://calypso.localhost:3000/email), then click the `Add G Suite` button
7. Fill in the form, and click the `Continue` button
8. Assert that the shopping cart looks like the screenshot above
9. Navigate back to the [`Plans`](http://calypso.localhost:3000/plans)
10. Click the `Cart` link in the upper right corner of the cake header
11. Assert that the shopping cart looks like the screenshot above

/cc @fditrapani