### PR TITLE
Atomic: Hosting Configuration Activate

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -198,7 +198,15 @@ const mapDispatchToProps = {
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const context = includes( ownProps.backUrl, 'plugins' ) ? 'plugins' : 'themes';
+	let context;
+	if ( includes( ownProps.backUrl, 'plugins' ) ) {
+		context = 'plugins';
+	} else if ( includes( ownProps.backUrl, 'themes' ) ) {
+		context = 'themes';
+	} else if ( includes( ownProps.backUrl, 'hosting' ) ) {
+		context = 'hosting';
+	}
+
 	const onCancel = () => dispatchProps.trackCancel( { context } );
 	const onProceed = () => {
 		ownProps.onProceed();

--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -8,6 +8,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import Hosting from './main';
+import HostingActivate from './hosting-activate';
 import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosting';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -50,5 +51,10 @@ export async function handleHostingPanelRedirect( context, next ) {
 
 export function layout( context, next ) {
 	context.primary = React.createElement( Hosting );
+	next();
+}
+
+export function activationLayout( context, next ) {
+	context.primary = React.createElement( HostingActivate );
 	next();
 }

--- a/client/my-sites/hosting/hosting-activate.js
+++ b/client/my-sites/hosting/hosting-activate.js
@@ -17,13 +17,11 @@ import { initiateThemeTransfer } from 'state/themes/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 const HostingActivate = ( { initiateTransfer, siteId, siteSlug, translate } ) => {
-	const getBackUrl = () => {
-		return `/hosting-config/${ siteSlug }`;
-	};
+	const backUrl = `/hosting-config/${ siteSlug }`;
 
 	const transferInitiate = () => {
 		initiateTransfer( siteId, null, null );
-		page( getBackUrl() );
+		page( backUrl );
 	};
 
 	return (
@@ -32,10 +30,10 @@ const HostingActivate = ( { initiateTransfer, siteId, siteSlug, translate } ) =>
 				path="/hosting-config/activate/:site"
 				title="Hosting Configuration > Activate"
 			/>
-			<HeaderCake isCompact={ true } backHref={ getBackUrl() }>
+			<HeaderCake isCompact={ true } backHref={ backUrl }>
 				{ translate( 'Activate Hosting Features' ) }
 			</HeaderCake>
-			<EligibilityWarnings onProceed={ transferInitiate } backUrl={ getBackUrl() } />
+			<EligibilityWarnings onProceed={ transferInitiate } backUrl={ backUrl } />
 		</MainComponent>
 	);
 };

--- a/client/my-sites/hosting/hosting-activate.js
+++ b/client/my-sites/hosting/hosting-activate.js
@@ -21,7 +21,7 @@ const HostingActivate = ( { initiateTransfer, siteId, siteSlug, translate } ) =>
 		return `/hosting-config/${ siteSlug }`;
 	};
 
-	const pluginTransferInitiate = () => {
+	const transferInitiate = () => {
 		initiateTransfer( siteId, null, null );
 		page( getBackUrl() );
 	};
@@ -35,7 +35,7 @@ const HostingActivate = ( { initiateTransfer, siteId, siteSlug, translate } ) =>
 			<HeaderCake isCompact={ true } backHref={ getBackUrl() }>
 				{ translate( 'Activate Hosting Features' ) }
 			</HeaderCake>
-			<EligibilityWarnings onProceed={ pluginTransferInitiate } backUrl={ getBackUrl() } />
+			<EligibilityWarnings onProceed={ transferInitiate } backUrl={ getBackUrl() } />
 		</MainComponent>
 	);
 };

--- a/client/my-sites/hosting/hosting-activate.js
+++ b/client/my-sites/hosting/hosting-activate.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import MainComponent from 'components/main';
+import HeaderCake from 'components/header-cake';
+import EligibilityWarnings from 'blocks/eligibility-warnings';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { initiateThemeTransfer } from 'state/themes/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+const HostingActivate = ( { initiateTransfer, siteId, siteSlug, translate } ) => {
+	const getBackUrl = () => {
+		return `/hosting-config/${ siteSlug }`;
+	};
+
+	const pluginTransferInitiate = () => {
+		initiateTransfer( siteId, null, null );
+		page( getBackUrl() );
+	};
+
+	return (
+		<MainComponent>
+			<PageViewTracker
+				path="/hosting-config/activate/:site"
+				title="Hosting Configuration > Activate"
+			/>
+			<HeaderCake isCompact={ true } backHref={ getBackUrl() }>
+				{ translate( 'Activate Hosting Features' ) }
+			</HeaderCake>
+			<EligibilityWarnings onProceed={ pluginTransferInitiate } backUrl={ getBackUrl() } />
+		</MainComponent>
+	);
+};
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	return {
+		siteId,
+		siteSlug,
+	};
+};
+
+const mapDispatchToProps = {
+	initiateTransfer: initiateThemeTransfer,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( HostingActivate ) );

--- a/client/my-sites/hosting/index.js
+++ b/client/my-sites/hosting/index.js
@@ -7,7 +7,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { handleHostingPanelRedirect, layout } from './controller';
+import { handleHostingPanelRedirect, layout, activationLayout } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
@@ -18,6 +18,16 @@ export default function() {
 		navigation,
 		handleHostingPanelRedirect,
 		layout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/hosting-config/activate/:site_id',
+		siteSelection,
+		navigation,
+		handleHostingPanelRedirect,
+		activationLayout,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -45,7 +45,7 @@ class Hosting extends Component {
 		const { COMPLETE } = transferStates;
 		const { isTransferring, transferState } = this.props;
 
-		if ( isTransferring && ! COMPLETE === transferState ) {
+		if ( isTransferring && COMPLETE !== transferState ) {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 			this.setState( { clickOutside: true } );
@@ -75,9 +75,11 @@ class Hosting extends Component {
 			// Transfer in progress
 			if (
 				( isTransferring && COMPLETE !== transferState ) ||
-				( isDisabled && COMPLETE === transferState && isTransferring )
+				( isDisabled && COMPLETE === transferState )
 			) {
-				requestSiteById( siteId );
+				if ( COMPLETE === transferState ) {
+					requestSiteById( siteId );
+				}
 
 				let activationText = translate( 'Please wait while we activate the hosting features.' );
 				if ( this.state.clickOutside ) {

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -61,7 +61,7 @@ const Hosting = ( {
 			requestSiteById( siteId );
 
 			return (
-				<Fragment>
+				<>
 					<Notice
 						className="hosting__activating-notice"
 						status="is-info"
@@ -69,13 +69,13 @@ const Hosting = ( {
 						text={ translate( 'Please wait while we activate the hosting features.' ) }
 						icon="sync"
 					/>
-				</Fragment>
+				</>
 			);
 		}
 
 		const failureNotice = FAILURE === transferState && (
 			<Notice
-				status="is-info"
+				status="is-error"
 				showDismiss={ false }
 				text={ translate( 'There was an error activating hosting features.' ) }
 				icon="bug"
@@ -84,7 +84,7 @@ const Hosting = ( {
 
 		if ( isDisabled && ! isTransferring ) {
 			return (
-				<Fragment>
+				<>
 					{ failureNotice }
 					<Notice
 						status="is-info"
@@ -102,7 +102,7 @@ const Hosting = ( {
 							{ translate( 'Activate' ) }
 						</NoticeAction>
 					</Notice>
-				</Fragment>
+				</>
 			);
 		}
 	};
@@ -112,7 +112,7 @@ const Hosting = ( {
 			isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 168768859;
 
 		return (
-			<Fragment>
+			<>
 				<div className="hosting__layout">
 					<div className="hosting__layout-col">
 						{ sftpPhpMyAdminFeaturesEnabled && <SFTPCard disabled={ isDisabled } /> }
@@ -123,7 +123,7 @@ const Hosting = ( {
 						<SupportCard />
 					</div>
 				</div>
-			</Fragment>
+			</>
 		);
 	};
 

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -29,7 +29,6 @@ import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-active';
 import { transferStates } from 'state/automated-transfer/constants';
 import QuerySites from 'components/data/query-sites';
-import { isRequestingSite } from 'state/sites/selectors';
 
 /**
  * Style dependencies
@@ -53,14 +52,20 @@ const Hosting = ( {
 	const getContent = () => {
 		const { COMPLETE, FAILURE } = transferStates;
 
-		if ( isTransferring && COMPLETE !== transferState ) {
+		if (
+			( isTransferring && COMPLETE !== transferState ) ||
+			( isDisabled && COMPLETE === transferState )
+		) {
 			return (
-				<Notice
-					status="is-info"
-					showDismiss={ false }
-					text={ translate( 'Please wait while we activate the hosting features.' ) }
-					icon="sync"
-				/>
+				<Fragment>
+					<QuerySites siteId={ siteId } />
+					<Notice
+						status="is-info"
+						showDismiss={ false }
+						text={ translate( 'Please wait while we activate the hosting features.' ) }
+						icon="sync"
+					/>
+				</Fragment>
 			);
 		}
 
@@ -69,7 +74,6 @@ const Hosting = ( {
 
 		return (
 			<Fragment>
-				<QuerySites siteId={ siteId } />
 				{ FAILURE === transferState && (
 					<Notice
 						status="is-info"
@@ -133,7 +137,6 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			isRequestingSite: isRequestingSite( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
 			isDisabled: ! isSiteAutomatedTransfer( state, siteId ),

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import wrapWithClickOutside from 'react-click-outside';
@@ -30,6 +30,7 @@ import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-active';
 import { transferStates } from 'state/automated-transfer/constants';
 import { requestSite } from 'state/sites/actions';
+import FeatureExample from 'components/feature-example';
 
 /**
  * Style dependencies
@@ -139,8 +140,10 @@ class Hosting extends Component {
 			const sftpPhpMyAdminFeaturesEnabled =
 				isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 168768859;
 
+			const WrapperComponent = isDisabled || isTransferring ? FeatureExample : Fragment;
+
 			return (
-				<>
+				<WrapperComponent>
 					<div className="hosting__layout">
 						<div className="hosting__layout-col">
 							{ sftpPhpMyAdminFeaturesEnabled && <SFTPCard disabled={ isDisabled } /> }
@@ -151,7 +154,7 @@ class Hosting extends Component {
 							<SupportCard />
 						</div>
 					</div>
-				</>
+				</WrapperComponent>
 			);
 		};
 

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -52,37 +52,20 @@ const Hosting = ( {
 	const getContent = () => {
 		const { COMPLETE, FAILURE } = transferStates;
 
-		if (
-			( isTransferring && COMPLETE !== transferState ) ||
-			( isDisabled && COMPLETE === transferState )
-		) {
+		const failureNotice = FAILURE === transferState && (
+			<Notice
+				status="is-info"
+				showDismiss={ false }
+				text={ translate( 'There was an error activating hosting features.' ) }
+				icon="bug"
+			/>
+		);
+
+		if ( isDisabled && ! isTransferring ) {
 			return (
 				<Fragment>
 					<QuerySites siteId={ siteId } />
-					<Notice
-						status="is-info"
-						showDismiss={ false }
-						text={ translate( 'Please wait while we activate the hosting features.' ) }
-						icon="sync"
-					/>
-				</Fragment>
-			);
-		}
-
-		const sftpPhpMyAdminFeaturesEnabled =
-			isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 168768859;
-
-		return (
-			<Fragment>
-				{ FAILURE === transferState && (
-					<Notice
-						status="is-info"
-						showDismiss={ false }
-						text={ translate( 'There was an error activating hosting features.' ) }
-						icon="bug"
-					/>
-				) }
-				{ isDisabled && (
+					{ failureNotice }
 					<Notice
 						status="is-info"
 						showDismiss={ false }
@@ -99,7 +82,29 @@ const Hosting = ( {
 							{ translate( 'Activate' ) }
 						</NoticeAction>
 					</Notice>
-				) }
+				</Fragment>
+			);
+		}
+
+		// Transfer in progress
+		if ( isTransferring && COMPLETE !== transferState ) {
+			return (
+				<Fragment>
+					<Notice
+						status="is-info"
+						showDismiss={ false }
+						text={ translate( 'Please wait while we activate the hosting features.' ) }
+						icon="sync"
+					/>
+				</Fragment>
+			);
+		}
+
+		const sftpPhpMyAdminFeaturesEnabled =
+			isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 168768859;
+
+		return (
+			<Fragment>
 				<div className="hosting__layout">
 					<div className="hosting__layout-col">
 						{ sftpPhpMyAdminFeaturesEnabled && <SFTPCard disabled={ isDisabled } /> }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -58,7 +58,7 @@ const Hosting = ( { translate, isDisabled, canViewAtomicHosting, siteId } ) => {
 				<div className="hosting__layout-col">
 					{ sftpPhpMyAdminFeaturesEnabled && <SFTPCard disabled={ isDisabled } /> }
 					{ sftpPhpMyAdminFeaturesEnabled && <PhpMyAdminCard disabled={ isDisabled } /> }
-					<PhpVersionCard />
+					{ ! isDisabled && <PhpVersionCard /> }
 				</div>
 				<div className="hosting__layout-col">
 					<SupportCard />

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -52,7 +52,7 @@ const Hosting = ( {
 		return null;
 	}
 
-	const getContent = () => {
+	const getAtomicActivationNotice = () => {
 		const { COMPLETE, FAILURE } = transferStates;
 
 		if ( isDisabled && COMPLETE === transferState && ! isRequestingCurrentSite ) {
@@ -108,7 +108,9 @@ const Hosting = ( {
 				</Fragment>
 			);
 		}
+	};
 
+	const getContent = () => {
 		const sftpPhpMyAdminFeaturesEnabled =
 			isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 168768859;
 
@@ -118,7 +120,7 @@ const Hosting = ( {
 					<div className="hosting__layout-col">
 						{ sftpPhpMyAdminFeaturesEnabled && <SFTPCard disabled={ isDisabled } /> }
 						{ sftpPhpMyAdminFeaturesEnabled && <PhpMyAdminCard disabled={ isDisabled } /> }
-						{ ! isDisabled && <PhpVersionCard /> }
+						{ <PhpVersionCard disabled={ isDisabled } /> }
 					</div>
 					<div className="hosting__layout-col">
 						<SupportCard />
@@ -138,6 +140,7 @@ const Hosting = ( {
 				subHeaderText={ translate( 'Access and manage more advanced settings of your website.' ) }
 				align="left"
 			/>
+			{ getAtomicActivationNotice() }
 			{ getContent() }
 		</Main>
 	);

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -29,7 +29,6 @@ import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-active';
 import { transferStates } from 'state/automated-transfer/constants';
 import { requestSite } from 'state/sites/actions';
-import { isRequestingSite } from 'state/sites/selectors';
 
 /**
  * Style dependencies
@@ -41,7 +40,6 @@ const Hosting = ( {
 	clickActivate,
 	isDisabled,
 	isTransferring,
-	isRequestingCurrentSite,
 	requestSiteById,
 	siteId,
 	siteSlug,
@@ -55,18 +53,17 @@ const Hosting = ( {
 	const getAtomicActivationNotice = () => {
 		const { COMPLETE, FAILURE } = transferStates;
 
-		if ( isDisabled && COMPLETE === transferState && ! isRequestingCurrentSite ) {
-			requestSiteById( siteId );
-		}
-
 		// Transfer in progress
 		if (
 			( isTransferring && COMPLETE !== transferState ) ||
-			( isDisabled && COMPLETE === transferState && isRequestingCurrentSite )
+			( isDisabled && COMPLETE === transferState )
 		) {
+			requestSiteById( siteId );
+
 			return (
 				<Fragment>
 					<Notice
+						className="hosting__activating-notice"
 						status="is-info"
 						showDismiss={ false }
 						text={ translate( 'Please wait while we activate the hosting features.' ) }
@@ -154,7 +151,6 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			isRequestingCurrentSite: isRequestingSite( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
 			isDisabled: ! isSiteAutomatedTransfer( state, siteId ),

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -43,8 +43,9 @@ class Hosting extends Component {
 
 	handleClickOutside( event ) {
 		const { COMPLETE } = transferStates;
+		const { isTransferring, transferState } = this.props;
 
-		if ( this.props.isTransferring && ! COMPLETE === this.props.transferState ) {
+		if ( isTransferring && ! COMPLETE === transferState ) {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 			this.setState( { clickOutside: true } );
@@ -74,7 +75,7 @@ class Hosting extends Component {
 			// Transfer in progress
 			if (
 				( isTransferring && COMPLETE !== transferState ) ||
-				( isDisabled && COMPLETE === transferState )
+				( isDisabled && COMPLETE === transferState && isTransferring )
 			) {
 				requestSiteById( siteId );
 

--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -93,7 +93,7 @@ const PhpVersionCard = ( {
 
 	useEffect( () => {
 		requestPhpVersion( siteId );
-	}, [ siteId ] );
+	}, [ siteId, disabled ] );
 
 	useEffect( () => {
 		const updateNoticeId = 'hosting-php-version';

--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -91,8 +91,12 @@ const PhpVersionCard = ( {
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
 	const [ currentPhpVersion, setCurrentPhpVersion ] = useState( '' );
 
+	const recommendedValue = '7.3';
+
 	useEffect( () => {
-		requestPhpVersion( siteId );
+		if ( ! disabled ) {
+			requestPhpVersion( siteId );
+		}
 	}, [ siteId, disabled ] );
 
 	useEffect( () => {
@@ -150,7 +154,7 @@ const PhpVersionCard = ( {
 				label: translate( '7.3 (recommended)', {
 					comment: 'PHP Version for a version switcher',
 				} ),
-				value: '7.3',
+				value: recommendedValue,
 			},
 			{
 				label: translate( '7.4', {
@@ -169,6 +173,9 @@ const PhpVersionCard = ( {
 		const isButtonDisabled =
 			disabled || ! selectedPhpVersion || selectedPhpVersion === currentPhpVersion;
 
+		const selectedValue =
+			selectedPhpVersion || currentPhpVersion || ( disabled && recommendedValue );
+
 		return (
 			<div>
 				<div>
@@ -177,7 +184,7 @@ const PhpVersionCard = ( {
 						disabled={ disabled }
 						className="php-version-card__version-select"
 						onChange={ changePhpVersion }
-						value={ selectedPhpVersion || currentPhpVersion }
+						value={ selectedValue }
 					>
 						{ getPhpVersions().map( option => {
 							return (

--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -150,7 +150,7 @@ const PhpVersionCard = ( {
 				value: '7.3',
 			},
 			{
-				label: translate( '7.4RC6', {
+				label: translate( '7.4', {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '7.4',

--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -86,6 +86,7 @@ const PhpVersionCard = ( {
 	updateResult,
 	updating,
 	version,
+	disabled,
 } ) => {
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
 	const [ currentPhpVersion, setCurrentPhpVersion ] = useState( '' );
@@ -165,13 +166,15 @@ const PhpVersionCard = ( {
 			return;
 		}
 
-		const isButtonDisabled = ! selectedPhpVersion || selectedPhpVersion === currentPhpVersion;
+		const isButtonDisabled =
+			disabled || ! selectedPhpVersion || selectedPhpVersion === currentPhpVersion;
 
 		return (
 			<div>
 				<div>
 					<FormLabel>{ translate( 'Your site is currently running:' ) }</FormLabel>
 					<FormSelect
+						disabled={ disabled }
 						className="php-version-card__version-select"
 						onChange={ changePhpVersion }
 						value={ selectedPhpVersion || currentPhpVersion }
@@ -227,7 +230,7 @@ export const recordHostingPhpVersionUpdate = ( version, result ) =>
 	);
 
 export default connect(
-	state => {
+	( state, props ) => {
 		const siteId = getSelectedSiteId( state );
 
 		const phpVersionGet = getHttpData( requestId( siteId, 'GET' ) );
@@ -235,7 +238,7 @@ export default connect(
 		const version = phpVersionGet?.data ?? '';
 
 		return {
-			loading: ! version && phpVersionGet.state === 'pending',
+			loading: ! props.disabled && ! version && phpVersionGet.state === 'pending',
 			siteId,
 			updating: phpVersionUpdate.state === 'pending',
 			updateResult: phpVersionUpdate.state,

--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -15,7 +15,7 @@ import FormSelect from 'components/forms/form-select';
 import FormLabel from 'components/forms/form-label';
 import MaterialIcon from 'components/material-icon';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
+import { getHttpData, requestHttpData, resetHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import Spinner from 'components/spinner';
 import { errorNotice, successNotice } from 'state/notices/actions';
@@ -87,8 +87,8 @@ const PhpVersionCard = ( {
 	updating,
 	version,
 } ) => {
-	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( null );
-	const [ currentPhpVersion, setCurrentPhpVersion ] = useState( null );
+	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
+	const [ currentPhpVersion, setCurrentPhpVersion ] = useState( '' );
 
 	useEffect( () => {
 		requestPhpVersion( siteId );
@@ -121,6 +121,8 @@ const PhpVersionCard = ( {
 		}
 
 		if ( [ 'success', 'failure' ].includes( updateResult ) ) {
+			resetHttpData( requestId( siteId, 'POST' ) );
+
 			recordHostingPhpVersionUpdate( selectedPhpVersion, updateResult );
 		}
 	}, [ updateResult ] );
@@ -230,7 +232,7 @@ export default connect(
 
 		const phpVersionGet = getHttpData( requestId( siteId, 'GET' ) );
 		const phpVersionUpdate = getHttpData( requestId( siteId, 'POST' ) );
-		const version = phpVersionGet?.data ?? null;
+		const version = phpVersionGet?.data ?? '';
 
 		return {
 			loading: ! version && phpVersionGet.state === 'pending',

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -51,3 +51,20 @@
 		width: 100%;
 	}
 }
+
+.hosting__activating-notice {
+	.gridicons-sync > use:first-child,
+	.gridicons-sync > g:first-child {
+		animation: spinning-sync-icon linear 2s infinite;
+		transform-origin: center;
+	}
+}
+
+@keyframes spinning-sync-icon {
+	from {
+		transform: rotate( 0deg );
+	}
+	to {
+		transform: rotate( 360deg );
+	}
+}

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -1,15 +1,8 @@
 /**
- * External Dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal Dependencies
  */
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isEnabled } from 'config';
-import { isBusinessPlan } from 'lib/plans';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteOnAtomicPlan from 'state/selectors/is-site-on-atomic-plan';
 
@@ -31,17 +24,5 @@ export default function canSiteViewAtomicHosting( state ) {
 		return false;
 	}
 
-	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-	if ( ! canManageOptions ) {
-		return false;
-	}
-
-	const isAtomicSite = !! isSiteAutomatedTransfer( state, siteId );
-	if ( isAtomicSite ) {
-		return true;
-	}
-
-	const planSlug = get( getSelectedSite( state ), [ 'plan', 'product_slug' ] );
-
-	return isBusinessPlan( planSlug ) && isEnabled( 'hosting/non-atomic-support' );
+	return canCurrentUser( state, siteId, 'manage_options' );
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -91,9 +91,9 @@ export function setBackPath( path ) {
  * Returns an action object to be used in signalling that a theme object has
  * been received.
  *
- * @param  {Object} theme  Theme received
- * @param  {Number} siteId ID of site for which themes have been received
- * @return {Object}        Action object
+ * @param  {object} theme  Theme received
+ * @param  {number} siteId ID of site for which themes have been received
+ * @returns {object}        Action object
  */
 export function receiveTheme( theme, siteId ) {
 	return receiveThemes( [ theme ], siteId );
@@ -105,9 +105,9 @@ export function receiveTheme( theme, siteId ) {
  *
  * @param {Array}  themes Themes received
  * @param {number} siteId ID of site for which themes have been received
- * @param {?Object} query Theme query used in the API request
+ * @param {?object} query Theme query used in the API request
  * @param {?number} foundCount Number of themes returned by the query
- * @return {Object} Action object
+ * @returns {object} Action object
  */
 export function receiveThemes( themes, siteId, query, foundCount ) {
 	return ( dispatch, getState ) => {
@@ -143,15 +143,15 @@ export function receiveThemes( themes, siteId, query, foundCount ) {
 /**
  * Triggers a network request to fetch themes for the specified site and query.
  *
- * @param  {Number|String} siteId        Jetpack site ID or 'wpcom' for any WPCOM site
- * @param  {Object}        query         Theme query
- * @param  {String}        query.search  Search string
- * @param  {String}        query.tier    Theme tier: 'free', 'premium', or '' (either)
- * @param  {String}        query.filter  Filter
- * @param  {Number}        query.number  How many themes to return per page
- * @param  {Number}        query.offset  At which item to start the set of returned themes
- * @param  {Number}        query.page    Which page of matching themes to return
- * @return {Function}                    Action thunk
+ * @param  {number|string} siteId        Jetpack site ID or 'wpcom' for any WPCOM site
+ * @param  {object}        query         Theme query
+ * @param  {string}        query.search  Search string
+ * @param  {string}        query.tier    Theme tier: 'free', 'premium', or '' (either)
+ * @param  {string}        query.filter  Filter
+ * @param  {number}        query.number  How many themes to return per page
+ * @param  {number}        query.offset  At which item to start the set of returned themes
+ * @param  {number}        query.page    Which page of matching themes to return
+ * @returns {Function}                    Action thunk
  */
 export function requestThemes( siteId, query = {} ) {
 	return ( dispatch, getState ) => {
@@ -228,9 +228,9 @@ export function themeRequestFailure( siteId, themeId, error ) {
 /**
  * Triggers a network request to fetch a specific theme from a site.
  *
- * @param  {String}   themeId Theme ID
- * @param  {Number}   siteId  Site ID
- * @return {Function}         Action thunk
+ * @param  {string}   themeId Theme ID
+ * @param  {number}   siteId  Site ID
+ * @returns {Function}         Action thunk
  */
 export function requestTheme( themeId, siteId ) {
 	return dispatch => {
@@ -311,8 +311,8 @@ export function requestTheme( themeId, siteId ) {
  * If request success information about active theme is stored in Redux themes subtree.
  * In case of error, error is stored in Redux themes subtree.
  *
- * @param  {Number}   siteId Site for which to check active theme
- * @return {Function}        Redux thunk with request action
+ * @param  {number}   siteId Site for which to check active theme
+ * @returns {Function}        Redux thunk with request action
  */
 export function requestActiveTheme( siteId ) {
 	return ( dispatch, getState ) => {
@@ -350,11 +350,11 @@ export function requestActiveTheme( siteId ) {
  * Triggers a network request to activate a specific theme on a given site.
  * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
  *
- * @param  {String}   themeId   Theme ID
- * @param  {Number}   siteId    Site ID
- * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
- * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
- * @return {Function}           Action thunk
+ * @param  {string}   themeId   Theme ID
+ * @param  {number}   siteId    Site ID
+ * @param  {string}   source    The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @returns {Function}           Action thunk
  */
 export function activate( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch, getState ) => {
@@ -372,11 +372,11 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 /**
  * Triggers a network request to activate a specific theme on a given site.
  *
- * @param  {String}   themeId   Theme ID
- * @param  {Number}   siteId    Site ID
- * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
- * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
- * @return {Function}           Action thunk
+ * @param  {string}   themeId   Theme ID
+ * @param  {number}   siteId    Site ID
+ * @param  {string}   source    The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @returns {Function}           Action thunk
  */
 export function activateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
 	return dispatch => {
@@ -410,11 +410,11 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
  * on a given site. Careful, this action is different from most others here in that
  * expects a theme stylesheet string (not just a theme ID).
  *
- * @param  {String}   themeStylesheet Theme stylesheet string (*not* just a theme ID!)
- * @param  {Number}   siteId          Site ID
- * @param  {String}   source          The source that is reuquesting theme activation, e.g. 'showcase'
- * @param  {Boolean}  purchased       Whether the theme has been purchased prior to activation
- * @return {Function}                 Action thunk
+ * @param  {string}   themeStylesheet Theme stylesheet string (*not* just a theme ID!)
+ * @param  {number}   siteId          Site ID
+ * @param  {string}   source          The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased       Whether the theme has been purchased prior to activation
+ * @returns {Function}                 Action thunk
  */
 export function themeActivated( themeStylesheet, siteId, source = 'unknown', purchased = false ) {
 	const themeActivatedThunk = ( dispatch, getState ) => {
@@ -448,9 +448,9 @@ export function themeActivated( themeStylesheet, siteId, source = 'unknown', pur
  * To install a theme from WordPress.com, suffix the theme name with '-wpcom'. Note that this options
  * requires Jetpack 4.4
  *
- * @param  {String}   themeId Theme ID. If suffixed with '-wpcom', install from WordPress.com
- * @param  {String}   siteId  Jetpack Site ID
- * @return {Function}         Action thunk
+ * @param  {string}   themeId Theme ID. If suffixed with '-wpcom', install from WordPress.com
+ * @param  {string}   siteId  Jetpack Site ID
+ * @returns {Function}         Action thunk
  */
 export function installTheme( themeId, siteId ) {
 	return ( dispatch, getState ) => {
@@ -497,8 +497,8 @@ export function installTheme( themeId, siteId ) {
  * Returns an action object to be used in signalling that theme activated status
  * for site should be cleared
  *
- * @param  {Number}   siteId    Site ID
- * @return {Object}        Action object
+ * @param  {number}   siteId    Site ID
+ * @returns {object}        Action object
  */
 export function clearActivated( siteId ) {
 	return {
@@ -511,9 +511,9 @@ export function clearActivated( siteId ) {
  * Switches to the customizer to preview a given theme.
  * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
  *
- * @param  {String}   themeId   Theme ID
- * @param  {Number}   siteId    Site ID
- * @return {Function}           Action thunk
+ * @param  {string}   themeId   Theme ID
+ * @param  {number}   siteId    Site ID
+ * @returns {Function}           Action thunk
  */
 export function tryAndCustomize( themeId, siteId ) {
 	return ( dispatch, getState ) => {
@@ -534,9 +534,9 @@ export function tryAndCustomize( themeId, siteId ) {
  * See installTheme doc for install options.
  * Requires Jetpack 4.4
  *
- * @param  {String}   themeId      WP.com Theme ID
- * @param  {String}   siteId       Jetpack Site ID
- * @return {Function}              Action thunk
+ * @param  {string}   themeId      WP.com Theme ID
+ * @param  {string}   siteId       Jetpack Site ID
+ * @returns {Function}              Action thunk
  */
 export function installAndTryAndCustomizeTheme( themeId, siteId ) {
 	return dispatch => {
@@ -551,9 +551,9 @@ export function installAndTryAndCustomizeTheme( themeId, siteId ) {
  * When theme is not available dispatches FAILURE action
  * that trigers displaying error notice by notices middlewaere
  *
- * @param  {String}   themeId      WP.com Theme ID
- * @param  {String}   siteId       Jetpack Site ID
- * @return {Function}              Action thunk
+ * @param  {string}   themeId      WP.com Theme ID
+ * @param  {string}   siteId       Jetpack Site ID
+ * @returns {Function}              Action thunk
  */
 export function tryAndCustomizeTheme( themeId, siteId ) {
 	return ( dispatch, getState ) => {
@@ -571,11 +571,11 @@ export function tryAndCustomizeTheme( themeId, siteId ) {
  * Jetpack site. If the themeId parameter is suffixed with '-wpcom', install the
  * theme from WordPress.com. Otherwise, install from WordPress.org.
  *
- * @param  {String}   themeId   Theme ID. If suffixed with '-wpcom', install theme from WordPress.com
- * @param  {Number}   siteId    Site ID
- * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
- * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
- * @return {Function}           Action thunk
+ * @param  {string}   themeId   Theme ID. If suffixed with '-wpcom', install theme from WordPress.com
+ * @param  {number}   siteId    Site ID
+ * @param  {string}   source    The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @returns {Function}           Action thunk
  */
 export function installAndActivateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
 	return dispatch => {
@@ -590,10 +590,10 @@ export function installAndActivateTheme( themeId, siteId, source = 'unknown', pu
 /**
  * Triggers a theme upload to the given site.
  *
- * @param {Number} siteId -- Site to upload to
+ * @param {number} siteId -- Site to upload to
  * @param {File} file -- the theme zip to upload
  *
- * @return {Function} the action function
+ * @returns {Function} the action function
  */
 export function uploadTheme( siteId, file ) {
 	return dispatch => {
@@ -633,9 +633,9 @@ export function uploadTheme( siteId, file ) {
  * Clears any state remaining from a previous
  * theme upload to the given site.
  *
- * @param {Number} siteId -- site to clear state for
+ * @param {number} siteId -- site to clear state for
  *
- * @return {Object} the action object to dispatch
+ * @returns {object} the action object to dispatch
  */
 export function clearThemeUpload( siteId ) {
 	return {
@@ -647,14 +647,18 @@ export function clearThemeUpload( siteId ) {
 /**
  * Start an Automated Transfer with an uploaded theme.
  *
- * @param {Number} siteId -- the site to transfer
+ * @param {number} siteId -- the site to transfer
  * @param {File} file -- theme zip to upload
- * @param {String} plugin -- plugin slug
+ * @param {string} plugin -- plugin slug
  *
  * @returns {Promise} for testing purposes only
  */
 export function initiateThemeTransfer( siteId, file, plugin ) {
-	const context = plugin ? 'plugins' : 'themes';
+	let context = plugin ? 'plugins' : 'themes';
+	if ( ! plugin && ! file ) {
+		context = 'hosting';
+	}
+
 	return dispatch => {
 		const themeInitiateRequest = {
 			type: THEME_TRANSFER_INITIATE_REQUEST,
@@ -680,7 +684,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 			.then( ( { transfer_id } ) => {
 				if ( ! transfer_id ) {
 					return dispatch(
-						transferInitiateFailure( siteId, { error: 'initiate_failure' }, plugin )
+						transferInitiateFailure( siteId, { error: 'initiate_failure' }, plugin, context )
 					);
 				}
 				const themeInitiateSuccessAction = {
@@ -694,10 +698,10 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 						themeInitiateSuccessAction
 					)
 				);
-				dispatch( pollThemeTransferStatus( siteId, transfer_id ) );
+				dispatch( pollThemeTransferStatus( siteId, transfer_id, context ) );
 			} )
 			.catch( error => {
-				dispatch( transferInitiateFailure( siteId, error, plugin ) );
+				dispatch( transferInitiateFailure( siteId, error, plugin, context ) );
 			} );
 	};
 }
@@ -725,8 +729,7 @@ function transferStatusFailure( siteId, transferId, error ) {
 }
 
 // receive a transfer initiation failure
-function transferInitiateFailure( siteId, error, plugin ) {
-	const context = plugin ? 'plugin' : 'theme';
+function transferInitiateFailure( siteId, error, plugin, context ) {
 	return dispatch => {
 		const themeInitiateFailureAction = {
 			type: THEME_TRANSFER_INITIATE_FAILURE,
@@ -748,14 +751,21 @@ function transferInitiateFailure( siteId, error, plugin ) {
  * The returned promise is only for testing purposes, and therefore is never rejected,
  * to avoid unhandled rejections in production.
  *
- * @param {Number} siteId -- the site being transferred
- * @param {Number} transferId -- the specific transfer
- * @param {Number} [interval] -- time between poll attemps
- * @param {Number} [timeout] -- time to wait for 'complete' status before bailing
+ * @param {number} siteId -- the site being transferred
+ * @param {number} transferId -- the specific transfer
+ * @param {string} context -- from which the transfer was initiated
+ * @param {number} [interval] -- time between poll attempts
+ * @param {number} [timeout] -- time to wait for 'complete' status before bailing
  *
- * @return {Promise} for testing purposes only
+ * @returns {Promise} for testing purposes only
  */
-export function pollThemeTransferStatus( siteId, transferId, interval = 3000, timeout = 180000 ) {
+export function pollThemeTransferStatus(
+	siteId,
+	transferId,
+	context,
+	interval = 3000,
+	timeout = 180000
+) {
 	const endTime = Date.now() + timeout;
 	return dispatch => {
 		const pollStatus = ( resolve, reject ) => {
@@ -771,7 +781,6 @@ export function pollThemeTransferStatus( siteId, transferId, interval = 3000, ti
 					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
 					if ( status === 'complete' ) {
 						// finished, stop polling
-						const context = uploaded_theme_slug ? 'themes' : 'plugins';
 						dispatch(
 							recordTracksEvent( 'calypso_automated_transfer_complete', {
 								transfer_id: transferId,
@@ -796,10 +805,10 @@ export function pollThemeTransferStatus( siteId, transferId, interval = 3000, ti
 /**
  * Deletes a theme from the given Jetpack site.
  *
- * @param {String} themeId -- Theme to delete
- * @param {Number} siteId -- Site to delete theme from
+ * @param {string} themeId -- Theme to delete
+ * @param {number} siteId -- Site to delete theme from
  *
- * @return {Function} Action thunk
+ * @returns {Function} Action thunk
  */
 export function deleteTheme( themeId, siteId ) {
 	return dispatch => {
@@ -834,10 +843,10 @@ export function deleteTheme( themeId, siteId ) {
  * Shows dialog asking user to confirm delete of theme
  * from jetpack site. Deletes theme if user confirms.
  *
- * @param {String} themeId -- Theme to delete
- * @param {Number} siteId -- Site to delete theme from
+ * @param {string} themeId -- Theme to delete
+ * @param {number} siteId -- Site to delete theme from
  *
- * @return {Function} Action thunk
+ * @returns {Function} Action thunk
  */
 export function confirmDelete( themeId, siteId ) {
 	return ( dispatch, getState ) => {
@@ -885,7 +894,7 @@ export function hideThemePreview() {
 /**
  * Triggers a network request to fetch all available theme filters.
  *
- * @return {Object} A nested list of theme filters, keyed by filter slug
+ * @returns {object} A nested list of theme filters, keyed by filter slug
  */
 export function requestThemeFilters() {
 	return {
@@ -898,10 +907,10 @@ export function requestThemeFilters() {
  * be suffixed with -wpcom. Themes on AT sites are not
  * installed via downloaded zip.
  *
- * @param {Object} state Global state tree
+ * @param {object} state Global state tree
  * @param {number} siteId Site ID
  * @param {string} themeId Theme ID
- * @return {string} the theme id to use when installing the theme
+ * @returns {string} the theme id to use when installing the theme
  */
 function suffixThemeIdForInstall( state, siteId, themeId ) {
 	// AT sites do not use the -wpcom suffix

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -542,18 +542,20 @@ describe( 'actions', () => {
 			} )
 		);
 
-		test( 'should dispatch installTheme() and activateTheme()', done => {
-			installAndActivateTheme(
-				'karuna-wpcom',
-				2211667
-			)( stub ).then( () => {
-				expect( stub ).to.have.been.calledWith(
-					matchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
-				);
-				expect( stub ).to.have.been.calledWith(
-					matchFunction( activateTheme( 'karuna-wpcom', 2211667 ) )
-				);
-				done();
+		test( 'should dispatch installTheme() and activateTheme()', () => {
+			return new Promise( done => {
+				installAndActivateTheme(
+					'karuna-wpcom',
+					2211667
+				)( stub ).then( () => {
+					expect( stub ).to.have.been.calledWith(
+						matchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
+					);
+					expect( stub ).to.have.been.calledWith(
+						matchFunction( activateTheme( 'karuna-wpcom', 2211667 ) )
+					);
+					done();
+				} );
 			} );
 		} );
 	} );
@@ -577,15 +579,17 @@ describe( 'actions', () => {
 					},
 				},
 			} );
-			test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', done => {
-				activate( 'karuna', 77203074 )( stub, fakeGetState ).then( () => {
-					expect( stub ).to.have.been.calledWith(
-						matchFunction( activateTheme( 'karuna', 77203074 ) )
-					);
-					expect( stub ).to.not.have.been.calledWith(
-						matchFunction( installAndActivateTheme( 'karuna-wpcom', 77203074 ) )
-					);
-					done();
+			test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', () => {
+				return new Promise( done => {
+					activate( 'karuna', 77203074 )( stub, fakeGetState ).then( () => {
+						expect( stub ).to.have.been.calledWith(
+							matchFunction( activateTheme( 'karuna', 77203074 ) )
+						);
+						expect( stub ).to.not.have.been.calledWith(
+							matchFunction( installAndActivateTheme( 'karuna-wpcom', 77203074 ) )
+						);
+						done();
+					} );
 				} );
 			} );
 		} );
@@ -612,15 +616,17 @@ describe( 'actions', () => {
 						},
 					},
 				} );
-				test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', done => {
-					activate( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-						expect( stub ).to.have.been.calledWith(
-							matchFunction( activateTheme( 'karuna', 2211667 ) )
-						);
-						expect( stub ).to.not.have.been.calledWith(
-							matchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
-						);
-						done();
+				test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', () => {
+					return new Promise( done => {
+						activate( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
+							expect( stub ).to.have.been.calledWith(
+								matchFunction( activateTheme( 'karuna', 2211667 ) )
+							);
+							expect( stub ).to.not.have.been.calledWith(
+								matchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
+							);
+							done();
+						} );
 					} );
 				} );
 			} );
@@ -633,15 +639,17 @@ describe( 'actions', () => {
 						queries: {},
 					},
 				} );
-				test( 'should dispatch (only) installAndActivateTheme() and pass the suffixed themeId', done => {
-					activate( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-						expect( stub ).to.not.have.been.calledWith(
-							matchFunction( activate( 'karuna', 2211667 ) )
-						);
-						expect( stub ).to.have.been.calledWith(
-							matchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
-						);
-						done();
+				test( 'should dispatch (only) installAndActivateTheme() and pass the suffixed themeId', () => {
+					return new Promise( done => {
+						activate( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
+							expect( stub ).to.not.have.been.calledWith(
+								matchFunction( activate( 'karuna', 2211667 ) )
+							);
+							expect( stub ).to.have.been.calledWith(
+								matchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
+							);
+							done();
+						} );
 					} );
 				} );
 			} );
@@ -767,7 +775,8 @@ describe( 'actions', () => {
 		test( 'should dispatch success on status complete', () => {
 			return pollThemeTransferStatus(
 				siteId,
-				1
+				1,
+				'themes'
 			)( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_TRANSFER_STATUS_RECEIVE,
@@ -784,6 +793,7 @@ describe( 'actions', () => {
 			return pollThemeTransferStatus(
 				siteId,
 				2,
+				'themes',
 				10,
 				25
 			)( spy ).then( () => {
@@ -800,6 +810,7 @@ describe( 'actions', () => {
 			return pollThemeTransferStatus(
 				siteId,
 				3,
+				'themes',
 				20
 			)( spy ).then( () => {
 				// Two 'progress' then a 'complete'
@@ -826,7 +837,8 @@ describe( 'actions', () => {
 		test( 'should dispatch failure on receipt of error', () => {
 			return pollThemeTransferStatus(
 				siteId,
-				4
+				4,
+				'themes'
 			)( spy ).then( () => {
 				expect( spy ).to.have.been.calledWithMatch( {
 					type: THEME_TRANSFER_STATUS_FAILURE,
@@ -1027,18 +1039,20 @@ describe( 'actions', () => {
 			} )
 		);
 
-		test( 'should dispatch installTheme(), and tryAndCustomizeTheme()', done => {
-			installAndTryAndCustomizeTheme(
-				'karuna-wpcom',
-				2211667
-			)( stub ).then( () => {
-				expect( stub ).to.have.been.calledWith(
-					matchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
-				);
-				expect( stub ).to.have.been.calledWith(
-					matchFunction( tryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
-				);
-				done();
+		test( 'should dispatch installTheme(), and tryAndCustomizeTheme()', () => {
+			return new Promise( done => {
+				installAndTryAndCustomizeTheme(
+					'karuna-wpcom',
+					2211667
+				)( stub ).then( () => {
+					expect( stub ).to.have.been.calledWith(
+						matchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
+					);
+					expect( stub ).to.have.been.calledWith(
+						matchFunction( tryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
+					);
+					done();
+				} );
 			} );
 		} );
 	} );
@@ -1062,15 +1076,17 @@ describe( 'actions', () => {
 					},
 				},
 			} );
-			test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', done => {
-				tryAndCustomize( 'karuna', 77203074 )( stub, fakeGetState ).then( () => {
-					expect( stub ).to.have.been.calledWith(
-						matchFunction( tryAndCustomizeTheme( 'karuna', 77203074 ) )
-					);
-					expect( stub ).to.not.have.been.calledWith(
-						matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 77203074 ) )
-					);
-					done();
+			test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', () => {
+				return new Promise( done => {
+					tryAndCustomize( 'karuna', 77203074 )( stub, fakeGetState ).then( () => {
+						expect( stub ).to.have.been.calledWith(
+							matchFunction( tryAndCustomizeTheme( 'karuna', 77203074 ) )
+						);
+						expect( stub ).to.not.have.been.calledWith(
+							matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 77203074 ) )
+						);
+						done();
+					} );
 				} );
 			} );
 		} );
@@ -1097,15 +1113,17 @@ describe( 'actions', () => {
 						},
 					},
 				} );
-				test( 'should dispatch (only) tryAndCustomizeTheme() and pass the unsuffixed themeId', done => {
-					tryAndCustomize( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-						expect( stub ).to.have.been.calledWith(
-							matchFunction( tryAndCustomizeTheme( 'karuna', 2211667 ) )
-						);
-						expect( stub ).to.not.have.been.calledWith(
-							matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
-						);
-						done();
+				test( 'should dispatch (only) tryAndCustomizeTheme() and pass the unsuffixed themeId', () => {
+					return new Promise( done => {
+						tryAndCustomize( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
+							expect( stub ).to.have.been.calledWith(
+								matchFunction( tryAndCustomizeTheme( 'karuna', 2211667 ) )
+							);
+							expect( stub ).to.not.have.been.calledWith(
+								matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
+							);
+							done();
+						} );
 					} );
 				} );
 			} );
@@ -1118,15 +1136,17 @@ describe( 'actions', () => {
 						queries: {},
 					},
 				} );
-				test( 'should dispatch (only) installAndTryAndCustomizeTheme() and pass the suffixed themeId', done => {
-					tryAndCustomize( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-						expect( stub ).to.not.have.been.calledWith(
-							matchFunction( tryAndCustomize( 'karuna', 2211667 ) )
-						);
-						expect( stub ).to.have.been.calledWith(
-							matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
-						);
-						done();
+				test( 'should dispatch (only) installAndTryAndCustomizeTheme() and pass the suffixed themeId', () => {
+					return new Promise( done => {
+						tryAndCustomize( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
+							expect( stub ).to.not.have.been.calledWith(
+								matchFunction( tryAndCustomize( 'karuna', 2211667 ) )
+							);
+							expect( stub ).to.have.been.calledWith(
+								matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
+							);
+							done();
+						} );
 					} );
 				} );
 			} );

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -36,7 +36,6 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": true,
-		"hosting/non-atomic-support": false,
 		"hosting/sftp-phpmyadmin": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": true,
-		"hosting/non-atomic-support": true,
 		"hosting/sftp-phpmyadmin": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -41,7 +41,6 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": true,
-		"hosting/non-atomic-support": false,
 		"hosting/sftp-phpmyadmin": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,6 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": true,
-		"hosting/non-atomic-support": false,
 		"hosting/sftp-phpmyadmin": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,7 +40,6 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": true,
-		"hosting/non-atomic-support": false,
 		"hosting/sftp-phpmyadmin": false,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,7 +40,6 @@
 		"google-my-business": false,
 		"help": true,
 		"hosting": true,
-		"hosting/non-atomic-support": false,
 		"hosting/sftp-phpmyadmin": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,7 +50,6 @@
 		"help": true,
 		"help/courses": true,
 		"hosting": true,
-		"hosting/non-atomic-support": false,
 		"hosting/sftp-phpmyadmin": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add the Hosting Configuration activation flow for Atomic.
- Refactor PHP Version card to display properly only when site is actually Atomic.

#### Testing instructions

- Create a site
- buy a business plan
- Got to hosting config
- Activate
- Proceed
- Wait, make sure all looks good