### PR TITLE
Fix undefined template class on unsupported theme activation

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -258,7 +258,7 @@ function populate_wp_template_data() {
 	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 
-	$theme_slug = normalize_theme_slug( get_stylesheet() );
+	$theme_slug = normalize_theme_slug( get_theme_slug() );
 
 	$template_inserter = new WP_Template_Inserter( $theme_slug );
 	$template_inserter->insert_default_template_data();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -251,12 +251,18 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
  * if the theme is unsupported.
  */
 function populate_wp_template_data() {
-	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
+	if ( ! is_theme_supported() ) {
+		return;
+	}
+
 	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 
-	$fse = Full_Site_Editing::get_instance();
-	$fse->insert_default_data();
+	$theme_slug = normalize_theme_slug( get_stylesheet() );
+
+	$template_inserter = new WP_Template_Inserter( $theme_slug );
+	$template_inserter->insert_default_template_data();
+	$template_inserter->insert_default_pages();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
 add_action( 'after_switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Use template inserter class by itself instead of with the FSE class. This way we avoid hooking into all of the WordPress actions if the theme is unsupported.

#### Testing instructions
1. Sync to sandbox. Sandbox a FSE site URL and the API.
2. Watch the error log on the sandbox. Look out for `Uncaught Error: Class 'A8C\FSE\WP_Template' not found`.
3. Activate maywood from the themes page. Click edit homepage and then back out of the editor after it loads.
4. Activate a non-FSE theme from the themes page. Immediately click edit homepage. **This is where the error happened before.**
5. Also test that template parts are still inserted correctly at these times:
a) Site creation (via horizon.wordpress.com/start/test-fse).
b) Activating a new theme (Exford or Shawburn)
