### PR TITLE
FSE Click anywhere on template block to navigate

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -124,11 +124,12 @@ const TemplateEdit = compose(
 		const { align, className } = attributes;
 
 		const save = event => {
+			event.preventDefault();
+			event.stopPropagation();
 			setNavigateToTemplate( true );
 			if ( ! isDirty ) {
 				return;
 			}
-			event.preventDefault();
 			savePost();
 		};
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -169,7 +169,7 @@ const TemplateEdit = compose(
 								/>
 							</div>
 						</Disabled>
-						<Placeholder className="template-block__overlay">
+						<Placeholder className="template-block__overlay" onClick={ save }>
 							{ navigateToTemplate && (
 								<div className="template-block__loading">
 									<Spinner /> { sprintf( __( 'Loading editor for: %s' ), templateTitle ) }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -124,12 +124,16 @@ const TemplateEdit = compose(
 		const { align, className } = attributes;
 
 		const save = event => {
-			event.preventDefault();
 			event.stopPropagation();
 			setNavigateToTemplate( true );
 			if ( ! isDirty ) {
 				return;
 			}
+			/**
+			 * This must be after setNavigateToTemplate so that local navigation
+			 * (without wpcom overrides) still works correctly.
+			 */
+			event.preventDefault();
 			savePost();
 		};
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -19,14 +19,14 @@
 	&.is-hovered, &.is-selected, .is-navigating-to-template {
 		.components-disabled {
 			filter: blur( 2px );
-			transition: filter 0.2s linear 0.7s;
+			transition: filter 0.2s linear;
 		}
 		.template-block__overlay {
 			opacity: 1;
 			transition: opacity 0.2s linear;
 			.components-button {
 				opacity: 1;
-				transition: opacity 0.2s linear 0.7s;
+				transition: opacity 0.2s linear;
 			}
 		}
 	}


### PR DESCRIPTION
cc @apeatling to see if we want to include this change. We discussed it in the user testing today, and it's a simple change.

![2019-11-26 16 08 28](https://user-images.githubusercontent.com/6265975/69682831-9a9edd80-1067-11ea-9566-c7e1df3e526b.gif)

### Changes proposed in this Pull Request

* Clicking anywhere on the template block will navigate to the header/footer editor.
* Remove the delay to show the button. My subjective opinion is that it looked laggy. I also remember a user not seeing the button because it didn't show up immediately and she moved the mouse outside of the block too quickly. Let me know what you think @Copons 

### Testing instructions
1. Test locally and on wpcom
2. Make sure that there is no delay for seeing the edit header button
3. Make sure you can click anywhere on the header and footer to go to the template editor
4. Make sure navigation around the template editor works clicking anywhere on the header/footer. (like the back button etc)
