### PR TITLE
Fix canary test: Use professional site type for premium plan test

### DIFF
--- a/test/e2e/lib/pages/signup/site-type-page.js
+++ b/test/e2e/lib/pages/signup/site-type-page.js
@@ -28,6 +28,10 @@ export default class SiteTypePage extends AsyncBaseContainer {
 		return await this._selectType( 'business' );
 	}
 
+	async selectProfessionalType() {
+		return await this._selectType( 'professional' );
+	}
+
 	async selectOnlineStoreType() {
 		return await this._selectType( 'online-store' );
 	}

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -424,7 +424,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		step( 'Can see the "Site Type" page, and enter some site information', async function() {
 			const siteTypePage = await SiteTypePage.Expect( driver );
-			return await siteTypePage.selectBusinessType();
+			return await siteTypePage.selectProfessionalType();
 		} );
 
 		step( 'Can see the "Site Topic" page, and enter the site topic', async function() {


### PR DESCRIPTION
The premium plan signup test expects to be able to select the premium plan immediately after landing on the plans page. But choosing the business site type means on phones the business plan is scrolled into view and the premium plan is unclickable.

Blocking deployment of the #36825

p1574829041096800-slack-C02DQP0FP
