### PR TITLE
Add ecommerce-design-first flow and condition to switch to it in SiteType

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -232,6 +232,20 @@ export function generateFlows( {
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2019-11-22',
 		};
+
+		flows[ 'ecommerce-design-first' ] = {
+			steps: [
+				'template-first-themes',
+				'user',
+				'site-type-with-theme',
+				'domains',
+				'plans-ecommerce',
+			],
+			destination: getSignupDestination,
+			description:
+				'Signup flow for creating an online store with an Atomic site, forked from the design-first flow',
+			lastModified: '2019-11-27',
+		};
 	}
 
 	if ( isEnabled( 'signup/wpcc' ) ) {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -45,6 +45,8 @@ class SiteType extends Component {
 		let flowName;
 		if ( 'import-onboarding' === this.props.flowName ) {
 			flowName = siteTypeToFlowname[ siteTypeValue ] || 'onboarding';
+		} else if ( 'design-first' === this.props.flowName && 'site-type-with-theme' === stepName ) {
+			flowName = 'online-store' === siteTypeValue ? 'ecommerce-design-first' : this.props.flowName;
 		} else {
 			flowName = siteTypeToFlowname[ siteTypeValue ] || this.props.flowName;
 		}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -45,7 +45,11 @@ class SiteType extends Component {
 		let flowName;
 		if ( 'import-onboarding' === this.props.flowName ) {
 			flowName = siteTypeToFlowname[ siteTypeValue ] || 'onboarding';
-		} else if ( 'design-first' === this.props.flowName && 'site-type-with-theme' === stepName ) {
+		} else if (
+			( 'design-first' === this.props.flowName ||
+				'ecommerce-design-first' === this.props.flowName ) &&
+			'site-type-with-theme' === stepName
+		) {
 			flowName = 'online-store' === siteTypeValue ? 'ecommerce-design-first' : this.props.flowName;
 		} else {
 			flowName = siteTypeToFlowname[ siteTypeValue ] || this.props.flowName;


### PR DESCRIPTION
This PR resolves an issue in https://github.com/Automattic/wp-calypso/pull/36825 where the `design-first` flow would switch to the `ecommerce-onboarding` flow at the site type step, if a user selects the `Online store` site type. This would then result in the user creating a site with the theme set by the `site-type` step, instead of the one they selected in the `design-first` flow, which is _not_ overridden by the `site-type-with-theme` step.

I went with the approach of adding an additional ecommerce flow, because this seemed clearer and more explicit than writing some awkward code to treat `site-type` and `site-type-with-theme` as though they're the same step — it also felt a bit safer not to mess with the Signup framework behaviour for this one case of a particular flow that had an issue.

#### Changes proposed in this Pull Request

* Add `ecommerce-design-first` flow
* Add conditional to `SiteType` to go to the `ecommerce-design-first` flow if the user selects the `online-store` from the `site-type-with-theme` step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/start/design-first
* Select a theme and create an account and then select the Online store segment, and you should be switched to the `ecommerce-design-first` flow
* Complete signup selecting the Business plan
* Finish creating a site, and the selected theme should be the one you chose at the start of the signup flow
* Go to http://calypso.localhost:3000/start/design-first again but this time select a different segment. You should remain on the same flow and the signup should work as normal.
* Go to http://calypso.localhost:3000/start and from the `site-type` step select `Online store` and ensure that you are still redirected to the `ecommerce-onboarding` flow.
* Complete signup from `/start` and select a different segment and ensure that you remain on the `onboarding` flow
