### PR TITLE
Gutenboarding: Try using Starter Page Templates

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -36,7 +36,7 @@ import ensureAssets from './utils/ensure-assets';
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
 
-class PageTemplateModal extends Component {
+export class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
 		previewedTemplate: null,

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,12 @@ const codeSplit = config.isEnabled( 'code-splitting' );
 const babelConfig = {
 	presets: [ [ '@automattic/calypso-build/babel/default', { modules } ] ],
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
-
+	overrides: [
+		{
+			test: './apps/full-site-editing',
+			presets: [ require.resolve( '@automattic/calypso-build/babel/wordpress-element' ) ],
+		},
+	],
 	env: {
 		production: {
 			plugins: [ 'babel-plugin-transform-react-remove-prop-types' ],

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -18,6 +18,7 @@ import { selectorDebounce } from '../../constants';
 
 interface Props {
 	isEditorSidebarOpened: boolean;
+	next: () => void;
 	toggleGeneralSidebar: () => void;
 	toggleSidebarShortcut: KeyboardShortcut;
 }
@@ -30,6 +31,7 @@ interface KeyboardShortcut {
 
 const Header: FunctionComponent< Props > = ( {
 	isEditorSidebarOpened,
+	next,
 	toggleGeneralSidebar,
 	toggleSidebarShortcut,
 } ) => {
@@ -96,7 +98,7 @@ const Header: FunctionComponent< Props > = ( {
 			</div>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Button isPrimary isLarge disabled={ ! siteTitle }>
+					<Button isPrimary isLarge disabled={ ! siteTitle } onClick={ next }>
 						{ NO__( 'Next' ) }
 					</Button>
 				</div>

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -30,6 +30,7 @@ import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import { Slot as SidebarSlot } from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
+import { SiteVertical } from './stores/onboard/types';
 import './stores/domain-suggestions';
 import './stores/onboard';
 import './stores/verticals-templates';
@@ -51,7 +52,7 @@ const onboardingBlock = createBlock( name, {} );
 
 const DesignSelector = () => {
 	const siteVertical = useSelect(
-		select => select( 'automattic/onboard' ).getState().siteVertical
+		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical
 	);
 	const templates = useSelect( select =>
 		select( 'automattic/verticals/templates' ).getTemplates( siteVertical.id )

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -50,10 +50,19 @@ registerBlockType( name, settings );
 const onboardingBlock = createBlock( name, {} );
 
 const DesignSelector = () => {
-	const templates = useSelect( select =>
-		select( 'automattic/verticals/templates' ).getTemplates( 'p13v1' )
+	const siteVertical = useSelect(
+		select => select( 'automattic/onboard' ).getState().siteVertical
 	);
-	return <PageTemplateModal templates={ templates } />;
+	const templates = useSelect( select =>
+		select( 'automattic/verticals/templates' ).getTemplates( siteVertical.id )
+	);
+	return (
+		<PageTemplateModal
+			segment="m1" // FIXME: Replace with actual segment!
+			templates={ templates }
+			vertical={ siteVertical }
+		/>
+	);
 };
 
 // Makeshift block so we can drop the modal into the block editor. Might want to change that later.

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -17,11 +17,11 @@ import {
 } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
+import { useSelect } from '@wordpress/data';
 import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useState } from 'react';
 import '@wordpress/components/build-style/style.css';
-import { registerCoreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -35,6 +35,8 @@ import './stores/onboard';
 import './stores/verticals-templates';
 import './style.scss';
 
+import { PageTemplateModal } from '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal';
+
 // Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
 // to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
 const toggleSidebarShortcut = {
@@ -47,8 +49,25 @@ registerBlockType( name, settings );
 
 const onboardingBlock = createBlock( name, {} );
 
-registerCoreBlocks();
-const templateBlock = createBlock( 'core/paragraph', { content: 'Template Selection' } );
+const DesignSelector = () => {
+	const templates = useSelect( select =>
+		select( 'automattic/verticals/templates' ).getTemplates( 'p13v1' )
+	);
+	return <PageTemplateModal templates={ templates } />;
+};
+
+// Makeshift block so we can drop the modal into the block editor. Might want to change that later.
+registerBlockType( 'automattic/page-templates', {
+	title: 'Page Templates',
+	icon: 'universal-access-alt',
+	category: 'layout',
+	attributes: {},
+	edit() {
+		return <DesignSelector />;
+	},
+} );
+
+const templateBlock = createBlock( 'automattic/page-templates', {} );
 
 export function Gutenboard() {
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,6 +21,7 @@ import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useState } from 'react';
 import '@wordpress/components/build-style/style.css';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -46,10 +47,16 @@ registerBlockType( name, settings );
 
 const onboardingBlock = createBlock( name, {} );
 
+registerCoreBlocks();
+const templateBlock = createBlock( 'core/paragraph', { content: 'Template Selection' } );
+
 export function Gutenboard() {
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );
-
 	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
+
+	// FIXME: Quick'n'dirty step state, replace with router
+	const [ currentStep, setStep ] = useState( 0 );
+	const goToNextStep = () => setStep( step => step + 1 );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -69,10 +76,14 @@ export function Gutenboard() {
 						/>
 						<Header
 							isEditorSidebarOpened={ isEditorSidebarOpened }
+							next={ goToNextStep }
 							toggleGeneralSidebar={ toggleGeneralSidebar }
 							toggleSidebarShortcut={ toggleSidebarShortcut }
 						/>
-						<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
+						<BlockEditorProvider
+							value={ [ currentStep === 0 ? onboardingBlock : templateBlock ] }
+							settings={ { templateLock: 'all' } }
+						>
 							<div className="edit-post-layout__content">
 								<div
 									className="edit-post-visual-editor editor-styles-wrapper"
@@ -98,5 +109,6 @@ export function Gutenboard() {
 			<Popover.Slot />
 		</div>
 	);
+
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -58,7 +58,8 @@ const DesignSelector = () => {
 	);
 	return (
 		<PageTemplateModal
-			segment="m1" // FIXME: Replace with actual segment!
+			saveTemplateChoice={ ( slug: string ) => console.log( `Template ${ slug } selected!` ) } // @FIXME
+			segment="m1" // @FIXME: Replace with actual segment!
 			templates={ templates }
 			vertical={ siteVertical }
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Try adding the plugin into Gutenboarding (not unlike #37951), with some quick and dirty step handling (no router yet), to work on replacing information coming from window  with our stores (or whateve else is applicable)

Informed by p7rd6c-295-p2. Supersedes #37950 and #37951.

#### Testing instructions

- Go to `http://calypso.localhost:3000/gutenboarding`
- Fill in vertical and site title
- Click 'Next'
- Select a template by clicking on it (caveat: Preview doesn't work yet, see below)
- Click the CTA button in the upper right corner, watch the browser console report the slug of the selected theme.

#### History/Roadmap

- [x] Merged #38002 and #38003 to contain globals
- [x] Merged `templates` prop handling #38042
- [ ] The preview isn't showing. There seems to be a problem with `parseBlocks` -- it returns `[]` :slightly_frowning_face: 