### PR TITLE
Change the product card action button label to "Manage Product"

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -474,12 +474,13 @@ export class ProductSelector extends Component {
 			const selectedProductSlug = this.state[ this.getStateKey( product.id, intervalType ) ];
 			const stateKey = this.getStateKey( product.id, intervalType );
 			let purchase = this.getPurchaseByProduct( product );
-			let isCurrent = this.getPurchaseBillingTimeframe( purchase ) === intervalType;
+			const isCurrent = this.getPurchaseBillingTimeframe( purchase ) === intervalType;
 			const hasProductPurchase = !! purchase;
+			let isIncludedInCurrentPlan = false;
 
 			if ( currentPlanIncludesProduct && ! hasProductPurchase ) {
 				purchase = this.getPurchaseByCurrentPlan();
-				isCurrent = currentPlanInSelectedTimeframe;
+				isIncludedInCurrentPlan = currentPlanInSelectedTimeframe;
 			}
 
 			let billingTimeFrame, fullPrice, discountedPrice, subtitle;
@@ -517,6 +518,7 @@ export class ProductSelector extends Component {
 					purchase={ purchase }
 					subtitle={ subtitle }
 					isCurrent={ isCurrent }
+					isIncludedInCurrentPlan={ isIncludedInCurrentPlan }
 				>
 					{ ! purchase && ! currentPlanIncludesProduct && (
 						<Fragment>

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -59,8 +59,10 @@ The following props can be passed to the Product Card component:
  displayed as a price range
 * `fullPrice`: ( number | array ) Full price of a product. If an array of 2 numbers is passed, it will be displayed as
  a price range
-* `isCurrent`: ( bool ) Flag indicating if a product is a currently purchased product. When true, will display a
- "Manage Subscription" button for the current product.
+* `isCurrent`: ( bool ) Flag indicating if a product is a currently purchased product. When true, will display an 
+ action button ("Manage Product") for the current product.
+* `isIncludedInCurrentPlan`: ( bool ) Flag indicating if a product is included in a plan the user is using. When true,
+ will display an action button ("Manage Plan") for the current plan.
 * `isPlaceholder`: ( bool ) Flag indicating if a product price is in a loading state and should be rendered as a
   placeholder
 * `purchase`: ( object ) A purchase object, associated with the product. [Read more about the way this flag

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -59,10 +59,6 @@ The following props can be passed to the Product Card component:
  displayed as a price range
 * `fullPrice`: ( number | array ) Full price of a product. If an array of 2 numbers is passed, it will be displayed as
  a price range
-* `isCurrent`: ( bool ) Flag indicating if a product is a currently purchased product. When true, will display an 
- action button ("Manage Product") for the current product.
-* `isIncludedInCurrentPlan`: ( bool ) Flag indicating if a product is included in a plan the user is using. When true,
- will display an action button ("Manage Plan") for the current plan.
 * `isPlaceholder`: ( bool ) Flag indicating if a product price is in a loading state and should be rendered as a
   placeholder
 * `purchase`: ( object ) A purchase object, associated with the product. [Read more about the way this flag

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -94,7 +94,7 @@ class ProductCard extends Component {
 						<ProductCardAction
 							onClick={ this.handleManagePurchase( purchase.productSlug ) }
 							href={ managePurchase( purchase.domain, purchase.id ) }
-							label={ translate( 'Manage Subscription' ) }
+							label={ translate( 'Manage Product' ) }
 							primary={ false }
 						/>
 					) }

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -33,6 +33,7 @@ class ProductCard extends Component {
 		] ),
 		fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
 		isCurrent: PropTypes.bool,
+		isIncludedInCurrentPlan: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		purchase: PropTypes.object,
 		subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
@@ -47,6 +48,28 @@ class ProductCard extends Component {
 		};
 	}
 
+	renderActionButton() {
+		const { isCurrent, isIncludedInCurrentPlan, purchase, translate } = this.props;
+
+		// Show an action button if the user owns a product or it is part of a plan.
+		const displayActionButton = purchase && ( isCurrent || isIncludedInCurrentPlan );
+
+		if ( ! displayActionButton ) {
+			return null;
+		}
+
+		return (
+			<ProductCardAction
+				onClick={ this.handleManagePurchase( purchase.productSlug ) }
+				href={ managePurchase( purchase.domain, purchase.id ) }
+				label={
+					isIncludedInCurrentPlan ? translate( 'Manage Plan' ) : translate( 'Manage Product' )
+				}
+				primary={ false }
+			/>
+		);
+	}
+
 	render() {
 		const {
 			billingTimeFrame,
@@ -55,12 +78,10 @@ class ProductCard extends Component {
 			description,
 			discountedPrice,
 			fullPrice,
-			isCurrent,
 			isPlaceholder,
 			purchase,
 			subtitle,
 			title,
-			translate,
 		} = this.props;
 		const cardClassNames = classNames( 'product-card', {
 			'is-placeholder': isPlaceholder,
@@ -90,14 +111,7 @@ class ProductCard extends Component {
 				</div>
 				<div className="product-card__description">
 					{ description && <p>{ description }</p> }
-					{ purchase && isCurrent && (
-						<ProductCardAction
-							onClick={ this.handleManagePurchase( purchase.productSlug ) }
-							href={ managePurchase( purchase.domain, purchase.id ) }
-							label={ translate( 'Manage Product' ) }
-							primary={ false }
-						/>
-					) }
+					{ this.renderActionButton() }
 				</div>
 				{ children }
 			</Card>

--- a/client/components/product-card/index.jsx
+++ b/client/components/product-card/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,111 +11,74 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
-import { managePurchase } from 'me/purchases/paths';
-import ProductCardAction from './action';
 import ProductCardPriceGroup from './price-group';
-import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-class ProductCard extends Component {
-	static propTypes = {
-		billingTimeFrame: PropTypes.string,
-		currencyCode: PropTypes.string,
-		description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
-		discountedPrice: PropTypes.oneOfType( [
-			PropTypes.number,
-			PropTypes.arrayOf( PropTypes.number ),
-		] ),
-		fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
-		isCurrent: PropTypes.bool,
-		isIncludedInCurrentPlan: PropTypes.bool,
-		isPlaceholder: PropTypes.bool,
-		purchase: PropTypes.object,
-		subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
-		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
-	};
+function ProductCard( {
+	billingTimeFrame,
+	children,
+	currencyCode,
+	description,
+	discountedPrice,
+	fullPrice,
+	isPlaceholder,
+	purchase,
+	subtitle,
+	title,
+} ) {
+	const cardClassNames = classNames( 'product-card', {
+		'is-placeholder': isPlaceholder,
+		'is-purchased': !! purchase,
+	} );
 
-	handleManagePurchase( productSlug ) {
-		return () => {
-			this.props.recordTracksEvent( 'calypso_manage_purchase_click', {
-				slug: productSlug,
-			} );
-		};
-	}
-
-	renderActionButton() {
-		const { isCurrent, isIncludedInCurrentPlan, purchase, translate } = this.props;
-
-		// Show an action button if the user owns a product or it is part of a plan.
-		const displayActionButton = purchase && ( isCurrent || isIncludedInCurrentPlan );
-
-		if ( ! displayActionButton ) {
-			return null;
-		}
-
-		return (
-			<ProductCardAction
-				onClick={ this.handleManagePurchase( purchase.productSlug ) }
-				href={ managePurchase( purchase.domain, purchase.id ) }
-				label={
-					isIncludedInCurrentPlan ? translate( 'Manage Plan' ) : translate( 'Manage Product' )
-				}
-				primary={ false }
-			/>
-		);
-	}
-
-	render() {
-		const {
-			billingTimeFrame,
-			children,
-			currencyCode,
-			description,
-			discountedPrice,
-			fullPrice,
-			isPlaceholder,
-			purchase,
-			subtitle,
-			title,
-		} = this.props;
-		const cardClassNames = classNames( 'product-card', {
-			'is-placeholder': isPlaceholder,
-			'is-purchased': !! purchase,
-		} );
-
-		return (
-			<Card className={ cardClassNames }>
-				<div className="product-card__header">
-					{ title && (
-						<div className="product-card__header-primary">
-							{ purchase && <Gridicon icon="checkmark" size={ 18 } /> }
-							<h3 className="product-card__title">{ title }</h3>
-						</div>
-					) }
-					<div className="product-card__header-secondary">
-						{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
-						{ ! purchase && (
-							<ProductCardPriceGroup
-								billingTimeFrame={ billingTimeFrame }
-								currencyCode={ currencyCode }
-								discountedPrice={ discountedPrice }
-								fullPrice={ fullPrice }
-							/>
-						) }
+	return (
+		<Card className={ cardClassNames }>
+			<div className="product-card__header">
+				{ title && (
+					<div className="product-card__header-primary">
+						{ purchase && <Gridicon icon="checkmark" size={ 18 } /> }
+						<h3 className="product-card__title">{ title }</h3>
 					</div>
+				) }
+				<div className="product-card__header-secondary">
+					{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
+					{ ! purchase && (
+						<ProductCardPriceGroup
+							billingTimeFrame={ billingTimeFrame }
+							currencyCode={ currencyCode }
+							discountedPrice={ discountedPrice }
+							fullPrice={ fullPrice }
+						/>
+					) }
 				</div>
+			</div>
+			{ description && (
 				<div className="product-card__description">
-					{ description && <p>{ description }</p> }
-					{ this.renderActionButton() }
+					<p>{ description }</p>
 				</div>
-				{ children }
-			</Card>
-		);
-	}
+			) }
+			{ children }
+		</Card>
+	);
 }
 
-export default connect( null, { recordTracksEvent } )( localize( ProductCard ) );
+ProductCard.propTypes = {
+	billingTimeFrame: PropTypes.string,
+	currencyCode: PropTypes.string,
+	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+	discountedPrice: PropTypes.oneOfType( [
+		PropTypes.number,
+		PropTypes.arrayOf( PropTypes.number ),
+	] ),
+	fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+	isPlaceholder: PropTypes.bool,
+	purchase: PropTypes.object,
+	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+};
+
+export default localize( ProductCard );


### PR DESCRIPTION
**Before**
<img width="538" alt="Screenshot 2019-11-27 at 11 51 16" src="https://user-images.githubusercontent.com/478735/69717413-4f8ad600-110c-11ea-80fb-00d7079463f4.png">

**After**
<img width="534" alt="Screenshot 2019-11-27 at 11 50 59" src="https://user-images.githubusercontent.com/478735/69717386-4437aa80-110c-11ea-912e-0ac281b212b7.png">

#### Changes proposed in this Pull Request

* Change the product card action button label to "Manage Product"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/plans/
* Select a Jetpack site that has one of the Jetpack Backup products
* Confirm that the action button inside the product card is now labelled: "Manage Product"

Fixes n/a
