### PR TITLE
Build: upgrade mini-css-extract-plugin-with-rtl to npm-published a8c fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
 			"version": "file:packages/calypso-build",
 			"dev": true,
 			"requires": {
+				"@automattic/mini-css-extract-plugin-with-rtl": "0.8.0",
 				"@babel/cli": "7.7.5",
 				"@babel/core": "7.7.5",
 				"@babel/plugin-proposal-class-properties": "7.7.4",
@@ -132,7 +133,6 @@
 				"jest-config": "24.9.0",
 				"jest-emotion": "^10.0.27",
 				"jest-enzyme": "7.1.2",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
 				"node-sass": "4.13.0",
 				"postcss-custom-properties": "9.0.2",
 				"postcss-loader": "3.0.0",
@@ -143,7 +143,6 @@
 				"typescript": "3.7.3",
 				"webpack": "4.41.3",
 				"webpack-cli": "3.3.10",
-				"webpack-filter-warnings-plugin": "1.2.1",
 				"webpack-rtl-plugin": "2.0.0"
 			},
 			"dependencies": {
@@ -281,6 +280,38 @@
 		"@automattic/material-design-icons": {
 			"version": "file:packages/material-design-icons"
 		},
+		"@automattic/mini-css-extract-plugin-with-rtl": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@automattic/mini-css-extract-plugin-with-rtl/-/mini-css-extract-plugin-with-rtl-0.8.0.tgz",
+			"integrity": "sha512-HEGnZjw4hpR3axUO8e3v7Is38VKrkrizdwianNCaEP3KW8Kx4z0fzc1DyiiLTptIrHy4VaoyHnfkA3+js5N7JQ==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^1.1.0",
+				"normalize-url": "1.9.1",
+				"schema-utils": "^1.0.0",
+				"webpack-sources": "^1.1.0"
+			},
+			"dependencies": {
+				"normalize-url": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+					"dev": true,
+					"requires": {
+						"object-assign": "^4.0.1",
+						"prepend-http": "^1.0.0",
+						"query-string": "^4.1.0",
+						"sort-keys": "^1.0.0"
+					}
+				},
+				"prepend-http": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+					"dev": true
+				}
+			}
+		},
 		"@automattic/muriel-style": {
 			"version": "file:packages/muriel-style"
 		},
@@ -391,6 +422,15 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"json5": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -4354,6 +4394,15 @@
 						"pretty-error": "^2.1.1",
 						"tapable": "^1.1.3",
 						"util.promisify": "1.0.0"
+					}
+				},
+				"json5": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
 					}
 				},
 				"locate-path": {
@@ -8590,6 +8639,15 @@
 						"resolve": "^1.12.0"
 					}
 				},
+				"json5": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -9513,9 +9571,9 @@
 			}
 		},
 		"case-sensitive-paths-webpack-plugin": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
-			"integrity": "sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
+			"integrity": "sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ==",
 			"dev": true
 		},
 		"caseless": {
@@ -13430,9 +13488,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.334",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.334.tgz",
-			"integrity": "sha512-RcjJhpsVaX0X6ntu/WSBlW9HE9pnCgXS9B8mTUObl1aDxaiOa0Lu+NMveIS5IDC+VELzhM32rFJDCC+AApVwcA=="
+			"version": "1.3.335",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.335.tgz",
+			"integrity": "sha512-ngKsDGd/xr2lAZvilxTfdvfEiQKmavyXd6irlswaHnewmXoz6JgbM9FUNwgp3NFIUHHegh1F87H8f5BJ8zABxw=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.1",
@@ -13806,9 +13864,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.1.tgz",
-			"integrity": "sha512-WmWNHWmm/LDwK8jaeZic/g6sU1ZckM+vvOyCV1qFRhJJ6hzve6DRgthNQB7Lra1ocrw68HexLKYgtdxIPcb3Fg==",
+			"version": "1.17.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
+			"integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
@@ -20689,9 +20747,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
@@ -20965,17 +21023,6 @@
 				"big.js": "^5.2.2",
 				"emojis-list": "^2.0.0",
 				"json5": "^1.0.1"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				}
 			}
 		},
 		"locate-path": {
@@ -21957,37 +22004,6 @@
 				}
 			}
 		},
-		"mini-css-extract-plugin-with-rtl": {
-			"version": "github:Automattic/mini-css-extract-plugin-with-rtl#f48ce03f385390257bdacbfec4759d38df983361",
-			"from": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.1.0",
-				"normalize-url": "1.9.1",
-				"schema-utils": "^1.0.0",
-				"webpack-sources": "^1.1.0"
-			},
-			"dependencies": {
-				"normalize-url": {
-					"version": "1.9.1",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-					"dev": true,
-					"requires": {
-						"object-assign": "^4.0.1",
-						"prepend-http": "^1.0.0",
-						"query-string": "^4.1.0",
-						"sort-keys": "^1.0.0"
-					}
-				},
-				"prepend-http": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-					"dev": true
-				}
-			}
-		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -22386,9 +22402,9 @@
 			}
 		},
 		"moo": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+			"integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
 			"dev": true
 		},
 		"morgan": {
@@ -22536,13 +22552,13 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.0.tgz",
-			"integrity": "sha512-2v52FTw7RPqieZr3Gth1luAXZR7Je6q3KaDHY5bjl/paDUdMu35fZ8ICNgiYJRr3tf3NMvIQQR1r27AvEr9CRA==",
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.1.tgz",
+			"integrity": "sha512-xq47GIUGXxU9vQg7g/y1o1xuKnkO7ev4nRWqftmQrLkfnE/FjRqDaGOUakM8XHPn/6pW3bGjU2wgoJyId90rqg==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
-				"moo": "^0.4.3",
+				"moo": "^0.5.0",
 				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6",
 				"semver": "^5.4.1"
@@ -29709,14 +29725,13 @@
 			}
 		},
 		"react-sizeme": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.11.tgz",
-			"integrity": "sha512-t/803grbHfvBnpPzjpzzvyl5L9Dj3ACMQS7qeScQoxDRmFC2VAU2gF+DYkclBDV9HN8hLFOWRdGkuN0xwGNZXQ==",
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.12.tgz",
+			"integrity": "sha512-tL4sCgfmvapYRZ1FO2VmBmjPVzzqgHA7kI8lSJ6JS6L78jXFNRdOZFpXyK6P1NBZvKPPCZxReNgzZNUajAerZw==",
 			"dev": true,
 			"requires": {
-				"element-resize-detector": "^1.1.16",
+				"element-resize-detector": "^1.2.1",
 				"invariant": "^2.2.4",
-				"prop-types": "^15.7.2",
 				"shallowequal": "^1.1.0",
 				"throttle-debounce": "^2.1.0"
 			}
@@ -36605,12 +36620,6 @@
 					}
 				}
 			}
-		},
-		"webpack-filter-warnings-plugin": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
-			"integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-			"dev": true
 		},
 		"webpack-hot-middleware": {
 			"version": "2.25.0",

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next
+
+- Upgrade [mini-css-extract-plugin-with-rtl](https://github.com/Automattic/mini-css-extract-plugin-with-rtl) to 0.8.0, use an npm-published version instead of GitHub branch reference
+
 # 6.0.0
 
 - Breaking Change: Replace `copy-styles` with a generic `copy-assets` script to handle both styles and images.

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -34,6 +34,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
+		"@automattic/mini-css-extract-plugin-with-rtl": "0.8.0",
 		"@babel/cli": "7.7.5",
 		"@babel/core": "7.7.5",
 		"@babel/plugin-proposal-class-properties": "7.7.4",
@@ -62,7 +63,6 @@
 		"jest-config": "24.9.0",
 		"jest-emotion": "^10.0.27",
 		"jest-enzyme": "7.1.2",
-		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
 		"node-sass": "4.13.0",
 		"postcss-custom-properties": "9.0.2",
 		"postcss-loader": "3.0.0",
@@ -73,7 +73,6 @@
 		"typescript": "3.7.3",
 		"webpack": "4.41.3",
 		"webpack-cli": "3.3.10",
-		"webpack-filter-warnings-plugin": "1.2.1",
 		"webpack-rtl-plugin": "2.0.0"
 	},
 	"peerDependencies": {

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-const FilterWarningsPlugin = require( 'webpack-filter-warnings-plugin' );
-const MiniCssExtractPluginWithRTL = require( 'mini-css-extract-plugin-with-rtl' );
+const MiniCssExtractPluginWithRTL = require( '@automattic/mini-css-extract-plugin-with-rtl' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 
 /**
@@ -57,12 +56,8 @@ module.exports.plugins = ( { chunkFilename, filename, minify } ) => [
 	new MiniCssExtractPluginWithRTL( {
 		chunkFilename,
 		filename,
+		ignoreOrder: true, // suppress conflicting order warnings from mini-css-extract-plugin
 		rtlEnabled: true,
-	} ),
-	new FilterWarningsPlugin( {
-		// suppress conflicting order warnings from mini-css-extract-plugin.
-		// see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
-		exclude: /mini-css-extract-plugin[^]*Conflicting order between:/,
 	} ),
 	new WebpackRTLPlugin( {
 		minify,


### PR DESCRIPTION
Updated the `mini-css-extract-plugin-with-rtl` package as follows:
- in https://github.com/Automattic/mini-css-extract-plugin-with-rtl, diverge from the original fork repo (https://github.com/beshanoe/mini-css-extract-plugin-with-rtl). I reused their code changes, but applied them as a different commit set on top of the `mini-css-extract-plugin`. The original fork repo uses a rather chaotic set of patch and merge commits that's difficult to rebase and maintain.
- apply the patch set to the `v0.8.0` version of `mini-css-extract-plugin`
- release to npm as `@automattic/mini-css-extract-plugin-with-rtl@0.8.0`

Then I updated the `calypso-build` package to use the npm-published package.

Because version 0.8.0 introduced a new `ignoreOrder` option that allows to disable the conflicting order warnings, we no longer need to disable them ourselves with `webpack-filter-warnings-plugin` and can remove that code and the `filter-warnings` plugin, too, as this was its only usage.

Then I also updated the lockfiles of `apps/full-site-editing` and `apps/wpcom-block-editor`. `full-site-editing` referenced npm-published `@automattic/calypso-build`, so I changed that to a `file:` reference: makes more sense for monorepo.

**How to test:**
Build and run Calypso with `?flags=quick-language-switcher`. Verify that when switching between LTR and RTL languages, the CSS chunks are switched at runtime.