### PR TITLE
SPT: No globals in components

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies */
-/* global starterPageTemplatesConfig */
 
 /**
  * External dependencies
@@ -16,9 +15,6 @@ import { PageTemplatesPlugin } from '../index';
 import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
 /* eslint-enable import/no-extraneous-dependencies */
-
-const { theme, isFrontPage } = starterPageTemplatesConfig;
-
 class SidebarModalOpener extends Component {
 	state = {
 		isTemplateModalOpen: false,
@@ -34,7 +30,7 @@ class SidebarModalOpener extends Component {
 	};
 
 	getLastTemplateUsed = () => {
-		const { templates } = this.props;
+		const { isFrontPage, templates, theme } = this.props;
 		let { lastTemplateUsedSlug } = this.props;
 		// Try to match the homepage of the theme. Note that as folks transition
 		// to using the slug-based version of the homepage (e.g. "shawburn"), the
@@ -57,7 +53,7 @@ class SidebarModalOpener extends Component {
 
 	render() {
 		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
-		const { templates, vertical, segment, siteInformation } = this.props;
+		const { isFrontPage, templates, theme, vertical, segment, siteInformation } = this.props;
 
 		return (
 			<div className="sidebar-modal-opener">
@@ -82,9 +78,11 @@ class SidebarModalOpener extends Component {
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
 						templates={ templates }
+						theme={ theme }
 						vertical={ vertical }
 						segment={ segment }
 						toggleTemplateModal={ this.toggleTemplateModal }
+						isFrontPage={ isFrontPage }
 						isPromptedFromSidebar
 					/>
 				) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -87,16 +87,16 @@ class PageTemplateModal extends Component {
 		let previouslyChosenTemplate = props._starter_page_template;
 
 		// Usally the "new page" case.
-		if ( ! isFrontPage && ! previouslyChosenTemplate ) {
+		if ( ! props.isFrontPage && ! previouslyChosenTemplate ) {
 			return blankTemplate;
 		}
 
 		// Normalize "home" slug into the current theme.
 		if ( previouslyChosenTemplate === 'home' ) {
-			previouslyChosenTemplate = theme;
+			previouslyChosenTemplate = props.theme;
 		}
 
-		const slug = previouslyChosenTemplate || theme;
+		const slug = previouslyChosenTemplate || props.theme;
 
 		if ( find( props.templates, { slug } ) ) {
 			return slug;
@@ -197,10 +197,10 @@ class PageTemplateModal extends Component {
 		} );
 
 		const currentThemeTemplate =
-			find( this.props.templates, { slug: theme } ) ||
+			find( this.props.templates, { slug: this.props.theme } ) ||
 			find( this.props.templates, { slug: DEFAULT_HOMEPAGE_TEMPLATE } );
 
-		if ( ! isFrontPage || ! currentThemeTemplate ) {
+		if ( ! this.props.isFrontPage || ! currentThemeTemplate ) {
 			return { homepageTemplates: sortBy( homepageTemplates, 'title' ), defaultTemplates };
 		}
 
@@ -275,7 +275,7 @@ class PageTemplateModal extends Component {
 					) : (
 						<>
 							<form className="page-template-modal__form">
-								{ isFrontPage ? (
+								{ this.props.isFrontPage ? (
 									<>
 										{ this.renderTemplatesList(
 											homepageTemplates,
@@ -385,10 +385,12 @@ if ( screenAction === 'add' ) {
 		render: () => {
 			return (
 				<PageTemplatesPlugin
+					isFrontPage={ isFrontPage }
+					segment={ segment }
 					shouldPrefetchAssets={ false }
 					templates={ templates }
+					theme={ theme }
 					vertical={ vertical }
-					segment={ segment }
 				/>
 			);
 		},
@@ -406,10 +408,12 @@ registerPlugin( 'page-templates-sidebar', {
 				icon="admin-page"
 			>
 				<SidebarTemplatesPlugin
-					templates={ templates }
-					vertical={ vertical }
+					isFrontPage={ isFrontPage }
 					segment={ segment }
 					siteInformation={ siteInformation }
+					templates={ templates }
+					theme={ theme }
+					vertical={ vertical }
 				/>
 			</PluginDocumentSettingPanel>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -68,10 +68,10 @@ class PageTemplateModal extends Component {
 
 		// Parse templates blocks and store them into the state.
 		const blocksByTemplateSlug = reduce(
-			templates,
+			this.props.templates,
 			( prev, { slug, content } ) => {
 				prev[ slug ] = content
-					? parseBlocks( replacePlaceholders( content, siteInformation ) )
+					? parseBlocks( replacePlaceholders( content, this.props.siteInformation ) )
 					: [];
 				return prev;
 			},
@@ -223,7 +223,7 @@ class PageTemplateModal extends Component {
 				blocksByTemplates={ this.state.blocksByTemplateSlug }
 				onTemplateSelect={ this.previewTemplate }
 				useDynamicPreview={ false }
-				siteInformation={ siteInformation }
+				siteInformation={ this.props.siteInformation }
 				selectedTemplate={ this.state.previewedTemplate }
 				handleTemplateConfirmation={ this.handleConfirmation }
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Both the `PageTemplateModal` and `SidebarModalOpener` components were found to directly rely on globals variables, rather than using the existing pattern of passing those globals as props into those components, to preserve some level of encapsulation.

This PR shouldn't change any functionality.

Required for p7rd6c-295-p2. Partial fix for #37998.

Preparatory step for moving [this](https://github.com/Automattic/wp-calypso/blob/02d3db2380ff3532fb636823ec683f29ce13eff8/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js#L30-L40) to a separate file.

#### Testing instructions

Verify that the the Starter Page Templates Modal works as before.
