### PR TITLE
SPT: Isolate `window` global

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -1,4 +1,87 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { select, dispatch, subscribe } from '@wordpress/data';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+
 /**
  * Internal dependencies
  */
-import './page-template-modal';
+import { PageTemplatesPlugin } from './page-template-modal';
+import SidebarTemplatesPlugin from './page-template-modal/components/sidebar-modal-opener';
+import { initializeWithIdentity } from './page-template-modal/utils/tracking';
+/* eslint-enable import/no-extraneous-dependencies */
+
+// Load config passed from backend.
+const {
+	templates = [],
+	vertical,
+	segment,
+	tracksUserData,
+	siteInformation = {},
+	screenAction,
+	theme,
+	isFrontPage,
+} = window.starterPageTemplatesConfig;
+
+if ( tracksUserData ) {
+	initializeWithIdentity( tracksUserData );
+}
+
+// Open plugin only if we are creating new page.
+if ( screenAction === 'add' ) {
+	registerPlugin( 'page-templates', {
+		render: () => {
+			return (
+				<PageTemplatesPlugin
+					isFrontPage={ isFrontPage }
+					segment={ segment }
+					shouldPrefetchAssets={ false }
+					templates={ templates }
+					theme={ theme }
+					vertical={ vertical }
+				/>
+			);
+		},
+	} );
+}
+
+// Always register ability to open from document sidebar.
+registerPlugin( 'page-templates-sidebar', {
+	render: () => {
+		return (
+			<PluginDocumentSettingPanel
+				name="Template Modal Opener"
+				title={ __( 'Page Layout' ) }
+				className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
+				icon="admin-page"
+			>
+				<SidebarTemplatesPlugin
+					isFrontPage={ isFrontPage }
+					segment={ segment }
+					siteInformation={ siteInformation }
+					templates={ templates }
+					theme={ theme }
+					vertical={ vertical }
+				/>
+			</PluginDocumentSettingPanel>
+		);
+	},
+} );
+
+// Make sidebar plugin open by default.
+const unsubscribe = subscribe( () => {
+	if (
+		! select( 'core/edit-post' ).isEditorPanelOpened(
+			'page-templates-sidebar/Template Modal Opener'
+		)
+	) {
+		dispatch( 'core/edit-post' ).toggleEditorPanelOpened(
+			'page-templates-sidebar/Template Modal Opener'
+		);
+	}
+	unsubscribe();
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -8,42 +8,22 @@ import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner, IconButton } from '@wordpress/components';
-import { registerPlugin } from '@wordpress/plugins';
-import {
-	withDispatch,
-	withSelect,
-	select as wpSelect,
-	dispatch as wpDispatch,
-	subscribe,
-} from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
 import { parse as parseBlocks } from '@wordpress/blocks';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+
 /**
  * Internal dependencies
  */
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
 import TemplateSelectorPreview from './components/template-selector-preview';
-import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
+import { trackDismiss, trackSelection, trackView } from './utils/tracking';
 import replacePlaceholders from './utils/replace-placeholders';
 import ensureAssets from './utils/ensure-assets';
-import SidebarTemplatesPlugin from './components/sidebar-modal-opener';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
-
-// Load config passed from backend.
-const {
-	templates = [],
-	vertical,
-	segment,
-	tracksUserData,
-	siteInformation = {},
-	screenAction,
-	theme,
-	isFrontPage,
-} = window.starterPageTemplatesConfig;
 
 class PageTemplateModal extends Component {
 	state = {
@@ -380,62 +360,3 @@ export const PageTemplatesPlugin = compose(
 		};
 	} )
 )( PageTemplateModal );
-
-if ( tracksUserData ) {
-	initializeWithIdentity( tracksUserData );
-}
-
-// Open plugin only if we are creating new page.
-if ( screenAction === 'add' ) {
-	registerPlugin( 'page-templates', {
-		render: () => {
-			return (
-				<PageTemplatesPlugin
-					isFrontPage={ isFrontPage }
-					segment={ segment }
-					shouldPrefetchAssets={ false }
-					templates={ templates }
-					theme={ theme }
-					vertical={ vertical }
-				/>
-			);
-		},
-	} );
-}
-
-// Always register ability to open from document sidebar.
-registerPlugin( 'page-templates-sidebar', {
-	render: () => {
-		return (
-			<PluginDocumentSettingPanel
-				name="Template Modal Opener"
-				title={ __( 'Page Layout' ) }
-				className="page-template-modal__sidebar"
-				icon="admin-page"
-			>
-				<SidebarTemplatesPlugin
-					isFrontPage={ isFrontPage }
-					segment={ segment }
-					siteInformation={ siteInformation }
-					templates={ templates }
-					theme={ theme }
-					vertical={ vertical }
-				/>
-			</PluginDocumentSettingPanel>
-		);
-	},
-} );
-
-// Make sidebar plugin open by default.
-const unsubscribe = subscribe( () => {
-	if (
-		! wpSelect( 'core/edit-post' ).isEditorPanelOpened(
-			'page-templates-sidebar/Template Modal Opener'
-		)
-	) {
-		wpDispatch( 'core/edit-post' ).toggleEditorPanelOpened(
-			'page-templates-sidebar/Template Modal Opener'
-		);
-	}
-	unsubscribe();
-} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Move use of the `window.starterPageTemplatesConfig` global from `apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js` to `apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js`. Also move Gutenberg plugin registration to that file, as it relies on that global.

I think that the latter file is the only entrypoint for the SPT modal, so this separation of concerns should make sense. AFAICS, it also breaks a circular dependency between `apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js` and `apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js`.

Required for p7rd6c-295-p2.

#### Testing instructions

Verify that Starter Page Templates still work as before.

(I didn't test myself, apologies -- wrote this in an airport briefly before boarding.)

Fixes #37998.
