### PR TITLE
Add an upsell nudge to Reader sidebar

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -15,6 +15,7 @@ import ReaderSidebarHelper from './helper';
 import ReaderSidebarLists from './reader-sidebar-lists';
 import ReaderSidebarTags from './reader-sidebar-tags';
 import ReaderSidebarTeams from './reader-sidebar-teams';
+import ReaderSidebarNudges from './reader-sidebar-nudges';
 import QueryReaderLists from 'components/data/query-reader-lists';
 import QueryReaderTeams from 'components/data/query-reader-teams';
 import Sidebar from 'layout/sidebar';
@@ -145,6 +146,7 @@ export class ReaderSidebar extends React.Component {
 		return (
 			<Sidebar onClick={ this.handleClick }>
 				<SidebarRegion>
+					<ReaderSidebarNudges />
 					<SidebarMenu>
 						<SidebarHeading>{ translate( 'Streams' ) }</SidebarHeading>
 						<ul>

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -11,6 +11,7 @@ import { localize, getLocaleSlug } from 'i18n-calypso';
 import QuerySitePlans from 'components/data/query-site-plans';
 import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-to-paid-upsell';
 import { isJetpackSite } from 'state/sites/selectors';
 import getSites from 'state/selectors/get-sites';
@@ -49,16 +50,20 @@ export function ReaderSidebarNudges( props ) {
 }
 
 function mapStateToProps( state ) {
+	const isDevelopment = 'development' === process.env.NODE_ENV;
 	const siteCount = getSites( state ).length;
 	const siteId = getPrimarySiteId( state );
 	const siteSlug = getPrimarySiteSlug( state );
+	const devCountryCode = isDevelopment && global.window && global.window.userCountryCode;
+	const countryCode = devCountryCode || getCurrentUserCountryCode( state );
 
 	return {
 		siteId,
 		siteSlug,
 		isEligibleForFreeToPaidUpsellNudge:
-			siteCount === 1 && // available for the user who owns one site only
+			siteCount === 1 && // available when a user owns one site only
 			'en' === getLocaleSlug( state ) && // only for English speakers
+			'US' === countryCode && // only for US residents
 			! isDomainOnlySite( state, siteId ) && // not for domain only sites
 			! isJetpackSite( state, siteId ) && // not for Jetpack sites
 			isEligibleForFreeToPaidUpsell( state, siteId ),

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -28,7 +28,6 @@ function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) 
 			icon="info-outline"
 			text={ translate( 'Free domain with a plan' ) }
 			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
-			className="reader-sidebar-nudges"
 		/>
 	);
 }

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -19,11 +19,6 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
 import { clickUpgradeNudge } from 'state/marketing/actions';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) {
 	return (
 		<SidebarBanner

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -4,6 +4,7 @@
 import React, { Fragment } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ import getSites from 'state/selectors/get-sites';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
 import { clickUpgradeNudge } from 'state/marketing/actions';
+
+const debug = debugFactory( 'calypso:reader:sidebar-nudges' );
 
 function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) {
 	return (
@@ -50,6 +53,14 @@ function mapStateToProps( state ) {
 	const siteSlug = getPrimarySiteSlug( state );
 	const devCountryCode = isDevelopment && global.window && global.window.userCountryCode;
 	const countryCode = devCountryCode || getCurrentUserCountryCode( state );
+
+	isDevelopment &&
+		debug(
+			'country: %s, siteCount: %d, eligible: %s',
+			countryCode,
+			siteCount,
+			isEligibleForFreeToPaidUpsell( state, siteId )
+		);
 
 	return {
 		siteId,

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import { localize, getLocaleSlug } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import QuerySitePlans from 'components/data/query-site-plans';
+import SidebarBanner from 'my-sites/current-site/sidebar-banner';
+import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-to-paid-upsell';
+import { isJetpackSite } from 'state/sites/selectors';
+import getSites from 'state/selectors/get-sites';
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
+import { clickUpgradeNudge } from 'state/marketing/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) {
+	return (
+		<SidebarBanner
+			ctaName={ 'free-to-paid-sidebar-reader' }
+			ctaText={ translate( 'Upgrade' ) }
+			href={ '/plans/' + siteSlug }
+			icon="info-outline"
+			text={ translate( 'Free domain with a plan' ) }
+			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
+			className="reader-sidebar-nudges"
+		/>
+	);
+}
+
+export function ReaderSidebarNudges( props ) {
+	const dispatch = useDispatch();
+
+	return (
+		<Fragment>
+			<QuerySitePlans siteId={ props.siteId } />
+			{ props.isEligibleForFreeToPaidUpsellNudge && renderFreeToPaidPlanNudge( props, dispatch ) }
+		</Fragment>
+	);
+}
+
+function mapStateToProps( state ) {
+	const siteCount = getSites( state ).length;
+	const siteId = getPrimarySiteId( state );
+	const siteSlug = getPrimarySiteSlug( state );
+
+	return {
+		siteId,
+		siteSlug,
+		isEligibleForFreeToPaidUpsellNudge:
+			siteCount === 1 && // available for the user who owns one site only
+			'en' === getLocaleSlug( state ) && // only for English speakers
+			! isDomainOnlySite( state, siteId ) && // not for domain only sites
+			! isJetpackSite( state, siteId ) && // not for Jetpack sites
+			isEligibleForFreeToPaidUpsell( state, siteId ),
+	};
+}
+
+export default connect( mapStateToProps )( localize( ReaderSidebarNudges ) );

--- a/client/reader/sidebar/reader-sidebar-nudges/style.scss
+++ b/client/reader/sidebar/reader-sidebar-nudges/style.scss
@@ -1,4 +1,0 @@
-.reader-sidebar-nudges .sidebar-banner__link {
-	background-color: var( --color-success );
-	color: var( --color-text-inverted );
-}

--- a/client/reader/sidebar/reader-sidebar-nudges/style.scss
+++ b/client/reader/sidebar/reader-sidebar-nudges/style.scss
@@ -1,0 +1,6 @@
+.reader-sidebar-nudges {
+	.sidebar-banner__link {
+		background-color: var( --color-plan-premium );
+		color: var( --color-text );
+	}
+}

--- a/client/reader/sidebar/reader-sidebar-nudges/style.scss
+++ b/client/reader/sidebar/reader-sidebar-nudges/style.scss
@@ -1,6 +1,4 @@
-.reader-sidebar-nudges {
-	.sidebar-banner__link {
-		background-color: var( --color-plan-premium );
-		color: var( --color-text );
-	}
+.reader-sidebar-nudges .sidebar-banner__link {
+	background-color: var( --color-success );
+	color: var( --color-text-inverted );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an upsell nudge to the Reader sidebar

See pbm1bU-4i-p2 for more details.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* _For reviewers who don't live in the US:_
   Since the nudge is available only for the US, you may need to provide a country code as below:
  ```
  // in browser console
  window.userCountryCode = 'US';
  ```
* _For US residents:_
  Please make sure this PR works for you without mocking country code.

1. Create a new user with a free plan site. Your language should be set to English.
1. Visit the Reader page.
1. **The upsell nudge should show up in the sidebar because you're the person who has only one site.**

![Screenshot 2019-11-27 20 45 29](https://user-images.githubusercontent.com/4924246/69777855-e2e8f900-1156-11ea-8a6a-d6b1eb31db88.png)

1. Click on "Upgrade" link in the nudge. You should be taken to the plans page of your site.
1. Create a new site.
1. Go to the Reader page again.
1. **The upsell nudge should not appear this time.**
1. Delete a site and the banner shows up again.
1. Switch your language to non-English one.
1. **The banner should disappear again**, since this nudge is available only for English speakers.
