### PR TITLE
Composite checkout: Stub domain in order summary

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -19,8 +19,11 @@ export default function WPCheckoutOrderSummary() {
 	const [ isCouponFieldVisible, setIsCouponFieldVisible ] = useState( false );
 	const [ hasCouponBeenApplied, setHasCouponBeenApplied ] = useState( false );
 
+	//TODO: Replace yourdomain.tld with actual domian: show .wordpress subdomain if no custom domain available or in the cart
 	return (
 		<React.Fragment>
+			<DomainURL>yourdomain.tld</DomainURL>
+
 			<SummaryContent>
 				<ProductList>
 					{ items.map( product => {
@@ -73,7 +76,13 @@ const CheckoutSummaryTotal = styled.span`
 	font-weight: ${props => props.theme.weights.bold};
 `;
 
+const DomainURL = styled.div`
+	margin-top: -12px;
+`;
+
 const SummaryContent = styled.div`
+	margin-top: 12px;
+
 	@media ( ${props => props.theme.breakpoints.smallPhoneUp} ) {
 		display: flex;
 		justify-content: space-between;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR stubs in the domain to the order summary.

![image](https://user-images.githubusercontent.com/6981253/69732402-93281480-10f9-11ea-8f6a-f182dc3e7ca9.png)


#### Testing instructions
* Get calypso up and running locally. 
* Add a product to your cart and checkout.
* Add `?flags=composite-checkout-wpcom` to your url to see the new checkout.
