### PR TITLE
Server: use modern webpack hook API to listen to the 'done' event

### DIFF
--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -33,7 +33,7 @@ function middleware( app ) {
 		);
 	}
 
-	compiler.plugin( 'done', function() {
+	compiler.hooks.done.tap( 'Calypso', function() {
 		built = true;
 
 		// Dequeue and call request handlers


### PR DESCRIPTION
Fixing the code that causes a webpack warning in console:
```
Tapable.plugin is deprecated. Use new API on `.hooks` instead
```