### PR TITLE
Composite checkout: Update domain contact info messaging

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -403,7 +403,7 @@ function DomainFields() {
 			</DomainContactFieldsTitle>
 			<DomainContactFieldsDescription>
 				{ translate(
-					'Domain owners have to share contact information in a public database of all domains. With our Privacy Protection, we publish our own information and privately forward any communication to you.'
+					'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
 				) }
 			</DomainContactFieldsDescription>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the copy in the domain registration contact info section based on p99Zz8-Ql-p2.

#### Testing instructions
We won't be able to test this until we merge https://github.com/Automattic/wp-calypso/pull/37881. For now, we'll just need to review the code.
