### PR TITLE
Fix/activity log date picker

### DIFF
--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -82,11 +82,11 @@
 	// ensures `em` element retains whitespace
 	// https://stackoverflow.com/questions/39325039/css-flex-box-last-space-removed
 	white-space: pre-wrap;
-	
+
 	@include breakpoint( '<480px' ) {
 		margin-bottom: 0.5em;
 	}
-	
+
 	// Match "naked" button and text styles
 	// to avoid small jumps in UI on date select
 	&,
@@ -223,6 +223,7 @@
 	.DayPicker-Day--end {
 		.date-picker__day {
 			color: var( --color-text-inverted );
+			background-color: var( --color-primary );
 		}
 	}
 

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -99,7 +99,7 @@
 
 	.button {
 		color: var( --color-link );
-		
+
 		&:hover,
 		&:focus {
 			color: var( --color-accent );
@@ -117,7 +117,7 @@
 		margin-top: 12px;
 		border-top: 1px solid var( --color-neutral-5 );
 	}
-	
+
 	.DayPicker-wrapper,
 	.DayPicker-Months {
 		display: flex;
@@ -200,7 +200,7 @@
 
 
 .date-range__picker {
-	
+
 	.DayPicker-Day,
 	.DayPicker-Day:not( .DayPicker-Day--disabled ):not( .DayPicker-Day--outside ),
 	.DayPicker-Day--range:not( .DayPicker-Day--disabled ):not( .DayPicker-Day--outside ) {
@@ -208,8 +208,8 @@
 		padding: 0.25em; // fix and allow target area
 		width: 24px; // fix and allow target area
 		height: 24px; // fix and allow target area
-		
-		
+
+
 		.date-picker__day {
 			&:hover,
 			&:focus {
@@ -238,7 +238,7 @@
 	.DayPicker-Day--end:not( .DayPicker-Day--disabled ):not( .DayPicker-Day--outside ) {
 		background-color: var( --color-primary );
 	}
-	
+
 
 	.DayPicker-Day--start,
 	.DayPicker-Day--end {
@@ -261,11 +261,10 @@
 			border-top-left-radius: 0;
 			border-bottom-left-radius: 0;
 		}
-		
+
 	}
 
 	.DayPicker-Day--start.DayPicker-Day--end {
 		border-radius: 200px !important;
 	}
 }
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently the selection of a date range is broken. 
See:
Before:
![Screen Shot 2019-11-27 at 4 03 43 PM](https://user-images.githubusercontent.com/115071/69735765-8e7f5280-1131-11ea-8712-5c5f3feb659e.png)


After:
![Screen Shot 2019-11-27 at 4 03 10 PM](https://user-images.githubusercontent.com/115071/69735771-917a4300-1131-11ea-89d0-6aeabf934a77.png)

This PR adds a background color to the selection.

#### Testing instructions
On a site that we show the full activity log (A non Free site)
Go to the activity log and select a date range.
 