### PR TITLE
Composite checkout: Fix buy button to the screen on mobile

### DIFF
--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -105,10 +105,14 @@ export default function Checkout( { steps, className } ) {
 	} );
 	const isThereAnotherNumberedStep = !! nextStep && nextStep.hasStepNumber;
 	const isThereAnIncompleteStep = !! annotatedSteps.find( step => ! step.isComplete );
+	const isCheckoutInProgress = isThereAnIncompleteStep || isThereAnotherNumberedStep;
 
 	return (
 		<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
-			<MainContent className={ joinClasses( [ className, 'checkout__content' ] ) }>
+			<MainContent
+				className={ joinClasses( [ className, 'checkout__content' ] ) }
+				isCheckoutInProgress={ isCheckoutInProgress }
+			>
 				<ActiveStepProvider step={ activeStep }>
 					{ annotatedSteps.map( step => (
 						<CheckoutStepContainer
@@ -131,13 +135,11 @@ export default function Checkout( { steps, className } ) {
 					) ) }
 				</ActiveStepProvider>
 
-				<CheckoutWrapper>
+				<CheckoutWrapper isCheckoutInProgress={ isCheckoutInProgress }>
 					<CheckoutErrorBoundary
 						errorMessage={ localize( 'There was a problem with the submit button.' ) }
 					>
-						<CheckoutSubmitButton
-							disabled={ isThereAnIncompleteStep || isThereAnotherNumberedStep }
-						/>
+						<CheckoutSubmitButton disabled={ isCheckoutInProgress } />
 					</CheckoutErrorBoundary>
 				</CheckoutWrapper>
 			</MainContent>
@@ -213,6 +215,7 @@ const MainContent = styled.div`
 	background: ${props => props.theme.colors.surface};
 	width: 100%;
 	box-sizing: border-box;
+	margin-bottom: ${props => ( props.isCheckoutInProgress ? 0 : '89px' )};
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};
@@ -225,6 +228,20 @@ const MainContent = styled.div`
 const CheckoutWrapper = styled.div`
 	background: ${props => props.theme.colors.background};
 	padding: 24px;
+	position: ${props => ( props.isCheckoutInProgress ? 'relative' : 'fixed' )};
+	bottom: 0;
+	left: 0;
+	box-sizing: border-box;
+	width: 100%;
+	z-index: 10;
+	border-top-width: ${props => ( props.isCheckoutInProgress ? '0' : '1px' )};
+	border-top-style: solid;
+	border-top-color: ${props => props.theme.colors.borderColorLight};
+
+	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
+		position: relative;
+		border: 0;
+	}
 `;
 
 function makeDefaultSteps( localize ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the pay button to the bottom of the screen when all the steps are completed. I debated whether to fix it there the entire time and then just change the state of the button when the states are all completed but decided to only fix it at the end so people have the entire screen to work on the previous steps. 

![image](https://user-images.githubusercontent.com/6981253/69742510-eeaece00-110a-11ea-92ec-b53a287cc27e.png)

#### Testing instructions
* Get calypso up and running locally.
* Add a product to your cart and checkout.
* Add ?flags=composite-checkout-wpcom to your url to see the new checkout.
* Complete all the steps until the pay button becomes active
* Resize your screen to see the pay button fix to the bottom of the screen on smaller devices and not do anything on larger screens.
* Try resize the browser vertically to make sure you can scroll to the bottom of the screen.

