### PR TITLE
Add template-first-themes step to test-fse flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -332,7 +332,7 @@ export function generateFlows( {
 
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
-			steps: [ 'user', 'domains', 'plans' ],
+			steps: [ 'user', 'template-first-themes', 'domains', 'plans' ],
 			destination: getEditorDestination,
 			description: 'User testing Signup flow for Full Site Editing',
 			lastModified: '2019-11-22',

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -125,9 +125,9 @@ class ThemeSelectionStep extends Component {
 	render() {
 		const { useHeadstart, flowName } = this.props;
 
-		// If a user skips the step in `design-first` let segment and vertical determine content.
+		// If a user skips the step in `design-first` or `test-fse` let segment and vertical determine content.
 		const defaultDependencies =
-			'design-first' === flowName
+			'design-first' === flowName || 'test-fse' === flowName
 				? { themeSlugWithRepo: 'pub/maywood', useThemeHeadstart: false }
 				: { themeSlugWithRepo: 'pub/twentysixteen', useThemeHeadstart: useHeadstart };
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -106,6 +106,17 @@ class ThemeSelectionStep extends Component {
 		return translate( 'Choose a theme.' );
 	}
 
+	headerTextIfFirstStep() {
+		const { flowName, translate } = this.props;
+
+		if ( flowName === 'test-fse' ) {
+			return translate( "Let's get started by picking your site design" );
+		}
+
+		// Use the default header text
+		return undefined;
+	}
+
 	subHeaderText() {
 		const { flowName, translate } = this.props;
 
@@ -132,11 +143,13 @@ class ThemeSelectionStep extends Component {
 				: { themeSlugWithRepo: 'pub/twentysixteen', useThemeHeadstart: useHeadstart };
 
 		const headerText = this.headerText();
+		const headerTextIfFirstStep = this.headerTextIfFirstStep();
 		const subHeaderText = this.subHeaderText();
 
 		return (
 			<StepWrapper
 				fallbackHeaderText={ headerText }
+				headerText={ headerTextIfFirstStep }
 				fallbackSubHeaderText={ subHeaderText }
 				subHeaderText={ subHeaderText }
 				stepContent={ this.renderThemesList() }

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -95,9 +95,35 @@ class ThemeSelectionStep extends Component {
 		);
 	}
 
+	headerText() {
+		const { flowName, translate } = this.props;
+
+		if ( this.isStoreSignup() ) {
+			return translate( 'Choose a store theme.' );
+		} else if ( flowName === 'test-fse' ) {
+			return translate( 'Pick your site design' );
+		}
+		return translate( 'Choose a theme.' );
+	}
+
+	subHeaderText() {
+		const { flowName, translate } = this.props;
+
+		if ( this.isStoreSignup() ) {
+			return translate( 'Pick one of our store themes to start with. You can change this later.', {
+				context: 'Themes step subheader in Signup',
+			} );
+		} else if ( flowName === 'test-fse' ) {
+			return translate( "You'll be able to customize your new site in hundreds of ways." );
+		}
+		return translate(
+			'Pick one of our popular themes to get started or choose from hundreds more after you sign up.',
+			{ context: 'Themes step subheader in Signup' }
+		);
+	}
+
 	render() {
-		const { translate, useHeadstart, flowName } = this.props;
-		const storeSignup = this.isStoreSignup();
+		const { useHeadstart, flowName } = this.props;
 
 		// If a user skips the step in `design-first` let segment and vertical determine content.
 		const defaultDependencies =
@@ -105,17 +131,8 @@ class ThemeSelectionStep extends Component {
 				? { themeSlugWithRepo: 'pub/maywood', useThemeHeadstart: false }
 				: { themeSlugWithRepo: 'pub/twentysixteen', useThemeHeadstart: useHeadstart };
 
-		const headerText = storeSignup
-			? translate( 'Choose a store theme.' )
-			: translate( 'Choose a theme.' );
-		const subHeaderText = storeSignup
-			? translate( 'Pick one of our store themes to start with. You can change this later.', {
-					context: 'Themes step subheader in Signup',
-			  } )
-			: translate(
-					'Pick one of our popular themes to get started or choose from hundreds more after you sign up.',
-					{ context: 'Themes step subheader in Signup' }
-			  );
+		const headerText = this.headerText();
+		const subHeaderText = this.subHeaderText();
 
 		return (
 			<StepWrapper


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds theme picking step to `test-fse` flow
* Update theme step header text to match figma
* Skipping theme selection will start the user with Maywood

Using Maywood as the default theme so that they will have a theme that supports FSE.

Part of #37870 task.
See Milestone 2 figma here paObgF-Jt-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch (`test-fse` flow only available in dev and horizon)
* Signed out, create site starting from `/start/test-fse`
* Choose one of the template first themes, check header text matches figma
* Complete signup, site should be headstarted with theme content
* Stay logged in and start again at `/start/test-fse`
* Skip theme selection (skip button is at bottom of step), header text makes sense p1574893200104900-slack-CCS1W9QVA
* Complete signup, site should have a fse compatible theme