### PR TITLE
Reader: fix clipped descenders in post excerpt on Firefox

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -443,7 +443,7 @@
 
 .reader-post-card .reader-excerpt {
 	font-size: 16px;
-	line-height: 1.6;
+	line-height: 1.55;
 	font-weight: 100;
 	margin-top: 9px;
 	word-break: break-word;


### PR DESCRIPTION
I've recently switched to Firefox as my primary browser and have noticed that lowercase descenders get clipped (typically 'g') in post excerpts:

<img width="533" alt="Screen Shot 2019-11-28 at 09 25 41" src="https://user-images.githubusercontent.com/17325/69762165-482c0100-11ce-11ea-98ba-1e92f86a2bd7.png">

#### Changes proposed in this Pull Request

A small tweak to line height so that descenders aren't clipped.

#### Testing instructions

Visit your feed at http://calypso.localhost:3000/ in Firefox. Check that no letters are clipped on the last line of the post excerpt.

Visit your feed in other browsers. Check the line height still looks sensible.

@Aurorum would you mind giving this one a look? 👀