### PR TITLE
Open layout picker after completing test-fse flow if user skips theme

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { assign, get, includes, indexOf, reject } from 'lodash';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -60,7 +61,13 @@ function getChecklistThemeDestination( dependencies ) {
 }
 
 function getEditorDestination( dependencies ) {
-	return `/block-editor/page/${ dependencies.siteSlug }/home`;
+	const url = `/block-editor/page/${ dependencies.siteSlug }/home`;
+
+	if ( ! dependencies.useThemeHeadstart ) {
+		return addQueryArgs( url, { 'new-homepage': true } );
+	}
+
+	return url;
 }
 
 const flows = generateFlows( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After completing the `test-fse` flow, the user is taken to the editor. They've already picked a theme as part of the flow, so the editor doesn't need to show the layout picker dialog.
But what if the user skips the theme step? In that case it might be a good idea to allow them to pick a layout once they make it to the editor.

* Open editor with `new-homepage` param if user skips the `template-first-themes` step of the `test-fse` flow.

Part of addressing #37895

#### Testing instructions

* Create a site from `/start/test-fse`
  * Choose a theme
  * Complete signup
  * Taken to the editor, without seeing the layout picker
* Create a site from `/start/test-fse`
  * Skip the theme step
  * Complete signup
  * Taken to the editor, with the layout picker open
