### PR TITLE
Don't open the layout picker when clicking "Update your homepa…

### DIFF
--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { find, get, some } from 'lodash';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -11,7 +10,6 @@ import { getPostsForQuery } from 'state/posts/selectors';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
 import createSelector from 'lib/create-selector';
-import { isEnabled } from 'config';
 
 export const FIRST_TEN_SITE_POSTS_QUERY = { type: 'any', number: 10, order_by: 'ID', order: 'ASC' };
 
@@ -44,17 +42,11 @@ export default createSelector(
 		const contactPageUrl = getPageEditorUrl( state, siteId, getContactPage( posts ) );
 		const frontPageUrl = getFrontPageEditorUrl( state, siteId );
 
-		const updateHomepageUrl = isEnabled( 'checklist-homepage-template-select' )
-			? addQueryArgs( frontPageUrl || getEditorUrl( state, siteId, null, 'page' ), {
-					'new-homepage': 1,
-			  } )
-			: frontPageUrl;
-
 		return {
 			post_published: getPageEditorUrl( state, siteId, firstPostID ),
 			contact_page_updated: contactPageUrl,
 			about_text_updated: frontPageUrl,
-			front_page_updated: updateHomepageUrl,
+			front_page_updated: frontPageUrl,
 			homepage_photo_updated: frontPageUrl,
 			business_hours_added: frontPageUrl,
 			service_list_added: frontPageUrl,

--- a/config/development.json
+++ b/config/development.json
@@ -34,7 +34,6 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
-		"checklist-homepage-template-select": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,7 +21,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"checklist-homepage-template-select": true,
 		"code-splitting": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,6 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"checklist-homepage-template-select": true,
 		"code-splitting": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're allowing the user to choose their design early in the `test-fse` flow, so we don't need to ask them again when they land in the editor. Otherwise it just feels like asking them the same question twice.

This feature only existed on some environments, probably so it was only available for user testing (it was introduced in #37458). We're using the `test-fse` flow for that now, so removed the entire config.

* The "Update your homepage" checklist task never opens the layout picker
* Remove the `checklist-homepage-template-select` config flag

Part of #37870

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site and get to the Customer Home
* Click "Update your homepage"
* Layout picker should not be opened