### PR TITLE
Fix regex in getLastNonEditorRoute so that /pages and /posts routes are not excluded

### DIFF
--- a/client/state/selectors/get-last-non-editor-route.js
+++ b/client/state/selectors/get-last-non-editor-route.js
@@ -26,7 +26,7 @@ const getLastNonEditorRoute = createSelector(
 		 * page, you go to `/page`, which then redirects to `/block-editor/page`.
 		 * Matching page or post handles that case.
 		 */
-		const editorPattern = /^\/(block-editor|page|post)/;
+		const editorPattern = /^\/(block-editor|page[^s]|post[^s])/;
 
 		if ( previousPath && ! editorPattern.test( previousPath ) ) {
 			return previousPath;

--- a/client/state/selectors/test/get-last-non-editor-route.js
+++ b/client/state/selectors/test/get-last-non-editor-route.js
@@ -1,0 +1,65 @@
+/**
+ * Internal dependencies
+ */
+import getLastNonEditorRoute from 'state/selectors/get-last-non-editor-route';
+import { ROUTE_SET } from 'state/action-types';
+
+function getRouteAndActionLogState( previousPath, actionLogPath ) {
+	return {
+		ui: {
+			route: {
+				path: {
+					previous: previousPath,
+				},
+			},
+			actionLog: [
+				{ type: ROUTE_SET, path: actionLogPath },
+				{ type: ROUTE_SET, path: previousPath },
+			],
+		},
+	};
+}
+
+describe( 'getLastNonEditorRoute()', () => {
+	test( 'should return last path from action log for block editor route', () => {
+		const previousPath = '/block-editor/page/my-test-site.wordpress.com/2';
+		const actionLogPath = '/action-log-path';
+		const state = getRouteAndActionLogState( previousPath, actionLogPath );
+		expect( getLastNonEditorRoute( state ) ).toEqual( actionLogPath );
+	} );
+
+	test( 'should return last path from action log for legacy editor page route', () => {
+		const previousPath = '/page/my-test-site.wordpress.com';
+		const actionLogPath = '/action-log-path';
+		const state = getRouteAndActionLogState( previousPath, actionLogPath );
+		expect( getLastNonEditorRoute( state ) ).toEqual( actionLogPath );
+	} );
+
+	test( 'should return last path from action log for legacy editor post route', () => {
+		const previousPath = '/post/my-test-site.wordpress.com';
+		const actionLogPath = '/action-log-path';
+		const state = getRouteAndActionLogState( previousPath, actionLogPath );
+		expect( getLastNonEditorRoute( state ) ).toEqual( actionLogPath );
+	} );
+
+	test( 'should return previousPath for pages route', () => {
+		const previousPath = '/pages/my-test-site.wordpress.com';
+		const actionLogPath = '/action-log-path';
+		const state = getRouteAndActionLogState( previousPath, actionLogPath );
+		expect( getLastNonEditorRoute( state ) ).toEqual( previousPath );
+	} );
+
+	test( 'should return previousPath for posts route', () => {
+		const previousPath = '/posts/my-test-site.wordpress.com';
+		const actionLogPath = '/action-log-path';
+		const state = getRouteAndActionLogState( previousPath, actionLogPath );
+		expect( getLastNonEditorRoute( state ) ).toEqual( previousPath );
+	} );
+
+	test( 'should return previousPath for home route', () => {
+		const previousPath = '/home/my-test-site.wordpress.com';
+		const actionLogPath = '/action-log-path';
+		const state = getRouteAndActionLogState( previousPath, actionLogPath );
+		expect( getLastNonEditorRoute( state ) ).toEqual( previousPath );
+	} );
+} );


### PR DESCRIPTION
This fixes a bug exposed in #36382 where opening a page or post from `/pages` or `/posts` in Calypso sets the back button in the editor to redirect to `/home`, but in these cases the button should go back to their respective parts of Calypso (Pages or Posts).

#### Changes proposed in this Pull Request

* Update the regex in `getLastNonEditorRoute` so that it'll match against `/page` or `/post` but _not_ against `/pages` or `/posts`.
* Add test coverage for the `getLastNonEditorRoute` selector.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Redirecting to Posts

* Open up an existing site in Calypso that has posts (or create one)
* Go to the Site > Posts page in Calypso `/posts` and open one of the posts in the editor
* The back button at the top left of the editor window should redirect you back to the Posts page

##### Redirecting to Pages

* Go to the Site > Pages page in Calypso `/pages` and open one of the pages in the editor
* The back button at the top left of the editor window should redirect you back to the Pages page

##### Redirecting to Customer Homer

* Go to the Customer Home page `/home` and click to Update your homepage in the checklist (if it's available)
* The back button at the top left of the editor window should redirect you back to the Customer Home
* Visit your site, and click one of the front-end Edit button links, e.g. at the bottom of the front page of the site.
* Once in the editor, the back button at the top left of the editor window should redirect you back to the Customer Home