### PR TITLE
SPT: Try using templates from REST API

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -17,7 +17,6 @@ import { initializeWithIdentity } from './page-template-modal/utils/tracking';
 
 // Load config passed from backend.
 const {
-	templates = [],
 	vertical,
 	segment,
 	tracksUserData,
@@ -40,7 +39,6 @@ if ( screenAction === 'add' ) {
 					isFrontPage={ isFrontPage }
 					segment={ segment }
 					shouldPrefetchAssets={ false }
-					templates={ templates }
 					theme={ theme }
 					vertical={ vertical }
 				/>
@@ -63,7 +61,6 @@ registerPlugin( 'page-templates-sidebar', {
 					isFrontPage={ isFrontPage }
 					segment={ segment }
 					siteInformation={ siteInformation }
-					templates={ templates }
 					theme={ theme }
 					vertical={ vertical }
 				/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/last-template-used.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/last-template-used.js
@@ -1,0 +1,67 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+/**
+ * Internal dependencies
+ */
+import TemplateSelectorItem from './template-selector-item';
+import replacePlaceholders from '../utils/replace-placeholders';
+import '../../../../../../client/landing/gutenboarding/stores/verticals-templates'; // Should be @automattic/stores/vertical-templates
+/* eslint-enable import/no-extraneous-dependencies */
+
+class LastTemplateUsedComponent extends Component {
+	getLastTemplateUsed = () => {
+		const { isFrontPage, templates, theme } = this.props;
+		let { lastTemplateUsedSlug } = this.props;
+		// Try to match the homepage of the theme. Note that as folks transition
+		// to using the slug-based version of the homepage (e.g. "shawburn"), the
+		// slug will work normally without going through this check.
+		if ( ! lastTemplateUsedSlug && isFrontPage ) {
+			lastTemplateUsedSlug = theme;
+		}
+
+		if ( ! lastTemplateUsedSlug || lastTemplateUsedSlug === 'blank' ) {
+			// If no template used or 'blank', preview any other template (1 is currently 'Home' template).
+			return templates[ 0 ];
+		}
+		const matchingTemplate = templates.find( temp => temp.slug === lastTemplateUsedSlug );
+		// If no matching template, return the blank template.
+		if ( ! matchingTemplate ) {
+			return templates[ 0 ];
+		}
+		return matchingTemplate;
+	};
+
+	render() {
+		if ( ! this.props.template ) {
+			return null;
+		}
+
+		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
+
+		return (
+			<TemplateSelectorItem
+				id="sidebar-modal-opener__last-template-used-preview"
+				value={ slug }
+				label={ replacePlaceholders( title, this.props.siteInformation ) }
+				staticPreviewImg={ preview }
+				staticPreviewImgAlt={ previewAlt }
+				onSelect={ this.toggleWarningModal }
+			/>
+		);
+	}
+}
+
+const LastTemplateUsed = compose(
+	withSelect( ( select, ownProps ) => ( {
+		lastTemplateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+			._starter_page_template,
+		templates: select( 'automattic/verticals/templates' ).getTemplates( ownProps.vertical.id ),
+	} ) )
+)( LastTemplateUsedComponent );
+
+export default LastTemplateUsed;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -9,7 +9,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { PageTemplatesPlugin, LastTemplateUsed } from '../index';
+import { PageTemplatesPlugin } from '../index';
+import LastTemplateUsed from './last-template-used';
 import '../../../../../../client/landing/gutenboarding/stores/verticals-templates'; // Should be @automattic/stores/vertical-templates
 /* eslint-enable import/no-extraneous-dependencies */
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { PageTemplatesPlugin } from '../index';
 import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
-import '../../../../../client/landing/gutenboarding/stores/verticals-templates'; // Should be @automattic/stores/vertical-templates
+import '../../../../../../client/landing/gutenboarding/stores/verticals-templates'; // Should be @automattic/stores/vertical-templates
 /* eslint-enable import/no-extraneous-dependencies */
 class SidebarModalOpener extends Component {
 	state = {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { PageTemplatesPlugin } from '../index';
 import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
+import '../../../../../client/landing/gutenboarding/stores/verticals-templates'; // Should be @automattic/stores/vertical-templates
 /* eslint-enable import/no-extraneous-dependencies */
 class SidebarModalOpener extends Component {
 	state = {
@@ -53,7 +54,7 @@ class SidebarModalOpener extends Component {
 
 	render() {
 		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
-		const { isFrontPage, templates, theme, vertical, segment, siteInformation } = this.props;
+		const { isFrontPage, theme, vertical, segment, siteInformation } = this.props;
 
 		return (
 			<div className="sidebar-modal-opener">
@@ -77,7 +78,6 @@ class SidebarModalOpener extends Component {
 				{ this.state.isTemplateModalOpen && (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
-						templates={ templates }
 						theme={ theme }
 						vertical={ vertical }
 						segment={ segment }
@@ -115,9 +115,10 @@ class SidebarModalOpener extends Component {
 }
 
 const SidebarTemplatesPlugin = compose(
-	withSelect( select => ( {
+	withSelect( ( select, ownProps ) => ( {
 		lastTemplateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 			._starter_page_template,
+		templates: select( 'automattic/verticals/templates' ).getTemplates( ownProps.vertical.id ),
 	} ) )
 )( SidebarModalOpener );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -4,19 +4,16 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
 import { Button, Modal } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { PageTemplatesPlugin } from '../index';
-import TemplateSelectorItem from './template-selector-item';
-import replacePlaceholders from '../utils/replace-placeholders';
+import { PageTemplatesPlugin, LastTemplateUsed } from '../index';
 import '../../../../../../client/landing/gutenboarding/stores/verticals-templates'; // Should be @automattic/stores/vertical-templates
 /* eslint-enable import/no-extraneous-dependencies */
-class SidebarModalOpener extends Component {
+
+class SidebarTemplatesPlugin extends Component {
 	state = {
 		isTemplateModalOpen: false,
 		isWarningOpen: false,
@@ -30,43 +27,12 @@ class SidebarModalOpener extends Component {
 		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
 	};
 
-	getLastTemplateUsed = () => {
-		const { isFrontPage, templates, theme } = this.props;
-		let { lastTemplateUsedSlug } = this.props;
-		// Try to match the homepage of the theme. Note that as folks transition
-		// to using the slug-based version of the homepage (e.g. "shawburn"), the
-		// slug will work normally without going through this check.
-		if ( ! lastTemplateUsedSlug && isFrontPage ) {
-			lastTemplateUsedSlug = theme;
-		}
-
-		if ( ! lastTemplateUsedSlug || lastTemplateUsedSlug === 'blank' ) {
-			// If no template used or 'blank', preview any other template (1 is currently 'Home' template).
-			return templates[ 0 ];
-		}
-		const matchingTemplate = templates.find( temp => temp.slug === lastTemplateUsedSlug );
-		// If no matching template, return the blank template.
-		if ( ! matchingTemplate ) {
-			return templates[ 0 ];
-		}
-		return matchingTemplate;
-	};
-
 	render() {
-		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
 		const { isFrontPage, theme, vertical, segment, siteInformation } = this.props;
 
 		return (
 			<div className="sidebar-modal-opener">
-				<TemplateSelectorItem
-					id="sidebar-modal-opener__last-template-used-preview"
-					value={ slug }
-					label={ replacePlaceholders( title, siteInformation ) }
-					staticPreviewImg={ preview }
-					staticPreviewImgAlt={ previewAlt }
-					onSelect={ this.toggleWarningModal }
-				/>
-
+				<LastTemplateUsed siteInformation={ siteInformation } />
 				<Button
 					isPrimary
 					onClick={ this.toggleWarningModal }
@@ -113,13 +79,5 @@ class SidebarModalOpener extends Component {
 		);
 	}
 }
-
-const SidebarTemplatesPlugin = compose(
-	withSelect( ( select, ownProps ) => ( {
-		lastTemplateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
-			._starter_page_template,
-		templates: select( 'automattic/verticals/templates' ).getTemplates( ownProps.vertical.id ),
-	} ) )
-)( SidebarModalOpener );
 
 export default SidebarTemplatesPlugin;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -21,6 +21,7 @@ import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView } from './utils/tracking';
 import replacePlaceholders from './utils/replace-placeholders';
 import ensureAssets from './utils/ensure-assets';
+import '../../../../../client/landing/gutenboarding/stores/verticals-templates'; // Should be @automattic/stores/vertical-templates
 /* eslint-enable import/no-extraneous-dependencies */
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
@@ -316,10 +317,11 @@ class PageTemplateModal extends Component {
 }
 
 export const PageTemplatesPlugin = compose(
-	withSelect( select => {
+	withSelect( ( select, ownProps ) => {
 		const getMeta = () => select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const { _starter_page_template } = getMeta();
 		return {
+			templates: select( 'automattic/verticals/templates' ).getTemplates( ownProps.vertical.id ),
 			getMeta,
 			_starter_page_template,
 			postContentBlock: select( 'core/editor' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* connect `SidebarTemplatesPlugin` and `PageTemplatesPlugin` to `automattic/verticals/templates` store
* stop using `window.starterPageTemplatesConfig.templates`

#### Testing instructions

FSE should work the same, with slightly faster startup time and some delay while loading templates in SPT.

#### To do:

- [ ] handle async update since previously `window` was server-side rendered
- [ ] extract `verticals-templates` store to `automattic/verticals/templates` package
- [ ] test FSE using a dotcom sandbox
