### PR TITLE
Extract the Recaptcha code into a separate module

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import { abtest, getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
-import { recordGoogleRecaptchaAction } from 'lib/analytics/ad-tracking';
+import { recordGoogleRecaptchaAction } from 'lib/analytics/recaptcha';
 import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -280,12 +280,12 @@ function setupAdRollGlobal() {
 	if ( ! window.adRoll ) {
 		window.adRoll = {
 			trackPageview: function() {
-				new Image().src = ADROLL_PAGEVIEW_PIXEL_URL_1;
-				new Image().src = ADROLL_PAGEVIEW_PIXEL_URL_2;
+				new window.Image().src = ADROLL_PAGEVIEW_PIXEL_URL_1;
+				new window.Image().src = ADROLL_PAGEVIEW_PIXEL_URL_2;
 			},
 			trackPurchase: function() {
-				new Image().src = ADROLL_PURCHASE_PIXEL_URL_1;
-				new Image().src = ADROLL_PURCHASE_PIXEL_URL_2;
+				new window.Image().src = ADROLL_PURCHASE_PIXEL_URL_1;
+				new window.Image().src = ADROLL_PURCHASE_PIXEL_URL_2;
 			},
 		};
 	}
@@ -525,7 +525,7 @@ export async function retarget( urlPath ) {
 		if ( isIconMediaEnabled ) {
 			const params = ICON_MEDIA_RETARGETING_PIXEL_URL;
 			debug( 'retarget: [Icon Media] [rate limited]', params );
-			new Image().src = params;
+			new window.Image().src = params;
 		}
 
 		// Twitter
@@ -539,7 +539,7 @@ export async function retarget( urlPath ) {
 		if ( isGeminiEnabled ) {
 			const params = YAHOO_GEMINI_AUDIENCE_BUILDING_PIXEL_URL;
 			debug( 'retarget: [Yahoo Gemini] [rate limited]', params );
-			new Image().src = params;
+			new window.Image().src = params;
 		}
 
 		// Quora
@@ -839,7 +839,7 @@ export async function recordSignup( slug ) {
 
 	if ( isIconMediaEnabled ) {
 		debug( 'recordSignup: [Icon Media]', ICON_MEDIA_SIGNUP_PIXEL_URL );
-		new Image().src = ICON_MEDIA_SIGNUP_PIXEL_URL;
+		new window.Image().src = ICON_MEDIA_SIGNUP_PIXEL_URL;
 	}
 
 	// Pinterest
@@ -1061,7 +1061,7 @@ export async function recordOrder( cart, orderId ) {
 	// Experian / One 2 One Media
 	if ( isExperianEnabled ) {
 		debug( 'recordOrder: [Experian]', EXPERIAN_CONVERSION_PIXEL_URL );
-		new Image().src = EXPERIAN_CONVERSION_PIXEL_URL;
+		new window.Image().src = EXPERIAN_CONVERSION_PIXEL_URL;
 	}
 
 	// Yahoo Gemini
@@ -1069,12 +1069,12 @@ export async function recordOrder( cart, orderId ) {
 		const params =
 			YAHOO_GEMINI_CONVERSION_PIXEL_URL + ( usdTotalCost !== null ? '&gv=' + usdTotalCost : '' );
 		debug( 'recordOrder: [Yahoo Gemini]', params );
-		new Image().src = params;
+		new window.Image().src = params;
 	}
 
 	if ( isPandoraEnabled ) {
 		debug( 'recordOrder: [Pandora]', PANDORA_CONVERSION_PIXEL_URL );
-		new Image().src = PANDORA_CONVERSION_PIXEL_URL;
+		new window.Image().src = PANDORA_CONVERSION_PIXEL_URL;
 	}
 
 	if ( isQuoraEnabled ) {
@@ -1088,7 +1088,7 @@ export async function recordOrder( cart, orderId ) {
 		const params =
 			ICON_MEDIA_ORDER_PIXEL_URL + `&tx=${ orderId }&sku=${ skus }&price=${ usdTotalCost }`;
 		debug( 'recordOrder: [Icon Media]', params );
-		new Image().src = params;
+		new window.Image().src = params;
 	}
 
 	// Twitter
@@ -1625,11 +1625,11 @@ async function recordInCriteo( eventName, eventProps ) {
  * @returns {string} 't', 'm', or 'd' for tablet, mobile, or desktop
  */
 function criteoSiteType() {
-	if ( /iPad/.test( navigator.userAgent ) ) {
+	if ( /iPad/.test( window.navigator.userAgent ) ) {
 		return 't';
 	}
 
-	if ( /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Silk/.test( navigator.userAgent ) ) {
+	if ( /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Silk/.test( window.navigator.userAgent ) ) {
 		return 'm';
 	}
 
@@ -1741,7 +1741,7 @@ export function getGoogleAnalyticsDefaultConfig() {
 	return {
 		...( currentUser && { user_id: currentUser.hashedPii.ID } ),
 		anonymize_ip: true,
-		transport_type: 'function' === typeof navigator.sendBeacon ? 'beacon' : 'xhr',
+		transport_type: 'function' === typeof window.navigator.sendBeacon ? 'beacon' : 'xhr',
 		use_amp_client_id: true,
 		custom_map: {
 			dimension3: 'client_id',

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -30,7 +30,6 @@ const debug = debugFactory( 'calypso:analytics:ad-tracking' );
 // Enable/disable ad-tracking
 // These should not be put in the json config as they must not differ across environments
 const isGoogleAnalyticsEnabled = true;
-const isGoogleRecaptchaEnabled = true;
 const isFloodlightEnabled = true;
 const isFacebookEnabled = true;
 const isBingEnabled = true;
@@ -59,7 +58,6 @@ let lastRetargetTime = 0;
  */
 const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevents.js';
 const GOOGLE_GTAG_SCRIPT_URL = 'https://www.googletagmanager.com/gtag/js?id=';
-const GOOGLE_RECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js?render=';
 const BING_TRACKING_SCRIPT_URL = 'https://bat.bing.com/bat.js';
 const CRITEO_TRACKING_SCRIPT_URL = 'https://static.criteo.net/js/ld/ld.js';
 const YAHOO_GEMINI_CONVERSION_PIXEL_URL =
@@ -108,7 +106,6 @@ const TRACKING_IDS = {
 	wpcomGoogleAdsGtagSignup: 'AW-946162814/5-NnCKy3xZQBEP6YlcMD', // "All Calypso Signups (WordPress.com)"
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
-	wpcomGoogleRecaptchaSiteKey: config( 'google_recaptcha_site_key' ),
 	pinterestInit: '2613194105266',
 };
 // This name is something we created to store a session id for DCM Floodlight session tracking
@@ -1821,109 +1818,4 @@ function initFacebook() {
 	// See: <https://developers.facebook.com/docs/facebook-pixel/api-reference#automatic-configuration>
 	window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookJetpackInit );
 	window.fbq( 'init', TRACKING_IDS.facebookJetpackInit, advancedMatching );
-}
-
-/**
- * Loads Google reCAPTCHA
- *
- * @returns {boolean} false if the script failed to load
- */
-async function loadGoogleRecaptchaScript() {
-	if ( window.grecaptcha ) {
-		// reCAPTCHA already loaded
-		return true;
-	}
-
-	// Use loadScript directly instead of the loadTrackingScripts function, to ensure that the
-	// reCAPTCHA script is only loaded when needed.
-	try {
-		const src = GOOGLE_RECAPTCHA_SCRIPT_URL + 'explicit';
-		await loadScript( src );
-		debug( 'loadGoogleRecaptchaScript: [Loaded]', src );
-	} catch ( error ) {
-		debug( 'loadGoogleRecaptchaScript: [Load Error] the script failed to load: ', error );
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Renders reCAPTCHA badge to an explicit DOM id that should already be on the page
- *
- * @param {string} elementId - render client to this existing DOM node
- * @returns {number} reCAPTCHA clientId
- */
-async function renderRecaptchaClient( elementId ) {
-	try {
-		const clientId = await window.grecaptcha.render( elementId, {
-			sitekey: TRACKING_IDS.wpcomGoogleRecaptchaSiteKey,
-			size: 'invisible',
-		} );
-		debug( 'renderRecaptchaClient: [Success]', elementId );
-		return clientId;
-	} catch ( error ) {
-		debug( 'renderRecaptchaClient: [Error]', error );
-		return null;
-	}
-}
-
-/**
- * Records an arbitrary action to Google reCAPTCHA
- *
- * @param {number} clientId - a clientId of the reCAPTCHA instance
- * @param {string} action  - name of action to record in reCAPTCHA
- */
-export async function recordGoogleRecaptchaAction( clientId, action ) {
-	if ( ! window.grecaptcha ) {
-		return null;
-	}
-	try {
-		const token = await window.grecaptcha.execute( clientId, {
-			action,
-		} );
-		debug( 'recordGoogleRecaptchaAction: [Success]', action, token, clientId );
-		return token;
-	} catch ( error ) {
-		debug( 'recordGoogleRecaptchaAction: [Error]', action, error );
-		return null;
-	}
-}
-
-/**
- * @typedef RecaptchaActionResult
- * @property {string} token
- * @property {number} clientId
- */
-
-/**
- * Records reCAPTCHA action, loading Google script if necessary.
- *
- * @param {string} elementId - a DOM id in which to render the reCAPTCHA client
- * @param {string} action - name of action to record in reCAPTCHA
- *
- * @returns {RecaptchaActionResult|null} either the reCAPTCHA token and clientId, or null if the function fails
- */
-export async function initGoogleRecaptcha( elementId, action ) {
-	if ( ! isGoogleRecaptchaEnabled || ! TRACKING_IDS.wpcomGoogleRecaptchaSiteKey ) {
-		return null;
-	}
-
-	if ( ! ( await loadGoogleRecaptchaScript() ) ) {
-		return null;
-	}
-
-	await new Promise( resolve => window.grecaptcha.ready( resolve ) );
-
-	try {
-		const clientId = await renderRecaptchaClient( elementId );
-		const token = await recordGoogleRecaptchaAction( clientId, action );
-		debug( 'initGoogleRecaptcha: [Success]', action, token, clientId );
-		return { token, clientId };
-	} catch ( error ) {
-		// We don't want errors interrupting our flow, so convert any exceptions
-		// into return values.
-		debug( 'initGoogleRecaptcha: [Error]', action, error );
-		return null;
-	}
 }

--- a/client/lib/analytics/recaptcha.js
+++ b/client/lib/analytics/recaptcha.js
@@ -27,12 +27,11 @@ async function loadGoogleRecaptchaScript() {
 		const src = GOOGLE_RECAPTCHA_SCRIPT_URL;
 		await loadScript( src );
 		debug( 'loadGoogleRecaptchaScript: [Loaded]', src );
+		return true;
 	} catch ( error ) {
 		debug( 'loadGoogleRecaptchaScript: [Load Error] the script failed to load: ', error );
 		return false;
 	}
-
-	return true;
 }
 
 /**
@@ -64,8 +63,12 @@ async function renderRecaptchaClient( elementId, siteKey ) {
  */
 export async function recordGoogleRecaptchaAction( clientId, action ) {
 	if ( ! window.grecaptcha ) {
+		debug(
+			'recordGoogleRecaptchaAction: [Error] window.grecaptcha not defined. Did you forget to init?'
+		);
 		return null;
 	}
+
 	try {
 		const token = await window.grecaptcha.execute( clientId, { action } );
 		debug( 'recordGoogleRecaptchaAction: [Success]', action, token, clientId );
@@ -104,7 +107,15 @@ export async function initGoogleRecaptcha( elementId, action, siteKey ) {
 
 	try {
 		const clientId = await renderRecaptchaClient( elementId, siteKey );
+		if ( clientId == null ) {
+			return null;
+		}
+
 		const token = await recordGoogleRecaptchaAction( clientId, action );
+		if ( token == null ) {
+			return null;
+		}
+
 		debug( 'initGoogleRecaptcha: [Success]', action, token, clientId );
 		return { token, clientId };
 	} catch ( error ) {

--- a/client/lib/analytics/recaptcha.js
+++ b/client/lib/analytics/recaptcha.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { loadScript } from '@automattic/load-script';
+
+const debug = debugFactory( 'calypso:analytics:recaptcha' );
+
+const GOOGLE_RECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js?render=explicit';
+
+/**
+ * Loads Google reCAPTCHA
+ *
+ * @returns {boolean} false if the script failed to load
+ */
+async function loadGoogleRecaptchaScript() {
+	if ( window.grecaptcha ) {
+		// reCAPTCHA already loaded
+		return true;
+	}
+
+	try {
+		const src = GOOGLE_RECAPTCHA_SCRIPT_URL;
+		await loadScript( src );
+		debug( 'loadGoogleRecaptchaScript: [Loaded]', src );
+	} catch ( error ) {
+		debug( 'loadGoogleRecaptchaScript: [Load Error] the script failed to load: ', error );
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Renders reCAPTCHA badge to an explicit DOM id that should already be on the page
+ *
+ * @param {string} elementId - render client to this existing DOM node
+ * @param {string} siteKey - reCAPTCHA site key
+ * @returns {number} reCAPTCHA clientId
+ */
+async function renderRecaptchaClient( elementId, siteKey ) {
+	try {
+		const clientId = await window.grecaptcha.render( elementId, {
+			sitekey: siteKey,
+			size: 'invisible',
+		} );
+		debug( 'renderRecaptchaClient: [Success]', elementId );
+		return clientId;
+	} catch ( error ) {
+		debug( 'renderRecaptchaClient: [Error]', error );
+		return null;
+	}
+}
+
+/**
+ * Records an arbitrary action to Google reCAPTCHA
+ *
+ * @param {number} clientId - a clientId of the reCAPTCHA instance
+ * @param {string} action  - name of action to record in reCAPTCHA
+ */
+export async function recordGoogleRecaptchaAction( clientId, action ) {
+	if ( ! window.grecaptcha ) {
+		return null;
+	}
+	try {
+		const token = await window.grecaptcha.execute( clientId, { action } );
+		debug( 'recordGoogleRecaptchaAction: [Success]', action, token, clientId );
+		return token;
+	} catch ( error ) {
+		debug( 'recordGoogleRecaptchaAction: [Error]', action, error );
+		return null;
+	}
+}
+
+/**
+ * @typedef RecaptchaActionResult
+ * @property {string} token
+ * @property {number} clientId
+ */
+
+/**
+ * Records reCAPTCHA action, loading Google script if necessary.
+ *
+ * @param {string} elementId - a DOM id in which to render the reCAPTCHA client
+ * @param {string} action - name of action to record in reCAPTCHA
+ * @param {string} siteKey - reCAPTCHA site key
+ *
+ * @returns {RecaptchaActionResult|null} either the reCAPTCHA token and clientId, or null if the function fails
+ */
+export async function initGoogleRecaptcha( elementId, action, siteKey ) {
+	if ( ! siteKey ) {
+		return null;
+	}
+
+	if ( ! ( await loadGoogleRecaptchaScript() ) ) {
+		return null;
+	}
+
+	await new Promise( resolve => window.grecaptcha.ready( resolve ) );
+
+	try {
+		const clientId = await renderRecaptchaClient( elementId, siteKey );
+		const token = await recordGoogleRecaptchaAction( clientId, action );
+		debug( 'initGoogleRecaptcha: [Success]', action, token, clientId );
+		return { token, clientId };
+	} catch ( error ) {
+		// We don't want errors interrupting our flow, so convert any exceptions
+		// into return values.
+		debug( 'initGoogleRecaptcha: [Error]', action, error );
+		return null;
+	}
+}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -77,11 +77,7 @@ export class UserStep extends Component {
 
 	componentDidMount() {
 		if ( 'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' ) ) {
-			initGoogleRecaptcha(
-				'g-recaptcha',
-				'calypso/signup/pageLoad',
-				config( 'google_recaptcha_site_key' )
-			).then( this.saveRecaptchaToken );
+			this.initGoogleRecaptcha();
 		}
 
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
@@ -154,14 +150,24 @@ export class UserStep extends Component {
 		this.setState( { subHeaderText } );
 	}
 
-	saveRecaptchaToken = ( { token, clientId } ) => {
-		this.setState( { recaptchaClientId: clientId } );
+	initGoogleRecaptcha() {
+		initGoogleRecaptcha(
+			'g-recaptcha',
+			'calypso/signup/pageLoad',
+			config( 'google_recaptcha_site_key' )
+		).then( result => {
+			if ( ! result ) {
+				return;
+			}
 
-		this.props.saveSignupStep( {
-			stepName: this.props.stepName,
-			recaptchaToken: typeof token === 'string' ? token : undefined,
+			this.setState( { recaptchaClientId: result.clientId } );
+
+			this.props.saveSignupStep( {
+				stepName: this.props.stepName,
+				recaptchaToken: typeof result.token === 'string' ? result.token : undefined,
+			} );
 		} );
-	};
+	}
 
 	save = form => {
 		this.props.saveSignupStep( {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -23,7 +23,7 @@ import { getSuggestedUsername } from 'state/signup/optional-dependencies/selecto
 import { recordTracksEvent } from 'state/analytics/actions';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { WPCC } from 'lib/url/support';
-import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'lib/analytics/ad-tracking';
+import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'lib/analytics/recaptcha';
 import config from 'config';
 import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
@@ -77,9 +77,11 @@ export class UserStep extends Component {
 
 	componentDidMount() {
 		if ( 'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' ) ) {
-			initGoogleRecaptcha( 'g-recaptcha', 'calypso/signup/pageLoad' ).then(
-				this.saveRecaptchaToken
-			);
+			initGoogleRecaptcha(
+				'g-recaptcha',
+				'calypso/signup/pageLoad',
+				config( 'google_recaptcha_site_key' )
+			).then( this.saveRecaptchaToken );
 		}
 
 		this.props.saveSignupStep( { stepName: this.props.stepName } );


### PR DESCRIPTION
The Recaptcha code is used by only one Calypso section: signup. Placing it into `lib/analytics/ad-tracking`, however, bundles it into all other sections, inflating the size of JavaScript that the browser needs to download (and never execute). Also, it's not related to Ad Tracking at all. This PR moves it to separate `lib/analytics/recaptcha` module.

I also improved how the library handles errors. Currently, when the reCAPTCHA script fails to load, I get runtime JS errors in the console because the `saveRecaptchaToken` handler tries to destructure `null`:
<img width="657" alt="Screenshot 2019-11-28 at 11 07 01" src="https://user-images.githubusercontent.com/664258/69799253-3862eb80-11d3-11ea-991a-a088a4aa28ae.png">
That's now fixed.

**How to test:**
In a logged-out session, go to `/start` and try to register a new user. @andrewserong and @p-jackson probably know much better how to test this thoroughly.
