### PR TITLE
Update the post-purchase Jetpack Daily Backup description in ProductCard

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -88,12 +88,7 @@ export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = translate(
 	'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
 );
 export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = translate(
-	'{{strong}}Looking for more?{{/strong}} With Real-time backups, we save as you edit and you’ll get unlimited backup archives.',
-	{
-		components: {
-			strong: <strong />,
-		},
-	}
+	'Always-on backups ensure you never lose your site. Your changes are saved every day with a 30-day archive.'
 );
 export const PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION = translate(
 	'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'


### PR DESCRIPTION
Currently the post-purchase description of the Jetpack Daily Backup contains an upsell message:

<img width="544" alt="Screenshot 2019-11-28 at 15 03 00" src="https://user-images.githubusercontent.com/478735/69812382-54c15100-11f0-11ea-8fdc-5bb2370b7690.png">

Since there's no way in the current implementation to upgrade to Real-Time option, it doesn't make sense to have such a message in the `ProductCard`.

This PR changes the description as follows:

<img width="548" alt="Screenshot 2019-11-28 at 15 02 49" src="https://user-images.githubusercontent.com/478735/69812456-74587980-11f0-11ea-9dd8-85522cb6963a.png">


#### Changes proposed in this Pull Request

* Update the post-purchase Jetpack Daily Backup description in `ProductCard`

#### Testing instructions

* Go to http://calypso.localhost:3000/plans/ and select a Jetpack site with Daily Backup
* Confirm the description in the `ProductCard` is now updated

Fixes n/a
