### PR TITLE
Store Active A/B Tests on Bootup

### DIFF
--- a/client/lib/abtest/utility.js
+++ b/client/lib/abtest/utility.js
@@ -4,10 +4,12 @@
 import activeTests from 'lib/abtest/active-tests';
 
 export const ABTEST_LOCALSTORAGE_KEY = 'ABTests';
+export const ABTEST_ACTIVE_TESTS = 'ActiveABTests';
 
 /**
  * Returns all active test names
- * @returns {String[]} All active test names with respective timestamp appended to the end
+ *
+ * @returns {string[]} All active test names with respective timestamp appended to the end
  */
 export function getActiveTestNames( { appendDatestamp = false, asCSV = false } = {} ) {
 	const output = Object.keys( activeTests ).map( key =>

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -33,6 +33,7 @@ const allowedKeys = [
 	'is_new_reader',
 	'social_login_connections',
 	'abtests',
+	'active_tests',
 ];
 const requiredKeys = [ 'ID' ];
 const decodedKeys = [ 'display_name', 'description', 'user_URL' ];

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -125,20 +125,15 @@ User.prototype.fetch = function() {
 		return this.fetching;
 	}
 
-	const flags = {
-		meta: 'flags',
-		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
-	};
-
-	if ( config.isEnabled( 'ive/me' ) ) {
-		flags.active_tests = true;
-	}
-
 	// Request current user info
 	debug( 'Getting user from api' );
 	this.fetching = wpcom
 		.me()
-		.get( flags )
+		.get( {
+			meta: 'flags',
+			abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
+			active_tets: config.isEnabled( 'ive/me' ),
+		} )
 		.then( data => {
 			debug( 'User successfully retrieved from api:', data );
 			const userData = filterUserObject( data );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -24,7 +24,11 @@ import { isE2ETest } from 'lib/e2e';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
 import { getLanguage } from 'lib/i18n-utils/utils';
 import { clearStorage } from 'lib/browser-storage';
-import { getActiveTestNames, ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
+import {
+	getActiveTestNames,
+	ABTEST_LOCALSTORAGE_KEY,
+	ABTEST_ACTIVE_TESTS,
+} from 'lib/abtest/utility';
 
 /**
  * User component
@@ -123,12 +127,10 @@ User.prototype.fetch = function() {
 
 	const flags = {
 		meta: 'flags',
-		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
+		abtests: config( 'ive/me' )
+			? true
+			: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
 	};
-
-	if ( config( 'ive/me' ) ) {
-		flags.active_tests = true;
-	}
 
 	// Request current user info
 	debug( 'Getting user from api' );
@@ -196,6 +198,11 @@ User.prototype.handleFetchSuccess = function( userData ) {
 			store.set( ABTEST_LOCALSTORAGE_KEY, userData.abtests );
 		}
 	}
+
+	if ( userData.active_tests ) {
+		store.set( store.set( ABTEST_ACTIVE_TESTS, userData.active_tests ) );
+	}
+
 	this.data = userData;
 	this.emit( 'change' );
 };

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -132,7 +132,7 @@ User.prototype.fetch = function() {
 		.get( {
 			meta: 'flags',
 			abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
-			active_tests: config.isEnabled( 'ive/me' ),
+			active_tests: config.isEnabled( 'ive/me' ) ? 'calypso' : false,
 		} )
 		.then( data => {
 			debug( 'User successfully retrieved from api:', data );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -132,7 +132,7 @@ User.prototype.fetch = function() {
 		.get( {
 			meta: 'flags',
 			abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
-			active_tets: config.isEnabled( 'ive/me' ),
+			active_tests: config.isEnabled( 'ive/me' ),
 		} )
 		.then( data => {
 			debug( 'User successfully retrieved from api:', data );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -28,6 +28,7 @@ import { getActiveTestNames, ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility'
 
 /**
  * User component
+ *
  * @class
  */
 function User() {
@@ -88,7 +89,7 @@ User.prototype.initialize = async function() {
  * Clear localStorage when we detect that there is a mismatch between the ID
  * of the user stored in localStorage and the current user ID
  *
- * @param {Number} userId The new user ID.
+ * @param {number} userId The new user ID.
  **/
 User.prototype.clearStoreIfChanged = function( userId ) {
 	const storedUserId = store.get( 'wpcom_user_id' );
@@ -102,7 +103,7 @@ User.prototype.clearStoreIfChanged = function( userId ) {
 /**
  * Get user data
  *
- * @returns {Object} The user data.
+ * @returns {object} The user data.
  */
 User.prototype.get = function() {
 	return this.data;
@@ -112,7 +113,6 @@ User.prototype.get = function() {
  * Fetch the current user from WordPress.com via the REST API
  * and stores it in local cache.
  *
- * @uses `wpcom`
  * @returns {Promise<void>} Promise that resolves (with no value) when fetching is finished
  */
 User.prototype.fetch = function() {
@@ -121,14 +121,20 @@ User.prototype.fetch = function() {
 		return this.fetching;
 	}
 
+	const flags = {
+		meta: 'flags',
+		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
+	};
+
+	if ( config( 'ive/me' ) ) {
+		flags.active_tests = true;
+	}
+
 	// Request current user info
 	debug( 'Getting user from api' );
 	this.fetching = wpcom
 		.me()
-		.get( {
-			meta: 'flags',
-			abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
-		} )
+		.get( flags )
 		.then( data => {
 			debug( 'User successfully retrieved from api:', data );
 			const userData = filterUserObject( data );
@@ -167,7 +173,7 @@ User.prototype.handleFetchFailure = function( error ) {
  * in the browser's localStorage. It also changes the User's fetching and initialized states
  * and emits a change event.
  *
- * @param {Object} userData an object containing the user's information.
+ * @param {object} userData an object containing the user's information.
  */
 User.prototype.handleFetchSuccess = function( userData ) {
 	this.clearStoreIfChanged( userData.ID );
@@ -203,9 +209,9 @@ User.prototype.getLanguage = function() {
  * the short-form query string parameters as options,
  * sets some sane defaults.
  *
- * @param {Object} options Options per https://secure.gravatar.com/site/implement/images/
+ * @param {object} options Options per https://secure.gravatar.com/site/implement/images/
  *
- * @returns {String} The user's avatar URL based on the options parameter.
+ * @returns {string} The user's avatar URL based on the options parameter.
  */
 User.prototype.getAvatarUrl = function( options ) {
 	const default_options = {
@@ -243,7 +249,7 @@ User.prototype.clear = async function() {
  *
  * @param {Function} [fn] A callback to receive the HTTP response from the send-verification-email endpoint.
  *
- * @returns {(Promise|Object)} If a callback is provided, this is an object representing an XMLHttpRequest.
+ * @returns {(Promise|object)} If a callback is provided, this is an object representing an XMLHttpRequest.
  *                             If no callback is provided, this is a Promise.
  */
 User.prototype.sendVerificationEmail = function( fn ) {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -127,10 +127,12 @@ User.prototype.fetch = function() {
 
 	const flags = {
 		meta: 'flags',
-		abtests: config( 'ive/me' )
-			? true
-			: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
+		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
 	};
+
+	if ( config.isEnabled( 'ive/me' ) ) {
+		flags.active_tests = true;
+	}
 
 	// Request current user info
 	debug( 'Getting user from api' );

--- a/config/development.json
+++ b/config/development.json
@@ -70,7 +70,7 @@
 		"hosting/sftp-phpmyadmin": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
-		"ive/me": false,
+		"ive/me": true,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,
 		"jetpack/api-cache": true,

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -22,9 +22,13 @@ const debug = debugFactory( 'calypso:bootstrap' ),
 	 */
 	SUPPORT_SESSION_API_KEY = config( 'wpcom_calypso_support_session_rest_api_key' ),
 	API_PATH = 'https://public-api.wordpress.com/rest/v1/me',
-	apiQuery = {
+	flags = {
 		meta: 'flags',
 		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
+		active_tests: config.isEnabled( 'ive/me' ),
+	},
+	apiQuery = {
+		flags,
 	},
 	url = `${ API_PATH }?${ stringify( apiQuery ) }`;
 

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -25,7 +25,7 @@ const debug = debugFactory( 'calypso:bootstrap' ),
 	apiQuery = {
 		meta: 'flags',
 		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
-		active_tests: config.isEnabled( 'ive/me' ),
+		active_tests: config.isEnabled( 'ive/me' ) ? 'calypso' : false,
 	},
 	url = `${ API_PATH }?${ stringify( apiQuery ) }`;
 

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -22,13 +22,10 @@ const debug = debugFactory( 'calypso:bootstrap' ),
 	 */
 	SUPPORT_SESSION_API_KEY = config( 'wpcom_calypso_support_session_rest_api_key' ),
 	API_PATH = 'https://public-api.wordpress.com/rest/v1/me',
-	flags = {
+	apiQuery = {
 		meta: 'flags',
 		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
 		active_tests: config.isEnabled( 'ive/me' ),
-	},
-	apiQuery = {
-		flags,
 	},
 	url = `${ API_PATH }?${ stringify( apiQuery ) }`;
 


### PR DESCRIPTION
Requests for active tests on bootup via the `/me` endpoint.

#### Changes proposed in this Pull Request

* Requests `?active_tests=true` to the `/me` endpoint, in order to request that the client receives all active tests the user is eligible for.
* Adds a new key in localstorage: `ActiveABTests` to store the active tests for the user
* Stores the active tests object to that key.

Todo:

1. Make endpoint return something when `active_tests=true`?
2. Put unrelated linter errors in a different PR so it doesn't trash this one :)
3. Enable configuration in development.
4. Document how to get the old behavior back for people working on A/B tests in development.

The last two are optional and probably belong in another PR.

#### Testing instructions

1. Apply the patch to wpcom: D36090-code
1. With this PR applied, a new localstorage key should exist: `ActiveABTests` with data.