### PR TITLE
Always show the rewind (...) menu if rewind data is available

### DIFF
--- a/client/my-sites/activity/activity-log-example/index.jsx
+++ b/client/my-sites/activity/activity-log-example/index.jsx
@@ -78,7 +78,6 @@ class ActivityLogExample extends Component {
 							activity={ log }
 							disableRestore={ true }
 							disableBackup={ true }
-							hideRestore={ true }
 							siteId={ siteId }
 						/>
 					) ) }

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -130,7 +130,6 @@ class ActivityLogAggregatedItem extends Component {
 			disableRestore,
 			gmtOffset,
 			moment,
-			rewindState,
 			siteId,
 			timezone,
 			translate,
@@ -158,7 +157,6 @@ class ActivityLogAggregatedItem extends Component {
 								activity={ log }
 								disableRestore={ disableRestore }
 								disableBackup={ disableBackup }
-								hideRestore={ 'active' !== rewindState }
 								siteId={ siteId }
 							/>
 						</Fragment>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -240,12 +240,11 @@ class ActivityLogItem extends Component {
 			createRewind,
 			disableRestore,
 			disableBackup,
-			hideRestore,
 			activity,
 			translate,
 		} = this.props;
 
-		if ( hideRestore || ! activity.activityIsRewindable ) {
+		if ( ! activity.activityIsRewindable ) {
 			return null;
 		}
 
@@ -273,7 +272,7 @@ class ActivityLogItem extends Component {
 	/**
 	 * Displays a button for users to get help. Tracks button click.
 	 *
-	 * @returns {Object} Get help button.
+	 * @returns {object} Get help button.
 	 */
 	renderHelpAction = () => (
 		<HappychatButton
@@ -291,7 +290,7 @@ class ActivityLogItem extends Component {
 	/**
 	 * Displays a button to take users to enter credentials.
 	 *
-	 * @returns {Object} Get button to fix credentials.
+	 * @returns {object} Get button to fix credentials.
 	 */
 	renderFixCredsAction = () => {
 		if ( this.props.rewindIsActive ) {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -470,7 +470,6 @@ class ActivityLog extends Component {
 											activity={ log }
 											disableRestore={ disableRestore }
 											disableBackup={ disableBackup }
-											hideRestore={ 'active' !== rewindState.state }
 											siteId={ siteId }
 											rewindState={ rewindState.state }
 										/>
@@ -483,7 +482,6 @@ class ActivityLog extends Component {
 											activity={ log }
 											disableRestore={ disableRestore }
 											disableBackup={ disableBackup }
-											hideRestore={ 'active' !== rewindState.state }
 											siteId={ siteId }
 										/>
 									</Fragment>

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -117,7 +117,6 @@ class ClonePointStep extends Component {
 									cloneOnClick={ this.selectedPoint }
 									disableRestore
 									disableBackup
-									hideRestore
 									enableClone
 								/>
 							</Fragment>


### PR DESCRIPTION
Jetpack Backup now supports backups without credentials.

We no longer want to hide the (...) action menu on activity log items when no credentials are on file; we want users without credentials to be able to download their backups.

The "Rewind" action is deactivated if credentials aren't on file, and that is enough.

#### Changes proposed in this Pull Request

- Don't hide the folding Rewind Actions menu on Activity Log items when no credentials are present.

#### Testing instructions

* Visit the Activity Log for any site using http-only backups. (For an example, see blog_id 169043470)
* Verify that the [...] menu still appears for full daily backup events, and that the Rewind action is unavailable, but the Download action is still available.

See screenshot:
<img width="1251" alt="Screen Shot 2019-11-29 at 12 54 14 pm" src="https://user-images.githubusercontent.com/1369626/69838670-a7f6da80-12a8-11ea-975c-65c57d46f62a.png">
