### PR TITLE
Reader Conversations: fix clipping of descenders in Firefox on title

### DIFF
--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -4,8 +4,8 @@
 
 .conversations__stream .reader-post-card.card.is-compact .reader-post-options-menu {
 	position: absolute;
-	right: -2px;
-	top: -16px;
+		right: -2px;
+		top: -16px;
 }
 
 .conversations__stream .reader-post-card.card.is-compact {

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -4,12 +4,11 @@
 
 .conversations__stream .reader-post-card.card.is-compact .reader-post-options-menu {
 	position: absolute;
-		right: -2px;
-		top: -16px;
+	right: -2px;
+	top: -16px;
 }
 
 .conversations__stream .reader-post-card.card.is-compact {
-
 	.reader-post-card__post-details {
 		margin-top: -2px;
 	}
@@ -29,7 +28,7 @@
 	}
 
 	.reader-post-card__title {
-		line-height: 1.2;
+		line-height: 1.25;
 		max-height: 16px * 1.6;
 		margin-top: 2px;
 		overflow: hidden;
@@ -91,4 +90,3 @@
 		margin-top: 70px;
 	}
 }
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Similar to https://github.com/Automattic/wp-calypso/pull/38014. I've recently switched to Firefox as my primary browser and have noticed that lowercase descenders get slightly clipped (typically 'g') in conversation post titles:

<img width="763" alt="Screen Shot 2019-11-29 at 16 10 16" src="https://user-images.githubusercontent.com/17325/69841083-c23db200-12c2-11ea-90c3-383ebbb35402.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit your conversations at http://calypso.localhost:3000/read/conversations in Firefox. Check that no letters are clipped in the post title.

Visit your feed in other browsers. Check the line height still looks sensible.
