### PR TITLE
SPT: Allow later passing of `templates` prop

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -45,7 +45,7 @@ class PageTemplateModal extends Component {
 	};
 
 	// Extract titles for faster lookup.
-	getTitlesByTemplateSlug = memoize( templates =>
+	getTitlesByTemplateSlugs = memoize( templates =>
 		mapValues( keyBy( templates, 'slug' ), 'title' )
 	);
 
@@ -191,7 +191,7 @@ class PageTemplateModal extends Component {
 	}
 
 	getTitleByTemplateSlug( slug ) {
-		return get( this.getTitlesByTemplateSlug( this.props.templates ), [ slug ], '' );
+		return get( this.getTitlesByTemplateSlugs( this.props.templates ), [ slug ], '' );
 	}
 
 	getTemplateGroups = () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,18 @@
 /**
  * External dependencies
  */
-import { find, isEmpty, reduce, get, keyBy, mapValues, partition, reject, sortBy } from 'lodash';
+import {
+	find,
+	isEmpty,
+	reduce,
+	get,
+	keyBy,
+	mapValues,
+	memoize,
+	partition,
+	reject,
+	sortBy,
+} from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -30,10 +41,14 @@ class PageTemplateModal extends Component {
 		isLoading: false,
 		previewedTemplate: null,
 		blocksByTemplateSlug: {},
-		titlesByTemplateSlug: {},
 		error: null,
 		isOpen: false,
 	};
+
+	// Extract titles for faster lookup.
+	getTitlesByTemplateSlug = memoize( templates =>
+		mapValues( keyBy( templates, 'slug' ), 'title' )
+	);
 
 	constructor( props ) {
 		super();
@@ -42,8 +57,6 @@ class PageTemplateModal extends Component {
 		if ( hasTemplates ) {
 			// Select the first template automatically.
 			this.state.previewedTemplate = this.getDefaultSelectedTemplate( props );
-			// Extract titles for faster lookup.
-			this.state.titlesByTemplateSlug = mapValues( keyBy( props.templates, 'slug' ), 'title' );
 		}
 	}
 
@@ -174,7 +187,7 @@ class PageTemplateModal extends Component {
 	}
 
 	getTitleByTemplateSlug( slug ) {
-		return get( this.state.titlesByTemplateSlug, [ slug ], '' );
+		return get( this.getTitlesByTemplateSlug( this.props.templates ), [ slug ], '' );
 	}
 
 	getTemplateGroups = () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -71,7 +71,10 @@ class PageTemplateModal extends Component {
 		// This makes it a reliable indicator for whether the modal has just been launched.
 		if ( ! state.previewedTemplate && ! isEmpty( props.templates ) ) {
 			// Show the modal, and select the first template automatically.
-			return { isOpen: true, previewedTemplate: this.getDefaultSelectedTemplate( props ) };
+			return {
+				isOpen: true,
+				previewedTemplate: PageTemplateModal.getDefaultSelectedTemplate( props ),
+			};
 		}
 		return null;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -73,6 +73,7 @@ class PageTemplateModal extends Component {
 			// Show the modal, and select the first template automatically.
 			return { isOpen: true, previewedTemplate: this.getDefaultSelectedTemplate( props ) };
 		}
+		return null;
 	}
 
 	componentDidMount() {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -79,8 +79,9 @@ class PageTemplateModal extends Component {
 		return null;
 	}
 
-	componentDidMount() {
-		if ( this.state.isOpen ) {
+	componentDidUpdate( prevProps, prevState ) {
+		// Only track when the modal is first displayed.
+		if ( ! prevState.isOpen && this.state.isOpen ) {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -69,6 +69,8 @@ class PageTemplateModal extends Component {
 		// `this.getDefaultSelectedTemplate`. Afterwards, the user can select a
 		// different template, but can never un-select it.
 		// This makes it a reliable indicator for whether the modal has just been launched.
+		// It's also possible that `templates` are present during initial mount, in which
+		// case this will be called before `componentDidMount`, which is also fine.
 		if ( ! state.previewedTemplate && ! isEmpty( props.templates ) ) {
 			// Show the modal, and select the first template automatically.
 			return {
@@ -79,8 +81,15 @@ class PageTemplateModal extends Component {
 		return null;
 	}
 
+	componentDidMount() {
+		if ( this.state.isOpen ) {
+			trackView( this.props.segment.id, this.props.vertical.id );
+		}
+	}
+
 	componentDidUpdate( prevProps, prevState ) {
-		// Only track when the modal is first displayed.
+		// Only track when the modal is first displayed
+		// and if it didn't already happen during componentDidMount.
 		if ( ! prevState.isOpen && this.state.isOpen ) {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -69,6 +69,11 @@ class PageTemplateModal extends Component {
 	}
 
 	static getDerivedStateFromProps( props, state ) {
+		// The only time `state.previewedTemplate` isn't set is before `templates`
+		// are loaded. As soon as we have our `templates`, we set it using
+		// `this.getDefaultSelectedTemplate`. Afterwards, the user can select a
+		// different template, but can never un-select it.
+		// This makes it a reliable indicator for whether the modal has just been launched.
 		if ( ! state.previewedTemplate && ! isEmpty( props.templates ) ) {
 			// Select the first template automatically.
 			return { previewedTemplate: this.getDefaultSelectedTemplate( props ) };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -49,7 +49,7 @@ class PageTemplateModal extends Component {
 		mapValues( keyBy( templates, 'slug' ), 'title' )
 	);
 
-	// Parse templates blocks and store them into the state.
+	// Parse templates blocks and memoize them.
 	getBlocksByTemplateSlugs = memoize( templates =>
 		reduce(
 			templates,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -63,11 +63,6 @@ class PageTemplateModal extends Component {
 		)
 	);
 
-	constructor( props ) {
-		super();
-		this.state.isOpen = ! isEmpty( props.templates );
-	}
-
 	static getDerivedStateFromProps( props, state ) {
 		// The only time `state.previewedTemplate` isn't set is before `templates`
 		// are loaded. As soon as we have our `templates`, we set it using
@@ -75,8 +70,8 @@ class PageTemplateModal extends Component {
 		// different template, but can never un-select it.
 		// This makes it a reliable indicator for whether the modal has just been launched.
 		if ( ! state.previewedTemplate && ! isEmpty( props.templates ) ) {
-			// Select the first template automatically.
-			return { previewedTemplate: this.getDefaultSelectedTemplate( props ) };
+			// Show the modal, and select the first template automatically.
+			return { isOpen: true, previewedTemplate: this.getDefaultSelectedTemplate( props ) };
 		}
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -67,9 +67,12 @@ class PageTemplateModal extends Component {
 		super();
 		const hasTemplates = ! isEmpty( props.templates );
 		this.state.isOpen = hasTemplates;
-		if ( hasTemplates ) {
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		if ( ! state.previewedTemplate && ! isEmpty( props.templates ) ) {
 			// Select the first template automatically.
-			this.state.previewedTemplate = this.getDefaultSelectedTemplate( props );
+			return { previewedTemplate: this.getDefaultSelectedTemplate( props ) };
 		}
 	}
 
@@ -79,7 +82,7 @@ class PageTemplateModal extends Component {
 		}
 	}
 
-	getDefaultSelectedTemplate = props => {
+	static getDefaultSelectedTemplate = props => {
 		const blankTemplate = get( props.templates, [ 0, 'slug' ] );
 		let previouslyChosenTemplate = props._starter_page_template;
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -65,8 +65,7 @@ class PageTemplateModal extends Component {
 
 	constructor( props ) {
 		super();
-		const hasTemplates = ! isEmpty( props.templates );
-		this.state.isOpen = hasTemplates;
+		this.state.isOpen = ! isEmpty( props.templates );
 	}
 
 	static getDerivedStateFromProps( props, state ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -50,7 +50,7 @@ class PageTemplateModal extends Component {
 	);
 
 	// Parse templates blocks and store them into the state.
-	getBlocksByTemplateSlug = memoize( templates =>
+	getBlocksByTemplateSlugs = memoize( templates =>
 		reduce(
 			templates,
 			( prev, { slug, content } ) => {
@@ -187,7 +187,7 @@ class PageTemplateModal extends Component {
 	};
 
 	getBlocksByTemplateSlug( slug ) {
-		return get( this.getBlocksByTemplateSlug( this.props.templates ), [ slug ], [] );
+		return get( this.getBlocksByTemplateSlugs( this.props.templates ), [ slug ], [] );
 	}
 
 	getTitleByTemplateSlug( slug ) {
@@ -223,7 +223,7 @@ class PageTemplateModal extends Component {
 			<TemplateSelectorControl
 				label={ __( 'Layout', 'full-site-editing' ) }
 				templates={ templatesList }
-				blocksByTemplates={ this.getBlocksByTemplateSlug( this.props.templates ) }
+				blocksByTemplates={ this.getBlocksByTemplateSlugs( this.props.templates ) }
 				onTemplateSelect={ this.previewTemplate }
 				useDynamicPreview={ false }
 				siteInformation={ this.props.siteInformation }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Spun off from #37995.

For Gutenboarding, we want to pass a `templates` prop to the page template modal that's coming from a `@wordpress/data` store, rather than a `window.` global.

However, there's a problem with `PageTemplateModal`'s state handling, which expects the `templates` prop to be available in its constructor (and sets e.g. its `isOpen` state accordingly, which determines the modal's visibility).

That doesn't work with a selector that returns `undefined` when first called, and only returns something after its corresponding resolver runs :roll_eyes: As a consequence, this PR refactors `PageTemplateModal` so it no longer relies on that assumption, but treats `templates` as a prop that might at first be `undefined` and only later get a meaningful value.

This necessitates a whole number of changes:

  - `this.state.titlesByTemplateSlug` and `this.state.blocksByTemplateSlug` are dropped in favor of two memoized helper functions, `getTitlesByTemplateSlugs` and `getBlocksByTemplateSlugs`, respectively. (Both plural, don't confuse with the two related helpers that use singular!). This allows us to compute their values later than in the constructor, while making sure that the costly computations required by them are only run when the `templates` prop actually does change (and not on every prop change).
  - `trackView` is now called in `componentDidUpdate` (rather than `componentDidMount`), when `this.state.isOpen` first changes from `false` to `true`. This only happens once, when `templates` have been received.
  - `this.state.previewedTemplate` is set in `getDerivedStateFromProps()`, but only if it hasn't been set before. The rationale is explained in a [code comment](https://github.com/Automattic/wp-calypso/pull/38042/files#diff-a664d83ace51cb87304bf656c9e9f303R67):
    > The only time `state.previewedTemplate` isn't set is before `templates`
    > are loaded. As soon as we have our `templates`, we set it using
    > `this.getDefaultSelectedTemplate`. Afterwards, the user can select a
    > different template, but can never un-select it.
    > This makes it a reliable indicator for whether the modal has just been launched.
    - Since `getDerivedStateFromProps` has to be `static`, we also need to change the one helper method is uses to `static`: `getDefaultSelectedTemplate`. Fortunately, that method was already independent of a class instance (no `this` used).
- The same rationale is applied to `this.state.isOpen`.

A lot of these changes follow the guidelines found in the [`getDerivedStateFromProps` docs](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops) (which also has some suggestions how to avoid that method).

#### Testing instructions

- Build Starter Page Templates as per Team Cylon's guide (see paAmJe-Nv-p2 and PCYsg-ly5-p2).
- Verify that the feature still works as before (select a theme, verify that it's properly previewed, click the CTA).
- Also verify that `trackView` is only called once (when the modal is first shown).

Disclaimer: I tested this only as part of #38042, where it seemed to work rather well. I don't have a lot of time left today and can't test in its actual FSE/SPT context myself, but would like to ask reviewers to do that on my behalf.