### PR TITLE
Domains: Change order of actions from the "free domain with upgrade" nudge 

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -210,7 +210,7 @@ export class SiteNotice extends React.Component {
 			<SidebarBanner
 				ctaName={ CTA_FREE_TO_PAID }
 				ctaText={ translate( 'Upgrade' ) }
-				href={ '/plans/' + site.slug }
+				href={ `/domains/add/${ site.slug }` }
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
 				onClick={ () => this.props.clickFreeToPaidPlanNotice( site.ID ) }

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -37,12 +37,13 @@ import PendingPaymentNotice from './pending-payment-notice';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import { getProductsList } from 'state/products-list/selectors';
 import QueryProductsList from 'components/data/query-products-list';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { currentUserHasFlag, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getUnformattedDomainPrice, getUnformattedDomainSalePrice } from 'lib/domains';
 import formatCurrency from '@automattic/format-currency/src';
 import { getPreference } from 'state/preferences/selectors';
 import { savePreference } from 'state/preferences/actions';
 import { CTA_FREE_TO_PAID } from './constants';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 
 const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
 
@@ -205,12 +206,15 @@ export class SiteNotice extends React.Component {
 		}
 
 		const { site, translate } = this.props;
+		const href = this.props.domainsWithPlansOnly
+			? `/domains/add/${ site.slug }`
+			: `/plans/${ site.slug }`;
 
 		return (
 			<SidebarBanner
 				ctaName={ CTA_FREE_TO_PAID }
 				ctaText={ translate( 'Upgrade' ) }
-				href={ `/domains/add/${ site.slug }` }
+				href={ href }
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
 				onClick={ () => this.props.clickFreeToPaidPlanNotice( site.ID ) }
@@ -334,6 +338,7 @@ export default connect(
 			isPlanOwner: isCurrentUserCurrentPlanOwner( state, siteId ),
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			domainUpsellNudgeDismissedDate: getPreference( state, DOMAIN_UPSELL_NUDGE_DISMISS_KEY ),
+			domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		};
 	},
 	dispatch => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently when you click on the "free domain with plan" nudge in the sidebar a customer is taken to a page to select a plan. Let's change the order and put a domain search first, then go to the plan selection page. 

<img width="277" alt="Screenshot 2019-11-29 at 07 38 14" src="https://user-images.githubusercontent.com/3392497/69852106-49ffce00-127b-11ea-89ad-3c8edd96aec5.png">

#### Testing instructions
Pick a site that's eligible to see this upsell. See: https://github.com/Automattic/wp-calypso/blob/f357e85c90211957e93398540db125cccf124cae/client/state/selectors/is-eligible-for-free-to-paid-upsell.js#L18-L32

Or just hardwire the logic to always show it.

Make sure the link goes to the `/domains/add` section on the current site if the user is DWPO or to Plans if not.

