### PR TITLE
Gutenboarding: test i18n

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -4,7 +4,7 @@
 import { __ as NO__, __ } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
 import { DomainSuggestions } from '@automattic/data-stores';
-import { translate, useTranslate } from 'i18n-calypso';
+import { localize, translate, useTranslate } from 'i18n-calypso';
 import { useDebounce } from 'use-debounce';
 import { useDispatch, useSelect } from '@wordpress/data';
 import classnames from 'classnames';
@@ -27,7 +27,7 @@ interface Props {
 	prev?: string;
 }
 
-const Header: FunctionComponent< Props > = ( { prev } ) => {
+const Header: FunctionComponent< Props > = ( { prev, ...props } ) => {
 	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
 	const { domain, selectedDesign, siteTitle, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
@@ -132,6 +132,10 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 					<p>
 						<code>__( 'Manage' ): { __( 'Manage' ) }</code>
 						<br />
+						<code>props.translate( 'Manage' ): { props.translate( 'Manage' ) }</code>
+						<br />
+						<code>translate( 'Manage' ): { translate( 'Manage' ) }</code>
+						<br />
 						<code>translate( 'Manage' ): { translate( 'Manage' ) }</code>
 						<br />
 						<code>ut( 'Manage' ): { ut( 'Manage' ) }</code>
@@ -150,4 +154,4 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
-export default Header;
+export default localize( Header );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { __ as NO__ } from '@wordpress/i18n';
+import { __ as NO__, __ } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
-import React, { FunctionComponent, useEffect } from 'react';
-import { useDebounce } from 'use-debounce';
-import classnames from 'classnames';
 import { DomainSuggestions } from '@automattic/data-stores';
+import { translate, useTranslate } from 'i18n-calypso';
+import { useDebounce } from 'use-debounce';
+import { useDispatch, useSelect } from '@wordpress/data';
+import classnames from 'classnames';
+import React, { FunctionComponent, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -83,6 +84,8 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 		...( selectedDesign?.slug && { theme: selectedDesign?.slug } ),
 	};
 
+	const ut = useTranslate();
+
 	return (
 		<div
 			className="gutenboarding__header"
@@ -126,6 +129,20 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 							{ NO__( 'Create my site' ) }
 						</Button>
 					) }
+					<p>
+						<code>__( 'Manage' ): { __( 'Manage' ) }</code>
+						<br />
+						<code>translate( 'Manage' ): { translate( 'Manage' ) }</code>
+						<br />
+						<code>ut( 'Manage' ): { ut( 'Manage' ) }</code>
+						<br />
+						<code>__( 'Next' ): { __( 'Next' ) }</code>
+						<br />
+						<code>translate( 'Next' ): { translate( 'Next' ) }</code>
+						<br />
+						<code>ut( 'Next' ): { ut( 'Next' ) }</code>
+						<br />
+					</p>
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import config from '../../config';
+import { setLocaleData } from '@wordpress/i18n';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,6 +25,14 @@ window.AppBoot = () => {
 	if ( ! config.isEnabled( 'gutenboarding' ) ) {
 		window.location.href = '/';
 	} else {
+		// JED locale comes in JS in a <script> tag. See `attachI18n` in client/server/render/index
+		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
+
+		// This is what i18n-calypso needs to work
+		i18n.setLocale( i18nLocaleStringsObject );
+		// This is what @wordpress/i18n needs to work
+		setLocaleData( i18nLocaleStringsObject );
+
 		setupWpDataDebug();
 
 		// Add accessible-focus listener.

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -125,6 +125,7 @@ export function render( element, key = JSON.stringify( element ), req ) {
 }
 
 export function attachI18n( context ) {
+	context.lang = 'es';
 	if ( ! isDefaultLocale( context.lang ) ) {
 		const langFileName = getCurrentLocaleVariant( context.store.getState() ) || context.lang;
 


### PR DESCRIPTION
Part of  https://github.com/Automattic/wp-calypso/issues/37665

I'd like to see if we can _actually_ change the locale and see translations working. If it doesn't work, we might need to kick off some work later down the road.

"Next" term is already used and thus translated in Calypso. 

#### Changes proposed in this Pull Request

* 

#### Testing instructions

- Open `/gutenboarding`
- Nothing should change