### PR TITLE
Hosting: Prepare SFTP/phpMyAdmin cards for activation flow

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -80,10 +80,12 @@ const SftpCard = ( {
 	};
 
 	useEffect( () => {
-		setIsLoading( true );
-		requestSftpUsers( siteId );
+		if ( ! disabled ) {
+			setIsLoading( true );
+			requestSftpUsers( siteId );
+		}
 		return onDestroy();
-	}, [ siteId ] );
+	}, [ disabled, siteId ] );
 
 	useEffect( () => {
 		if ( username === null || username || password ) {
@@ -127,7 +129,7 @@ const SftpCard = ( {
 		);
 	};
 
-	const displayQuestionsAndButton = ! ( disabled || username || isLoading );
+	const displayQuestionsAndButton = ! ( username || isLoading );
 
 	return (
 		<Card className="sftp-card">
@@ -159,8 +161,8 @@ const SftpCard = ( {
 				<div className="sftp-card__questions">
 					<Accordion title={ translate( 'What is SFTP?' ) }>
 						{ translate(
-							'SFTP stands for Secure File Transfer Protocol (or SSH File Transfer Protocol). It’s a secure way for you to access your website files on your local computer via a client program such as {{a}}Filezilla{{/a}} ' +
-								'For more information see {{supportLink}}SFTP on WordPress.com{{/supportLink}} ',
+							'SFTP stands for Secure File Transfer Protocol (or SSH File Transfer Protocol). It’s a secure way for you to access your website files on your local computer via a client program such as {{a}}Filezilla{{/a}}. ' +
+								'For more information see {{supportLink}}SFTP on WordPress.com{{/supportLink}}.',
 							{
 								components: {
 									a: <ExternalLink icon target="_blank" href={ FILEZILLA_URL } />,
@@ -194,7 +196,7 @@ const SftpCard = ( {
 					</Button>
 				</>
 			) }
-			{ ( username || disabled ) && (
+			{ username && (
 				<FormFieldset className="sftp-card__info-field">
 					<FormLabel>{ translate( 'URL' ) }</FormLabel>
 					<div className="sftp-card__copy-field">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Shows the "Create SFTP credentials" state when the hosting features have not been activated yet (aka site is not Atomic). This will match what users see once the activation has been completed.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/1233880/69864001-62cdab00-129e-11ea-999c-8eded3c4ce96.png) | ![image](https://user-images.githubusercontent.com/1233880/69864016-69f4b900-129e-11ea-8d81-72fa9ebdd889.png) |

#### Testing instructions

* Create a site.
* Buy a business plan.
* Go to Hosting Configuration.
* Make sure the "Create SFTP credentials" button is displayed, and no credentials are displayed.
* Activate the hosting features and wait.
* Click on the SFTP credentials.
* Make sure the SFTP credentials are created as expected.
