### PR TITLE
Fix syncing of i18n-calypso and Redux state

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -10,7 +10,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { configureReduxStore, locales, setupMiddlewares, utils } from './common';
+import { configureReduxStore, setupMiddlewares, utils } from './common';
+import { setupLocale } from './locale';
 import { createReduxStore } from 'state';
 import initialReducer from 'state/reducer';
 import { getInitialState, persistOnChange } from 'state/initial-state';
@@ -31,7 +32,7 @@ const boot = currentUser => {
 	getInitialState( initialReducer ).then( initialState => {
 		const reduxStore = createReduxStore( initialState, initialReducer );
 		persistOnChange( reduxStore );
-		locales( currentUser, reduxStore );
+		setupLocale( currentUser.get(), reduxStore );
 		configureReduxStore( currentUser, reduxStore );
 		setupMiddlewares( currentUser, reduxStore );
 		detectHistoryNavigation.start();

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -6,7 +6,7 @@ import debugFactory from 'debug';
 import page from 'page';
 import { parse } from 'qs';
 import url from 'url';
-import { get, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
 import Modal from 'react-modal';
@@ -42,20 +42,10 @@ import { getHappychatAuth } from 'state/happychat/utils';
 import wasHappychatRecentlyActive from 'state/happychat/selectors/was-happychat-recently-active';
 import { setRoute as setRouteAction } from 'state/ui/actions';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
-import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import setupGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
-import { loadUserUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
 
 const debug = debugFactory( 'calypso' );
-
-const switchUserLocale = ( currentUser, reduxStore ) => {
-	const { localeSlug, localeVariant } = currentUser.get();
-
-	if ( localeSlug ) {
-		reduxStore.dispatch( setLocale( localeSlug, localeVariant ) );
-	}
-};
 
 const setupContextMiddleware = reduxStore => {
 	page( '*', ( context, next ) => {
@@ -171,29 +161,6 @@ const clearNoticesMiddleware = () => {
 const unsavedFormsMiddleware = () => {
 	// warn against navigating from changed, unsaved forms
 	page.exit( '*', checkFormHandler );
-};
-
-export const locales = ( currentUser, reduxStore ) => {
-	debug( 'Executing Calypso locales.' );
-
-	if ( window.i18nLocaleStrings ) {
-		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
-		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
-		const languageSlug = get( i18nLocaleStringsObject, [ '', 'localeSlug' ] );
-		if ( languageSlug ) {
-			debug( 'Checking for load-user-translations parameter' );
-			loadUserUndeployedTranslations( languageSlug );
-		}
-	}
-
-	// Use current user's locale if it was not bootstrapped (non-ssr pages)
-	if (
-		! window.i18nLocaleStrings &&
-		! config.isEnabled( 'wpcom-user-bootstrap' ) &&
-		currentUser.get()
-	) {
-		switchUserLocale( currentUser, reduxStore );
-	}
 };
 
 export const utils = () => {

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { loadUserUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
+import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
+
+export const setupLocale = ( currentUser, reduxStore ) => {
+	if ( window.i18nLocaleStrings ) {
+		// Use the locale translation data that were boostrapped by the server
+		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
+		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
+		const languageSlug = get( i18nLocaleStringsObject, [ '', 'localeSlug' ] );
+		if ( languageSlug ) {
+			loadUserUndeployedTranslations( languageSlug );
+		}
+	} else if ( currentUser && currentUser.localeSlug ) {
+		// Use the current user's and load traslation data with a fetch request
+		reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
+	}
+
+	// If user is logged out and translations are not boostrapped, we assume default locale
+};

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -12,6 +12,7 @@ import debugFactory from 'debug';
 import config from 'config';
 import analytics from 'lib/analytics';
 import getSuperProps from 'lib/analytics/super-props';
+import { bindState as bindWpLocaleState } from 'lib/wp/localization';
 import { setCurrentUser } from 'state/current-user/actions';
 import setRouteAction from 'state/ui/actions/set-route';
 
@@ -78,6 +79,8 @@ function renderDevHelpers( reduxStore ) {
 
 export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
+
+	bindWpLocaleState( reduxStore );
 
 	if ( currentUser.get() ) {
 		// Set current user in Redux store

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -17,6 +17,7 @@ import createStore from './store';
 import { setupMiddlewares, configureReduxStore } from './common';
 import initLoginSection from 'login';
 import userFactory from 'lib/user';
+import { setupLocale } from 'boot/locale';
 
 const debug = debugFactory( 'calypso' );
 
@@ -32,6 +33,7 @@ const boot = currentUser => {
 
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
+	setupLocale( currentUser.get(), store );
 
 	page( '*', ( context, next ) => {
 		context.store = store;

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-
 import { parse, stringify } from 'qs';
-import { getLocaleSlug } from 'lib/i18n-utils';
 
 /**
  * Internal dependencies
  */
-import { getCurrentUserLocale, getCurrentUserLocaleVariant } from 'state/current-user/selectors';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import getCurrentLocaleVariant from 'state/selectors/get-current-locale-variant';
 
 /**
  * Module variables
@@ -18,7 +17,7 @@ let locale;
 /**
  * Setter function for internal locale value
  *
- * @param {String} localeToSet Locale to set
+ * @param {string} localeToSet Locale to set
  */
 export function setLocale( localeToSet ) {
 	locale = localeToSet;
@@ -27,7 +26,7 @@ export function setLocale( localeToSet ) {
 /**
  * Getter function for internal locale value
  *
- * @return {String} Locale
+ * @returns {string} Locale
  */
 export function getLocale() {
 	return locale;
@@ -37,8 +36,8 @@ export function getLocale() {
  * Given a WPCOM parameter set, modifies the query such that a non-default
  * locale is added to the query parameter.
  *
- * @param  {Object} params Original parameters
- * @return {Object}        Revised parameters, if non-default locale
+ * @param  {object} params Original parameters
+ * @returns {object}        Revised parameters, if non-default locale
  */
 export function addLocaleQueryParam( params ) {
 	if ( ! locale || 'en' === locale ) {
@@ -65,8 +64,8 @@ export function addLocaleQueryParam( params ) {
  * localization helpers. Specifically, this adds a locale query parameter
  * by default.
  *
- * @param  {Object} wpcom Original WPCOM instance
- * @return {Object}       Modified WPCOM instance with localization helpers
+ * @param {object} wpcom Original WPCOM instance
+ * @returns {object} Modified WPCOM instance with localization helpers
  */
 export function injectLocalization( wpcom ) {
 	const originalRequest = wpcom.request.bind( wpcom );
@@ -83,15 +82,14 @@ export function injectLocalization( wpcom ) {
  * Subscribes to the provided Redux store instance, updating the known locale
  * value to the latest value when state changes.
  *
- * @param {Object} store Redux store instance
+ * @param {object} store Redux store instance
  */
 export function bindState( store ) {
 	function setLocaleFromState() {
-		setLocale(
-			getCurrentUserLocaleVariant( store.getState() ) ||
-				getCurrentUserLocale( store.getState() ) ||
-				getLocaleSlug()
-		);
+		const state = store.getState();
+		const localeVariant = getCurrentLocaleVariant( state );
+		const localeSlug = getCurrentLocaleSlug( state );
+		setLocale( localeVariant || localeSlug );
 	}
 
 	store.subscribe( setLocaleFromState );

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -1,21 +1,12 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { addLocaleQueryParam, bindState, getLocale, injectLocalization, setLocale } from '../';
-import {
-	getCurrentUserLocale as getCurrentUserLocaleMock,
-	getCurrentUserLocaleVariant as getCurrentUserLocaleVariantMock,
-} from 'state/current-user/selectors';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import getCurrentLocaleVariant from 'state/selectors/get-current-locale-variant';
 
-jest.mock( 'state/current-user/selectors', () => ( {
-	getCurrentUserLocale: jest.fn(),
-	getCurrentUserLocaleVariant: jest.fn(),
-} ) );
+jest.mock( 'state/selectors/get-current-locale-slug' );
+jest.mock( 'state/selectors/get-current-locale-variant' );
 
 describe( 'index', () => {
 	beforeEach( () => {
@@ -26,29 +17,27 @@ describe( 'index', () => {
 		test( 'should not modify params if locale unknown', () => {
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
 
-			expect( params ).to.eql( { query: 'search=foo' } );
+			expect( params ).toEqual( { query: 'search=foo' } );
 		} );
 
 		test( 'should not modify params if locale is default', () => {
 			setLocale( 'en' );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
 
-			expect( params ).to.eql( { query: 'search=foo' } );
+			expect( params ).toEqual( { query: 'search=foo' } );
 		} );
 
 		test( 'should include the locale query parameter for a non-default locale', () => {
 			setLocale( 'fr' );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
 
-			expect( params ).to.eql( {
-				query: 'search=foo&locale=fr',
-			} );
+			expect( params ).toEqual( { query: 'search=foo&locale=fr' } );
 		} );
 
 		test( 'should prefer and set initial variant locale from state', () => {
-			getCurrentUserLocaleVariantMock.mockReturnValueOnce( 'fr_formal' );
+			getCurrentLocaleVariant.mockReturnValueOnce( 'fr_formal' );
 			bindState( { subscribe() {}, getState() {} } );
-			expect( getLocale() ).to.equal( 'fr_formal' );
+			expect( getLocale() ).toBe( 'fr_formal' );
 		} );
 	} );
 
@@ -57,7 +46,7 @@ describe( 'index', () => {
 			const wpcom = { request() {} };
 			injectLocalization( wpcom );
 
-			expect( wpcom.localized ).to.exist;
+			expect( wpcom ).toHaveProperty( 'localized' );
 		} );
 
 		test( 'should override the default request method', () => {
@@ -65,28 +54,27 @@ describe( 'index', () => {
 			const wpcom = { request };
 			injectLocalization( wpcom );
 
-			expect( wpcom.request ).to.not.equal( request );
+			expect( wpcom.request ).not.toBe( request );
 		} );
 
-		test( 'should modify params by default', done => {
+		test( 'should modify params by default', async () => {
 			setLocale( 'fr' );
 			const wpcom = {
-				request( params ) {
-					expect( params.query ).to.equal( 'search=foo&locale=fr' );
-					done();
+				async request( params ) {
+					expect( params.query ).toBe( 'search=foo&locale=fr' );
 				},
 			};
 
 			injectLocalization( wpcom );
-			wpcom.request( { query: 'search=foo' } );
+			await wpcom.request( { query: 'search=foo' } );
 		} );
 	} );
 
 	describe( '#bindState()', () => {
 		test( 'should set initial locale from state', () => {
-			getCurrentUserLocaleMock.mockReturnValueOnce( 'fr' );
+			getCurrentLocaleSlug.mockReturnValueOnce( 'fr' );
 			bindState( { subscribe() {}, getState() {} } );
-			expect( getLocale() ).to.equal( 'fr' );
+			expect( getLocale() ).toBe( 'fr' );
 		} );
 
 		test( 'should subscribe to the store, setting locale on change', () => {
@@ -97,10 +85,10 @@ describe( 'index', () => {
 				},
 				getState() {},
 			} );
-			getCurrentUserLocaleMock.mockReturnValueOnce( 'de' );
+			getCurrentLocaleSlug.mockReturnValueOnce( 'de' );
 			listener();
 
-			expect( getLocale() ).to.equal( 'de' );
+			expect( getLocale() ).toBe( 'de' );
 		} );
 	} );
 } );

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -1,24 +1,23 @@
 /**
  * Internal dependencies
  */
-import { withSchemaValidation } from 'state/utils';
+import config from 'config';
 import { LOCALE_SET } from 'state/action-types';
-import { localeSchema } from './schema';
 
 const initialState = {
-	localeSlug: null,
+	localeSlug: config( 'i18n_default_locale_slug' ),
 	localeVariant: null,
 };
 
 /**
  * Tracks the state of the ui locale
  *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
+ * @param {object} state  Current state
+ * @param {object} action Action payload
+ * @returns {object} Updated state
  *
  */
-export default withSchemaValidation( localeSchema, ( state = initialState, action ) => {
+export default function language( state = initialState, action ) {
 	switch ( action.type ) {
 		case LOCALE_SET:
 			return {
@@ -29,4 +28,4 @@ export default withSchemaValidation( localeSchema, ( state = initialState, actio
 		default:
 			return state;
 	}
-} );
+}

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,7 +1,0 @@
-export const localeSchema = {
-	type: 'object',
-	properties: {
-		localeSlug: { type: [ 'string', 'null' ] },
-		localeVariant: { type: [ 'string', 'null' ] },
-	},
-};

--- a/client/state/ui/language/test/actions.js
+++ b/client/state/ui/language/test/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { setLocale, setLocaleRawData } from '../actions';
@@ -12,7 +7,7 @@ import { LOCALE_SET } from 'state/action-types';
 describe( 'actions', () => {
 	describe( 'setLocale', () => {
 		test( 'returns an appropriate action', () => {
-			expect( setLocale( 'he' ) ).to.eql( {
+			expect( setLocale( 'he' ) ).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: null,
@@ -20,7 +15,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'returns an action with localeVariant set', () => {
-			expect( setLocale( 'he', 'he_formal' ) ).to.eql( {
+			expect( setLocale( 'he', 'he_formal' ) ).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: 'he_formal',
@@ -36,7 +31,7 @@ describe( 'actions', () => {
 						localeSlug: 'he',
 					},
 				} )
-			).to.eql( {
+			).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: null,
@@ -51,7 +46,7 @@ describe( 'actions', () => {
 						localeVariant: 'he_formal',
 					},
 				} )
-			).to.eql( {
+			).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: 'he_formal',

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -6,7 +6,7 @@ import { LOCALE_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
 	test( 'returns default state with undefined state and empty action', () => {
-		expect( reducer( undefined, {} ) ).toEqual( { localeSlug: null, localeVariant: null } );
+		expect( reducer( undefined, {} ) ).toEqual( { localeSlug: 'en', localeVariant: null } );
 	} );
 
 	test( 'returns previous state with empty action', () => {


### PR DESCRIPTION
This PR fixes a family of messy bugs that stem from the fact that the `i18n-calypso` locale and the locale in `state.ui.language` are sometimes out of sync.

Also adds some locale setup to the login entrypoint -- another little thing that was left out when the entrypoint was introduced.

Possible manifestations of the out-of-sync Redux state:
- if you recently switched between locales, and their LTR/RTL flags were different, you could end up with a RTL TinyMCE toolbar in a LTR UI:
<img width="712" alt="Screenshot 2019-11-28 at 18 34 54" src="https://user-images.githubusercontent.com/664258/69869990-b34d0480-12ae-11ea-9c63-8b166ac07e56.png">
- also, moment.js localizations of dates could be in a different language from the current one
- REST requests sent by the login entrypoint (e.g., `auth-options`) were missing the `locale` query param and response errors were not localized
- when loading localized login (e.g., `/log-in/de`), the UI was initially rendered in English, and after a moment flashed into German. That was because locale initialization (`setupLocale`) was missing in the login entrypoint.

Descriptions of the commits:

**Don't persist the state.ui.language Redux state, initialize to default lang slug**
Stop persisting the `state.ui.language` state. The source of truth for i18n is always something else: either the bootstrapped locale in `window.i18nLanguageStrings` or locale information in the `currentUser` object. Both are initialized at boot.

Loading from persisted state only leads to subtle bugs where the boot code fails to init the Redux state in certain conditions and an outdated data are loaded from Indexed DB.

**Use better selectors to get locale info for REST API requests, initialize for login entrypoint**
There is a WP.com REST API middleware that for every request figures out the current locale and if it's not the default EN one, adds a `locale` (or `_locale`) query parameter to the request. That ensures that responses (mainly error messages) can be localized.

This code should get the current locale from the `state.ui.language` Redux state rather than from `state.currentUser`, as the earlier is correctly set also in logged-out sessions, where the desired locale is a part of the URL (e.g., `/log-in/de` or `/start/de`).

(Ideally, this handler shouldn't use Redux at all and get the language info from `i18n-calypso`, but that's for another patch.)

Also, the middleware wan't property registered (i.e., subscribed to the Redux store) in the login entrypoint.

**Setup locale at boot even if user boostrapping is enabled, setup also in login**
Fixes a bug where the locale setup function wouldn't dispatch the `setLocale` action
in case when the translations aren't server boostrapped (i.e., `window.i18nLocaleStrings`
is not present) and when user boostrapping is enabled: see the
```js
! config.isEnabled( 'wpcom-user-bootstrap' )
```
condition that is in the original code and this PR removes it.

In that case, the `state.ui.language` Redux state would be left in default state, which in combination with persistence can lead to weird states. Indexed DB contains some locale, then I change my locale in another session, the load Calypso again and load Redux state from Indexed DB. Things that depend on `state.ui.language` (moment.js localization, TinyMCE localization, REST API `locale` query arg...) would use the old locale, while `i18n-calypso` translations use the new locale.

**Future improvements:**
The `MomentProvider`, TinyMCE localization and the `wpcom` REST handler should get locale info from `i18n-calypso` instead of Redux. Redux `state.ui.language` should be used only for language-related UI, and not for the i18n infrastructure.