### PR TITLE
FSE: Add upgrade nudge to Blog Posts Listing block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/editor.scss
@@ -1,0 +1,16 @@
+div.posts-list__notice {
+	margin: 0 0 5px;
+
+	p {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-size: 13px;
+		margin: 1em 0;
+		padding: 2px;
+
+		.posts-list__message {
+			margin-right: 1em;
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -18,6 +18,7 @@ import { select, dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import * as metadata from './block.json';
+import './editor.scss';
 import './style.scss';
 import { transforms, isValidHomepagePostsBlockType } from './transforms';
 
@@ -58,24 +59,26 @@ registerBlockType( metadata.name, {
 
 		return (
 			<Fragment>
+				{ canBeUpgraded && (
+					<div className="posts-list__notice notice notice-info notice-alt">
+						<p>
+							<span className="posts-list__message">
+								{ __(
+									'An improved version of this block is available. Upgrade for a better, more natural way to manage your blog post listings.',
+									'full-site-editing'
+								) }
+							</span>
+							<Button isButton isLarge isDefault onClick={ upgradeBlock }>
+								{ __( 'Upgrade Block', 'full-site-editing' ) }
+							</Button>
+						</p>
+					</div>
+				) }
 				<Placeholder
 					icon={ icon }
 					label={ __( 'Your recent blog posts will be displayed here.', 'full-site-editing' ) }
-					instructions={
-						canBeUpgraded
-							? __(
-									'An improved version of this block is available. Get more controls and visual preview right inside the block editor.',
-									'full-site-editing'
-							  )
-							: null
-					}
 				>
-					{ canBeUpgraded ? (
-						<Button isPrimary onClick={ upgradeBlock }>
-							{ __( 'Upgrade Block', 'full-site-editing' ) }
-						</Button>
-					) : null }
-					{ ! canBeUpgraded && isSelected ? (
+					{ isSelected ? (
 						<RangeControl
 							label={ __( 'Number of posts to show', 'full-site-editing' ) }
 							value={ attributes.postsPerPage }

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -2,11 +2,16 @@
 /**
  * WordPress dependencies
  */
-import { registerBlockType, createBlock } from '@wordpress/blocks';
+import {
+	registerBlockType,
+	switchToBlockType,
+	getPossibleBlockTransformations,
+} from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { Placeholder, RangeControl, PanelBody } from '@wordpress/components';
+import { Placeholder, RangeControl, PanelBody, Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
+import { select, dispatch } from '@wordpress/data';
 /* eslint-enable import/no-extraneous-dependencies */
 
 /**
@@ -14,6 +19,7 @@ import { InspectorControls } from '@wordpress/block-editor';
  */
 import * as metadata from './block.json';
 import './style.scss';
+import { transforms, isValidHomepagePostsBlockType } from './transforms';
 
 const icon = (
 	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
@@ -33,52 +39,66 @@ registerBlockType( metadata.name, {
 		reusable: false,
 	},
 	attributes: metadata.attributes,
-	edit: ( { attributes, setAttributes, isSelected } ) => (
-		<Fragment>
-			<Placeholder
-				icon={ icon }
-				label={ __( 'Your recent blog posts will be displayed here.', 'full-site-editing' ) }
-			>
-				{ isSelected ? (
-					<RangeControl
-						label={ __( 'Number of posts to show', 'full-site-editing' ) }
-						value={ attributes.postsPerPage }
-						onChange={ val => setAttributes( { postsPerPage: val } ) }
-						min={ 1 }
-						max={ 50 }
-					/>
-				) : null }
-			</Placeholder>
-			<InspectorControls>
-				<PanelBody>
-					<RangeControl
-						label={ __( 'Number of posts', 'full-site-editing' ) }
-						value={ attributes.postsPerPage }
-						onChange={ val => setAttributes( { postsPerPage: val } ) }
-						min={ 1 }
-						max={ 50 }
-					/>
-				</PanelBody>
-			</InspectorControls>
-		</Fragment>
-	),
-	save: () => null,
-	transforms: {
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'newspack-blocks/homepage-articles' ],
-				transform: ( { postsPerPage } ) => {
-					// Configure the Newspack block to look as close as possible
-					// to the output of this one.
-					return createBlock( 'newspack-blocks/homepage-articles', {
-						postsToShow: postsPerPage,
-						showAvatar: false,
-						displayPostDate: true,
-						displayPostContent: true,
-					} );
-				},
-			},
-		],
+	edit: ( { attributes, setAttributes, clientId, isSelected } ) => {
+		const block = select( 'core/block-editor' ).getBlock( clientId );
+
+		// Find if any of possible transformations is into the Homepage Posts block.
+		const possibleTransforms = getPossibleBlockTransformations( [ block ] );
+		const homepagePostsTransform = possibleTransforms.find(
+			transform => transform && isValidHomepagePostsBlockType( transform.name )
+		);
+		const canBeUpgraded = !! homepagePostsTransform;
+
+		const upgradeBlock = () => {
+			dispatch( 'core/block-editor' ).replaceBlocks(
+				block.clientId,
+				switchToBlockType( block, homepagePostsTransform.name )
+			);
+		};
+
+		return (
+			<Fragment>
+				<Placeholder
+					icon={ icon }
+					label={ __( 'Your recent blog posts will be displayed here.', 'full-site-editing' ) }
+					instructions={
+						canBeUpgraded
+							? __(
+									'An improved version of this block is available. Get more controls and visual preview right inside the block editor.',
+									'full-site-editing'
+							  )
+							: null
+					}
+				>
+					{ canBeUpgraded ? (
+						<Button isPrimary onClick={ upgradeBlock }>
+							{ __( 'Upgrade Block', 'full-site-editing' ) }
+						</Button>
+					) : null }
+					{ ! canBeUpgraded && isSelected ? (
+						<RangeControl
+							label={ __( 'Number of posts to show', 'full-site-editing' ) }
+							value={ attributes.postsPerPage }
+							onChange={ val => setAttributes( { postsPerPage: val } ) }
+							min={ 1 }
+							max={ 50 }
+						/>
+					) : null }
+				</Placeholder>
+				<InspectorControls>
+					<PanelBody>
+						<RangeControl
+							label={ __( 'Number of posts', 'full-site-editing' ) }
+							value={ attributes.postsPerPage }
+							onChange={ val => setAttributes( { postsPerPage: val } ) }
+							min={ 1 }
+							max={ 50 }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
 	},
+	save: () => null,
+	transforms,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/transforms.js
@@ -1,0 +1,33 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+/* eslint-enable import/no-extraneous-dependencies */
+
+export const HOMEPAGE_POSTS_BLOCK_TYPES = [
+	'a8c/homepage-posts',
+	'newspack-blocks/homepage-articles',
+];
+
+const getTransformFunction = type => ( { postsPerPage } ) => {
+	// Configure the Newspack block to look as close as possible
+	// to the output of this one.
+	return createBlock( type, {
+		postsToShow: postsPerPage,
+		showAvatar: false,
+		displayPostDate: true,
+		displayPostContent: true,
+	} );
+};
+
+export const isValidHomepagePostsBlockType = type =>
+	HOMEPAGE_POSTS_BLOCK_TYPES.indexOf( type ) > -1;
+
+export const transforms = {
+	to: HOMEPAGE_POSTS_BLOCK_TYPES.map( type => ( {
+		type: 'block',
+		blocks: [ type ],
+		transform: getTransformFunction( type ),
+	} ) ),
+};

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/transforms.js
@@ -9,7 +9,7 @@
 import { createBlock } from '@wordpress/blocks';
 /* eslint-enable import/no-extraneous-dependencies */
 
-const HOMEPAGE_POSTS_BLOCK_TYPES = [ 'a8c/homepage-posts', 'newspack-blocks/homepage-articles' ];
+const HOMEPAGE_POSTS_BLOCK_TYPES = [ 'a8c/blog-posts', 'newspack-blocks/homepage-articles' ];
 
 const getTransformFunction = type => ( { postsPerPage } ) => {
 	// Configure the Newspack block to look as close as possible

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/transforms.js
@@ -1,3 +1,7 @@
+/**
+ * External dependencies
+ */
+
 /* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
@@ -5,10 +9,7 @@
 import { createBlock } from '@wordpress/blocks';
 /* eslint-enable import/no-extraneous-dependencies */
 
-export const HOMEPAGE_POSTS_BLOCK_TYPES = [
-	'a8c/homepage-posts',
-	'newspack-blocks/homepage-articles',
-];
+const HOMEPAGE_POSTS_BLOCK_TYPES = [ 'a8c/homepage-posts', 'newspack-blocks/homepage-articles' ];
 
 const getTransformFunction = type => ( { postsPerPage } ) => {
 	// Configure the Newspack block to look as close as possible


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If Blog Posts Listing detects a presence of Homepage Posts block, it shows a UI that makes it easy to transform itself into the new block

#### Testing instructions

* Test Blog Posts Listing on its own - add to editor, configuration should work and on frontend, it shows posts
* Install [Newspack Blocks](https://github.com/automattic/newspack-blocks) plugin (don't forget `npm run build`)
* Refresh the editor with Blog Posts Listing - it should now show the option to Upgrade

#### Demo

- shows normal block functionality
- activates Newspack Blocks
- shows upgrade nudge
- uses it

Click to play:

<a href="https://cloudup.com/ceHa_H_reFg"><img width="318" alt="Screenshot 2019-11-29 at 16 12 35" src="https://user-images.githubusercontent.com/156676/69877672-15176980-12c3-11ea-8292-0c538aa8f35f.png"></a>
