### PR TITLE
Admin Page: update date format of Backup card to be consistent

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -164,9 +164,9 @@ export class ProductSelector extends Component {
 			return;
 		}
 
-		return translate( 'Purchased %(purchaseDate)s', {
+		return translate( 'Purchased on %(purchaseDate)s', {
 			args: {
-				purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
+				purchaseDate: moment( purchase.subscribedDate ).format( 'LL' ),
 			},
 		} );
 	}

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -28,7 +28,7 @@
 .product-card__header-primary {
 	display: flex;
 	padding-top: 16px;
-	padding-bottom: 4px;
+	padding-bottom: 2px;
 
 	@include breakpoint( '>480px' ) {
 		padding-top: 24px;
@@ -53,8 +53,7 @@
 
 .product-card__header-secondary {
 	position: relative;
-	padding-top: 4px;
-	padding-bottom: 16px;
+	padding-bottom: 14px;
 
 	@include breakpoint( '>480px' ) {
 		padding-bottom: 24px;

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -53,6 +53,7 @@
 
 .product-card__header-secondary {
 	position: relative;
+	padding-top: 4px;
 	padding-bottom: 16px;
 
 	@include breakpoint( '>480px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

* On the "My Plan" page, we display full dates. On the "Plans" page, we should use a similar date format.

Related discussion:
p8oabR-qW-p2#comment-3635

Matching Jetpack PR:
https://github.com/Automattic/jetpack/pull/14150

**Note**: this should only be a temporary solution. Ideally, we'd want to modify this further, to change the date we display depending on the date and your renewal settings. I think we could also aim to use the date format used by WordPress on the whole site.

#### Testing instructions:

* Go to Jetpack > Dashboard > Plans and follow the CTA to buy a Jetpack Backup.
* After your purchase, head to "Plans". 
* The date in the Jetpack Backup card should match the date format used in "My Plan".
