### PR TITLE
Pausing Premium bump test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -97,10 +97,10 @@ export default {
 		defaultVariation: 'default',
 	},
 	showPlanUpsellConcierge: {
-		datestamp: '20191106',
+		datestamp: '20291106',
 		variations: {
-			variantShowPlanBump: 50,
-			control: 50,
+			variantShowPlanBump: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR pauses the Premium bump test by shifting all traffic to the control and setting a date in the future to prevent further assignment.

#### Testing instructions

* Signup for a new account from http://calypso.localhost:3000/start.
 * Add a Personal plan to cart and complete the purchase
 * Verify the following:
    - That you are shown the concierge upsell and assigned on the `control` variation of `showPlanUpsellConcierge` test.

This should be the same for new account, new site or upgrading an existing site.
