### PR TITLE
Jetpack Backup: do not show card when site is a multisite site.

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -66,6 +66,7 @@ import {
 	getSiteSlug,
 	isJetpackMinimumVersion,
 	isJetpackSite,
+	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
 import { getSiteType as getSignupSiteType } from 'state/signup/steps/site-type/selectors';
 import { getTld } from 'lib/domains';
@@ -96,10 +97,15 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	isJetpackBackupAvailable() {
-		const { displayJetpackPlans, jetpackSupportsBackupProducts, siteId } = this.props;
+		const { displayJetpackPlans, isMultisite, jetpackSupportsBackupProducts, siteId } = this.props;
 
 		// Jetpack Backup products are currently under a feature flag
 		if ( ! isEnabled( 'plans/jetpack-backup' ) ) {
+			return false;
+		}
+
+		// Jetpack Backup does not support Multisite yet.
+		if ( isMultisite ) {
 			return false;
 		}
 
@@ -552,6 +558,7 @@ export default connect(
 			domains: getDomainsBySiteId( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack: isJetpackSite( state, siteId ),
+			isMultisite: isJetpackSiteMultiSite( state, siteId ),
 			jetpackSupportsBackupProducts: isJetpackMinimumVersion( state, siteId, '7.9-alpha' ),
 			siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Jetpack Backup does not support Multisite yet, so let's not show the product card on sites that are part of a Multisite network.

Internal reference: p8oabR-qW-p2#comment-3724

Matching Jetpack PR:
https://github.com/Automattic/jetpack/pull/14153

#### Testing instructions

* Start with 2 Jetpack sites, not yet connected to WordPress.com. One of them must be a single site, the other must be part of a Multisite network. Here are 2 handy links to get you started with both (those sites will also be running the matching Jetpack PR's branch, so you can test both PRs at once):
    - [Single site](https://href.li/?https://jurassic.ninja/create?jetpack-beta&branch=update/hide-jetpack-backup-multisite&wp-debug-log)
    - [Multisite](https://href.li/?https://jurassic.ninja/create?jetpack-beta&branch=update/hide-jetpack-backup-multisite&wp-debug-log&subdir_multisite)
* On both sites, add the following to `wp-config.php`: `define( 'CALYPSO_ENV', 'development' );`
* Check out this branch in your local copy of Calypso and start up Calypso.
* Now you should be able to connect both sites to your WordPress.com account.
    * On the multisite site, you should not see the Jetpack Backup card at any point during the connection process, or after when visiting the Plans page in Calypso (or in wp-admin).
    * On the single site, you should see the card.
* On your local Calypso, you can also check other sites of yours, and see if the Jetpack Backup card appears when it should.


