### PR TITLE
Starter Page Templates: Update the selector look and feel

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/preview-template-title.js
@@ -3,13 +3,15 @@
  * applying the css classes needed to follow the styles
  * inherited from the Editor.
  *
- * @param {string} title Template title - transform css rule.
- * @return {*} Component
+ * @param {object} props Component props.
+ * @param {string} props.title Template title - transform css rule.
+ * @param {number} props.scale Scale transform based upon the preview viewport width.
+ * @returns {*} Component
  */
 
-const PreviewTemplateTitle = ( { title, transform } ) => (
+const PreviewTemplateTitle = ( { title, scale } ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	<div className="editor-post-title" style={ { transform } }>
+	<div className="editor-post-title" style={ { transform: `scale(${ scale })` } }>
 		<div className="wp-block editor-post-title__block">
 			<textarea className="editor-post-title__input" value={ title } onChange={ () => {} } />
 		</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -12,7 +12,14 @@ import classnames from 'classnames';
 /* eslint-disable import/no-extraneous-dependencies */
 import { __ } from '@wordpress/i18n';
 import { Disabled } from '@wordpress/components';
-import { useState, useEffect, useLayoutEffect, useRef, useReducer } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useReducer,
+	useCallback,
+} from '@wordpress/element';
 /* eslint-enable import/no-extraneous-dependencies */
 
 /**
@@ -25,6 +32,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 	const THRESHOLD_RESIZE = 300;
 
 	const [ visibility, setVisibility ] = useState( 'hidden' );
+	const [ previewViewport, setPreviewViewport ] = useState( viewportWidth );
 	const ref = useRef( null );
 
 	const [ recompute, triggerRecompute ] = useReducer( state => state + 1, 0 );
@@ -38,52 +46,61 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 	const updateTemplateTitle = () => {
 		// Get DOM reference.
-		setTimeout( () => {
-			if ( ! ref || ! ref.current ) {
-				return;
+		if ( ! ref || ! ref.current ) {
+			return;
+		}
+
+		// Try to get the preview content element.
+		const previewContainerEl = ref.current.querySelector( '.block-editor-block-preview__content' );
+		if ( ! previewContainerEl ) {
+			return;
+		}
+
+		// Try to get the `transform` css rule from the preview container element.
+		const elStyles = window.getComputedStyle( previewContainerEl );
+		if ( elStyles && elStyles.transform ) {
+			const titleElement = ref.current.querySelector( '.editor-post-title' );
+			if ( titleElement ) {
+				// Apply the same transform css rule at template title element.
+				titleElement.style.transform = elStyles.transform;
 			}
 
-			// Try to get the preview content element.
-			const previewContainerEl = ref.current.querySelector(
-				'.block-editor-block-preview__content'
+			// Pick up scale factor from `transform` css.
+			let scale = elStyles.transform.replace( /matrix\((.+)\)$/i, '$1' ).split( ',' );
+			scale = scale && scale.length ? Number( scale[ 0 ] ) : null;
+			scale = isNaN( scale ) ? null : scale;
+
+			// Try to adjust vertical offset of the large preview.
+			const offsetCorrectionEl = previewContainerEl.closest(
+				'.template-selector-preview__offset-correction'
 			);
-			if ( ! previewContainerEl ) {
-				return;
+
+			if ( offsetCorrectionEl && scale ) {
+				const titleHeight = titleElement ? titleElement.offsetHeight : null;
+				offsetCorrectionEl.style.top = `${ titleHeight * scale }px`;
 			}
+		}
 
-			// Try to get the `transform` css rule from the preview container element.
-			const elStyles = window.getComputedStyle( previewContainerEl );
-			if ( elStyles && elStyles.transform ) {
-				const titleElement = ref.current.querySelector( '.editor-post-title' );
-				if ( titleElement ) {
-					// Apply the same transform css rule at template title element.
-					titleElement.style.transform = elStyles.transform;
-				}
-
-				// Pick up scale factor from `transform` css.
-				let scale = elStyles.transform.replace( /matrix\((.+)\)$/i, '$1' ).split( ',' );
-				scale = scale && scale.length ? Number( scale[ 0 ] ) : null;
-				scale = isNaN( scale ) ? null : scale;
-
-				// Try to adjust vertical offset of the large preview.
-				const offsetCorrectionEl = previewContainerEl.closest(
-					'.template-selector-preview__offset-correction'
-				);
-
-				if ( offsetCorrectionEl && scale ) {
-					const titleHeight = titleElement ? titleElement.offsetHeight : null;
-					offsetCorrectionEl.style.top = `${ titleHeight * scale }px`;
-				}
-			}
-
-			setVisibility( 'visible' );
-		}, 300 );
+		setVisibility( 'visible' );
 	};
+
+	const updatePreviewViewport = useCallback( () => {
+		if ( ! ref || ! ref.current ) {
+			return;
+		}
+		const wrapperWidth = ref.current.clientWidth;
+		if ( wrapperWidth >= viewportWidth ) {
+			setPreviewViewport( wrapperWidth );
+		} else {
+			setPreviewViewport( viewportWidth );
+		}
+	}, [ viewportWidth ] );
 
 	useLayoutEffect( () => {
 		setVisibility( 'hidden' );
+		updatePreviewViewport();
 		updateTemplateTitle();
-	}, [ blocks ] );
+	}, [ blocks, updatePreviewViewport ] );
 
 	useEffect( () => {
 		if ( ! blocks || ! blocks.length ) {
@@ -92,6 +109,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 
 		const rePreviewTemplate = () => {
 			updateTemplateTitle();
+			updatePreviewViewport();
 			triggerRecompute();
 		};
 
@@ -101,7 +119,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 		return () => {
 			window.removeEventListener( 'resize', refreshPreview );
 		};
-	}, [ blocks ] );
+	}, [ blocks, updatePreviewViewport ] );
 
 	if ( isEmpty( blocks ) || ! isArray( blocks ) ) {
 		return (
@@ -122,7 +140,11 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 						<div className="editor-writing-flow">
 							<PreviewTemplateTitle title={ title } />
 							<div className="template-selector-preview__offset-correction">
-								<BlockPreview key={ recompute } blocks={ blocks } viewportWidth={ viewportWidth } />
+								<BlockPreview
+									key={ recompute }
+									blocks={ blocks }
+									viewportWidth={ previewViewport }
+								/>
 							</div>
 						</div>
 					</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -95,6 +95,11 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 		const refreshPreview = debounce( rePreviewTemplate, THRESHOLD_RESIZE );
 		window.addEventListener( 'resize', refreshPreview );
 
+		// In wp-admin, listen to the jQuery `wp-collapse-menu` event to refresh the preview on sidebar toggle.
+		if ( window.jQuery ) {
+			window.jQuery( window.document ).on( 'wp-collapse-menu', rePreviewTemplate );
+		}
+
 		return () => {
 			window.removeEventListener( 'resize', refreshPreview );
 		};

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview-test.js.snap
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview-test.js.snap
@@ -13,13 +13,13 @@ exports[`TemplateSelectorPreview Basic rendering renders the preview when blocks
       >
         <div
           class="editor-styles-wrapper"
-          style="visibility: hidden;"
         >
           <div
             class="editor-writing-flow"
           >
             <div
               class="editor-post-title"
+              style="transform: scale(1);"
             >
               <div
                 class="wp-block editor-post-title__block"
@@ -31,6 +31,7 @@ exports[`TemplateSelectorPreview Basic rendering renders the preview when blocks
             </div>
             <div
               class="template-selector-preview__offset-correction"
+              style="top: 120px;"
             >
               <div
                 data-testid="block-template-preview"

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -41,6 +41,7 @@ $wp-org-admin-bar-mobile: 46px;
 .page-template-modal-screen-overlay {
 	animation: none;
 	background-color: transparent; // hide the overlay visually
+	z-index: 99; // Right below the wp-admin admin bar and sidebar.
 }
 
 // When not in fullscreen mode allow space for WP.org sidebar

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -338,7 +338,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	body.is-fullscreen-mode & {
 		top: 111px;
 		@media screen and ( min-width: $breakpoint-tablet ) {
-			left: calc( 30% + #{$preview-right-margin * 2} );
+			left: calc( 30% + #{$preview-right-margin * 2} ) !important;
 		}
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -274,7 +274,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 .page-template-modal__buttons {
-	display: none;
 	position: absolute;
 	right: 0;
 	top: 0;
@@ -355,7 +354,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 
 		.editor-post-title {
-			transform-origin: top left;
+			transform-origin: top center;
 			width: 100%;
 			display: block;
 			position: absolute;
@@ -404,6 +403,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 
 		// `core/columns`
+		/* stylelint-disable selector-combinator-space-before */
 		.wp-block-columns
 			> .editor-inner-blocks
 			> .editor-block-list__layout
@@ -412,6 +412,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			> div
 			> .block-core-columns
 			> .editor-inner-blocks {
+			/* stylelint-enable */
 			margin-top: 0;
 			margin-bottom: 0;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -11,6 +11,7 @@
 	word-wrap: normal !important;
 }
 
+$template-modal-background-color: #eeeeee;
 $template-selector-border-color: #e2e4e7;
 $template-selector-border-color-selected: #555d66;
 $template-selector-border-color-active: #00a0d2;
@@ -21,14 +22,20 @@ $template-selector-modal-offset-right: 32px;
 $template-selector-blank-template-mobile-height: 70px;
 $template-large-preview-title-height: 120px;
 
-$wp-org-sidebar-reduced: 36px;
-$wp-org-sidebar-full: 160px;
-
 // Preview positioning
-$preview-max-width: 960px;
 $preview-right-margin: 24px;
-$preview-left-sidebar-reduced: calc( 30% + #{$wp-org-sidebar-reduced} );
-$preview-left-sidebar-full: calc( 30% + #{$wp-org-sidebar-full} );
+
+// Breakpoints
+$breakpoint-mobile: 660px;
+$breakpoint-tablet: 783px;
+$breakpoint-desktop: 961px;
+$breakpoint-huge: 1648px;
+
+// WP.org sidebar and admin bar sizes
+$wp-org-sidebar-full: 160px;
+$wp-org-sidebar-collapsed: 36px;
+$wp-org-admin-bar-full: 32px;
+$wp-org-admin-bar-mobile: 46px;
 
 // Modal Overlay
 .page-template-modal-screen-overlay {
@@ -39,17 +46,17 @@ $preview-left-sidebar-full: calc( 30% + #{$wp-org-sidebar-full} );
 // When not in fullscreen mode allow space for WP.org sidebar
 body:not( .is-fullscreen-mode ) {
 	.page-template-modal-screen-overlay {
-		@media screen and ( min-width: 783px ) {
-			left: $wp-org-sidebar-reduced;
+		@media screen and ( min-width: $breakpoint-tablet ) {
+			left: $wp-org-sidebar-collapsed;
 		}
 
-		@media screen and ( min-width: 961px ) {
+		@media screen and ( min-width: $breakpoint-desktop ) {
 			left: $wp-org-sidebar-full;
 		}
 	}
-	@media screen and ( min-width: 783px ) {
+	@media screen and ( min-width: $breakpoint-tablet ) {
 		&.folded .page-template-modal-screen-overlay {
-			left: $wp-org-sidebar-reduced;
+			left: $wp-org-sidebar-collapsed;
 		}
 		&:not( .folded ):not( .auto-fold ) .page-template-modal-screen-overlay {
 			left: $wp-org-sidebar-full;
@@ -59,10 +66,10 @@ body:not( .is-fullscreen-mode ) {
 
 // Allow space for admin bar if present and not in full screen mode
 body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
-	top: 46px;
+	top: $wp-org-admin-bar-mobile;
 
-	@media screen and ( min-width: 783px ) {
-		top: 32px;
+	@media screen and ( min-width: $breakpoint-tablet ) {
+		top: $wp-org-admin-bar-full;
 	}
 }
 
@@ -74,13 +81,13 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	box-shadow: none; // cancel "modal" appearance
 	border: none; // cancel "modal" appearance
 	top: 0; // overlay the Block Editor toolbar
-    left: 0;
-    right: 0;
-    bottom: 0;
-    transform: none;
-    max-width: none;
-    max-height: none;
-    background-color: #eeeeee;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	transform: none;
+	max-width: none;
+	max-height: none;
+	background-color: $template-modal-background-color;
 }
 
 .page-template-modal .components-modal__header-heading-container {
@@ -88,7 +95,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 // Show close button in all modes.
-// Removed previous condition to only show in fullscreen with PR #37500.
 .page-template-modal__close-button {
 	display: block;
 	position: absolute;
@@ -99,210 +105,161 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	left: 10px;
 }
 
-.page-template-modal .components-modal__header {
-	&::after {
-		display: block;
-		position: absolute;
-		content: ' ';
-		border-right: 1px solid #e2e4e7;
-		height: 100%;
-		left: 56px;
-	}
+.page-template-modal .components-modal__header::after {
+	display: block;
+	position: absolute;
+	content: ' ';
+	border-right: 1px solid $template-selector-border-color;
+	height: 100%;
+	left: 56px;
 }
 
 .page-template-modal .components-modal__content {
 	overflow-y: scroll;
 	-webkit-overflow-scrolling: touch;
 }
-
 .page-template-modal__inner {
 	position: relative;
 	margin: 0 auto;
-	padding: 0;
-
-	@media screen and ( max-width: 659px ) {
-		padding: 0 14% 3em;
-	}
-
-	@media screen and ( max-width: 440px ) {
-		padding: 0 15px 3em;
-	}
-
-	@media screen and ( min-width: 1200px ) {
-		max-width: 100%;
-	}
+	padding: 0 20px 40px;
 }
 
 .page-template-modal__list {
 	margin-bottom: 20px;
-}
 
-.page-template-modal__list,
-.sidebar-modal-opener {
 	.components-base-control__label {
 		@include screen-reader-text();
 	}
+}
 
-	.template-selector-control__options {
-		display: grid;
-		// stylelint-disable-next-line unit-whitelist
-		grid-template-columns: 1fr;
-		grid-gap: 1.75em;
+.template-selector-control__options {
+	display: grid;
+	// stylelint-disable-next-line unit-whitelist
+	grid-template-columns: 1fr;
+	grid-gap: 1.75em;
 
-		@media screen and ( min-width: 660px ) {
-			margin-top: 0;
-			// stylelint-disable unit-whitelist
-			grid-template-columns: repeat(
-				auto-fit,
-				minmax( 110px, 1fr )
-			); // allow grid to take over number of cols on large screens
-			// stylelint-enable unit-whitelist
-		}
+	@media screen and ( min-width: $breakpoint-mobile ) {
+		margin-top: 0;
+		// stylelint-disable unit-whitelist
+		grid-template-columns: repeat(
+			auto-fit,
+			minmax( 110px, 1fr )
+		); // allow grid to take over number of cols on large screens
+		// stylelint-enable unit-whitelist
 	}
+}
 
-	.template-selector-control__option {
-		margin-bottom: 4px;
-	}
+.template-selector-item__label {
+	display: block;
+	width: 100%;
+	font-size: 14px;
+	text-align: center;
+	border: solid 2px $template-selector-border-color;
+	border-radius: 6px;
+	cursor: pointer;
+	appearance: none;
+	padding: 0;
+	overflow: hidden;
+	background-color: $template-selector-empty-background;
+	position: relative;
+	transform: translateZ( 0 ); // Fix for Safari rounded border overflow (1/2).
 
-	.template-selector-item__label {
-		display: block;
+	.template-selector-item__template-title {
 		width: 100%;
-		font-size: 14px;
-		text-align: center;
-		border: solid 2px $template-selector-border-color;
-		border-radius: 6px;
-		cursor: pointer;
-		appearance: none;
-		padding: 0;
-		overflow: hidden;
-		background-color: #fff;
-		position: relative;
-		transform: translateZ( 0 ); // Fix for Safari rounded border overflow (1/2).
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		height: 40px;
+		line-height: 40px;
+		background-color: $template-selector-empty-background;
+	}
 
-		.template-selector-item__template-title {
-			width: 100%;
-			position: absolute;
-			bottom: 0;
-			left: 0;
-			height: 40px;
-			line-height: 40px;
-			background-color: #fff;
-		}
+	&:focus {
+		box-shadow: 0 0 0 1px $template-selector-empty-background,
+			0 0 0 3px $template-selector-border-color-active;
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+	}
+
+	&:hover {
+		border: solid 2px $template-selector-border-color-hover;
+	}
+
+	&.is-selected {
+		border: solid 2px $template-selector-border-color-selected;
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+		outline-offset: -2px;
 
 		&:focus {
-			box-shadow: 0 0 0 1px #fff, 0 0 0 3px $template-selector-border-color-active;
-
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 2px solid transparent;
-		}
-
-		&:hover {
-			border: solid 2px $template-selector-border-color-hover;
-		}
-
-		&.is-selected {
+			box-shadow: 0 0 0 1px $template-selector-empty-background,
+				0 0 0 3px $template-selector-border-color-active;
 			border: solid 2px $template-selector-border-color-selected;
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 2px solid transparent;
-			outline-offset: -2px;
-
-			&:focus {
-				box-shadow: 0 0 0 1px #fff, 0 0 0 3px $template-selector-border-color-active;
-				border: solid 2px $template-selector-border-color-selected;
-
-				// Windows High Contrast mode will show this outline, but not the box-shadow.
-				outline: 4px solid transparent;
-				outline-offset: -4px;
-			}
+			outline: 4px solid transparent;
+			outline-offset: -4px;
 		}
-
-
 	}
+}
 
-	.template-selector-item__preview-wrap {
-		width: 100%;
-		display: block;
-		margin: 0 auto;
-		background: $template-selector-empty-background;
-		border-radius: 0;
-		overflow: hidden;
-		height: 0;
+.template-selector-item__preview-wrap {
+	width: 100%;
+	display: block;
+	margin: 0 auto;
+	background: $template-selector-empty-background;
+	border-radius: 0;
+	overflow: hidden;
+	height: 0;
+	padding-top: 120%;
+	box-sizing: content-box;
+	position: relative;
+	pointer-events: none;
+	opacity: 1;
+	transform: translateZ( 0 ); // Fix for Safari rounded border overflow (2/2).
+
+	@media screen and ( min-width: $breakpoint-mobile ) {
 		padding-top: 100%; // Aspect radio boxes. It will take the 100% of width.
-		box-sizing: content-box;
-		position: relative;
-		pointer-events: none;
-		opacity: 1;
-		transform: translateZ( 0 ); // Fix for Safari rounded border overflow (2/2).
-
-		@media screen and ( max-width: 659px ) {
-			padding-top: 120%;
-		}
-
-		&.is-rendering {
-			opacity: 0.5;
-		}
-
-        .block-editor-block-list__layout,
-        .block-editor-block-list__block {
-			padding: inherit;
-        }
 	}
 
-	.template-selector-item__media {
-		width: 100%;
-		display: block;
-		position: absolute;
-		top: 0;
-		left: 0;
+	&.is-rendering {
+		opacity: 0.5;
 	}
 
-	// Blank template
+	.block-editor-block-list__layout,
+	.block-editor-block-list__block {
+		padding: inherit;
+	}
+}
+
+.template-selector-item__media {
+	width: 100%;
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+// Blank template
+@media screen and ( max-width: ( $breakpoint-mobile - 1px ) ) {
 	.template-selector-control__template:first-child {
 		.template-selector-item__preview-wrap {
-			@media screen and ( max-width: 659px ) {
-				padding-top: 0%;
-				height: $template-selector-blank-template-mobile-height;
-			}
+			padding-top: 0%;
+			height: $template-selector-blank-template-mobile-height;
 		}
 		.template-selector-item__template-title {
-			@media screen and ( max-width: 659px ) {
-				height: $template-selector-blank-template-mobile-height;
-				line-height: $template-selector-blank-template-mobile-height;
-			}
+			height: $template-selector-blank-template-mobile-height;
+			line-height: $template-selector-blank-template-mobile-height;
 		}
-	}
-}
-
-.page-template-modal__actions {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-
-	@media screen and ( min-width: 960px ) {
-		flex-direction: row;
-		justify-content: flex-end;
-	}
-}
-
-.page-template-modal__action {
-	@media screen and ( max-width: 960px ) {
-		margin-bottom: 1em;
-	}
-}
-
-.page-template-modal__action-use {
-	@media screen and ( min-width: 960px ) {
-		margin-right: 1em;
 	}
 }
 
 .page-template-modal__form {
-	@media screen and ( min-width: 660px ) {
+	@media screen and ( min-width: $breakpoint-mobile ) {
 		max-width: 20%;
 	}
 
-	@media screen and ( min-width: 783px ) {
+	@media screen and ( min-width: $breakpoint-tablet ) {
 		max-width: 30%;
 	}
 }
@@ -310,46 +267,54 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .page-template-modal__form-title {
 	font-weight: bold;
 	margin-bottom: 1em;
-	@media screen and ( max-width: 659px ) {
-		text-align: center;
+	text-align: center;
+	@media screen and ( min-width: $breakpoint-mobile ) {
+		text-align: left;
 	}
 }
 
 .page-template-modal__buttons {
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: 10;
-    height: 56px;
-    display: flex;
-    align-items: center;
+	display: none;
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: 10;
+	height: 56px;
+	display: flex;
+	align-items: center;
 	padding-right: 24px;
 
-	@media screen and ( max-width: 659px ) {
-		display: none;
+	@media screen and ( min-width: $breakpoint-mobile ) {
+		display: flex;
 	}
 
-    &.is-visually-hidden {
-    	@include screen-reader-text();
-    }
+	&.is-visually-hidden {
+		@include screen-reader-text();
+	}
 
 	.components-button {
 		height: 33px; // match to Gutenberg toolbar styles
-	    line-height: 32px; // match to Gutenberg toolbar styles
+		line-height: 32px; // match to Gutenberg toolbar styles
 	}
 }
 
 // Template Selector Preview
 .template-selector-preview {
-	@media screen and ( max-width: 659px ) {
-		display: none;
-	}
+	display: none;
+	position: fixed;
+	top: 111px + $wp-org-admin-bar-mobile;
+	bottom: 24px;
+	left: calc( 20% + #{$preview-right-margin * 2} );
+	right: $preview-right-margin;
+	background: $template-selector-empty-background;
+	border-radius: 2px;
+	overflow-x: hidden;
+	overflow-y: auto;
+	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
+		0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 
-	@media screen and ( min-width: 783px ) {
-		width: calc( 70% - 50px );
-	}
-
-	@media screen and ( min-width: 660px ) {
+	@media screen and ( min-width: $breakpoint-mobile ) {
+		display: block;
 		&.is-blank-preview {
 			align-items: center;
 			display: flex;
@@ -357,24 +322,26 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 	}
 
-	@media screen and ( min-width: 1648px ) {
-		right: unset;
-		left: calc( #{$preview-left-sidebar-full} + ( 100vw - #{$preview-left-sidebar-full} - #{$preview-max-width} - #{$preview-right-margin} ) / 2 );
+	@media screen and ( min-width: $breakpoint-tablet ) {
+		top: 111px + $wp-org-admin-bar-full;
+		left: calc( 30% + #{$preview-right-margin * 1.5 + $wp-org-sidebar-collapsed} );
+		body:not( .auto-fold ):not( .folded ) & {
+			left: calc( 30% + #{$preview-right-margin / 2 + $wp-org-sidebar-full} );
+		}
+	}
+	@media screen and ( min-width: $breakpoint-desktop ) {
+		left: calc( 30% + #{$preview-right-margin / 2 + $wp-org-sidebar-full} );
 		body.folded & {
-			left: calc( #{$preview-left-sidebar-reduced} + ( 100vw - #{$preview-left-sidebar-reduced} - #{$preview-max-width} - #{$preview-right-margin} ) / 2 );
+			left: calc( 30% + #{$preview-right-margin * 1.5 + $wp-org-sidebar-collapsed} );
 		}
 	}
 
-	position: fixed;
-	top: 111px;
-	bottom: 24px;
-	right: $preview-right-margin;
-	width: calc( 80% - 50px );
-	background: $template-selector-empty-background;
-	border-radius: 2px;
-	overflow-x: hidden;
-	overflow-y: auto;
-	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
+	body.is-fullscreen-mode & {
+		top: 111px;
+		@media screen and ( min-width: $breakpoint-tablet ) {
+			left: calc( 30% + #{$preview-right-margin * 2} );
+		}
+	}
 
 	.edit-post-visual-editor {
 		margin: 0;
@@ -389,7 +356,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 		.editor-post-title {
 			transform-origin: top left;
-			width: 960px;
+			width: 100%;
 			display: block;
 			position: absolute;
 			top: 0;
@@ -414,26 +381,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 }
 
-body:not( .is-fullscreen-mode ) {
-	.template-selector-preview {
-		@media screen and ( min-width: 783px ) {
-			width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
-		}
-
-		@media screen and ( min-width: 961px ) {
-			width: calc( 70% - #{$wp-org-sidebar-full } );
-		}
-	}
-	@media screen and ( min-width: 783px ) {
-		&.folded .template-selector-preview {
-			width: calc( 70% - #{$wp-org-sidebar-reduced + (24px * 2 ) } );
-		}
-		&:not( .folded ):not( .auto-fold ) .template-selector-preview {
-			width: calc( 70% - #{$wp-org-sidebar-full } );
-		}
-	}
-}
-
 .template-selector-preview__placeholder {
 	color: var( --color-text-subtle );
 	font-size: 15px;
@@ -442,17 +389,10 @@ body:not( .is-fullscreen-mode ) {
 
 // Preview adjustments.
 // Tweak styles which are inside of the preview container.
-.block-editor-block-preview__container,
-.template-selector-preview {
-	max-width: $preview-max-width;
-
+.block-editor-block-preview__container {
 	.editor-styles-wrapper {
 		.wp-block {
 			width: 100%;
-		}
-
-		.wp-block[data-align='wide'] {
-			//max-width: 800px;
 		}
 
 		// `core/cover`
@@ -464,14 +404,16 @@ body:not( .is-fullscreen-mode ) {
 		}
 
 		// `core/columns`
-		.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type='core/column'] {
-			//margin-left: -14px;
-			//margin-right: -14px;
-
-			& > .editor-block-list__block-edit > div > .block-core-columns > .editor-inner-blocks {
-				margin-top: 0;
-				margin-bottom: 0;
-			}
+		.wp-block-columns
+			> .editor-inner-blocks
+			> .editor-block-list__layout
+			> [data-type='core/column']
+			> .editor-block-list__block-edit
+			> div
+			> .block-core-columns
+			> .editor-inner-blocks {
+			margin-top: 0;
+			margin-bottom: 0;
 		}
 
 		.block-editor-block-list__block {
@@ -507,12 +449,12 @@ body:not( .is-fullscreen-mode ) {
 }
 
 .page-template-modal__loading {
-    position: absolute;
-    top: 50%;
-    left: 50%;
+	position: absolute;
+	top: 50%;
+	left: 50%;
 	transform: translate( -50%, -50% );
 	display: flex;
-    align-items: flex-end;
+	align-items: flex-end;
 
 	.components-spinner {
 		float: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a replacement of #37744.

* Restructure the SPT selector modal.
* The modal is now less dependant from the WP sidebar state (expanded, collapsed, hidden).
* The modal z-index is now below the wp-admin admin bar and sidebar.
* The template selector and preview are fully now responsive (roughly filling a 30/70 of the screen).
* The template preview doesn't scale more than if it was rendered in a 960px viewport. This means that: it shrinks down when the preview is <960px wide, and simply remains at the same size (filling the available space responsively) when >960px.
* The template preview title uses the same scale value of the content.
* The preview re-renders on window resize and, if in wp-admin, also on sidebar toggle.

#### Video

https://cloudup.com/cjjFwMPrG2o

#### Known issues

- When changing layout (edit page -> click on Change Layout) in Fullscreen Mode, resizing down to a mobile breakpoint hides the modal. This doesn't happen when creating a new page, even in Fullscreen Mode.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new page on an FSE site.
* Smoke test the SPT selector modal, resize the browser, click around, select different layouts. Expand and collapse the wp-admin sidebar at multiple browser sizes.
* Back in the page editor, enable the Fullscreen Mode (from the More menu in the top right corner).
* Create a new page or click on Change Layout in the document sidebar.
* Smoke test the SPT selector modal again.