### PR TITLE
Fix Themes showcase to go to results when loaded with a query

### DIFF
--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -18,6 +18,13 @@ class RecommendedThemes extends React.Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { isLoading, isQueried, scrollToSearchInput } = this.props;
+		if ( prevProps.isLoading !== isLoading && isLoading === false && isQueried ) {
+			scrollToSearchInput();
+		}
+	}
+
 	render() {
 		return (
 			<>

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -20,6 +20,7 @@ class RecommendedThemes extends React.Component {
 
 	componentDidUpdate( prevProps ) {
 		const { isLoading, isQueried, scrollToSearchInput } = this.props;
+		// When Recommended Themes load, trigger a scroll to results if queried.
 		if ( prevProps.isLoading !== isLoading && isLoading === false && isQueried ) {
 			scrollToSearchInput();
 		}

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -20,7 +20,7 @@ class RecommendedThemes extends React.Component {
 
 	componentDidUpdate( prevProps ) {
 		const { isLoading, isQueried, scrollToSearchInput } = this.props;
-		// When Recommended Themes load, trigger a scroll to results if queried.
+		// When Recommended Themes load, trigger a scroll-to results if queried.
 		if ( prevProps.isLoading !== isLoading && isLoading === false && isQueried ) {
 			scrollToSearchInput();
 		}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -100,6 +100,13 @@ class ThemeShowcase extends React.Component {
 		showUploadButton: true,
 	};
 
+	componentDidMount() {
+		// Hack-Fix for scroll to searchbar when queried to consistently work from "back" button.
+		if ( this.props.search || ( this.props.filter && ! this.props.loggedOutComponent ) ) {
+			setTimeout( this.scrollToSearchInput, 50 );
+		}
+	}
+
 	scrollToSearchInput = () => {
 		if ( ! this.props.loggedOutComponent ) {
 			this.scrollRef.current.scrollIntoView();

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -65,7 +65,6 @@ class ThemeShowcase extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.scrollRef = React.createRef();
-
 		this.state = {
 			page: 1,
 			showPreview: false,

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -65,10 +65,12 @@ class ThemeShowcase extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.scrollRef = React.createRef();
+
 		this.state = {
 			page: 1,
 			showPreview: false,
-			isShowcaseOpen: false,
+			// Start with showcase open if there are queried params.
+			isShowcaseOpen: !! ( this.props.search || this.props.filter ),
 		};
 	}
 
@@ -98,15 +100,6 @@ class ThemeShowcase extends React.Component {
 		upsellBanner: false,
 		showUploadButton: true,
 	};
-
-	componentDidMount() {
-		if ( ! this.props.loggedOutComponent ) {
-			if ( this.props.search || this.props.filter ) {
-				// open showcase so it doesn't close when search field is deleted
-				this.toggleShowcase();
-			}
-		}
-	}
 
 	scrollToSearchInput = () => {
 		if ( ! this.props.loggedOutComponent ) {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -239,7 +239,7 @@ class ThemeShowcase extends React.Component {
 		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
 		const { isShowcaseOpen } = this.state;
-		const isQueried = this.props.query || this.props.filter;
+		const isQueried = this.props.search || this.props.filter;
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -101,14 +101,18 @@ class ThemeShowcase extends React.Component {
 
 	componentDidMount() {
 		if ( ! this.props.loggedOutComponent ) {
-			if ( this.props.query || this.props.filter ) {
-				// scroll to the results section
-				this.scrollRef.current.scrollIntoView();
+			if ( this.props.search || this.props.filter ) {
 				// open showcase so it doesn't close when search field is deleted
 				this.toggleShowcase();
 			}
 		}
 	}
+
+	scrollToSearchInput = () => {
+		if ( ! this.props.loggedOutComponent ) {
+			this.scrollRef.current.scrollIntoView();
+		}
+	};
 
 	toggleShowcase = () => {
 		this.setState( { isShowcaseOpen: ! this.state.isShowcaseOpen } );
@@ -131,9 +135,7 @@ class ThemeShowcase extends React.Component {
 				.trim(),
 		} );
 		page( url );
-		if ( ! this.props.loggedOutComponent ) {
-			this.scrollRef.current.scrollIntoView();
-		}
+		this.scrollToSearchInput();
 	};
 
 	/**
@@ -166,9 +168,7 @@ class ThemeShowcase extends React.Component {
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );
-		if ( ! this.props.loggedOutComponent ) {
-			this.scrollRef.current.scrollIntoView();
-		}
+		this.scrollToSearchInput();
 	};
 
 	onUploadClick = () => {
@@ -303,6 +303,8 @@ class ThemeShowcase extends React.Component {
 								} }
 								trackScrollPage={ this.props.trackScrollPage }
 								emptyContent={ this.props.emptyContent }
+								scrollToSearchInput={ this.scrollToSearchInput }
+								isQueried={ isQueried }
 							/>
 							<div className="theme-showcase__open-showcase-button-holder">
 								{ isShowcaseOpen || isQueried ? (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -68,7 +68,7 @@ class ThemeShowcase extends React.Component {
 		this.state = {
 			page: 1,
 			showPreview: false,
-			isShowcaseOpen: !! this.props.loggedOutComponent,
+			isShowcaseOpen: false,
 		};
 	}
 
@@ -98,6 +98,17 @@ class ThemeShowcase extends React.Component {
 		upsellBanner: false,
 		showUploadButton: true,
 	};
+
+	componentDidMount() {
+		if ( ! this.props.loggedOutComponent ) {
+			if ( this.props.query || this.props.filter ) {
+				// scroll to the results section
+				this.scrollRef.current.scrollIntoView();
+				// open showcase so it doesn't close when search field is deleted
+				this.toggleShowcase();
+			}
+		}
+	}
 
 	toggleShowcase = () => {
 		this.setState( { isShowcaseOpen: ! this.state.isShowcaseOpen } );
@@ -228,7 +239,7 @@ class ThemeShowcase extends React.Component {
 		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
 		const { isShowcaseOpen } = this.state;
-
+		const isQueried = this.props.query || this.props.filter;
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -294,7 +305,7 @@ class ThemeShowcase extends React.Component {
 								emptyContent={ this.props.emptyContent }
 							/>
 							<div className="theme-showcase__open-showcase-button-holder">
-								{ isShowcaseOpen ? (
+								{ isShowcaseOpen || isQueried ? (
 									<hr ref={ this.scrollRef } />
 								) : (
 									<Button onClick={ this.toggleShowcase } data-e2e-value="open-themes-button">
@@ -307,7 +318,7 @@ class ThemeShowcase extends React.Component {
 
 					<div
 						className={
-							! this.state.isShowcaseOpen
+							! ( this.state.isShowcaseOpen || isQueried || this.props.loggedOutComponent )
 								? 'themes__hidden-content theme-showcase__all-themes'
 								: 'theme-showcase__all-themes'
 						}


### PR DESCRIPTION
#### Edit 
CLOSED - PR #38107 used as replacement.

#### Changes proposed in this Pull Request

*  Opens and Scrolls to the "All Themes" search area of the Themes showcase when there is a query present.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch with `npm start`
* Navigate to `calypso.localhost:3000/themes` while logged in.
* Open the "More Themes" Section and apply a search critera.
* Reload the browser window.
* Verify that the All Themes search section is open and that the page auto scrolls to this area.
* Clear the search criteria rom the input.
* Reload the browser and confirm that Recommended Themes and the "More Themes" button are present.
* Test this same process with a site selected through the my-sites/themes section.

**Before - Loading with a search and/or filter present lands you here**
![Screen Shot 2019-11-29 at 5 42 18 PM](https://user-images.githubusercontent.com/28742426/69892097-eb187400-12cf-11ea-8b3b-09698ff4247c.png)

**Before - Then you scroll down and see the button, where are the results!?**
![Screen Shot 2019-11-29 at 5 42 25 PM](https://user-images.githubusercontent.com/28742426/69892101-f8cdf980-12cf-11ea-9791-30d9e4295670.png)

**After - Loading with a search and/or filter present lands you here**
![Screen Shot 2019-11-29 at 5 43 34 PM](https://user-images.githubusercontent.com/28742426/69892106-0aaf9c80-12d0-11ea-8232-fb2de4ee6c48.png)



Fixes #38061
