### PR TITLE
Atomic Hosting: Add definition of SFTP to the "what is SFTP?" text.

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -159,7 +159,7 @@ const SftpCard = ( {
 				<div className="sftp-card__questions">
 					<Accordion title={ translate( 'What is SFTP?' ) }>
 						{ translate(
-							'It’s a secure way for you to access your website files on your local computer via a client program such as {{a}}Filezilla{{/a}} ' +
+							'SFTP stands for Secure File Transfer Protocol (or SSH File Transfer Protocol). It’s a secure way for you to access your website files on your local computer via a client program such as {{a}}Filezilla{{/a}} ' +
 								'For more information see {{supportLink}}SFTP on WordPress.com{{/supportLink}} ',
 							{
 								components: {


### PR DESCRIPTION
This PR updates the "What is FTP?" content in the hosting section's SFTP card.

See: p1575057401495900-slack-serenity

<img width="845" alt="Screen Shot 2019-11-29 at 3 05 42 PM" src="https://user-images.githubusercontent.com/349751/69892398-e5b02f00-12b9-11ea-9dc2-a08bb8ae98f3.png">


#### Testing instructions

* On Horizon, load an Atomic site with no existing SFTP credentials, and go to the Hosting section.
* Verify the new text in the SFTP card, under the "What is SFTP?" accordion.
