### PR TITLE
FSE: Make Template Part back button consistent with page back button

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -258,7 +258,13 @@ class Full_Site_Editing {
 			return null;
 		}
 
-		$parent_post_type        = get_post_type( $parent_post_id );
+		$parent_post_type = get_post_type( $parent_post_id );
+
+		// See https://github.com/Automattic/wp-calypso/issues/38075#issuecomment-559900054.
+		if ( 'page' === $parent_post_type ) {
+			return __( 'Page Layout' );
+		}
+
 		$parent_post_type_object = get_post_type_object( $parent_post_type );
 
 		/* translators: %s: "Back to Post", "Back to Page", "Back to Template", etc. */

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -81,40 +81,20 @@ domReady( () => {
 			closeButtonLabel = calypsoifyGutenberg.closeButtonLabel;
 		}
 
-		// Create custom close button for the template part editor.
-		if ( 'wp_template_part' === editorPostType ) {
-			const newCloseButton = document.createElement( 'a' );
-			newCloseButton.href = closeButtonUrl || 'edit.php?post_type=page';
-			const backupLabel = __( 'Go Back' );
-			newCloseButton.setAttribute( 'aria-label', closeButtonLabel || backupLabel );
-			newCloseButton.className = 'components-button components-icon-button is-button is-default';
-			const wideContent = document.createElement( 'div' );
-			wideContent.innerHTML = closeButtonLabel || backupLabel;
-			wideContent.className = 'close-button-override-wide';
-			newCloseButton.prepend( wideContent );
-			const thinContent = document.createElement( 'div' );
-			const abbreviatedContent = __( 'Back' );
-			thinContent.innerHTML = abbreviatedContent;
-			thinContent.className = 'close-button-override-thin';
-			newCloseButton.prepend( thinContent );
-			componentsToolbar.prepend( newCloseButton );
+		const defaultUrl = closeButtonUrl || `edit.php?post_type=${ editorPostType }`;
+
+		let defaultLabel = closeButtonLabel || 'Back';
+		if ( 'page' === editorPostType && ! closeButtonLabel ) {
+			defaultLabel = __( 'Pages' );
+		} else if ( 'post' === editorPostType && ! closeButtonLabel ) {
+			defaultLabel = __( 'Posts' );
+		} else if ( 'wp_template_part' === editorPostType && ! closeButtonLabel ) {
+			defaultLabel = __( 'Template Parts' );
 		}
 
-		// Create a "normal" close button for the page/post editor.
-		if ( 'page' === editorPostType || 'post' === editorPostType ) {
-			const defaultUrl = closeButtonUrl || `edit.php?post_type=${ editorPostType }`;
-
-			let defaultLabel = closeButtonLabel || 'Back';
-			if ( 'page' === editorPostType && ! closeButtonLabel ) {
-				defaultLabel = __( 'Pages' );
-			} else if ( 'post' === editorPostType && ! closeButtonLabel ) {
-				defaultLabel = __( 'Posts' );
-			}
-
-			ReactDOM.render(
-				<BackButtonOverride defaultLabel={ defaultLabel } defaultUrl={ defaultUrl } />,
-				componentsToolbar
-			);
-		}
+		ReactDOM.render(
+			<BackButtonOverride defaultLabel={ defaultLabel } defaultUrl={ defaultUrl } />,
+			componentsToolbar
+		);
 	} );
 } );

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -24,11 +24,11 @@ import getLastNonEditorRoute from 'state/selectors/get-last-non-editor-route';
  */
 
 export default function getEditorCloseConfig( state, siteId, postType, fseParentPageId ) {
-	// Handle returning to parent editor for full site editing templates
-	if ( 'wp_template_part' === postType ) {
+	// Handle returning to parent editor for full site editing template parts.
+	if ( 'wp_template_part' === postType && fseParentPageId ) {
+		// Note: the label is handled correctly by the FSE plugin in this case.
 		return {
 			url: getGutenbergEditorUrl( state, siteId, fseParentPageId, 'page' ),
-			label: fseParentPageId ? translate( 'Back to page' ) : translate( 'Back' ),
 		};
 	}
 


### PR DESCRIPTION
### Before.
<img width="983" alt="Screen Shot 2019-11-29 at 6 57 33 PM" src="https://user-images.githubusercontent.com/6265975/69894829-1c963d00-12da-11ea-9abf-bbdd9424eead.png">


### When there is a parent page it says "< Page Layout".
<img width="983" alt="Screen Shot 2019-11-29 at 6 46 21 PM" src="https://user-images.githubusercontent.com/6265975/69894804-ce813980-12d9-11ea-9453-2d36a85ac3b2.png">

### When there is no parent page the label reflects the last non-editor route you visited.
<img width="983" alt="Screen Shot 2019-11-29 at 6 47 06 PM" src="https://user-images.githubusercontent.com/6265975/69894810-e22ca000-12d9-11ea-8859-ca880c38cd72.png">


### Changes proposed in this Pull Request
* Consistent back button style for template parts
* New label per @olaolusoga's suggestion.
* Fix some bugs with going back from template parts when there is no parent post in the query param.

### Testing instructions
1. Run this change on your sandbox.
2. Go to the FSE page editor **via customer home**, and edit the header.
3. The back button should look consistent and the label should say "< Page Layout"
4. Click the back button and it should work.
5. Edit the footer.
6. The back button behave the same as step 3.
7. Now, remove the `?fse_parent_post` query param from the URL and go to that URL.
7. The back button should say "< Home" and clicking it should take you to customer home.

Feel free to also test this in your local WordPress setup, making sure that navigation works properly to and from template parts via the page editor.

Fixes #38075
