### PR TITLE
composite-checkout: Set onSuccess/onFailure to use calypso notices

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -13,11 +13,16 @@ import {
 	makeShoppingCartHook,
 	mockPayPalExpressRequest,
 } from '@automattic/composite-checkout-wpcom';
+import { useTranslate } from 'i18n-calypso';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import wp from 'lib/wp';
+import notices from 'notices';
+
+const debug = debugFactory( 'calypso:composite-checkout-container' );
 
 const initialCart = {
 	coupon: '',
@@ -121,11 +126,25 @@ export function isApplePayAvailable() {
 const availablePaymentMethods = [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean );
 
 export default function CompositeCheckoutContainer() {
+	const translate = useTranslate();
+	const onSuccess = () => {
+		debug( 'success' );
+		notices.success( translate( 'Your purchase was successful!' ) );
+	};
+
+	const onFailure = error => {
+		debug( 'error', error );
+		const message = error && error.toString ? error.toString() : error;
+		notices.error( message || translate( 'An error occurred during your purchase.' ) );
+	};
+
 	return (
 		<WPCheckoutWrapper
 			useShoppingCart={ useShoppingCart }
 			availablePaymentMethods={ availablePaymentMethods }
 			registry={ registry }
+			onSuccess={ onSuccess }
+			onFailure={ onFailure }
 		/>
 	);
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-wrapper.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-wrapper.js
@@ -11,11 +11,6 @@ import { CheckoutProvider } from '@automattic/composite-checkout';
 import WPCheckout from './wp-checkout';
 import { useWpcomStore } from '../hooks/wpcom-store';
 
-// These are used only for non-redirect payment methods
-// TODO: write this
-const onSuccess = () => alert( 'Payment succeeded!' );
-const onFailure = error => alert( 'There was a problem with your payment' + error );
-
 // These are used only for redirect payment methods
 const successRedirectUrl = window.location.href;
 const failureRedirectUrl = window.location.href;
@@ -26,7 +21,13 @@ const handleCheckoutEvent = () => () => {
 };
 
 // This is the parent component which would be included on a host page
-export function WPCheckoutWrapper( { useShoppingCart, availablePaymentMethods, registry } ) {
+export function WPCheckoutWrapper( {
+	useShoppingCart,
+	availablePaymentMethods,
+	registry,
+	onSuccess,
+	onFailure,
+} ) {
 	const { itemsWithTax, total, deleteItem, changePlanLength } = useShoppingCart();
 
 	const { select, subscribe, registerStore } = registry;

--- a/packages/composite-checkout-wpcom/test/wp-checkout-wrapper.js
+++ b/packages/composite-checkout-wpcom/test/wp-checkout-wrapper.js
@@ -77,6 +77,8 @@ test( 'When we enter checkout, the line items and total are rendered', async () 
 	// Using a mocked server responses
 	const useShoppingCart = makeShoppingCartHook( mockCartEndpoint, initialCart );
 
+	const noop = () => {};
+
 	const MyCheckout = () => (
 		<WPCheckoutWrapper
 			useShoppingCart={ useShoppingCart }
@@ -87,6 +89,8 @@ test( 'When we enter checkout, the line items and total are rendered', async () 
 				} ),
 			] }
 			registry={ registry }
+			onSuccess={ noop }
+			onFailure={ noop }
 		/>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the `onSuccess`/`onFailure` handlers to be injected with Calypso's `notices.success`/`notices.error` functions.

#### Testing instructions

Do not sandbox the store. Start calypso and load checkout with the `composite-checkout-wpcom` flag. You should see an error that the Stripe fields require HTTPS, but that error should appear using Calypso's native notification system, rather than a browser alert.