### PR TITLE
composite-checkout: Only enable continue if stripe fields are complete

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -95,17 +95,16 @@ When using the individual API components, you can also pass a `className` prop, 
 
 ## Payment Methods
 
-A payment method, in the context of this package, consists of the following pieces:
+Each payment method is an object with the following properties:
 
-- `id`: A unique id.
-- `LabelComponent`: A component that displays that payment method selection button which can be as simple as the name and an icon. It will receive the props of the `CheckoutStep`.
-- `PaymentMethodComponent`: A component that displays that payment method (this can return null or something like a credit card form). It will receive the props of the `CheckoutStep`.
-- `SubmitButtonComponent`: A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. The button can access the success and failure handlers by calling the `useCheckoutHandlers()` custom Hook or it can find the redirect urls by calling the `useCheckoutRedirects()` custom Hook.
-- `CheckoutWrapper`: (Optional) A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).
-- `SummaryComponent`: A component that renders a summary of the selected payment method when the step is inactive.
-- `getAriaLabel`: A function to return the name of the Payment Method. It will receive the localize function as an argument.
-
-Each payment method has the following schema:
+- `id: string`. A unique id.
+- `LabelComponent: React.Component`. A component that displays that payment method selection button which can be as simple as the name and an icon. It will receive the props of the `CheckoutStep`.
+- `PaymentMethodComponent: React.Component`. A component that displays that payment method (this can return null or something like a credit card form). It will receive the props of the `CheckoutStep`.
+- `SubmitButtonComponent: React.Component`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. The button can access the success and failure handlers by calling the `useCheckoutHandlers()` custom Hook or it can find the redirect urls by calling the `useCheckoutRedirects()` custom Hook.
+- `SummaryComponent: React.Component`. A component that renders a summary of the selected payment method when the step is inactive.
+- `CheckoutWrapper?: React.Component`. A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).
+- `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.
+- `isCompleteCallback?: ({paymentData: object, activeStep: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning true.
 
 ```
 {

--- a/packages/composite-checkout/src/components/default-steps.js
+++ b/packages/composite-checkout/src/components/default-steps.js
@@ -32,7 +32,9 @@ export function getDefaultPaymentMethodStep() {
 		activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
 		incompleteStepContent: null,
 		completeStepContent: <CheckoutPaymentMethods summary isComplete={ true } />,
-		isCompleteCallback: () => true, // TODO: make sure any required fields in the selected payment method are complete
+		isCompleteCallback: ( { activePaymentMethod, activeStep, paymentData } ) => {
+			return activePaymentMethod?.isCompleteCallback?.( { activeStep, paymentData } ) ?? true;
+		},
 		isEditableCallback: () => true,
 		// These cannot be translated because they are not inside a component and
 		// we don't know if they are being created by the package or the host page.

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -77,26 +77,7 @@ export function createStripeMethod( {
 		*beginStripeTransaction( payload ) {
 			let stripeResponse;
 			try {
-				const paymentMethodToken = yield {
-					type: 'STRIPE_CREATE_PAYMENT_METHOD_TOKEN',
-					payload: {
-						...payload,
-						country: getCountry(),
-						postalCode: getPostalCode(),
-						phoneNumber: getPhoneNumber(),
-					},
-				};
-				stripeResponse = yield {
-					type: 'STRIPE_TRANSACTION_BEGIN',
-					payload: {
-						...payload,
-						siteId: getSiteId(),
-						country: getCountry(),
-						postalCode: getPostalCode(),
-						subdivisionCode: getSubdivisionCode(),
-						paymentMethodToken,
-					},
-				};
+				stripeResponse = yield { type: 'STRIPE_TRANSACTION_BEGIN', payload };
 			} catch ( error ) {
 				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
 			}
@@ -166,7 +147,7 @@ export function createStripeMethod( {
 		}
 	}
 
-	registerStore( 'stripe', {
+	const store = registerStore( 'stripe', {
 		reducer(
 			state = {
 				cardDataErrors: cardDataErrorsReducer(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the payment methods (default) step so that its `isCompleteCallback` calls the payment method's `isCompleteCallback` (optional, added in this PR) to determine if the step is complete.

For the stripe payment method, we examine the cardholderName field and the three stripe elements fields, to make sure each is valid and not empty before marking the step as complete. To do this, we have to move the errors state to the 'stripe' store and add an additional state in the store for each field's completeness.

Finally, in order to make sure the `isCompleteCallback` is called each time the 'stripe' store (only used in the stripe payment method) is updated, we have to subscribe the `Checkout` component to _all_ store updates in the checkout registry. I don't think that will have too much of a performance impact, but it's worth paying attention to in the future.

#### Testing instructions

1. Visit checkout with the store sandboxed. Add the `composite-checkout-wpcom` flag. Make sure that the "Continue" button in the first step is disabled.
2. Fill in the cardholder name field. Be sure the button remains disabled.
3. Fill in all the stripe fields with valid data. Be sure the button becomes enabled.
4. Empty the CVC field. Be sure the button becomes disabled.
5. Restore the CVC field and enter an invalid expiry date in the expiry field. Be sure the button becomes disabled.
