### PR TITLE
Update flow destination for test-fse to redirect to customer home

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,7 +16,6 @@ export function generateFlows( {
 	getSignupDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
-	getEditorDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -347,7 +346,7 @@ export function generateFlows( {
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
 			steps: [ 'user', 'fse-themes', 'domains', 'plans' ],
-			destination: getEditorDestination,
+			destination: getSignupDestination,
 			description: 'User testing Signup flow for Full Site Editing',
 			lastModified: '2019-12-02',
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update flow destination for `test-fse` to point to the customer home
* Note that the `getEditorDestination` function is retained in `flows.js` because we will be using it again in Milestone 3 of the 0-FSE work.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/test-fse` and complete signup with a free plan, double check that you are redirected to the Customer Home after signup, and that the header says "Your site has been created!"
* Go to `/start/test-fse` and complete signup with a paid plan (e.g. Personal plan), and check that you are redirected to the Customer Home after completing the checkout, and that the header says "Thank you for your purchase!"

Fixes #38057 
