### PR TITLE
Hide recommended themes when query present.

### DIFF
--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -18,6 +18,14 @@ class RecommendedThemes extends React.Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		// Wait until rec themes to be loaded to scroll to search input if its in use.
+		const { isLoading, isShowcaseOpen, scrollToSearchInput } = this.props;
+		if ( prevProps.isLoading !== isLoading && isLoading === false && isShowcaseOpen ) {
+			scrollToSearchInput();
+		}
+	}
+
 	render() {
 		return (
 			<>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -64,11 +64,14 @@ const optionShape = PropTypes.shape( {
 class ThemeShowcase extends React.Component {
 	constructor( props ) {
 		super( props );
-		this.scrollRef = React.createRef();
 		this.state = {
 			page: 1,
 			showPreview: false,
-			isShowcaseOpen: !! this.props.loggedOutComponent,
+			isShowcaseOpen: !! (
+				this.props.loggedOutComponent ||
+				this.props.search ||
+				this.props.filter
+			),
 		};
 	}
 
@@ -120,9 +123,6 @@ class ThemeShowcase extends React.Component {
 				.trim(),
 		} );
 		page( url );
-		if ( ! this.props.loggedOutComponent ) {
-			this.scrollRef.current.scrollIntoView();
-		}
 	};
 
 	/**
@@ -155,9 +155,6 @@ class ThemeShowcase extends React.Component {
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );
-		if ( ! this.props.loggedOutComponent ) {
-			this.scrollRef.current.scrollIntoView();
-		}
 	};
 
 	onUploadClick = () => {
@@ -228,7 +225,7 @@ class ThemeShowcase extends React.Component {
 		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
 		const { isShowcaseOpen } = this.state;
-
+		const isQueried = this.props.search || this.props.filter;
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -256,7 +253,7 @@ class ThemeShowcase extends React.Component {
 							{ translate( 'Install Theme' ) }
 						</Button>
 					) }
-					{ ! this.props.loggedOutComponent && (
+					{ ! this.props.loggedOutComponent && ! isQueried && (
 						<>
 							<RecommendedThemes
 								upsellUrl={ this.props.upsellUrl }
@@ -295,7 +292,7 @@ class ThemeShowcase extends React.Component {
 							/>
 							<div className="theme-showcase__open-showcase-button-holder">
 								{ isShowcaseOpen ? (
-									<hr ref={ this.scrollRef } />
+									<hr />
 								) : (
 									<Button onClick={ this.toggleShowcase } data-e2e-value="open-themes-button">
 										{ translate( 'Show All Themes' ) }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -64,6 +64,7 @@ const optionShape = PropTypes.shape( {
 class ThemeShowcase extends React.Component {
 	constructor( props ) {
 		super( props );
+		this.scrollRef = React.createRef();
 		this.state = {
 			page: 1,
 			showPreview: false,
@@ -102,6 +103,12 @@ class ThemeShowcase extends React.Component {
 		showUploadButton: true,
 	};
 
+	scrollToSearchInput = () => {
+		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
+			this.scrollRef.current.scrollIntoView();
+		}
+	};
+
 	toggleShowcase = () => {
 		this.setState( { isShowcaseOpen: ! this.state.isShowcaseOpen } );
 		this.props.trackMoreThemesClick();
@@ -123,6 +130,7 @@ class ThemeShowcase extends React.Component {
 				.trim(),
 		} );
 		page( url );
+		this.scrollToSearchInput();
 	};
 
 	/**
@@ -155,6 +163,7 @@ class ThemeShowcase extends React.Component {
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );
+		this.scrollToSearchInput();
 	};
 
 	onUploadClick = () => {
@@ -292,7 +301,7 @@ class ThemeShowcase extends React.Component {
 							/>
 							<div className="theme-showcase__open-showcase-button-holder">
 								{ isShowcaseOpen ? (
-									<hr />
+									<hr ref={ this.scrollRef } />
 								) : (
 									<Button onClick={ this.toggleShowcase } data-e2e-value="open-themes-button">
 										{ translate( 'Show All Themes' ) }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -103,6 +103,12 @@ class ThemeShowcase extends React.Component {
 		showUploadButton: true,
 	};
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.search !== this.props.search || prevProps.filter !== this.props.filter ) {
+			this.scrollToSearchInput();
+		}
+	}
+
 	scrollToSearchInput = () => {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
 			this.scrollRef.current.scrollIntoView();
@@ -298,10 +304,12 @@ class ThemeShowcase extends React.Component {
 								} }
 								trackScrollPage={ this.props.trackScrollPage }
 								emptyContent={ this.props.emptyContent }
+								isShowcaseOpen={ this.state.isShowcaseOpen }
+								scrollToSearchInput={ this.scrollToSearchInput }
 							/>
 							<div className="theme-showcase__open-showcase-button-holder">
 								{ isShowcaseOpen ? (
-									<hr ref={ this.scrollRef } />
+									<hr />
 								) : (
 									<Button onClick={ this.toggleShowcase } data-e2e-value="open-themes-button">
 										{ translate( 'Show All Themes' ) }
@@ -312,6 +320,7 @@ class ThemeShowcase extends React.Component {
 					) }
 
 					<div
+						ref={ this.scrollRef }
 						className={
 							! this.state.isShowcaseOpen
 								? 'themes__hidden-content theme-showcase__all-themes'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* alternative solution to PR #38086

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch with `npm start`
* Navigate to `calypso.localhost:3000/themes` while logged in.
* Open the "More Themes" Section and apply a search critera.
* Verify Recommended Themes section disappears.
* Reload the browser window.
* Verify that the All Themes search section is open and that the page auto scrolls to this area.
* Clear the search criteria rom the input.
* Reload the browser and confirm that Recommended Themes and the "More Themes" button are present.
* Test this same process with a site selected through the my-sites/themes section.

Fixes #38061
