### PR TITLE
Add/test fse only choose compatible themes

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -291,7 +291,7 @@ export const themes = [
 		fallback: true,
 		description: '',
 		design: 'template-first',
-		demo_uri: 'https:/shawburndemo.wordpress.com',
+		demo_uri: 'https://shawburndemo.wordpress.com',
 		verticals: [],
 	},
 	{

--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -424,4 +424,36 @@ export const themes = [
 		demo_uri: 'https://twentyfifteendemo.wordpress.com',
 		verticals: [],
 	},
+
+	// Start full-site-editing compatible themes
+	{
+		name: 'Exford',
+		slug: 'exford',
+		repo: 'pub',
+		fallback: true,
+		description: '',
+		design: 'fse-compatible',
+		demo_uri: 'https://exforddemo.wordpress.com',
+		verticals: [],
+	},
+	{
+		name: 'Maywood',
+		slug: 'maywood',
+		repo: 'pub',
+		fallback: true,
+		description: '',
+		design: 'fse-compatible',
+		demo_uri: 'https://maywooddemo.wordpress.com',
+		verticals: [],
+	},
+	{
+		name: 'Shawburn',
+		slug: 'shawburn',
+		repo: 'pub',
+		fallback: true,
+		description: '',
+		design: 'fse-compatible',
+		demo_uri: 'https://shawburndemo.wordpress.com',
+		verticals: [],
+	},
 ];

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -349,7 +349,7 @@ export function generateFlows( {
 			steps: [ 'user', 'fse-themes', 'domains', 'plans' ],
 			destination: getEditorDestination,
 			description: 'User testing Signup flow for Full Site Editing',
-			lastModified: '2019-11-22',
+			lastModified: '2019-12-02',
 		};
 	}
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -346,7 +346,7 @@ export function generateFlows( {
 
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
-			steps: [ 'user', 'template-first-themes', 'domains', 'plans' ],
+			steps: [ 'user', 'fse-themes', 'domains', 'plans' ],
 			destination: getEditorDestination,
 			description: 'User testing Signup flow for Full Site Editing',
 			lastModified: '2019-11-22',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -49,6 +49,7 @@ const stepNameToModuleName = {
 	themes: 'theme-selection',
 	'themes-site-selected': 'theme-selection',
 	'template-first-themes': 'theme-selection',
+	'fse-themes': 'theme-selection',
 	user: 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -70,6 +70,16 @@ export function generateSteps( {
 			providesDependencies: [ 'themeSlugWithRepo', 'useThemeHeadstart' ],
 		},
 
+		'fse-themes': {
+			stepName: 'fse-themes',
+			props: {
+				designType: 'fse-compatible',
+				quantity: 3,
+			},
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'themeSlugWithRepo', 'useThemeHeadstart' ],
+		},
+
 		// `themes` does not update the theme for an existing site as we normally
 		// do this when the site is created. In flows where a site is merely being
 		// updated, we need to use a different API request function.


### PR DESCRIPTION
The `test-fse` flow was using the `template-first-themes` step which was originally created for the `design-first` flow. This flow shows template-first themes. The problem is not every template-first theme is FSE compatible.

I created a new step that only shows FSE compatible themes. I got the list of themes by search the `pub` repo for `add_theme_support( 'full-site-editing' );`

#### Changes proposed in this Pull Request

* Created `fse-themes` step
* Changed `test-fse` flow to use the new step
* Fixed an unrelated shawburndemo URI typo in `themes-data.js`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start/test-fse`
* Only FSE compatible themes are shown during signup
* Complete signup, the correct theme has been applied
* `/start/design-first`
* Flow still shows 18 template-first themes

Fixes #38059
