### PR TITLE
Gutenboarding: Drop EMPTY_FORM_VALUE and friends

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -14,7 +14,6 @@ import { STORE_KEY as DOMAIN_STORE } from '../../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import './style.scss';
 import { DomainPickerButton } from '../domain-picker';
-import { isFilledFormValue } from '../../stores/onboard/types';
 import { selectorDebounce } from '../../constants';
 
 interface Props {
@@ -43,10 +42,7 @@ const Header: FunctionComponent< Props > = ( {
 		// eslint-disable-next-line no-nested-ternary
 		domain // If we know a domain, do not search.
 			? null
-			: isFilledFormValue( siteTitle ) // If we have a siteTitle, use it.
-			? siteTitle
-			: // Otherwise, do not search.
-			  null,
+			: siteTitle, // If we have a siteTitle, use it.
 		selectorDebounce
 	);
 	const freeDomainSuggestion = useSelect(
@@ -58,7 +54,7 @@ const Header: FunctionComponent< Props > = ( {
 				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
 				include_wordpressdotcom: true,
 				quantity: 1,
-				...( isFilledFormValue( siteVertical ) && { vertical: siteVertical.id } ),
+				...{ vertical: siteVertical?.id },
 			} )?.[ 0 ];
 		},
 		[ domainSearch, siteVertical ]
@@ -88,11 +84,9 @@ const Header: FunctionComponent< Props > = ( {
 					{ currentDomain ? (
 						<DomainPickerButton
 							className="gutenboarding__header-domain-picker-button"
-							defaultQuery={ isFilledFormValue( siteTitle ) ? siteTitle : undefined }
+							defaultQuery={ siteTitle }
 							onDomainSelect={ setDomain }
-							queryParameters={
-								isFilledFormValue( siteVertical ) ? { vertical: siteVertical.id } : undefined
-							}
+							queryParameters={ siteVertical ? { vertical: siteVertical.id } : undefined }
 						>
 							{ siteTitleElement }
 							<span>{ currentDomain.domain_name }</span>
@@ -104,11 +98,7 @@ const Header: FunctionComponent< Props > = ( {
 			</div>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Button
-						isPrimary
-						isLarge
-						disabled={ isFilledFormValue( siteVertical ) || ! siteVertical }
-					>
+					<Button isPrimary isLarge disabled={ ! siteTitle }>
 						{ NO__( 'Next' ) }
 					</Button>
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -39,9 +39,8 @@ const Header: FunctionComponent< Props > = ( {
 	const { setDomain } = useDispatch( ONBOARD_STORE );
 
 	const [ domainSearch ] = useDebounce(
-		domain // If we know a domain, do not search.
-			? null
-			: siteTitle, // If we have a siteTitle, use it.
+		// If we know a domain, do not search.
+		! domain && siteTitle,
 		selectorDebounce
 	);
 	const freeDomainSuggestion = useSelect(

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -86,7 +86,7 @@ const Header: FunctionComponent< Props > = ( {
 							className="gutenboarding__header-domain-picker-button"
 							defaultQuery={ siteTitle }
 							onDomainSelect={ setDomain }
-							queryParameters={ siteVertical ? { vertical: siteVertical.id } : undefined }
+							queryParameters={ siteVertical && { vertical: siteVertical.id } }
 						>
 							{ siteTitleElement }
 							<span>{ currentDomain.domain_name }</span>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -84,7 +84,7 @@ const Header: FunctionComponent< Props > = ( {
 							className="gutenboarding__header-domain-picker-button"
 							defaultQuery={ siteTitle }
 							onDomainSelect={ setDomain }
-							queryParameters={ siteVertical && { vertical: siteVertical.id } }
+							queryParameters={ { vertical: siteVertical?.id } }
 						>
 							{ siteTitleElement }
 							<span>{ currentDomain.domain_name }</span>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -39,7 +39,6 @@ const Header: FunctionComponent< Props > = ( {
 	const { setDomain } = useDispatch( ONBOARD_STORE );
 
 	const [ domainSearch ] = useDebounce(
-		// eslint-disable-next-line no-nested-ternary
 		domain // If we know a domain, do not search.
 			? null
 			: siteTitle, // If we have a siteTitle, use it.

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -23,12 +23,12 @@ export default function OnboardingEdit() {
 			<div className="onboarding-block__questions">
 				<h2 className="onboarding-block__questions-heading">
 					{ ! siteVertical &&
-						! siteTitle.length &&
+						! siteTitle &&
 						NO__( "Let's set up your website – it takes only a moment." ) }
 				</h2>
 				<StepperWizard>
 					<VerticalSelect />
-					{ ( siteVertical || siteTitle.length ) && <SiteTitle /> }
+					{ ( siteVertical || siteTitle ) && <SiteTitle /> }
 				</StepperWizard>
 				{ siteVertical && (
 					<div className="onboarding-block__footer">

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -9,7 +9,6 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { isFilledFormValue } from '../stores/onboard/types';
 import { STORE_KEY } from '../stores/onboard';
 import StepperWizard from './stepper-wizard';
 import VerticalSelect from './vertical-select';
@@ -23,15 +22,15 @@ export default function OnboardingEdit() {
 		<div className="onboarding-block__acquire-intent">
 			<div className="onboarding-block__questions">
 				<h2 className="onboarding-block__questions-heading">
-					{ ! isFilledFormValue( siteVertical ) &&
+					{ ! siteVertical &&
 						! siteTitle.length &&
 						NO__( "Let's set up your website – it takes only a moment." ) }
 				</h2>
 				<StepperWizard>
 					<VerticalSelect />
-					{ ( isFilledFormValue( siteVertical ) || siteTitle.length ) && <SiteTitle /> }
+					{ ( siteVertical || siteTitle.length ) && <SiteTitle /> }
 				</StepperWizard>
-				{ isFilledFormValue( siteVertical ) && (
+				{ siteVertical && (
 					<div className="onboarding-block__footer">
 						<Button className="onboarding-block__question-skip" isLink>
 							{ NO__( "Don't know yet" ) } →

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -11,7 +11,7 @@ import { ENTER } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { SiteVertical, isFilledFormValue } from '../../stores/onboard/types';
+import { SiteVertical } from '../../stores/onboard/types';
 import { InjectedStepProps } from '../stepper-wizard';
 import Question from '../question';
 import { __TodoAny__ } from 'client/types';
@@ -111,9 +111,7 @@ const VerticalSelect: FunctionComponent< InjectedStepProps > = ( {
 		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
 
 	const label = NO__( 'My site is about' );
-	const displayValue = isFilledFormValue( siteVertical )
-		? siteVertical.label
-		: NO__( 'enter a topic' );
+	const displayValue = siteVertical?.label ?? NO__( 'enter a topic' );
 
 	// Focus the input when we change to active
 	const inputRef = createRef< HTMLInputElement >();

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -11,10 +11,10 @@ import { ActionType, Vertical, SiteVertical } from './types';
 import { DomainSuggestion } from '../domain-suggestions/types';
 import * as Actions from './actions';
 
-const domain: Reducer< DomainSuggestion | null, ReturnType< typeof Actions[ 'setDomain' ] > > = (
-	state = null,
-	action
-) => {
+const domain: Reducer<
+	DomainSuggestion | undefined,
+	ReturnType< typeof Actions[ 'setDomain' ] >
+> = ( state = undefined, action ) => {
 	if ( action.type === ActionType.SET_DOMAIN ) {
 		return action.domain;
 	}

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -7,7 +7,7 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { ActionType, FormValue, EMPTY_FORM_VALUE, Vertical, SiteVertical } from './types';
+import { ActionType, Vertical, SiteVertical } from './types';
 import { DomainSuggestion } from '../domain-suggestions/types';
 import * as Actions from './actions';
 
@@ -42,14 +42,14 @@ const verticals: Reducer< Vertical[], ReturnType< typeof Actions[ 'receiveVertic
 };
 
 const siteVertical: Reducer<
-	FormValue< SiteVertical >,
+	SiteVertical | undefined,
 	ReturnType< typeof Actions[ 'setSiteVertical' ] >
-> = ( state = EMPTY_FORM_VALUE, action ) => {
+> = ( state = undefined, action ) => {
 	if ( action.type === ActionType.SET_SITE_VERTICAL ) {
 		return action.siteVertical;
 	}
 	if ( action.type === ActionType.RESET_SITE_VERTICAL ) {
-		return EMPTY_FORM_VALUE;
+		return undefined;
 	}
 	return state;
 };

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import isShallowEqual from '@wordpress/is-shallow-equal';
-
 enum ActionType {
 	RECEIVE_VERTICALS = 'RECEIVE_VERTICALS',
 	RESET_SITE_TYPE = 'RESET_SITE_TYPE',
@@ -17,12 +12,6 @@ export { ActionType };
 export interface SiteVertical {
 	label: string;
 	id: string;
-}
-
-export const EMPTY_FORM_VALUE = Object.freeze( { __EFV__: '__EFV__' } );
-export type FormValue< T > = T | typeof EMPTY_FORM_VALUE;
-export function isFilledFormValue< T >( value: FormValue< T > ): value is T {
-	return value !== EMPTY_FORM_VALUE && ! isShallowEqual( value, EMPTY_FORM_VALUE );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm starting to think we're doing a bit too much ceremony for our `EMPTY_FORM_VALUE` handling.

Consider the shape of any form value object:
This means that our type information is no longer just an added layer that's removed when transpiling to JS, but we're actually carrying it over there, and I think it could lead to some confusion.

Furthermore, it seems to possibly cause more problems than it solves. Consider this type error:

```
client/landing/gutenboarding/stores/onboard/types.ts:25:57 - error TS2345: Argument of type 'FormValue<T>' is not assignable to parameter of type 'object | ArrayLike<any>'.
  Type 'T' is not assignable to type 'object | ArrayLike<any>'.
    Type 'T' is not assignable to type 'ArrayLike<any>'.

25  return value !== EMPTY_FORM_VALUE && ! isShallowEqual( value, EMPTY_FORM_VALUE );
```

From an implementation perspective, I've never liked that criterion. IMO, needing a helper like `isShallowEqual` in a case like this is a sign that we're overthinking it.

My proposal is thus to go back to `undefined`, and even frop the `isFilledFormValue` in favor of a bunch of `?.`s. I think the diff illustrates that it makes our lives easier, and code more intuitive. I'll just say that I think it also makes sense on a conceptual level:

We need to reflect empty form state in our Redux state (i.e. reducer), and we need to be able persist it, (and restore it correctly). Furthermore, I think it's rather fine to say that the initial state (if nothing has been persisted) for those reducers makes sense to be `undefined`; much like our `EMPTY_FORM_VALUE` construct, it's pretty much agnostic of _what_ type of (form) state we're dealing with (string, number, vertical, etc).

#### Testing instructions

Verify that Gutenboarding works as before

Also: `npm run typecheck -- -p client/landing/gutenboarding` shows fewer errors than on `master`.