### PR TITLE
Hosting: Add unit tests for the SFTP card UI

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -47,7 +47,7 @@ const FILEZILLA_URL = 'https://filezilla-project.org/';
 const SFTP_URL = 'sftp.wp.com';
 const SFTP_PORT = 22;
 
-const SftpCard = ( {
+export const SftpCard = ( {
 	translate,
 	username,
 	password,

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -102,7 +102,7 @@ export const SftpCard = ( {
 		if ( password ) {
 			return (
 				<>
-					<div className="sftp-card__copy-field">
+					<div className="sftp-card__copy-field sftp-card__password-field">
 						<FormTextInput className="sftp-card__copy-input" value={ password } onChange={ noop } />
 						<ClipboardButton className="sftp-card__copy-button" text={ password } compact>
 							{ translate( 'Copy', { context: 'verb' } ) }
@@ -122,7 +122,12 @@ export const SftpCard = ( {
 				<p className="sftp-card__password-explainer">
 					{ translate( 'For security reasons, your password needs a reset to view' ) }
 				</p>
-				<Button onClick={ resetPassword } disabled={ isPasswordLoading } busy={ isPasswordLoading }>
+				<Button
+					onClick={ resetPassword }
+					disabled={ isPasswordLoading }
+					busy={ isPasswordLoading }
+					className="sftp-card__password-reset-button"
+				>
 					{ translate( 'Reset Password' ) }
 				</Button>
 			</>
@@ -191,7 +196,7 @@ export const SftpCard = ( {
 							}
 						) }
 					</p>
-					<Button onClick={ createUser } primary>
+					<Button onClick={ createUser } primary className="sftp-card__create-credentials-button">
 						{ translate( 'Create SFTP Credentials' ) }
 					</Button>
 				</>

--- a/client/my-sites/hosting/sftp-card/test/index.js
+++ b/client/my-sites/hosting/sftp-card/test/index.js
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow, mount } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { SftpCard } from '..';
+
+const translate = x => x;
+const requestSftpUsers = x => x;
+
+describe( 'SftpCard', () => {
+	describe( 'Sftp Questions', () => {
+		it( 'should display sftp questions if no sftp username', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } /> );
+
+			expect( wrapper.find( '.sftp-card__questions' ).length ).toEqual( 1 );
+		} );
+		it( 'should not display sftp questions if sftp username is set', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+
+			expect( wrapper.find( '.sftp-card__questions' ).length ).toEqual( 0 );
+		} );
+		it( 'should not display sftp questions if loading', () => {
+			// need to use a mount rather than shallow for tests that require useEffects to run
+			const wrapper = mount(
+				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } />
+			);
+
+			expect( wrapper.find( '.sftp-card__questions' ).length ).toEqual( 0 );
+		} );
+	} );
+
+	describe( 'Loading', () => {
+		it( 'should display spinner if username not set and not disabled', () => {
+			const wrapper = mount(
+				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } />
+			);
+
+			expect( wrapper.find( 'Spinner' ).length ).toEqual( 1 );
+		} );
+		it( 'should note display spinner if disabled', () => {
+			const wrapper = mount(
+				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } disabled={ true } />
+			);
+
+			expect( wrapper.find( 'Spinner' ).length ).toEqual( 0 );
+		} );
+	} );
+
+	describe( 'Create SFTP Credentials', () => {
+		it( 'should display create SFTP credentials if username not set', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } /> );
+
+			expect( wrapper.find( '.sftp-card__create-credentials-button' ).length ).toEqual( 1 );
+		} );
+		it( 'should not display create SFTP credentials if username set', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+
+			expect( wrapper.find( '.sftp-card__create-credentials-button' ).length ).toEqual( 0 );
+		} );
+	} );
+
+	describe( 'User info fields', () => {
+		it( 'should display user info fields if username set', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+
+			expect( wrapper.find( '.sftp-card__info-field' ).length ).toEqual( 1 );
+		} );
+		it( 'should not display user info fields if username not set', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } /> );
+
+			expect( wrapper.find( '.sftp-card__info-field' ).length ).toEqual( 0 );
+		} );
+	} );
+
+	describe( 'Password', () => {
+		it( 'should display password field if password set', () => {
+			const wrapper = shallow(
+				<SftpCard translate={ translate } username="testuser" password="secret" />
+			);
+
+			expect( wrapper.find( '.sftp-card__password-field' ).length ).toEqual( 1 );
+		} );
+		it( 'should not display password field if password not set', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+
+			expect( wrapper.find( '.sftp-card__password-field' ).length ).toEqual( 0 );
+		} );
+		it( 'should display password reset button if password not set', () => {
+			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+
+			expect( wrapper.find( '.sftp-card__password-reset-button' ).length ).toEqual( 1 );
+		} );
+	} );
+} );

--- a/client/my-sites/hosting/sftp-card/test/index.js
+++ b/client/my-sites/hosting/sftp-card/test/index.js
@@ -21,12 +21,12 @@ describe( 'SftpCard', () => {
 		it( 'should display sftp questions if no sftp username', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } /> );
 
-			expect( wrapper.find( '.sftp-card__questions' ).length ).toEqual( 1 );
+			expect( wrapper.find( '.sftp-card__questions' ) ).toHaveLength( 1 );
 		} );
 		it( 'should not display sftp questions if sftp username is set', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__questions' ).length ).toEqual( 0 );
+			expect( wrapper.find( '.sftp-card__questions' ) ).toHaveLength( 0 );
 		} );
 		it( 'should not display sftp questions if loading', () => {
 			// need to use a mount rather than shallow for tests that require useEffects to run
@@ -34,7 +34,7 @@ describe( 'SftpCard', () => {
 				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } />
 			);
 
-			expect( wrapper.find( '.sftp-card__questions' ).length ).toEqual( 0 );
+			expect( wrapper.find( '.sftp-card__questions' ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -44,14 +44,14 @@ describe( 'SftpCard', () => {
 				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } />
 			);
 
-			expect( wrapper.find( 'Spinner' ).length ).toEqual( 1 );
+			expect( wrapper.find( 'Spinner' ) ).toHaveLength( 1 );
 		} );
-		it( 'should note display spinner if disabled', () => {
+		it( 'should not display spinner if disabled', () => {
 			const wrapper = mount(
 				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } disabled={ true } />
 			);
 
-			expect( wrapper.find( 'Spinner' ).length ).toEqual( 0 );
+			expect( wrapper.find( 'Spinner' ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -59,12 +59,12 @@ describe( 'SftpCard', () => {
 		it( 'should display create SFTP credentials if username not set', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } /> );
 
-			expect( wrapper.find( '.sftp-card__create-credentials-button' ).length ).toEqual( 1 );
+			expect( wrapper.find( '.sftp-card__create-credentials-button' ) ).toHaveLength( 1 );
 		} );
 		it( 'should not display create SFTP credentials if username set', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__create-credentials-button' ).length ).toEqual( 0 );
+			expect( wrapper.find( '.sftp-card__create-credentials-button' ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -72,12 +72,12 @@ describe( 'SftpCard', () => {
 		it( 'should display user info fields if username set', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__info-field' ).length ).toEqual( 1 );
+			expect( wrapper.find( '.sftp-card__info-field' ) ).toHaveLength( 1 );
 		} );
 		it( 'should not display user info fields if username not set', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } /> );
 
-			expect( wrapper.find( '.sftp-card__info-field' ).length ).toEqual( 0 );
+			expect( wrapper.find( '.sftp-card__info-field' ) ).toHaveLength( 0 );
 		} );
 	} );
 
@@ -87,17 +87,17 @@ describe( 'SftpCard', () => {
 				<SftpCard translate={ translate } username="testuser" password="secret" />
 			);
 
-			expect( wrapper.find( '.sftp-card__password-field' ).length ).toEqual( 1 );
+			expect( wrapper.find( '.sftp-card__password-field' ) ).toHaveLength( 1 );
 		} );
 		it( 'should not display password field if password not set', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__password-field' ).length ).toEqual( 0 );
+			expect( wrapper.find( '.sftp-card__password-field' ) ).toHaveLength( 0 );
 		} );
 		it( 'should display password reset button if password not set', () => {
 			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__password-reset-button' ).length ).toEqual( 1 );
+			expect( wrapper.find( '.sftp-card__password-reset-button' ) ).toHaveLength( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds some basic unit tests checking the SFTP card component, as there are a few places where we could easily get a regression with this component, so this will hopefully help to pick these up.

Originally added by @glendaviesnz in #38045 but moved to a separate PR to help unblocking the initial SFTP/phpMyAdmin rollout. 

#### Testing instructions

Check the tests passed on CircleCI.
