### PR TITLE
Config: Remove unused Jetpack onboarding flag

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -52,7 +52,6 @@
 		"jetpack/connect/site-questions": false,
 		"jetpack/connection-rebranding": true,
 		"jetpack/happychat": true,
-		"jetpack/onboarding": true,
 		"jetpack_core_inline_update": true,
 		"jitms": false,
 		"keyboard-shortcuts": true,


### PR DESCRIPTION
After #38000 landed, we forgot to remove an obsolete feature flag. This PR removes it.

#### Changes proposed in this Pull Request

* Config: Remove unused Jetpack onboarding flag

#### Testing instructions

* Verify the removed feature flag is indeed not used anywhere.
* Further testing not needed
