### PR TITLE
Add/domains for all sites page

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -40,7 +40,7 @@ function getStateFromStores( props ) {
 		selectedSite: props.selectedSite,
 		sitePlans: props.sitePlans,
 		user: props.currentUser,
-		users: UsersStore.getUsers( { siteId: props.selectedSite.ID } ),
+		users: UsersStore.getUsers( { siteId: get( props.selectedSite, 'ID' ) } ),
 		wapiDomainInfo: WapiDomainInfoStore.getByDomainName( props.selectedDomainName ),
 	};
 }

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -54,6 +54,11 @@ export default {
 		next();
 	},
 
+	domainManagementListAllSites( pageContext, next ) {
+		pageContext.primary = <div>figure out how to call &lt;DomainManagementData for every site</div>;
+		next();
+	},
+
 	domainManagementEdit( pageContext, next ) {
 		const isTransfer = includes( pageContext.path, '/transfer/in/' );
 		const component = isTransfer ? DomainManagement.TransferIn : DomainManagement.Edit;

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -55,7 +55,7 @@ export default {
 	},
 
 	domainManagementListAllSites( pageContext, next ) {
-		pageContext.primary = <div>figure out how to call &lt;DomainManagementData for every site</div>;
+		pageContext.primary = <DomainManagement.ListAll />;
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -17,6 +17,7 @@ import TransferIn from './edit/transfer-in';
 import TransferOut from './transfer/transfer-out';
 import TransferToOtherSite from './transfer/transfer-to-other-site';
 import TransferToOtherUser from './transfer/transfer-to-other-user';
+import ListAll from './list/list-all';
 
 export default {
 	ChangeSiteAddress,
@@ -27,6 +28,7 @@ export default {
 	EditContactInfo,
 	ManageConsent,
 	List,
+	ListAll,
 	NameServers,
 	PrimaryDomain,
 	SiteRedirect,

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -168,6 +168,10 @@ export class List extends React.Component {
 			return null;
 		}
 
+		if ( this.props.selectedSite.jetpack && this.props.renderAllSites ) {
+			return null;
+		}
+
 		if ( this.props.isDomainOnly ) {
 			if ( ! this.props.renderAllSites ) {
 				return (

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -61,7 +61,7 @@ export class List extends React.Component {
 	static propTypes = {
 		selectedSite: PropTypes.object.isRequired,
 		domains: PropTypes.array.isRequired,
-		isRequestingDomains: PropTypes.bool.isRequired,
+		isRequestingDomains: PropTypes.bool,
 		cart: PropTypes.object,
 		context: PropTypes.object,
 		renderAllSites: PropTypes.bool,

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -8,6 +8,7 @@ import { find, findIndex, get, identity, noop, times } from 'lodash';
 import Gridicon from 'components/gridicon';
 import page from 'page';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -57,6 +58,15 @@ import { withLocalizedMoment } from 'components/localized-moment';
 import './style.scss';
 
 export class List extends React.Component {
+	static propTypes = {
+		selectedSite: PropTypes.object.isRequired,
+		domains: PropTypes.array.isRequired,
+		isRequestingDomains: PropTypes.bool.isRequired,
+		cart: PropTypes.object,
+		context: PropTypes.object,
+		renderAllSites: PropTypes.bool,
+	};
+
 	static defaultProps = {
 		translate: identity,
 		enablePrimaryDomainMode: noop,
@@ -136,6 +146,9 @@ export class List extends React.Component {
 
 	render() {
 		if ( ! this.props.userCanManageOptions ) {
+			if ( this.props.renderAllSites ) {
+				return null;
+			}
 			return (
 				<Main>
 					<SidebarNavigation />
@@ -151,7 +164,7 @@ export class List extends React.Component {
 			return null;
 		}
 
-		if ( this.props.isDomainOnly ) {
+		if ( this.props.isDomainOnly && ! this.props.renderAllSites ) {
 			return (
 				<Main>
 					<DocumentHead title={ this.props.translate( 'Settings' ) } />
@@ -165,23 +178,33 @@ export class List extends React.Component {
 		}
 
 		const headerText = this.props.translate( 'Domains', { context: 'A navigation label.' } );
+		const sectionLabel = this.props.renderAllSites ? this.props.selectedSite.title : null;
+		const sectionHref = this.props.renderAllSites
+			? domainManagementList( this.props.selectedSite.slug )
+			: null;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main wideLayout>
 				<DocumentHead title={ headerText } />
 				<SidebarNavigation />
-				<FormattedHeader
-					className="domain-management__page-heading"
-					headerText={ this.props.translate( 'Domains' ) }
-					align="left"
-				/>
-				<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
-				{ this.domainWarnings() }
+				{ ! this.props.renderAllSites && (
+					<FormattedHeader
+						className="domain-management__page-heading"
+						headerText={ this.props.translate( 'Domains' ) }
+						align="left"
+					/>
+				) }
+				{ ! this.props.renderAllSites && (
+					<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
+				) }
+				{ ! this.props.renderAllSites && this.domainWarnings() }
 
-				{ this.domainCreditsInfoNotice() }
+				{ ! this.props.renderAllSites && this.domainCreditsInfoNotice() }
 
-				<SectionHeader>{ this.headerButtons() }</SectionHeader>
+				<SectionHeader label={ sectionLabel } href={ sectionHref }>
+					{ this.headerButtons() }
+				</SectionHeader>
 
 				<div className="domain-management-list__items">
 					{ this.notice() }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -179,9 +179,6 @@ export class List extends React.Component {
 
 		const headerText = this.props.translate( 'Domains', { context: 'A navigation label.' } );
 		const sectionLabel = this.props.renderAllSites ? this.props.selectedSite.title : null;
-		const sectionHref = this.props.renderAllSites
-			? domainManagementList( this.props.selectedSite.slug )
-			: null;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -202,9 +199,7 @@ export class List extends React.Component {
 
 				{ ! this.props.renderAllSites && this.domainCreditsInfoNotice() }
 
-				<SectionHeader label={ sectionLabel } href={ sectionHref }>
-					{ this.headerButtons() }
-				</SectionHeader>
+				<SectionHeader label={ sectionLabel }>{ this.headerButtons() }</SectionHeader>
 
 				<div className="domain-management-list__items">
 					{ this.notice() }

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { get, times, isEmpty, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+import getVisibleSites from 'state/selectors/get-visible-sites';
+import SectionHeader from 'components/section-header';
+import QuerySiteDomains from 'components/data/query-site-domains';
+import { getAllDomains } from 'state/sites/domains/selectors';
+import { type } from 'lib/domains/constants';
+import ListItemPlaceholder from './item-placeholder';
+import ListItem from './item';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementTransferIn,
+} from 'my-sites/domains/paths';
+import FormattedHeader from 'components/formatted-header';
+
+class ListAll extends Component {
+	renderDomain( site, domain, index ) {
+		return (
+			<ListItem
+				key={ index + domain.name }
+				domain={ domain }
+				selectionIndex={ index }
+				onClick={ this.goToEditDomainRoot( site ) }
+				onSelect={ noop }
+			/>
+		);
+	}
+
+	renderSiteDomains( site ) {
+		if ( this.isLoading( site ) ) {
+			return times( 3, n => <ListItemPlaceholder key={ `item-${ n }` } /> );
+		}
+		return this.props.domains[ site.ID ].map( ( domain, domainIndex ) =>
+			this.renderDomain( site, domain, domainIndex )
+		);
+	}
+
+	isLoading( site ) {
+		return isEmpty( get( this.props.domains, site.ID ) );
+	}
+
+	renderSingleSite( site, siteIndex ) {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<div key={ siteIndex } className="list-all__site">
+				<QuerySiteDomains siteId={ site.ID } />
+				<SectionHeader label={ site.title } href={ domainManagementList( site.slug ) } />
+				<div className="domain-management-list__items">{ this.renderSiteDomains( site ) }</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<React.Fragment>
+				<FormattedHeader headerText={ translate( 'All Domains' ) } align="left" />
+				<div className="list-all__container">
+					{ this.props.sites.map( ( site, index ) => this.renderSingleSite( site, index ) ) }
+				</div>
+			</React.Fragment>
+		);
+	}
+
+	goToEditDomainRoot = site => domain => {
+		if ( domain.type !== type.TRANSFER ) {
+			page( domainManagementEdit( site.slug, domain.name ) );
+		} else {
+			page( domainManagementTransferIn( site.slug, domain.name ) );
+		}
+	};
+}
+
+export default connect( state => {
+	return {
+		user: getCurrentUser( state ),
+		sites: getVisibleSites( state ),
+		domains: getAllDomains( state ),
+	};
+} )( localize( ListAll ) );

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -113,3 +113,7 @@ input[type='radio'].domain-management-list-item__radio {
 		margin-right: 15px;
 	}
 }
+
+.list-all__container .list-all__site {
+	margin-bottom: 10px;
+}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -161,13 +161,17 @@ export default function() {
 		clientRender
 	);
 
-	page(
-		paths.domainManagementRoot(),
-		...getCommonHandlers( { noSitePath: false } ),
-		domainManagementController.domainManagementListAllSites,
-		makeLayout,
-		clientRender
-	);
+	if ( config.isEnabled( 'manage/all-domains' ) ) {
+		page(
+			paths.domainManagementRoot(),
+			...getCommonHandlers( { noSitePath: false } ),
+			domainManagementController.domainManagementListAllSites,
+			makeLayout,
+			clientRender
+		);
+	} else {
+		page( paths.domainManagementRoot(), siteSelection, sites, makeLayout, clientRender );
+	}
 
 	page(
 		paths.domainManagementList( ':site' ),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -161,7 +161,13 @@ export default function() {
 		clientRender
 	);
 
-	page( paths.domainManagementRoot(), siteSelection, sites, makeLayout, clientRender );
+	page(
+		paths.domainManagementRoot(),
+		...getCommonHandlers( { noSitePath: false } ),
+		domainManagementController.domainManagementListAllSites,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		paths.domainManagementList( ':site' ),

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -333,13 +333,14 @@ export class MySitesSidebar extends Component {
 
 	upgrades() {
 		const { path, translate, canUserManageOptions } = this.props;
-		const domainsLink = '/domains/manage' + this.props.siteSuffix;
 
-		if ( ! this.props.siteId ) {
-			return null;
+		let domainsLink = '/domains/manage';
+
+		if ( this.props.siteSuffix ) {
+			domainsLink += this.props.siteSuffix;
 		}
 
-		if ( ! canUserManageOptions ) {
+		if ( this.props.siteId && ! canUserManageOptions ) {
 			return null;
 		}
 
@@ -706,7 +707,6 @@ export class MySitesSidebar extends Component {
 		}
 
 		const tools = !! this.tools() || !! this.marketing() || !! this.earn() || !! this.activity();
-		const manage = !! this.upgrades() || !! this.users() || !! this.siteSettings();
 
 		return (
 			<div className="sidebar__menu-wrapper">
@@ -754,7 +754,7 @@ export class MySitesSidebar extends Component {
 					</ExpandableSidebarMenu>
 				) }
 
-				{ manage && (
+				{
 					<ExpandableSidebarMenu
 						onClick={ this.toggleSection( SIDEBAR_SECTION_MANAGE ) }
 						expanded={ this.props.isManageSectionOpen }
@@ -768,7 +768,7 @@ export class MySitesSidebar extends Component {
 							{ this.siteSettings() }
 						</ul>
 					</ExpandableSidebarMenu>
-				) }
+				}
 
 				{ this.wpAdmin() }
 			</div>

--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -17,6 +17,10 @@ export const getDomainsBySiteId = ( state, siteId ) => {
 	return state.sites.domains.items[ siteId ] || EMPTY_SITE_DOMAINS;
 };
 
+export const getAllDomains = state => {
+	return state.sites.domains.items;
+};
+
 /**
  * Returns the list of site domains for the specified site.
  *

--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -58,6 +58,10 @@ export const isRequestingSiteDomains = ( state, siteId ) => {
 	return state.sites.domains.requesting[ siteId ] || false;
 };
 
+export const getAllRequestingSiteDomains = state => {
+	return state.sites.domains.requesting;
+};
+
 export const isUpdatingDomainPrivacy = ( state, siteId, domain ) => {
 	return state?.sites?.domains?.updatingPrivacy?.[ siteId ]?.[ domain ];
 };

--- a/config/development.json
+++ b/config/development.json
@@ -86,6 +86,7 @@
 		"login/wp-login": true,
 		"happychat": true,
 		"mailchimp": true,
+		"manage/all-domains": true,
 		"manage/comments": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -58,6 +58,7 @@
 		"login/native-login-links": true,
 		"login/wp-login": true,
 		"mailchimp": true,
+		"manage/all-domains": true,
 		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -68,6 +68,7 @@
 		"login/wp-login": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
+		"manage/all-domains": true,
 		"manage/comments": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a new path `/domains/manage` where you can see and manage all your domains in one place

#### Testing instructions

* In My Sites click on "Switch site" in the sidebar navigation and then on "All Sites". Then click on Manage -> Domains - you should see all your domains across all the sites that you can manage. Reload the page, check that all the links work
