### PR TITLE
Adjusted height of sidebar item containing badge

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -98,6 +98,10 @@
 		}
 	}
 
+	.badge {
+		margin: -7px 0 -8px;
+	}
+
 	.selected &,
 	.selected &:hover {
 		color: var( --color-sidebar-menu-selected-text );


### PR DESCRIPTION
##  Description

I noticed that the "New" badge that we added to the "Earn" section left nav menu was causing that menu item to be taller than the rest of the nav options. I fixed it with this one line PR.

**Before**

[![](https://d1czrtm2mp3lak.cloudfront.net/items/0y461R462j3j3Z3l131L/Screen%20Recording%202019-11-27%20at%2002.56%20PM.gif)](https://cl.ly/2ac43c3d210a)

**After**

[![](https://d1czrtm2mp3lak.cloudfront.net/items/3G302u3b0s292a1c3D2W/Screen%20Recording%202019-12-02%20at%2010.54%20AM.gif)](https://cl.ly/15faf601156e)