### PR TITLE
Composite checkout: fix style leaks on stripe fields

### DIFF
--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -110,8 +110,9 @@ const Input = styled.input`
 	box-sizing: border-box;
 	font-size: 16px;
 	border: 1px solid
-		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
-	padding: 13px ${props => ( props.icon ? '60px' : '10px' )} 12px 10px;
+		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )} !important;
+	padding: 12px ${props => ( props.icon ? '60px' : '10px' )} 12px 10px !important;
+	line-height: 1.2 !important;
 
 	:focus {
 		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -109,11 +109,15 @@ const Input = styled.input`
 	width: 100%;
 	box-sizing: border-box;
 	font-size: 16px;
+
 	//override leaky styles with important
-	border: 1px solid
-		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )} !important;
-	padding: 12px ${props => ( props.icon ? '60px' : '10px' )} 12px 10px !important;
-	line-height: 1.2 !important;
+	&[type='text'],
+	&[type='number'] {
+		border: 1px solid
+			${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
+		padding: 13px ${props => ( props.icon ? '60px' : '10px' )} 11px 10px;
+		line-height: 1.2;
+	}
 
 	:focus {
 		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
@@ -125,8 +129,8 @@ const Input = styled.input`
 		-webkit-appearance: none;
 	}
 
-	[type='number'],
-	[type='number'] {
+	&[type='number'],
+	&[type='number'] {
 		-moz-appearance: none;
 		appearance: none;
 	}
@@ -135,7 +139,10 @@ const Input = styled.input`
 		color: ${props => props.theme.colors.placeHolderTextColor};
 	}
 
-	:disabled {
+	&[type='text']:disabled,
+	&[type='number']:disabled {
+		border: 1px solid
+			${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
 		background: ${props => props.theme.colors.disabledField};
 	}
 `;

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -109,6 +109,7 @@ const Input = styled.input`
 	width: 100%;
 	box-sizing: border-box;
 	font-size: 16px;
+	//override leaky styles with important
 	border: 1px solid
 		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )} !important;
 	padding: 12px ${props => ( props.icon ? '60px' : '10px' )} 12px 10px !important;

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -110,7 +110,7 @@ const Input = styled.input`
 	box-sizing: border-box;
 	font-size: 16px;
 
-	//override leaky styles with important
+	//override leaky styles from Calypso
 	&[type='text'],
 	&[type='number'] {
 		border: 1px solid

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -375,10 +375,12 @@ const StripeFieldWrapper = styled.span`
 	.StripeElement {
 		display: block;
 		width: 100%;
+		font-size: 16px;
 		box-sizing: border-box;
 		border: 1px solid
 			${props => ( props.hasError ? props.theme.colors.error : props.theme.colors.borderColor )};
 		padding: 12px 10px;
+		line-height: 1.2;
 	}
 
 	.StripeElement--focus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the styles of our composite checkout fields to prevent leakage from calypso.

**Before**
![Screeny Video Dec 2, 2019 at 10 59 55 AM](https://user-images.githubusercontent.com/6981253/69974351-1202c000-14f3-11ea-9b47-4f5819cfd9da.gif)

**After**
![Screeny Video Dec 2, 2019 at 11 03 59 AM](https://user-images.githubusercontent.com/6981253/69974631-a5d48c00-14f3-11ea-9799-3250103098fe.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit checkout with the store sandboxed. Add the `composite-checkout-wpcom` flag. Keep an eye on the fields as they load. You shouldn't see any flickering.


