### PR TITLE
Composite checkout: update duplicate ID

### DIFF
--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -14,6 +14,7 @@ import Button from './button';
 import { CheckIcon } from './shared-icons';
 
 export default function CheckoutStep( {
+	id,
 	className,
 	stepNumber,
 	title,
@@ -31,6 +32,7 @@ export default function CheckoutStep( {
 		...( isActive ? [ 'checkout-step--is-active' ] : [] ),
 		...( isComplete ? [ 'checkout-step--is-complete' ] : [] ),
 	];
+
 	return (
 		<StepWrapper
 			isActive={ isActive }
@@ -39,6 +41,7 @@ export default function CheckoutStep( {
 			finalStep={ finalStep }
 		>
 			<CheckoutStepHeader
+				id={ id }
 				stepNumber={ stepNumber }
 				title={ title }
 				isActive={ isActive }
@@ -59,6 +62,7 @@ export default function CheckoutStep( {
 }
 
 CheckoutStep.propTypes = {
+	id: PropTypes.string,
 	className: PropTypes.string,
 	stepNumber: PropTypes.number,
 	title: PropTypes.node.isRequired,
@@ -70,6 +74,7 @@ CheckoutStep.propTypes = {
 };
 
 function CheckoutStepHeader( {
+	id,
 	className,
 	stepNumber,
 	title,
@@ -87,7 +92,7 @@ function CheckoutStepHeader( {
 			isActive={ isActive }
 			className={ joinClasses( [ className, 'checkout-step__header' ] ) }
 		>
-			<Stepper isComplete={ isComplete } isActive={ isActive } stepNumber={ stepNumber || 0 }>
+			<Stepper isComplete={ isComplete } isActive={ isActive } id={ id }>
 				{ stepNumber || null }
 			</Stepper>
 			<StepTitle
@@ -112,15 +117,15 @@ function CheckoutStepHeader( {
 }
 
 CheckoutStepHeader.propTypes = {
+	id: PropTypes.string,
 	className: PropTypes.string,
-	stepNumber: PropTypes.number,
 	title: PropTypes.node.isRequired,
 	isActive: PropTypes.bool,
 	isComplete: PropTypes.bool,
 	onEdit: PropTypes.func,
 };
 
-function Stepper( { isComplete, isActive, className, children, stepNumber } ) {
+function Stepper( { isComplete, isActive, className, children, id } ) {
 	// Prevent showing complete stepper when active
 	const isCompleteAndInactive = isActive ? false : isComplete;
 	return (
@@ -130,7 +135,7 @@ function Stepper( { isComplete, isActive, className, children, stepNumber } ) {
 					{ children }
 				</StepNumber>
 				<StepNumberCompleted>
-					<CheckIcon stepNumber={ stepNumber } />
+					<CheckIcon id={ id } />
 				</StepNumberCompleted>
 			</StepNumberInnerWrapper>
 		</StepNumberOuterWrapper>
@@ -138,10 +143,10 @@ function Stepper( { isComplete, isActive, className, children, stepNumber } ) {
 }
 
 Stepper.propTypes = {
+	id: PropTypes.string,
 	className: PropTypes.string,
 	isComplete: PropTypes.bool,
 	isActive: PropTypes.bool,
-	stepNumber: PropTypes.number,
 };
 
 const StepWrapper = styled.div`

--- a/packages/composite-checkout/src/components/checkout-step.js
+++ b/packages/composite-checkout/src/components/checkout-step.js
@@ -87,7 +87,7 @@ function CheckoutStepHeader( {
 			isActive={ isActive }
 			className={ joinClasses( [ className, 'checkout-step__header' ] ) }
 		>
-			<Stepper isComplete={ isComplete } isActive={ isActive }>
+			<Stepper isComplete={ isComplete } isActive={ isActive } stepNumber={ stepNumber || 0 }>
 				{ stepNumber || null }
 			</Stepper>
 			<StepTitle
@@ -120,7 +120,7 @@ CheckoutStepHeader.propTypes = {
 	onEdit: PropTypes.func,
 };
 
-function Stepper( { isComplete, isActive, className, children } ) {
+function Stepper( { isComplete, isActive, className, children, stepNumber } ) {
 	// Prevent showing complete stepper when active
 	const isCompleteAndInactive = isActive ? false : isComplete;
 	return (
@@ -130,7 +130,7 @@ function Stepper( { isComplete, isActive, className, children } ) {
 					{ children }
 				</StepNumber>
 				<StepNumberCompleted>
-					<CheckIcon />
+					<CheckIcon stepNumber={ stepNumber } />
 				</StepNumberCompleted>
 			</StepNumberInnerWrapper>
 		</StepNumberOuterWrapper>
@@ -141,6 +141,7 @@ Stepper.propTypes = {
 	className: PropTypes.string,
 	isComplete: PropTypes.bool,
 	isActive: PropTypes.bool,
+	stepNumber: PropTypes.number,
 };
 
 const StepWrapper = styled.div`

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -177,6 +177,7 @@ function CheckoutStepContainer( {
 		>
 			<RenderedStepProvider stepId={ id }>
 				<CheckoutStep
+					id={ id }
 					className={ className }
 					isActive={ isActive }
 					isComplete={ isComplete }

--- a/packages/composite-checkout/src/components/shared-icons.js
+++ b/packages/composite-checkout/src/components/shared-icons.js
@@ -16,7 +16,7 @@ export function CheckIcon( { className, stepNumber } ) {
 			className={ className }
 		>
 			<mask
-				id={ 'mask' + stepNumber }
+				id={ 'check-icon-mask' + stepNumber }
 				mask-type="alpha"
 				maskUnits="userSpaceOnUse"
 				x="2"
@@ -29,7 +29,7 @@ export function CheckIcon( { className, stepNumber } ) {
 					fill="white"
 				/>
 			</mask>
-			<g mask={ 'url(#mask' + stepNumber + ')' }>
+			<g mask={ 'url(#check-icon-mask' + stepNumber + ')' }>
 				<rect width="20" height="20" fill="white" />
 			</g>
 		</svg>

--- a/packages/composite-checkout/src/components/shared-icons.js
+++ b/packages/composite-checkout/src/components/shared-icons.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function CheckIcon( { className, stepNumber } ) {
+export function CheckIcon( { className, id } ) {
 	return (
 		<svg
 			width="20"
@@ -16,7 +16,7 @@ export function CheckIcon( { className, stepNumber } ) {
 			className={ className }
 		>
 			<mask
-				id={ 'check-icon-mask' + stepNumber }
+				id={ id + '-check-icon-mask' }
 				mask-type="alpha"
 				maskUnits="userSpaceOnUse"
 				x="2"
@@ -29,7 +29,7 @@ export function CheckIcon( { className, stepNumber } ) {
 					fill="white"
 				/>
 			</mask>
-			<g mask={ 'url(#check-icon-mask' + stepNumber + ')' }>
+			<g mask={ 'url(#' + id + '-check-icon-mask)' }>
 				<rect width="20" height="20" fill="white" />
 			</g>
 		</svg>
@@ -38,7 +38,7 @@ export function CheckIcon( { className, stepNumber } ) {
 
 CheckIcon.propTypes = {
 	className: PropTypes.string,
-	stepNumber: PropTypes.number,
+	id: PropTypes.string,
 };
 
 export function ErrorIcon( { className } ) {

--- a/packages/composite-checkout/src/components/shared-icons.js
+++ b/packages/composite-checkout/src/components/shared-icons.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function CheckIcon( { className } ) {
+export function CheckIcon( { className, stepNumber } ) {
 	return (
 		<svg
 			width="20"
@@ -16,7 +16,7 @@ export function CheckIcon( { className } ) {
 			className={ className }
 		>
 			<mask
-				id="mask1"
+				id={ 'mask' + stepNumber }
 				mask-type="alpha"
 				maskUnits="userSpaceOnUse"
 				x="2"
@@ -29,7 +29,7 @@ export function CheckIcon( { className } ) {
 					fill="white"
 				/>
 			</mask>
-			<g mask="url(#mask1)">
+			<g mask={ 'url(#mask' + stepNumber + ')' }>
 				<rect width="20" height="20" fill="white" />
 			</g>
 		</svg>
@@ -38,6 +38,7 @@ export function CheckIcon( { className } ) {
 
 CheckIcon.propTypes = {
 	className: PropTypes.string,
+	stepNumber: PropTypes.number,
 };
 
 export function ErrorIcon( { className } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While running an accessibility report, it came to my attention that we had a duplicate id being used on the checkmark. This PR updates the check icon component to prevent the duplication.

#### Testing instructions
* Get checkout running with the `composite-checkout-wpcom` flag. 
* Go through the steps and check the id for each checkmark to make sure they're unique. 
