### PR TITLE
Customer Home: Adjust layout to use CSS grid with a 12-col layout

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -13,7 +13,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 .checklist__tasks-completed-title {
 	order: 3;
-	margin: 40px 0 8px 25px;
+	margin: 40px 0 8px 16px;
 
 	@include breakpoint( '>660px' ) {
 		margin-left: 0;
@@ -51,12 +51,16 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		display: block;
 		position: absolute;
 		top: 16px;
-		left: 24px;
+		left: 16px;
 		width: 16px;
 		height: 16px;
 		border: 2px solid var( --color-neutral-5 );
 		border-radius: 16px;
 		background: var( --color-surface );
+
+		@include breakpoint( '>660px' ) {
+			left: 24px;
+		}
 
 		.gridicons-checkmark {
 			display: none;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -458,28 +458,32 @@ class Home extends Component {
 								{ translate( 'Make changes to your site or view its current state' ) }
 							</h6>
 							<div className="customer-home__card-col">
-								{ isStaticHomePage ? (
-									<Button
-										href={ editHomePageUrl }
-										primary={ isPrimary }
-										onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
-									>
-										{ translate( 'Edit Homepage' ) }
+								<div className="customer-home__card-col-left">
+									{ isStaticHomePage ? (
+										<Button
+											href={ editHomePageUrl }
+											primary={ isPrimary }
+											onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
+										>
+											{ translate( 'Edit Homepage' ) }
+										</Button>
+									) : (
+										<Button
+											href={ `/post/${ siteSlug }` }
+											primary={ isPrimary }
+											onClick={ () => {
+												trackAction( 'my_site', 'write_post' );
+											} }
+										>
+											{ translate( 'Write Blog Post' ) }
+										</Button>
+									) }
+								</div>
+								<div className="customer-home__card-col-right">
+									<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
+										{ translate( 'View Site' ) }
 									</Button>
-								) : (
-									<Button
-										href={ `/post/${ siteSlug }` }
-										primary={ isPrimary }
-										onClick={ () => {
-											trackAction( 'my_site', 'write_post' );
-										} }
-									>
-										{ translate( 'Write Blog Post' ) }
-									</Button>
-								) }
-								<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
-									{ translate( 'View Site' ) }
-								</Button>
+								</div>
 							</div>
 						</Card>
 					) }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -241,7 +241,6 @@ class Home extends Component {
 		// Show the standard heading otherwise
 		return (
 			<FormattedHeader
-				className="customer-home__page-heading"
 				headerText={ translate( 'My Home' ) }
 				subHeaderText={ translate(
 					'Your home base for all the posting, editing, and growing of your site'
@@ -279,7 +278,7 @@ class Home extends Component {
 				<DocumentHead title={ translate( 'Customer Home' ) } />
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				<SidebarNavigation />
-				{ this.renderCustomerHomeHeader() }
+				<div className="customer-home__page-heading">{ this.renderCustomerHomeHeader() }</div>
 				{ //Only show upgrade nudges to sites > 2 days old
 				isEstablishedSite && (
 					<div class="customer-home__upsells">

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -281,7 +281,7 @@ class Home extends Component {
 				<div className="customer-home__page-heading">{ this.renderCustomerHomeHeader() }</div>
 				{ //Only show upgrade nudges to sites > 2 days old
 				isEstablishedSite && (
-					<div class="customer-home__upsells">
+					<div className="customer-home__upsells">
 						<StatsBanners
 							siteId={ siteId }
 							slug={ siteSlug }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -458,32 +458,28 @@ class Home extends Component {
 								{ translate( 'Make changes to your site or view its current state' ) }
 							</h6>
 							<div className="customer-home__card-col">
-								<div className="customer-home__card-col-left">
-									{ isStaticHomePage ? (
-										<Button
-											href={ editHomePageUrl }
-											primary={ isPrimary }
-											onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
-										>
-											{ translate( 'Edit Homepage' ) }
-										</Button>
-									) : (
-										<Button
-											href={ `/post/${ siteSlug }` }
-											primary={ isPrimary }
-											onClick={ () => {
-												trackAction( 'my_site', 'write_post' );
-											} }
-										>
-											{ translate( 'Write Blog Post' ) }
-										</Button>
-									) }
-								</div>
-								<div className="customer-home__card-col-right">
-									<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
-										{ translate( 'View Site' ) }
+								{ isStaticHomePage ? (
+									<Button
+										href={ editHomePageUrl }
+										primary={ isPrimary }
+										onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
+									>
+										{ translate( 'Edit Homepage' ) }
 									</Button>
-								</div>
+								) : (
+									<Button
+										href={ `/post/${ siteSlug }` }
+										primary={ isPrimary }
+										onClick={ () => {
+											trackAction( 'my_site', 'write_post' );
+										} }
+									>
+										{ translate( 'Write Blog Post' ) }
+									</Button>
+								) }
+								<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
+									{ translate( 'View Site' ) }
+								</Button>
 							</div>
 						</Card>
 					) }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -282,11 +282,13 @@ class Home extends Component {
 				{ this.renderCustomerHomeHeader() }
 				{ //Only show upgrade nudges to sites > 2 days old
 				isEstablishedSite && (
-					<StatsBanners
-						siteId={ siteId }
-						slug={ siteSlug }
-						primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }
-					/>
+					<div class="customer-home__upsells">
+						<StatsBanners
+							siteId={ siteId }
+							slug={ siteSlug }
+							primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }
+						/>
+					</div>
 				) }
 				{ renderChecklistCompleteBanner && (
 					<Banner

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -6,7 +6,7 @@
 @mixin grid-template-columns( $cols, $gap, $fr ) {
 	-ms-grid-columns: $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr;
 	grid-template-columns: repeat( $cols, [col-start] minmax( 0, $fr ) );
-	grid-gap: $gap;
+	grid-column-gap: $gap;
 }
 @mixin grid-column( $col-start, $span ) {
 	-ms-grid-column: $col-start * 2 - 1;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -19,7 +19,7 @@
 		@include breakpoint( '>1040px' ) {
 			@include display-grid;
 			// stylelint-disable-next-line unit-whitelist
-			@include grid-template-columns( 12, 0, 1fr );
+			@include grid-template-columns( 12, 24px, 1fr );
 		}
 	}
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -186,7 +186,7 @@
 	}
 	&__layout-col-left {
 		@include breakpoint( '>960px' ) {
-			width: 60%;
+			width: 70%;
 
 			.card,
 			.checklist__tasks {
@@ -210,7 +210,7 @@
 		}
 
 		@include breakpoint( '>960px' ) {
-			width: 40%;
+			width: 30%;
 
 			.card {
 				margin-left: 8px;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -4,6 +4,7 @@
 		@include breakpoint( '>1040px' ) {
 			display: grid;
 			grid-gap: 0;
+			// stylelint-disable-next-line unit-whitelist
 			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
 		}
 	}
@@ -188,6 +189,7 @@
 			grid-column: 1 / span 12;
 			display: grid;
 			grid-gap: 24px;
+			// stylelint-disable-next-line unit-whitelist
 			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
 		}
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -163,16 +163,8 @@
 	&__card-mobile {
 		display: flex;
 
-		@include breakpoint( '>1040px' ) {
-			flex-direction: column;
-		}
-
 		.get-apps__app-badge.android-app-badge img {
 			margin-top: 0;
-
-			@include breakpoint( '>1040px' ) {
-				margin: 0 0 0 -9px;
-			}
 		}
 	}
 	&__card-subheader {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -9,7 +9,7 @@
 	grid-gap: $gap;
 }
 @mixin grid-column( $col-start, $span ) {
-	-ms-grid-column: $col-start;
+	-ms-grid-column: $col-start * 2 - 1;
 	-ms-grid-column-span: $span + ($span - 1);
 		grid-column: $col-start / span $span;
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,15 +1,21 @@
 
 .customer-home {
-
 	&__main {
-		display: grid;
-		grid-gap: 0;
-		grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
+		@include breakpoint( '>1040px' ) {
+			display: grid;
+			grid-gap: 0;
+			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
+		}
 	}
 
 	&__page-heading.formatted-header.is-left-align {
-		grid-column: 2 / span 10;
-		margin: 0;
+		@include breakpoint( '>1040px' ) {
+			grid-column: 1 / span 12;
+			margin: 0;
+		}
+		@include breakpoint( '>1280px' ) {
+			grid-column: 2 / span 10;
+		}
 	}
 	&__confetti {
 		display: block;
@@ -157,7 +163,19 @@
 		}
 	}
 	&__card-mobile {
-		justify-content: space-around;
+		display: flex;
+
+		@include breakpoint( '>1280px' ) {
+			flex-direction: column;
+		}
+
+		.get-apps__app-badge.android-app-badge img {
+			margin-top: 0;
+
+			@include breakpoint( '>1280px' ) {
+				margin: 0 0 0 -9px;
+			}
+		}
 	}
 	&__card-subheader {
 		color: var( --color-text-subtle );
@@ -169,12 +187,15 @@
 		padding-bottom: 12px;
 	}
 	&__layout {
-
-		grid-column: 2 / span 10;
-
-		@include breakpoint( '>960px' ) {
+		@include breakpoint( '>1040px' ) {
+			grid-column: 1 / span 12;
 			display: grid;
 			grid-gap: 24px;
+			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
+		}
+
+		@include breakpoint( '>1280px' ) {
+			grid-column: 2 / span 10;
 			grid-template-columns: repeat( 10, [col-start] minmax( 0, 1fr ) );
 		}
 
@@ -200,7 +221,10 @@
 		}
 	}
 	&__layout-col-left {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint( '>1040px' ) {
+			grid-column: 1 / span 8;
+		}
+		@include breakpoint( '>1280px' ) {
 			grid-column: 1 / span 7;
 		}
 	}
@@ -218,30 +242,16 @@
 				right: 0;
 			}
 		}
-
-		@include breakpoint( '>960px' ) {
+		@include breakpoint( '>1040px' ) {
+			grid-column: 9 / span 4;
+		}
+		@include breakpoint( '>1280px' ) {
 			grid-column: 8 / span 3;
 		}
 	}
 
 	&__loading-placeholder {
 		@include placeholder();
-	}
-}
-
-.get-apps__app-badge {
-	display: inline-block;
-
-	@include breakpoint( '>960px' ) {
-		img {
-			max-height: 41px;
-			margin: 0;
-			width: auto;
-		}
-
-		&.android-app-badge img {
-			max-height: 63px;
-			margin-left: -9px;
-		}
+		grid-column: 1 / span 12;
 	}
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -13,9 +13,6 @@
 			grid-column: 1 / span 12;
 			margin: 0;
 		}
-		@include breakpoint( '>1280px' ) {
-			grid-column: 2 / span 10;
-		}
 	}
 	&__confetti {
 		display: block;
@@ -165,14 +162,14 @@
 	&__card-mobile {
 		display: flex;
 
-		@include breakpoint( '>1280px' ) {
+		@include breakpoint( '>1040px' ) {
 			flex-direction: column;
 		}
 
 		.get-apps__app-badge.android-app-badge img {
 			margin-top: 0;
 
-			@include breakpoint( '>1280px' ) {
+			@include breakpoint( '>1040px' ) {
 				margin: 0 0 0 -9px;
 			}
 		}
@@ -192,11 +189,6 @@
 			display: grid;
 			grid-gap: 24px;
 			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
-		}
-
-		@include breakpoint( '>1280px' ) {
-			grid-column: 2 / span 10;
-			grid-template-columns: repeat( 10, [col-start] minmax( 0, 1fr ) );
 		}
 
 		.checklist__tasks {
@@ -224,9 +216,6 @@
 		@include breakpoint( '>1040px' ) {
 			grid-column: 1 / span 8;
 		}
-		@include breakpoint( '>1280px' ) {
-			grid-column: 1 / span 7;
-		}
 	}
 	&__layout-col-right {
 		.vertical-nav {
@@ -244,9 +233,6 @@
 		}
 		@include breakpoint( '>1040px' ) {
 			grid-column: 9 / span 4;
-		}
-		@include breakpoint( '>1280px' ) {
-			grid-column: 8 / span 3;
 		}
 	}
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -8,6 +8,11 @@
 	grid-template-columns: repeat( $cols, [col-start] minmax( 0, $fr ) );
 	grid-column-gap: $gap;
 }
+@mixin grid-row( $row-start, $span ) {
+	-ms-grid-row: $row-start;
+	-ms-grid-row-span: $span;
+		grid-row: $row-start / span $span;
+}
 @mixin grid-column( $col-start, $span ) {
 	-ms-grid-column: $col-start * 2 - 1;
 	-ms-grid-column-span: $span + ($span - 1);
@@ -28,6 +33,7 @@
 	}
 
 	&__page-heading {
+		@include grid-row( 1, 1 );
 		@include breakpoint( '>1040px' ) {
 			@include grid-column( 1, 12 );
 			margin: 0;
@@ -195,6 +201,7 @@
 		padding-bottom: 12px;
 	}
 	&__layout {
+		@include grid-row( 2, 1 );
 		@include breakpoint( '>1040px' ) {
 			@include grid-column( 1, 12 );
 			@include display-grid;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,3 +1,4 @@
+
 .customer-home {
 	&__confetti {
 		display: block;
@@ -87,7 +88,7 @@
 		}
 	}
 	&__card-col-left {
-		margin-bottom: 16px;
+		margin-bottom: 24px;
 		width: 100%;
 
 		@mixin card-col-left-two-col {
@@ -122,14 +123,6 @@
 			@include card-col-right-two-col;
 		}
 	}
-	&__card-mobile {
-		justify-content: space-around;
-	}
-	&__card-subheader {
-		color: var( --color-text-subtle );
-		font-size: 0.85rem;
-		margin: -0.5rem 0 1rem;
-	}
 	&__card-support {
 		display: flex;
 		justify-content: space-between;
@@ -139,7 +132,7 @@
 			width: 137px;
 			height: 119px;
 
-			@include breakpoint( '960px-1040px' ) {
+			@include breakpoint( '>960px' ) {
 				display: none;
 			}
 		}
@@ -147,24 +140,33 @@
 		.vertical-nav {
 			width: 60%;
 
-			@include breakpoint( '960px-1040px' ) {
+			@include breakpoint( '>960px' ) {
 				width: 100%;
 			}
 		}
+	}
+	&__card-mobile {
+		justify-content: space-around;
+	}
+	&__card-subheader {
+		color: var( --color-text-subtle );
+		font-size: 0.85rem;
+		margin: -0.5rem 0 1rem;
 	}
 	&__go-mobile,
 	&__grow-earn {
 		padding-bottom: 12px;
 	}
 	&__layout {
+
 		@include breakpoint( '>960px' ) {
-			display: flex;
-			justify-content: space-between;
-			flex-wrap: wrap;
+			display: grid;
+			grid-gap: 24px;
+			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
 		}
 
 		.checklist__tasks {
-			margin-bottom: 8px;
+			margin-bottom: 16px;
 
 			&-completed-title {
 				margin-top: 24px;
@@ -186,12 +188,7 @@
 	}
 	&__layout-col-left {
 		@include breakpoint( '>960px' ) {
-			width: 70%;
-
-			.card,
-			.checklist__tasks {
-				margin-right: 8px;
-			}
+			grid-column: 1 / span 9;
 		}
 	}
 	&__layout-col-right {
@@ -210,20 +207,7 @@
 		}
 
 		@include breakpoint( '>960px' ) {
-			width: 30%;
-
-			.card {
-				margin-left: 8px;
-			}
-
-			.card.vertical-nav-item {
-				margin-left: 0;
-			}
-		}
-		@include breakpoint( '960px-1040px' ) {
-			.android-app-badge {
-				margin-left: -8px;
-			}
+			grid-column: 10 / span 3;
 		}
 	}
 
@@ -234,21 +218,17 @@
 
 .get-apps__app-badge {
 	display: inline-block;
-	img {
-		max-height: 41px;
-		margin: 9px 0;
-		width: auto;
-	}
 
-	&.android-app-badge {
+	@include breakpoint( '>960px' ) {
 		img {
-			max-height: 59px;
-			margin-top: 0;
-			margin-bottom: 0;
-			margin-right: 0;
+			max-height: 41px;
+			margin: 0;
+			width: auto;
 		}
-		& + .ios-app-badge img {
-			margin-left: 0;
+
+		&.android-app-badge img {
+			max-height: 63px;
+			margin-left: -9px;
 		}
 	}
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -94,10 +94,10 @@
 				width: auto;
 			}
 		}
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint( '>1280px' ) {
 			@include card-col-two-col;
 		}
-		@include breakpoint( '800px-960px' ) {
+		@include breakpoint( '800px-1040px' ) {
 			@include card-col-two-col;
 		}
 	}
@@ -113,10 +113,10 @@
 				margin-right: 6px;
 			}
 		}
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint( '>1280px' ) {
 			@include card-col-left-two-col;
 		}
-		@include breakpoint( '800px-960px' ) {
+		@include breakpoint( '800px-1040px' ) {
 			@include card-col-left-two-col;
 		}
 	}
@@ -130,10 +130,10 @@
 				margin-left: 6px;
 			}
 		}
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint( '>1280px' ) {
 			@include card-col-right-two-col;
 		}
-		@include breakpoint( '800px-960px' ) {
+		@include breakpoint( '800px-1040px' ) {
 			@include card-col-right-two-col;
 		}
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,5 +1,16 @@
 
 .customer-home {
+
+	&__main {
+		display: grid;
+		grid-gap: 0;
+		grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
+	}
+
+	&__page-heading.formatted-header.is-left-align {
+		grid-column: 2 / span 10;
+		margin: 0;
+	}
 	&__confetti {
 		display: block;
 		width: 320px;
@@ -159,10 +170,12 @@
 	}
 	&__layout {
 
+		grid-column: 2 / span 10;
+
 		@include breakpoint( '>960px' ) {
 			display: grid;
 			grid-gap: 24px;
-			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
+			grid-template-columns: repeat( 10, [col-start] minmax( 0, 1fr ) );
 		}
 
 		.checklist__tasks {
@@ -188,7 +201,7 @@
 	}
 	&__layout-col-left {
 		@include breakpoint( '>960px' ) {
-			grid-column: 1 / span 9;
+			grid-column: 1 / span 7;
 		}
 	}
 	&__layout-col-right {
@@ -207,7 +220,7 @@
 		}
 
 		@include breakpoint( '>960px' ) {
-			grid-column: 10 / span 3;
+			grid-column: 8 / span 3;
 		}
 	}
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -13,9 +13,9 @@
 		grid-column: span 12;
 	}
 
-	&__page-heading.formatted-header.is-left-align {
+	&__page-heading {
 		@include breakpoint( '>1040px' ) {
-			grid-column: 1 / span 12;
+			grid-column: span 12;
 			margin: 0;
 		}
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -9,6 +9,10 @@
 		}
 	}
 
+	&__upsells {
+		grid-column: span 12;
+	}
+
 	&__page-heading.formatted-header.is-left-align {
 		@include breakpoint( '>1040px' ) {
 			grid-column: 1 / span 12;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -186,20 +186,8 @@
 	}
 	&__card-mobile {
 		display: flex;
-
-		.get-apps__app-badge {
-			margin: 0 9px 0 0;
-
-			img {
-				margin: 0;
-			}
-
-			&.android-app-badge img {
-				position: relative;
-				top: -16%;
-				left: -6.1919%;
-			}
-		}
+		flex-direction: row;
+		align-items: center;
 	}
 	&__card-subheader {
 		color: var( --color-text-subtle );

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,21 +1,35 @@
 
+@mixin display-grid {
+	display: -ms-grid;
+	display: grid;
+}
+@mixin grid-template-columns( $cols, $gap, $fr ) {
+	-ms-grid-columns: $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr;
+	grid-template-columns: repeat( $cols, [col-start] minmax( 0, $fr ) );
+	grid-gap: $gap;
+}
+@mixin grid-column( $col-start, $span ) {
+	-ms-grid-column: $col-start;
+	-ms-grid-column-span: $span + ($span - 1);
+		grid-column: $col-start / span $span;
+}
+
 .customer-home {
 	&__main {
 		@include breakpoint( '>1040px' ) {
-			display: grid;
-			grid-gap: 0;
+			@include display-grid;
 			// stylelint-disable-next-line unit-whitelist
-			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
+			@include grid-template-columns( 12, 0, 1fr );
 		}
 	}
 
 	&__upsells {
-		grid-column: span 12;
+		@include grid-column( 1, 12 );
 	}
 
 	&__page-heading {
 		@include breakpoint( '>1040px' ) {
-			grid-column: span 12;
+			@include grid-column( 1, 12 );
 			margin: 0;
 		}
 	}
@@ -182,11 +196,11 @@
 	}
 	&__layout {
 		@include breakpoint( '>1040px' ) {
-			grid-column: 1 / span 12;
-			display: grid;
-			grid-gap: 24px;
+			@include grid-column( 1, 12 );
+			@include display-grid;
 			// stylelint-disable-next-line unit-whitelist
-			grid-template-columns: repeat( 12, [col-start] minmax( 0, 1fr ) );
+			@include grid-template-columns( 12, 24px, 1fr );
+			grid-gap: 24px;
 		}
 
 		.checklist__tasks {
@@ -212,7 +226,7 @@
 	}
 	&__layout-col-left {
 		@include breakpoint( '>1040px' ) {
-			grid-column: 1 / span 8;
+			@include grid-column( 1, 8 );
 		}
 	}
 	&__layout-col-right {
@@ -230,12 +244,12 @@
 			}
 		}
 		@include breakpoint( '>1040px' ) {
-			grid-column: 9 / span 4;
+			@include grid-column( 9, 4 );
 		}
 	}
 
 	&__loading-placeholder {
 		@include placeholder();
-		grid-column: 1 / span 12;
+		@include grid-column( 1, 12 );
 	}
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -187,8 +187,18 @@
 	&__card-mobile {
 		display: flex;
 
-		.get-apps__app-badge.android-app-badge img {
-			margin-top: 0;
+		.get-apps__app-badge {
+			margin: 0 9px 0 0;
+
+			img {
+				margin: 0;
+			}
+
+			&.android-app-badge img {
+				position: relative;
+				top: -16%;
+				left: -6.1919%;
+			}
 		}
 	}
 	&__card-subheader {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Attempt to apply @jffng 's work with CSS grid to Customer Home; 12 columns with a 24px gap.
* Adjusts columns to 8 / 4 rather than 60%/40%.
* Removes the Support illustration on large screens due to lack of space in that column

**Before**

<img width="1117" alt="Screen Shot 2019-12-02 at 2 29 03 PM" src="https://user-images.githubusercontent.com/2124984/69988817-65cfd200-1510-11ea-98ff-0d2d534fa557.png">

**After**

<img width="1675" alt="Screen Shot 2019-12-03 at 6 00 51 PM" src="https://user-images.githubusercontent.com/2124984/70097419-5a0b0b00-15f7-11ea-8322-ff2f73818690.png">

#### Testing instructions

* Switch to this PR and start a new site from `/start/test-fse`
* Create your site and you'll be brought to the Customer Home screen
* Check the design on multiple screen sizes to make sure nothing breaks as a result of the changes.
* Needs to be tested in IE since grid support is usually spotty there.