### PR TITLE
[e2e] Use different domain for mapping

### DIFF
--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -123,7 +123,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 	} );
 
 	describe( 'Map a domain to an existing site @parallel', function() {
-		const blogName = 'go.com';
+		const blogName = 'nature.com';
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Test `Map a domain to an existing site` is failing because domain `go.com`, which we are using for this test, is already mapped to the test site. I changed it to `nature.com` and test should work as usual. 
