### PR TITLE
[e2e] Fix failing Activate theme test

### DIFF
--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -100,7 +100,6 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async clearSearch() {
-		await this.openShowcase();
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			by.css( '.themes-magic-search-card__icon-close' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Test `Activate a theme @parallel` started with [failing](https://circleci.com/gh/Automattic/wp-e2e-tests-for-branches/36207) after https://github.com/Automattic/wp-calypso/pull/38107 was merged. With this fix it should work as usual. 

#### Testing instructions

Make sure that tests are green in CircleCI