### PR TITLE
Customer Home: Only show upgrade nudges (StatsBanners) for sites > 2 days

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { flowRight } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -229,6 +230,7 @@ class Home extends Component {
 			siteId,
 			isChecklistComplete,
 			siteIsUnlaunched,
+			isEstablishedSite,
 		} = this.props;
 
 		if ( ! canUserUseCustomerHome ) {
@@ -249,11 +251,14 @@ class Home extends Component {
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				<SidebarNavigation />
 				{ this.renderCustomerHomeHeader() }
-				<StatsBanners
-					siteId={ siteId }
-					slug={ siteSlug }
-					primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }
-				/>
+				{ //Only show upgrade nudges to sites > 2 days old
+				isEstablishedSite && (
+					<StatsBanners
+						siteId={ siteId }
+						slug={ siteSlug }
+						primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }
+					/>
+				) }
 				{ renderChecklistCompleteBanner && (
 					<Banner
 						dismissPreferenceName="checklist-complete"
@@ -554,6 +559,7 @@ const connectHome = connect(
 
 		const isAtomic = isAtomicSite( state, siteId );
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
+		const createdAt = getSiteOption( state, siteId, 'created_at' );
 
 		return {
 			// For now we are hiding the checklist on Atomic sites see pb5gDS-7c-p2 for more information
@@ -571,6 +577,7 @@ const connectHome = connect(
 			isStaticHomePage: 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 			siteHasPaidPlan: isSiteOnPaidPlan( state, siteId ),
 			isNewlyCreatedSite: isNewSite( state, siteId ),
+			isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
 			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 			staticHomePageId: getSiteFrontPage( state, siteId ),
 			showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only show upgrade nudges (like GSuite) when a site is greater than two days old.
* This only affects Customer Home, not the visibility of the StatsBanners on the Stats page.

Site older than 2 days:

<img width="1112" alt="Screen Shot 2019-12-02 at 5 30 04 PM" src="https://user-images.githubusercontent.com/2124984/70000643-6cb70e80-1529-11ea-8a1e-0db475f6e94c.png">

Site just created:

<img width="1120" alt="Screen Shot 2019-12-02 at 5 30 53 PM" src="https://user-images.githubusercontent.com/2124984/70000700-82c4cf00-1529-11ea-8d47-29371399c34a.png">


#### Testing instructions

* Switch to this PR
* Create a new site from `/start/test-fse`
* Go to Customer Home at `/home/`
* You should not see any upgrade nudges above the checklist.
* Check Customer Home for an established site > 2 days old. If you haven't already dismissed them, you should see the upgrade nudges above the checklist.

Fixes #37273