### PR TITLE
Migration: resolve confirmation path ambiguity

### DIFF
--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -8,11 +8,15 @@ import page from 'page';
  * Internal Dependencies
  */
 import SectionMigrate from 'my-sites/migrate/section-migrate';
+import getSiteId from 'state/selectors/get-site-id';
 import { isEnabled } from 'config';
 
 export function migrateSite( context, next ) {
 	if ( isEnabled( 'tools/migrate' ) ) {
-		context.primary = <SectionMigrate sourceSiteId={ context.params.sourceSiteId || null } />;
+		const sourceSiteId =
+			context.params.sourceSiteId &&
+			getSiteId( context.store.getState(), context.params.sourceSiteId );
+		context.primary = <SectionMigrate sourceSiteId={ sourceSiteId } />;
 		return next();
 	}
 

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import page from 'page';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,7 +12,18 @@ import { makeLayout, render as clientRender } from 'controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'my-sites/controller';
 
 export default function() {
-	page( '/migrate', siteSelection, navigation, sites, makeLayout, clientRender );
+	page(
+		'/migrate',
+		( context, next ) => {
+			context.getSiteSelectionHeaderText = () => i18n.translate( 'Select a site to migrate to' );
+			next();
+		},
+		siteSelection,
+		navigation,
+		sites,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/migrate/:site_id',
@@ -32,4 +44,7 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
+
+	// Fallback to handle /migrate/* routes that aren't previously matched
+	page( '/migrate/*', () => page.redirect( '/migrate' ) );
 }

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -24,7 +24,7 @@ export default function() {
 	);
 
 	page(
-		'/migrate/:sourceSiteId/:site_id',
+		'/migrate/from/:sourceSiteId/to/:site_id',
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/migrate' ),

--- a/client/my-sites/migrate/section-migrate.js
+++ b/client/my-sites/migrate/section-migrate.js
@@ -65,7 +65,7 @@ class SectionMigrate extends Component {
 	};
 
 	setSourceSiteId = sourceSiteId => {
-		page( `/migrate/${ sourceSiteId }/${ this.props.targetSiteSlug }` );
+		this.props.navigateToSelectedSourceSite( sourceSiteId );
 	};
 
 	startMigration = () => {
@@ -277,15 +277,27 @@ class SectionMigrate extends Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const targetSiteId = getSelectedSiteId( state );
-	return {
-		isTargetSiteAtomic: !! isSiteAutomatedTransfer( state, targetSiteId ),
-		isTargetSiteJetpack: !! isJetpackSite( state, targetSiteId ),
-		sourceSite: ownProps.sourceSiteId && getSite( state, ownProps.sourceSiteId ),
-		targetSite: getSelectedSite( state ),
-		targetSiteId,
-		targetSiteImportAdminUrl: getSiteAdminUrl( state, targetSiteId, 'import.php' ),
-		targetSiteSlug: getSelectedSiteSlug( state ),
-	};
-} )( localize( SectionMigrate ) );
+const navigateToSelectedSourceSite = sourceSiteId => ( dispatch, getState ) => {
+	const state = getState();
+	const sourceSite = getSite( state, sourceSiteId );
+	const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
+	const targetSiteSlug = getSelectedSiteSlug( state );
+
+	page( `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }` );
+};
+
+export default connect(
+	( state, ownProps ) => {
+		const targetSiteId = getSelectedSiteId( state );
+		return {
+			isTargetSiteAtomic: !! isSiteAutomatedTransfer( state, targetSiteId ),
+			isTargetSiteJetpack: !! isJetpackSite( state, targetSiteId ),
+			sourceSite: ownProps.sourceSiteId && getSite( state, ownProps.sourceSiteId ),
+			targetSite: getSelectedSite( state ),
+			targetSiteId,
+			targetSiteImportAdminUrl: getSiteAdminUrl( state, targetSiteId, 'import.php' ),
+			targetSiteSlug: getSelectedSiteSlug( state ),
+		};
+	},
+	{ navigateToSelectedSourceSite }
+)( localize( SectionMigrate ) );


### PR DESCRIPTION
Note: This change is behind a feature-flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

Prior to this PR, the path for source-site selection for migration was `/migrate/:targetSiteSlug`. Upon selecting the target site, the path would update for confirmation of the selected source site to `/migrate/:sourceSiteId/:targetSiteSlug`. This had a few problems. One, if the sites list wasn't fully hydrated, `redirectWithoutSite` would cause a redirection to `/migrate/:sourceSiteId?site=:targetSiteSlug`. Since `/migrate/:sourceSiteId` resembled the `/migrate/:targetSiteSlug` path, that path was rendered, displaying a selector for the target site. Two, the combination of ID and slug in the URL doesn't look as nice as using slug for both the source and target site.

This PR updates the path for confirmation of the source-site to `/migrate/from/:sourceSiteSlug/to/:targetSiteSlug`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this pull request and run Calypso locally, or view it on calypso.live with the flag `tools/migrate`.
* Viewing calypso.localhost:3000/migrate/, you should see a `SiteSelector` component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another `SiteSelector` component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen, and the URL should be updated to match the `/migrate/from/:sourceSiteSlug/to/:targetSiteSlug` pattern.
