### PR TITLE
[e2e] Additional step to check is account closed

### DIFF
--- a/test/e2e/lib/flows/delete-account-flow.js
+++ b/test/e2e/lib/flows/delete-account-flow.js
@@ -19,6 +19,7 @@ export default class DeleteAccountFlow {
 			const closeAccountPage = await CloseAccountPage.Expect( this.driver );
 			await closeAccountPage.chooseCloseAccount();
 			await closeAccountPage.enterAccountNameAndClose( name );
+			await closeAccountPage.ConfirmAccountHasBeenClosed();
 			return await LoggedOutMasterbarComponent.Expect( this.driver );
 		} )().catch( err => {
 			SlackNotifier.warn(

--- a/test/e2e/lib/pages/account/account-settings-page.js
+++ b/test/e2e/lib/pages/account/account-settings-page.js
@@ -16,10 +16,9 @@ export default class AccountSettingsPage extends AsyncBaseContainer {
 	}
 
 	async chooseCloseYourAccount() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			by.css( '.account__settings-close' )
-		);
+		const closeAccountSelector = by.css( '.account__settings-close' );
+		await driverHelper.scrollIntoView( this.driver, closeAccountSelector, 'end' );
+		return await driverHelper.clickWhenClickable( this.driver, closeAccountSelector );
 	}
 
 	async getUsername() {

--- a/test/e2e/lib/pages/account/close-account-page.js
+++ b/test/e2e/lib/pages/account/close-account-page.js
@@ -52,4 +52,13 @@ export default class CloseAccountPage extends AsyncBaseContainer {
 			by.css( '.dialog button.is-scary' )
 		);
 	}
+
+	async ConfirmAccountHasBeenClosed() {
+		await driverHelper.verifyTextPresent(
+			this.driver,
+			by.css( '.empty-content__title' ),
+			'Your account has been closed'
+		);
+		return driverHelper.clickWhenClickable( this.driver, by.css( 'button.empty-content__action' ) );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As introduced in the PR https://github.com/Automattic/wp-calypso/pull/37688 closing account now has one additional screen - empty screen with `Your account has been closed` message and `Return to WordPress.com` button. This affects e2e tests when they try to delete the account. Tests didn't fail because `deleteAccount` flow is in the `after` block. 

I added one more check - verify `Your account has been closed` screen and click on the button to return to WordPress.com.

#### Testing instructions

Make sure that tests are green. 