### PR TITLE
Recurring Payments: In-app nudge

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -86,6 +86,7 @@ $z-layers: (
 		'.comment-detail.card.accessible-focus:focus': 1,
 		'.web-preview__inner .spinner-line': 1,
 		'.google-my-business__close-icon': 1,
+		'.recurring-payments-nudge__close-icon': 1,
 		'.google-my-business__stats-nudge.dismissible-card__close-icon': 1,
 		'.is-section-purchases .search': 1,
 		'.editor-sidebar': 2,

--- a/client/blocks/recurring-payments-stats-nudge/actions.js
+++ b/client/blocks/recurring-payments-stats-nudge/actions.js
@@ -1,0 +1,26 @@
+/**
+ * Internal Dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { savePreference } from 'state/preferences/actions';
+
+export const dismissNudge = () => ( dispatch, getState ) => {
+	const siteId = getSelectedSiteId( getState() );
+	const preference = getPreference( getState(), 'recurring-payments-dismissible-nudge' ) || {};
+
+	return dispatch(
+		savePreference( 'recurring-payments-dismissible-nudge', {
+			...preference,
+			...{
+				[ siteId ]: [
+					...( preference[ siteId ] || [] ),
+					{
+						dismissedAt: Date.now(),
+						type: 'dismiss',
+					},
+				],
+			},
+		} )
+	);
+};

--- a/client/blocks/recurring-payments-stats-nudge/index.js
+++ b/client/blocks/recurring-payments-stats-nudge/index.js
@@ -33,6 +33,7 @@ class RecurringPaymentsStatsNudge extends Component {
 		siteId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		primaryButton: PropTypes.bool.isRequired,
 	};
 
 	componentDidMount() {

--- a/client/blocks/recurring-payments-stats-nudge/index.js
+++ b/client/blocks/recurring-payments-stats-nudge/index.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Internal Dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import isRecurringPaymentsStatsNudgeDismissed from 'state/selectors/is-recurring-payments-stats-nudge-dismissed';
+import QueryPreferences from 'components/data/query-preferences';
+import SectionHeader from 'components/section-header';
+import { dismissNudge } from './actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { withEnhancers } from 'state/utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class RecurringPaymentsStatsNudge extends Component {
+	static propTypes = {
+		isDismissed: PropTypes.bool.isRequired,
+		plan: PropTypes.object,
+		recordTracksEvent: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		siteSlug: PropTypes.string.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		this.recordView();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteId && this.props.siteId && this.props.siteId !== prevProps.siteId ) {
+			this.recordView();
+		}
+	}
+
+	recordView() {
+		if ( this.isVisible() ) {
+			this.props.recordTracksEvent( 'calypso_recurring_payments_stats_nudge_view' );
+		}
+	}
+
+	recordClick = eventName => {
+		const plan = this.props.plan ? this.props.plan.productSlug : '';
+
+		this.props.recordTracksEvent( eventName, { plan } );
+	};
+
+	onDismissClick = () => {
+		this.recordClick( 'calypso_recurring_payments_stats_nudge_dismiss_icon_click' );
+		this.props.dismissNudge();
+	};
+
+	onStartNowClick = () => {
+		this.recordClick( 'calypso_recurring_payments_stats_nudge_start_now_button_click' );
+	};
+
+	isVisible() {
+		return ! this.props.isDismissed;
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		if ( ! this.isVisible() ) {
+			return null;
+		}
+
+		return (
+			<Card className="recurring-payments-stats-nudge">
+				<QueryPreferences />
+
+				<Gridicon
+					icon="cross"
+					className="recurring-payments-stats-nudge__close-icon"
+					onClick={ this.onDismissClick }
+				/>
+
+				<SectionHeader
+					className="recurring-payments-stats-nudge__header"
+					label={ translate( 'Recommendations from WordPress.com' ) }
+				/>
+
+				<div className="recurring-payments-stats-nudge__body">
+					<div className="recurring-payments-stats-nudge__image-wrapper">
+						<img
+							className="recurring-payments-stats-nudge__image"
+							src="/calypso/images/earn/earn-section.svg"
+							alt={ translate( 'Collect recurring revenue with Recurring Payments' ) }
+						/>
+					</div>
+
+					<div className="recurring-payments-stats-nudge__info">
+						<h1 className="recurring-payments-stats-nudge__title">
+							{ translate( "There's a new way to Earn on WordPress.com" ) }
+						</h1>
+						<p>
+							{ translate(
+								'Use Recurring Payments to collect regular monthly or yearly contributions from your customers and fans.'
+							) }
+						</p>
+						<p>{ translate( 'Sustain your work and your site with a reliable income stream!' ) }</p>
+						<div className="recurring-payments-stats-nudge__button-row">
+							<Button
+								href={ `/earn/payments/${ this.props.siteSlug }` }
+								primary={ this.props.primaryButton }
+								onClick={ this.onStartNowClick }
+							>
+								{ translate( 'Set Up Recurring Payments' ) }
+							</Button>
+						</div>
+					</div>
+				</div>
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		isDismissed: isRecurringPaymentsStatsNudgeDismissed( state, ownProps.siteId ),
+		plan: getCurrentPlan( state, ownProps.siteId ),
+	} ),
+	{
+		dismissNudge,
+		recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithSiteType ] ),
+	}
+)( localize( RecurringPaymentsStatsNudge ) );

--- a/client/blocks/recurring-payments-stats-nudge/style.scss
+++ b/client/blocks/recurring-payments-stats-nudge/style.scss
@@ -73,5 +73,5 @@
 	right: 18px;
 	color: var( --color-neutral-light );
 	cursor: pointer;
-	z-index: z-index( 'root', '.recurring-payments-stats-nudge__close-icon' );
+	z-index: z-index( 'root', '.recurring-payments-nudge__close-icon' );
 }

--- a/client/blocks/recurring-payments-stats-nudge/style.scss
+++ b/client/blocks/recurring-payments-stats-nudge/style.scss
@@ -1,0 +1,77 @@
+.card.recurring-payments-stats-nudge {
+	padding: 0; // allow section header to perfectly sit over the top of the card
+}
+
+.recurring-payments-stats-nudge__body {
+	align-items: flex-end;
+	display: flex;
+	padding: 11px 24px; // Standard padding
+
+	@include breakpoint( '>960px' ) {
+		max-height: 300px;
+		padding-bottom: 0; // Allow image to go right to the edge of the card
+	}
+}
+
+.recurring-payments-stats-nudge__info {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+
+	@include breakpoint( '>960px' ) {
+		padding-right: 12px; // The image has about 12 px of whitespace, this helps "balance" the block
+	}
+}
+
+.recurring-payments-stats-nudge__title {
+	font-size: 21px;
+	font-weight: 400;
+	margin: 10px 0 5px;
+}
+
+.recurring-payments-stats-nudge__description {
+	font-size: 16px;
+	font-weight: 400;
+}
+
+.recurring-payments-stats-nudge__button-row {
+	align-content: center;
+	display: flex;
+	margin-bottom: 20px;
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 30px;
+	}
+
+	.button {
+		@include breakpoint( '<480px' ) {
+			width: 100%;
+			text-align: center;
+		}
+	}
+}
+
+.recurring-payments-stats-nudge__image-wrapper {
+	display: none;
+
+	@include breakpoint( '>960px' ) {
+		display: flex;
+		height: 200px;
+		margin-right: 40px;
+		min-width: 260px;
+	}
+}
+
+.recurring-payments-stats-nudge__image {
+	width: 80%;
+	margin-left: 25px;
+}
+
+.recurring-payments-stats-nudge__close-icon {
+	position: absolute;
+	top: 14px;
+	right: 18px;
+	color: var( --color-neutral-light );
+	cursor: pointer;
+	z-index: z-index( 'root', '.recurring-payments-stats-nudge__close-icon' );
+}

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -18,6 +18,7 @@ import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import { getEligibleGSuiteDomain } from 'lib/gsuite';
 import { getSitePlanSlug } from 'state/sites/selectors';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
+import RecurringPaymentsStatsNudge from 'blocks/recurring-payments-stats-nudge';
 import GSuiteStatsNudge from 'blocks/gsuite-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
 import isGSuiteStatsNudgeVisible from 'state/selectors/is-gsuite-stats-nudge-visible';

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -60,7 +60,6 @@ class StatsBanners extends Component {
 				<RecurringPaymentsStatsNudge
 					siteSlug={ this.props.slug }
 					siteId={ this.props.siteId }
-					visible={ true }
 					primaryButton={ this.props.primaryButton }
 				/>
 			);

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -21,6 +21,7 @@ import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
 import RecurringPaymentsStatsNudge from 'blocks/recurring-payments-stats-nudge';
 import GSuiteStatsNudge from 'blocks/gsuite-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
+import isRecurringPaymentsStatsNudgeVisibleSelector from 'state/selectors/is-recurring-payments-stats-nudge-visible';
 import isGSuiteStatsNudgeVisible from 'state/selectors/is-gsuite-stats-nudge-visible';
 import isUpworkStatsNudgeDismissed from 'state/selectors/is-upwork-stats-nudge-dismissed';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
@@ -54,7 +55,16 @@ class StatsBanners extends Component {
 	}
 
 	renderBanner() {
-		if ( this.showUpworkBanner() ) {
+		if ( this.props.isRecurringPaymentsStatsNudgeVisible ) {
+			return (
+				<RecurringPaymentsStatsNudge
+					siteSlug={ this.props.slug }
+					siteId={ this.props.siteId }
+					visible={ true }
+					primaryButton={ this.props.primaryButton }
+				/>
+			);
+		} else if ( this.showUpworkBanner() ) {
 			return this.renderUpworkBanner();
 		} else if ( this.showGSuiteBanner() ) {
 			return this.renderGSuiteBanner();
@@ -145,6 +155,10 @@ export default connect( ( state, ownProps ) => {
 		gsuiteDomainName: getEligibleGSuiteDomain( null, domains ),
 		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
 		isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
+			state,
+			ownProps.siteId
+		),
+		isRecurringPaymentsStatsNudgeVisible: isRecurringPaymentsStatsNudgeVisibleSelector(
 			state,
 			ownProps.siteId
 		),

--- a/client/state/selectors/is-recurring-payments-stats-nudge-dismissed.js
+++ b/client/state/selectors/is-recurring-payments-stats-nudge-dismissed.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns the last time the nudge was dismissed by the current user or 0 if it was never dismissed
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId The Id of the site
+ * @returns {number}  Timestamp marking the last time the nudge was dismissed
+ */
+const getLastDismissTime = ( state, siteId ) => {
+	const preference = getPreference( state, 'recurring-payments-dismissible-nudge' ) || {};
+	const sitePreference = preference[ siteId ] || [];
+	const lastEvent = last( sitePreference.filter( event => 'dismiss' === event.type ) );
+
+	return lastEvent ? lastEvent.dismissedAt : 0;
+};
+
+/**
+ * Returns true if the Upwork nudge has recently been dismissed by the current user
+ * and this action is still effective for this site
+ *
+ * The conditions for it to be effective (and thus make the nudge invisible) are the following:
+ * - The last time it was dismissed must be less than 2 weeks ago
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId The Id of the site
+ * @returns {boolean} True if the nudge has been dismissed
+ */
+export default function isRecurringPaymentsStatsNudgeDismissed( state, siteId ) {
+	const lastDismissTime = getLastDismissTime( state, siteId );
+
+	// Return false if it has never been dismissed
+	if ( lastDismissTime === 0 ) {
+		return false;
+	}
+
+	return lastDismissTime > Date.now() - 2 * WEEK_IN_MS;
+}

--- a/client/state/selectors/is-recurring-payments-stats-nudge-visible.js
+++ b/client/state/selectors/is-recurring-payments-stats-nudge-visible.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { get, isArray } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isCurrentPlanPaid,
+	isJetpackSite,
+	isJetpackMinimumVersion,
+	getSite,
+} from 'state/sites/selectors';
+import { userCan } from 'lib/site/utils';
+
+/**
+ * Returns true if the Recurring Payments nudge should be visible in stats
+ * Context: https://wordpress.com/read/blogs/122326716/posts/8496#comment-3782
+ * It should be visible for sites that:
+ * - are on a paid plan (feature availability)
+ * - avarage more than a 1000 uniques per month
+ *
+ * This selector makes a point of not requesting any new data, so tries to reuse stats being already available in state tree
+ * Sometimes they are not 100% accurate, but this is a nudge and it's good enough for our purposes.
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {string}  siteId The Site ID
+ * @returns {boolean} True if we should show the nudge
+ */
+export default function isRecurringPaymentsStatsNudgeVisible( state, siteId ) {
+	if ( ! isCurrentPlanPaid( state, siteId ) ) {
+		return false;
+	}
+	// We don't want to show notice if JP is too old
+	if (
+		isJetpackSite( state, siteId ) &&
+		isJetpackMinimumVersion( state, siteId, '7.4' ) === false
+	) {
+		return false;
+	}
+	// We don't want to show the notice to the user that can't use recurring payments
+	if ( ! userCan( 'manage_options', getSite( state, siteId ) ) ) {
+		return false;
+	}
+
+	// Now let's try to calculate monthly uniques.
+	const dayStats = get( state, [ 'stats', 'chartTabs', 'counts', siteId, 'day' ] );
+	const monthStats = get( state, [ 'stats', 'chartTabs', 'counts', siteId, 'month' ] );
+	const yearStats = get( state, [ 'stats', 'chartTabs', 'counts', siteId, 'year' ] );
+	const weekStats = get( state, [ 'stats', 'chartTabs', 'counts', siteId, 'week' ] );
+	let monthlyVisitors = 0;
+	if ( isArray( dayStats ) ) {
+		// Last 30 days of stats
+		monthlyVisitors = dayStats.slice( -30 ).reduce( function( total, curr ) {
+			return total + curr.views;
+		}, 0 );
+	} else if ( isArray( monthStats ) ) {
+		// We want the stats from the previous month, not this one.
+		monthlyVisitors = get( monthStats.slice( -2 ), [ 0, 'views' ], 0 );
+	} else if ( isArray( weekStats ) ) {
+		// Last 4 weeks
+		monthlyVisitors = weekStats.slice( -4 ).reduce( function( total, curr ) {
+			return total + curr.views;
+		}, 0 );
+	} else if ( isArray( yearStats ) ) {
+		monthlyVisitors = get( yearStats.slice( -1 ), [ 0, 'views' ], 0 ) / 12;
+	}
+
+	return monthlyVisitors > 10000;
+}

--- a/client/state/selectors/is-recurring-payments-stats-nudge-visible.js
+++ b/client/state/selectors/is-recurring-payments-stats-nudge-visible.js
@@ -13,6 +13,7 @@ import {
 	getSite,
 } from 'state/sites/selectors';
 import { userCan } from 'lib/site/utils';
+import isRecurringPaymentsStatsNudgeDismissed from 'state/selectors/is-recurring-payments-stats-nudge-dismissed';
 
 /**
  * Returns true if the Recurring Payments nudge should be visible in stats
@@ -41,6 +42,10 @@ export default function isRecurringPaymentsStatsNudgeVisible( state, siteId ) {
 	}
 	// We don't want to show the notice to the user that can't use recurring payments
 	if ( ! userCan( 'manage_options', getSite( state, siteId ) ) ) {
+		return false;
+	}
+
+	if ( isRecurringPaymentsStatsNudgeDismissed( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-recurring-payments-stats-nudge-visible.js
+++ b/client/state/selectors/is-recurring-payments-stats-nudge-visible.js
@@ -67,5 +67,5 @@ export default function isRecurringPaymentsStatsNudgeVisible( state, siteId ) {
 		monthlyVisitors = get( yearStats.slice( -1 ), [ 0, 'views' ], 0 ) / 12;
 	}
 
-	return monthlyVisitors > 10000;
+	return monthlyVisitors > 1000;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This Diff introduces a "Recommended by WPCOM" nudge in stats.
This is meant to nudge people into trying recurring payments.

This came out as a product marketing effort to drive more usage of recurring payments:
p8hgLy-2d2-p2

![Zrzut ekranu 2019-12-3 o 17 51 12](https://user-images.githubusercontent.com/3775068/70071356-8aea4080-15f5-11ea-894b-c473f886ce4e.png)

The nudge shows:

- for sites that are on a paid plan
- for users that are site admins
- for sites that have over 1000 monthly users visitors
- if the site is Jetpack, it has to have JP > 7.4

#### Testing instructions

* Find a site that checks off all the boxes above
* Go to stats
* Marvel at a nudge


