### PR TITLE
Checklist: update copy on CTA buttons to be more descriptive

### DIFF
--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -125,6 +125,7 @@ class Task extends PureComponent {
 			buttonText,
 			collapsed,
 			completed,
+			completedDescription,
 			completedButtonText,
 			completedTitle,
 			description,
@@ -184,10 +185,12 @@ class Task extends PureComponent {
 
 					{ ! _collapsed && (
 						<div className="checklist__task-content">
-							<p className="checklist__task-description">{ description }</p>
+							<p className="checklist__task-description">
+								{ completed && completedDescription ? completedDescription : description }
+							</p>
 
 							<div className="checklist__task-action-duration-wrapper">
-								{ duration && (
+								{ ! completed && duration && (
 									<small className="checklist__task-duration">
 										{ translate( 'Estimated time:' ) } { duration }
 									</small>

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -475,7 +475,7 @@ class WpcomChecklistComponent extends PureComponent {
 			<TaskComponent
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/create-tagline.svg"
-				completedButtonText={ translate( 'Change' ) }
+				completedButtonText={ translate( 'Edit tagline' ) }
 				completedTitle={ translate( 'You created a tagline' ) }
 				description={ translate(
 					'Pique readers’ interest with a little more detail about your site.'
@@ -489,7 +489,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Create a tagline' ) }
 				showSkip={ false }
-				buttonText={ translate( 'Start' ) }
+				buttonText={ translate( 'Create tagline' ) }
 			/>
 		);
 	};
@@ -897,9 +897,12 @@ class WpcomChecklistComponent extends PureComponent {
 				title={ translate( 'Update your homepage' ) }
 				completedTitle={ translate( 'You updated your homepage' ) }
 				bannerImageSrc="/calypso/images/stats/tasks/personalize-your-site.svg"
-				completedButtonText={ translate( 'Change' ) }
+				completedButtonText={ translate( 'Edit homepage' ) }
 				description={ translate(
 					`We've created the basics, now it's time for you to update the images and text.`
+				) }
+				completedDescription={ translate(
+					`Edit your page anytime you want to change the text or images.`
 				) }
 				steps={ [] }
 				duration={ translate( '%d minute', '%d minutes', { count: 20, args: [ 20 ] } ) }
@@ -911,7 +914,7 @@ class WpcomChecklistComponent extends PureComponent {
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
 				showSkip={ false }
-				buttonText={ translate( 'Start' ) }
+				buttonText={ translate( 'Update homepage' ) }
 			/>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improve the copy on the CTA buttons inside the checklist instead of generic "Start" actions. This is better for usability and accessibility.
* Change description text on the completed `update homepage` task so it makes sense in the context of the completed state.
* This also removed the estimated time on a completed task as it's no longer relevant for completed tasks.

Update homepage before | Update homepage after
----- | -----
<img width="635" alt="Screen Shot 2019-12-03 at 12 06 14 PM" src="https://user-images.githubusercontent.com/448298/70073936-ccfc8d80-15c7-11ea-8a6c-be0a6af5307b.png"> | <img width="642" alt="Screen Shot 2019-12-03 at 12 05 39 PM" src="https://user-images.githubusercontent.com/448298/70073950-d4239b80-15c7-11ea-9e1d-2628404b6d09.png">

Create tagline before | Create tagline after
----- | -----
<img width="631" alt="Screen Shot 2019-12-03 at 12 06 20 PM" src="https://user-images.githubusercontent.com/448298/70073989-e30a4e00-15c7-11ea-965d-bff5f15f49dc.png"> | <img width="637" alt="Screen Shot 2019-12-03 at 12 05 48 PM" src="https://user-images.githubusercontent.com/448298/70074000-e9002f00-15c7-11ea-8151-0da4e1600aee.png">

Homepage updated before | Homepage updated after
----- | -----
<img width="634" alt="Screen Shot 2019-12-03 at 12 08 07 PM" src="https://user-images.githubusercontent.com/448298/70073870-b3f3dc80-15c7-11ea-949b-5511370a4895.png"> | <img width="633" alt="Screen Shot 2019-12-03 at 12 07 55 PM" src="https://user-images.githubusercontent.com/448298/70073891-b8b89080-15c7-11ea-9718-b124321301ae.png">

Tagline Completed Before | Tagline completed After
------------ | -------------
<img width="631" alt="Screen Shot 2019-12-03 at 12 08 45 PM" src="https://user-images.githubusercontent.com/448298/70073493-07195f80-15c7-11ea-8151-73ee852532d4.png"> | <img width="632" alt="Screen Shot 2019-12-03 at 12 08 35 PM" src="https://user-images.githubusercontent.com/448298/70073531-16001200-15c7-11ea-8cdb-88708be9c30b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site or visit `My Home` on a site that has checklist tasks
* Make sure incomplete tasks have a descriptive button label (not just `Start`)
* Complete tasks
* Make sure completed tasks have a descriptive button label and duration is removed

Fixes #37803
