### PR TITLE
Customer Home: Update heading logic

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -173,7 +173,7 @@ class Home extends Component {
 				);
 
 			case 'launched':
-				return translate( 'Next, add fresh content to grow your audience.' );
+				return translate( 'Make sure you share it with everyone and show it off.' );
 
 			default:
 				return translate( 'Next, use this quick list of setup tasks to get it ready to share.' );

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -185,13 +185,43 @@ class Home extends Component {
 			checklistMode,
 			siteId,
 			currentThemeId,
+			siteIsUnlaunched,
+			isAtomic,
 		} = this.props;
 
+		// Show a thank-you message 30 mins post site creation/purchase
 		if ( isNewlyCreatedSite && displayChecklist ) {
+			if ( siteIsUnlaunched || isAtomic ) {
+				//Only show pre-launch or for Atomic sites
+				return (
+					<React.Fragment>
+						{ siteId && 'theme' === checklistMode && <QueryActiveTheme siteId={ siteId } /> }
+						{ currentThemeId && (
+							<QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } />
+						) }
+						<img
+							src="/calypso/images/signup/confetti.svg"
+							aria-hidden="true"
+							className="customer-home__confetti"
+							alt=""
+						/>
+						<FormattedHeader
+							headerText={
+								this.props.siteHasPaidPlan
+									? translate( 'Thank you for your purchase!' )
+									: translate( 'Your site has been created!' )
+							}
+							subHeaderText={ this.getChecklistSubHeaderText() }
+						/>
+					</React.Fragment>
+				);
+			}
+		}
+
+		// Show a congratulatory message 30 mins post-launch
+		if ( ! siteIsUnlaunched && true ) {
 			return (
 				<React.Fragment>
-					{ siteId && 'theme' === checklistMode && <QueryActiveTheme siteId={ siteId } /> }
-					{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 					<img
 						src="/calypso/images/signup/confetti.svg"
 						aria-hidden="true"
@@ -199,17 +229,14 @@ class Home extends Component {
 						alt=""
 					/>
 					<FormattedHeader
-						headerText={
-							this.props.siteHasPaidPlan
-								? translate( 'Thank you for your purchase!' )
-								: translate( 'Your site has been created!' )
-						}
-						subHeaderText={ this.getChecklistSubHeaderText() }
+						headerText={ translate( 'You launched your site!' ) }
+						subHeaderText={ translate( 'Next, keep adding fresh content to grow your audience.' ) }
 					/>
 				</React.Fragment>
 			);
 		}
 
+		// Show the standard heading otherwise
 		return (
 			<FormattedHeader
 				className="customer-home__page-heading"

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -172,6 +172,9 @@ class Home extends Component {
 					}
 				);
 
+			case 'launched':
+				return translate( 'Next, add fresh content to grow your audience.' );
+
 			default:
 				return translate( 'Next, use this quick list of setup tasks to get it ready to share.' );
 		}
@@ -192,7 +195,7 @@ class Home extends Component {
 		// Show a thank-you message 30 mins post site creation/purchase
 		if ( isNewlyCreatedSite && displayChecklist ) {
 			if ( siteIsUnlaunched || isAtomic ) {
-				//Only show pre-launch or for Atomic sites
+				//Only show pre-launch, or for Atomic sites
 				return (
 					<React.Fragment>
 						{ siteId && 'theme' === checklistMode && <QueryActiveTheme siteId={ siteId } /> }
@@ -219,7 +222,7 @@ class Home extends Component {
 		}
 
 		// Show a congratulatory message 30 mins post-launch
-		if ( ! siteIsUnlaunched && true ) {
+		if ( ! siteIsUnlaunched && 'launched' === checklistMode ) {
 			return (
 				<React.Fragment>
 					<img
@@ -230,7 +233,7 @@ class Home extends Component {
 					/>
 					<FormattedHeader
 						headerText={ translate( 'You launched your site!' ) }
-						subHeaderText={ translate( 'Next, keep adding fresh content to grow your audience.' ) }
+						subHeaderText={ this.getChecklistSubHeaderText() }
 					/>
 				</React.Fragment>
 			);

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -221,7 +221,7 @@ class Home extends Component {
 			}
 		}
 
-		// Show a congratulatory message 30 mins post-launch
+		// Show a congratulatory message post-launch
 		if ( ! siteIsUnlaunched && 'launched' === checklistMode ) {
 			return (
 				<React.Fragment>

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -14,6 +14,7 @@ export function generateFlows( {
 	getSiteDestination = noop,
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
+	getLaunchDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
 } = {} ) {
@@ -283,7 +284,7 @@ export function generateFlows( {
 
 	flows[ 'launch-site' ] = {
 		steps: [ 'domains-launch', 'plans-launch', 'launch' ],
-		destination: getSignupDestination,
+		destination: getLaunchDestination,
 		description: 'A flow to launch a private site.',
 		providesDependenciesInQuery: [ 'siteSlug' ],
 		lastModified: '2019-11-22',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -51,6 +51,10 @@ function getSignupDestination( dependencies ) {
 	return `/checklist/${ dependencies.siteSlug }`;
 }
 
+function getLaunchDestination( dependencies ) {
+	return `/checklist/${ dependencies.siteSlug }?d=launched`;
+}
+
 function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
@@ -67,6 +71,7 @@ const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
 	getSignupDestination,
+	getLaunchDestination,
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 	getEditorDestination,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Post signup, if a site is unlaunched or Atomic, the heading will show a "thank you" message for 30 mins (this is the same functionality, but now restricted to unlaunched sites to avoid confusion documented in #37930).
* After completing the launch flow, the heading will show a "congrats" message, using a query arg passed from the launch flow site destination.
* Outside these cases, the heading will show the standard "My Home" text.

**Before**

A site, just launched, with the incorrect header text and no acknowledgement of the launch.

<img src="https://user-images.githubusercontent.com/4924246/69573416-e4f66080-0f7a-11ea-9cf0-88cee2249fb2.png">

**After**

A site, just launched.

<img width="1106" alt="Screen Shot 2019-12-03 at 2 49 46 PM" src="https://user-images.githubusercontent.com/2124984/70084442-41d9c280-15dc-11ea-8435-210284e10edc.png">

#### Testing instructions

* Switch to this PR, create a new site through `/start/test-fse`
* You should see a Thank You message in the header; this will persist for 30 minutes after site creation, or until the site is launched, whichever comes first.
* Launch your new site. You should see a "You launched your site!" message in the header, triggered by `?d=launched` in the URL.
* Removing `?d=launched` from the URL should return the Customer Home header to normal.
* My copy for the new congratulations message needs a second set of eyes.

Fixes #37930
