### PR TITLE
Unify sidebar nudge style and colors

### DIFF
--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Button from 'components/button';
 
 /**
  * Internal dependencies
@@ -55,13 +55,10 @@ export class SidebarBanner extends Component {
 					eventProperties={ { cta_name: ctaName } }
 				/>
 				<a className="sidebar-banner__link" onClick={ this.onClick } href={ href }>
-					<span className="sidebar-banner__icon-wrapper">
-						<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
-					</span>
 					<span className="sidebar-banner__content">
 						<span className="sidebar-banner__text">{ text }</span>
 					</span>
-					<span className="sidebar-banner__cta">{ ctaText }</span>
+					<Button compact primary>{ ctaText }</Button>
 				</a>
 			</div>
 		);

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -1,28 +1,19 @@
 .sidebar-banner {
+	border-left: 4px solid var( --color-accent );
 	font-size: 12px;
 
 	.sidebar-banner__link {
-		background-color: var( --color-success );
+		background-color: var(--color-neutral-80);
 		color: var( --color-text-inverted );
 		display: flex;
-
-		@include breakpoint( '<660px' ) {
-			padding: 0 19px;
-		}
-
-		.sidebar-banner__icon-wrapper {
-			flex: 0 0 auto;
-			padding: 5px 5px 2px;
-		}
+		padding: 8px;
 
 		.sidebar-banner__content {
-			width: 100%;
-			padding: 6px 5px 5px;
+			padding: 5px;
 		}
 
-		.sidebar-banner__cta {
-			padding: 6px 8px 2px 5px;
-			text-transform: uppercase;
+		.button {
+			margin-left: auto;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A new nudge style that:

<li>utilize our <a href="https://wpcalypso.wordpress.com/devdocs/blocks/upgrade-nudge" rel="nofollow ugc">upsell nudge component</a> for sidebar nudges</li>
<li>be its own reusable component (right now, the green nudge isn't a reusable component)</li>
<li>work well with our different Dashboard Color Schemes</li>

**Current:**
![Screenshot 2019-12-03 13 40 14](https://user-images.githubusercontent.com/4924246/70092139-7779ae00-15d2-11ea-9ef0-1c36475c523d.png)

**Proposed designs (WIP):**

| Default  | Classic Blue |
| ------------- | ------------- |
| ![Screenshot 2019-12-03 13 47 53](https://user-images.githubusercontent.com/4924246/70092612-8a40b280-15d3-11ea-96e1-5c4ddcad873f.png) | ![Screenshot 2019-12-03 13 47 58](https://user-images.githubusercontent.com/4924246/70092621-8d3ba300-15d3-11ea-8eec-6abea09ae59f.png) |

| Powder Snow  | Nightfall |
| ------------- | ------------- |
| ![Screenshot 2019-12-03 13 49 08](https://user-images.githubusercontent.com/4924246/70092688-b1977f80-15d3-11ea-8285-7fd423e29c44.png) | ![Screenshot 2019-12-03 13 49 13](https://user-images.githubusercontent.com/4924246/70092713-c07e3200-15d3-11ea-8ed1-4e563f409117.png) |

| Sakura | Ocean |
| ------------- | ------------- |
| ![Screenshot 2019-12-03 13 50 47](https://user-images.githubusercontent.com/4924246/70092816-f4f1ee00-15d3-11ea-8675-b0f22558dbda.png) | ![Screenshot 2019-12-03 13 50 52](https://user-images.githubusercontent.com/4924246/70092825-f91e0b80-15d3-11ea-8c1b-34a429d116ea.png) |

| Sunset | Midnight |
| ------------- | ------------- |
| ![Screenshot 2019-12-03 13 51 59](https://user-images.githubusercontent.com/4924246/70092882-19e66100-15d4-11ea-8380-cbf7cfb07101.png) | ![Screenshot 2019-12-03 13 52 02](https://user-images.githubusercontent.com/4924246/70092891-1eab1500-15d4-11ea-9fcb-20e389640abc.png) |

| Contrast |
| ------------- |
| ![Screenshot 2019-12-03 13 52 08](https://user-images.githubusercontent.com/4924246/70092927-34203f00-15d4-11ea-845a-cf8a2b81d528.png) |

The dark gray (var(--color-neutral-80)) works well in a few Dashboard color combos, but we need to experiment with different color variables to make it work in others. So if we have to deviate from the dark nudge color, that's fine too.

Please see Figma with filename `Sidebar Nudge Color Schemes` for additional reference.

#### Testing instructions

1. Go to My Sites
2. Check the sidebar nudges, make sure they are update to the new style

Note that there different types of nudges displayed here depending on different use cases.

Please see Figma with the filename `Calypso Nudges Audit and Tracks Events`. This is where you'll find the different nudges we display in the sidebar.

cc @ianstewart @lcollette @rickybanister @sixhours 
