### PR TITLE
Classic Editor: Enable autoresize TinyMCE plugin for iOS

### DIFF
--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -21,8 +21,7 @@ function wcpomAutoResize( editor ) {
 		return editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen();
 	}
 
-	// do not autoreize on iOS
-	if ( editor.settings.inline || tinymce.Env.iOS ) {
+	if ( editor.settings.inline ) {
 		return;
 	}
 

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -5,7 +5,6 @@
  *
  *
  * @copyright 2015 by the WordPress contributors.
- * @license See CREDITS.md.
  */
 
 /**
@@ -14,8 +13,8 @@
 import tinymce from 'tinymce/tinymce';
 
 function wcpomAutoResize( editor ) {
-	let settings = editor.settings,
-		oldSize = 0;
+	const settings = { ...editor.settings };
+	let oldSize = 0;
 
 	function isFullscreen() {
 		return editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen();
@@ -26,15 +25,15 @@ function wcpomAutoResize( editor ) {
 	}
 
 	function isEndOfEditor() {
-		let range, start, body, element, child;
-		range = editor.selection.getRng();
+		let element, child;
+		const range = editor.selection.getRng();
 
 		if ( ( range.startOffset === 0 && range.endOffset !== 0 ) || ! range.collapsed ) {
 			return false;
 		}
 
-		start = range.startContainer;
-		body = editor.getBody();
+		const start = range.startContainer;
+		const body = editor.getBody();
 		element = start;
 		do {
 			child = element;
@@ -47,27 +46,15 @@ function wcpomAutoResize( editor ) {
 	}
 
 	function resize( e ) {
-		let deltaSize,
-			doc,
-			body,
-			docElm,
-			DOM = tinymce.DOM,
-			resizeHeight,
-			myHeight,
-			marginTop,
-			marginBottom,
-			paddingTop,
-			paddingBottom,
-			borderTop,
-			borderBottom;
+		let deltaSize, resizeHeight, myHeight;
+		const DOM = tinymce.DOM;
+		const doc = editor.getDoc();
+		const { body, documentElement: docElm } = doc;
 
-		doc = editor.getDoc();
 		if ( ! doc ) {
 			return;
 		}
 
-		body = doc.body;
-		docElm = doc.documentElement;
 		resizeHeight = settings.autoresize_min_height;
 
 		if ( ! body || ( e && e.type === 'setcontent' && e.initial ) || isFullscreen() ) {
@@ -80,14 +67,14 @@ function wcpomAutoResize( editor ) {
 		}
 
 		// Calculate outer height of the body element using CSS styles
-		marginTop = editor.dom.getStyle( body, 'margin-top', true );
-		marginBottom = editor.dom.getStyle( body, 'margin-bottom', true );
-		paddingTop = editor.dom.getStyle( body, 'padding-top', true );
-		borderTop = editor.dom.getStyle( body, 'border-top-width', true );
-		borderBottom = editor.dom.getStyle( body, 'border-bottom-width', true );
+		const marginTop = editor.dom.getStyle( body, 'margin-top', true );
+		const marginBottom = editor.dom.getStyle( body, 'margin-bottom', true );
+		const paddingTop = editor.dom.getStyle( body, 'padding-top', true );
+		const borderTop = editor.dom.getStyle( body, 'border-top-width', true );
+		const borderBottom = editor.dom.getStyle( body, 'border-bottom-width', true );
 		// paddingBottom seems to get reset to 1 somewhere, so grab
 		// autoresize_bottom_margin directly here
-		paddingBottom = editor.getParam( 'autoresize_bottom_margin', 50 );
+		const paddingBottom = editor.getParam( 'autoresize_bottom_margin', 50 );
 
 		myHeight =
 			body.offsetHeight +
@@ -177,10 +164,8 @@ function wcpomAutoResize( editor ) {
 
 	// Add padding at the bottom for better UX
 	editor.on( 'init', function() {
-		let overflowPadding, bottomMargin;
-
-		overflowPadding = editor.getParam( 'autoresize_overflow_padding', 1 );
-		bottomMargin = editor.getParam( 'autoresize_bottom_margin', 50 );
+		const overflowPadding = editor.getParam( 'autoresize_overflow_padding', 1 );
+		const bottomMargin = editor.getParam( 'autoresize_bottom_margin', 50 );
 
 		if ( overflowPadding !== false ) {
 			editor.dom.setStyles( editor.getBody(), {


### PR DESCRIPTION
### Summary

This PR fixes an issue in which the height of the TinyMCE iFrame in the Classic Editor was set to 100px on iOS devices. The autoresize plugin was set to be disabled for iOS environments. Turning off that check fixes the problem, and seems to not cause other issues.

### Testing

* Spin up a local Calypso development environment
* Open a Classic Editor and ensure that your browser is set to emulate an iOS device
* Ensure that the height of the Classic Editor fills the screen

Fixes #36763 