### PR TITLE
Hosting: Allow sites dating back a year to be eligible.

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -72,7 +72,7 @@ class Hosting extends Component {
 		}
 
 		const sftpPhpMyAdminFeaturesEnabled =
-			isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 168768859;
+			isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 155000000;
 
 		const getAtomicActivationNotice = () => {
 			const { COMPLETE, FAILURE } = transferStates;


### PR DESCRIPTION
To get a better idea of the Hosting features' performance, let's open up eligible Atomic sites back to November 28, 2018 (currently, only sites since October 31, 2019 have been eligible).

#### Testing instructions

* Apply this branch, and go to `http://calypso.localhost:3000/hosting-config/`.
* Select an Atomic site created before Nov 28, 2018, and verify the Hosting section is not available (you should be redirected to the stats page).
* Select an Atomic site created after Nov 28, 2018, and verify the Hosting section is displayed.

Fixes #38148
