### PR TITLE
Add Alves theme to themes-data and increase limit of themes displayed on `fse-themes` step

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -456,4 +456,14 @@ export const themes = [
 		demo_uri: 'https://shawburndemo.wordpress.com',
 		verticals: [],
 	},
+	{
+		name: 'Alves',
+		slug: 'alves',
+		repo: 'pub',
+		fallback: true,
+		description: '',
+		design: 'fse-compatible',
+		demo_uri: 'https://alvesdemo.wordpress.com',
+		verticals: [],
+	},
 ];

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -74,7 +74,7 @@ export function generateSteps( {
 			stepName: 'fse-themes',
 			props: {
 				designType: 'fse-compatible',
-				quantity: 3,
+				quantity: 18,
 			},
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'themeSlugWithRepo', 'useThemeHeadstart' ],


### PR DESCRIPTION
**Note 1**: this is a WIP PR — adding in a single additional theme looks a bit odd at 4 themes. I recommend we keep this PR open until we have a pleasing number of themes e.g. 6 and then merge in.

**Note 2**: this needs to wait until Alves has been deployed on dotcom: D36095-code — until that's been deployed FSE isn't active for Alves just yet.

Example screenshot:

![image](https://user-images.githubusercontent.com/14988353/70102587-af452c00-168c-11ea-8541-bda8c5cc103f.png)

#### Changes proposed in this Pull Request

* Increase the limit of themes displayed on the `fse-themes` step to 18
* Add the `Alves` theme to `themes-data.js` now that [FSE support has been added](https://github.com/Automattic/themes/pull/1681)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/test-fse`
* Check that the new theme (Alves) is displayed on the `fse-themes` step
* Complete signup and go to edit the home page (e.g. pages > home) and confirm that FSE is enabled (you should see the editable site header at the top of the editor)
