### PR TITLE
Update text colors on migration confirmation screen

### DIFF
--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -21,11 +21,11 @@
 }
 
 .migrate__card-footer {
-	color: var( --color-neutral-40 );
+	color: var( --color-text-subtle );
 	font-size: 13px;
 
 	a {
-		color: var( --color-neutral-40 );
+		color: var( --color-text-subtle );
 		text-decoration: underline;
 	}
 }
@@ -44,7 +44,7 @@
 
 .migrate__sites-arrow {
 	display: flex;
-	color: var( --color-neutral-10 );
+	color: var( --color-text-subtle );
 	padding: 20px 40px 20px 0;
 	@include breakpoint( '>1040px' ) {
 		padding-right: 64px;


### PR DESCRIPTION
Note: This change is behind a feature-flag and is part of an in-progress larger project. This PR is intentionally incomplete. For context, see pbkcP4-8-p2.

Updates the text colors for the site-confirmation screen of migration so that the arrow and the "A Business Plan" text at the bottom of the screen are now more accessible.

#### Changes proposed in this Pull Request

Before:

<img width="736" alt="ScreenCapture at Tue Dec 3 22:27:14 EST 2019" src="https://user-images.githubusercontent.com/2098816/70110467-0e6b5800-161d-11ea-9d71-720cf9ddb2a3.png">

After:

<img width="738" alt="ScreenCapture at Tue Dec 3 22:27:32 EST 2019" src="https://user-images.githubusercontent.com/2098816/70110480-14f9cf80-161d-11ea-8e44-cbfdb64a6ec8.png">


Note: the site-names / addresses have been partially-removed from the screenshots

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this pull request and run Calypso locally, or view it on calypso.live with the flag `tools/migrate.`
* Viewing calypso.localhost:3000/migrate/, you should see a `SiteSelector` component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another `SiteSelector` component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen. Verify that the colors of the arrow and the "A Business Plan" are now more accessible (using `--color-text-subtle`)


