### PR TITLE
Remove Redux dependency from the wpcom localization middleware

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -21,7 +21,6 @@ import emailVerification from 'calypso/components/email-verification';
 import { getSavedVariations } from 'calypso/lib/abtest'; // used by error logger
 import accessibleFocus from 'calypso/lib/accessible-focus';
 import Logger from 'calypso/lib/catch-js-errors';
-import { bindState as bindWpLocaleState } from 'calypso/lib/wp/localization';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import { installPerfmonPageHandlers } from 'calypso/lib/perfmon';
 import { setupRoutes } from 'calypso/sections-middleware';
@@ -209,8 +208,6 @@ const utils = () => {
 
 const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
-
-	bindWpLocaleState( reduxStore );
 
 	if ( currentUser.get() ) {
 		// Set current user in Redux store

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -10,7 +10,6 @@ import debugFactory from 'debug';
 import config from 'calypso/config';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
-import { bindState as bindWpLocaleState } from 'calypso/lib/wp/localization';
 import { getUrlParts } from 'calypso/lib/url';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { setRoute } from 'calypso/state/route/actions';
@@ -81,8 +80,6 @@ function renderDevHelpers( reduxStore ) {
 
 export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
-
-	bindWpLocaleState( reduxStore );
 
 	if ( currentUser.get() ) {
 		// Set current user in Redux store

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -2,35 +2,7 @@
  * External dependencies
  */
 import { parse, stringify } from 'qs';
-
-/**
- * Internal dependencies
- */
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
-
-/**
- * Module variables
- */
-let locale;
-
-/**
- * Setter function for internal locale value
- *
- * @param {string} localeToSet Locale to set
- */
-export function setLocale( localeToSet ) {
-	locale = localeToSet;
-}
-
-/**
- * Getter function for internal locale value
- *
- * @returns {string} Locale
- */
-export function getLocale() {
-	return locale;
-}
+import i18n from 'i18n-calypso';
 
 /**
  * Given a WPCOM parameter set, modifies the query such that a non-default
@@ -40,6 +12,8 @@ export function getLocale() {
  * @returns {object}        Revised parameters, if non-default locale
  */
 export function addLocaleQueryParam( params ) {
+	const locale = i18n.getLocaleVariant() || i18n.getLocaleSlug();
+
 	if ( ! locale || 'en' === locale ) {
 		return params;
 	}
@@ -76,22 +50,4 @@ export function injectLocalization( wpcom ) {
 			return originalRequest( addLocaleQueryParam( params ), callback );
 		},
 	} );
-}
-
-/**
- * Subscribes to the provided Redux store instance, updating the known locale
- * value to the latest value when state changes.
- *
- * @param {object} store Redux store instance
- */
-export function bindState( store ) {
-	function setLocaleFromState() {
-		const state = store.getState();
-		const localeVariant = getCurrentLocaleVariant( state );
-		const localeSlug = getCurrentLocaleSlug( state );
-		setLocale( localeVariant || localeSlug );
-	}
-
-	store.subscribe( setLocaleFromState );
-	setLocaleFromState();
 }

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -1,16 +1,16 @@
 /**
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
-import { addLocaleQueryParam, bindState, getLocale, injectLocalization, setLocale } from '../';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
-
-jest.mock( 'state/selectors/get-current-locale-slug' );
-jest.mock( 'state/selectors/get-current-locale-variant' );
+import { addLocaleQueryParam, injectLocalization } from '../';
 
 describe( 'index', () => {
 	beforeEach( () => {
-		setLocale( undefined );
+		i18n.configure(); // ensure everything is reset
 	} );
 
 	describe( '#addLocaleQueryParam()', () => {
@@ -21,23 +21,20 @@ describe( 'index', () => {
 		} );
 
 		test( 'should not modify params if locale is default', () => {
-			setLocale( 'en' );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
-
 			expect( params ).toEqual( { query: 'search=foo' } );
 		} );
 
 		test( 'should include the locale query parameter for a non-default locale', () => {
-			setLocale( 'fr' );
+			i18n.setLocale( { '': { localeSlug: 'fr' } } );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
-
 			expect( params ).toEqual( { query: 'search=foo&locale=fr' } );
 		} );
 
-		test( 'should prefer and set initial variant locale from state', () => {
-			getCurrentLocaleVariant.mockReturnValueOnce( 'fr_formal' );
-			bindState( { subscribe() {}, getState() {} } );
-			expect( getLocale() ).toBe( 'fr_formal' );
+		test( 'should include the locale query parameter for a locale variant', () => {
+			i18n.setLocale( { '': { localeSlug: 'de', localeVariant: 'de_formal' } } );
+			const params = addLocaleQueryParam( { query: 'search=foo' } );
+			expect( params ).toEqual( { query: 'search=foo&locale=de_formal' } );
 		} );
 	} );
 
@@ -45,7 +42,6 @@ describe( 'index', () => {
 		test( 'should return a modified object', () => {
 			const wpcom = { request() {} };
 			injectLocalization( wpcom );
-
 			expect( wpcom ).toHaveProperty( 'localized' );
 		} );
 
@@ -53,12 +49,11 @@ describe( 'index', () => {
 			const request = () => {};
 			const wpcom = { request };
 			injectLocalization( wpcom );
-
 			expect( wpcom.request ).not.toBe( request );
 		} );
 
 		test( 'should modify params by default', async () => {
-			setLocale( 'fr' );
+			i18n.setLocale( { '': { localeSlug: 'fr' } } );
 			const wpcom = {
 				async request( params ) {
 					expect( params.query ).toBe( 'search=foo&locale=fr' );
@@ -67,28 +62,6 @@ describe( 'index', () => {
 
 			injectLocalization( wpcom );
 			await wpcom.request( { query: 'search=foo' } );
-		} );
-	} );
-
-	describe( '#bindState()', () => {
-		test( 'should set initial locale from state', () => {
-			getCurrentLocaleSlug.mockReturnValueOnce( 'fr' );
-			bindState( { subscribe() {}, getState() {} } );
-			expect( getLocale() ).toBe( 'fr' );
-		} );
-
-		test( 'should subscribe to the store, setting locale on change', () => {
-			let listener;
-			bindState( {
-				subscribe( _listener ) {
-					listener = _listener;
-				},
-				getState() {},
-			} );
-			getCurrentLocaleSlug.mockReturnValueOnce( 'de' );
-			listener();
-
-			expect( getLocale() ).toBe( 'de' );
 		} );
 	} );
 } );

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -7,19 +7,6 @@ jest.mock( 'lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'lib/analytics/ad-tracking', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
-
 jest.mock( 'state/sites/plans/selectors', () => ( {
 	getPlanDiscountedRawPrice: jest.fn(),
 	getSitePlanRawPrice: jest.fn(),

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -24,17 +24,10 @@ jest.mock( 'my-sites/plan-features', () => 'PlanFeatures' );
 jest.mock( 'my-sites/plans-features-main/wpcom-faq', () => 'WpcomFAQ' );
 jest.mock( 'my-sites/plans-features-main/jetpack-faq', () => 'JetpackFAQ' );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Component ) => ( props ) => <Component { ...props } translate={ ( x ) => x } />,
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
-
 /**
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -53,19 +53,6 @@ jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
 jest.mock( 'components/notice', () => 'Notice' );
 jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
-
 const selectedSite = {
 	plan: {
 		product_slug: PLAN_FREE,

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0 (next)
+
+- Add `i18n.getLocaleVariant()` method to get a nonstandard locale variant slug
+
 ## 5.0.0
 
 - Dependencies: Move `react` to `peerDependencies`. `i18n-calypso` no longer depends on `react` directly and consumers should install the dependency.
@@ -5,15 +9,11 @@
 - Update debug to v4
 - Switch from Jed to Tannin, for smaller size as well as runtime speedups
 
-  4.1.0
-
----
+## 4.1.0
 
 - Add `i18n.isRtl()` method to determine current locale's text direction and the `useRtl` and `withRtl` React wrappers
 
-  4.0.0
-
----
+## 4.0.0
 
 - Move i18n-calypso into Calypso repository.
 - Refactor i18n-calypso to Calypso standards.
@@ -23,22 +23,16 @@
 - Update `xgettext-js` to `^3.0.0`
 - Moved the CLI tool to separate package `i18n-calypso-cli`
 
-  3.0.0
-
----
+## 3.0.0
 
 - Update Jed dependency to v1.1.1. This is a breaking change, since as of Jed v1.1, the format of Jed translation files has changed. Refer to <https://github.com/messageformat/Jed/pull/33> for details.
 
-  2.0.2
-
----
+## 2.0.2
 
 - The localize HoC will now pass down the current locale slug as a `locale` prop to the wrapped component [#77](https://github.com/Automattic/i18n-calypso/pull/77).
 - Open up the range on the moment-timezone dependency to allow clients to use any moment-timezone from the 0.5 range. [#78](https://github.com/Automattic/i18n-calypso/pull/78)
 
-  2.0.1
-
----
+## 2.0.1
 
 - Update parseOptions passed to xgettext to include more modern features <https://github.com/Automattic/i18n-calypso/pull/68>
 - Switch to hash.js from sha1 for hashing to cut size <https://github.com/Automattic/i18n-calypso/pull/67>
@@ -56,9 +50,7 @@
 - Fix circular reference when calling JSON.stringify with the Community Translator enabled in Calypso [#54](https://github.com/Automattic/i18n-calypso/pull/54).
 - Update CI image to node:10 and use `npm cit`, see [#63](https://github.com/Automattic/i18n-calypso/pull/63).
 
-  1.9.1
-
----
+## 1.9.1
 
 Fix a reference to an undefined value.
 
@@ -107,9 +99,7 @@ Update `moment-timezone` to version `0.5.11`.
 - Allow exposed composed component, see [#25](https://github.com/Automattic/i18n-calypso/pull/25).
 - Change Localize HOC display name to be consistent with react-redux, see [#29](https://github.com/Automattic/i18n-calypso/pull/29).
 
-  1.7.0
-
----
+## 1.7.0
 
 Replace LRU cache implementation, see [#18](https://github.com/Automattic/i18n-calypso/pull/18).
 
@@ -126,8 +116,6 @@ Fix invalid POT output when strings contained a line break, see [#14](https://gi
 - Add method to add/overwrite translations, see [#10](https://github.com/Automattic/i18n-calypso/pull/10).
 - Add ability to parse Calypso source by switching to xgettext-js 1.0.0 and enabling the necessary plugins, see [#13](https://github.com/Automattic/i18n-calypso/pull/13).
 
-  1.5.0
-
----
+## 1.5.0
 
 - POT: enable output of string locations, see [#12](https://github.com/Automattic/i18n-calypso/pull/12).

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -150,6 +150,7 @@ function I18N() {
 		tannin: undefined,
 		locale: undefined,
 		localeSlug: undefined,
+		localeVariant: undefined,
 		textDirection: undefined,
 		translations: LRU( { max: 100 } ),
 	};
@@ -270,6 +271,7 @@ I18N.prototype.setLocale = function ( localeData ) {
 	}
 
 	this.state.localeSlug = this.state.locale[ '' ].localeSlug;
+	this.state.localeVariant = this.state.locale[ '' ].localeVariant;
 
 	// extract the `textDirection` info (LTR or RTL) from either:
 	// - the translation for the special string "ltr" (standard in Core, not present in Calypso)
@@ -310,9 +312,19 @@ I18N.prototype.getLocale = function () {
  * Get the current locale slug.
  *
  * @returns {string} The string representing the currently loaded locale
- **/
+ */
 I18N.prototype.getLocaleSlug = function () {
 	return this.state.localeSlug;
+};
+
+/**
+ * Get the current locale variant. That's set for some special locales that don't have a
+ * standard ISO code, like `de_formal` or `sr_latin`.
+ *
+ * @returns {string|undefined} The string representing the currently loaded locale's variant
+ */
+I18N.prototype.getLocaleVariant = function () {
+	return this.state.localeVariant;
 };
 
 /**

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -6,15 +6,23 @@ import localizeFactory from './localize';
 import translateHookFactory from './use-translate';
 import rtlFactory from './rtl';
 
-const i18n = new I18N();
+// Export the `I18N` class
 export { I18N };
+
+// Create a default instance of `I18N` and make it the module default export
+const i18n = new I18N();
 export default i18n;
+
+// Export the default instance's properties and bound methods for convenience
+// These should be deprecated eventually, exposing only the default `i18n` instance
 export const numberFormat = i18n.numberFormat.bind( i18n );
 export const translate = i18n.translate.bind( i18n );
 export const configure = i18n.configure.bind( i18n );
 export const setLocale = i18n.setLocale.bind( i18n );
 export const getLocale = i18n.getLocale.bind( i18n );
 export const getLocaleSlug = i18n.getLocaleSlug.bind( i18n );
+export const getLocaleVariant = i18n.getLocaleVariant.bind( i18n );
+export const isRtl = i18n.isRtl.bind( i18n );
 export const addTranslations = i18n.addTranslations.bind( i18n );
 export const reRenderTranslations = i18n.reRenderTranslations.bind( i18n );
 export const registerComponentUpdateHook = i18n.registerComponentUpdateHook.bind( i18n );
@@ -24,6 +32,8 @@ export const stateObserver = i18n.stateObserver;
 export const on = i18n.on.bind( i18n );
 export const off = i18n.off.bind( i18n );
 export const emit = i18n.emit.bind( i18n );
+
+// Export the React helpers bound to the default `i18n` instance
 export const localize = localizeFactory( i18n );
 export const useTranslate = translateHookFactory( i18n );
 const { useRtl, withRtl } = rtlFactory( i18n );


### PR DESCRIPTION
This PR is a followup to #38047 that further simplifies the `lib/wp/localization` middleware for the `wpcom` library that adds a `locale` query param to every request, based on current locale.

It removes the Redux dependency by getting the current locale slug and locale variant not from Redux, but directly from the `i18n-calypso` library.

After the Redux dependency is removed, we also no longer need to bind the middleware to Redux by importing and calling `bindState` in the entrypoint boot code.

To make that work, I also had to add the `i18n.getLocaleVariant` method to `i18n-calypso`, in order to make special locales like `sr_latin` and `de_formal` behave correctly.

To make unit tests pass, I had to remove unneeded and incomplete mocking of `i18n-calypso` from several Enzyme tests. When a unit test makes a network request (intercepted by `nock`), the `i18n.getLocaleVariant()` and `i18n.getLocaleSlug()` are called by the `wpcom` localization middleware, and that fails if the `i18n-calypso` library is an incomplete mock that doesn't define these methods.

**How to test:**
1. Set your locale to a non-English language and verify that all WP.com REST API requests have a `locale` or `_locale` query param with the current locale.
2. Check also the special cases for `sr_latin` and `de_formal` locales. These should load the `sr_latin` and `de_formal` translation files, send `language=sr_latin` and `language=de_formal` slugs with REST request, **but**: the `document.lang` in DOM should be set to `sr` and `de` respectively, and `sr` and `de` moment.js localizations should be loaded. These two locales are specialized ones that are unknown to services and libraries outside WP.com.

@Automattic/i18n: please verify that I understand the "locale variant" concept correctly and that it really applies only to `sr_latin` and `de_formal`.
