### PR TITLE
Make mobile app task skippable

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -616,7 +616,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Get the WordPress app' ) }
-				showSkip={ false }
+				showSkip={ true }
 				buttonText={ translate( 'Start' ) }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: p9OQAC-lY-p2

This PR is a follow up to https://github.com/Automattic/wp-calypso/pull/37721

It takes the mobile app task and adds a "skip" button.

Before:

<img width="652" alt="Zrzut ekranu 2019-12-4 o 12 23 40" src="https://user-images.githubusercontent.com/205419/70138619-ecabb880-1690-11ea-96e0-3da524534620.png">

After:

<img width="633" alt="Zrzut ekranu 2019-12-4 o 12 23 32" src="https://user-images.githubusercontent.com/205419/70138622-ecabb880-1690-11ea-8ca1-2ab97441987f.png">


#### Testing instructions

This PR updates dead code that's going to be tested separately as part of D36171-code. For this reason just eyeballing should be enough.