### PR TITLE
FSE: Remove Serenity as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,9 +121,9 @@
 /docs/coding-guidelines/typescript* @Automattic/type-review
 
 # FSE (Full Site Editing)
-/apps/full-site-editing/* @Automattic/serenity @Automattic/cylon @Automattic/ajax
-/apps/full-site-editing/full-site-editing-plugin/* @Automattic/serenity @Automattic/cylon @Automattic/ajax
-/apps/full-site-editing/full-site-editing-plugin/full-site-editing @Automattic/serenity @Automattic/cylon
+/apps/full-site-editing/* @Automattic/cylon @Automattic/ajax
+/apps/full-site-editing/full-site-editing-plugin/* @Automattic/cylon @Automattic/ajax
+/apps/full-site-editing/full-site-editing-plugin/full-site-editing @Automattic/cylon
 /apps/full-site-editing/full-site-editing-plugin/posts-list-block @Automattic/ajax
 /apps/full-site-editing/full-site-editing-plugin/starter-page-templates @Automattic/ajax
 /apps/full-site-editing/full-site-editing-plugin/global-styles @Automattic/cylon @nosolosw


### PR DESCRIPTION
Since late September, Team Serenity is no longer focused on FSE in order to work on the WordPress block editor integration, plugin updates and maintenance (paYKcK-gB-p2). 

Most of the team actually lost track of the current FSE technical implementation and I don't think it makes sense to have us as code owner, which should result in less notifications noise.
