### PR TITLE
Full Site Editing: Update margins and paddings in the Template Part preview

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -7,8 +7,7 @@
 
 // Override some very specific theme styles.
 .post-type-page .editor-styles-wrapper .template-block .fse-template-part {
-	padding-left: 0;
-	padding-right: 0;
+	padding: 0;
 }
 
 .template__block-container {
@@ -16,7 +15,9 @@
 		cursor: pointer;
 	}
 
-	&.is-hovered, &.is-selected, .is-navigating-to-template {
+	&.is-hovered,
+	&.is-selected,
+	.is-navigating-to-template {
 		.components-disabled {
 			filter: blur( 2px );
 			transition: filter 0.2s linear;
@@ -93,7 +94,8 @@
 // Hide the site logo description and buttons when not editing the Template
 .block-editor-page:not( .post-type-wp_template_part ) {
 	.fse-site-logo {
-		.components-placeholder__fieldset, .components-placeholder__instructions {
+		.components-placeholder__fieldset,
+		.components-placeholder__instructions {
 			display: none;
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -20,7 +20,8 @@
 	}
 }
 
-.post-type-page, .post-type-wp_template_part {
+.post-type-page,
+.post-type-wp_template_part {
 	@media ( min-width: 768px ) {
 		// @TODO: remove .edit-post-layout__content when Gutenberg 7.0.0 lands in production
 		.edit-post-layout__content,
@@ -31,7 +32,8 @@
 		// @TODO: remove .edit-post-layout__content when Gutenberg 7.0.0 lands in production
 		.edit-post-layout__content .edit-post-visual-editor,
 		.edit-post-editor-regions__content .edit-post-visual-editor {
-			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
+			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
+				0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 			flex: none;
 			margin: 36px 32px;
 		}
@@ -42,23 +44,22 @@
 		padding-right: 0;
 	}
 
-	.block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit {
+	.block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit {
 		margin-right: 0;
 		margin-left: 0;
 	}
 
-	.block-editor-block-list__block[data-align=wide] > .block-editor-block-list__block-edit {
+	.block-editor-block-list__block[data-align='wide'] > .block-editor-block-list__block-edit {
 		margin-right: 14px;
 		margin-left: 14px;
 	}
 
-	@media( max-width: 1200px ) {
+	@media ( max-width: 1200px ) {
 		// Try to ensure that normally-aligned blocks work properly.
-		.wp-block:not( [data-align=full] ):not( [data-align=wide] ) {
+		.wp-block:not( [data-align='full'] ):not( [data-align='wide'] ) {
 			max-width: 580px;
-
 		}
-		.is-sidebar-opened .wp-block:not( [data-align=full] ):not( [data-align=wide] ) {
+		.is-sidebar-opened .wp-block:not( [data-align='full'] ):not( [data-align='wide'] ) {
 			max-width: 400px;
 		}
 	}
@@ -83,9 +84,5 @@
 
 	.block-editor-writing-flow {
 		display: block;
-	}
-
-	.wp-block.template__block-container [data-block] {
-		margin: 0;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -85,4 +85,11 @@
 	.block-editor-writing-flow {
 		display: block;
 	}
+
+	.wp-block.template__block-container
+		.wp-block-column
+		[data-type='core/social-links']
+		[data-block] {
+		margin: 0;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

These changes only affect the Template Part preview, which is when they are rendered inside the page editor.
Template Part editor and front end are unaffected.

* Delete the `margin: 0` affecting blocks inside the Template Part preview.
* Remove the vertical paddings on the Template Part preview.

#### Screenshots

| Theme | Page Editor (old) | Page Editor (new) | Template Part (unchanged) |
| - | - | - | - | 
| Alves | <img width="1333" alt="alves-page-old" src="https://user-images.githubusercontent.com/2070010/70159438-ceee4b80-16b0-11ea-8479-0159ba55b9c1.png"> | <img width="1185" alt="alves-page" src="https://user-images.githubusercontent.com/2070010/70159463-d9a8e080-16b0-11ea-81e3-56cb6ded593d.png"> | <img width="1197" alt="alves-template" src="https://user-images.githubusercontent.com/2070010/70159473-de6d9480-16b0-11ea-8976-d1b7fb25cbcd.png"> |
| Maywood | <img width="1325" alt="maywood-page-old" src="https://user-images.githubusercontent.com/2070010/70159585-11178d00-16b1-11ea-82e5-162c8c9d7019.png"> | <img width="1322" alt="maywood-page" src="https://user-images.githubusercontent.com/2070010/70159596-14127d80-16b1-11ea-9cf5-29c90869042a.png"> | <img width="1335" alt="maywood-template" src="https://user-images.githubusercontent.com/2070010/70159602-183e9b00-16b1-11ea-8cb2-e7c06e689579.png"> |
| Morden | <img width="1123" alt="morden-page-old" src="https://user-images.githubusercontent.com/2070010/70160756-eaf2ec80-16b2-11ea-8cfc-794e743a7f1a.png"> | <img width="998" alt="morden-page" src="https://user-images.githubusercontent.com/2070010/70160757-eaf2ec80-16b2-11ea-8993-54c1b54b155a.png"> | <img width="1132" alt="morden-template" src="https://user-images.githubusercontent.com/2070010/70160758-eb8b8300-16b2-11ea-9cdf-f6d32f33f1b6.png"> |
| Shawburn | <img width="1116" alt="shawburn-page-old" src="https://user-images.githubusercontent.com/2070010/70159638-25f42080-16b1-11ea-84bf-a39cc4fc14a2.png"> | <img width="1189" alt="shawburn-page" src="https://user-images.githubusercontent.com/2070010/70159662-2bea0180-16b1-11ea-8e65-e133cdab2eb3.png"> | <img width="1203" alt="shawburn-template" src="https://user-images.githubusercontent.com/2070010/70159671-30aeb580-16b1-11ea-9be6-4f976393faa6.png"> |

Notes to the screenshots: 

Alves now _seems_ to have more padding than before, but it's just an illusion.
Fact is: the Alves default template part has a Spacer block on top which didn't have vertical margins before, and now it does.

Maywood is basically unaffected by these changes.

Shawburn, the reason for this PR, didn't have margins around the Social Links block, and now it does.

#### Testing instructions

* Smoke test the **page editor** on an FSE site, with several different FSE-ready themes.
* All blocks inside a Template Part should have some vertical margins around them, and look the same as in the Template Part editor.
* The Template Part preview should not have unnecessary vertical paddings, and have roughly the same whitespace as the Template Part editor.