### PR TITLE
Enable the new WooCommerce onboarding flow in production and staging

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -49,7 +49,7 @@
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/site-questions": false,
-		"jetpack/connect/woocommerce": false,
+		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"login/magic-login": true,
@@ -147,7 +147,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
-		"woocommerce/onboarding-oauth": false,
+		"woocommerce/onboarding-oauth": true,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,7 @@
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/site-questions": false,
-		"jetpack/connect/woocommerce": false,
+		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"login/magic-login": true,
@@ -149,7 +149,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
-		"woocommerce/onboarding-oauth": false,
+		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
Part of #3055. This PR enables our special WooCommerce onboarding flows for Jetpack and the WooCommerce.com OAuth connection flow in the `production` and `stage` environments.

These flows are only active when a certain query string is present (`?from=woocommerce-onboarding` for Jetpack or `?wccom-from=onboarding` for OAuth).

In WooCommerce 3.9 (beta releasing soon), we will be exposing users publicly to the new WooCommerce Core onboarding experience with uses both of these Calypso flows.

<img width="1286" alt="Screen Shot 2019-12-04 at 11 24 24 AM" src="https://user-images.githubusercontent.com/689165/70160845-2678c100-1689-11ea-8e54-f53b11226bf6.png">

<img width="1680" alt="Screen Shot 2019-12-04 at 11 27 57 AM" src="https://user-images.githubusercontent.com/689165/70160861-2b3d7500-1689-11ea-9415-c411a3821019.png">

#### Testing instructions

Nothing specific to test, but if you want to optionally try out the flows, you can access them via WooCommerce Admin.

* Install WooCommerce
* Install WooCommerce Admin from GitHub
* Enable WP_DEBUG
* Go to WooCommerce > Settings > Help > Setup Wizard and connect via the Jetpack flow
* Go to WooCommerce > Settings > Help > Setup Wizard and connect via the WooCommerce.com flow.