### PR TITLE
Checklist: update mobile app button label

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -153,12 +153,13 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		margin-bottom: 4px;
 	}
 
-	.checklist__task-action {
-		white-space: nowrap;
+	.checklist__task-action-wrapper .button {
+		margin-bottom: 8px;
 	}
 
-	.checklist__task-skip {
-		margin-left: 8px;
+	.checklist__task-action {
+		white-space: nowrap;
+		margin-right: 8px;
 	}
 
 	&.warning {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -603,7 +603,7 @@ class WpcomChecklistComponent extends PureComponent {
 			<TaskComponent
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/mobile-app.svg"
-				completedButtonText={ translate( 'Download' ) }
+				completedButtonText={ translate( 'Download mobile app' ) }
 				completedTitle={ translate( 'You downloaded the WordPress app' ) }
 				description={ translate(
 					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
@@ -617,7 +617,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Get the WordPress app' ) }
 				showSkip={ true }
-				buttonText={ translate( 'Start' ) }
+				buttonText={ translate( 'Download mobile app' ) }
 			/>
 		);
 	};


### PR DESCRIPTION
The mobile app nudge was recently reintroduced to the Checklist. This updates the button label to be more in line with the changes from #38149.

**To test:**
- create a new website
- verify that the checklist has a mobile app item
- verify that the button for the item reads "Download mobile app" 