### PR TITLE
FSE: limit FSE themes in signup to 6

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -74,7 +74,7 @@ export function generateSteps( {
 			stepName: 'fse-themes',
 			props: {
 				designType: 'fse-compatible',
-				quantity: 9,
+				quantity: 6,
 			},
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'themeSlugWithRepo', 'useThemeHeadstart' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show 6 themes in signup selection step instead of 7.

Follow up to https://github.com/Automattic/wp-calypso/pull/38163.

<img width="991" alt="Screenshot 2019-12-04 at 18 46 09" src="https://user-images.githubusercontent.com/1182160/70171304-5e522980-16c6-11ea-8064-9bb783873660.png">

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/start/test-fse/fse-themes
2. Verify that you can see 6 of the newly supported FSE themes.
3. It should be a random sampling from the following set: Alves, Maywood, Morden, Stow, Hever, Exford, Shawburn.

