### PR TITLE
Devdocs: Remove columns from UI components list

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -1,4 +1,5 @@
 $devdocs-max-width: 720px;
+$devdocs-max-width-large: 1040px;
 
 // Sidebar Title
 .devdocs__title {
@@ -51,22 +52,6 @@ $devdocs-max-width: 720px;
 .main.devdocs.devdocs__components {
 	// Make way for showing big components and multiple columns
 	max-width: 100%;
-}
-
-.design__collection {
-	// Use multiple columns when listing components
-	.main.devdocs.is-list & {
-		column-gap: 24px;
-
-		// Show 2 columns for big screens
-		@include breakpoint( '>1280px' ) {
-			column-count: 2;
-		}
-
-		@media ( min-width: 2000px ) {
-			column-count: 3;
-		}
-	}
 }
 
 // We show a list of links for results above
@@ -178,6 +163,10 @@ $devdocs-max-width: 720px;
 		// set the max-width to line up with search
 		@include breakpoint( '<1280px' ) {
 			max-width: $devdocs-max-width;
+		}
+
+		@include breakpoint( '>1280px' ) {
+			max-width: $devdocs-max-width-large;
 		}
 
 		@media ( min-width: 2000px ) {


### PR DESCRIPTION
This PR attempts to address a problem I've encountered with the UI Components list in devdocs. 

Normally, the components are displayed in two columns, which makes visual scanning slightly more difficult than necessary. This behavior by itself isn't really a problem when we're talking about static content. However, because the components are loaded via infinite scroll, it ends up with two (or three) columns that continually re-organize themselves as a user scrolls down through the list. This ruins the mental map of the locations of previously seen components, because a component that may have previously been at the top of the right column may now be at the bottom of the left column (as a basic example). I know this makes scanning the components list more difficult for me, personally.

#### Changes proposed in this Pull Request

*  Removes the `column-count` CSS from `.design__collection` and adds `max-width: 1040px` to the component example wrappers to keep them from taking up the whole screen on large displays (`>1280px`).

#### Testing instructions
* Go to http://calypso.localhost:3000/devdocs/design
* Make your browser window larger than 1280px
* There should only be one column of components in the list

**Before**
![Screenshot_2019-12-04 UI Components — WordPress com (before)](https://user-images.githubusercontent.com/4297811/70189238-dd2f6e00-1696-11ea-9544-e26779801995.png)

**After**
![Screenshot_2019-12-04 UI Components — WordPress com (after)](https://user-images.githubusercontent.com/4297811/70189239-df91c800-1696-11ea-9ad0-e8a6e84840dd.png)
