### PR TITLE
Hosting: Show only eligible sites in the site selector.

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -42,6 +42,11 @@ class Sites extends Component {
 			return ! site.is_vip;
 		}
 
+		// Hosting routes are not applicable to Jetpack or VIP sites.
+		if ( /^\/hosting-config/.test( path ) ) {
+			return ! site.is_vip && ! ( site.jetpack && ! site.options.is_automated_transfer );
+		}
+
 		return site;
 	};
 


### PR DESCRIPTION
**This PR relies on #38155 being merged first.**

When directly accessing the `/hosting-config/` path, the site selector is displayed; however, currently all of a user's sites are available, regardless of their eligibility for hosting features. This PR filters the list of sites in the selector, removing both VIP and Jetpack sites (the two types of ineligible sites).

#### Testing instructions

* Fire up #38155 locally and cherry-pick this PR's commit: `git cherry-pick ba69d2b9e7c74cd7da181177ff90ff9c0e224bd7`.
* Load https://calypso.localhost/hosting-config/.
* Search for both a VIP and a Jetpack site; ensure they are not found.
* Search for both a Simple and an Atomic site; ensure they are found.

Fixes #38127 .
