### PR TITLE
Plan features tooltip copy updates

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -68,6 +68,9 @@ export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
 export const FEATURE_COMMUNITY_SUPPORT = 'community-support';
 export const FEATURE_EMAIL_SUPPORT = 'email-support';
 export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT = 'email-live-chat-support';
+export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS =
+	'email-live-chat-support-business-days';
+export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS = 'email-live-chat-support-all-days';
 export const FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT = 'email-forwarding-extended-limit';
 export const FEATURE_PREMIUM_SUPPORT = 'priority-support';
 export const FEATURE_BASIC_DESIGN = 'basic-design';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -113,7 +113,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Advanced customization' ),
 		getDescription: () =>
 			i18n.translate(
-				'In addition to extended color schemes and backgrounds, you have access to edit CSS, giving you complete control over how your site displays.'
+				'Access extended color schemes, backgrounds, and CSS, giving you complete control over how your site looks.'
 			),
 	},
 
@@ -217,9 +217,7 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_UNLIMITED_STORAGE_SIGNUP,
 		getTitle: () => i18n.translate( '200 GB storage' ),
 		getDescription: () =>
-			i18n.translate(
-				'Upload more images, audio, and documents to your website with increased storage space.'
-			),
+			i18n.translate( 'Upload more images, videos, audio, and documents to your website.' ),
 	},
 
 	[ constants.FEATURE_ADVANCED_SEO_TOOLS ]: {
@@ -293,10 +291,7 @@ export const FEATURES_LIST = {
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
-				'Upload more images, audio, and documents to your website with ' +
-					'increased storage space.'
-			),
+			i18n.translate( 'Upload more images, videos, audio, and documents to your website.' ),
 		getStoreSlug: () => 'unlimited_space',
 	},
 
@@ -356,8 +351,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Jetpack Essential Features' ),
 		getDescription: () =>
 			i18n.translate(
-				'Optimize your site for better SEO, faster-loading pages, and protection from spam. ' +
-					'You can also automate social sharing and access detailed reports of all activity on your site.'
+				'Optimize your site for better SEO, faster-loading pages, and protection from spam.'
 			),
 	},
 
@@ -458,9 +452,7 @@ export const FEATURES_LIST = {
 			} ),
 		getDescription: () =>
 			i18n.translate(
-				'In addition to extended color schemes and backgrounds, ' +
-					'you have access to edit CSS, giving you complete control over ' +
-					'how your site displays.'
+				'Access extended color schemes, backgrounds, and CSS, giving you complete control over how your site looks.'
 			),
 		getStoreSlug: () => constants.FEATURE_ADVANCED_DESIGN,
 	},
@@ -503,7 +495,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Get Personalized Help' ),
 		getDescription: () =>
 			i18n.translate(
-				"Get one-on-one help from a WordPress.com expert who'll help you set up your site and services exactly as you need them."
+				"Meet one-on-one with a WordPress.com expert who'll help you set up your site exactly as you need it."
 			),
 	},
 
@@ -541,7 +533,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Site Monetization' ),
 		getDescription: () =>
 			i18n.translate(
-				'More ways to earn by displaying ads and collecting recurring payments or donations from visitors.'
+				'Earn money on your site by displaying ads and collecting recurring payments or donations.'
 			),
 	},
 
@@ -580,10 +572,7 @@ export const FEATURES_LIST = {
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
-				'Upload more images, audio, and documents to your website with ' +
-					'increased storage space.'
-			),
+			i18n.translate( 'Upload more images, audio, and documents to your website.' ),
 	},
 
 	[ constants.FEATURE_13GB_STORAGE ]: {
@@ -595,10 +584,7 @@ export const FEATURES_LIST = {
 				},
 			} ),
 		getDescription: () =>
-			i18n.translate(
-				'Upload more images, audio, and documents to your website with ' +
-					'increased storage space.'
-			),
+			i18n.translate( 'Upload more images, videos, audio, and documents to your website.' ),
 	},
 
 	[ constants.FEATURE_COMMUNITY_SUPPORT ]: {
@@ -629,7 +615,7 @@ export const FEATURES_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'Live chat is available 24 hours a day from Monday through Friday. ' +
-					'You can also email us any day of the week for personalized support for your site.'
+					'You can also email us any day of the week for personalized support.'
 			),
 	},
 
@@ -639,7 +625,7 @@ export const FEATURES_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'Live chat is available 24/7. ' +
-					'You can also email us any day of the week for personalized support for your site.'
+					'You can also email us any day of the week for personalized support.'
 			),
 	},
 

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -218,7 +218,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( '200 GB storage' ),
 		getDescription: () =>
 			i18n.translate(
-				"With increased storage space you'll be able to upload more images, videos, audio, and documents to your website."
+				'Upload more images, audio, and documents to your website with increased storage space.'
 			),
 	},
 
@@ -294,8 +294,8 @@ export const FEATURES_LIST = {
 			} ),
 		getDescription: () =>
 			i18n.translate(
-				"With increased storage space you'll be able to upload " +
-					'more images, videos, audio, and documents to your website.'
+				'Upload more images, audio, and documents to your website with ' +
+					'increased storage space.'
 			),
 		getStoreSlug: () => 'unlimited_space',
 	},
@@ -596,8 +596,8 @@ export const FEATURES_LIST = {
 			} ),
 		getDescription: () =>
 			i18n.translate(
-				"With increased storage space you'll be able to upload " +
-					'more images, videos, audio, and documents to your website.'
+				'Upload more images, audio, and documents to your website with ' +
+					'increased storage space.'
 			),
 	},
 

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -153,7 +153,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
 		getDescription: () =>
 			i18n.translate(
-				'Unlimited access to all of our advanced premium theme templates, including templates specifically tailored for businesses.'
+				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
 			),
 	},
 
@@ -383,8 +383,8 @@ export const FEATURES_LIST = {
 			} ),
 		getDescription: () =>
 			i18n.translate(
-				'Unlimited access to all of our advanced premium theme templates, ' +
-					'including templates specifically tailored for businesses.'
+				'Unlimited access to all of our advanced premium themes, ' +
+					'including designs specifically tailored for businesses.'
 			),
 		getStoreSlug: () => 'unlimited_themes',
 	},
@@ -621,6 +621,26 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Email & Live Chat Support' ),
 		getDescription: () =>
 			i18n.translate( 'Live chat support to help you get started with your site.' ),
+	},
+
+	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS ]: {
+		getSlug: () => constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
+		getTitle: () => i18n.translate( 'Email & Live Chat Support' ),
+		getDescription: () =>
+			i18n.translate(
+				'Live chat is available 24 hours a day from Monday through Friday. ' +
+					'You can also email us any day of the week for personalized support for your site.'
+			),
+	},
+
+	[ constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS ]: {
+		getSlug: () => constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
+		getTitle: () => i18n.translate( 'Email & Live Chat Support' ),
+		getDescription: () =>
+			i18n.translate(
+				'Live chat is available 24/7. ' +
+					'You can also email us any day of the week for personalized support for your site.'
+			),
 	},
 
 	[ constants.FEATURE_PREMIUM_SUPPORT ]: {

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -113,7 +113,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Advanced customization' ),
 		getDescription: () =>
 			i18n.translate(
-				'Customize your selected theme template with extended color schemes, background designs, and complete control over website CSS.'
+				'In addition to extended color schemes and backgrounds, you have access to edit CSS, giving you complete control over how your site displays.'
 			),
 	},
 
@@ -132,8 +132,8 @@ export const FEATURES_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'Get a free domain for one year. ' +
-					'Premium domains not included. ' +
-					'Your domain will renew at its {{a}}regular price{{/a}}.',
+					'Doesn’t apply to plan upgrades, renewals, or to premium domains. ' +
+					'After one year, domain renews at its {{a}}regular price{{/a}}.',
 				{
 					components: {
 						a: (
@@ -200,7 +200,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Dozens of Free Themes' ),
 		getDescription: () =>
 			i18n.translate(
-				"Access to a wide range of professional theme templates for your website so you can find the exact design you're looking for."
+				"Access to a wide range of professional themes so you can find a design that's just right for your site."
 			),
 	},
 
@@ -227,7 +227,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Advanced SEO tools' ),
 		getDescription: () =>
 			i18n.translate(
-				"Adds tools to enhance your site's content for better results on search engines and social media."
+				'Boost traffic to your site with tools that make your content more findable on search engines and social media.'
 			),
 	},
 
@@ -269,8 +269,8 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Google Analytics Integration' ),
 		getDescription: () =>
 			i18n.translate(
-				'Track website statistics with Google Analytics for a ' +
-					'deeper understanding of your website visitors and customers.'
+				"Track your site's stats with Google Analytics for a " +
+					'deeper understanding of your visitors and customers.'
 			),
 	},
 
@@ -334,8 +334,8 @@ export const FEATURES_LIST = {
 
 			return i18n.translate(
 				'Get a free domain for one year. ' +
-					'Premium domains not included. ' +
-					'Your domain will renew at its {{a}}regular price{{/a}}.',
+					'Doesn’t apply to plan upgrades, renewals, or to premium domains. ' +
+					'After one year, domain renews at its {{a}}regular price{{/a}}.',
 				{
 					components: {
 						a: (
@@ -356,9 +356,8 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Jetpack Essential Features' ),
 		getDescription: () =>
 			i18n.translate(
-				'Speed up your site’s performance and protect it from spammers. ' +
-					'Access detailed records of all activity on your site. ' +
-					'While you’re at it, improve your SEO and automate social media sharing.'
+				'Optimize your site for better SEO, faster-loading pages, and protection from spam. ' +
+					'You can also automate social sharing and access detailed reports of all activity on your site.'
 			),
 	},
 
@@ -443,7 +442,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Basic Design Customization' ),
 		getDescription: () =>
 			i18n.translate(
-				'Customize your selected theme template with pre-set color schemes, ' +
+				'Customize your selected theme with pre-set color schemes, ' +
 					'background designs, and font styles.'
 			),
 		getStoreSlug: () => constants.FEATURE_ADVANCED_DESIGN,
@@ -459,8 +458,9 @@ export const FEATURES_LIST = {
 			} ),
 		getDescription: () =>
 			i18n.translate(
-				'Customize your selected theme template with extended color schemes, ' +
-					'background designs, and complete control over website CSS.'
+				'In addition to extended color schemes and backgrounds, ' +
+					'you have access to edit CSS, giving you complete control over ' +
+					'how your site displays.'
 			),
 		getStoreSlug: () => constants.FEATURE_ADVANCED_DESIGN,
 	},
@@ -503,7 +503,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Get Personalized Help' ),
 		getDescription: () =>
 			i18n.translate(
-				'Schedule a one-on-one orientation with a Happiness Engineer to set up your site and learn more about WordPress.com.'
+				"Get one-on-one help from a WordPress.com expert who'll help you set up your site and services exactly as you need them."
 			),
 	},
 
@@ -512,20 +512,28 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'SEO Tools' ),
 		getDescription: () =>
 			i18n.translate(
-				"Adds tools to enhance your site's content for better results on search engines and social media."
+				'Boost traffic to your site with tools that make your content more findable on search engines and social media.'
 			),
 	},
 
 	[ constants.FEATURE_UPLOAD_PLUGINS ]: {
 		getSlug: () => constants.FEATURE_UPLOAD_PLUGINS,
 		getTitle: () => i18n.translate( 'Install Plugins' ),
-		getDescription: () => i18n.translate( 'Install custom plugins on your site.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Plugins extend the functionality of your site and ' +
+					'open up endless possibilities for presenting your content and interacting with visitors.'
+			),
 	},
 
 	[ constants.FEATURE_UPLOAD_THEMES ]: {
 		getSlug: () => constants.FEATURE_UPLOAD_THEMES,
 		getTitle: () => i18n.translate( 'Install Themes' ),
-		getDescription: () => i18n.translate( 'Upload custom themes on your site.' ),
+		getDescription: () =>
+			i18n.translate(
+				'With the option to upload themes, you can give your site a professional polish ' +
+					'that will help it stand out among the rest.'
+			),
 	},
 
 	[ constants.FEATURE_WORDADS_INSTANT ]: {
@@ -533,7 +541,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Site Monetization' ),
 		getDescription: () =>
 			i18n.translate(
-				'Put your site to work and earn through ad revenue, easy-to-add PayPal buttons, and more.'
+				'More ways to earn by displaying ads and collecting recurring payments or donations from visitors.'
 			),
 	},
 
@@ -551,8 +559,8 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Dozens of Free Themes' ),
 		getDescription: () =>
 			i18n.translate(
-				'Access to a wide range of professional theme templates ' +
-					"for your website so you can find the exact design you're looking for."
+				'Access to a wide range of professional themes ' +
+					"so you can find a design that's just right for your site."
 			),
 	},
 
@@ -573,8 +581,8 @@ export const FEATURES_LIST = {
 			} ),
 		getDescription: () =>
 			i18n.translate(
-				"With increased storage space you'll be able to upload " +
-					'more images, audio, and documents to your website.'
+				'Upload more images, audio, and documents to your website with ' +
+					'increased storage space.'
 			),
 	},
 

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -99,7 +99,7 @@ const getPlanPersonalDetails = () => ( {
 		// pay attention to ordering, shared features should align on /plan page
 		constants.FEATURE_CUSTOM_DOMAIN,
 		constants.FEATURE_JETPACK_ESSENTIAL,
-		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 		constants.FEATURE_FREE_THEMES,
 		constants.FEATURE_BASIC_DESIGN,
 		constants.FEATURE_6GB_STORAGE,
@@ -162,7 +162,7 @@ const getPlanEcommerceDetails = () => ( {
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
 			constants.FEATURE_JETPACK_ADVANCED,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
 			constants.FEATURE_UNLIMITED_STORAGE,
@@ -249,7 +249,7 @@ const getPlanPremiumDetails = () => ( {
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
 			constants.FEATURE_JETPACK_ESSENTIAL,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
 			constants.FEATURE_13GB_STORAGE,
@@ -322,7 +322,7 @@ const getPlanBusinessDetails = () => ( {
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
 			constants.FEATURE_JETPACK_ADVANCED,
-			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
 			constants.FEATURE_UNLIMITED_STORAGE,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implement copy updates to the plan features tooltip seen in `/plans/{SITE_SLUG}` page while logged in. Check paObgF-Iu-p2 for context.

<img width="1656" alt="Screenshot 2019-12-12 at 11 12 12 AM" src="https://user-images.githubusercontent.com/1269602/70685759-5438b800-1cd0-11ea-88ec-ca102d959d79.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the tooltip for each feature in /plans and verify that the relevant copy updates are in place.

