### PR TITLE
Domains: Fix how the TLD Filter bar is ordered

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -91,13 +91,13 @@
 
 .search-filters__buttons {
 	display: flex;
-	flex-flow: row-reverse;
+	flex-flow: row;
 	justify-content: space-between;
 
 	.button {
 		flex: 1 0 auto;
 		margin-left: 1em;
-		&:last-child {
+		&:first-child {
 			margin-left: 0;
 		}
 
@@ -120,7 +120,7 @@
 	}
 
 	&.search-filters__tld-filter-bar--is-domain-management
-		.search-filters__tld-button:nth-child( n + 6 ) {
+		.search-filters__tld-button:nth-child( n + 8 ) {
 		display: none;
 	}
 

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -217,5 +217,9 @@
 
 	.token-field__suggestion {
 		color: var( --color-neutral-70 );
+		&.is-selected span {
+			color: var( --color-text-inverted );
+		}
 	}
 }
+

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -119,11 +119,6 @@
 		}
 	}
 
-	&.search-filters__tld-filter-bar--is-domain-management
-		.search-filters__tld-button:nth-child( n + 8 ) {
-		display: none;
-	}
-
 	@include breakpoint( '<960px' ) {
 		&.is-compact {
 			padding-bottom: 0.5em;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -93,6 +93,7 @@
 	display: flex;
 	flex-flow: row;
 	justify-content: space-between;
+	overflow: hidden;
 
 	.button {
 		flex: 1 0 auto;

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -106,8 +106,8 @@ export class TldFilterBar extends Component {
 
 		return (
 			<CompactCard className={ className }>
-				{ this.renderSuggestedButtons() }
 				{ this.renderPopoverButton() }
+				{ this.renderSuggestedButtons() }
 				{ this.state.showPopover && this.renderPopover() }
 			</CompactCard>
 		);
@@ -182,10 +182,10 @@ export class TldFilterBar extends Component {
 				</FormFieldset>
 				<FormFieldset className="search-filters__buttons-fieldset">
 					<div className="search-filters__buttons">
-						<Button onClick={ this.handleFiltersReset }>{ translate( 'Reset' ) }</Button>
 						<Button primary onClick={ this.handleFiltersSubmit }>
 							{ translate( 'Apply' ) }
 						</Button>
+						<Button onClick={ this.handleFiltersReset }>{ translate( 'Reset' ) }</Button>
 					</div>
 				</FormFieldset>
 			</Popover>

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -40,7 +40,7 @@ export class TldFilterBar extends Component {
 	};
 
 	static defaultProps = {
-		numberOfTldsShown: 8,
+		numberOfTldsShown: 6,
 	};
 
 	state = {


### PR DESCRIPTION
The TLD Filter bar was ordered backwards for some reason - so instead of `.com/.net/.org/.blog/.club` we show `.club/.blog/.org/.net/.com`. I've updated how the buttons are displayed and fixed the filter buttons order too so that they're all consistent (primary button is first and then secondary). We'll stop reordering the TLDs based on the domain search terms so we need to make sure that the TLD Filter bar is displayed correctly.

@fditrapani I'm shamelessly pulling you in this 🙏 

#### Changes proposed in this Pull Request

* change the order of the TLD Filter buttons
* change the order of the filters Apply/Reset buttons too

### TLD Filter bar

Before:
<img width="1061" alt="Screenshot 2019-12-05 at 12 07 33" src="https://user-images.githubusercontent.com/1355045/70225623-0e23a780-1758-11ea-9948-1895c7bffa27.png">

After:
<img width="1052" alt="Screenshot 2019-12-05 at 12 07 43" src="https://user-images.githubusercontent.com/1355045/70225634-124fc500-1758-11ea-8374-ba67a9e884bd.png">

### Filters

Before:
<img width="368" alt="Screenshot 2019-12-05 at 12 07 53" src="https://user-images.githubusercontent.com/1355045/70225709-38756500-1758-11ea-93d0-45c0d35f0a3f.png">

After (ignore the max chars and dashes - they're feature flagged). Just check the buttons:
<img width="343" alt="Screenshot 2019-12-05 at 12 07 59" src="https://user-images.githubusercontent.com/1355045/70225717-3c08ec00-1758-11ea-9147-7fe4fd3f74a5.png">

#### Testing instructions

* add a domain to an existing site and verify that the order of the TLD Filter buttons matches the TLD list returned from the API Endpoint - `/rest/v1.1/domains/suggestions/tlds`
* go in `/domains/start` and search for a domain - check that the TLD filter buttons order is correct. Also check the "Filter" button and the "More extensions" button and the Apply/Reset buttons inside.
* verify that tabbing between those buttons works correctly
