### PR TITLE
i18n: get the value of HTML lang attribute from a special translation string

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -65,8 +65,22 @@ export function getLanguageFileUrl( localeSlug, fileType = 'json', languageRevis
 	return typeof revision === 'number' ? fileUrl + `?v=${ revision }` : fileUrl;
 }
 
-function setLocaleInDOM( localeSlug, isRTL ) {
-	document.documentElement.lang = localeSlug;
+function getHtmlLangAttribute() {
+	// translation of this string contains the desired HTML attribute value
+	const slug = i18n.translate( 'html_lang_attribute' );
+
+	// Hasn't been translated? Likely the default `en` locale. Return the default i18n slug.
+	if ( slug === 'html_lang_attribute' ) {
+		return i18n.getLocaleSlug();
+	}
+
+	return slug;
+}
+
+function setLocaleInDOM() {
+	const htmlLangAttribute = getHtmlLangAttribute();
+	const isRTL = i18n.isRtl();
+	document.documentElement.lang = htmlLangAttribute;
 	document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
 	document.body.classList[ isRTL ? 'add' : 'remove' ]( 'rtl' );
 
@@ -106,32 +120,25 @@ export default function switchLocale( localeSlug ) {
 		return;
 	}
 
-	const { langSlug: targetLocaleSlug, parentLangSlug } = language;
+	lastRequestedLocale = localeSlug;
 
-	// variant lang objects contain references to their parent lang, which is what we want to tell the browser we're running
-	const domLocaleSlug = parentLangSlug || targetLocaleSlug;
-
-	lastRequestedLocale = targetLocaleSlug;
-
-	if ( isDefaultLocale( targetLocaleSlug ) ) {
-		i18n.configure( { defaultLocaleSlug: targetLocaleSlug } );
-		setLocaleInDOM( domLocaleSlug, !! language.rtl );
+	if ( isDefaultLocale( localeSlug ) ) {
+		i18n.configure( { defaultLocaleSlug: localeSlug } );
+		setLocaleInDOM();
 	} else {
-		getLanguageFile( targetLocaleSlug ).then(
+		getLanguageFile( localeSlug ).then(
 			// Success.
 			body => {
 				if ( body ) {
 					// Handle race condition when we're requested to switch to a different
 					// locale while we're in the middle of request, we should abandon result
-					if ( targetLocaleSlug !== lastRequestedLocale ) {
+					if ( localeSlug !== lastRequestedLocale ) {
 						return;
 					}
 
 					i18n.setLocale( body );
-
-					setLocaleInDOM( domLocaleSlug, !! language.rtl );
-
-					loadUserUndeployedTranslations( targetLocaleSlug );
+					setLocaleInDOM();
+					loadUserUndeployedTranslations( localeSlug );
 				}
 			},
 			// Failure.

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -69,7 +69,9 @@ function getHtmlLangAttribute() {
 	// translation of this string contains the desired HTML attribute value
 	const slug = i18n.translate( 'html_lang_attribute' );
 
-	// Hasn't been translated? Likely the default `en` locale. Return the default i18n slug.
+	// Hasn't been translated? Some languages don't have the translation for this string,
+	// or maybe we are dealing with the default `en` locale. Return the general purpose locale slug
+	// -- there's no special one available for `<html lang>`.
 	if ( slug === 'html_lang_attribute' ) {
 		return i18n.getLocaleSlug();
 	}


### PR DESCRIPTION
To determine the locale slug to set as the `<html lang>` attribute, use the special translation string `html_lang_attribute` that WordPress translation files provide.

Removes the need to retrieve that info from the list in the `client/languages.js` module. The translations files should be the preferred source of truth of all things i18n.

The `client/languages` module should be eventually used only by the Language Picker UI and should be removed from the entrypoint JS chunks (another little win for bundle size).

**How to test:**
Choose one of the languages where the HTML lang attribute will be different from the language slug. I.e., `sr_latin`, `de_formal` or `es-mx`.

To test this even better, find some language where the translation file has different values for `html_lang_attribute` and `[ '' ][ 'localeSlug' ]`. Does such one even exist?