### PR TITLE
FSE: Add transform + upgrade nudge from A8c Nav Block to Core Nav Block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -52,14 +52,14 @@ const NavigationMenuEdit = ( {
 					onRemove={ () => setUpgradeNudgeVisible( false ) }
 					actions={ [
 						{
-							label: __( 'Upgrade Block', 'full-site-editing' ),
+							label: __( 'Update Block', 'full-site-editing' ),
 							onClick: upgradeToCoreNavigationBlock,
 						},
 					] }
 				>
 					<p>
 						{ __(
-							'An improved version of this block is now available. Upgrade and then preview before updating your site.',
+							'An improved version of this block is now available. Update and then preview before updating your site.',
 							'full-site-editing'
 						) }
 					</p>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -60,7 +60,7 @@ const NavigationMenuEdit = ( {
 					<p>
 						<span className="posts-list__message">
 							{ __(
-								'An improved version of the Navigation block is available. Upgrade for a better, more natural way to manage your Navigation.',
+								'Upgrade to an improved version of the Navigation block. There may be small visual changes. As such, we recommend you upgrade and preview your changes before updating your site.',
 								'full-site-editing'
 							) }
 						</span>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -58,12 +58,10 @@ const NavigationMenuEdit = ( {
 					] }
 				>
 					<p>
-						<span className="posts-list__message">
-							{ __(
-								'Upgrade to an improved version of the Navigation block. There may be small visual changes. As such, we recommend you upgrade and preview your changes before updating your site.',
-								'full-site-editing'
-							) }
-						</span>
+						{ __(
+							'An improved version of this block is now available. Upgrade and then preview before updating your site.',
+							'full-site-editing'
+						) }
 					</p>
 				</Notice>
 			) }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -4,7 +4,7 @@
  * WordPress dependencies
  */
 import ServerSideRender from '@wordpress/server-side-render';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
@@ -17,7 +17,7 @@ import {
 	withColors,
 	withFontSizes,
 } from '@wordpress/block-editor';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, Notice } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -35,12 +35,36 @@ const NavigationMenuEdit = ( {
 	textColor,
 	isPublished,
 } ) => {
+	const [ upgradeNudgeVisible, setUpgradeNudgeVisible ] = useState( true );
+
 	const { customFontSize, textAlign } = attributes;
 
 	const actualFontSize = customFontSize || fontSize.size;
 
+	const upgradeBlock = () => {};
+
 	return (
 		<Fragment>
+			{ upgradeNudgeVisible && (
+				<Notice
+					onRemove={ () => setUpgradeNudgeVisible( false ) }
+					actions={ [
+						{
+							label: __( 'Upgrade Block', 'full-site-editing' ),
+							onClick: upgradeBlock,
+						},
+					] }
+				>
+					<p>
+						<span className="posts-list__message">
+							{ __(
+								'An improved version of the Navigation block is available. Upgrade for a better, more natural way to manage your Navigation.',
+								'full-site-editing'
+							) }
+						</span>
+					</p>
+				</Notice>
+			) }
 			<BlockControls>
 				<AlignmentToolbar
 					value={ textAlign }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import edit from './edit';
+import transforms from './transforms';
 import './style.scss';
 
 const icon = (
@@ -30,4 +31,5 @@ registerBlockType( 'a8c/navigation-menu', {
 	},
 	edit,
 	save: () => null,
+	transforms,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -101,6 +101,7 @@ function render_navigation_menu_block( $attributes ) {
 	</script>
 		<?php
 	endif;
+
 	// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	return ob_get_clean();
 }
@@ -124,25 +125,25 @@ function get_nav_menu_items_data( string $menu_location ) {
 	}
 
 	// Access all Nav Menu Theme locations.
-	$locations = get_nav_menu_locations();
+	$locations = \get_nav_menu_locations();
 
 	if ( empty( $locations ) || empty( $locations[ $menu_location ] ) ) {
-		return false;
+		return \get_pages();
 	}
 
 	// Get the full Nav Menu object from the location
 	// https://codex.wordpress.org/Function_Reference/wp_get_nav_menu_object.
-	$menu_obj = wp_get_nav_menu_object( $locations[ $menu_location ] );
+	$menu_obj = \wp_get_nav_menu_object( $locations[ $menu_location ] );
 
 	if ( empty( $menu_obj ) || empty( $menu_obj->term_id ) ) {
 		return false;
 	}
 
 	// Retrieve data on the individual Menu items.
-	$nav_items = wp_get_nav_menu_items( $menu_obj->term_id );
+	$nav_items = \wp_get_nav_menu_items( $menu_obj->term_id );
 
 	if ( empty( $nav_items ) ) {
-		$nav_items = get_pages();
+		$nav_items = \get_pages();
 	}
 
 	return $nav_items;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -62,16 +62,19 @@ function render_navigation_menu_block( $attributes ) {
 	$container_class .= $class;
 	$toggle_class    .= $class;
 
-	$menu = wp_nav_menu(
-		[
+	$menu       = wp_nav_menu(
+		array(
 			'echo'           => false,
 			'fallback_cb'    => 'get_fallback_navigation_menu',
 			'items_wrap'     => '<ul id="%1$s" class="%2$s" aria-label="submenu">%3$s</ul>',
 			'menu_class'     => 'main-menu footer-menu',
 			'theme_location' => 'menu-1',
 			'container'      => '',
-		]
+		)
 	);
+	$locations  = get_nav_menu_locations();
+	$menu_obj   = wp_get_nav_menu_object( $locations['menu-1'] );
+	$menu_items = wp_get_nav_menu_items( $menu_obj->term_id );
 
 	ob_start();
 	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -90,7 +93,14 @@ function render_navigation_menu_block( $attributes ) {
 		</div>
 	</nav>
 	<!-- #site-navigation -->
-	<?php
+	<?php if ( ! empty( $menu_items ) ) : ?>
+	<script id="<?php echo esc_attr( uniqid() ); ?>" type="application/json">
+		<?php
+		echo \wp_json_encode( $menu_items );
+		?>
+	</script>
+		<?php
+	endif;
 	// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	return ob_get_clean();
 }
@@ -103,14 +113,14 @@ function render_navigation_menu_block( $attributes ) {
  */
 function get_fallback_navigation_menu() {
 	$menu = wp_page_menu(
-		[
+		array(
 			'after'       => false,
 			'before'      => false,
 			'container'   => 'ul',
 			'echo'        => false,
 			'menu_class'  => 'main-menu footer-menu',
 			'sort_column' => 'menu_order, post_date',
-		]
+		)
 	);
 
 	/**
@@ -118,8 +128,8 @@ function get_fallback_navigation_menu() {
 	 * CSS class structure as a regularly built menu
 	 * so we don't have to duplicate CSS selectors everywhere.
 	 */
-	$original_classes    = [ 'children', 'page_item_has_sub-menu' ];
-	$replacement_classes = [ 'sub-menu', 'menu-item-has-children' ];
+	$original_classes    = array( 'children', 'page_item_has_sub-menu' );
+	$replacement_classes = array( 'sub-menu', 'menu-item-has-children' );
 
 	return str_replace( $original_classes, $replacement_classes, $menu );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -139,7 +139,13 @@ function get_nav_menu_items_data( string $menu_location ) {
 	}
 
 	// Retrieve data on the individual Menu items.
-	return wp_get_nav_menu_items( $menu_obj->term_id );
+	$nav_items = wp_get_nav_menu_items( $menu_obj->term_id );
+
+	if ( empty( $nav_items ) ) {
+		$nav_items = get_pages();
+	}
+
+	return $nav_items;
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/style.scss
@@ -1,3 +1,34 @@
+$gutenberg-default-font-size: 13px;
+$gutenberg-default-line-height: 1.4;
+
+[data-type='a8c/navigation-menu'] {
+
+	.components-notice {
+
+		&.is-dismissible {
+			padding-right: 0;
+		}
+
+		.components-notice__content p {
+			margin-top: 0;
+			margin-bottom: 1em;
+			font-size: $gutenberg-default-font-size;
+			line-height: $gutenberg-default-line-height;
+		}
+
+		.components-notice__action {
+			margin-bottom: 0.2em;
+			margin-left: 0;
+		}
+
+		.components-notice__dismiss {
+			position: relative;
+			top: -8px;
+		}
+
+	}
+}
+
 .wp-block-a8c-navigation-menu.main-navigation {
 	pointer-events: none;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
@@ -19,20 +19,27 @@ export default {
 			type: 'block',
 			blocks: [ CORE_NAVIGATION_BLOCK_TYPE ],
 			__experimentalConvert( { attributes, clientId } ) {
-				// Existing Menu items are stored as JSON alongside the ServerSideRendered
-				// block HTML markup.
-				const menuItems = JSON.parse(
-					document.querySelector( `#block-${ clientId } script` ).innerHTML
-				);
+				let menuItems;
+				let navItems;
 
-				// Each Menu Items should become a Nav Link Block
-				const navItems = menuItems.map( item => {
-					return createBlock( CORE_NAVIGATION_ITEM_BLOCK_TYPE, {
-						label: item.post_title || item.title,
-						title: item.post_title || item.title,
-						url: item.url,
+				const menuItemScriptTag = document.querySelector( `#block-${ clientId } script` );
+
+				if ( menuItemScriptTag ) {
+					// Existing Menu items are stored as JSON alongside the ServerSideRendered
+					// block HTML markup.
+					menuItems = JSON.parse( menuItemScriptTag.innerHTML );
+				}
+
+				if ( menuItems ) {
+					// Each Menu Items should become a Nav Link Block
+					navItems = menuItems.map( item => {
+						return createBlock( CORE_NAVIGATION_ITEM_BLOCK_TYPE, {
+							label: item.post_title || item.title,
+							title: item.post_title || item.title,
+							url: item.url,
+						} );
 					} );
-				} );
+				}
 
 				// Create Nav Block mapping attrs and Nav Items
 				return createBlock(

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
@@ -28,8 +28,8 @@ export default {
 				// Each Menu Items should become a Nav Link Block
 				const navItems = menuItems.map( item => {
 					return createBlock( CORE_NAVIGATION_ITEM_BLOCK_TYPE, {
-						label: item.post_title,
-						title: item.post_title,
+						label: item.post_title || item.title,
+						title: item.post_title || item.title,
 						url: item.url,
 					} );
 				} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
@@ -18,8 +18,11 @@ export default {
 		{
 			type: 'block',
 			blocks: [ CORE_NAVIGATION_BLOCK_TYPE ],
-			transform: () => {
-				return createBlock( CORE_NAVIGATION_BLOCK_TYPE, {} );
+			transform: attributes => {
+				return createBlock( CORE_NAVIGATION_BLOCK_TYPE, {
+					align: attributes.align,
+					itemsJustification: attributes.textAlign,
+				} );
 			},
 		},
 	],

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+/* eslint-enable import/no-extraneous-dependencies */
+
+const CORE_NAVIGATION_BLOCK_TYPE = 'core/navigation';
+
+export const isValidCoreNavigationBlockType = type => CORE_NAVIGATION_BLOCK_TYPE === type;
+
+export default {
+	to: [
+		{
+			type: 'block',
+			blocks: [ CORE_NAVIGATION_BLOCK_TYPE ],
+			transform: () => {
+				return createBlock( CORE_NAVIGATION_BLOCK_TYPE, {} );
+			},
+		},
+	],
+};

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/transforms.js
@@ -10,7 +10,7 @@ import { createBlock } from '@wordpress/blocks';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const CORE_NAVIGATION_BLOCK_TYPE = 'core/navigation';
-
+const CORE_NAVIGATION_ITEM_BLOCK_TYPE = 'core/navigation-link';
 export const isValidCoreNavigationBlockType = type => CORE_NAVIGATION_BLOCK_TYPE === type;
 
 export default {
@@ -18,11 +18,31 @@ export default {
 		{
 			type: 'block',
 			blocks: [ CORE_NAVIGATION_BLOCK_TYPE ],
-			transform: attributes => {
-				return createBlock( CORE_NAVIGATION_BLOCK_TYPE, {
-					align: attributes.align,
-					itemsJustification: attributes.textAlign,
+			__experimentalConvert( { attributes, clientId } ) {
+				// Existing Menu items are stored as JSON alongside the ServerSideRendered
+				// block HTML markup.
+				const menuItems = JSON.parse(
+					document.querySelector( `#block-${ clientId } script` ).innerHTML
+				);
+
+				// Each Menu Items should become a Nav Link Block
+				const navItems = menuItems.map( item => {
+					return createBlock( CORE_NAVIGATION_ITEM_BLOCK_TYPE, {
+						label: item.post_title,
+						title: item.post_title,
+						url: item.url,
+					} );
 				} );
+
+				// Create Nav Block mapping attrs and Nav Items
+				return createBlock(
+					CORE_NAVIGATION_BLOCK_TYPE,
+					{
+						align: attributes.align,
+						itemsJustification: attributes.textAlign,
+					},
+					navItems
+				);
 			},
 		},
 	],


### PR DESCRIPTION
Gutenberg now has a native Nav Block `core/navigation`. As a result we can start to deprecate the `a8c/navigation-menu` block from FSE.

To do this we are going to add a transform to the a8c block and then prompt the user to run the upgrade manually.

For more see `paYJgx-lF-p2`

### Screenshots

![Screen Capture on 2019-12-10 at 16-02-51](https://user-images.githubusercontent.com/444434/70546132-9cd46200-1b66-11ea-8121-64647078e3d4.gif)


### Testing instructions

It is...complicated.

* Follow `paAmJe-Nv-p2` and have the sync from FSE to Dotcom up and running.
* From Calypso root run `npx lerna run dev --scope='@automattic/full-site-editing' --stream` to watch and build FSE files.
* On Dotcom, active [`Alves` FSE Theme](https://wordpress.com/theme/alves/).
* Add a new `Page`.
* Edit the `Header` template part.
* See the a8c nav Block upgrade nudge.
* Click the update button.
* See the block transformed to the `core/navigation` Block.


