### PR TITLE
[PBD interim fix] Add cleaned up version of checkout thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -26,13 +26,16 @@ import { localize } from 'i18n-calypso';
 import { preventWidows } from 'lib/formatting';
 import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
-import getCheckoutUpgradeIntent from 'state/selectors/get-checkout-upgrade-intent';
+import Gridicon from 'components/gridicon';
+import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgrade-intent';
 
 class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
 		isDataLoaded: PropTypes.bool.isRequired,
 		primaryPurchase: PropTypes.object,
 		hasFailedPurchases: PropTypes.bool,
+		isSimplified: PropTypes.bool,
+		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
 		primaryCta: PropTypes.func,
 	};
 
@@ -279,9 +282,13 @@ class CheckoutThankYouHeader extends PureComponent {
 		} = this.props;
 
 		switch ( upgradeIntent ) {
+			case 'browse_plugins':
+				return translate( 'Continue Browsing Plugins' );
 			case 'plugins':
+			case 'install_plugin':
 				return translate( 'Continue Installing Plugin' );
 			case 'themes':
+			case 'install_themes':
 				return translate( 'Continue Installing Theme' );
 		}
 
@@ -352,7 +359,7 @@ class CheckoutThankYouHeader extends PureComponent {
 	}
 
 	render() {
-		const { isDataLoaded, hasFailedPurchases, primaryPurchase } = this.props;
+		const { isDataLoaded, isSimplified, hasFailedPurchases, primaryPurchase } = this.props;
 		const classes = { 'is-placeholder': ! isDataLoaded };
 
 		let svg = 'thank-you.svg';
@@ -377,7 +384,11 @@ class CheckoutThankYouHeader extends PureComponent {
 					<div className="checkout-thank-you__header-copy">
 						<h1 className="checkout-thank-you__header-heading">{ this.getHeading() }</h1>
 
-						<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>
+						{ primaryPurchase && isSimplified ? (
+							this.renderSimplifiedContent()
+						) : (
+							<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>
+						) }
 
 						{ this.getButton() }
 					</div>
@@ -385,11 +396,48 @@ class CheckoutThankYouHeader extends PureComponent {
 			</div>
 		);
 	}
+
+	renderSimplifiedContent() {
+		const { translate, primaryPurchase } = this.props;
+		const messages = [
+			translate(
+				'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
+					'Enjoy your powerful new features!',
+				{
+					args: { productName: primaryPurchase.productName },
+					components: { strong: <strong /> },
+				}
+			),
+		];
+		if ( this.props.siteUnlaunchedBeforeUpgrade ) {
+			messages.push(
+				translate(
+					"Your site has been launched. You can share it with the world whenever you're ready."
+				)
+			);
+		}
+
+		if ( messages.length === 1 ) {
+			return <h2 className="checkout-thank-you__header-text">{ messages[ 0 ] }</h2>;
+		}
+
+		const CHECKMARK_SIZE = 24;
+		return (
+			<ul className="checkout-thank-you__success-messages">
+				{ messages.map( message => (
+					<li className="checkout-thank-you__success-message-item">
+						<Gridicon icon="checkmark" size={ CHECKMARK_SIZE } />
+						<div>{ preventWidows( message ) }</div>
+					</li>
+				) ) }
+			</ul>
+		);
+	}
 }
 
 export default connect(
-	state => ( {
-		upgradeIntent: getCheckoutUpgradeIntent( state ),
+	( state, ownProps ) => ( {
+		upgradeIntent: ownProps.upgradeIntent || getCheckoutUpgradeIntent( state ),
 	} ),
 	{
 		recordStartTransferClickInThankYou,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -29,7 +29,7 @@ import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import Gridicon from 'components/gridicon';
 import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgrade-intent';
 
-class CheckoutThankYouHeader extends PureComponent {
+export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
 		isDataLoaded: PropTypes.bool.isRequired,
 		primaryPurchase: PropTypes.object,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -426,7 +426,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			<ul className="checkout-thank-you__success-messages">
 				{ messages.map( message => (
 					<li className="checkout-thank-you__success-message-item">
-						<Gridicon icon="checkmark" size={ CHECKMARK_SIZE } />
+						<Gridicon icon="checkmark-circle" size={ CHECKMARK_SIZE } />
 						<div>{ preventWidows( message ) }</div>
 					</li>
 				) ) }

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -384,7 +384,7 @@ class CheckoutThankYouHeader extends PureComponent {
 					<div className="checkout-thank-you__header-copy">
 						<h1 className="checkout-thank-you__header-heading">{ this.getHeading() }</h1>
 
-						{ primaryPurchase && isSimplified ? (
+						{ isPlan( primaryPurchase ) && isSimplified ? (
 							this.renderSimplifiedContent()
 						) : (
 							<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -384,7 +384,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 					<div className="checkout-thank-you__header-copy">
 						<h1 className="checkout-thank-you__header-heading">{ this.getHeading() }</h1>
 
-						{ isPlan( primaryPurchase ) && isSimplified ? (
+						{ primaryPurchase && isPlan( primaryPurchase ) && isSimplified ? (
 							this.renderSimplifiedContent()
 						) : (
 							<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -54,6 +54,7 @@ import {
 	isSiteRedirect,
 	isTheme,
 } from 'lib/products-values';
+import { isExternal } from 'lib/url';
 import JetpackPlanDetails from './jetpack-plan-details';
 import Main from 'components/main';
 import BloggerPlanDetails from './blogger-plan-details';
@@ -76,7 +77,6 @@ import { isRebrandCitiesSiteUrl } from 'lib/rebrand-cities';
 import { fetchAtomicTransfer } from 'state/atomic-transfer/actions';
 import { transferStates } from 'state/atomic-transfer/constants';
 import getAtomicTransfer from 'state/selectors/get-atomic-transfer';
-import getCheckoutUpgradeIntent from 'state/selectors/get-checkout-upgrade-intent';
 import isFetchingTransfer from 'state/selectors/is-fetching-atomic-transfer';
 import { getSiteHomeUrl, getSiteSlug } from 'state/sites/selectors';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
@@ -111,12 +111,15 @@ export class CheckoutThankYou extends React.Component {
 		domainOnlySiteFlow: PropTypes.bool.isRequired,
 		failedPurchases: PropTypes.array,
 		isFetchingTransfer: PropTypes.bool,
+		isSimplified: PropTypes.bool,
 		receiptId: PropTypes.number,
 		gsuiteReceiptId: PropTypes.number,
 		selectedFeature: PropTypes.string,
+		upgradeIntent: PropTypes.string,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		siteHomeUrl: PropTypes.string.isRequired,
 		transferComplete: PropTypes.bool,
+		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -284,7 +287,7 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	primaryCta = () => {
-		const { selectedSite, upgradeIntent } = this.props;
+		const { selectedSite, redirectTo } = this.props;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			const purchases = getPurchases( this.props );
@@ -294,10 +297,8 @@ export class CheckoutThankYou extends React.Component {
 				return page( '/start/domain-first' );
 			}
 
-			switch ( upgradeIntent ) {
-				case 'plugins':
-				case 'themes':
-					return page( `/${ upgradeIntent }/${ siteSlug }` );
+			if ( ! isExternal( redirectTo ) ) {
+				return page( redirectTo );
 			}
 
 			if ( purchases.some( isPlan ) ) {
@@ -457,14 +458,15 @@ export class CheckoutThankYou extends React.Component {
 				<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 
 				<Card className="checkout-thank-you__content">{ this.productRelatedMessages() }</Card>
-
-				<Card className="checkout-thank-you__footer">
-					<HappinessSupport
-						isJetpack={ wasJetpackPlanPurchased }
-						liveChatButtonEventName="calypso_plans_autoconfig_chat_initiated"
-						showLiveChatButton={ this.isEligibleForLiveChat() }
-					/>
-				</Card>
+				{ ! this.props.isSimplified && (
+					<Card className="checkout-thank-you__footer">
+						<HappinessSupport
+							isJetpack={ wasJetpackPlanPurchased }
+							liveChatButtonEventName="calypso_plans_autoconfig_chat_initiated"
+							showLiveChatButton={ this.isEligibleForLiveChat() }
+						/>
+					</Card>
+				) }
 			</Main>
 		);
 	}
@@ -531,7 +533,15 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	productRelatedMessages = () => {
-		const { selectedSite, sitePlans, displayMode, customizeUrl } = this.props;
+		const {
+			selectedSite,
+			siteUnlaunchedBeforeUpgrade,
+			upgradeIntent,
+			isSimplified,
+			sitePlans,
+			displayMode,
+			customizeUrl,
+		} = this.props;
 		const purchases = getPurchases( this.props );
 		const failedPurchases = getFailedPurchases( this.props );
 		const hasFailedPurchases = failedPurchases.length > 0;
@@ -551,17 +561,24 @@ export class CheckoutThankYou extends React.Component {
 				<div>
 					<CheckoutThankYouHeader
 						isDataLoaded={ false }
+						isSimplified={ isSimplified }
 						selectedSite={ selectedSite }
+						upgradeIntent={ upgradeIntent }
+						siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
 						displayMode={ displayMode }
 					/>
 
-					<CheckoutThankYouFeaturesHeader isDataLoaded={ false } />
+					{ ! isSimplified && (
+						<>
+							<CheckoutThankYouFeaturesHeader isDataLoaded={ false } />
 
-					<div className="checkout-thank-you__purchase-details-list">
-						<PurchaseDetail isPlaceholder />
-						<PurchaseDetail isPlaceholder />
-						<PurchaseDetail isPlaceholder />
-					</div>
+							<div className="checkout-thank-you__purchase-details-list">
+								<PurchaseDetail isPlaceholder />
+								<PurchaseDetail isPlaceholder />
+								<PurchaseDetail isPlaceholder />
+							</div>
+						</>
+					) }
 				</div>
 			);
 		}
@@ -570,14 +587,17 @@ export class CheckoutThankYou extends React.Component {
 			<div>
 				<CheckoutThankYouHeader
 					isDataLoaded={ this.isDataLoaded() }
+					isSimplified={ isSimplified }
 					primaryPurchase={ primaryPurchase }
 					selectedSite={ selectedSite }
 					hasFailedPurchases={ hasFailedPurchases }
+					siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
+					upgradeIntent={ upgradeIntent }
 					primaryCta={ this.primaryCta }
 					displayMode={ displayMode }
 				/>
 
-				{ primaryPurchase && (
+				{ ! isSimplified && primaryPurchase && (
 					<CheckoutThankYouFeaturesHeader
 						isDataLoaded={ this.isDataLoaded() }
 						isGenericReceipt={ this.isGenericReceipt() }
@@ -586,7 +606,7 @@ export class CheckoutThankYou extends React.Component {
 					/>
 				) }
 
-				{ ComponentClass && (
+				{ ! isSimplified && ComponentClass && (
 					<div className="checkout-thank-you__purchase-details-list">
 						<ComponentClass
 							customizeUrl={ customizeUrl }
@@ -618,7 +638,9 @@ export default connect(
 			receipt: getReceiptById( state, props.receiptId ),
 			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
 			sitePlans: getPlansBySite( state, props.selectedSite ),
-			upgradeIntent: getCheckoutUpgradeIntent( state ),
+			isSimplified:
+				[ 'install_theme', 'install_plugin', 'browse_plugins' ].indexOf( props.upgradeIntent ) !==
+				-1,
 			user: getCurrentUser( state ),
 			userDate: getCurrentUserDate( state ),
 			transferComplete:

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -83,6 +83,7 @@ import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getActiveTheme } from 'state/themes/selectors';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
+import getCheckoutUpgradeIntent from 'state/selectors/get-checkout-upgrade-intent';
 
 /**
  * Style dependencies
@@ -287,7 +288,7 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	primaryCta = () => {
-		const { selectedSite, redirectTo } = this.props;
+		const { selectedSite, upgradeIntent, redirectTo } = this.props;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			const purchases = getPurchases( this.props );
@@ -299,6 +300,13 @@ export class CheckoutThankYou extends React.Component {
 
 			if ( ! isExternal( redirectTo ) ) {
 				return page( redirectTo );
+			}
+
+			switch ( upgradeIntent ) {
+				case 'plugins':
+					return page( redirectTo );
+				case 'themes':
+					return page( `/${ upgradeIntent }/${ siteSlug }` );
 			}
 
 			if ( purchases.some( isPlan ) ) {
@@ -638,6 +646,7 @@ export default connect(
 			receipt: getReceiptById( state, props.receiptId ),
 			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
 			sitePlans: getPlansBySite( state, props.selectedSite ),
+			upgradeIntent: props.upgradeIntent || getCheckoutUpgradeIntent( state ),
 			isSimplified:
 				[ 'install_theme', 'install_plugin', 'browse_plugins' ].indexOf( props.upgradeIntent ) !==
 				-1,

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -304,7 +304,6 @@ export class CheckoutThankYou extends React.Component {
 
 			switch ( upgradeIntent ) {
 				case 'plugins':
-					return page( redirectTo );
 				case 'themes':
 					return page( `/${ upgradeIntent }/${ siteSlug }` );
 			}

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -114,7 +114,7 @@
 
 .checkout-thank-you__header-content {
 	margin: 0 auto;
-	max-width: 700px;
+	max-width: 750px;
 }
 
 .checkout-thank-you__header-icon {
@@ -129,8 +129,34 @@
 	width: 100%;
 }
 
+.checkout-thank-you__success-messages,
+.checkout-thank-you__success-message-item {
+	padding: 0;
+	margin: 0;
+	list-style-type: none;
+}
+
+.checkout-thank-you__success-messages {
+	margin-top: 25px;
+}
+
+.checkout-thank-you__success-message-item {
+	display: flex;
+	text-align: left;
+	margin-top: 15px;
+
+	.gridicons-checkmark {
+		position: relative;
+		flex: 24px 0 0;
+		top: 1px;
+		fill: var( --color-success );
+		margin-right: 11px;
+	}
+}
+
 .checkout-thank-you__header-heading,
-.checkout-thank-you__header-text {
+.checkout-thank-you__header-text,
+.checkout-thank-you__success-message-item {
 	clear: none;
 }
 
@@ -144,7 +170,8 @@
 	margin: 24px 0 8px;
 }
 
-.checkout-thank-you__header-text {
+.checkout-thank-you__header-text,
+.checkout-thank-you__success-message-item {
 	font-size: 18px;
 	font-weight: 300;
 }
@@ -163,7 +190,8 @@
 	}
 
 	.checkout-thank-you__header-heading,
-	.checkout-thank-you__header-text {
+	.checkout-thank-you__header-text,
+	.checkout-thank-you__success-message-item {
 		@include placeholder( --color-neutral-10 );
 
 		display: block;
@@ -177,7 +205,8 @@
 		width: 50%;
 	}
 
-	.checkout-thank-you__header-text {
+	.checkout-thank-you__header-text,
+	.checkout-thank-you__success-message-item {
 		line-height: 2em;
 		margin-bottom: 8px;
 		margin-top: 15px;

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -145,7 +145,7 @@
 	text-align: left;
 	margin-top: 15px;
 
-	.gridicons-checkmark {
+	.gridicons-checkmark-circle {
 		position: relative;
 		flex: 24px 0 0;
 		top: 1px;

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { CheckoutThankYouHeader } from '../header';
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.unmock( 'lib/plans' );
+const plans = require( 'lib/plans' );
+plans.getFeatureByKey = () => null;
+plans.shouldFetchSitePlans = () => false;
+
+jest.unmock( 'lib/products-values' );
+const productValues = require( 'lib/products-values' );
+productValues.isDotComPlan = jest.fn( () => false );
+
+jest.mock( 'lib/analytics', () => ( {
+	tracks: {
+		recordEvent: () => null,
+	},
+} ) );
+jest.mock( '../domain-registration-details', () => 'component--domain-registration-details' );
+jest.mock( '../google-apps-details', () => 'component--google-apps-details' );
+jest.mock( '../jetpack-plan-details', () => 'component--jetpack-plan-details' );
+jest.mock( '../rebrand-cities-thank-you', () => 'component--RebrandCitiesThankYou' );
+jest.mock( '../atomic-store-thank-you-card', () => 'component--AtomicStoreThankYouCard' );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( 'components/happiness-support', () => 'HappinessSupport' );
+jest.mock( 'lib/rebrand-cities', () => ( {
+	isRebrandCitiesSiteUrl: jest.fn( () => false ),
+} ) );
+
+// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
+jest.mock( 'lib/user', () => () => {} );
+
+const translate = x => x;
+
+describe( 'CheckoutThankYouHeader', () => {
+	const defaultProps = {
+		translate,
+		primaryPurchase: {
+			product_slug: 'business-bundle',
+		},
+	};
+	describe( 'Basic tests', () => {
+		test( "Should display a loading indicator while data isn't loaded yet", () => {
+			const comp = shallow( <CheckoutThankYouHeader isDataLoaded={ false } { ...defaultProps } /> );
+			expect( comp.find( '.checkout-thank-you__header-heading' ).text() ).toBe( 'Loading…' );
+		} );
+		test( 'Should display getText()-based success message when isSimplified=false (default)', () => {
+			const comp = shallow( <CheckoutThankYouHeader isDataLoaded={ true } { ...defaultProps } /> );
+			expect( comp.find( '.checkout-thank-you__header-heading' ).text() ).toEqual(
+				'Congratulations on your purchase!'
+			);
+			expect( comp.find( '.checkout-thank-you__header-text' ).text() ).toEqual(
+				"Your site is now on the {{strong}}%(productName)s{{/strong}} plan. It's doing somersaults in excitement!"
+			);
+		} );
+		test( 'Should display an alternative success message when isSimplified=true', () => {
+			const comp = shallow(
+				<CheckoutThankYouHeader isDataLoaded={ true } isSimplified={ true } { ...defaultProps } />
+			);
+			expect( comp.find( '.checkout-thank-you__header-heading' ).text() ).toEqual(
+				'Congratulations on your purchase!'
+			);
+			expect( comp.find( '.checkout-thank-you__header-text' ).text() ).toEqual(
+				'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. Enjoy your powerful new features!'
+			);
+		} );
+		test( 'Should display a list of success messages when siteUnlaunchedBeforeUpgrade=true', () => {
+			const comp = shallow(
+				<CheckoutThankYouHeader
+					isDataLoaded={ true }
+					isSimplified={ true }
+					siteUnlaunchedBeforeUpgrade={ true }
+					{ ...defaultProps }
+				/>
+			);
+			expect( comp.find( '.checkout-thank-you__header-heading' ).text() ).toEqual(
+				'Congratulations on your purchase!'
+			);
+			expect( comp.find( '.checkout-thank-you__header-text' ).length ).toBe( 0 );
+			expect( comp.find( '.checkout-thank-you__success-message-item' ).length ).toEqual( 2 );
+			expect(
+				comp.find( '.checkout-thank-you__success-message-item:last-child div' ).text()
+			).toEqual(
+				"Your site has been launched. You can share it with the world whenever you're ready."
+			);
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -119,13 +119,27 @@ describe( 'CheckoutThankYou', () => {
 			const comp = shallow( <CheckoutThankYou { ...props } /> );
 			expect( comp.find( '.checkout-thank-you__purchase-details-list' ) ).toHaveLength( 1 );
 			expect( comp.find( 'HappinessSupport' ) ).toHaveLength( 1 );
-			expect( comp.find( 'CheckoutThankYouHeader' ).props().siteJustLaunched ).toBeFalsy();
+			expect( comp.find( 'CheckoutThankYouHeader' ).props().isSimplified ).toBeFalsy();
 		} );
 		test( 'Should display a simplified version when isSimplified is set to true', () => {
 			const comp = shallow( <CheckoutThankYou { ...props } isSimplified={ true } /> );
 			expect( comp.find( '.checkout-thank-you__purchase-details-list' ) ).toHaveLength( 0 );
 			expect( comp.find( 'HappinessSupport' ) ).toHaveLength( 0 );
-			expect( comp.find( 'CheckoutThankYouHeader' ).props().siteJustLaunched ).toBe( true );
+			expect( comp.find( 'CheckoutThankYouHeader' ).props().isSimplified ).toBe( true );
+		} );
+		test( 'Should pass props down to CheckoutThankYou', () => {
+			const comp = shallow(
+				<CheckoutThankYou
+					{ ...props }
+					isSimplified={ true }
+					siteUnlaunchedBeforeUpgrade={ true }
+					upgradeIntent={ 'plugins' }
+				/>
+			);
+			expect( comp.find( 'CheckoutThankYouHeader' ).props().siteUnlaunchedBeforeUpgrade ).toBe(
+				true
+			);
+			expect( comp.find( 'CheckoutThankYouHeader' ).props().upgradeIntent ).toBe( 'plugins' );
 		} );
 	} );
 

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -51,6 +51,9 @@ jest.mock( '../google-apps-details', () => 'component--google-apps-details' );
 jest.mock( '../jetpack-plan-details', () => 'component--jetpack-plan-details' );
 jest.mock( '../rebrand-cities-thank-you', () => 'component--RebrandCitiesThankYou' );
 jest.mock( '../atomic-store-thank-you-card', () => 'component--AtomicStoreThankYouCard' );
+jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
+jest.mock( '../header', () => 'CheckoutThankYouHeader' );
+jest.mock( 'components/happiness-support', () => 'HappinessSupport' );
 jest.mock( 'lib/rebrand-cities', () => ( {
 	isRebrandCitiesSiteUrl: jest.fn( () => false ),
 } ) );
@@ -90,6 +93,39 @@ describe( 'CheckoutThankYou', () => {
 		test( 'Show WordPressLogo when there are no purchase but a receipt is present', () => {
 			const comp = shallow( <CheckoutThankYou { ...defaultProps } receiptId={ 12 } /> );
 			expect( comp.find( 'WordPressLogo' ) ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'Simplified page', () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			selectedSite: {
+				ID: 12,
+			},
+			sitePlans: {
+				hasLoadedFromServer: true,
+			},
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [ { productSlug: PLAN_BUSINESS }, [] ],
+				},
+			},
+			refreshSitePlans: selectedSite => selectedSite,
+			planSlug: PLAN_BUSINESS,
+		};
+		test( 'Should display a full version when isSimplified is missing', () => {
+			const comp = shallow( <CheckoutThankYou { ...props } /> );
+			expect( comp.find( '.checkout-thank-you__purchase-details-list' ) ).toHaveLength( 1 );
+			expect( comp.find( 'HappinessSupport' ) ).toHaveLength( 1 );
+			expect( comp.find( 'CheckoutThankYouHeader' ).props().siteJustLaunched ).toBeFalsy();
+		} );
+		test( 'Should display a simplified version when isSimplified is set to true', () => {
+			const comp = shallow( <CheckoutThankYou { ...props } isSimplified={ true } /> );
+			expect( comp.find( '.checkout-thank-you__purchase-details-list' ) ).toHaveLength( 0 );
+			expect( comp.find( 'HappinessSupport' ) ).toHaveLength( 0 );
+			expect( comp.find( 'CheckoutThankYouHeader' ).props().siteJustLaunched ).toBe( true );
 		} );
 	} );
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -113,6 +113,9 @@ export function checkoutThankYou( context, next ) {
 			gsuiteReceiptId={ gsuiteReceiptId }
 			domainOnlySiteFlow={ isEmpty( context.params.site ) }
 			selectedFeature={ context.params.feature }
+			redirectTo={ context.query.redirect_to }
+			upgradeIntent={ context.query.intent }
+			siteUnlaunchedBeforeUpgrade={ context.query.site_unlaunched_before_upgrade === 'true' }
 			selectedSite={ selectedSite }
 			displayMode={ displayMode }
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is part of the PBD interim fix (https://github.com/Automattic/wp-calypso/issues/38110).
it's a subset of a super large https://github.com/Automattic/wp-calypso/pull/38139

It adds support for an alternate, "simplified" mode of showing things on checkout "thank you" page. It doesn't actually enable it for anyone yet.

**Before:**

<img width="1029" alt="Zrzut ekranu 2019-12-3 o 14 56 52" src="https://user-images.githubusercontent.com/205419/70057278-27541900-15dd-11ea-9846-b6f513422e6b.png">

**After:**
![Screenshot 2019-12-05 21 06 59](https://user-images.githubusercontent.com/4924246/70297508-3be20e00-17a3-11ea-8726-b71afe12e569.png)

#### Testing instructions

1. Upgrade to personal/premium/business/ecommerce from both signup and /plans, confirm you see the **Before** page
1. Create a free/personal/premium site
1. Go to /plugins and click on the business plan upgrade nudge (both on plugins list and specific plugin's page)
1. Upgrade to business
1. Confirm the thank you page still looks like **Before** screenshot above
1. Append the following query string args and confirm it looks like the **After** screenshot above: 
`?intent=install_plugin&site_unlaunched_before_upgrade=true`
1. Append the following query string args and confirm it looks like the **After** screenshot above except it doesn't have checkmarks and doesn't mention launching the site: 
`?intent=install_plugin&site_unlaunched_before_upgrade=false`