### PR TITLE
Checkout: Disallow Atomic to add Jetpack Backup to cart

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -279,7 +279,7 @@ export class Checkout extends React.Component {
 	}
 
 	addNewItemToCart() {
-		const { planSlug, cart } = this.props;
+		const { planSlug, cart, isJetpackNotAtomic } = this.props;
 
 		let cartItem, cartMeta;
 
@@ -301,7 +301,7 @@ export class Checkout extends React.Component {
 			cartItem = ! hasConciergeSession( cart ) && conciergeSessionItem();
 		}
 
-		if ( startsWith( this.props.product, 'jetpack_backup' ) ) {
+		if ( startsWith( this.props.product, 'jetpack_backup' ) && isJetpackNotAtomic ) {
 			cartItem = jetpackProductItem( this.props.product );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Checkout: Disallow Atomic sites from adding add Jetpack Backup to cart

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/checkout/jetpack_backup_daily_monthly/:site where `:site` is an Atomic site. 
* Verify your cart remains empty and you're redirected to the plans page.
* Go to http://calypso.localhost:3000/checkout/jetpack_backup_daily_monthly/:site where `:site` is a Jetpack site on a free plan without any backup products purchased. 
* Verify that after your cart loads, it has a Jetpack Backup product.
* Verify you can purchase it.

