### PR TITLE
Add support for redirect_to query string argument on /plans

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -544,7 +544,7 @@ export class PlanFeatures extends Component {
 	}
 
 	handleUpgradeClick( singlePlanProperties ) {
-		const { isInSignup, onUpgradeClick: ownPropsOnUpgradeClick } = this.props;
+		const { isInSignup, onUpgradeClick: ownPropsOnUpgradeClick, redirectTo } = this.props;
 
 		const {
 			availableForPurchase,
@@ -563,20 +563,22 @@ export class PlanFeatures extends Component {
 			return;
 		}
 
+		const checkoutUrlWithArgs = addQueryArgs( { redirect_to: redirectTo }, checkoutUrl );
+
 		if ( siteIsPrivateAndGoingAtomic ) {
 			if ( isInSignup ) {
 				// Let signup do its thing
 				return;
 			}
 			this.setState( {
-				checkoutUrl,
+				checkoutUrl: checkoutUrlWithArgs,
 				choosingPlanSlug: productSlug,
 				showingSiteLaunchDialog: true,
 			} );
 			return;
 		}
 
-		page( checkoutUrl );
+		page( checkoutUrlWithArgs );
 	}
 
 	renderTopButtons() {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -138,6 +138,7 @@ export class PlansFeaturesMain extends Component {
 			selectedPlan,
 			withDiscount,
 			discountEndDate,
+			redirectTo,
 			siteId,
 			siteType,
 			plansWithScroll,
@@ -180,6 +181,7 @@ export class PlansFeaturesMain extends Component {
 					isLaunchPage={ isLaunchPage }
 					onUpgradeClick={ onUpgradeClick }
 					plans={ plans }
+					redirectTo={ redirectTo }
 					visiblePlans={ visiblePlans }
 					selectedFeature={ selectedFeature }
 					selectedPlan={ selectedPlan }
@@ -376,14 +378,20 @@ export class PlansFeaturesMain extends Component {
 			<SegmentedControl className={ segmentClasses } primary={ true }>
 				<SegmentedControl.Item
 					selected={ customerType === 'personal' }
-					path={ addQueryArgs( { ...queryArgs, customerType: 'personal' }, '' ) }
+					path={ addQueryArgs(
+						{ ...queryArgs, customerType: 'personal' },
+						document.location.search
+					) }
 				>
 					{ translate( 'Blogs and Personal Sites' ) }
 				</SegmentedControl.Item>
 
 				<SegmentedControl.Item
 					selected={ customerType === 'business' }
-					path={ addQueryArgs( { ...queryArgs, customerType: 'business' }, '' ) }
+					path={ addQueryArgs(
+						{ ...queryArgs, customerType: 'business' },
+						document.location.search
+					) }
 				>
 					{ translate( 'Business Sites and Online Stores' ) }
 				</SegmentedControl.Item>
@@ -436,7 +444,7 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { basePlansPath, intervalType, translate } = this.props;
+		const { basePlansPath, intervalType, translate, redirectTo } = this.props;
 
 		return (
 			<div className="plans-features-main__group is-narrow">
@@ -452,6 +460,7 @@ export class PlansFeaturesMain extends Component {
 					intervalType={ intervalType }
 					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }
+					redirectTo={ redirectTo }
 				/>
 			</div>
 		);
@@ -508,6 +517,7 @@ PlansFeaturesMain.propTypes = {
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
+	redirectTo: PropTypes.string,
 	selectedFeature: PropTypes.string,
 	selectedPlan: PropTypes.string,
 	showFAQ: PropTypes.bool,

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -238,6 +238,11 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		hideFreePlan: true,
 		withWPPlanTabs: true,
 	};
+
+	beforeEach( () => {
+		global.document = { location: { search: '' } };
+	} );
+
 	test( 'Should render <PlanFeatures /> with tab picker when requested', () => {
 		const instance = new PlansFeaturesMain( { ...myProps } );
 		const comp = shallow( instance.render() );
@@ -292,6 +297,19 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		expect(
 			comp.find( 'SegmentedControlItem[path="?customerType=personal"]' ).props().selected
 		).toBe( false );
+	} );
+
+	test( 'Should add existing query arguments to personal and business tab links', () => {
+		global.document = { location: { search: '?fake=item' } };
+		const instance = new PlansFeaturesMain( { ...myProps, customerType: 'business' } );
+		const comp = shallow( instance.render() );
+		expect( comp.find( 'SegmentedControl' ).length ).toBe( 1 );
+		expect(
+			comp.find( 'SegmentedControlItem[path="?fake=item&customerType=personal"]' ).length
+		).toBe( 1 );
+		expect(
+			comp.find( 'SegmentedControlItem[path="?fake=item&customerType=business"]' ).length
+		).toBe( 1 );
 	} );
 
 	test( 'Highlights TYPE_PERSONAL as popular plan for blog site type', () => {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -21,6 +21,7 @@ export function plans( context, next ) {
 			selectedPlan={ context.query.plan }
 			withDiscount={ context.query.discount }
 			discountEndDate={ context.query.ts }
+			redirectTo={ context.query.redirect_to }
 		/>
 	);
 	next();

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -39,6 +39,7 @@ class Plans extends React.Component {
 		intervalType: PropTypes.string,
 		customerType: PropTypes.string,
 		selectedFeature: PropTypes.string,
+		redirectTo: PropTypes.string,
 		selectedSite: PropTypes.object,
 	};
 
@@ -159,6 +160,7 @@ class Plans extends React.Component {
 								intervalType={ this.props.intervalType }
 								selectedFeature={ this.props.selectedFeature }
 								selectedPlan={ this.props.selectedPlan }
+								redirectTo={ this.props.redirectTo }
 								withDiscount={ this.props.withDiscount }
 								discountEndDate={ this.props.discountEndDate }
 								site={ selectedSite }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to Private by Default interim fix: https://github.com/Automattic/wp-calypso/pull/38139

Adds support for `redirect_to` querystring argument on /plans page. Anything that's passed as such, will be passed to `/checkout` if user decides to upgrade.

#### Testing instructions

* Go to /plans, press "Upgrade" a couple of times and confirm it works as usual including tabs navigation
* Repeat for Jetpack site
* Repeat for Signup
* Go to `/plans/<siteSlug>?redirect_to=/stats`
* Confirm that every time you click "Upgrade", you're redirected to /checkout?redirect_to=/stats
* This should work even if you switch active tab a couple of times (Personal vs Business plans tabs)

