### PR TITLE
Domain step test: Increase variation to 90%

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -117,8 +117,8 @@ export default {
 	domainStepCopyUpdates: {
 		datestamp: '20191121',
 		variations: {
-			variantShowUpdates: 50,
-			control: 50,
+			variantShowUpdates: 90,
+			control: 10,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For the domain step improvements A/B test launched in https://github.com/Automattic/wp-calypso/pull/37661, we are increasing the variation to be shown to 90% of users as per discussions in p8Eqe3-Yc#comment-2850-p2.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the Test Plan given in https://github.com/Automattic/wp-calypso/pull/37661.

