### PR TITLE
Link upgrade banners on /themes and /plugins linked to a simplified thank you page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,6 +76,7 @@ module.exports = {
 		globalThis: true,
 		window: true,
 		document: true,
+		fetch: true,
 		// this is our custom function that's transformed by babel into either a dynamic import or a normal require
 		asyncRequire: true,
 		// this is the SHA of the current commit. Injected at boot in a script tag.

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -36,7 +36,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		primaryPurchase: PropTypes.object,
 		hasFailedPurchases: PropTypes.bool,
 		isSimplified: PropTypes.bool,
-		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
 		primaryCta: PropTypes.func,
 	};
 
@@ -435,13 +434,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 				}
 			),
 		];
-		if ( this.props.siteUnlaunchedBeforeUpgrade ) {
-			messages.push(
-				translate(
-					"Your site has been launched. You can share it with the world whenever you're ready."
-				)
-			);
-		}
 
 		if ( messages.length === 1 ) {
 			return <h2 className="checkout-thank-you__header-text">{ messages[ 0 ] }</h2>;

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -120,7 +120,6 @@ export class CheckoutThankYou extends React.Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		siteHomeUrl: PropTypes.string.isRequired,
 		transferComplete: PropTypes.bool,
-		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -542,7 +541,6 @@ export class CheckoutThankYou extends React.Component {
 	productRelatedMessages = () => {
 		const {
 			selectedSite,
-			siteUnlaunchedBeforeUpgrade,
 			upgradeIntent,
 			isSimplified,
 			sitePlans,
@@ -571,7 +569,6 @@ export class CheckoutThankYou extends React.Component {
 						isSimplified={ isSimplified }
 						selectedSite={ selectedSite }
 						upgradeIntent={ upgradeIntent }
-						siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
 						displayMode={ displayMode }
 					/>
 
@@ -598,7 +595,6 @@ export class CheckoutThankYou extends React.Component {
 					primaryPurchase={ primaryPurchase }
 					selectedSite={ selectedSite }
 					hasFailedPurchases={ hasFailedPurchases }
-					siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
 					upgradeIntent={ upgradeIntent }
 					primaryCta={ this.primaryCta }
 					displayMode={ displayMode }

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -75,25 +75,5 @@ describe( 'CheckoutThankYouHeader', () => {
 				'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. Enjoy your powerful new features!'
 			);
 		} );
-		test( 'Should display a list of success messages when siteUnlaunchedBeforeUpgrade=true', () => {
-			const comp = shallow(
-				<CheckoutThankYouHeader
-					isDataLoaded={ true }
-					isSimplified={ true }
-					siteUnlaunchedBeforeUpgrade={ true }
-					{ ...defaultProps }
-				/>
-			);
-			expect( comp.find( '.checkout-thank-you__header-heading' ).text() ).toEqual(
-				'Congratulations on your purchase!'
-			);
-			expect( comp.find( '.checkout-thank-you__header-text' ).length ).toBe( 0 );
-			expect( comp.find( '.checkout-thank-you__success-message-item' ).length ).toEqual( 2 );
-			expect(
-				comp.find( '.checkout-thank-you__success-message-item:last-child div' ).text()
-			).toEqual(
-				"Your site has been launched. You can share it with the world whenever you're ready."
-			);
-		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -129,15 +129,7 @@ describe( 'CheckoutThankYou', () => {
 		} );
 		test( 'Should pass props down to CheckoutThankYou', () => {
 			const comp = shallow(
-				<CheckoutThankYou
-					{ ...props }
-					isSimplified={ true }
-					siteUnlaunchedBeforeUpgrade={ true }
-					upgradeIntent={ 'plugins' }
-				/>
-			);
-			expect( comp.find( 'CheckoutThankYouHeader' ).props().siteUnlaunchedBeforeUpgrade ).toBe(
-				true
+				<CheckoutThankYou { ...props } isSimplified={ true } upgradeIntent={ 'plugins' } />
 			);
 			expect( comp.find( 'CheckoutThankYouHeader' ).props().upgradeIntent ).toBe( 'plugins' );
 		} );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -126,7 +126,6 @@ export function checkoutThankYou( context, next ) {
 			selectedFeature={ context.params.feature }
 			redirectTo={ context.query.redirect_to }
 			upgradeIntent={ context.query.intent }
-			siteUnlaunchedBeforeUpgrade={ context.query.site_unlaunched_before_upgrade === 'true' }
 			selectedSite={ selectedSite }
 			displayMode={ displayMode }
 		/>

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -20,6 +20,7 @@ import NoticeAction from 'components/notice/notice-action';
 import ExternalLink from 'components/external-link';
 import Notice from 'components/notice';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import { UPGRADE_INTENT_INSTALL_PLUGIN } from 'lib/checkout/constants';
 import PluginsActions from 'lib/plugins/actions';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
@@ -44,7 +45,6 @@ import { encodeQueryParameters } from 'state/http';
 import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-active';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { INSTALL_PLUGIN } from 'state/plugins/installed/constants';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { isATEnabled } from 'lib/automated-transfer';
 
@@ -614,7 +614,7 @@ export class PluginMeta extends Component {
 					'redirect_to',
 					`/checkout/thank-you/${ slug }/:receiptId?` +
 						encodeQueryParameters( [
-							[ 'intent', INSTALL_PLUGIN ],
+							[ 'intent', UPGRADE_INTENT_INSTALL_PLUGIN ],
 							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 						] ),

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -44,7 +44,6 @@ import isVipSite from 'state/selectors/is-vip-site';
 import { encodeQueryParameters } from 'state/http';
 import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-active';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { isATEnabled } from 'lib/automated-transfer';
 
@@ -602,7 +601,7 @@ export class PluginMeta extends Component {
 	};
 
 	renderUpsell() {
-		const { translate, slug, isSiteUnlaunched } = this.props;
+		const { translate, slug } = this.props;
 
 		if ( this.props.isVipSite ) {
 			return null;
@@ -615,7 +614,6 @@ export class PluginMeta extends Component {
 					`/checkout/thank-you/${ slug }/:receiptId?` +
 						encodeQueryParameters( [
 							[ 'intent', UPGRADE_INTENT_INSTALL_PLUGIN ],
-							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 						] ),
 				],
@@ -730,7 +728,6 @@ const mapStateToProps = state => {
 		atEnabled: isATEnabled( selectedSite ),
 		isTransferring: isAutomatedTransferActive( state, siteId ),
 		automatedTransferSite: isSiteAutomatedTransfer( state, siteId ),
-		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		isVipSite: isVipSite( state, siteId ),
 		slug: getSiteSlug( state, siteId ),
 	};

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -44,6 +44,7 @@ import { encodeQueryParameters } from 'state/http';
 import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-active';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { INSTALL_PLUGIN } from 'state/plugins/installed/constants';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { isATEnabled } from 'lib/automated-transfer';
 
@@ -613,7 +614,7 @@ export class PluginMeta extends Component {
 					'redirect_to',
 					`/checkout/thank-you/${ slug }/:receiptId?` +
 						encodeQueryParameters( [
-							[ 'intent', 'install_plugin' ],
+							[ 'intent', INSTALL_PLUGIN ],
 							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 						] ),

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -78,6 +78,8 @@ const props = {
 	translate: x => x,
 };
 
+global.document = { location: {} };
+
 describe( 'PluginMeta basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const comp = shallow( <PluginMeta { ...props } /> );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -22,6 +22,7 @@ import NavItem from 'components/section-nav/item';
 import InfiniteScroll from 'components/infinite-scroll';
 import NoResults from 'my-sites/no-results';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { UPGRADE_INTENT_INSTALL_PLUGIN } from 'lib/checkout/constants';
 import PluginsBrowserList from 'my-sites/plugins/plugins-browser-list';
 import PluginsListStore from 'lib/plugins/wporg-data/list-store';
 import PluginsActions from 'lib/plugins/wporg-data/actions';
@@ -46,7 +47,6 @@ import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
 import { Button } from '@automattic/components';
 import { isBusiness, isEcommerce, isEnterprise, isPremium } from 'lib/products-values';
 import { TYPE_BUSINESS } from 'lib/plans/constants';
-import { INSTALL_PLUGIN } from 'state/plugins/installed/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import Banner from 'components/banner';
 import { isEnabled } from 'config';
@@ -566,7 +566,7 @@ export class PluginsBrowser extends Component {
 					'redirect_to',
 					`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 						encodeQueryParameters( [
-							[ 'intent', INSTALL_PLUGIN ],
+							[ 'intent', UPGRADE_INTENT_INSTALL_PLUGIN ],
 							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 						] ),

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -46,6 +46,7 @@ import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
 import { Button } from '@automattic/components';
 import { isBusiness, isEcommerce, isEnterprise, isPremium } from 'lib/products-values';
 import { TYPE_BUSINESS } from 'lib/plans/constants';
+import { INSTALL_PLUGIN } from 'state/plugins/installed/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import Banner from 'components/banner';
 import { isEnabled } from 'config';
@@ -565,7 +566,7 @@ export class PluginsBrowser extends Component {
 					'redirect_to',
 					`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 						encodeQueryParameters( [
-							[ 'intent', 'install_plugin' ],
+							[ 'intent', INSTALL_PLUGIN ],
 							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 						] ),

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -41,7 +41,6 @@ import {
 	canJetpackSiteManage,
 } from 'state/sites/selectors';
 import { encodeQueryParameters } from 'state/http';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import isVipSite from 'state/selectors/is-vip-site';
 import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
 import { Button } from '@automattic/components';
@@ -557,7 +556,7 @@ export class PluginsBrowser extends Component {
 			return null;
 		}
 
-		const { translate, siteSlug, isSiteUnlaunched } = this.props;
+		const { translate, siteSlug } = this.props;
 
 		const bannerURL =
 			`/checkout/${ siteSlug }/business?` +
@@ -567,7 +566,6 @@ export class PluginsBrowser extends Component {
 					`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 						encodeQueryParameters( [
 							[ 'intent', UPGRADE_INTENT_INSTALL_PLUGIN ],
-							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 						] ),
 				],
@@ -670,7 +668,6 @@ export default flow(
 				selectedSite: getSelectedSite( state ),
 				siteSlug: getSelectedSiteSlug( state ),
 				sites: getSelectedOrAllSitesJetpackCanManage( state ),
-				isSiteUnlaunched: isUnlaunchedSite( state, selectedSiteId ),
 				isRequestingRecommendedPlugins: ! Array.isArray( recommendedPlugins ),
 				recommendedPlugins: recommendedPlugins || [],
 			};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -60,6 +60,7 @@ import { setThemePreviewOptions } from 'state/themes/actions';
 import ThemeNotFoundError from './theme-not-found-error';
 import ThemeFeaturesCard from './theme-features-card';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
+import { INSTALL_THEME } from 'state/plugins/installed/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
 import getPreviousRoute from 'state/selectors/get-previous-route';
 
@@ -661,7 +662,7 @@ class ThemeSheet extends React.Component {
 						'redirect_to',
 						`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 							encodeQueryParameters( [
-								[ 'intent', 'install_theme' ],
+								[ 'intent', INSTALL_THEME ],
 								[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 								[ 'redirect_to', document.location.pathname ],
 							] ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -661,7 +661,7 @@ class ThemeSheet extends React.Component {
 						'redirect_to',
 						`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 							encodeQueryParameters( [
-								[ 'intent', 'install_plugin' ],
+								[ 'intent', 'install_theme' ],
 								[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 								[ 'redirect_to', document.location.pathname ],
 							] ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -50,7 +50,6 @@ import {
 	getThemeForumUrl,
 } from 'state/themes/selectors';
 import { encodeQueryParameters } from 'state/http';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
@@ -94,7 +93,6 @@ class ThemeSheet extends React.Component {
 		isActive: PropTypes.bool,
 		isPurchased: PropTypes.bool,
 		isJetpack: PropTypes.bool,
-		isSiteUnlaunched: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 		backPath: PropTypes.string,
@@ -607,7 +605,6 @@ class ThemeSheet extends React.Component {
 			isJetpack,
 			isVip,
 			translate,
-			isSiteUnlaunched,
 			hasUnlimitedPremiumThemes,
 			previousRoute,
 		} = this.props;
@@ -663,7 +660,6 @@ class ThemeSheet extends React.Component {
 						`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 							encodeQueryParameters( [
 								[ 'intent', UPGRADE_INTENT_INSTALL_THEME ],
-								[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 								[ 'redirect_to', document.location.pathname ],
 							] ),
 					],
@@ -808,7 +804,6 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),
-			isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			// No siteId specified since we want the *canonical* URL :-)
 			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -55,12 +55,12 @@ import { getBackPath } from 'state/themes/themes-ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import { decodeEntities } from 'lib/formatting';
+import { UPGRADE_INTENT_INSTALL_THEME } from 'lib/checkout/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setThemePreviewOptions } from 'state/themes/actions';
 import ThemeNotFoundError from './theme-not-found-error';
 import ThemeFeaturesCard from './theme-features-card';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
-import { INSTALL_THEME } from 'state/plugins/installed/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
 import getPreviousRoute from 'state/selectors/get-previous-route';
 
@@ -662,7 +662,7 @@ class ThemeSheet extends React.Component {
 						'redirect_to',
 						`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 							encodeQueryParameters( [
-								[ 'intent', INSTALL_THEME ],
+								[ 'intent', UPGRADE_INTENT_INSTALL_THEME ],
 								[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 								[ 'redirect_to', document.location.pathname ],
 							] ),

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -21,6 +21,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { INSTALL_PLUGIN } from 'state/plugins/installed/constants';
 import isVipSite from 'state/selectors/is-vip-site';
 import { encodeQueryParameters } from 'state/http';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
@@ -50,7 +51,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 					'redirect_to',
 					`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 						encodeQueryParameters( [
-							[ 'intent', 'install_plugin' ],
+							[ 'intent', INSTALL_PLUGIN ],
 							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 							[ 'plan', PLAN_PREMIUM ],

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -22,11 +22,14 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
+import { encodeQueryParameters } from 'state/http';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const {
 		hasUnlimitedPremiumThemes,
 		requestingSitePlans,
+		isSiteUnlaunched,
 		siteId,
 		isVip,
 		siteSlug,
@@ -40,10 +43,25 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;
 	if ( displayUpsellBanner ) {
+		const bannerURL =
+			`/plans/${ siteSlug }?` +
+			encodeQueryParameters( [
+				[
+					'redirect_to',
+					`/checkout/thank-you/${ siteSlug }/:receiptId?` +
+						encodeQueryParameters( [
+							[ 'intent', 'install_plugin' ],
+							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
+							[ 'redirect_to', document.location.pathname ],
+							[ 'plan', PLAN_PREMIUM ],
+						] ),
+				],
+			] );
 		if ( bannerLocationBelowSearch ) {
 			upsellBanner = (
 				<Banner
 					plan={ PLAN_PREMIUM }
+					href={ bannerURL + '&customerType=business' }
 					customerType="business"
 					className="themes__showcase-banner"
 					title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
@@ -56,6 +74,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 			upsellBanner = (
 				<Banner
 					plan={ PLAN_PREMIUM }
+					href={ bannerURL }
 					title={ translate(
 						'Access all our premium themes with our Premium and Business plans!'
 					) }
@@ -96,6 +115,7 @@ export default connect( ( state, { siteId } ) => ( {
 	isJetpack: isJetpackSite( state, siteId ),
 	isVip: isVipSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
+	isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),
 } ) )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -21,7 +21,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import { INSTALL_PLUGIN } from 'state/plugins/installed/constants';
+import { UPGRADE_INTENT_INSTALL_THEME } from 'lib/checkout/constants';
 import isVipSite from 'state/selectors/is-vip-site';
 import { encodeQueryParameters } from 'state/http';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
@@ -51,7 +51,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 					'redirect_to',
 					`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 						encodeQueryParameters( [
-							[ 'intent', INSTALL_PLUGIN ],
+							[ 'intent', UPGRADE_INTENT_INSTALL_THEME ],
 							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 							[ 'plan', PLAN_PREMIUM ],

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -24,13 +24,11 @@ import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { UPGRADE_INTENT_INSTALL_THEME } from 'lib/checkout/constants';
 import isVipSite from 'state/selectors/is-vip-site';
 import { encodeQueryParameters } from 'state/http';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const {
 		hasUnlimitedPremiumThemes,
 		requestingSitePlans,
-		isSiteUnlaunched,
 		siteId,
 		isVip,
 		siteSlug,
@@ -52,7 +50,6 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 					`/checkout/thank-you/${ siteSlug }/:receiptId?` +
 						encodeQueryParameters( [
 							[ 'intent', UPGRADE_INTENT_INSTALL_THEME ],
-							[ 'site_unlaunched_before_upgrade', isSiteUnlaunched ? 'true' : 'false' ],
 							[ 'redirect_to', document.location.pathname ],
 							[ 'plan', PLAN_PREMIUM ],
 						] ),
@@ -116,7 +113,6 @@ export default connect( ( state, { siteId } ) => ( {
 	isJetpack: isJetpackSite( state, siteId ),
 	isVip: isVipSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
-	isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),
 } ) )( ConnectedSingleSiteWpcom );

--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -10,7 +10,7 @@ import { extendAction } from 'state/utils';
 import { HTTP_REQUEST } from 'state/action-types';
 import { failureMeta, successMeta } from 'state/data-layer/wpcom-http';
 
-const encodeQueryParameters = queryParams => {
+export const encodeQueryParameters = queryParams => {
 	return queryParams
 		.map(
 			( [ queryKey, queryValue ] ) =>

--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -80,7 +80,6 @@ export const httpHandler = async ( { dispatch }, action ) => {
 
 	let response, json;
 	try {
-		// eslint thinks fetch is not defined
 		response = await fetch( queryString.length ? `${ url }?${ queryString }` : url, {
 			method,
 			headers: fetchHeaders,

--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -28,7 +28,7 @@ const isAllHeadersValid = headers =>
 			typeof headerPair[ 1 ] === 'string'
 	);
 
-/***
+/**
  * Handler to perform an http request based on `HTTP_REQUEST` action parameters:
  * {string} url the url to request
  * {string} method the method we should use in the request: GET, POST etc.
@@ -80,6 +80,7 @@ export const httpHandler = async ( { dispatch }, action ) => {
 
 	let response, json;
 	try {
+		// eslint thinks fetch is not defined
 		response = await fetch( queryString.length ? `${ url }?${ queryString }` : url, {
 			method,
 			headers: fetchHeaders,

--- a/client/state/http/test/index.js
+++ b/client/state/http/test/index.js
@@ -225,4 +225,13 @@ describe( 'encodeQueryParameters()', () => {
 			'%40home=Rest%20%26%20Relaxation&%40work=Focus%20%26%20Determination&%40thebeach=Chillin%D5%9A%20%26%20Grillin%D5%9A'
 		);
 	} );
+
+	test( 'should cast true and false to strings', () => {
+		expect(
+			encodeQueryParameters( [
+				[ 'x', true ],
+				[ 'y', false ],
+			] )
+		).toBe( 'x=true&y=false' );
+	} );
 } );

--- a/client/state/http/test/index.js
+++ b/client/state/http/test/index.js
@@ -10,7 +10,7 @@ const fetch = require( 'jest-fetch-mock' );
 /**
  * Internal dependencies
  */
-import { httpHandler } from '../';
+import { encodeQueryParameters, httpHandler } from '../';
 import { failureMeta, successMeta } from 'state/data-layer/wpcom-http';
 import { extendAction } from 'state/utils';
 
@@ -188,5 +188,41 @@ describe( '#httpHandler', () => {
 		);
 
 		expect( fetch.mock.calls[ fetch.mock.calls.length - 1 ][ 0 ] ).not.toContain( '?' );
+	} );
+} );
+
+describe( 'encodeQueryParameters()', () => {
+	test( 'empty array to return empty string', () => {
+		expect( encodeQueryParameters( [] ) ).toBe( '' );
+	} );
+
+	test( 'should cast undefined second pair to "undefined" in result', () => {
+		expect( encodeQueryParameters( [ [ 'oat-milk' ] ] ) ).toBe( 'oat-milk=undefined' );
+	} );
+
+	test( 'should combine one string pair to equal left=right', () => {
+		expect( encodeQueryParameters( [ [ 'large', '20oz' ] ] ) ).toBe( 'large=20oz' );
+	} );
+
+	test( 'should join string pairs with a &', () => {
+		expect(
+			encodeQueryParameters( [
+				[ 'small', '12oz' ],
+				[ 'medium', '16oz' ],
+				[ 'large', '20oz' ],
+			] )
+		).toBe( 'small=12oz&medium=16oz&large=20oz' );
+	} );
+
+	test( 'should URI encode strings', () => {
+		expect(
+			encodeQueryParameters( [
+				[ '@home', 'Rest & Relaxation' ],
+				[ '@work', 'Focus & Determination' ],
+				[ '@thebeach', 'Chillin՚ & Grillin՚' ],
+			] )
+		).toBe(
+			'%40home=Rest%20%26%20Relaxation&%40work=Focus%20%26%20Determination&%40thebeach=Chillin%D5%9A%20%26%20Grillin%D5%9A'
+		);
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More context: https://github.com/Automattic/wp-calypso/pull/38139

Pre-requisites:
* ~~https://github.com/Automattic/wp-calypso/pull/38201~~
* ~~https://github.com/Automattic/wp-calypso/pull/38199~~

This PR updates business plan upgrade nudges on /plugins and /themes to make sure purchasing a plan through these nudges will show a simplified version of a Thank you page.

#### Testing instructions

* As a free user, go to /plugins and upgrade via nudge. Confirm you got a success message similar to this and that CTA redirects back to /plugins:

![Screenshot 2019-12-05 21 06 59](https://user-images.githubusercontent.com/4924246/70297698-e6f2c780-17a3-11ea-90bb-bc739a5f7db0.png)

* Repeat for specific plugin. Additionally the CTA should redirect back to that plugin's page
* Repeat for /themes. Additionally the CTA should redirect back to /themes
* Repeat for nudge on specific theme's page. Additionally the CTA should redirect back that theme page
* Try paying via PayPal and confirm it still works
* Upgrade via /plans instead of following the nudges, confirm the thank you page looks like usual:

<img width="1029" alt="70057278-27541900-15dd-11ea-9846-b6f513422e6b" src="https://user-images.githubusercontent.com/205419/70247528-cc0b5d80-1779-11ea-904d-720bae4931ef.png">

