### PR TITLE
Fix/migration todo comment

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -379,7 +379,6 @@ class SectionMigrate extends Component {
 
 		return (
 			<Main>
-				// TODO - maybe only refresh while we're on the progress page at some point
 				<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
 				<DocumentHead title="Migrate" />
 				<SidebarNavigation />

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -293,9 +293,6 @@ class SectionMigrate extends Component {
 			case 'restoring':
 				progressItemText = `Restoring to ${ targetSiteDomain }`;
 				break;
-			case 'done':
-				progressItemText = 'Wrapping up';
-				break;
 		}
 
 		return (
@@ -309,7 +306,7 @@ class SectionMigrate extends Component {
 	}
 
 	renderProgressList() {
-		const steps = [ 'backing-up', 'restoring', 'done' ];
+		const steps = [ 'backing-up', 'restoring' ];
 
 		return (
 			<ul className="migrate__progress-list">

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -117,7 +117,7 @@
 
 .migrate__progress-item-icon {
 	width: 24px;
-	margin-right: 12px;
+	margin-right: 6px;
 	display: flex;
 
 	.spinner {


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Delete the stray TODO comment which is showing above the site selector.
* Delete the "Wrapping up" step from the migration progress list. It's not really needed since we have a spinner and a change of item text to indicate where we are in the process.
* Slightly reduce the right margin of the progress item icon.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this pull request and run Calypso locally, or view it on calypso.live with the flag tools/migrate.
* This PR requires D36080-code and a sandboxed API. See the testing instructions for running D36080-code.
* Viewing calypso.localhost:3000/migrate/, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Accept the confirmation. You should see a progress screen detailing the steps of the migration.
* When the migration is done you should see a message telling you it is complete.

Fixes #
