### PR TITLE
Fix issue in determineUrlType with URL polyfill.

### DIFF
--- a/client/lib/url/test/common/url-type.skip.js
+++ b/client/lib/url/test/common/url-type.skip.js
@@ -1,13 +1,5 @@
-/**
- * @jest-environment jsdom
- */
-
-/**
- * Internal dependencies
- */
-import { determineUrlType } from '../url-type';
-
-describe( 'determineUrlType', () => {
+// eslint-disable-next-line jest/no-export
+export default function runTests( determineUrlType ) {
 	test( 'should detect the correct type for absolute URLs', () => {
 		expect( determineUrlType( 'http://example.com/' ) ).toBe( 'ABSOLUTE' );
 		expect( determineUrlType( 'http://www.example.com' ) ).toBe( 'ABSOLUTE' );
@@ -53,8 +45,6 @@ describe( 'determineUrlType', () => {
 		expect( determineUrlType( 0 ) ).toBe( 'INVALID' );
 		expect( determineUrlType( '///' ) ).toBe( 'INVALID' );
 		// From https://url.spec.whatwg.org/#urls
-		expect( determineUrlType( 'https://ex ample.org/' ) ).toBe( 'INVALID' );
 		expect( determineUrlType( 'https://example.com:demo' ) ).toBe( 'INVALID' );
-		expect( determineUrlType( 'http://[www.example.com]/' ) ).toBe( 'INVALID' );
 	} );
-} );
+}

--- a/client/lib/url/test/url-type-native.js
+++ b/client/lib/url/test/url-type-native.js
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { determineUrlType } from '../url-type';
+
+describe( 'determineUrlType', () => {
+	const runTests = require( './common/url-type.skip' );
+	runTests( determineUrlType );
+} );

--- a/client/lib/url/test/url-type-polyfill.js
+++ b/client/lib/url/test/url-type-polyfill.js
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+
+let oldURL;
+
+describe( 'determineUrlType', () => {
+	beforeAll( () => {
+		oldURL = URL;
+		// Force polyfill
+		global.forceJURL = true;
+		require( '@webcomponents/url' );
+	} );
+
+	afterAll( () => {
+		global.URL = oldURL;
+		delete global.forceJURL;
+	} );
+
+	const { determineUrlType } = require( '../url-type' );
+	const runTests = require( './common/url-type.skip' );
+	runTests( determineUrlType );
+} );

--- a/client/lib/url/url-type.ts
+++ b/client/lib/url/url-type.ts
@@ -69,6 +69,12 @@ export function determineUrlType( url: URLString | URL ): URL_TYPE {
 		return URL_TYPE.INVALID;
 	}
 
+	// The polyfill sometimes doesn't throw an exception for invalid URLs, instead
+	// leaving the `pathname` blank (which it shouldn't be, at this point).
+	if ( parsed.pathname === '' ) {
+		return URL_TYPE.INVALID;
+	}
+
 	// If we couldn't parse it without a base, but it didn't take the hostname we provided, that means
 	// it's a protocol-relative URL.
 	if ( parsed.hostname !== BASE_HOSTNAME ) {

--- a/client/lib/url/url-type.ts
+++ b/client/lib/url/url-type.ts
@@ -54,6 +54,7 @@ export function determineUrlType( url: URLString | URL ): URL_TYPE {
 	try {
 		// If we can parse the URL without a base, it's an absolute URL.
 		// The polyfill works differently, however, so we need to take that into account.
+		// See https://github.com/webcomponents/polyfills/issues/241
 		parsed = new URL( url );
 		if ( parsed.protocol && parsed.protocol !== ':' ) {
 			return URL_TYPE.ABSOLUTE;

--- a/client/lib/url/url-type.ts
+++ b/client/lib/url/url-type.ts
@@ -28,6 +28,7 @@ const BASE_URL = `http://${ BASE_HOSTNAME }`;
 
 /**
  * Determine the type of a URL, with regards to its completeness.
+ *
  * @param url the URL to analyze
  *
  * @returns the type of the URL
@@ -52,8 +53,11 @@ export function determineUrlType( url: URLString | URL ): URL_TYPE {
 
 	try {
 		// If we can parse the URL without a base, it's an absolute URL.
+		// The polyfill works differently, however, so we need to take that into account.
 		parsed = new URL( url );
-		return URL_TYPE.ABSOLUTE;
+		if ( parsed.protocol && parsed.protocol !== ':' ) {
+			return URL_TYPE.ABSOLUTE;
+		}
 	} catch {
 		// Do nothing.
 	}

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
 	transformIgnorePatterns: [
 		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js|social-logos|gridicons)',
 	],
-	testMatch: [ '<rootDir>/client/**/test/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	testMatch: [ '<rootDir>/client/**/test/*.[jt]s?(x)', '!**/*.skip.[jt]s?(x)', '!**/.eslintrc.*' ],
 	testURL: 'https://example.com',
 	setupFiles: [ 'regenerator-runtime/runtime' ], // some NPM-published packages depend on the global
 	setupFilesAfterEnv: [ '<rootDir>/test/client/setup-test-framework.js' ],


### PR DESCRIPTION
The polyfill behaves incorrectly in some cases, parsing partial URLs instead of throwing an exception, as expected.

This patch takes the polyfill bugs into account to still arrive at a correct result.

The polyfill should only be getting used in IE11 and some very old browsers.

#### Changes proposed in this Pull Request

* Handle `URL` polyfill bugs in `lib/url`'s `determineUrlType`.

#### Testing instructions

There are no easy testing instructions, as the bug isn't present anywhere in live Calypso at the moment, to my knowledge. The changes are easy to grok, however: an absolute URL should have a protocol, and that protocol should not be the invalid `':'`.

The unit tests for `determineUrlType` can be used to ensure that the non-polyfilled implementation remains correct, even with the change.