### PR TITLE
Posts List: Use Notice component for nudge

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/editor.scss
@@ -1,16 +1,9 @@
 div.posts-list__notice {
 	margin: 0 0 5px;
 
-	p {
+	.components-notice__content {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		font-size: 13px;
-		margin: 1em 0;
-		padding: 2px;
-
-		.posts-list__message {
-			margin-right: 1em;
-		}
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -8,7 +8,7 @@ import {
 	getPossibleBlockTransformations,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { Placeholder, RangeControl, PanelBody, Button } from '@wordpress/components';
+import { Placeholder, RangeControl, PanelBody, Notice } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { select, dispatch } from '@wordpress/data';
@@ -60,19 +60,21 @@ registerBlockType( metadata.name, {
 		return (
 			<Fragment>
 				{ canBeUpgraded && (
-					<div className="posts-list__notice notice notice-info notice-alt">
-						<p>
-							<span className="posts-list__message">
-								{ __(
-									'An improved version of this block is available. Upgrade for a better, more natural way to manage your blog post listings.',
-									'full-site-editing'
-								) }
-							</span>
-							<Button isButton isLarge isDefault onClick={ upgradeBlock }>
-								{ __( 'Upgrade Block', 'full-site-editing' ) }
-							</Button>
-						</p>
-					</div>
+					<Notice
+						actions={ [
+							{
+								label: __( 'Upgrade Block', 'full-site-editing' ),
+								onClick: upgradeBlock,
+							},
+						] }
+						className="posts-list__notice"
+						isDismissible={ false }
+					>
+						{ __(
+							'An improved version of this block is available. Upgrade for a better, more natural way to manage your blog post listings.',
+							'full-site-editing'
+						) }
+					</Notice>
 				) }
 				<Placeholder
 					icon={ icon }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses the proper `Notice` component instead of winging it.

#### Testing instructions

* Add a posts list block in your editor
* hit the Upgrade button and make sure it converts to Blog Posts block.