### PR TITLE
Gutenboarding: Fix DomainSuggestionsQuery type

### DIFF
--- a/client/landing/gutenboarding/stores/domain-suggestions/types.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/types.ts
@@ -3,10 +3,9 @@
  */
 import { InputArgs } from '@wordpress/url';
 
-enum ActionType {
+export enum ActionType {
 	RECEIVE_DOMAIN_SUGGESTIONS = 'RECEIVE_DOMAIN_SUGGESTIONS',
 }
-export { ActionType };
 
 // We're extending InputArgs in order to add an index signature,
 // which we need for using `DomainSuggestionQuery` objects with `addQueryArgs`.

--- a/client/landing/gutenboarding/stores/domain-suggestions/types.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/types.ts
@@ -1,9 +1,16 @@
+/**
+ * External dependencies
+ */
+import { InputArgs } from '@wordpress/url';
+
 enum ActionType {
 	RECEIVE_DOMAIN_SUGGESTIONS = 'RECEIVE_DOMAIN_SUGGESTIONS',
 }
 export { ActionType };
 
-export interface DomainSuggestionQuery {
+// We're extending InputArgs in order to add an index signature,
+// which we need for using `DomainSuggestionQuery` objects with `addQueryArgs`.
+export interface DomainSuggestionQuery extends InputArgs {
 	/**
 	 * True to include .blog subdomain suggestions
 	 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make `DomainSuggestionsQuery` extend `InputArgs` in order to add an index signature,
which we need for using `DomainSuggestionQuery` objects with `addQueryArgs`.

This fixes one TS error.

Also simplify a type export while we're at it.

#### Testing instructions

```
npm run typecheck -- --project client/landing/gutenboarding
```

should give one error less than on `master`.

Also, verify that the app still builds and runs.