### PR TITLE
Check that siteId is set before dispatching the requestSelectedEditor action

### DIFF
--- a/client/components/data/query-site-selected-editor/index.jsx
+++ b/client/components/data/query-site-selected-editor/index.jsx
@@ -14,7 +14,9 @@ export default function QuerySiteSelectedEditor( { siteId } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( requestSelectedEditor( siteId ) );
+		if ( siteId ) {
+			dispatch( requestSelectedEditor( siteId ) );
+		}
 	}, [ dispatch, siteId ] );
 
 	return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a check to verify siteId is set before dispatching the requestSelectedEditor action

With the change to useEffect in #37521, the action was being dispatched with every prop change, some of which included a null siteId

#### Testing instructions

* Before checking out this PR load local calypso with network panel open and filtered to `/v3/sites`. You should see a number of requests to /v3/sites/null/gutenberg?_envelope=1
* Check out this PR and you should then only see requests with valid site ids

Before:

<img width="943" alt="Screen Shot 2019-12-06 at 9 19 17 AM" src="https://user-images.githubusercontent.com/3629020/70270534-84341700-1809-11ea-9d10-20ab20434ec8.png">


After:

<img width="946" alt="Screen Shot 2019-12-06 at 9 18 37 AM" src="https://user-images.githubusercontent.com/3629020/70270554-8c8c5200-1809-11ea-9229-e833254cf8a9.png">

Fixes #38220
