### PR TITLE
composite-checkout: Add stripe test key to demo

### DIFF
--- a/packages/composite-checkout/.gitignore
+++ b/packages/composite-checkout/.gitignore
@@ -1,2 +1,1 @@
 dist
-private.js

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -21,7 +21,8 @@ import {
 	getDefaultOrderSummaryStep,
 	getDefaultOrderReviewStep,
 } from '../src/public-api';
-import { stripeKey } from './private';
+
+const stripeKey = 'pk_test_zIh4nRbVgmaetTZqoG4XKxWT';
 
 const initialItems = [
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since apparently the test Stripe key does not need to be kept secure, this adds it directly to the demo so that the demo can be run more easily.

#### Testing instructions

- Run `npm run composite-checkout-demo`.
- Verify that the form works as expected.