### PR TITLE
Ignores *.code-workspace files from VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .DS_Store
 .idea
 .vscode
+*.code-workspace
 *.iml
 *.iws
 /tags


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds [VSCode Workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) to the gitignore file

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `touch test.code-workspace` in repo root.
* Run `git status` to see if file is detected by version control.
