### PR TITLE
Domain step test: Wrap all strings in translate()

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -47,12 +47,13 @@ class DomainProductPrice extends React.Component {
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
 				if ( this.props.showTestCopy ) {
-					message = (
-						<>
-							Registration fee: <del>{ this.props.price }</del>{' '}
-							<span className="domain-product-price__free-price">Free</span>
-						</>
-					);
+					message = translate( 'Registration fee: {{del}}%(cost)s{{/del}} {{span}}Free{{/span}}', {
+						args: { cost: this.props.price },
+						components: {
+							del: <del />,
+							span: <span className="domain-product-price__free-price" />,
+						},
+					} );
 				} else {
 					message = translate( 'First year included in paid plans' );
 				}
@@ -75,7 +76,10 @@ class DomainProductPrice extends React.Component {
 		}
 
 		const priceText = this.props.showTestCopy
-			? `Renews at ${ this.props.price }/year`
+			? this.props.translate( 'Renews at %(cost)s {{small}}/year{{/small}}', {
+					args: { cost: this.props.price },
+					components: { small: <small /> },
+			  } )
 			: this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
 					args: { cost: this.props.price },
 					components: { small: <small /> },

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -76,9 +76,8 @@ class DomainProductPrice extends React.Component {
 		}
 
 		const priceText = this.props.showTestCopy
-			? this.props.translate( 'Renews at %(cost)s {{small}}/year{{/small}}', {
+			? this.props.translate( 'Renews at %(cost)s / year', {
 					args: { cost: this.props.price },
-					components: { small: <small /> },
 			  } )
 			: this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
 					args: { cost: this.props.price },

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -241,7 +241,9 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let title, progressBarProps;
 		if ( isRecommended ) {
-			title = this.props.showTestCopy ? 'Our Recommendation' : translate( 'Best Match' );
+			title = this.props.showTestCopy
+				? translate( 'Our Recommendation' )
+				: translate( 'Best Match' );
 			progressBarProps = {
 				color: NOTICE_GREEN,
 				title,

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,25 +21,28 @@ class FreeDomainExplainer extends React.Component {
 		this.props.onSkip( undefined, hideFreePlan );
 	};
 	render() {
+		const { translate } = this.props;
+
 		return (
 			<div className="free-domain-explainer card is-compact">
 				<header>
 					<h1 className="free-domain-explainer__title">
-						Get a free one-year domain registration with any paid plan.
+						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
 					<p className="free-domain-explainer__subtitle">
-						We'll pay the registration fees for your new domain when you choose a paid plan during
-						the next step.
+						{ translate(
+							"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
+						) }
 					</p>
 					<p className="free-domain-explainer__subtitle">
-						You can claim your free custom domain later if you aren't ready yet.
+						{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }
 						<Button
 							borderless
 							className="free-domain-explainer__subtitle-link"
 							onClick={ this.handleClick }
 							href
 						>
-							Review our plans to get started &raquo;
+							{ translate( 'Review our plans to get started' ) } &raquo;
 						</Button>
 					</p>
 				</header>
@@ -47,4 +51,4 @@ class FreeDomainExplainer extends React.Component {
 	}
 }
 
-export default FreeDomainExplainer;
+export default localize( FreeDomainExplainer );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -389,7 +389,9 @@ class RegisterDomainStep extends React.Component {
 	getPlaceholderText() {
 		const { showTestCopy, translate } = this.props;
 
-		return showTestCopy ? 'Type the domain you want here' : translate( 'Enter a name or keyword' );
+		return showTestCopy
+			? translate( 'Type the domain you want here' )
+			: translate( 'Enter a name or keyword' );
 	}
 
 	render() {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -122,5 +122,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -122,6 +122,16 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+	},
+	nonEnglishDomainStepCopyUpdates: {
+		datestamp: '20191219',
+		variations: {
+			variantShowUpdates: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
 		localeTargets: 'any',
+		localeExceptions: [ 'en' ],
 	},
 };

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -105,9 +105,10 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."
 			),
-			domainsStepHeaderTestCopy: "Let's get your blog a domain!",
-			domainsStepSubheaderTestCopy:
-				"Tell us your blog's name or a few keywords, and we'll come up with some suggestions.",
+			domainsStepHeaderTestCopy: i18n.translate( "Let's get your blog a domain!" ),
+			domainsStepSubheaderTestCopy: i18n.translate(
+				"Tell us your blog's name or a few keywords, and we'll come up with some suggestions."
+			),
 		},
 		{
 			id: 1, // This value must correspond with its sibling in the /segments API results
@@ -124,9 +125,10 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your business's name or some keywords that describe it to get started."
 			),
-			domainsStepHeaderTestCopy: "Let's get your business a domain!",
-			domainsStepSubheaderTestCopy:
-				"Tell us your business's name or a few keywords, and we'll come up with some suggestions.",
+			domainsStepHeaderTestCopy: i18n.translate( "Let's get your business a domain!" ),
+			domainsStepSubheaderTestCopy: i18n.translate(
+				"Tell us your business's name or a few keywords, and we'll come up with some suggestions."
+			),
 			customerType: 'business',
 		},
 		{
@@ -165,9 +167,10 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your site's name or some keywords that describe it to get started."
 			),
-			domainsStepHeaderTestCopy: "Let's get your store a domain!",
-			domainsStepSubheaderTestCopy:
-				"Tell us your store's name or a few keywords, and we'll come up with some suggestions.",
+			domainsStepHeaderTestCopy: i18n.translate( "Let's get your store a domain!" ),
+			domainsStepSubheaderTestCopy: i18n.translate(
+				"Tell us your store's name or a few keywords, and we'll come up with some suggestions."
+			),
 		},
 	];
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -36,9 +36,10 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			domainsStepSubheader: i18n.translate(
 				'Enter a keyword that describes your site to get started.'
 			),
-			domainsStepHeaderTestCopy: "Let's get your site a domain!",
-			domainsStepSubheaderTestCopy:
-				"Tell us your site's name or a few keywords, and we'll come up with some suggestions.",
+			domainsStepHeaderTestCopy: i18n.translate( "Let's get your site a domain!" ),
+			domainsStepSubheaderTestCopy: i18n.translate(
+				"Tell us your site's name or a few keywords, and we'll come up with some suggestions."
+			),
 			// Site styles step
 			siteStyleSubheader: i18n.translate(
 				'This will help you get started with a theme you might like. You can change it later.'

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -122,11 +122,13 @@ class DomainsStep extends React.Component {
 
 		this.showTestCopy = false;
 
-		if (
-			false !== this.props.shouldShowDomainTestCopy &&
-			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
-		) {
-			this.showTestCopy = true;
+		if ( false !== this.props.shouldShowDomainTestCopy ) {
+			if (
+				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' ) ||
+				'variantShowUpdates' === abtest( 'nonEnglishDomainStepCopyUpdates' )
+			) {
+				this.showTestCopy = true;
+			}
 		}
 
 		this.showTestParagraph = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The domain step test introduced in https://github.com/Automattic/wp-calypso/pull/37661 is declared a winner, so this PR submits all the english language strings for translation. 
* The A/B test is opened to all locales except `en`.

Screenshots:

<img width="999" alt="Screenshot 2019-12-13 at 7 12 11 PM" src="https://user-images.githubusercontent.com/1269602/70804473-9a7b3d80-1ddc-11ea-8842-4315cc8be0cd.png">

<img width="1017" alt="Screenshot 2019-12-13 at 7 12 33 PM" src="https://user-images.githubusercontent.com/1269602/70804485-a1a24b80-1ddc-11ea-9cda-4f2ad9d916ad.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the test plan in https://github.com/Automattic/wp-calypso/pull/37661
* Verify that all strings introduced as part of the domain step test appear translated(go through the signup flow in any non-en locale while you are assigned to the variation). 
* If you go through the signup flow in `en` you should not get assigned to the `nonEnglishDomainStepCopyUpdates` test.