### PR TITLE
composite-checkout: Refactor cart hook to be static

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -8,11 +8,7 @@ import {
 	createStripeMethod,
 	createApplePayMethod,
 } from '@automattic/composite-checkout';
-import {
-	WPCheckoutWrapper,
-	makeShoppingCartHook,
-	mockPayPalExpressRequest,
-} from '@automattic/composite-checkout-wpcom';
+import { WPCheckoutWrapper, mockPayPalExpressRequest } from '@automattic/composite-checkout-wpcom';
 
 /**
  * Internal dependencies
@@ -25,13 +21,6 @@ const { registerStore } = registry;
 const wpcom = wp.undocumented();
 
 export const getServerCart = wpcom.getCart;
-
-const useShoppingCart = cartKey => {
-	return makeShoppingCartHook(
-		cartParam => wpcom.setCart( cartKey, cartParam ),
-		() => wpcom.getCart( cartKey )
-	);
-};
 
 async function fetchStripeConfiguration( requestArgs ) {
 	return wpcom.stripeConfiguration( requestArgs );
@@ -90,7 +79,9 @@ const availablePaymentMethods = [ applePayMethod, stripeMethod, paypalMethod ].f
 export function CompositeCheckoutContainer( { siteSlug } ) {
 	return (
 		<WPCheckoutWrapper
-			useShoppingCart={ useShoppingCart( siteSlug ) }
+			siteSlug={ siteSlug }
+			getCart={ wpcom.getCart }
+			setCart={ wpcom.setCart }
 			availablePaymentMethods={ availablePaymentMethods }
 			registry={ registry }
 		/>

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -20,8 +20,6 @@ const { registerStore } = registry;
 
 const wpcom = wp.undocumented();
 
-export const getServerCart = wpcom.getCart;
-
 async function fetchStripeConfiguration( requestArgs ) {
 	return wpcom.stripeConfiguration( requestArgs );
 }
@@ -76,12 +74,15 @@ export function isApplePayAvailable() {
 
 const availablePaymentMethods = [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean );
 
+const getCart = ( ...args ) => wpcom.getCart( ...args );
+const setCart = ( ...args ) => wpcom.setCart( ...args );
+
 export function CompositeCheckoutContainer( { siteSlug } ) {
 	return (
 		<WPCheckoutWrapper
 			siteSlug={ siteSlug }
-			getCart={ wpcom.getCart }
-			setCart={ wpcom.setCart }
+			getCart={ getCart }
+			setCart={ setCart }
 			availablePaymentMethods={ availablePaymentMethods }
 			registry={ registry }
 		/>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-wrapper.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-wrapper.js
@@ -66,6 +66,8 @@ export function WPCheckoutWrapper( {
 
 WPCheckoutWrapper.propTypes = {
 	availablePaymentMethods: PropTypes.arrayOf( PropTypes.object ).isRequired,
-	useShoppingCart: PropTypes.func.isRequired,
 	registry: PropTypes.object.isRequired,
+	siteSlug: PropTypes.string,
+	setCart: PropTypes.func.isRequired,
+	getCart: PropTypes.func.isRequired,
 };

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-wrapper.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-wrapper.js
@@ -10,6 +10,7 @@ import { CheckoutProvider } from '@automattic/composite-checkout';
  */
 import WPCheckout from './wp-checkout';
 import { useWpcomStore } from '../hooks/wpcom-store';
+import { useShoppingCart } from '../hooks/shopping-cart-hook';
 
 // These are used only for non-redirect payment methods
 // TODO: write this
@@ -26,8 +27,18 @@ const handleCheckoutEvent = () => () => {
 };
 
 // This is the parent component which would be included on a host page
-export function WPCheckoutWrapper( { useShoppingCart, availablePaymentMethods, registry } ) {
-	const { items, tax, total, removeItem, changePlanLength } = useShoppingCart();
+export function WPCheckoutWrapper( {
+	siteSlug,
+	setCart,
+	getCart,
+	availablePaymentMethods,
+	registry,
+} ) {
+	const { items, tax, total, removeItem, changePlanLength } = useShoppingCart(
+		siteSlug,
+		setCart,
+		getCart
+	);
 
 	const { select, subscribe, registerStore } = registry;
 	useWpcomStore( registerStore );


### PR DESCRIPTION
This is a proposal to change how the `useShoppingCart` hook is created.

useShoppingCart was being dynamically created by the
makeShoppingCartHook function. There's nothing wrong with this in
theory, but it does introduce additional complexity and might make the
code harder to understand since Hooks are stateful functions with
side-effects by definition.

This commit changes the code such that useShoppingCart is a regular Hook
instead.

One advantage of this is that the data dependencies of the hook become
more explicit. It requires functions to call the API (we could import
those directly into the Hook file instead but this way they can be
controlled by the main host component where all the other host-specific
logic lives; either way would be fine) and a key which in theory may
change (but in practice should not).