### PR TITLE
State: Add missing handlers to upgrade nudge data layer

### DIFF
--- a/client/state/data-layer/wpcom/marketing/index.js
+++ b/client/state/data-layer/wpcom/marketing/index.js
@@ -3,6 +3,7 @@
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { noop } from 'lodash';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 import { MARKETING_CLICK_UPGRADE_NUDGE } from 'state/action-types';
@@ -24,6 +25,8 @@ registerHandlers( 'state/data-layer/wpcom/marketing/index.js', {
 	[ MARKETING_CLICK_UPGRADE_NUDGE ]: [
 		dispatchRequest( {
 			fetch: notifyUpgradeNudgeClick,
+			onSuccess: noop,
+			onError: noop,
 		} ),
 	],
 } );


### PR DESCRIPTION
This PR removes a couple of warnings that are caused by the fact that some data layer handlers aren't being registered:

![](https://cldup.com/qW2z1s0o_z.png)

#### Changes proposed in this Pull Request

* State: Add missing handlers to upgrade nudge data layer

#### Testing instructions

* Checkout this branch.
* Open Calypso with your dev console open.
* Verify you no longer see the warnings from the screenshot.
