### PR TITLE
Site migration: progress view add start time

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -39,16 +39,10 @@ class SectionMigrate extends Component {
 	state = {
 		migrationStatus: 'unknown',
 		percent: 0,
-		startTime: null,
 	};
 
 	componentDidMount() {
 		this.updateFromAPI();
-		this.onMount( () => {
-			if ( null === this.state.startTime ) {
-				this.setState( { startTime: this.getStartTime() } );
-			}
-		} );
 	}
 
 	getImportHref = () => {
@@ -91,8 +85,7 @@ class SectionMigrate extends Component {
 		const localeSlug = getLocaleSlug();
 		const startTime = moment()
 			.locale( localeSlug )
-			.format( 'h:m a D MMM' );
-		this.setState( { startTime: startTime } );
+			.format( 'LT D MMMM' );
 		window.localStorage.setItem( 'siteMigrationStartTime', startTime );
 	};
 
@@ -100,14 +93,7 @@ class SectionMigrate extends Component {
 		if ( ! window.localStorage ) {
 			return;
 		}
-		this.setState( { startTime: null } );
 		window.localStorage.removeItem( 'siteMigrationStartTime' );
-	};
-
-	renderMigrationTime = () => {
-		if ( null !== this.state.startTime ) {
-			return 'Migration started at ' + this.state.startTime;
-		}
 	};
 
 	startMigration = () => {
@@ -286,11 +272,21 @@ class SectionMigrate extends Component {
 						subHeaderText={ `We're moving everything from ${ sourceSiteDomain } to ${ targetSiteDomain }.` }
 						align="center"
 					/>
+					{ this.renderStartTime() }
 					{ this.renderProgressBar() }
 					{ this.renderProgressList() }
 				</Card>
 			</>
 		);
+	}
+
+	renderStartTime() {
+		const startTime = this.getStartTime();
+		if ( ! startTime ) {
+			return;
+		}
+
+		return <div className="migrate__start-time">Migration started at { startTime }</div>;
 	}
 
 	renderProgressBar() {
@@ -417,7 +413,6 @@ class SectionMigrate extends Component {
 			case 'unknown':
 			default:
 				migrationElement = this.renderLoading();
-				this.clearStartTime();
 		}
 
 		return (

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -286,7 +286,7 @@ class SectionMigrate extends Component {
 			return;
 		}
 
-		return <div className="migrate__start-time">Migration started at { startTime }</div>;
+		return <div className="migrate__start-time">Migration started { startTime }</div>;
 	}
 
 	renderProgressBar() {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -101,7 +101,7 @@
 }
 
 .migrate__progress {
-	width: 350px;
+	max-width: 350px;
 	margin-bottom: 2rem;
 }
 

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -105,6 +105,12 @@
 	margin-bottom: 2rem;
 }
 
+.migrate__start-time {
+	margin-bottom: 8px;
+	color: var( --color-text-subtle );
+	font-size: 14px;
+}
+
 .migrate__progress-item {
 	position: relative;
 	list-style-type: none;

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -106,6 +106,7 @@
 }
 
 .migrate__start-time {
+	height: 1.5rem;
 	margin-bottom: 8px;
 	color: var( --color-text-subtle );
 	font-size: 14px;


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Stores migration start time in localStorage, and shows it during a migration.
* The design for this view had the time string worded as "Migration started on Nov 15, 2019 at 12:38 pm". This is a US-style date format, but having a preposition between date and time doesn't lend itself to translation. It's also more efficient to store the timestamp as one string, so I've done it as shown.

![image](https://user-images.githubusercontent.com/1647564/70321154-881e6400-181e-11ea-8cab-0d7ca6d82c85.png)

#### Testing instructions

(Note: most of these instructions are general instructions for testing migration. The bolded steps are the ones specific to this change)

* **Check out D36604-code and follow the test instructions for that patch.**
* Check out this pull request and run Calypso locally.
* Viewing calypso.localhost:3000/migrate/, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Accept the confirmation. You should see a progress screen detailing the steps of the migration.
  * **The migration start time should be displayed above the progress bar.** 
  * **It should persist when you navigate away from the page and back, and when you refresh the page.**
* **After the migration, when you start a new migration, a new start time should be displayed.**
