### PR TITLE
Add getUrlParts to lib/url.

### DIFF
--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -12,3 +12,4 @@ export { default as isHttps } from './is-https';
 export { addSchemeIfMissing, setUrlScheme } from './scheme-utils';
 export { decodeURIIfValid, decodeURIComponentIfValid } from './decode-utils';
 export { default as format } from './format';
+export { getUrlParts } from './url-parts';

--- a/client/lib/url/test/url-parts.js
+++ b/client/lib/url/test/url-parts.js
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getUrlParts } from '../url-parts';
+
+describe( 'getUrlParts', () => {
+	test( 'should empty parts for invalid URLs', () => {
+		expect( getUrlParts( '///' ) ).toEqual( {
+			hash: '',
+			host: '',
+			hostname: '',
+			origin: '',
+			password: '',
+			pathname: '',
+			port: '',
+			protocol: '',
+			search: '',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+
+		expect( getUrlParts( 'https://example.com:badport?foo=bar#baz' ) ).toEqual( {
+			hash: '',
+			host: '',
+			hostname: '',
+			origin: '',
+			password: '',
+			pathname: '',
+			port: '',
+			protocol: '',
+			search: '',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+	} );
+
+	test( 'should return the right parts for absolute URLs', () => {
+		expect( getUrlParts( 'http://example.com' ) ).toEqual( {
+			hash: '',
+			host: 'example.com',
+			hostname: 'example.com',
+			origin: 'http://example.com',
+			password: '',
+			pathname: '/',
+			port: '',
+			protocol: 'http:',
+			search: '',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+
+		expect( getUrlParts( 'http://user:pass@example.com:8080/path?foo=bar#baz' ) ).toEqual( {
+			hash: '#baz',
+			host: 'example.com:8080',
+			hostname: 'example.com',
+			origin: 'http://example.com:8080',
+			password: 'pass',
+			pathname: '/path',
+			port: '8080',
+			protocol: 'http:',
+			search: '?foo=bar',
+			searchParams: expect.any( URLSearchParams ),
+			username: 'user',
+		} );
+	} );
+
+	test( 'should return the right parts for scheme-relative URLs', () => {
+		expect( getUrlParts( '//example.com' ) ).toEqual( {
+			hash: '',
+			host: 'example.com',
+			hostname: 'example.com',
+			origin: '',
+			password: '',
+			pathname: '/',
+			port: '',
+			protocol: '',
+			search: '',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+
+		expect( getUrlParts( '//user:pass@example.com:8080/path?foo=bar#baz' ) ).toEqual( {
+			hash: '#baz',
+			host: 'example.com:8080',
+			hostname: 'example.com',
+			origin: '',
+			password: 'pass',
+			pathname: '/path',
+			port: '8080',
+			protocol: '',
+			search: '?foo=bar',
+			searchParams: expect.any( URLSearchParams ),
+			username: 'user',
+		} );
+	} );
+
+	test( 'should return the right parts for path-absolute URLs', () => {
+		expect( getUrlParts( '/' ) ).toEqual( {
+			hash: '',
+			host: '',
+			hostname: '',
+			origin: '',
+			password: '',
+			pathname: '/',
+			port: '',
+			protocol: '',
+			search: '',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+
+		expect( getUrlParts( '/path?foo=bar#baz' ) ).toEqual( {
+			hash: '#baz',
+			host: '',
+			hostname: '',
+			origin: '',
+			password: '',
+			pathname: '/path',
+			port: '',
+			protocol: '',
+			search: '?foo=bar',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+	} );
+
+	test( 'should return the right parts for path-relative URLs', () => {
+		expect( getUrlParts( 'path' ) ).toEqual( {
+			hash: '',
+			host: '',
+			hostname: '',
+			origin: '',
+			password: '',
+			pathname: 'path',
+			port: '',
+			protocol: '',
+			search: '',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+
+		expect( getUrlParts( '../path?foo=bar#baz' ) ).toEqual( {
+			hash: '#baz',
+			host: '',
+			hostname: '',
+			origin: '',
+			password: '',
+			pathname: '../path',
+			port: '',
+			protocol: '',
+			search: '?foo=bar',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+
+		expect( getUrlParts( '../path#baz' ) ).toEqual( {
+			hash: '#baz',
+			host: '',
+			hostname: '',
+			origin: '',
+			password: '',
+			pathname: '../path',
+			port: '',
+			protocol: '',
+			search: '',
+			searchParams: expect.any( URLSearchParams ),
+			username: '',
+		} );
+	} );
+} );

--- a/client/lib/url/url-parts.ts
+++ b/client/lib/url/url-parts.ts
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { URL as URLString } from 'types';
+
+/**
+ * Internal dependencies
+ */
+import { determineUrlType, URL_TYPE } from './url-type';
+
+const BASE_URL = `http://__domain__.invalid`;
+
+type UrlPartKey = keyof URL;
+
+const URL_PART_KEYS: UrlPartKey[] = [
+	'protocol',
+	'host',
+	'hostname',
+	'port',
+	'origin',
+	'pathname',
+	'hash',
+	'search',
+	'searchParams',
+	'username',
+	'password',
+];
+
+interface UrlParts {
+	protocol: string;
+	host: string;
+	hostname: string;
+	port: string;
+	origin: string;
+	pathname: string;
+	hash: string;
+	search: string;
+	searchParams: URLSearchParams;
+	username: string;
+	password: string;
+}
+
+function pickUrlParts(
+	parsedUrl: URL | undefined,
+	include: UrlPartKey[] = URL_PART_KEYS
+): UrlParts {
+	const result = URL_PART_KEYS.reduce(
+		( parts, part ) => ( {
+			...parts,
+			[ part ]: include.includes( part ) ? parsedUrl?.[ part ] ?? '' : '',
+		} ),
+		{} as UrlParts
+	);
+	result.searchParams = result.searchParams || new URLSearchParams();
+
+	return result;
+}
+
+/**
+ * Returns the various available URL parts.
+ *
+ * @param url the URL to analyze
+ *
+ * @returns   the URL parts
+ */
+export function getUrlParts( url: URLString | URL ): UrlParts {
+	const urlType = determineUrlType( url );
+
+	// Invalid URL; return empty URL parts.
+	if ( urlType === URL_TYPE.INVALID ) {
+		return pickUrlParts( undefined, [] );
+	}
+
+	const parsed = url instanceof URL ? url : new URL( url, BASE_URL );
+
+	// Absolute URL; pick all parts.
+	if ( urlType === URL_TYPE.ABSOLUTE ) {
+		return pickUrlParts( parsed );
+	}
+
+	// Scheme-relative URL; pick everything except the protocol and origin.
+	if ( urlType === URL_TYPE.SCHEME_RELATIVE ) {
+		return pickUrlParts(
+			parsed,
+			URL_PART_KEYS.filter( item => item !== 'protocol' && item !== 'origin' )
+		);
+	}
+
+	// Path-absolute or path-relative URL; pick only a few parts.
+	const pathPartKeys: UrlPartKey[] = [ 'pathname', 'hash', 'search' ];
+	const pathParts = pickUrlParts( parsed, pathPartKeys );
+
+	// Path-relative URLs require special handling, because they cannot be transformed
+	// into an absolute URL without potentially losing path information.
+	// E.g. `../foo?bar=baz` becomes `<base>/foo?bar=baz` when fed to `new URL()`
+	// with a base, losing the traversal into the parent directory.
+	// We need to handle these with string functions instead.
+	if ( urlType === URL_TYPE.PATH_RELATIVE ) {
+		pathParts.pathname = ( url as URLString ).split( /[?#]/, 1 )[ 0 ];
+	}
+
+	return pathParts;
+}

--- a/client/lib/url/url-parts.ts
+++ b/client/lib/url/url-parts.ts
@@ -67,7 +67,7 @@ export function getUrlParts( url: URLString | URL ): UrlParts {
 
 	// Invalid URL; return empty URL parts.
 	if ( urlType === URL_TYPE.INVALID ) {
-		return pickUrlParts( undefined, [] );
+		return { ...EMPTY_URL };
 	}
 
 	const parsed = url instanceof URL ? url : new URL( url, BASE_URL );

--- a/client/lib/url/url-parts.ts
+++ b/client/lib/url/url-parts.ts
@@ -10,22 +10,6 @@ import { determineUrlType, URL_TYPE } from './url-type';
 
 const BASE_URL = `http://__domain__.invalid`;
 
-type UrlPartKey = keyof URL;
-
-const URL_PART_KEYS: UrlPartKey[] = [
-	'protocol',
-	'host',
-	'hostname',
-	'port',
-	'origin',
-	'pathname',
-	'hash',
-	'search',
-	'searchParams',
-	'username',
-	'password',
-];
-
 interface UrlParts {
 	protocol: string;
 	host: string;
@@ -40,20 +24,35 @@ interface UrlParts {
 	password: string;
 }
 
+type UrlPartKey = keyof UrlParts;
+
+const EMPTY_URL: Readonly< UrlParts > = Object.freeze( {
+	protocol: '',
+	host: '',
+	hostname: '',
+	port: '',
+	origin: '',
+	pathname: '',
+	hash: '',
+	search: '',
+	searchParams: new URLSearchParams(),
+	username: '',
+	password: '',
+} );
+
+const URL_PART_KEYS = Object.keys( EMPTY_URL ) as UrlPartKey[];
+
 function pickUrlParts(
 	parsedUrl: URL | undefined,
 	include: UrlPartKey[] = URL_PART_KEYS
 ): UrlParts {
-	const result = URL_PART_KEYS.reduce(
-		( parts, part ) => ( {
-			...parts,
-			[ part ]: include.includes( part ) ? parsedUrl?.[ part ] ?? '' : '',
-		} ),
-		{} as UrlParts
-	);
-	result.searchParams = result.searchParams || new URLSearchParams();
+	const pickedUrl = { ...EMPTY_URL };
 
-	return result;
+	include.forEach( < T extends UrlPartKey >( name: T ) => {
+		pickedUrl[ name ] = parsedUrl?.[ name ] ?? EMPTY_URL[ name ];
+	} );
+
+	return pickedUrl;
 }
 
 /**


### PR DESCRIPTION
Add `getUrlParts` to `lib/url`.

This new method serves a similar purpose to `new URL( urlString )`, while handling invalid and partial URLs of all types as well.

It returns the available parts in the URL, with unavailable parts being represented as "empty" values (an empty `URLSearchParams` object for `searchParams` and an empty string for everything else).

This allows for easy usage, e.g.:

```js
const hostname = getUrlParts( urlString ).hostname || '<no hostname>';
```

as opposed to e.g.:

```js
let hostname;
try {
  const parsed = new URL( urlString, 'http://fakedomain.invalid' );
  if ( parsed.hostname !== 'fakedomain.invalid' ) {
    hostname = parsed.hostname;
  }
} catch {
  // Do nothing;
}

hostname = hostname || '<no hostname>';
```

This method will serve as a tool in ongoing efforts in removing usage of `node`'s deprecated `url` module.

#### Changes proposed in this Pull Request

* Add new `getUrlParts` method to `lib/url`.
* Fix some lint issues in touched file.

#### Testing instructions

This is a new method that is not being used anywhere yet, so it won't introduce any bugs. The included unit tests should verify that the actual output matches the expected output.
