### PR TITLE
Allow fetching README files of components from outside of client folder

### DIFF
--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -198,9 +198,12 @@ class DesignAssets extends React.Component {
 					<Banner readmeFilePath="banner" />
 					<BulkSelect readmeFilePath="bulk-select" />
 					<ButtonGroups readmeFilePath="button-group" />
-					<Buttons componentUsageStats={ componentsUsageStats.button } readmeFilePath="button" />
+					<Buttons
+						componentUsageStats={ componentsUsageStats.button }
+						readmeFilePath="/packages/components/src/button"
+					/>
 					<SplitButton readmeFilePath="split-button" />
-					<Cards readmeFilePath="card" />
+					<Cards readmeFilePath="/packages/components/src/card" />
 					<CardHeading readmeFilePath="card-heading" />
 					<Chart readmeFilePath="chart" />
 					<Checklist readmeFilePath="checklist" />
@@ -253,13 +256,13 @@ class DesignAssets extends React.Component {
 					<PlansSkipButton readmeFilePath="plans/plans-skip-button" />
 					<PodcastIndicator readmeFilePath="podcast-indicator" />
 					<Popovers readmeFilePath="popover" />
-					<ProgressBar readmeFilePath="progress-bar" />
+					<ProgressBar readmeFilePath="/packages/components/src/progress-bar" />
 					<PromoSection readmeFilePath="promo-section" />
 					<PromoCard readmeFilePath="promo-section/promo-card" />
 					<Ranges readmeFilePath="forms/range" />
 					<Rating readmeFilePath="rating" />
-					<Ribbon readmeFilePath="ribbon" />
-					<ScreenReaderTextExample readmeFilePath="screen-reader-text" />
+					<Ribbon readmeFilePath="/packages/components/src/ribbon" />
+					<ScreenReaderTextExample readmeFilePath="/packages/components/src/screen-reader-text" />
 					<SearchDemo readmeFilePath="search" />
 					<SectionHeader readmeFilePath="section-header" />
 					<SectionNav readmeFilePath="section-nav" />
@@ -273,7 +276,7 @@ class DesignAssets extends React.Component {
 					<Spinner searchKeywords="loading" readmeFilePath="spinner" />
 					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />
 					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
-					<Suggestions readmeFilePath="suggestions" />
+					<Suggestions readmeFilePath="/packages/components/src/suggestions" />
 					<SuggestionSearchExample />
 					<SupportInfoExample />
 					<TextareaAutosize readmeFilePath="textarea-autosize" />

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -35,20 +35,21 @@ const shouldShowInstance = ( example, filter, component ) => {
 };
 
 const getReadmeFilePath = ( section, example ) => {
-	if ( ! example.props.readmeFilePath ) {
+	let path = example.props.readmeFilePath;
+
+	if ( ! path ) {
 		return null;
 	}
 
-	if ( example.props.readmeFilePath.charAt( 0 ) === '/' ) {
-		return `${ example.props.readmeFilePath }/README.md`;
+	if ( ! path.startsWith( '/' ) ) {
+		path = `/client/${ section === 'design' ? 'components' : section }/${ path }`;
 	}
 
-	switch ( section ) {
-		case 'design':
-			return `/client/components/${ example.props.readmeFilePath }/README.md`;
-		default:
-			return `/client/${ section }/${ example.props.readmeFilePath }/README.md`;
+	if ( ! path.endsWith( 'README.md' ) ) {
+		path = `${ path }/README.md`;
 	}
+
+	return path;
 };
 
 const Collection = ( {

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -35,6 +35,14 @@ const shouldShowInstance = ( example, filter, component ) => {
 };
 
 const getReadmeFilePath = ( section, example ) => {
+	if ( ! example.props.readmeFilePath ) {
+		return null;
+	}
+
+	if ( example.props.readmeFilePath.charAt( 0 ) === '/' ) {
+		return `${ example.props.readmeFilePath }/README.md`;
+	}
+
 	switch ( section ) {
 		case 'design':
 			return `/client/components/${ example.props.readmeFilePath }/README.md`;


### PR DESCRIPTION
After the recent [migration of common UI components to `@automattic/components` package](https://github.com/Automattic/wp-calypso/pull/36889) their README files were no longer displayed in devdocs.

This PR fixes this issue by supporting absolute paths in the `readmeFilePath` prop. Whenever the readme path starts with a forward slash, no default `client/${ section }` path will be used for fetching the file.  

**Before:**
<img width="800" alt="Screenshot 2019-12-06 at 13 23 37" src="https://user-images.githubusercontent.com/478735/70322932-bfdfd880-182b-11ea-9130-2e0888dca493.png">

**After:**
<img width="800" alt="Screenshot 2019-12-06 at 13 23 12" src="https://user-images.githubusercontent.com/478735/70322902-ad659f00-182b-11ea-954f-94fedad18703.png">

#### Changes proposed in this Pull Request

* Allow fetching README files of components from outside of client folder

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In devdocs go to one of the `@automattic` UI components example, e.g. http://calypso.localhost:3000/devdocs/design/ribbon
* Confirm that the readme file is rendered under the example as expected.
* Check the remaining UI components using the following URL sctructure: `http://calypso.localhost:3000/devdocs/design/{slug}`, where the `{slug}` is one of the following:
  * `button`
  * `card`
  * `progress-bar`
  * `screen-reader-text`
  * `suggestions`

Fixes n/a
