### PR TITLE
Validate siteId in queries.

### DIFF
--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -21,7 +21,9 @@ export default function QueryPostCounts( { siteId, type } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( request( siteId, type ) );
+		if ( siteId ) {
+			dispatch( request( siteId, type ) );
+		}
 	}, [ dispatch, siteId, type ] );
 
 	return null;

--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -21,7 +21,7 @@ export default function QueryPostCounts( { siteId, type } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		if ( siteId ) {
+		if ( siteId && type ) {
 			dispatch( request( siteId, type ) );
 		}
 	}, [ dispatch, siteId, type ] );
@@ -30,6 +30,6 @@ export default function QueryPostCounts( { siteId, type } ) {
 }
 
 QueryPostCounts.propTypes = {
-	siteId: PropTypes.number.isRequired,
-	type: PropTypes.string.isRequired,
+	siteId: PropTypes.number,
+	type: PropTypes.string,
 };

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -26,4 +26,4 @@ export default function QuerySiteChecklist( { siteId } ) {
 	return null;
 }
 
-QuerySiteChecklist.propTypes = { siteId: PropTypes.number.isRequired };
+QuerySiteChecklist.propTypes = { siteId: PropTypes.number };

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -18,7 +18,9 @@ export default function QuerySiteChecklist( { siteId } ) {
 	);
 
 	useEffect( () => {
-		dispatch( requestSiteChecklist( siteId, isSiteEligibleForFSE ) );
+		if ( siteId ) {
+			dispatch( requestSiteChecklist( siteId, isSiteEligibleForFSE ) );
+		}
 	}, [ dispatch, siteId, isSiteEligibleForFSE ] );
 
 	return null;


### PR DESCRIPTION
Fixes two instances where actions could be dispatched with a falsy `siteId` value.

I've marked this PR as `[Type] Bug`, but it's more of a **potential** bug, as far as I'm aware.

#### Changes proposed in this Pull Request

* Validate `siteId` in `QueryPostCounts` and `QuerySiteChecklist`.

#### Testing instructions

It's not clear to me whether this translates to an actual issue in production, so I can't provide any testing instructions. Please analyse the logic and validate that it makes sense for the actions in question.