### PR TITLE
Hosting: Improve reset SFTP password copy

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -110,7 +110,7 @@ export const SftpCard = ( {
 					</div>
 					<p className="sftp-card__password-warning">
 						{ translate(
-							'Save your password someplace safe. A reset will be needed to view again.'
+							'Save your password somewhere safe. You will need to reset it to view it again.'
 						) }
 					</p>
 				</>
@@ -120,7 +120,7 @@ export const SftpCard = ( {
 		return (
 			<>
 				<p className="sftp-card__password-explainer">
-					{ translate( 'For security reasons, your password needs a reset to view' ) }
+					{ translate( 'For security reasons, you must reset your password to view it.' ) }
 				</p>
 				<Button
 					onClick={ resetPassword }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The current message displayed on the hosting section for resetting the SFTP password seems cut off, so this PR aims to improve a little bit the copy.

| Before | After |
|---|---|
| <img width="428" alt="Screenshot 2019-12-06 at 15 17 23" src="https://user-images.githubusercontent.com/1233880/70329739-5b794500-183c-11ea-8455-5e2de702f5f0.png"> | <img width="428" alt="Screenshot 2019-12-06 at 15 24 20" src="https://user-images.githubusercontent.com/1233880/70330005-efe3a780-183c-11ea-9f2e-9d15a448fe8a.png"> |
| <img width="649" alt="Screenshot 2019-12-06 at 15 17 35" src="https://user-images.githubusercontent.com/1233880/70329758-616f2600-183c-11ea-90f2-1fabec7bcd0c.png"> | <img width="646" alt="Screenshot 2019-12-06 at 15 24 27" src="https://user-images.githubusercontent.com/1233880/70330025-fa05a600-183c-11ea-9525-3981f6a0db4f.png"> |

#### Testing instructions

* Go to `/hosting-config` and select an Atomic site created before Nov 28, 2018.
* Make sure the reset SFTP password messages (before/after resetting) are understandable. 
