### PR TITLE
Config: Remove Jetpack Backup feature flag

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -486,13 +486,11 @@ class ManagePurchase extends Component {
 						purchase={ purchase }
 						editCardDetailsPath={ editCardDetailsPath }
 					/>
-					{ config.isEnabled( 'plans/jetpack-backup' ) && (
-						<ProductPlanOverlapNotices
-							plans={ JETPACK_PLANS }
-							products={ JETPACK_BACKUP_PRODUCTS }
-							siteId={ siteId }
-						/>
-					) }
+					<ProductPlanOverlapNotices
+						plans={ JETPACK_PLANS }
+						products={ JETPACK_BACKUP_PRODUCTS }
+						siteId={ siteId }
+					/>
 					{ this.renderPurchaseDetail() }
 				</Main>
 			</Fragment>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -99,11 +99,6 @@ export class PlansFeaturesMain extends Component {
 	isJetpackBackupAvailable() {
 		const { displayJetpackPlans, isMultisite, jetpackSupportsBackupProducts, siteId } = this.props;
 
-		// Jetpack Backup products are currently under a feature flag
-		if ( ! isEnabled( 'plans/jetpack-backup' ) ) {
-			return false;
-		}
-
 		// Jetpack Backup does not support Multisite yet.
 		if ( isMultisite ) {
 			return false;

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -97,7 +97,6 @@
 		"oauth": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/jetpack-backup": false,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -72,7 +72,6 @@
 		"me/trophies": false,
 		"oauth": true,
 		"persist-redux": true,
-		"plans/jetpack-backup": false,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,

--- a/config/development.json
+++ b/config/development.json
@@ -123,7 +123,6 @@
 		"oauth": false,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/jetpack-backup": true,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,7 +81,6 @@
 		"network-connection": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-backup": false,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,

--- a/config/production.json
+++ b/config/production.json
@@ -87,7 +87,6 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-backup": true,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,7 +89,6 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-backup": true,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,

--- a/config/test.json
+++ b/config/test.json
@@ -77,7 +77,6 @@
 		"network-connection": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/jetpack-backup": false,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -101,7 +101,6 @@
 		"nps-survey/dev-trigger": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-backup": true,
 		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,


### PR DESCRIPTION
We're no longer using the Jetpack Backup feature flag as it's been in production for a while now. It's time to cleanup and remove the unnecessary feature flag.

#### Changes proposed in this Pull Request

* Config: Remove Jetpack Backup feature flag

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/:site where `:site` is a Jetpack site slug.
* Verify Jetpack Backup purchase UI is still displayed.
* Go to http://calypso.localhost:3000/plans/my-plan/:site where `:site` is a Jetpack site slug of a site that has both a Backup product and a plan. If you don't have such site, you can get one by buying the product first, and then the plan.
* Click "Manage Plan" or "Manage Product".
* Verify you can still see the overlap notices. 