### PR TITLE
Fix: Pro-rated credits banner does not show for Atomic sites

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -982,6 +982,8 @@ export default connect(
 			planProperties = planProperties.filter( p => visiblePlans.indexOf( p.planName ) !== -1 );
 		}
 
+		const isJetpackNotAtomic = isJetpack && ! isSiteAT;
+
 		return {
 			canPurchase,
 			currentSitePlanSlug: get( currentPlanObj, 'productSlug', null ),
@@ -997,7 +999,7 @@ export default connect(
 				sitePlan &&
 				sitePlan.product_slug !== PLAN_FREE &&
 				planCredits &&
-				! isJetpack &&
+				! isJetpackNotAtomic &&
 				! isInSignup,
 		};
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In /plans page, the pro-rated credits banner does not show for Atomic sites on a Business plan:

**BEFORE**:

<img width="1679" alt="Screenshot 2019-12-06 at 8 37 34 PM" src="https://user-images.githubusercontent.com/1269602/70332768-42868900-1868-11ea-808d-fb0593c1e8db.png">

**AFTER**

<img width="1609" alt="Screenshot 2019-12-06 at 8 38 35 PM" src="https://user-images.githubusercontent.com/1269602/70332839-6518a200-1868-11ea-8567-11ebdee31f55.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**
* For a site on a free plan, verify no banner is shown.
* Upgrade to Premium -verify banner is shown
* Upgrade to eCommerce - verify banner is not shown(because we are on the highest tier already, so there's nothing more to upgrade too).

**Scenario 2**

* For a site on a Business plan, verify banner is shown
* Install a plugin on the site so that it goes atomic while continuing to be on the Business plan
* Verify that the banner still shows(without this patch it wouldn't have shown).

