### PR TITLE
Hosting: Only expose Simple sites when behind the all-sites flag.

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import Card from 'components/card';
 import Main from 'components/main';
 import SiteSelector from 'components/site-selector';
@@ -42,9 +43,19 @@ class Sites extends Component {
 			return ! site.is_vip;
 		}
 
-		// Hosting routes are not applicable to Jetpack or VIP sites.
 		if ( /^\/hosting-config/.test( path ) ) {
-			return ! site.is_vip && ! ( site.jetpack && ! site.options.is_automated_transfer );
+			// Hosting routes are not applicable to any VIP or WP.org Jetpack sites.
+			if ( site.is_vip || ( site.jetpack && ! site.options.is_automated_transfer ) ) {
+				return false;
+			}
+
+			// Hosting routes apply to all Atomic sites.
+			if ( site.options.is_automated_transfer ) {
+				return true;
+			}
+
+			// hosting/all-sites allows Simple sites, so they can be exposed to upgrade notices.
+			return isEnabled( 'hosting/all-sites' );
 		}
 
 		return site;


### PR DESCRIPTION
#38184 introduced filtering of the sites selector for the `/hosting-config` path, but it failed to consider the `hosting/all-sites` flag when evaluating Simple sites. This PR corrects this oversight.

#### Testing instructions

* On `master` or production, load the `/hosting-config` path directly and notice all Simple sites are still available.
* Switch to this PR, and load the same path; notice Simple sites are no longer available (you should only see Atomic sites listed).
* Load the path with the `hosting/all-sites` flag enabled (`/hosting-config?flags=hosting/all-sites`), and ensure Simple sites are available again.
