### PR TITLE
Hosting: Allow sites of any age.

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -71,8 +71,7 @@ class Hosting extends Component {
 			return null;
 		}
 
-		const sftpPhpMyAdminFeaturesEnabled =
-			isEnabled( 'hosting/sftp-phpmyadmin' ) && siteId > 155000000;
+		const sftpPhpMyAdminFeaturesEnabled = isEnabled( 'hosting/sftp-phpmyadmin' );
 
 		const getAtomicActivationNotice = () => {
 			const { COMPLETE, FAILURE } = transferStates;


### PR DESCRIPTION
Allow sites of any age to be eligible for Hosting features. 

Part of #38258 .

#### Testing instructions

* Start this branch locally with `hosting/all-sites` enabled: `ENABLE_FEATURES=hosting/all-sites npm start`.
* Visit `https://calypso.localhost:3000/hosting-config` and select any site older than a year.
* Verify that the hosting section loads.
