### PR TITLE
Allow removing domain mappings included with a plan

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -13,6 +13,7 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import { getRenewalItemFromProduct } from 'lib/cart-values/cart-items';
 import {
+	isDomainMapping,
 	isDomainRegistration,
 	isDomainTransfer,
 	isJetpackPlan,
@@ -271,6 +272,9 @@ function isRemovable( purchase ) {
 	}
 
 	if ( isIncludedWithPlan( purchase ) ) {
+		if ( isDomainMapping( purchase ) ) {
+			return true;
+		}
 		return false;
 	}
 

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -261,7 +261,6 @@ function isRefundable( purchase ) {
 
 /**
  * Checks whether the specified purchase can be removed from a user account.
- * Purchases included with a plan can't be removed.
  *
  * @param {Object} purchase - the purchase with which we are concerned
  * @return {boolean} true if the purchase can be removed, false otherwise


### PR DESCRIPTION
#### Changes proposed in this Pull Request
After making mappings free and always included with a plan, we broke the ability to remove them without removing the plan first. This PR addresses that.

#### Testing instructions
Have a site with a paid plan. Add one or more mappings. Check in `/me/purchases` that you can remove them without removing the plan. There should be no refund (they were $0), but the subscription should be properly removed.

<img width="746" alt="Screenshot 2019-12-07 at 01 57 29" src="https://user-images.githubusercontent.com/3392497/70364676-3fa28d00-1896-11ea-948f-87dadcfd2b03.png">

Go to a site with a paid plan and a bundled domain _registration_. Make sure there is no regression in that case (and any other you can think of).
