### PR TITLE
composite-checkout: Refactor payment method components as React nodes

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -101,7 +101,7 @@ Each payment method is an object with the following properties:
 
 - `id: string`. A unique id.
 - `label: React.ReactNode`. A component that displays that payment method selection button which can be as simple as the name and an icon.
-- `PaymentMethodComponent: React.Component`. A component that displays that payment method (this can return null or something like a credit card form). It will receive the props of the `CheckoutStep`.
+- `activeContent: React.ReactNode`. A component that displays that payment method (this can return null or something like a credit card form).
 - `SubmitButtonComponent: React.Component`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. The button can access the success and failure handlers by calling the `useCheckoutHandlers()` custom Hook or it can find the redirect urls by calling the `useCheckoutRedirects()` custom Hook.
 - `inactiveContent: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
 - `CheckoutWrapper?: React.Component`. A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -102,7 +102,7 @@ Each payment method is an object with the following properties:
 - `id: string`. A unique id.
 - `label: React.ReactNode`. A component that displays that payment method selection button which can be as simple as the name and an icon.
 - `activeContent: React.ReactNode`. A component that displays that payment method (this can return null or something like a credit card form).
-- `SubmitButtonComponent: React.Component`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. The button can access the success and failure handlers by calling the `useCheckoutHandlers()` custom Hook or it can find the redirect urls by calling the `useCheckoutRedirects()` custom Hook.
+- `submitButton: React.Component`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. The button can access the success and failure handlers by calling the `useCheckoutHandlers()` custom Hook or it can find the redirect urls by calling the `useCheckoutRedirects()` custom Hook. When disabled, it will be provided with the `disabled` prop and must disable the button.
 - `inactiveContent: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
 - `CheckoutWrapper?: React.Component`. A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).
 - `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.
@@ -169,7 +169,7 @@ The `displayValue` property of both the items and the total can use limited Mark
 
 ### CheckoutReviewOrder
 
-Renders a list of the line items and their `displayValue` properties followed by the `total` line item, and whatever `SubmitButtonComponent` is in the current payment method.
+Renders a list of the line items and their `displayValue` properties followed by the `total` line item, and whatever `submitButton` is in the current payment method.
 
 ### CheckoutStep
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -103,7 +103,7 @@ Each payment method is an object with the following properties:
 - `label: React.ReactNode`. A component that displays that payment method selection button which can be as simple as the name and an icon.
 - `PaymentMethodComponent: React.Component`. A component that displays that payment method (this can return null or something like a credit card form). It will receive the props of the `CheckoutStep`.
 - `SubmitButtonComponent: React.Component`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. The button can access the success and failure handlers by calling the `useCheckoutHandlers()` custom Hook or it can find the redirect urls by calling the `useCheckoutRedirects()` custom Hook.
-- `SummaryComponent: React.Component`. A component that renders a summary of the selected payment method when the step is inactive.
+- `inactiveContent: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
 - `CheckoutWrapper?: React.Component`. A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).
 - `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.
 - `isCompleteCallback?: ({paymentData: object, activeStep: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning true.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -100,25 +100,13 @@ When using the individual API components, you can also pass a `className` prop, 
 Each payment method is an object with the following properties:
 
 - `id: string`. A unique id.
-- `LabelComponent: React.Component`. A component that displays that payment method selection button which can be as simple as the name and an icon. It will receive the props of the `CheckoutStep`.
+- `label: React.ReactNode`. A component that displays that payment method selection button which can be as simple as the name and an icon.
 - `PaymentMethodComponent: React.Component`. A component that displays that payment method (this can return null or something like a credit card form). It will receive the props of the `CheckoutStep`.
 - `SubmitButtonComponent: React.Component`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. The button can access the success and failure handlers by calling the `useCheckoutHandlers()` custom Hook or it can find the redirect urls by calling the `useCheckoutRedirects()` custom Hook.
 - `SummaryComponent: React.Component`. A component that renders a summary of the selected payment method when the step is inactive.
 - `CheckoutWrapper?: React.Component`. A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).
 - `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.
 - `isCompleteCallback?: ({paymentData: object, activeStep: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning true.
-
-```
-{
-	id: string,
-	LabelComponent: component,
-	PaymentMethodComponent: ?component,
-	SubmitButtonComponent: component,
-	CheckoutWrapper: ?component,
-	SummaryComponent: component,
-	getAriaLabel: function,
-}
-```
 
 Within the components, the Hook `usePaymentMethod()` will return an object of the above form with the key of the currently selected payment method or null if none is selected. To retrieve all the payment methods and their properties, the Hook `useAllPaymentMethods()` will return an array that contains them all.
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -85,7 +85,7 @@ export function CheckoutPaymentMethodsTitle() {
 function PaymentMethod( {
 	id,
 	label,
-	PaymentMethodComponent,
+	activeContent,
 	inactiveContent,
 	checked,
 	onClick,
@@ -106,9 +106,7 @@ function PaymentMethod( {
 			ariaLabel={ ariaLabel }
 			label={ label }
 		>
-			{ PaymentMethodComponent && (
-				<PaymentMethodComponent isActive={ checked } summary={ summary } />
-			) }
+			{ activeContent && activeContent }
 		</RadioButton>
 	);
 }
@@ -118,7 +116,7 @@ PaymentMethod.propTypes = {
 	onClick: PropTypes.func,
 	checked: PropTypes.bool.isRequired,
 	ariaLabel: PropTypes.string.isRequired,
-	PaymentMethodComponent: PropTypes.elementType,
+	activeContent: PropTypes.node,
 	label: PropTypes.node,
 	inactiveContent: PropTypes.node,
 	summary: PropTypes.bool,

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -84,7 +84,7 @@ export function CheckoutPaymentMethodsTitle() {
 
 function PaymentMethod( {
 	id,
-	LabelComponent,
+	label,
 	PaymentMethodComponent,
 	SummaryComponent,
 	checked,
@@ -104,7 +104,7 @@ function PaymentMethod( {
 			checked={ checked }
 			onChange={ onClick ? () => onClick( id ) : null }
 			ariaLabel={ ariaLabel }
-			label={ <LabelComponent /> }
+			label={ label }
 		>
 			{ PaymentMethodComponent && (
 				<PaymentMethodComponent isActive={ checked } summary={ summary } />
@@ -119,7 +119,7 @@ PaymentMethod.propTypes = {
 	checked: PropTypes.bool.isRequired,
 	ariaLabel: PropTypes.string.isRequired,
 	PaymentMethodComponent: PropTypes.elementType,
-	LabelComponent: PropTypes.elementType,
+	label: PropTypes.node,
 	SummaryComponent: PropTypes.elementType,
 	summary: PropTypes.bool,
 };

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -86,14 +86,14 @@ function PaymentMethod( {
 	id,
 	label,
 	PaymentMethodComponent,
-	SummaryComponent,
+	inactiveContent,
 	checked,
 	onClick,
 	ariaLabel,
 	summary,
 } ) {
 	if ( summary ) {
-		return <SummaryComponent id={ id } />;
+		return inactiveContent;
 	}
 
 	return (
@@ -120,7 +120,7 @@ PaymentMethod.propTypes = {
 	ariaLabel: PropTypes.string.isRequired,
 	PaymentMethodComponent: PropTypes.elementType,
 	label: PropTypes.node,
-	SummaryComponent: PropTypes.elementType,
+	inactiveContent: PropTypes.node,
 	summary: PropTypes.bool,
 };
 

--- a/packages/composite-checkout/src/components/checkout-submit-button.js
+++ b/packages/composite-checkout/src/components/checkout-submit-button.js
@@ -14,10 +14,13 @@ export default function CheckoutSubmitButton( { className, disabled } ) {
 	if ( ! paymentMethod ) {
 		return null;
 	}
-	const { SubmitButtonComponent } = paymentMethod;
+	const { submitButton } = paymentMethod;
+
+	// We clone the element to add the disabled prop
+	const clonedSubmitButton = React.cloneElement( submitButton, { disabled } );
 	return (
 		<div className={ joinClasses( [ className, 'checkout-submit-button' ] ) }>
-			<SubmitButtonComponent disabled={ disabled } />
+			{ clonedSubmitButton }
 		</div>
 	);
 }

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -64,7 +64,7 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 		id: 'apple-pay',
 		label: <ApplePayLabel />,
 		SubmitButtonComponent: ApplePaySubmitButton,
-		SummaryComponent: ApplePaySummary,
+		inactiveContent: <ApplePaySummary />,
 		CheckoutWrapper: StripeHookProvider,
 		getAriaLabel: localize => localize( 'Apple Pay' ),
 	};

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -63,7 +63,7 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 	return {
 		id: 'apple-pay',
 		label: <ApplePayLabel />,
-		SubmitButtonComponent: ApplePaySubmitButton,
+		submitButton: <ApplePaySubmitButton />,
 		inactiveContent: <ApplePaySummary />,
 		CheckoutWrapper: StripeHookProvider,
 		getAriaLabel: localize => localize( 'Apple Pay' ),

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -62,7 +62,7 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 	} );
 	return {
 		id: 'apple-pay',
-		LabelComponent: ApplePayLabel,
+		label: <ApplePayLabel />,
 		SubmitButtonComponent: ApplePaySubmitButton,
 		SummaryComponent: ApplePaySummary,
 		CheckoutWrapper: StripeHookProvider,

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -19,7 +19,7 @@ export function createCreditCardMethod() {
 	return {
 		id: 'card',
 		label: <CreditCardLabel />,
-		PaymentMethodComponent: CreditCardFields,
+		activeContent: <CreditCardFields />,
 		SubmitButtonComponent: CreditCardSubmitButton,
 		inactiveContent: <CreditCardSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -18,7 +18,7 @@ import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 export function createCreditCardMethod() {
 	return {
 		id: 'card',
-		LabelComponent: CreditCardLabel,
+		label: <CreditCardLabel />,
 		PaymentMethodComponent: CreditCardFields,
 		SubmitButtonComponent: CreditCardSubmitButton,
 		SummaryComponent: CreditCardSummary,
@@ -116,5 +116,5 @@ function CreditCardLogos( className ) {
 }
 
 function submitCreditCardPayment() {
-	alert( 'Thank you!' );
+	window.alert( 'Thank you!' );
 }

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -20,7 +20,7 @@ export function createCreditCardMethod() {
 		id: 'card',
 		label: <CreditCardLabel />,
 		activeContent: <CreditCardFields />,
-		SubmitButtonComponent: CreditCardSubmitButton,
+		submitButton: <CreditCardSubmitButton />,
 		inactiveContent: <CreditCardSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),
 	};

--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -21,7 +21,7 @@ export function createCreditCardMethod() {
 		label: <CreditCardLabel />,
 		PaymentMethodComponent: CreditCardFields,
 		SubmitButtonComponent: CreditCardSubmitButton,
-		SummaryComponent: CreditCardSummary,
+		inactiveContent: <CreditCardSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),
 	};
 }
@@ -55,13 +55,13 @@ export function CreditCardSubmitButton( { disabled } ) {
 	);
 }
 
-export function CreditCardSummary( { id } ) {
+export function CreditCardSummary() {
 	const localize = useLocalize();
 	const [ paymentData ] = usePaymentData();
 
 	let PaymentLogo = null;
 
-	if ( paymentData.creditCard && id === 'card' ) {
+	if ( paymentData.creditCard ) {
 		//TODO: Update this with all credit card types we support
 		switch ( Number( paymentData.creditCard.cardNumber[ 0 ] ) ) {
 			case 3:

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -79,7 +79,7 @@ export function createPayPalMethod( { registerStore, makePayPalExpressRequest } 
 
 	return {
 		id: 'paypal',
-		LabelComponent: PaypalLabel,
+		label: <PaypalLabel />,
 		SubmitButtonComponent: PaypalSubmitButton,
 		SummaryComponent: () => {
 			const localize = useLocalize();

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -81,10 +81,7 @@ export function createPayPalMethod( { registerStore, makePayPalExpressRequest } 
 		id: 'paypal',
 		label: <PaypalLabel />,
 		SubmitButtonComponent: PaypalSubmitButton,
-		SummaryComponent: () => {
-			const localize = useLocalize();
-			return localize( 'PayPal' );
-		},
+		inactiveContent: <PaypalSummary />,
 		getAriaLabel: localize => localize( 'PayPal' ),
 	};
 }
@@ -152,9 +149,9 @@ const ButtonPayPalIcon = styled( PaypalLogo )`
 	transform: translateY( 2px );
 `;
 
-export function PaypalSummary() {
+function PaypalSummary() {
 	const localize = useLocalize();
-	return <React.Fragment>{ localize( 'Paypal' ) }</React.Fragment>;
+	return localize( 'Paypal' );
 }
 
 function PaypalLogo( { className } ) {

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -80,7 +80,7 @@ export function createPayPalMethod( { registerStore, makePayPalExpressRequest } 
 	return {
 		id: 'paypal',
 		label: <PaypalLabel />,
-		SubmitButtonComponent: PaypalSubmitButton,
+		submitButton: <PaypalSubmitButton />,
 		inactiveContent: <PaypalSummary />,
 		getAriaLabel: localize => localize( 'PayPal' ),
 	};

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -213,7 +213,7 @@ export function createStripeMethod( {
 		id: 'stripe-card',
 		label: <CreditCardLabel />,
 		activeContent: <StripeCreditCardFields />,
-		SubmitButtonComponent: StripePayButton,
+		submitButton: <StripePayButton />,
 		CheckoutWrapper: StripeHookProvider,
 		inactiveContent: <StripeSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -212,7 +212,7 @@ export function createStripeMethod( {
 	return {
 		id: 'stripe-card',
 		label: <CreditCardLabel />,
-		PaymentMethodComponent: StripeCreditCardFields,
+		activeContent: <StripeCreditCardFields />,
 		SubmitButtonComponent: StripePayButton,
 		CheckoutWrapper: StripeHookProvider,
 		inactiveContent: <StripeSummary />,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -211,7 +211,7 @@ export function createStripeMethod( {
 
 	return {
 		id: 'stripe-card',
-		LabelComponent: CreditCardLabel,
+		label: <CreditCardLabel />,
 		PaymentMethodComponent: StripeCreditCardFields,
 		SubmitButtonComponent: StripePayButton,
 		CheckoutWrapper: StripeHookProvider,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -215,7 +215,7 @@ export function createStripeMethod( {
 		PaymentMethodComponent: StripeCreditCardFields,
 		SubmitButtonComponent: StripePayButton,
 		CheckoutWrapper: StripeHookProvider,
-		SummaryComponent: StripeSummary,
+		inactiveContent: <StripeSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),
 		isCompleteCallback: () => {
 			const cardholderName = selectors.getCardholderName( store.getState() );

--- a/packages/composite-checkout/src/lib/validation.js
+++ b/packages/composite-checkout/src/lib/validation.js
@@ -16,13 +16,13 @@ export function validatePaymentMethods( paymentMethods ) {
 
 export function validatePaymentMethod( {
 	id,
-	LabelComponent,
+	label,
 	SubmitButtonComponent,
 	SummaryComponent,
 	getAriaLabel,
 } ) {
 	validateArg( id, 'Invalid payment method; missing id property' );
-	validateArg( LabelComponent, `Invalid payment method '${ id }'; missing LabelComponent` );
+	validateArg( label, `Invalid payment method '${ id }'; missing label` );
 	validateArg(
 		SubmitButtonComponent,
 		`Invalid payment method '${ id }'; missing SubmitButtonComponent`

--- a/packages/composite-checkout/src/lib/validation.js
+++ b/packages/composite-checkout/src/lib/validation.js
@@ -17,16 +17,13 @@ export function validatePaymentMethods( paymentMethods ) {
 export function validatePaymentMethod( {
 	id,
 	label,
-	SubmitButtonComponent,
+	submitButton,
 	inactiveContent,
 	getAriaLabel,
 } ) {
 	validateArg( id, 'Invalid payment method; missing id property' );
 	validateArg( label, `Invalid payment method '${ id }'; missing label` );
-	validateArg(
-		SubmitButtonComponent,
-		`Invalid payment method '${ id }'; missing SubmitButtonComponent`
-	);
+	validateArg( submitButton, `Invalid payment method '${ id }'; missing submitButton` );
 	validateArg( inactiveContent, `Invalid payment method '${ id }'; missing inactiveContent` );
 	validateArg( getAriaLabel, `Invalid payment method '${ id }'; missing getAriaLabel` );
 }

--- a/packages/composite-checkout/src/lib/validation.js
+++ b/packages/composite-checkout/src/lib/validation.js
@@ -18,7 +18,7 @@ export function validatePaymentMethod( {
 	id,
 	label,
 	SubmitButtonComponent,
-	SummaryComponent,
+	inactiveContent,
 	getAriaLabel,
 } ) {
 	validateArg( id, 'Invalid payment method; missing id property' );
@@ -27,7 +27,7 @@ export function validatePaymentMethod( {
 		SubmitButtonComponent,
 		`Invalid payment method '${ id }'; missing SubmitButtonComponent`
 	);
-	validateArg( SummaryComponent, `Invalid payment method '${ id }'; missing SummaryComponent` );
+	validateArg( inactiveContent, `Invalid payment method '${ id }'; missing inactiveContent` );
 	validateArg( getAriaLabel, `Invalid payment method '${ id }'; missing getAriaLabel` );
 }
 

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -461,7 +461,7 @@ function createMockMethod() {
 		label: <span data-testid="mock-label">Mock Label</span>,
 		PaymentMethodComponent: MockPaymentForm,
 		SubmitButtonComponent: props => <button { ...props }>Pay Please</button>,
-		SummaryComponent: () => 'Mock Method',
+		inactiveContent: 'Mock Method',
 		getAriaLabel: () => 'Mock Method',
 	};
 }

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -460,7 +460,7 @@ function createMockMethod() {
 		id: 'mock',
 		label: <span data-testid="mock-label">Mock Label</span>,
 		activeContent: <MockPaymentForm />,
-		submitButton: props => <button { ...props }>Pay Please</button>,
+		submitButton: <button>Pay Please</button>,
 		inactiveContent: 'Mock Method',
 		getAriaLabel: () => 'Mock Method',
 	};

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -70,7 +70,7 @@ describe( 'Checkout', () => {
 				);
 			} );
 
-			it( 'renders the payment method LabelComponent', () => {
+			it( 'renders the payment method label', () => {
 				const { getAllByText } = render( <MyCheckout /> );
 				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
 			} );
@@ -136,7 +136,7 @@ describe( 'Checkout', () => {
 				);
 			} );
 
-			it( 'renders the payment method LabelComponent', () => {
+			it( 'renders the payment method label', () => {
 				const { getAllByText } = render( <MyCheckout /> );
 				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
 			} );
@@ -458,7 +458,7 @@ describe( 'Checkout', () => {
 function createMockMethod() {
 	return {
 		id: 'mock',
-		LabelComponent: () => <span data-testid="mock-label">Mock Label</span>,
+		label: <span data-testid="mock-label">Mock Label</span>,
 		PaymentMethodComponent: MockPaymentForm,
 		SubmitButtonComponent: props => <button { ...props }>Pay Please</button>,
 		SummaryComponent: () => 'Mock Method',

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -89,7 +89,7 @@ describe( 'Checkout', () => {
 				expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
 			} );
 
-			it( 'renders the payment method SubmitButtonComponent', () => {
+			it( 'renders the payment method submitButton', () => {
 				const { getByText } = render( <MyCheckout /> );
 				expect( getByText( 'Pay Please' ) ).toBeTruthy();
 			} );
@@ -155,7 +155,7 @@ describe( 'Checkout', () => {
 				expect( getAllByText( items[ 1 ].amount.displayValue ) ).toHaveLength( 1 );
 			} );
 
-			it( 'renders the payment method SubmitButtonComponent', () => {
+			it( 'renders the payment method submitButton', () => {
 				const { getByText } = render( <MyCheckout /> );
 				expect( getByText( 'Pay Please' ) ).toBeTruthy();
 			} );
@@ -424,31 +424,31 @@ describe( 'Checkout', () => {
 			expect( getByTextInNode( step, 'Edit' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders the payment method SubmitButtonComponent', () => {
+		it( 'renders the payment method submitButton', () => {
 			const { getByText } = render( <MyCheckout /> );
 			expect( getByText( 'Pay Please' ) ).toBeTruthy();
 		} );
 
-		it( 'renders the payment method SubmitButtonComponent disabled if any steps are incomplete and the last step is not active', () => {
+		it( 'renders the payment method submitButton disabled if any steps are incomplete and the last step is not active', () => {
 			const { getByText } = render(
 				<MyCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 2 ] ] } />
 			);
 			expect( getByText( 'Pay Please' ) ).toBeDisabled();
 		} );
 
-		it( 'renders the payment method SubmitButtonComponent disabled if any steps are incomplete and the last step is active', () => {
+		it( 'renders the payment method submitButton disabled if any steps are incomplete and the last step is active', () => {
 			const { getByText } = render( <MyCheckout steps={ [ steps[ 0 ], steps[ 3 ] ] } /> );
 			expect( getByText( 'Pay Please' ) ).toBeDisabled();
 		} );
 
-		it( 'renders the payment method SubmitButtonComponent disabled if all steps are complete but the last step is not active', () => {
+		it( 'renders the payment method submitButton disabled if all steps are complete but the last step is not active', () => {
 			const { getByText } = render(
 				<MyCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 2 ] ] } />
 			);
 			expect( getByText( 'Pay Please' ) ).toBeDisabled();
 		} );
 
-		it( 'renders the payment method SubmitButtonComponent active if all steps are complete and the last step is active', () => {
+		it( 'renders the payment method submitButton active if all steps are complete and the last step is active', () => {
 			const { getByText } = render( <MyCheckout steps={ [ steps[ 0 ], steps[ 1 ] ] } /> );
 			expect( getByText( 'Pay Please' ) ).not.toBeDisabled();
 		} );
@@ -460,7 +460,7 @@ function createMockMethod() {
 		id: 'mock',
 		label: <span data-testid="mock-label">Mock Label</span>,
 		activeContent: <MockPaymentForm />,
-		SubmitButtonComponent: props => <button { ...props }>Pay Please</button>,
+		submitButton: props => <button { ...props }>Pay Please</button>,
 		inactiveContent: 'Mock Method',
 		getAriaLabel: () => 'Mock Method',
 	};

--- a/packages/composite-checkout/test/components/checkout.js
+++ b/packages/composite-checkout/test/components/checkout.js
@@ -75,7 +75,7 @@ describe( 'Checkout', () => {
 				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
 			} );
 
-			it( 'renders the payment method PaymentMethodComponent', () => {
+			it( 'renders the payment method activeContent', () => {
 				const { getByTestId } = render( <MyCheckout /> );
 				const activeComponent = getByTestId( 'mock-payment-form' );
 				expect( activeComponent ).toHaveTextContent( 'Cardholder Name' );
@@ -141,7 +141,7 @@ describe( 'Checkout', () => {
 				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
 			} );
 
-			it( 'renders the payment method PaymentMethodComponent', () => {
+			it( 'renders the payment method activeContent', () => {
 				const { getByTestId } = render( <MyCheckout /> );
 				const activeComponent = getByTestId( 'mock-payment-form' );
 				expect( activeComponent ).toHaveTextContent( 'Cardholder Name' );
@@ -459,7 +459,7 @@ function createMockMethod() {
 	return {
 		id: 'mock',
 		label: <span data-testid="mock-label">Mock Label</span>,
-		PaymentMethodComponent: MockPaymentForm,
+		activeContent: <MockPaymentForm />,
 		SubmitButtonComponent: props => <button { ...props }>Pay Please</button>,
 		inactiveContent: 'Mock Method',
 		getAriaLabel: () => 'Mock Method',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Payment Method object contains several properties which it will use to display the behavior of that component. Currently those properties require React component _types_, that is, a reference to a component itself. This is a pretty uncommon pattern in the React ecosystem and since most of these components use hooks to decide on their behavior we no longer really need to render them inside their containers directly.

This PR changes most of the properties into React nodes instead, which is a very common pattern and should be easier for future developers to understand. The only one not changed is the `CheckoutWrapper`, which must be rendered by its container because it is passed children (there are other ways to do this but for now this seems an acceptable trade-off).

Before:

```js
{
  id: 'card',
  SubmitButtonComponent: PayPalButton,
  //...
}
```

After:

```js
{
  id: 'card',
  submitButton: <PayPalButton />,
  //...
}
```

The only component for which we still need to override props is the submit button, where we need to sometimes set `disabled`. This is handled by cloning the element instead.

#### Testing instructions

- Add a file called `packages/composite-checkout/demo/private.js` and inside it put the following: `export const stripeKey = 'TEST KEY HERE'`;
- Run `npm run composite-checkout-demo`.
- Verify that the form works as expected.