### PR TITLE
replacing outdated link

### DIFF
--- a/server/bundler/README.md
+++ b/server/bundler/README.md
@@ -5,7 +5,7 @@ This module contains the code for generating the JavaScript files that are sent 
 
 ### Glossary
 
-__Code Splitting__ - [Code splitting](https://webpack.js.org/guides/code-splitting/#root) is the term that Webpack uses to describe the process of splitting the dependency graph for the application into chunks. Assets (javascript files) are then created for the chunks and loaded as part of the initial HTML request via `<script />` tags if the chunk is created as a section and asynchronously via `require.ensure` calls.
+__Code Splitting__ - [Code splitting](https://webpack.js.org/guides/code-splitting) is the term that Webpack uses to describe the process of splitting the dependency graph for the application into chunks. Assets (javascript files) are then created for the chunks and loaded as part of the initial HTML request via `<script />` tags if the chunk is created as a section and asynchronously via `require.ensure` calls.
 
 __File Watching__ - File watching is the process by which files are monitered for changes. If a file changes, the javascript assets are regenerated.
 

--- a/server/bundler/README.md
+++ b/server/bundler/README.md
@@ -1,21 +1,21 @@
 Bundler
 =======
 
-This module contains the code for generating the JavaScript files that are sent to the browser. The code leverages [Webpack](http://webpack.github.io/), [uglifyjs](http://lisperator.net/uglifyjs/), and the sections module at `client/sections.js` that defines the various sections of the application.
+This module contains the code for generating the JavaScript files that are sent to the browser. The code leverages [webpack](http://webpack.github.io/), [uglifyjs](http://lisperator.net/uglifyjs/), and the sections module at `client/sections.js` that defines the various sections of the application.
 
 ### Glossary
 
-__Code Splitting__ - [Code splitting](https://webpack.js.org/guides/code-splitting) is the term that Webpack uses to describe the process of splitting the dependency graph for the application into chunks. Assets (javascript files) are then created for the chunks and loaded as part of the initial HTML request via `<script />` tags if the chunk is created as a section and asynchronously via `require.ensure` calls.
+__Code Splitting__ - [Code splitting](https://webpack.js.org/guides/code-splitting) is the term that webpack uses to describe the process of splitting the dependency graph for the application into chunks. Assets (JavaScript files) are then created for the chunks and loaded as part of the initial HTML request via `<script />` tags if the chunk is created as a section and asynchronously via `require.ensure` calls.
 
-__File Watching__ - File watching is the process by which files are monitered for changes. If a file changes, the javascript assets are regenerated.
+__File Watching__ - File watching is the process by which files are monitered for changes. If a file changes, the JavaScript assets are regenerated.
 
-__Section__ - A set of related URL routes in Calypso that have a shared entrypoint. The entrypoint is a javascript module (usually `index.js`) in `client` that includes the code for registering one or more `page.js` routes and is the top of the dependency tree for the chunk.
+__Section__ - A set of related URL routes in Calypso that have a shared entrypoint. The entrypoint is a JavaScript module (usually `index.js`) in `client` that includes the code for registering one or more `page.js` routes and is the top of the dependency tree for the chunk.
 
 __Router__ - The library that manages parsing the URL and calling code when the URL changes. The `page` npm package is used for client-side routing (using HTML5 History API) and `express` is used on the server. The two routers are similar in terms of how they work, but not identical.
 
-__Webpack loader__ - A loader is a Webpack extension that transforms code from one form into another. Multiple loaders can process the same module. The configuration of the loaders is specified in the webpack config file `webpack.config.js`.
+__Webpack loader__ - A loader is a webpack extension that transforms code from one form into another. Multiple loaders can process the same module. The configuration of the loaders is specified in the webpack config file `webpack.config.js`.
 
-__Webpack plugin__ - A plugin is a Webpack extension that hooks into Webpack in order to enhance or change how it does its thing.
+__Webpack plugin__ - A plugin is a webpack extension that hooks into webpack in order to enhance or change how it does its thing.
 
 ### Sections and Webpack
 
@@ -24,7 +24,7 @@ The concept of sections is something that is unique to Calypso. It was created t
 
 #### Client
 
-The sections module `client/sections.js` is transformed via a custom Webpack loader `server/bundler/loader.js` into a series of `page.js` route handlers that use `require.ensure` to asynchronously load the JavaScript code needed for the route.
+The sections module `client/sections.js` is transformed via a custom webpack loader `server/bundler/loader.js` into a series of `page.js` route handlers that use `require.ensure` to asynchronously load the JavaScript code needed for the route.
 
 __before__:
 

--- a/server/bundler/README.md
+++ b/server/bundler/README.md
@@ -5,7 +5,7 @@ This module contains the code for generating the JavaScript files that are sent 
 
 ### Glossary
 
-__Code Splitting__ - [Code splitting](https://webpack.github.io/docs/code-splitting.html) is the term that Webpack uses to describe the process of splitting the dependency graph for the application into chunks. Assets (javascript files) are then created for the chunks and loaded as part of the initial HTML request via `<script />` tags if the chunk is created as a section and asynchronously via `require.ensure` calls.
+__Code Splitting__ - [Code splitting](https://webpack.js.org/guides/code-splitting/#root) is the term that Webpack uses to describe the process of splitting the dependency graph for the application into chunks. Assets (javascript files) are then created for the chunks and loaded as part of the initial HTML request via `<script />` tags if the chunk is created as a section and asynchronously via `require.ensure` calls.
 
 __File Watching__ - File watching is the process by which files are monitered for changes. If a file changes, the javascript assets are regenerated.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The link to the Web Pack Code Splitting docs in /server/bundler/README.md is outdated, since the webpack docs have migrated out of github docs. Clicking the link will now reroute you to the Web Pack homepage, but not to the specific intended topic.

#### Testing instructions
### current link
https://webpack.github.io/docs/code-splitting.html 
This will reroute you to https://webpack.js.org/

### updated link 
https://webpack.js.org/guides/code-splitting/#root
This will route you to the intended information