### PR TITLE
Remove withoutPersistence from state/help

### DIFF
--- a/client/state/help/courses/reducer.js
+++ b/client/state/help/courses/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { HELP_COURSES_RECEIVE } from 'state/action-types';
 
-export const items = withoutPersistence( ( state = null, action ) => {
+export const items = ( state = null, action ) => {
 	switch ( action.type ) {
 		case HELP_COURSES_RECEIVE: {
 			const { courses } = action;
@@ -14,7 +14,7 @@ export const items = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	items,

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
@@ -22,7 +22,7 @@ export const questionAsked = ( state = null, action ) => {
 	return state;
 };
 
-export const status = withoutPersistence( ( state = STATUS_UNINITIALIZED, action ) => {
+export const status = ( state = STATUS_UNINITIALIZED, action ) => {
 	switch ( action.type ) {
 		case DIRECTLY_INITIALIZATION_START:
 			return STATUS_INITIALIZING;
@@ -33,7 +33,7 @@ export const status = withoutPersistence( ( state = STATUS_UNINITIALIZED, action
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	questionAsked,

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -3,32 +3,32 @@
  */
 import { HELP_CONTACT_FORM_SITE_SELECT, HELP_LINKS_RECEIVE } from 'state/action-types';
 import courses from './courses/reducer';
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import directly from './directly/reducer';
 import ticket from './ticket/reducer';
 
 /**
  * Tracks the site id for the selected site in the help/contact form
  *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
+ * @param  {object} state  Current state
+ * @param  {object} action Action payload
+ * @returns {object}        Updated state
  */
-export const selectedSiteId = withoutPersistence( ( state = null, action ) => {
+export const selectedSiteId = ( state = null, action ) => {
 	switch ( action.type ) {
 		case HELP_CONTACT_FORM_SITE_SELECT:
 			return action.siteId;
 	}
 
 	return state;
-} );
+};
 
 /**
  * Responsible for the help search results links
  *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
+ * @param  {object} state  Current state
+ * @param  {object} action Action payload
+ * @returns {object}        Updated state
  */
 export const links = ( state = {}, action ) => {
 	switch ( action.type ) {

--- a/client/state/help/ticket/reducer.js
+++ b/client/state/help/ticket/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
 	HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
@@ -10,7 +10,7 @@ import {
 	HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 } from 'state/action-types';
 
-const isRequesting = withoutPersistence( ( state = false, action ) => {
+const isRequesting = ( state = false, action ) => {
 	switch ( action.type ) {
 		case HELP_TICKET_CONFIGURATION_REQUEST:
 			return true;
@@ -21,9 +21,9 @@ const isRequesting = withoutPersistence( ( state = false, action ) => {
 	}
 
 	return state;
-} );
+};
 
-const isUserEligible = withoutPersistence( ( state = false, action ) => {
+const isUserEligible = ( state = false, action ) => {
 	switch ( action.type ) {
 		case HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS: {
 			const { configuration } = action;
@@ -32,18 +32,18 @@ const isUserEligible = withoutPersistence( ( state = false, action ) => {
 	}
 
 	return state;
-} );
+};
 
-const isReady = withoutPersistence( ( state = false, action ) => {
+const isReady = ( state = false, action ) => {
 	switch ( action.type ) {
 		case HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS:
 			return true;
 	}
 
 	return state;
-} );
+};
 
-const requestError = withoutPersistence( ( state = null, action ) => {
+const requestError = ( state = null, action ) => {
 	switch ( action.type ) {
 		case HELP_TICKET_CONFIGURATION_REQUEST:
 			return null;
@@ -58,7 +58,7 @@ const requestError = withoutPersistence( ( state = null, action ) => {
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	isReady,


### PR DESCRIPTION
I've been touching `state/help` today with some bugfixes, and this is a drive-by patch that uses the opportunity to remove `withoutPersistence` from its reducers.

There is no persistence in `state/help` at all, and it's the default state even without the `withoutPersistence` helper (`combineReducers` adds that automatically).

There are not even any failing tests after the helper is removed.
