### PR TITLE
Gutenboarding: Try using `TemplateSelectorControl`

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -36,7 +36,7 @@ import ensureAssets from './utils/ensure-assets';
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
 
-class PageTemplateModal extends Component {
+export class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
 		previewedTemplate: null,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -36,7 +36,7 @@ import ensureAssets from './utils/ensure-assets';
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
 
-export class PageTemplateModal extends Component {
+class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
 		previewedTemplate: null,

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,12 @@ const codeSplit = config.isEnabled( 'code-splitting' );
 const babelConfig = {
 	presets: [ [ '@automattic/calypso-build/babel/default', { modules } ] ],
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
-
+	overrides: [
+		{
+			test: './apps/full-site-editing',
+			presets: [ require.resolve( '@automattic/calypso-build/babel/wordpress-element' ) ],
+		},
+	],
 	env: {
 		production: {
 			plugins: [ 'babel-plugin-transform-react-remove-prop-types' ],

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -18,7 +18,7 @@ import { selectorDebounce } from '../../constants';
 
 interface Props {
 	isEditorSidebarOpened: boolean;
-	next: () => void;
+	next?: () => void;
 	toggleGeneralSidebar: () => void;
 	toggleSidebarShortcut: KeyboardShortcut;
 }
@@ -98,7 +98,7 @@ const Header: FunctionComponent< Props > = ( {
 			</div>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Button isPrimary isLarge disabled={ ! siteTitle } onClick={ next }>
+					<Button isPrimary isLarge disabled={ ! next } onClick={ next }>
 						{ NO__( 'Next' ) }
 					</Button>
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -19,6 +19,7 @@ import { selectorDebounce } from '../../constants';
 interface Props {
 	isEditorSidebarOpened: boolean;
 	next?: () => void;
+	prev?: () => void;
 	toggleGeneralSidebar: () => void;
 	toggleSidebarShortcut: KeyboardShortcut;
 }
@@ -32,6 +33,7 @@ interface KeyboardShortcut {
 const Header: FunctionComponent< Props > = ( {
 	isEditorSidebarOpened,
 	next,
+	prev,
 	toggleGeneralSidebar,
 	toggleSidebarShortcut,
 } ) => {
@@ -77,6 +79,11 @@ const Header: FunctionComponent< Props > = ( {
 			tabIndex={ -1 }
 		>
 			<div className="gutenboarding__header-section">
+				<div className="gutenboarding__header-group">
+					<Button disabled={ ! prev } onClick={ prev }>
+						{ NO__( 'Back' ) }
+					</Button>
+				</div>
 				<div className="gutenboarding__header-group">
 					<Icon icon="wordpress-alt" color="#066188" />
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -18,6 +18,7 @@ import { selectorDebounce } from '../../constants';
 
 interface Props {
 	isEditorSidebarOpened: boolean;
+	next: () => void;
 	toggleGeneralSidebar: () => void;
 	toggleSidebarShortcut: KeyboardShortcut;
 }
@@ -30,6 +31,7 @@ interface KeyboardShortcut {
 
 const Header: FunctionComponent< Props > = ( {
 	isEditorSidebarOpened,
+	next,
 	toggleGeneralSidebar,
 	toggleSidebarShortcut,
 } ) => {
@@ -96,7 +98,7 @@ const Header: FunctionComponent< Props > = ( {
 			</div>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Button isPrimary isLarge disabled={ ! siteTitle }>
+					<Button isPrimary isLarge disabled={ ! siteTitle } onClick={ next }>
 						{ NO__( 'Next' ) }
 					</Button>
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -80,7 +80,12 @@ const Header: FunctionComponent< Props > = ( {
 		>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Button disabled={ ! prev } onClick={ prev }>
+					<Button
+						className="gutenboarding__header-back-button"
+						disabled={ ! prev }
+						onClick={ prev }
+					>
+						<Icon icon="arrow-left-alt" />
 						{ NO__( 'Back' ) }
 					</Button>
 				</div>

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -23,9 +23,16 @@
 	}
 }
 
-.gutenboarding__header-section {
+.gutenboarding__header-section,
+.gutenboarding__header-back-button {
 	display: flex;
 	align-items: center;
+}
+
+.gutenboarding__header-back-button {
+	.dashicons-arrow-left-alt {
+		margin-right: 5px;
+	}
 }
 
 .gutenboarding__header-group {

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -64,6 +64,7 @@ export function Gutenboard() {
 	const goToNextStep = stepCompleted[ currentStep ]( onboardingState )
 		? () => setStep( step => step + 1 )
 		: undefined;
+	const goToPrevStep = currentStep > 0 ? () => setStep( step => step - 1 ) : undefined;
 
 	const onboardingBlock = useMemo( () => createBlock( name, { step: currentStep } ), [
 		currentStep,
@@ -88,6 +89,7 @@ export function Gutenboard() {
 						<Header
 							isEditorSidebarOpened={ isEditorSidebarOpened }
 							next={ goToNextStep }
+							prev={ goToPrevStep }
 							toggleGeneralSidebar={ toggleGeneralSidebar }
 							toggleSidebarShortcut={ toggleSidebarShortcut }
 						/>

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
-
+import { useSelect } from '@wordpress/data';
 import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useMemo, useState } from 'react';
@@ -30,11 +30,18 @@ import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import { Slot as SidebarSlot } from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
+import { State as OnboardingState } from './stores/onboard/reducer';
+import { STORE_KEY } from './stores/onboard';
+import { Steps } from './types';
 import './stores/domain-suggestions';
-import './stores/onboard';
 import './stores/verticals-templates';
 import './style.scss';
 import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
+
+const stepCompleted: Record< Steps, ( state: OnboardingState ) => boolean > = {
+	[ Steps.IntentGathering ]: ( { siteTitle } ) => !! siteTitle,
+	[ Steps.DesignSelection ]: () => false, // ( { design } ) => !! design, // TODO: Enable once we have `design` in onboarding state
+};
 
 // Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
 // to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
@@ -50,9 +57,13 @@ export function Gutenboard() {
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );
 	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
 
+	const onboardingState = useSelect( select => select( STORE_KEY ).getState() );
+
 	// FIXME: Quick'n'dirty step state, replace with router
-	const [ currentStep, setStep ] = useState( 0 );
-	const goToNextStep = () => setStep( step => step + 1 );
+	const [ currentStep, setStep ] = useState( Steps.IntentGathering );
+	const goToNextStep = stepCompleted[ currentStep ]( onboardingState )
+		? () => setStep( step => step + 1 )
+		: undefined;
 
 	const onboardingBlock = useMemo( () => createBlock( name, { step: currentStep } ), [
 		currentStep,

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -60,7 +60,9 @@ const DesignSelector = () => {
 			select( 'automattic/verticals/templates' ).getTemplates( siteVertical.id )
 		) ?? [];
 
-	const blocksByTemplateSlug = templates.reduce( ( prev, { slug, content } ) => {
+	const homepageTemplates = templates.filter( template => template.category === 'home' );
+
+	const blocksByTemplateSlug = homepageTemplates.reduce( ( prev, { slug, content } ) => {
 		prev[ slug ] = content ? parseBlocks( replacePlaceholders( content ) ) : [];
 		return prev;
 	}, {} );
@@ -69,7 +71,7 @@ const DesignSelector = () => {
 	return (
 		<TemplateSelectorControl
 			label={ __( 'Layout', 'full-site-editing' ) }
-			templates={ templates }
+			templates={ homepageTemplates }
 			blocksByTemplates={ blocksByTemplateSlug }
 			onTemplateSelect={ setPreviewedTemplate }
 			useDynamicPreview={ false }

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -30,6 +30,7 @@ import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import { Slot as SidebarSlot } from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
+import { SiteVertical } from './stores/onboard/types';
 import './stores/domain-suggestions';
 import './stores/onboard';
 import './stores/verticals-templates';
@@ -51,7 +52,7 @@ const onboardingBlock = createBlock( name, {} );
 
 const DesignSelector = () => {
 	const siteVertical = useSelect(
-		select => select( 'automattic/onboard' ).getState().siteVertical
+		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical
 	);
 	const templates = useSelect( select =>
 		select( 'automattic/verticals/templates' ).getTemplates( siteVertical.id )

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -50,10 +50,19 @@ registerBlockType( name, settings );
 const onboardingBlock = createBlock( name, {} );
 
 const DesignSelector = () => {
-	const templates = useSelect( select =>
-		select( 'automattic/verticals/templates' ).getTemplates( 'p13v1' )
+	const siteVertical = useSelect(
+		select => select( 'automattic/onboard' ).getState().siteVertical
 	);
-	return <PageTemplateModal templates={ templates } />;
+	const templates = useSelect( select =>
+		select( 'automattic/verticals/templates' ).getTemplates( siteVertical.id )
+	);
+	return (
+		<PageTemplateModal
+			segment="m1" // FIXME: Replace with actual segment!
+			templates={ templates }
+			vertical={ siteVertical }
+		/>
+	);
 };
 
 // Makeshift block so we can drop the modal into the block editor. Might want to change that later.

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -39,7 +39,7 @@ import './style.scss';
 import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
 
 const stepCompleted: Record< Steps, ( state: OnboardingState ) => boolean > = {
-	[ Steps.IntentGathering ]: ( { siteTitle } ) => !! siteTitle,
+	[ Steps.IntentGathering ]: ( { siteVertical } ) => !! siteVertical,
 	[ Steps.DesignSelection ]: () => false, // ( { design } ) => !! design, // TODO: Enable once we have `design` in onboarding state
 };
 

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -17,11 +17,11 @@ import {
 } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
+import { useSelect } from '@wordpress/data';
 import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useState } from 'react';
 import '@wordpress/components/build-style/style.css';
-import { registerCoreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -35,6 +35,8 @@ import './stores/onboard';
 import './stores/verticals-templates';
 import './style.scss';
 
+import { PageTemplateModal } from '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal';
+
 // Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
 // to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
 const toggleSidebarShortcut = {
@@ -47,8 +49,25 @@ registerBlockType( name, settings );
 
 const onboardingBlock = createBlock( name, {} );
 
-registerCoreBlocks();
-const templateBlock = createBlock( 'core/paragraph', { content: 'Template Selection' } );
+const DesignSelector = () => {
+	const templates = useSelect( select =>
+		select( 'automattic/verticals/templates' ).getTemplates( 'p13v1' )
+	);
+	return <PageTemplateModal templates={ templates } />;
+};
+
+// Makeshift block so we can drop the modal into the block editor. Might want to change that later.
+registerBlockType( 'automattic/page-templates', {
+	title: 'Page Templates',
+	icon: 'universal-access-alt',
+	category: 'layout',
+	attributes: {},
+	edit() {
+		return <DesignSelector />;
+	},
+} );
+
+const templateBlock = createBlock( 'automattic/page-templates', {} );
 
 export function Gutenboard() {
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,6 +21,7 @@ import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useState } from 'react';
 import '@wordpress/components/build-style/style.css';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -46,10 +47,16 @@ registerBlockType( name, settings );
 
 const onboardingBlock = createBlock( name, {} );
 
+registerCoreBlocks();
+const templateBlock = createBlock( 'core/paragraph', { content: 'Template Selection' } );
+
 export function Gutenboard() {
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );
-
 	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
+
+	// FIXME: Quick'n'dirty step state, replace with router
+	const [ currentStep, setStep ] = useState( 0 );
+	const goToNextStep = () => setStep( step => step + 1 );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -69,10 +76,14 @@ export function Gutenboard() {
 						/>
 						<Header
 							isEditorSidebarOpened={ isEditorSidebarOpened }
+							next={ goToNextStep }
 							toggleGeneralSidebar={ toggleGeneralSidebar }
 							toggleSidebarShortcut={ toggleSidebarShortcut }
 						/>
-						<BlockEditorProvider value={ [ onboardingBlock ] } settings={ { templateLock: 'all' } }>
+						<BlockEditorProvider
+							value={ [ currentStep === 0 ? onboardingBlock : templateBlock ] }
+							settings={ { templateLock: 'all' } }
+						>
 							<div className="edit-post-layout__content">
 								<div
 									className="edit-post-visual-editor editor-styles-wrapper"
@@ -98,5 +109,6 @@ export function Gutenboard() {
 			<Popover.Slot />
 		</div>
 	);
+
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -15,7 +15,7 @@ import {
 	DropZoneProvider,
 	KeyboardShortcuts,
 } from '@wordpress/components';
-import { createBlock, parse as parseBlocks, registerBlockType } from '@wordpress/blocks';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 import '@wordpress/format-library';
@@ -32,7 +32,6 @@ import { Slot as SidebarSlot } from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
 import { SiteVertical } from './stores/onboard/types';
 import { TemplateSelectorControl } from '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control';
-import replacePlaceholders from '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders';
 import './stores/domain-suggestions';
 import './stores/onboard';
 import './stores/verticals-templates';
@@ -62,17 +61,12 @@ const DesignSelector = () => {
 
 	const homepageTemplates = templates.filter( template => template.category === 'home' );
 
-	const blocksByTemplateSlug = homepageTemplates.reduce( ( prev, { slug, content } ) => {
-		prev[ slug ] = content ? parseBlocks( replacePlaceholders( content ) ) : [];
-		return prev;
-	}, {} );
-
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (
 		<TemplateSelectorControl
 			label={ __( 'Layout', 'full-site-editing' ) }
 			templates={ homepageTemplates }
-			blocksByTemplates={ blocksByTemplateSlug }
+			blocksByTemplates={ {} /* Unneeded, since we're setting `useDynamicPreview` to `false` */ }
 			onTemplateSelect={ setPreviewedTemplate }
 			useDynamicPreview={ false }
 			siteInformation={ undefined }

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -36,6 +36,7 @@ import './stores/domain-suggestions';
 import './stores/onboard';
 import './stores/verticals-templates';
 import './style.scss';
+import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
 
 // Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
 // to be consistent with Gutenberg's shortcuts, and in order to avoid pulling in all of `@wordpress/edit-post`.
@@ -63,16 +64,20 @@ const DesignSelector = () => {
 
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (
-		<TemplateSelectorControl
-			label={ __( 'Layout', 'full-site-editing' ) }
-			templates={ homepageTemplates }
-			blocksByTemplates={ {} /* Unneeded, since we're setting `useDynamicPreview` to `false` */ }
-			onTemplateSelect={ setPreviewedTemplate }
-			useDynamicPreview={ false }
-			siteInformation={ undefined }
-			selectedTemplate={ previewedTemplate }
-			// handleTemplateConfirmation={ this.handleConfirmation }
-		/>
+		<div
+			className="page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
+		>
+			<TemplateSelectorControl
+				label={ __( 'Layout', 'full-site-editing' ) }
+				templates={ homepageTemplates }
+				blocksByTemplates={ {} /* Unneeded, since we're setting `useDynamicPreview` to `false` */ }
+				onTemplateSelect={ setPreviewedTemplate }
+				useDynamicPreview={ false }
+				siteInformation={ undefined }
+				selectedTemplate={ previewedTemplate }
+				// handleTemplateConfirmation={ this.handleConfirmation }
+			/>
+		</div>
 	);
 };
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { __ as NO__ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import React, { useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { SiteVertical } from '../../stores/onboard/types';
+import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control';
+
+export default () => {
+	const siteVertical = useSelect(
+		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical
+	);
+
+	const templates =
+		useSelect( select =>
+			select( 'automattic/verticals/templates' ).getTemplates( siteVertical.id )
+		) ?? [];
+
+	const homepageTemplates = templates.filter( template => template.category === 'home' );
+
+	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
+	return (
+		<div
+			className="page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
+		>
+			<TemplateSelectorControl
+				label={ NO__( 'Layout', 'full-site-editing' ) }
+				templates={ homepageTemplates }
+				blocksByTemplates={ {} /* Unneeded, since we're setting `useDynamicPreview` to `false` */ }
+				onTemplateSelect={ setPreviewedTemplate }
+				useDynamicPreview={ false }
+				siteInformation={ undefined }
+				selectedTemplate={ previewedTemplate }
+				// handleTemplateConfirmation={ this.handleConfirmation }
+			/>
+		</div>
+	);
+};

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -14,13 +14,14 @@ import DesignSelector from './design-selector';
 import StepperWizard from './stepper-wizard';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
+import { Steps } from '../types';
 import './style.scss';
 
 export default function OnboardingEdit( { attributes: { step = 0 } } ) {
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 
 	switch ( step ) {
-		case 0:
+		case Steps.IntentGathering:
 			return (
 				<div className="onboarding-block__acquire-intent">
 					<div className="onboarding-block__questions">
@@ -43,7 +44,7 @@ export default function OnboardingEdit( { attributes: { step = 0 } } ) {
 					</div>
 				</div>
 			);
-		case 1:
+		case Steps.DesignSelection:
 			return <DesignSelector />;
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -10,34 +10,42 @@ import { Button } from '@wordpress/components';
  * Internal dependencies
  */
 import { STORE_KEY } from '../stores/onboard';
+import DesignSelector from './design-selector';
 import StepperWizard from './stepper-wizard';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
 import './style.scss';
 
-export default function OnboardingEdit() {
+export default function OnboardingEdit( { attributes: { step = 0 } } ) {
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 
-	return (
-		<div className="onboarding-block__acquire-intent">
-			<div className="onboarding-block__questions">
-				<h2 className="onboarding-block__questions-heading">
-					{ ! siteVertical &&
-						! siteTitle &&
-						NO__( "Let's set up your website – it takes only a moment." ) }
-				</h2>
-				<StepperWizard>
-					<VerticalSelect />
-					{ ( siteVertical || siteTitle ) && <SiteTitle /> }
-				</StepperWizard>
-				{ siteVertical && (
-					<div className="onboarding-block__footer">
-						<Button className="onboarding-block__question-skip" isLink>
-							{ NO__( "Don't know yet" ) } →
-						</Button>
+	switch ( step ) {
+		case 0:
+			return (
+				<div className="onboarding-block__acquire-intent">
+					<div className="onboarding-block__questions">
+						<h2 className="onboarding-block__questions-heading">
+							{ ! siteVertical &&
+								! siteTitle &&
+								NO__( "Let's set up your website – it takes only a moment." ) }
+						</h2>
+						<StepperWizard>
+							<VerticalSelect />
+							{ ( siteVertical || siteTitle ) && <SiteTitle /> }
+						</StepperWizard>
+						{ siteVertical && (
+							<div className="onboarding-block__footer">
+								<Button className="onboarding-block__question-skip" isLink>
+									{ NO__( "Don't know yet" ) } →
+								</Button>
+							</div>
+						) }
 					</div>
-				) }
-			</div>
-		</div>
-	);
+				</div>
+			);
+		case 1:
+			return <DesignSelector />;
+	}
+
+	return null;
 }

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { __ as NO__ } from '@wordpress/i18n';
+import { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { Button } from '@wordpress/components';
 
 /**
@@ -14,10 +15,13 @@ import DesignSelector from './design-selector';
 import StepperWizard from './stepper-wizard';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
+import { Attributes } from './types';
 import { Steps } from '../types';
 import './style.scss';
 
-export default function OnboardingEdit( { attributes: { step = 0 } } ) {
+const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = ( {
+	attributes: { step = 0 },
+} ) => {
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 
 	switch ( step ) {
@@ -49,4 +53,6 @@ export default function OnboardingEdit( { attributes: { step = 0 } } ) {
 	}
 
 	return null;
-}
+};
+
+export default OnboardingEdit;

--- a/client/landing/gutenboarding/onboarding-block/index.ts
+++ b/client/landing/gutenboarding/onboarding-block/index.ts
@@ -14,7 +14,7 @@ export const name = 'automattic/onboarding';
 
 export interface Attributes {
 	align: 'full';
-	step: Steps.IntentGathering;
+	step: Steps;
 }
 
 export const settings: BlockConfiguration< Attributes > = {

--- a/client/landing/gutenboarding/onboarding-block/index.ts
+++ b/client/landing/gutenboarding/onboarding-block/index.ts
@@ -7,15 +7,10 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import { Attributes, Steps } from './types';
 import edit from './edit';
-import { Steps } from '../types';
 
 export const name = 'automattic/onboarding';
-
-export interface Attributes {
-	align: 'full';
-	step: Steps;
-}
 
 export const settings: BlockConfiguration< Attributes > = {
 	title: NO__( 'Onboarding' ),

--- a/client/landing/gutenboarding/onboarding-block/index.ts
+++ b/client/landing/gutenboarding/onboarding-block/index.ts
@@ -8,12 +8,13 @@ import { BlockConfiguration } from '@wordpress/blocks';
  * Internal dependencies
  */
 import edit from './edit';
+import { Steps } from '../types';
 
 export const name = 'automattic/onboarding';
 
 export interface Attributes {
 	align: 'full';
-	step: 0;
+	step: Steps.IntentGathering;
 }
 
 export const settings: BlockConfiguration< Attributes > = {
@@ -27,7 +28,7 @@ export const settings: BlockConfiguration< Attributes > = {
 		},
 		step: {
 			type: 'number',
-			default: 0,
+			default: Steps.IntentGathering,
 		},
 	},
 	supports: {

--- a/client/landing/gutenboarding/onboarding-block/index.ts
+++ b/client/landing/gutenboarding/onboarding-block/index.ts
@@ -13,6 +13,7 @@ export const name = 'automattic/onboarding';
 
 export interface Attributes {
 	align: 'full';
+	step: 0;
 }
 
 export const settings: BlockConfiguration< Attributes > = {
@@ -23,6 +24,10 @@ export const settings: BlockConfiguration< Attributes > = {
 		align: {
 			type: 'string',
 			default: 'full',
+		},
+		step: {
+			type: 'number',
+			default: 0,
 		},
 	},
 	supports: {

--- a/client/landing/gutenboarding/onboarding-block/index.ts
+++ b/client/landing/gutenboarding/onboarding-block/index.ts
@@ -7,7 +7,8 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { Attributes, Steps } from './types';
+import { Attributes } from './types';
+import { Steps } from '../types';
 import edit from './edit';
 
 export const name = 'automattic/onboarding';

--- a/client/landing/gutenboarding/onboarding-block/types.ts
+++ b/client/landing/gutenboarding/onboarding-block/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { Steps } from '../types';
+
+export interface Attributes {
+	align: 'full';
+	step: Steps;
+}

--- a/client/landing/gutenboarding/types.ts
+++ b/client/landing/gutenboarding/types.ts
@@ -1,4 +1,4 @@
 export enum Steps {
-	IntentGathering = 0,
+	IntentGathering,
 	DesignSelection,
 }

--- a/client/landing/gutenboarding/types.ts
+++ b/client/landing/gutenboarding/types.ts
@@ -1,0 +1,4 @@
+export enum Steps {
+	IntentGathering = 0,
+	DesignSelection,
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Similar to #37995 (and using pieces from there), but with `TemplateSelectorControl` rather than `PageTemplateModal`, since this might after all be a better fit for what we're wanting to do.

* Transpile stuff in `apps/full-site-editing` using the `@wordpress/element` preset
* Add some basic step state handling. I opted against introducing state in our `@wordpress/data` store. Instead, I'm using top-level component state and pass it down as a block attribute to the onboarding block. I hope that this will make it easier to swap it out later when we move the 'Continue' button into the block. Furthermore, I've added a stub mechanism that should scale to adding more steps and allowing/forbidding proceeding to next step.
* Use `TemplateSelectorControl`

#### Screencast

![design-selector](https://user-images.githubusercontent.com/96308/70453239-a44a2b80-1ad2-11ea-8a3d-b39e66bc8caf.gif)

#### Testing instructions

- Go to `http://calypso.localhost:3000/gutenboarding`
- Fill in vertical and site title
- Click 'Next'
- Select a template by clicking on it

#### Follow-up (for separate PRs)

- Modify styling so designs appear bigger. Need to make sure that doesn't break SPT since we're reusing their styling.
- In order not to depend on Calypso soup, we'll also need to extract `TemplateSelectorControl` (and `TemplateSelectorItem`, which it depends on) into a package (probably `@automattic/components`).