### PR TITLE
Config: Remove unused scan feature flag

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -97,7 +97,6 @@
 		"oauth": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -72,7 +72,6 @@
 		"me/trophies": false,
 		"oauth": true,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/development.json
+++ b/config/development.json
@@ -123,7 +123,6 @@
 		"oauth": false,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,7 +81,6 @@
 		"network-connection": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/production.json
+++ b/config/production.json
@@ -87,7 +87,6 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,7 +89,6 @@
 		"nps-survey/dev-trigger": false,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -77,7 +77,6 @@
 		"network-connection": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/image-editor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -101,7 +101,6 @@
 		"nps-survey/dev-trigger": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/jetpack-scan": false,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
In #38244 @delawski suggested that we remove the `plans/jetpack-scan` feature flag too, as we're not using that anywhere. This PR gets rid of it.

#### Changes proposed in this Pull Request

* Config: Remove unused scan feature flag

#### Testing instructions

* Checkout this branch
* Verify there are no usages of `plans/jetpack-scan` in the codebase.
