### PR TITLE
Concierge upsell: Show for redirect payment types

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -469,10 +469,10 @@ export class Checkout extends React.Component {
 		return;
 	}
 
-	maybeShowPlanBumpOfferConcierge( receiptId ) {
+	maybeShowPlanBumpOfferConcierge( receiptId, stepResult ) {
 		const { cart, selectedSiteSlug } = this.props;
 
-		if ( hasPersonalPlan( cart ) ) {
+		if ( hasPersonalPlan( cart ) && stepResult && isEmpty( stepResult.failed_purchases ) ) {
 			if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellConcierge' ) ) {
 				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
 			}
@@ -490,14 +490,12 @@ export class Checkout extends React.Component {
 		// then skip this section so that we do not show further upsells.
 		if (
 			config.isEnabled( 'upsell/concierge-session' ) &&
-			stepResult &&
-			isEmpty( stepResult.failed_purchases ) &&
 			! hasConciergeSession( cart ) &&
 			! hasJetpackPlan( cart ) &&
 			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
 			! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-plan-upgrade` )
 		) {
-			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId );
+			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId, stepResult );
 			if ( upgradePath ) {
 				return upgradePath;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show the concierge upsell nudge if a redirect payment type such as Giropay was used.
* In https://github.com/Automattic/wp-calypso/pull/37349, we added a condition to check for failed_purchases in `stepResult` - this was to ensure that if payment failed, then we don't assign the user to the plan bump A/B test. However, the conditional prevented concierge upsell nudges from being shown. This PR fixes the issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the Test Plan from https://github.com/Automattic/wp-calypso/pull/37349 works.
* Go through signup flow while you are proxied through Europe. Pay for a Personal plan through Giropay and verify that you see the Concierge nudge. Also verify that typing `localstorage.ABTests` in your browser console should not show the `showPlanUpsellConcierge ` test in the list of assigned tests. 

Fixes https://github.com/Automattic/wp-calypso/issues/34434
