### PR TITLE
Reinstate isRequired in Query propTypes.

### DIFF
--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -30,6 +30,6 @@ export default function QueryPostCounts( { siteId, type } ) {
 }
 
 QueryPostCounts.propTypes = {
-	siteId: PropTypes.number,
-	type: PropTypes.string,
+	siteId: PropTypes.number.isRequired,
+	type: PropTypes.string.isRequired,
 };

--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -26,4 +26,4 @@ export default function QuerySiteChecklist( { siteId } ) {
 	return null;
 }
 
-QuerySiteChecklist.propTypes = { siteId: PropTypes.number };
+QuerySiteChecklist.propTypes = { siteId: PropTypes.number.isRequired };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reinstate `isRequired` in Query component `propTypes`. See https://github.com/Automattic/wp-calypso/pull/38240#discussion_r355441969

#### Testing instructions

No testing should be needed, as this is a development-only feature that is being restored.
