### PR TITLE
Checklist: Remove isAtomic restriction

### DIFF
--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -18,7 +18,6 @@ import { Card } from '@automattic/components';
 class Checklist extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
-		phase2: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		onExpandTask: PropTypes.func,
 		showChecklistHeader: PropTypes.bool,
@@ -120,11 +119,7 @@ class Checklist extends PureComponent {
 		let skippedChildren = 0;
 
 		return (
-			<div
-				className={ classNames( 'checklist', this.props.className, {
-					'checklist-phase2': this.props.phase2,
-				} ) }
-			>
+			<div className={ classNames( 'checklist', this.props.className ) }>
 				{ showChecklistHeader && completed !== total && this.renderChecklistHeader() }
 
 				<div className="checklist__tasks">

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -241,7 +241,6 @@ class WpcomChecklistComponent extends PureComponent {
 
 	render() {
 		const {
-			phase2,
 			siteId,
 			taskList,
 			taskStatuses,
@@ -284,7 +283,6 @@ class WpcomChecklistComponent extends PureComponent {
 					setStoredTask={ setStoredTask }
 					storedTask={ storedTask }
 					taskList={ taskList }
-					phase2={ phase2 }
 					onExpandTask={ this.trackExpandTask }
 					showChecklistHeader={ false }
 				>
@@ -1093,7 +1091,6 @@ export default connect(
 
 		return {
 			designType: getSiteOption( state, siteId, 'design_type' ),
-			phase2: get( siteChecklist, 'phase2' ),
 			siteId,
 			siteSlug,
 			siteVerticals: get( siteChecklist, 'verticals' ),

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -1,100 +1,10 @@
 /**
  * External dependencies
  */
-import { get, isBoolean, memoize, omit, pick, size } from 'lodash';
-import debugModule from 'debug';
-
-/**
- * Internal dependencies
- */
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-import { getVerticalTaskList } from './vertical-task-list';
-
-const debug = debugModule( 'calypso:wpcom-task-list' );
-
-function getTasks( {
-	designType,
-	siteIsUnlaunched,
-	phase2,
-	siteSegment,
-	siteVerticals,
-	taskStatuses,
-} ) {
-	// The getTasks function can be removed when we make a full switch to "phase 2"
-	if ( phase2 && size( taskStatuses ) ) {
-		// Use the server response, Luke
-		return taskStatuses;
-	}
-
-	const tasks = [];
-	const segmentSlug = getSiteTypePropertyValue( 'id', siteSegment, 'slug' );
-
-	const getTask = taskId =>
-		taskStatuses ? taskStatuses.filter( task => task.id === taskId )[ 0 ] : undefined;
-	const hasTask = taskId => getTask( taskId ) !== undefined;
-	const isCompleted = taskId => get( getTask( taskId ), 'isCompleted', false );
-	const addTask = ( taskId, completed ) => {
-		const task = Object.assign( omit( getTask( taskId ), [ 'isCompleted' ] ), {
-			id: taskId,
-			isCompleted: isBoolean( completed ) ? completed : isCompleted( taskId ),
-		} );
-
-		tasks.push( task );
-	};
-
-	addTask( 'email_verified' );
-	addTask( 'site_created', true );
-
-	if ( 'business' === segmentSlug ) {
-		addTask( 'about_text_updated' );
-		addTask( 'homepage_photo_updated' );
-		addTask( 'business_hours_added' );
-
-		getVerticalTaskList( siteVerticals ).forEach( addTask );
-	} else {
-		addTask( 'blogname_set' );
-		addTask( 'blogdescription_set' );
-
-		if ( designType === 'blog' ) {
-			addTask( 'avatar_uploaded' );
-		}
-
-		addTask( 'contact_page_updated' );
-
-		if ( designType === 'blog' ) {
-			addTask( 'post_published' );
-		}
-
-		addTask( 'site_icon_set' );
-	}
-
-	addTask( 'custom_domain_registered' );
-	addTask( 'mobile_app_installed' );
-
-	if ( get( taskStatuses, 'email_verified.completed' ) && siteIsUnlaunched ) {
-		addTask( 'site_launched' );
-	}
-
-	if ( hasTask( 'email_setup' ) ) {
-		addTask( 'email_setup' );
-	}
-
-	if ( hasTask( 'email_forwarding_upgraded_to_gsuite' ) ) {
-		addTask( 'email_forwarding_upgraded_to_gsuite' );
-	}
-
-	if ( hasTask( 'gsuite_tos_accepted' ) ) {
-		addTask( 'gsuite_tos_accepted' );
-	}
-
-	debug( 'Site info: ', { designType, segmentSlug, siteVerticals } );
-	debug( 'Task list: ', tasks );
-
-	return tasks;
-}
+import { memoize, pick } from 'lodash';
 
 class WpcomTaskList {
-	constructor( tasks ) {
+	constructor( tasks = [] ) {
 		this.tasks = tasks;
 	}
 
@@ -151,7 +61,7 @@ class WpcomTaskList {
 }
 
 export const getTaskList = memoize(
-	params => new WpcomTaskList( getTasks( params ) ),
+	params => new WpcomTaskList( params?.taskStatuses ),
 	params => {
 		const key = pick( params, [
 			'taskStatuses',

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -592,8 +592,7 @@ const connectHome = connect(
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
 
 		return {
-			// For now we are hiding the checklist on Atomic sites see pb5gDS-7c-p2 for more information
-			displayChecklist: ! isAtomic && hasChecklistData && ! isChecklistComplete,
+			displayChecklist: !! ( hasChecklistData && ! isChecklistComplete ),
 			site: getSelectedSite( state ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -196,7 +196,7 @@ class Home extends Component {
 			if ( siteIsUnlaunched || isAtomic ) {
 				//Only show pre-launch, or for Atomic sites
 				return (
-					<React.Fragment>
+					<>
 						{ siteId && 'theme' === checklistMode && <QueryActiveTheme siteId={ siteId } /> }
 						{ currentThemeId && (
 							<QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } />
@@ -215,7 +215,7 @@ class Home extends Component {
 							}
 							subHeaderText={ this.getChecklistSubHeaderText() }
 						/>
-					</React.Fragment>
+					</>
 				);
 			}
 		}
@@ -223,7 +223,7 @@ class Home extends Component {
 		// Show a congratulatory message post-launch
 		if ( ! siteIsUnlaunched && 'launched' === checklistMode ) {
 			return (
-				<React.Fragment>
+				<>
 					<img
 						src="/calypso/images/signup/confetti.svg"
 						aria-hidden="true"
@@ -234,7 +234,7 @@ class Home extends Component {
 						headerText={ translate( 'You launched your site!' ) }
 						subHeaderText={ this.getChecklistSubHeaderText() }
 					/>
-				</React.Fragment>
+				</>
 			);
 		}
 

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -66,7 +66,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 	 * Returns the localized duration of a task in given minutes.
 	 *
 	 * @param  minutes Number of minutes.
-	 * @return Localized duration.
+	 * @returns Localized duration.
 	 */
 	getDuration( minutes: number ) {
 		return this.props.translate( '%d minute', '%d minutes', { count: minutes, args: [ minutes ] } );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -28,8 +28,7 @@ import { URL } from 'types';
 import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { isBusinessPlan, isPremiumPlan } from 'lib/plans';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
-import { Button } from '@automattic/components';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 
 /**

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -392,9 +392,6 @@ const connectComponent = connect(
 			isProfessional,
 			isPaidPlan,
 			rewindState,
-			// `phase2: true` is passed to `getTaskList()` in the component and makes it possible to use
-			// the array-based checklist data format
-			phase2: true,
 			productInstallStatus,
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -23,7 +23,7 @@ export const fetchChecklist = action =>
 		{
 			path: `/sites/${ action.siteId }/checklist`,
 			method: 'GET',
-			apiNamespace: 'rest/v1.1',
+			apiNamespace: 'rest/v1.2',
 			query: {
 				http_envelope: 1,
 				with_domain_verification: action.isSiteEligibleForFSE ? 1 : 0,

--- a/client/state/selectors/get-site-task-list.js
+++ b/client/state/selectors/get-site-task-list.js
@@ -12,15 +12,14 @@ import getChecklistTaskUrls from './get-checklist-task-urls';
 /**
  * Returns the checklist for the specified site ID
  *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {Object}        Site settings
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId Site ID
+ * @returns {object}        Site settings
  */
 export default function getSiteTaskList( state, siteId ) {
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const taskList = getTaskList( {
 		taskStatuses: get( siteChecklist, 'tasks' ),
-		phase2: get( siteChecklist, 'phase2' ),
 		siteVerticals: get( siteChecklist, 'verticals' ),
 		siteSegment: get( siteChecklist, 'siteSegment' ),
 	} );

--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -16,22 +16,16 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
  * @returns {boolean} True if current user is able to see the checklist
  */
 export default function isEligibleForDotcomChecklist( state, siteId ) {
-	const siteOptions = getSiteOptions( state, siteId );
-	const isWpComStore = get( siteOptions, 'is_wpcom_store' );
-	const createdAt = get( siteOptions, 'created_at', '' );
-
-	// Checklist should not show up if the site is created before the feature was launched.
-	if (
-		! createdAt ||
-		createdAt.substr( 0, 4 ) === '0000' ||
-		new Date( createdAt ) < new Date( '2018-02-01' )
-	) {
-		return false;
-	}
-
 	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
 		return false;
 	}
 
-	return ! isWpComStore;
+	const siteOptions = getSiteOptions( state, siteId );
+
+	// Checklist should not show up if the site is created before the feature was launched.
+	if ( get( siteOptions, 'created_at', '' ) < '2018-02-01' ) {
+		return false;
+	}
+
+	return true;
 }

--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -7,14 +7,13 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import getSiteOptions from 'state/selectors/get-site-options';
-import { isJetpackSite } from 'state/sites/selectors';
+import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 /**
- * @param {Object} state Global state tree
- * @param {Number} siteId Site ID
- * @param {Object} cart object
- * @return {Boolean} True if current user is able to see the checklist
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} True if current user is able to see the checklist
  */
 export default function isEligibleForDotcomChecklist( state, siteId ) {
 	const siteOptions = getSiteOptions( state, siteId );

--- a/client/state/selectors/test/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/test/is-eligible-for-dotcom-checklist.js
@@ -1,0 +1,135 @@
+/**
+ * Internal dependencies
+ */
+import isEligibleForDotcomChecklist from '../is-eligible-for-dotcom-checklist';
+
+describe( 'isEligibleForDotcomChecklist()', () => {
+	test( 'should return false for simple sites without a created_at option', () => {
+		const state = { sites: { items: { 99: { options: {} } } } };
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return false for unresolved sites', () => {
+		expect( isEligibleForDotcomChecklist( { sites: [] }, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return false for old sites', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							created_at: '2018-01-31',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return true for recent simple sites', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							created_at: '2018-02-01',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
+	} );
+
+	test( 'should return true for recent AT sites', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							is_automated_transfer: '1',
+							created_at: '2018-02-01',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
+	} );
+
+	test( 'should return false for AT sites without a created_at option', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							is_automated_transfer: '1',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return false for recent non-atomic jetpack sites', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						jetpack: true,
+						options: {
+							created_at: '2018-02-01',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return true for recent AT non-store sites', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						jetpack: true,
+						options: {
+							created_at: '2018-02-01',
+							is_automated_transfer: '1',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
+	} );
+
+	test( 'should return true for recent AT store sites', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						jetpack: true,
+						options: {
+							created_at: '2018-02-01',
+							is_automated_transfer: '1',
+							is_wpcom_store: '1',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `isAtomic` restriction from the Customer Home component
* Excise references to `phase2`
* Apply `phase2` behavior for all! Remove `getTasks` wrapper function and just use tasks from the server
* Short `React.Fragment` syntax
* Fixup jsDoc & import syntax for `isEligibleForDotcomChecklist`
* Enable dotcom checklist for Atomic sites in the client (even in ecommerce -- Let the server decide if tasks are provided)
* Add tests for `isEligibleForDotcomChecklist` selector

#### Testing instructions

* Verify test behavior coverage & `npm run test-client client/state/selectors/test/is-eligible-for-dotcom-checklist.js`
* Apply D36492-code & sandbox the API
* Visit `/home` for a newish simple site
  * The checklist should be displayed & functional
* Visit `/home` for a newish Atomic site without the WooCommerce plugin installed
  * The checklist should be displayed & functional
* Visit `/home` for a newish Atomic site with the WooCommerce plugin installed
  * The checklist should *NOT* be displayed
* Visit `/plans/my-plan` for verious Jetpack sites
  * The checklist should be displayed (with appropriate items) & functional 
