### PR TITLE
Add domains title to domains screens

### DIFF
--- a/client/my-sites/domains/domain-management/components/header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/header/index.jsx
@@ -9,6 +9,8 @@ import React from 'react';
  */
 import HeaderCake from 'components/header-cake';
 import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -17,15 +19,23 @@ import './style.scss';
 
 export default function DomainManagementHeader( props ) {
 	const { onClick, backHref, children } = props;
+	const translate = useTranslate();
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<HeaderCake className="domain-management-header" onClick={ onClick } backHref={ backHref }>
-			<div className="domain-management-header__children">
-				<span className="domain-management-header__title">{ children }</span>
-			</div>
-			<DocumentHead title={ children } />
-		</HeaderCake>
+		<React.Fragment>
+			<FormattedHeader
+				className="stats__section-header"
+				headerText={ translate( 'Domains' ) }
+				align="left"
+			/>
+			<HeaderCake className="domain-management-header" onClick={ onClick } backHref={ backHref }>
+				<div className="domain-management-header__children">
+					<span className="domain-management-header__title">{ children }</span>
+				</div>
+				<DocumentHead title={ children } />
+			</HeaderCake>
+		</React.Fragment>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -62,7 +62,7 @@ class EmailManagement extends React.Component {
 	};
 
 	render() {
-		const { selectedSiteId } = this.props;
+		const { selectedSiteId, selectedDomainName } = this.props;
 
 		return (
 			<Main className="email-management" wideLayout>
@@ -70,11 +70,14 @@ class EmailManagement extends React.Component {
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				<DocumentHead title={ this.props.translate( 'Email' ) } />
 				<SidebarNavigation />
-				<FormattedHeader
-					className="email-management__page-heading"
-					headerText={ this.props.translate( 'Email' ) }
-					align="left"
-				/>
+				{ ! selectedDomainName && (
+					<FormattedHeader
+						className="email-management__page-heading"
+						headerText={ this.props.translate( 'Email' ) }
+						align="left"
+					/>
+				) }
+
 				{ this.headerOrPlansNavigation() }
 				{ this.content() }
 			</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a page title to the domains child pages. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/70451344-e319ba80-1aad-11ea-92c9-9b88498242c6.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/70451305-cb423680-1aad-11ea-88ea-1a3be4c45ed6.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a site with a custom domain: `/domains/manage/[site-url]`
* Click the custom domain to go to the domain settings screen.
* Verify the `Domains` title appears at the top of the page.
* Click on all the sub pages (Email, Name servers and DNS, Contacts and Privacy, Transfer Domains).
* Verify the Domains title appears at the top of the page. 
* Now go to `/plans/my-plan/[site-url]`
* Click on the `Email` tab.
* Verify that the page title is email and not domains.


cc @danhauk, @sixhours 
