### PR TITLE
BPB: Add `path` mode in bin sync script

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/README.md
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/README.md
@@ -28,3 +28,11 @@ npm run sync:blog-posts-block --release=1.0.0-alpha.17
 ```
 
 This will pull the code from the release and integrate it into this repository. Please review changes, make sure to update `NEWSPACK_BLOCKS__VERSION` in [index.php](./index.php) and commit.
+
+### Local development
+
+Sometimes, probably, you will need to sync the NHA code straight in your local environment. It means you will get working on both projects at the same time. For this situation, you'd like to reference the code source through the `path` bin script argument.
+
+```js
+npm run sync:blog-posts-block --path=/Absolute/path/of/newspack-blocks/
+```


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a `path` mode to the FSE bin script in order to sync NHA with BPB locally.

#### Testing instructions

You need the [Newspack Blocks repository](https://github.com/Automattic/newspack-blocks) cloned locally.

1) Edit some files of NHA in your local repository
2) Run the following code in order to sync FSE with these changes. For instance, in my local env, I run

```cli
> npm run sync:blog-posts-block --path=/Users/retrofox/lab/newspack-blocks/
```

Also, test with the `release` and `branch` mode in order to ensure it doesn't break the current behavior.

```
> npm run sync:blog-posts-block --branch=master
```

```
> npm run sync:blog-posts-block --release=1.0.0-alpha.18
```