### PR TITLE
Migration: redirect to the active migration when it's in progress

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -88,7 +88,10 @@ class SectionMigrate extends Component {
 		wpcom
 			.getMigrationStatus( targetSiteId )
 			.then( response => {
-				const { status: migrationStatus, percent } = response;
+				const { status: migrationStatus, percent, source_blog_id: sourceSiteId } = response;
+				if ( sourceSiteId && sourceSiteId !== this.props.sourceSiteId ) {
+					this.setSourceSiteId( sourceSiteId );
+				}
 				if ( migrationStatus ) {
 					this.setState( {
 						migrationStatus,


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Prior to this PR, if you navigated to the migration section for an active migration (via the sidebar, or direct navigation), the migration progress page would be shown, but the source site would be undefined. This PR populates the source-site via a redirect to the `/from/:sourceSiteSlug/to/:targetSiteSlug` path when the source site returned from the API differs from the local source site (if any). This depends on D36498-code

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
(Note: most of these instructions are general instructions for testing migration. The **bolded** steps are the ones specific to this change)

* Check out this pull request and run Calypso locally, or view it on calypso.live with the flag tools/migrate.
* Viewing calypso.localhost:3000/migrate/, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Accept the confirmation. You should see a progress screen detailing the steps of the migration.
* **Navigate to `/migrate/:targetSiteSlug` directly while the migration is still in process. You should be redirected to `/migrate/from/:sourceSiteSlug/to/:targetSiteSlug`.**

