### PR TITLE
Fix author selector on user deletion flow

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -160,11 +160,12 @@ export default class InfiniteList extends React.Component {
 
 		// we may have guessed item heights wrong - now we have real heights
 		if ( ! this.isScrolling ) {
-			setTimeout( () => {
+			this.scrollUpdate = setTimeout( () => {
 				this.cancelAnimationFrame();
 				this.updateScroll( {
 					triggeredByScroll: false,
 				} );
+				this.scrollUpdate = false;
 			} );
 		}
 	}
@@ -199,6 +200,7 @@ export default class InfiniteList extends React.Component {
 		this._scrollContainer.removeEventListener( 'scroll', this.onScroll );
 		this._scrollContainer.removeEventListener( 'scroll', this._resetScroll );
 		this.cancelAnimationFrame();
+		this.cancelScrollUpdate();
 		this._isMounted = false;
 	}
 
@@ -208,6 +210,13 @@ export default class InfiniteList extends React.Component {
 			this.scrollRAFHandle = null;
 		}
 		this.lastScrollTop = -1;
+	}
+
+	cancelScrollUpdate() {
+		if ( this.scrollUpdate ) {
+			clearTimeout( this.scrollUpdate );
+			this.scrollUpdate = false;
+		}
 	}
 
 	onScroll = () => {
@@ -319,12 +328,14 @@ export default class InfiniteList extends React.Component {
 		this.bottomPlaceholderRef.current && this.bottomPlaceholderRef.current.getBoundingClientRect();
 
 	/**
-	 * Returns a list of visible item indexes. This includes any items that are
-	 * partially visible in the viewport. Instance method that is called externally
-	 * (via a ref) by a parent component.
-	 * @param {Object} options - offset properties
-	 * @param {Integer} options.offsetTop - in pixels, 0 if unspecified
-	 * @param {Integer} options.offsetBottom - in pixels, 0 if unspecified
+	 * Returns a list of visible item indexes.
+	 *
+	 * This includes any items that are partially visible in the viewport.
+	 * Instance method that is called externally (via a ref) by a parent component.
+	 *
+	 * @param {object} options - offset properties
+	 * @param {number} options.offsetTop - in pixels, 0 if unspecified
+	 * @param {number} options.offsetBottom - in pixels, 0 if unspecified
 	 * @returns {Array} This list of indexes
 	 */
 	getVisibleItemIndexes( options ) {
@@ -456,7 +467,8 @@ export default class InfiniteList extends React.Component {
 
 	/**
 	 * Determine whether context is available or still being rendered.
-	 * @return {bool} whether context is available
+	 *
+	 * @returns {boolean} whether context is available
 	 */
 	_contextLoaded() {
 		return this.props.context || this.props.context === false || ! ( 'context' in this.props );

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -263,11 +263,11 @@ class DeleteUser extends React.Component {
 							/>
 
 							<span>{ this.getTranslatedAssignLabel() }</span>
-
-							{ this.state.authorSelectorToggled ? (
-								<div className="delete-user__author-selector">{ this.getAuthorSelector() }</div>
-							) : null }
 						</FormLabel>
+
+						{ this.state.authorSelectorToggled ? (
+							<div className="delete-user__author-selector">{ this.getAuthorSelector() }</div>
+						) : null }
 
 						<FormLabel>
 							<FormRadio


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the replacement author selection flow when removing a user from a site
* Also make the Infinite List behave better when unmounting. Cancel the scroll update triggered in componentDidUpdate


#### Testing instructions

* Try to remove a user with posts from a multiuser site. Choose to replace the author with another author. Does the picker work?
* Try scrolling posts in the Reader. Does it work as expected?


#### Explanation

The bug occurred because a `<label>` is surrounding the `<Popover>` that shows the author list. The label ends up redirecting the click event on the chevron to the radio that the label contains. You can see this by setting a break in the onClose event on the popover and walk up the stack to inspect the event that triggered the close. I'm not entirely sure _why_ this is happening, it's not behavior I've seen before. 

The fix was to move the author selector outside of the DOM tree of the label. The click event no longer bubbles through the label and everything works as it should.

I also noticed that closing the popover by clicking outside it caused infinite list's scroll helper to emit a warning about setting state after unmount. I tracked that down to a setTimeout in InfiniteList that was not being properly cancelled when the list unmounted. 