### PR TITLE
Themes - Fix "show all" link for search card filters.

### DIFF
--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -222,12 +222,14 @@ class KeyedSuggestions extends React.Component {
 
 			//check if we have showAll key match. If we have then don't filter, use all and reorder.
 			if ( showAll === key ) {
+				// console.log( terms[key] );
 				// split to terms matching an non matching to the input
-				const parts = partition( terms[ key ], term => term.indexOf( filterTerm ) !== -1 );
+				// const parts = partition( terms[ key ], term => term.indexOf( filterTerm ) !== -1 );
 				// sort matching so that the best hit is first
-				const matchingSorted = sortBy( parts[ 0 ], term => term.indexOf( filterTerm ) );
+				// const matchingSorted = sortBy( parts[ 0 ], term => term.indexOf( filterTerm ) );
 				// concatenate mathing and non matchin - this is full set of filters just reordered.
-				filtered[ key ] = [ ...matchingSorted, ...parts[ 1 ] ];
+				// filtered[ key ] = [ ...matchingSorted, ...parts[ 1 ] ];
+				filtered[ key ] = Object.keys( terms[ key ] );
 			} else {
 				// Try a full match first and try substring matches
 				let multiRegex = filterTerm;
@@ -245,7 +247,7 @@ class KeyedSuggestions extends React.Component {
 				);
 			}
 		}
-
+		console.log( filtered );
 		return this.removeEmptySuggestions( filtered );
 	};
 

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -220,44 +220,36 @@ class KeyedSuggestions extends React.Component {
 				continue;
 			}
 
+			// Try a full match first and try substring matches
+			let multiRegex = filterTerm;
+			for ( let i = filterTerm.length; i > 1; i-- ) {
+				multiRegex += '|' + filterTerm.replace( new RegExp( '(.{' + i + '})', 'g' ), '$1.*' );
+			}
+			const regex = new RegExp( multiRegex, 'iu' );
+
 			//check if we have showAll key match. If we have then don't filter, use all and reorder.
 			if ( showAll === key ) {
-				// split to terms matching an non matching to the input
-				// const parts = partition( terms[ key ], term => term.indexOf( filterTerm ) !== -1 );
-				let multiRegex = filterTerm;
-				for ( let i = filterTerm.length; i > 1; i-- ) {
-					multiRegex += '|' + filterTerm.replace( new RegExp( '(.{' + i + '})', 'g' ), '$1.*' );
-				}
-				const regex = new RegExp( multiRegex, 'iu' );
-
 				const ourTerms = terms[ key ];
 				const keys = Object.keys( ourTerms );
-
-				let matching = [];
-				let notMatching = [];
-
-				for ( const i in keys ) {
-					if (
-						ourTerms[ keys[ i ] ].name.match( regex ) ||
-						ourTerms[ keys[ i ] ].description.match( regex )
-					) {
-						matching.push( keys[ i ] );
-					} else {
-						notMatching.push( keys[ i ] );
-					}
-				}
-				// sort matching so that the best hit is first
-				// const matchingSorted = sortBy( parts[ 0 ], term => term.indexOf( filterTerm ) );
+				// split to terms matching an non matching to the input
+				const [ matching, notMatching ] = partition( keys, term => {
+					return (
+						ourTerms[ term ].name.match( regex ) || ourTerms[ term ].description.match( regex )
+					);
+				} );
+				// Sort matching so that the best hit is first.
+				const sortedMatching = sortBy( matching, match => {
+					const term = ourTerms[ match ];
+					const hits = [ 100000 ];
+					const nameHit = term.name.toLowerCase().indexOf( filterTerm.toLowerCase() );
+					nameHit >= 0 && hits.push( nameHit );
+					const descriptionHit = term.description.toLowerCase().indexOf( filterTerm.toLowerCase() );
+					descriptionHit >= 0 && hits.push( descriptionHit );
+					return Math.min( ...hits );
+				} );
 				// concatenate mathing and non matchin - this is full set of filters just reordered.
-				filtered[ key ] = [ ...matching, ...notMatching ];
-				// filtered[ key ] = Object.keys( terms[ key ] );
+				filtered[ key ] = [ ...sortedMatching, ...notMatching ];
 			} else {
-				// Try a full match first and try substring matches
-				let multiRegex = filterTerm;
-				for ( let i = filterTerm.length; i > 1; i-- ) {
-					multiRegex += '|' + filterTerm.replace( new RegExp( '(.{' + i + '})', 'g' ), '$1.*' );
-				}
-				const regex = new RegExp( multiRegex, 'iu' );
 				filtered[ key ] = take(
 					filter(
 						map( terms[ key ], ( term, k ) =>

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -240,12 +240,9 @@ class KeyedSuggestions extends React.Component {
 				// Sort matching so that the best hit is first.
 				const sortedMatching = sortBy( matching, match => {
 					const term = ourTerms[ match ];
-					const hits = [ 100000 ];
-					const nameHit = term.name.toLowerCase().indexOf( filterTerm.toLowerCase() );
-					nameHit >= 0 && hits.push( nameHit );
-					const descriptionHit = term.description.toLowerCase().indexOf( filterTerm.toLowerCase() );
-					descriptionHit >= 0 && hits.push( descriptionHit );
-					return Math.min( ...hits );
+					const termString = term.name + ' ' + term.description;
+					const hitIndex = termString.toLowerCase().indexOf( filterTerm.toLowerCase() );
+					return hitIndex >= 0 && hitIndex;
 				} );
 				// Concatenate mathing and non matchin - this is full set of filters just reordered.
 				filtered[ key ] = [ ...sortedMatching, ...notMatching ];

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -227,11 +227,11 @@ class KeyedSuggestions extends React.Component {
 			}
 			const regex = new RegExp( multiRegex, 'iu' );
 
-			//check if we have showAll key match. If we have then don't filter, use all and reorder.
+			// Check if we have showAll key match. If we have then don't filter, use all and reorder.
 			if ( showAll === key ) {
 				const ourTerms = terms[ key ];
 				const keys = Object.keys( ourTerms );
-				// split to terms matching an non matching to the input
+				// Split to terms matching an non matching to the input.
 				const [ matching, notMatching ] = partition( keys, term => {
 					return (
 						ourTerms[ term ].name.match( regex ) || ourTerms[ term ].description.match( regex )
@@ -247,7 +247,7 @@ class KeyedSuggestions extends React.Component {
 					descriptionHit >= 0 && hits.push( descriptionHit );
 					return Math.min( ...hits );
 				} );
-				// concatenate mathing and non matchin - this is full set of filters just reordered.
+				// Concatenate mathing and non matchin - this is full set of filters just reordered.
 				filtered[ key ] = [ ...sortedMatching, ...notMatching ];
 			} else {
 				filtered[ key ] = take(

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -222,14 +222,35 @@ class KeyedSuggestions extends React.Component {
 
 			//check if we have showAll key match. If we have then don't filter, use all and reorder.
 			if ( showAll === key ) {
-				// console.log( terms[key] );
 				// split to terms matching an non matching to the input
 				// const parts = partition( terms[ key ], term => term.indexOf( filterTerm ) !== -1 );
+				let multiRegex = filterTerm;
+				for ( let i = filterTerm.length; i > 1; i-- ) {
+					multiRegex += '|' + filterTerm.replace( new RegExp( '(.{' + i + '})', 'g' ), '$1.*' );
+				}
+				const regex = new RegExp( multiRegex, 'iu' );
+
+				const ourTerms = terms[ key ];
+				const keys = Object.keys( ourTerms );
+
+				let matching = [];
+				let notMatching = [];
+
+				for ( const i in keys ) {
+					if (
+						ourTerms[ keys[ i ] ].name.match( regex ) ||
+						ourTerms[ keys[ i ] ].description.match( regex )
+					) {
+						matching.push( keys[ i ] );
+					} else {
+						notMatching.push( keys[ i ] );
+					}
+				}
 				// sort matching so that the best hit is first
 				// const matchingSorted = sortBy( parts[ 0 ], term => term.indexOf( filterTerm ) );
 				// concatenate mathing and non matchin - this is full set of filters just reordered.
-				// filtered[ key ] = [ ...matchingSorted, ...parts[ 1 ] ];
-				filtered[ key ] = Object.keys( terms[ key ] );
+				filtered[ key ] = [ ...matching, ...notMatching ];
+				// filtered[ key ] = Object.keys( terms[ key ] );
 			} else {
 				// Try a full match first and try substring matches
 				let multiRegex = filterTerm;
@@ -247,7 +268,6 @@ class KeyedSuggestions extends React.Component {
 				);
 			}
 		}
-		console.log( filtered );
 		return this.removeEmptySuggestions( filtered );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Theme search card "show all" to work again.

This component was getting objects where it had expected arrays, causing errors and breaking functionality at use of array methods like `indexOf` etc.

Regex declarations have been moved above the if/else statement for use in both conditions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Navigate to `Themes` section of calypso.
* Scroll down and open "More Themes"
* Select a filter type such as "Subject"
* Click "Show all" in the top right of the suggestions.
* Verify all filters of this type are now shown.
* Type a filter term such as "ed" (in the example of subject the search input should now say `subject:ed`
* Verify that results appear ordered by relevance in the list.

ex)
![Screen Shot 2019-12-09 at 4 27 05 PM](https://user-images.githubusercontent.com/28742426/70474530-c62aba80-1aa0-11ea-9c3c-fb4ee3b4d845.png)


Fixes #38272
