### PR TITLE
Test Gutenberg 7.1.0 RC1 with new gutenberg edge sticker and add PressThis test

### DIFF
--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -27,7 +27,14 @@ export default class ReaderPage extends AsyncBaseContainer {
 	}
 
 	async shareLatestPost() {
-		await driverHelper.clickWhenClickable( this.driver, by.css( '.reader-share__button' ) );
+		const shareButtonSelector = by.css( '.reader-share__button' );
+		const hasSharablePost = await driverHelper.isElementPresent( this.driver, shareButtonSelector );
+
+		if ( ! hasSharablePost ) {
+			return new Error( 'No sharable posts found in reader' );
+		}
+
+		await driverHelper.clickWhenClickable( this.driver, shareButtonSelector );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			by.css( '.reader-popover .site__content' )

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -26,6 +26,14 @@ export default class ReaderPage extends AsyncBaseContainer {
 		return URL.parse( href ).host;
 	}
 
+	async shareLatestPost() {
+		await driverHelper.clickWhenClickable( this.driver, by.css( '.reader-share__button' ) );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( '.reader-popover .site__content' )
+		);
+	}
+
 	async commentOnLatestPost( comment ) {
 		await driverHelper.clickWhenClickable( this.driver, by.css( '.comment-button' ) );
 		await driverHelper.setWhenSettable(

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -382,7 +382,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.closeScheduledPanel();
 				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
-				await gSidebarComponent.selectDocumentTab();
 				await gSidebarComponent.trashPost();
 			} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1195,7 +1195,10 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Find a post to share (press this)', async function() {
 			const readerPage = await ReaderPage.Expect( driver );
-			return await readerPage.shareLatestPost();
+			const sharePostError = await readerPage.shareLatestPost();
+			if ( sharePostError instanceof Error ) {
+				throw sharePostError;
+			}
 		} );
 
 		step( 'Block Editor loads with shared content', async function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1185,4 +1185,35 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await driverHelper.acceptAlertIfPresent( driver );
 		} );
 	} );
+
+	describe( 'Can Share Posts From Reader (PressThis)! @parallel', function() {
+		step( 'Can log in', async function() {
+			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			await this.loginFlow.login();
+			return this.loginFlow.checkForDevDocsAndRedirectToReader();
+		} );
+
+		step( 'Find a post to share (press this)', async function() {
+			const readerPage = await ReaderPage.Expect( driver );
+			return await readerPage.shareLatestPost();
+		} );
+
+		step( 'Block Editor loads with shared content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.closeSidebar();
+		} );
+
+		step( 'Can publish and view content', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.publish( { visit: true } );
+		} );
+
+		step( 'Can see a post title and post content', async function() {
+			const viewPostPage = await ViewPostPage.Expect( driver );
+			const postTitle = await viewPostPage.postTitle();
+			const postContent = await viewPostPage.postContent();
+			assert.ok( postTitle.length > 0, 'Press This did not copy a post title!' );
+			assert.ok( postContent.length > 0, 'Press This did not copy any post content!' );
+		} );
+	} );
 } );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -382,6 +382,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.closeScheduledPanel();
 				const gSidebarComponent = await GutenbergEditorSidebarComponent.Expect( driver );
+				await gSidebarComponent.selectDocumentTab();
 				await gSidebarComponent.trashPost();
 			} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes e2e test to match changes in gutenberg core
* Adds a basic test to /wp-calypso/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js` that makes sure when posts are shared from the reader, they load with some title and post content.


