### PR TITLE
Use switch_theme hook for template part population

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -265,7 +265,7 @@ function populate_wp_template_data() {
 	$template_inserter->insert_default_pages();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
-add_action( 'after_switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
+add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
 
 /**
  * Add front-end CoBlocks gallery block scripts.


### PR DESCRIPTION
### Changes proposed in this Pull Request
Use `switch_theme` instead of `after_switch_theme` for template part population. The `after_switch_theme` hook runs the callback on the **next request**, which means that population does not happen instantly. As you can imagine, this is problematic since FSE is not active if the template parts do not exist. Without this change there are weird periods where we expect FSE to be active, but it is not (see the bugs this fixes for more details).

### Testing Instructions
1. Load this to your wpcom sandbox and sandbox the API.
2. On a **logged-in** WordPress.com account, go to https://horizon.wordpress.com/start/test-fse. Go through the flow selecting any theme.

#### Update Homepage
1. Once you land in Calypso, wait a few seconds. Make sure that the "Customizer" item in the sidebar does not exist and that it does not suddenly appear after a few seconds.
2. Click the "Update homepage" item from your checklist, going to the page editor.
3. Open the help dialogue and make sure that there is no "switch to classic" button.
4. Open the three dot menu thing and make sure there is no switch to classic entry there either.

<img width="392" alt="Screen Shot 2019-12-09 at 4 57 17 PM" src="https://user-images.githubusercontent.com/6265975/70485884-0a1fbe80-1aa5-11ea-81da-21e6f42517ad.png">

#### Switch Themes
1. Now, go to the themes section in Calypso.
2. Activate a different FSE theme (one that has not been active on this site previously).
3. After it activates, make sure the "Customizer" item does not appear in the sidebar suddenly.
4. Make sure the front end of the website shows the FSE template parts.

Fixes #38305, Fixes #38056