### PR TITLE
Move FSE-specific functions outside of main plugin file

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -14,6 +14,21 @@
 namespace A8C\FSE;
 
 /**
+ * This file should only be used to load files needed for each subfeature.
+ *
+ * For example, if you are adding a new feature to this plugin called "Foo",
+ * you would create a directory `./foo` to contain all code needed by your
+ * feature. Then, in this file, you would add a `load_foo()` function which
+ * includes your feature's files via the 'plugins_loaded' action.
+ *
+ * Please take care to _not_ load your feature's files if there are situations
+ * which could cause bugs. For example, FSE files are only loaded if FSE is
+ * active on the site.
+ *
+ * Finally, don't forget to use the A8C\FSE namespace for your code. :)
+ */
+
+/**
  * Plugin version.
  *
  * Can be used in cache keys to invalidate caches on plugin update.
@@ -21,6 +36,9 @@ namespace A8C\FSE;
  * @var string
  */
 define( 'PLUGIN_VERSION', '0.17' );
+
+// Always include these helper files for FSE.
+require_once __DIR__ . '/full-site-editing/helpers.php';
 
 /**
  * Load Full Site Editing.
@@ -36,147 +54,6 @@ function load_full_site_editing() {
 	Full_Site_Editing::get_instance();
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
-
-/**
- * NOTE: In most cases, you should NOT use this function. Please use
- * load_full_site_editing instead. This function should only be used if you need
- * to include the FSE files somewhere like a script. I.e. if you want to access
- * a class defined here without needing full FSE functionality.
- */
-function dangerously_load_full_site_editing_files() {
-	require_once __DIR__ . '/full-site-editing/blocks/navigation-menu/index.php';
-	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
-	require_once __DIR__ . '/full-site-editing/blocks/site-description/index.php';
-	require_once __DIR__ . '/full-site-editing/blocks/site-title/index.php';
-	require_once __DIR__ . '/full-site-editing/blocks/template/index.php';
-	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
-	require_once __DIR__ . '/full-site-editing/templates/class-rest-templates-controller.php';
-	require_once __DIR__ . '/full-site-editing/templates/class-wp-template.php';
-	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
-	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
-	require_once __DIR__ . '/full-site-editing/serialize-block-fallback.php';
-}
-
-/**
- * Whether or not FSE is active.
- * If false, FSE functionality should be disabled.
- *
- * @returns bool True if FSE is active, false otherwise.
- */
-function is_full_site_editing_active() {
-	/**
-	 * There are times when this function is called from the WordPress.com public
-	 * API context. In this case, we need to switch to the correct blog so that
-	 * the functions reference the correct blog context.
-	 */
-	$multisite_id  = apply_filters( 'a8c_fse_get_multisite_id', false );
-	$should_switch = is_multisite() && $multisite_id;
-	if ( $should_switch ) {
-		switch_to_blog( $multisite_id );
-	}
-
-	$is_active = is_site_eligible_for_full_site_editing() && is_theme_supported() && did_insert_template_parts();
-
-	if ( $should_switch ) {
-		restore_current_blog();
-	}
-	return $is_active;
-}
-
-/**
- * Returns the slug for the current theme.
- *
- * This even works for the WordPress.com API context where the current theme is
- * not correct. The filter correctly switches to the correct blog context if
- * that is the case.
- *
- * @return string Theme slug.
- */
-function get_theme_slug() {
-	/**
-	 * Used to get the correct theme in certain contexts.
-	 *
-	 * For example, in the wpcom API context, the theme slug is a8c/public-api,
-	 * so we need to grab the correct one with the filter.
-	 *
-	 * @since 0.7
-	 *
-	 * @param string current theme slug is the default if nothing overrides it.
-	 */
-	return apply_filters( 'a8c_fse_get_theme_slug', get_stylesheet() );
-}
-
-/**
- * Returns a normalized slug for the current theme.
- *
- * In some cases, the theme is located in a subfolder like `pub/maywood`. Use
- * this function to get the slug without the prefix.
- *
- * @param string $theme_slug The raw theme_slug to normalize.
- * @return string Theme slug.
- */
-function normalize_theme_slug( $theme_slug ) {
-	// Normalize the theme slug.
-	if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
-		$theme_slug = substr( $theme_slug, 4 );
-	}
-
-	if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
-		$theme_slug = substr( $theme_slug, 0, -6 );
-	}
-
-	return $theme_slug;
-}
-
-/**
- * Whether or not the site is eligible for FSE. This is essentially a feature
- * gate to disable FSE on some sites which could theoretically otherwise use it.
- *
- * @return bool True if current site is eligible for FSE, false otherwise.
- */
-function is_site_eligible_for_full_site_editing() {
-	/**
-	 * Can be used to disable Full Site Editing functionality.
-	 *
-	 * @since 0.2
-	 *
-	 * @param bool true if Full Site Editing should be disabled, false otherwise.
-	 */
-	return ! apply_filters( 'a8c_disable_full_site_editing', false );
-}
-
-/**
- * Whether or not current theme is enabled for FSE.
- *
- * @return bool True if current theme supports FSE, false otherwise.
- */
-function is_theme_supported() {
-	// Use un-normalized theme slug because get_theme requires the full string.
-	$theme = wp_get_theme( get_theme_slug() );
-	return ! $theme->errors() && in_array( 'full-site-editing', $theme->tags, true );
-}
-
-/**
- * Determines if the template parts have been inserted for the current theme.
- *
- * We want to gate on this check in is_full_site_editing_active so that we don't
- * load FSE for sites which did not get template parts for some reason or another.
- *
- * For example, if a user activates theme A on their site and gets FSE, but then
- * activates theme B which does not have FSE, they will not get FSE flows. If we
- * retroactively add FSE support to theme B, the user should not get FSE flows
- * because their site would be modified. Instead, FSE flows would become active
- * when they specifically take action to re-activate the theme.
- *
- * @return bool True if the template parts have been inserted. False otherwise.
- */
-function did_insert_template_parts() {
-	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
-
-	$theme_slug = normalize_theme_slug( get_theme_slug() );
-	$inserter   = new WP_Template_Inserter( $theme_slug );
-	return $inserter->is_template_data_inserted();
-}
 
 /**
  * Load Posts List Block.
@@ -238,34 +115,6 @@ function load_global_styles() {
 	require_once __DIR__ . '/global-styles/class-global-styles.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
-
-/**
- * Inserts default full site editing data for current theme on plugin/theme activation.
- *
- * We put this here outside of the normal FSE class because FSE is not active
- * until the template parts are inserted. This makes sure we insert the template
- * parts when switching to a theme which supports FSE.
- *
- * This will populate the default header and footer for current theme, and create
- * About and Contact pages. Nothing will populate if the data already exists, or
- * if the theme is unsupported.
- */
-function populate_wp_template_data() {
-	if ( ! is_theme_supported() ) {
-		return;
-	}
-
-	require_once __DIR__ . '/full-site-editing/templates/class-template-image-inserter.php';
-	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
-
-	$theme_slug = normalize_theme_slug( get_theme_slug() );
-
-	$template_inserter = new WP_Template_Inserter( $theme_slug );
-	$template_inserter->insert_default_template_data();
-	$template_inserter->insert_default_pages();
-}
-register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
-add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
 
 /**
  * Add front-end CoBlocks gallery block scripts.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/helpers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/helpers.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Helpers for Full Site Editing.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * NOTE: In most cases, you should NOT use this function. Please use
+ * load_full_site_editing instead. This function should only be used if you need
+ * to include the FSE files somewhere like a script. I.e. if you want to access
+ * a class defined here without needing full FSE functionality.
+ */
+function dangerously_load_full_site_editing_files() {
+	require_once __DIR__ . '/blocks/navigation-menu/index.php';
+	require_once __DIR__ . '/blocks/post-content/index.php';
+	require_once __DIR__ . '/blocks/site-description/index.php';
+	require_once __DIR__ . '/blocks/site-title/index.php';
+	require_once __DIR__ . '/blocks/template/index.php';
+	require_once __DIR__ . '/class-full-site-editing.php';
+	require_once __DIR__ . '/templates/class-rest-templates-controller.php';
+	require_once __DIR__ . '/templates/class-wp-template.php';
+	require_once __DIR__ . '/templates/class-wp-template-inserter.php';
+	require_once __DIR__ . '/templates/class-template-image-inserter.php';
+	require_once __DIR__ . '/serialize-block-fallback.php';
+}
+
+/**
+ * Whether or not FSE is active.
+ * If false, FSE functionality should be disabled.
+ *
+ * @returns bool True if FSE is active, false otherwise.
+ */
+function is_full_site_editing_active() {
+	/**
+	 * There are times when this function is called from the WordPress.com public
+	 * API context. In this case, we need to switch to the correct blog so that
+	 * the functions reference the correct blog context.
+	 */
+	$multisite_id  = apply_filters( 'a8c_fse_get_multisite_id', false );
+	$should_switch = is_multisite() && $multisite_id;
+	if ( $should_switch ) {
+		switch_to_blog( $multisite_id );
+	}
+
+	$is_active = is_site_eligible_for_full_site_editing() && is_theme_supported() && did_insert_template_parts();
+
+	if ( $should_switch ) {
+		restore_current_blog();
+	}
+	return $is_active;
+}
+
+/**
+ * Returns the slug for the current theme.
+ *
+ * This even works for the WordPress.com API context where the current theme is
+ * not correct. The filter correctly switches to the correct blog context if
+ * that is the case.
+ *
+ * @return string Theme slug.
+ */
+function get_theme_slug() {
+	/**
+	 * Used to get the correct theme in certain contexts.
+	 *
+	 * For example, in the wpcom API context, the theme slug is a8c/public-api,
+	 * so we need to grab the correct one with the filter.
+	 *
+	 * @since 0.7
+	 *
+	 * @param string current theme slug is the default if nothing overrides it.
+	 */
+	return apply_filters( 'a8c_fse_get_theme_slug', get_stylesheet() );
+}
+
+/**
+ * Returns a normalized slug for the current theme.
+ *
+ * In some cases, the theme is located in a subfolder like `pub/maywood`. Use
+ * this function to get the slug without the prefix.
+ *
+ * @param string $theme_slug The raw theme_slug to normalize.
+ * @return string Theme slug.
+ */
+function normalize_theme_slug( $theme_slug ) {
+	// Normalize the theme slug.
+	if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
+		$theme_slug = substr( $theme_slug, 4 );
+	}
+
+	if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
+		$theme_slug = substr( $theme_slug, 0, -6 );
+	}
+
+	return $theme_slug;
+}
+
+/**
+ * Whether or not the site is eligible for FSE. This is essentially a feature
+ * gate to disable FSE on some sites which could theoretically otherwise use it.
+ *
+ * @return bool True if current site is eligible for FSE, false otherwise.
+ */
+function is_site_eligible_for_full_site_editing() {
+	/**
+	 * Can be used to disable Full Site Editing functionality.
+	 *
+	 * @since 0.2
+	 *
+	 * @param bool true if Full Site Editing should be disabled, false otherwise.
+	 */
+	return ! apply_filters( 'a8c_disable_full_site_editing', false );
+}
+
+/**
+ * Whether or not current theme is enabled for FSE.
+ *
+ * @return bool True if current theme supports FSE, false otherwise.
+ */
+function is_theme_supported() {
+	// Use un-normalized theme slug because get_theme requires the full string.
+	$theme = wp_get_theme( get_theme_slug() );
+	return ! $theme->errors() && in_array( 'full-site-editing', $theme->tags, true );
+}
+
+/**
+ * Determines if the template parts have been inserted for the current theme.
+ *
+ * We want to gate on this check in is_full_site_editing_active so that we don't
+ * load FSE for sites which did not get template parts for some reason or another.
+ *
+ * For example, if a user activates theme A on their site and gets FSE, but then
+ * activates theme B which does not have FSE, they will not get FSE flows. If we
+ * retroactively add FSE support to theme B, the user should not get FSE flows
+ * because their site would be modified. Instead, FSE flows would become active
+ * when they specifically take action to re-activate the theme.
+ *
+ * @return bool True if the template parts have been inserted. False otherwise.
+ */
+function did_insert_template_parts() {
+	require_once __DIR__ . '/templates/class-wp-template-inserter.php';
+
+	$theme_slug = normalize_theme_slug( get_theme_slug() );
+	$inserter   = new WP_Template_Inserter( $theme_slug );
+	return $inserter->is_template_data_inserted();
+}
+
+/**
+ * Inserts default full site editing data for current theme on plugin/theme activation.
+ *
+ * We put this here outside of the normal FSE class because FSE is not active
+ * until the template parts are inserted. This makes sure we insert the template
+ * parts when switching to a theme which supports FSE.
+ *
+ * This will populate the default header and footer for current theme, and create
+ * About and Contact pages. Nothing will populate if the data already exists, or
+ * if the theme is unsupported.
+ */
+function populate_wp_template_data() {
+	if ( ! is_theme_supported() ) {
+		return;
+	}
+
+	require_once __DIR__ . '/templates/class-template-image-inserter.php';
+	require_once __DIR__ . '/templates/class-wp-template-inserter.php';
+
+	$theme_slug = normalize_theme_slug( get_theme_slug() );
+
+	$template_inserter = new WP_Template_Inserter( $theme_slug );
+	$template_inserter->insert_default_template_data();
+	$template_inserter->insert_default_pages();
+}
+register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
+add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/helpers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/helpers.php
@@ -2,6 +2,10 @@
 /**
  * Helpers for Full Site Editing.
  *
+ * This file is always loaded, so these functions should always exist if the
+ * plugin is activated on the site. (Not to be confused with whether FSE is
+ * active on the site!)
+ *
  * @package A8C\FSE
  */
 


### PR DESCRIPTION
This moves FSE-specific functions into the `full-site-editing` function and out of the main plugin function. Since we are including more and more features in our plugin (and possibly renaming it), it makes sense to remove FSE-specific files out of the function to improve code quality. Plus, this file was getting pretty big anyways :)

Do you have feedback on the filename or location?

#### Testing instructions
Essentially, smoke test everything to do with FSE locally and on your sandbox, paying close attention to template population and the `is_fse_active` stuff.
