### PR TITLE
Fix typo in upgrade intent for install_theme

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -288,7 +288,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			case 'install_plugin':
 				return translate( 'Continue Installing Plugin' );
 			case 'themes':
-			case 'install_themes':
+			case 'install_theme':
 				return translate( 'Continue Installing Theme' );
 		}
 


### PR DESCRIPTION
I missed this one while reviewing https://github.com/Automattic/wp-calypso/pull/38199, the upgrade intent should be the singular `install_theme` to match how the `isSimplified` prop is determined: https://github.com/automattic/wp-calypso/blob/05ea6bad5f05738690bf8e8922e4e1a1c3d6a3fd/client/my-sites/checkout/checkout-thank-you/index.jsx#L650

#### Changes proposed in this Pull Request

* Update the upgrade intent check for `install_themes` to be `install_theme`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the steps in https://github.com/Automattic/wp-calypso/pull/38199 (however since this isn't currently visible to a user, it likely doesn't need to be tested exhaustively)
