### PR TITLE
Move Jetpack Backup landing page link from selector to formatted header

### DIFF
--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -45,7 +45,6 @@ The following props can be passed to the Product Selector block:
 	* `title`: ( string ) Product title.
 	* `description`: ( string ) Product description.
 	* `id`: ( string ) Product ID.
-	* `landingPageUrl`: ( string ) URL of the landing page for more information about the product.
 	* `options`: ( object ) Product options. Each option has the billing interval as a key, and the value is an array with corresponding product slugs. Example:
 		```
 		options: {

--- a/client/blocks/product-selector/docs/example.jsx
+++ b/client/blocks/product-selector/docs/example.jsx
@@ -13,14 +13,8 @@ import ProductSelector from '../';
 const products = [
 	{
 		title: 'Jetpack Backup',
-		description: (
-			<Fragment>
-				Always-on backups ensure you never lose your site. Choose from real-time or daily backups.{ ' ' }
-				<a href="https://jetpack.com/upgrade/backup/" target="_blank" rel="noopener noreferrer">
-					Which one do I need?
-				</a>
-			</Fragment>
-		),
+		description:
+			'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.',
 		id: 'jetpack_backup',
 		options: {
 			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -12,14 +12,12 @@ import { recordTracksEvent } from 'state/analytics/actions';
 /**
  * Internal dependencies
  */
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import ProductCard from 'components/product-card';
 import ProductCardAction from 'components/product-card/action';
 import ProductCardOptions from 'components/product-card/options';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
-import { addQueryArgs } from 'lib/route';
 import { extractProductSlugs, filterByProductSlugs } from './utils';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -42,7 +40,6 @@ export class ProductSelector extends Component {
 				title: PropTypes.string,
 				id: PropTypes.string,
 				description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
-				landingPageUrl: PropTypes.string,
 				options: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.string ) ).isRequired,
 				optionDescriptions: PropTypes.objectOf(
 					PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] )
@@ -172,7 +169,6 @@ export class ProductSelector extends Component {
 	}
 
 	getDescriptionByProduct( product ) {
-		const { basePlansPath, selectedSiteSlug, translate } = this.props;
 		const { description, optionDescriptions } = product;
 		const purchase = this.getPurchaseByProduct( product );
 
@@ -187,34 +183,8 @@ export class ProductSelector extends Component {
 			return optionDescriptions[ planProductSlug ];
 		}
 
-		// Default product description, without a landing page link.
-		let linkUrl = product.landingPageUrl;
-		if ( ! linkUrl || !! basePlansPath ) {
-			return description;
-		}
-
-		// If we have a site in this context, add it to the landing page URL.
-		if ( selectedSiteSlug ) {
-			linkUrl = addQueryArgs( { site: selectedSiteSlug }, linkUrl );
-		}
-
-		// Default product description, with a link to the landing page appended to it.
-		return (
-			<Fragment>
-				{ description }{ ' ' }
-				<ExternalLinkWithTracking
-					href={ linkUrl }
-					tracksEventName="calypso_plan_link_click"
-					tracksEventProps={ {
-						link_location: 'product_jetpack_backup_description',
-						link_slug: 'which-one-do-i-need',
-					} }
-					icon
-				>
-					{ translate( 'Which one do I need?' ) }
-				</ExternalLinkWithTracking>
-			</Fragment>
-		);
+		// Default product description.
+		return description;
 	}
 
 	getProductName( product, productSlug ) {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -624,6 +624,17 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		margin-bottom: 8px;
 	}
 
+	.formatted-header a {
+		color: var( --color-neutral-20 );
+		text-decoration: underline;
+
+		&:hover,
+		&:focus {
+			color: var( --color-primary-20 );
+			text-decoration: underline;
+		}
+	}
+
 	.jetpack-connect__happychat-button {
 		text-align: center;
 	}

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -101,6 +101,8 @@ export const JETPACK_BACKUP_PRODUCT_DESCRIPTIONS = {
 	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION,
 };
 
+export const JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/backup/';
+
 export const JETPACK_PRODUCT_PRICE_MATRIX = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: {
 		relatedProduct: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
@@ -117,7 +119,6 @@ export const JETPACK_PRODUCTS = [
 		title: translate( 'Jetpack Backup' ),
 		description: PRODUCT_JETPACK_BACKUP_DESCRIPTION,
 		id: PRODUCT_JETPACK_BACKUP,
-		landingPageUrl: 'https://jetpack.com/upgrade/backup/',
 		options: {
 			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
 			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,

--- a/client/my-sites/plans-features-main/header.jsx
+++ b/client/my-sites/plans-features-main/header.jsx
@@ -1,24 +1,122 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 
-const PlansFeaturesMainHeader = ( { heading, subhead } ) => (
-	<div className="plans-features-main__header">
-		<h2 className="plans-features-main__heading">{ heading }</h2>
-		{ subhead && <p className="plans-features-main__subhead">{ subhead }</p> }
-	</div>
-);
+/**
+ * Internal dependencies
+ */
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+import FormattedHeader from 'components/formatted-header';
+import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
+import { getSitePurchases } from 'state/purchases/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { planHasFeature } from 'lib/plans';
+import { isJetpackBackup } from 'lib/products-values';
+import {
+	JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL,
+	JETPACK_BACKUP_PRODUCTS,
+} from 'lib/products-values/constants';
+import { addQueryArgs } from 'lib/route';
+import QuerySitePlans from 'components/data/query-site-plans';
+import QuerySitePurchases from 'components/data/query-site-purchases';
+
+class PlansFeaturesMainHeader extends Component {
+	siteHasJetpackBackup() {
+		const { purchases } = this.props;
+
+		if ( isEmpty( purchases ) ) {
+			return false;
+		}
+
+		// Search through purchased products for Jetpack Backup.
+		return ! isEmpty(
+			purchases.find( purchase => purchase.active && isJetpackBackup( purchase ) )
+		);
+	}
+
+	planHasJetpackBackup() {
+		const { sitePlanSlug } = this.props;
+
+		if ( ! sitePlanSlug ) {
+			return false;
+		}
+
+		// Check if the current site plan has a backup feature.
+		return ! isEmpty(
+			JETPACK_BACKUP_PRODUCTS.find( productSlug => planHasFeature( sitePlanSlug, productSlug ) )
+		);
+	}
+
+	getSubHeader() {
+		const { siteSlug, translate } = this.props;
+		const baseCopy = translate( "Just looking for a backups? We've got you covered." );
+
+		// Don't render a link if a user already has a Jetpack Backup product or a plan with a backup feature.
+		if ( this.siteHasJetpackBackup() || this.planHasJetpackBackup() ) {
+			return baseCopy;
+		}
+
+		// If we have a site in this context, add it to the landing page URL.
+		const linkUrl = siteSlug
+			? addQueryArgs( { site: siteSlug }, JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL )
+			: JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL;
+
+		return (
+			<Fragment>
+				{ baseCopy }
+				<br />
+				<ExternalLinkWithTracking
+					href={ linkUrl }
+					tracksEventName="calypso_plan_link_click"
+					tracksEventProps={ {
+						link_location: 'product_jetpack_backup_description',
+						link_slug: 'which-one-do-i-need',
+					} }
+					icon
+				>
+					{ translate( 'Which backup option is best for me?' ) }
+				</ExternalLinkWithTracking>
+			</Fragment>
+		);
+	}
+
+	render() {
+		const { selectedSiteId, translate } = this.props;
+
+		return (
+			<Fragment>
+				<QuerySitePlans siteId={ selectedSiteId } />
+				<QuerySitePurchases siteId={ selectedSiteId } />
+				<FormattedHeader
+					headerText={ translate( 'Solutions' ) }
+					subHeaderText={ this.getSubHeader() }
+					compactOnMobile
+					isSecondary
+				/>
+			</Fragment>
+		);
+	}
+}
 
 PlansFeaturesMainHeader.propTypes = {
-	heading: PropTypes.string.isRequired,
-	subhead: PropTypes.string,
+	purchases: PropTypes.array,
+	siteId: PropTypes.number,
+	sitePlanSlug: PropTypes.string,
+	siteSlug: PropTypes.string,
 };
 
-PlansFeaturesMainHeader.defaultProps = {
-	heading: '',
-	subhead: null,
-};
+export default connect( ( state, { siteId } ) => {
+	const selectedSiteId = siteId || getSelectedSiteId( state );
 
-export default PlansFeaturesMainHeader;
+	return {
+		purchases: getSitePurchases( state, selectedSiteId ),
+		selectedSiteId,
+		sitePlanSlug: getSitePlanSlug( state, selectedSiteId ),
+		siteSlug: getSiteSlug( state, selectedSiteId ),
+	};
+} )( localize( PlansFeaturesMainHeader ) );

--- a/client/my-sites/plans-features-main/header.jsx
+++ b/client/my-sites/plans-features-main/header.jsx
@@ -105,7 +105,7 @@ class PlansFeaturesMainHeader extends Component {
 
 PlansFeaturesMainHeader.propTypes = {
 	purchases: PropTypes.array,
-	siteId: PropTypes.number,
+	selectedSiteId: PropTypes.number,
 	sitePlanSlug: PropTypes.string,
 	siteSlug: PropTypes.string,
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -35,7 +35,7 @@ import {
 } from 'lib/products-values/constants';
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
-import PlansFeaturesMainHeader from './header';
+import PlansFeaturesMainProductsHeader from './products-header';
 import WpcomFAQ from './wpcom-faq';
 import CartData from 'components/data/cart';
 import QueryPlans from 'components/data/query-plans';
@@ -444,7 +444,7 @@ export class PlansFeaturesMain extends Component {
 
 		return (
 			<div className="plans-features-main__group is-narrow">
-				<PlansFeaturesMainHeader />
+				<PlansFeaturesMainProductsHeader />
 				<AsyncLoad
 					require="blocks/product-plan-overlap-notices"
 					placeholder={ null }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -444,20 +444,20 @@ export class PlansFeaturesMain extends Component {
 		const { purchases, sitePlanSlug } = this.props;
 
 		// Search through purchased products.
-		const hasJetpackBackup =
+		if (
 			! isEmpty( purchases ) &&
-			! isEmpty( purchases.find( purchase => purchase.active && isJetpackBackup( purchase ) ) );
-		if ( hasJetpackBackup ) {
+			! isEmpty( purchases.find( purchase => purchase.active && isJetpackBackup( purchase ) ) )
+		) {
 			return true;
 		}
 
 		// Check if the current site plan has a backup feature.
-		const planHasJetpackBackup =
+		if (
 			sitePlanSlug &&
 			! isEmpty(
 				JETPACK_BACKUP_PRODUCTS.find( productSlug => planHasFeature( sitePlanSlug, productSlug ) )
-			);
-		if ( planHasJetpackBackup ) {
+			)
+		) {
 			return true;
 		}
 

--- a/client/my-sites/plans-features-main/products-header.jsx
+++ b/client/my-sites/plans-features-main/products-header.jsx
@@ -12,20 +12,17 @@ import { isEmpty } from 'lodash';
  */
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 import FormattedHeader from 'components/formatted-header';
-import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { planHasFeature } from 'lib/plans';
 import { isJetpackBackup } from 'lib/products-values';
-import {
-	JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL,
-	JETPACK_BACKUP_PRODUCTS,
-} from 'lib/products-values/constants';
+import { JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL } from 'lib/products-values/constants';
 import { addQueryArgs } from 'lib/route';
+import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 
-class PlansFeaturesMainHeader extends Component {
+class PlansFeaturesMainProductsHeader extends Component {
 	siteHasJetpackBackup() {
 		const { purchases } = this.props;
 
@@ -39,25 +36,12 @@ class PlansFeaturesMainHeader extends Component {
 		);
 	}
 
-	planHasJetpackBackup() {
-		const { sitePlanSlug } = this.props;
-
-		if ( ! sitePlanSlug ) {
-			return false;
-		}
-
-		// Check if the current site plan has a backup feature.
-		return ! isEmpty(
-			JETPACK_BACKUP_PRODUCTS.find( productSlug => planHasFeature( sitePlanSlug, productSlug ) )
-		);
-	}
-
 	getSubHeader() {
 		const { siteSlug, translate } = this.props;
 		const baseCopy = translate( "Just looking for a backups? We've got you covered." );
 
 		// Don't render a link if a user already has a Jetpack Backup product or a plan with a backup feature.
-		if ( this.siteHasJetpackBackup() || this.planHasJetpackBackup() ) {
+		if ( this.siteHasJetpackBackup() ) {
 			return baseCopy;
 		}
 
@@ -90,6 +74,7 @@ class PlansFeaturesMainHeader extends Component {
 
 		return (
 			<Fragment>
+				<QueryPlans />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				<QuerySitePurchases siteId={ selectedSiteId } />
 				<FormattedHeader
@@ -103,10 +88,9 @@ class PlansFeaturesMainHeader extends Component {
 	}
 }
 
-PlansFeaturesMainHeader.propTypes = {
+PlansFeaturesMainProductsHeader.propTypes = {
 	purchases: PropTypes.array,
 	selectedSiteId: PropTypes.number,
-	sitePlanSlug: PropTypes.string,
 	siteSlug: PropTypes.string,
 };
 
@@ -116,7 +100,6 @@ export default connect( ( state, { siteId } ) => {
 	return {
 		purchases: getSitePurchases( state, selectedSiteId ),
 		selectedSiteId,
-		sitePlanSlug: getSitePlanSlug( state, selectedSiteId ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),
 	};
-} )( localize( PlansFeaturesMainHeader ) );
+} )( localize( PlansFeaturesMainProductsHeader ) );

--- a/client/my-sites/plans-features-main/products-header.jsx
+++ b/client/my-sites/plans-features-main/products-header.jsx
@@ -14,21 +14,18 @@ import { addQueryArgs } from 'lib/route';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 import FormattedHeader from 'components/formatted-header';
 import { getSiteSlug } from 'state/sites/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
+import { getSitePurchases, isFetchingSitePurchases } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackBackup } from 'lib/products-values';
 import { JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL } from 'lib/products-values/constants';
-import QueryPlans from 'components/data/query-plans';
-import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 
 class PlansFeaturesMainProductsHeader extends Component {
 	static propTypes = {
-		siteId: PropTypes.number,
-
 		// Connected props
+		isFetching: PropTypes.bool,
 		purchases: PropTypes.array,
-		selectedSiteId: PropTypes.number,
+		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 
 		// From localize() HoC
@@ -47,11 +44,11 @@ class PlansFeaturesMainProductsHeader extends Component {
 	}
 
 	getSubHeader() {
-		const { siteSlug, translate } = this.props;
+		const { isFetching, siteSlug, translate } = this.props;
 		const baseCopy = translate( "Just looking for a backups? We've got you covered." );
 
 		// Don't render a link if a user already has a Jetpack Backup product or a plan with a backup feature.
-		if ( this.siteHasJetpackBackup() ) {
+		if ( isFetching || this.siteHasJetpackBackup() ) {
 			return baseCopy;
 		}
 
@@ -80,13 +77,11 @@ class PlansFeaturesMainProductsHeader extends Component {
 	}
 
 	render() {
-		const { selectedSiteId, translate } = this.props;
+		const { siteId, translate } = this.props;
 
 		return (
 			<Fragment>
-				<QueryPlans />
-				<QuerySitePlans siteId={ selectedSiteId } />
-				<QuerySitePurchases siteId={ selectedSiteId } />
+				<QuerySitePurchases siteId={ siteId } />
 				<FormattedHeader
 					headerText={ translate( 'Solutions' ) }
 					subHeaderText={ this.getSubHeader() }
@@ -98,12 +93,13 @@ class PlansFeaturesMainProductsHeader extends Component {
 	}
 }
 
-export default connect( ( state, { siteId } ) => {
-	const selectedSiteId = siteId || getSelectedSiteId( state );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
 
 	return {
-		purchases: getSitePurchases( state, selectedSiteId ),
-		selectedSiteId,
-		siteSlug: getSiteSlug( state, selectedSiteId ),
+		isFetching: isFetchingSitePurchases( state ),
+		purchases: getSitePurchases( state, siteId ),
+		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( localize( PlansFeaturesMainProductsHeader ) );

--- a/client/my-sites/plans-features-main/products-header.jsx
+++ b/client/my-sites/plans-features-main/products-header.jsx
@@ -4,12 +4,13 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { isEmpty, some } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { addQueryArgs } from 'lib/route';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 import FormattedHeader from 'components/formatted-header';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -17,12 +18,23 @@ import { getSitePurchases } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackBackup } from 'lib/products-values';
 import { JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL } from 'lib/products-values/constants';
-import { addQueryArgs } from 'lib/route';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 
 class PlansFeaturesMainProductsHeader extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+
+		// Connected props
+		purchases: PropTypes.array,
+		selectedSiteId: PropTypes.number,
+		siteSlug: PropTypes.string,
+
+		// From localize() HoC
+		translate: PropTypes.func.isRequired,
+	};
+
 	siteHasJetpackBackup() {
 		const { purchases } = this.props;
 
@@ -31,9 +43,7 @@ class PlansFeaturesMainProductsHeader extends Component {
 		}
 
 		// Search through purchased products for Jetpack Backup.
-		return ! isEmpty(
-			purchases.find( purchase => purchase.active && isJetpackBackup( purchase ) )
-		);
+		return some( purchases, purchase => purchase.active && isJetpackBackup( purchase ) );
 	}
 
 	getSubHeader() {
@@ -87,12 +97,6 @@ class PlansFeaturesMainProductsHeader extends Component {
 		);
 	}
 }
-
-PlansFeaturesMainProductsHeader.propTypes = {
-	purchases: PropTypes.array,
-	selectedSiteId: PropTypes.number,
-	siteSlug: PropTypes.string,
-};
 
 export default connect( ( state, { siteId } ) => {
 	const selectedSiteId = siteId || getSelectedSiteId( state );


### PR DESCRIPTION
As part of the work related to p1HpG7-87V-p2, this PR moves the link to Jetpack Backup landing page from `ProductSelector` to `FormattedHeader`.

**Before**
<img width="557" alt="Screenshot 2019-12-10 at 13 02 41" src="https://user-images.githubusercontent.com/478735/70527959-5f170f80-1b4d-11ea-817d-ec434ef3c360.png">

**After**
<img width="563" alt="Screenshot 2019-12-10 at 13 02 08" src="https://user-images.githubusercontent.com/478735/70527918-4b6ba900-1b4d-11ea-89ec-cfe3ddea2991.png">

#### Changes proposed in this Pull Request

* Move Jetpack Backup landing page link from selector to formatted header

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/plans/ and select a Jetpack site having no Jetpack Backup product
* Confirm that the link to the landing page is now located in the header and not inside the products selector.
* Purchase one of the Backup products and confirm that there's no link displayed on 
http://calypso.localhost:3000/plans/ for the Jetpack site.
* Remove the previously purchased Backup product and purchase one of the paid plans. Confirm that there's still no link displayed on http://calypso.localhost:3000/plans/ for the Jetpack site.

Fixes n/a
