### PR TITLE
Composite Checkout: Fix test setup

### DIFF
--- a/packages/composite-checkout-wpcom/jest.config.js
+++ b/packages/composite-checkout-wpcom/jest.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-	rootDir: __dirname,
-	testMatch: [ '**/test/**/*.[jt]s?(x)' ],
-	modulePathIgnorePatterns: [ 'enzyme-adapter.js' ],
-};
+module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };

--- a/packages/composite-checkout-wpcom/test/enzyme-adapter.js
+++ b/packages/composite-checkout-wpcom/test/enzyme-adapter.js
@@ -1,8 +1,0 @@
-/**
- * External dependencies
- */
-import { configure, shallow, mount, render } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-configure( { adapter: new Adapter() } );
-export { shallow, mount, render };

--- a/packages/composite-checkout-wpcom/test/wp-checkout-wrapper.js
+++ b/packages/composite-checkout-wpcom/test/wp-checkout-wrapper.js
@@ -1,4 +1,7 @@
 /**
+ * @jest-environment jsdom
+ */
+/**
  * External dependencies
  */
 import React from 'react';

--- a/packages/composite-checkout/jest.config.js
+++ b/packages/composite-checkout/jest.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-	rootDir: __dirname,
-	testMatch: [ '**/test/**/*.[jt]s?(x)' ],
-	modulePathIgnorePatterns: [ 'enzyme-adapter.js' ],
-};
+module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };

--- a/packages/composite-checkout/test/components/checkout-step.js
+++ b/packages/composite-checkout/test/components/checkout-step.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { shallow } from '../enzyme-adapter';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies

--- a/packages/composite-checkout/test/enzyme-adapter.js
+++ b/packages/composite-checkout/test/enzyme-adapter.js
@@ -1,8 +1,0 @@
-/**
- * External dependencies
- */
-import { configure, shallow, mount, render } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-configure( { adapter: new Adapter() } );
-export { shallow, mount, render };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Needed to make #38308 work.

`composite-checkout` currently duplicates a lot of test configuration that's readily available from `@automattic/calypso-build`. This PR updates it to make use of the latter.

The previous setup was causing trouble with #38308. Specifically, when tests were run in `composite-checkout`, they would somehow also test other packages, such as `@automattic/components`, and specifically, its `dist/cjs/` subfolder, which at build time contains code transpiled to CommonJS, with style imports (`import './style.scss'`) transpiled to CJS (`require( './style.scss' )`). Naturally, the latter didn't work with Jest.

I'm not totally clear about the exact error on #38308, though I've seen that sort of test directory spillage before. This PR streamlines Jest tooling by re-using stuff from `calypso-build` as much as possible, much like our other packages do -- and as a side effect, it makes #38308 work.

_Edit:_ I think [this](https://github.com/Automattic/wp-calypso/pull/35811/commits/881c31edea52ba3a7b62a24985fe522cae02aae7) is the relevant commit that fixed the same issue for `calypso-build`, which we're reusing here.

#### Testing instructions

```
npm run test-packages -- --clearCache && npm run test-packages
```

Passes?
