### PR TITLE
Add support for globalThis.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,7 @@ module.exports = {
 		// allow the browser globals. ESLint's `browser` env is too permissive and allows referencing
 		// directly hundreds of properties that are available on `window` and `document`. That
 		// frequently caused bugs where we used an undefined variable and ESLint didn't warn us.
+		globalThis: true,
 		window: true,
 		document: true,
 		// this is our custom function that's transformed by babel into either a dynamic import or a normal require

--- a/client/boot/polyfills.js
+++ b/client/boot/polyfills.js
@@ -6,6 +6,7 @@ import svg4everybody from 'svg4everybody';
 import '@webcomponents/url';
 import URLSearchParamsPolyfill from '@ungap/url-search-params';
 import 'isomorphic-fetch';
+import 'globalthis/auto';
 
 /**
  * Internal dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -468,6 +468,7 @@
 				"@emotion/core": "10.0.22",
 				"@emotion/styled": "10.0.23",
 				"@wordpress/data": "^4.9.2",
+				"debug": "4.1.1",
 				"emotion-theming": "10.0.19",
 				"i18n-calypso": "file:packages/i18n-calypso",
 				"prop-types": "^15.7.2",
@@ -675,15 +676,15 @@
 						"to-fast-properties": "^2.0.0"
 					}
 				},
-				"jsesc": {
-                  "version": "2.5.2",
-                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                  "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
-                },
 				"find-up": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 				},
 				"json5": {
 					"version": "2.1.1",
@@ -14067,6 +14068,16 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
+		"globalthis": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.0.tgz",
+			"integrity": "sha512-vcCAZTJ3r5Qcu5l8/2oyVdoFwxKgfYnMTR2vwWeux/NAVZK3PwcMaWkdUIn4GJbmKuRK7xcvDsLuK+CKcXyodg==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"object-keys": "^1.0.12"
+			}
+		},
 		"globby": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
@@ -19953,7 +19964,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
@@ -19962,7 +19973,7 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
@@ -19971,7 +19982,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
@@ -20014,7 +20025,7 @@
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
 		"fuse.js": "3.4.6",
 		"get-video-id": "3.1.4",
 		"gfm-code-blocks": "1.0.0",
+		"globalthis": "1.0.0",
 		"globby": "10.0.1",
 		"gridicons": "3.3.1",
 		"gzip-size": "5.1.1",


### PR DESCRIPTION
Adds a polyfill to support `globalThis` everywhere, and enables it as a global in ESLint.

Unfortunately, this polyfill needs to be shipped with the evergreen build, since Edge and Opera don't yet have support for `globalThis`, according to `caniuse`.

#### Changes proposed in this Pull Request

* Add `globalthis` dependency to serve as a polyfill for `globalThis`
* Run polyfill on boot
* Modify ESLint configuration to allow for `globalThis`

#### Testing instructions

No specific testing instructions beyond ensuring that Calypso continues to build and work correctly. You can also fork this branch and test things locally:
a) Ensure that your IDE (if any) doesn't show any ESLint errors for `globalThis` usage
b) Ensure that `globalThis` usage doesn't throw any errors