### PR TITLE
FSE: Update block switch nudge text

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -71,7 +71,7 @@ registerBlockType( metadata.name, {
 						isDismissible={ false }
 					>
 						{ __(
-							'An improved version of this block is available. Update for a better, more natural way to manage your blog post listings.',
+							'An improved version of this block is available. Update for a better, more natural way to manage your blog post listings. There may be small visual changes.',
 							'full-site-editing'
 						) }
 					</Notice>

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/index.js
@@ -63,7 +63,7 @@ registerBlockType( metadata.name, {
 					<Notice
 						actions={ [
 							{
-								label: __( 'Upgrade Block', 'full-site-editing' ),
+								label: __( 'Update Block', 'full-site-editing' ),
 								onClick: upgradeBlock,
 							},
 						] }
@@ -71,7 +71,7 @@ registerBlockType( metadata.name, {
 						isDismissible={ false }
 					>
 						{ __(
-							'An improved version of this block is available. Upgrade for a better, more natural way to manage your blog post listings.',
+							'An improved version of this block is available. Update for a better, more natural way to manage your blog post listings.',
 							'full-site-editing'
 						) }
 					</Notice>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update nudge text to remove mentions of upgrading which are more than often connected with some sort of payment or a paid plan change. 

#### Testing instructions

* Connect FSE to your WP dev env
* Build FSE `lerna run build --scope='@automattic/full-site-editing' --stream`
* In the editor, insert "Blog Posts Listing" block and observe the blue Notice
* It should no longer say "Upgrade" anywhere

#### Screenshot Before

<img width="722" alt="Screenshot 2019-12-10 at 15 00 09" src="https://user-images.githubusercontent.com/156676/70535701-cc32a100-1b5d-11ea-8656-119925029f48.png">

#### Screenshot After

<img width="722" alt="Screenshot 2019-12-10 at 15 00 51" src="https://user-images.githubusercontent.com/156676/70535741-df457100-1b5d-11ea-8611-500bf456af7e.png">
