### PR TITLE
Activity Log: Consider Backup products when displaying intro banner

### DIFF
--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -13,6 +13,7 @@ import { Button } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import DismissibleCard from 'blocks/dismissible-card';
 import ExternalLink from 'components/external-link';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import {
 	FEATURE_JETPACK_ESSENTIAL,
 	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -23,6 +24,7 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { isFreePlan } from 'lib/plans';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { siteHasBackupProductPurchase } from 'state/purchases/selectors';
 
 /**
  * Style dependencies
@@ -43,7 +45,7 @@ class IntroBanner extends Component {
 	recordDismiss = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_dismiss' );
 
 	renderCardContent() {
-		const { siteIsJetpack, siteIsOnFreePlan, siteSlug, translate } = this.props;
+		const { siteIsJetpack, siteHasBackup, siteSlug, translate } = this.props;
 		const upgradePlan = siteIsJetpack ? PLAN_JETPACK_PERSONAL_MONTHLY : PLAN_PERSONAL;
 		const upgradeFeature = siteIsJetpack
 			? FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY
@@ -57,7 +59,7 @@ class IntroBanner extends Component {
 					) }
 				</p>
 				<p>
-					{ siteIsOnFreePlan
+					{ ! siteHasBackup
 						? translate(
 								'With your free plan, you can monitor the 20 most recent ' +
 									'events. A paid plan unlocks more powerful features. ' +
@@ -79,7 +81,7 @@ class IntroBanner extends Component {
 					</ExternalLink>
 				</p>
 
-				{ siteIsOnFreePlan && (
+				{ ! siteHasBackup && (
 					<Button
 						className="activity-log-banner__intro-button"
 						href={ `/plans/${ siteSlug }?feature=${ upgradeFeature }&plan=${ upgradePlan }` }
@@ -93,36 +95,46 @@ class IntroBanner extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { siteId, translate } = this.props;
+
 		return (
-			<DismissibleCard
-				preferenceName="activity-introduction-banner"
-				className="activity-log-banner__intro"
-				onClick={ this.recordDismiss }
-			>
-				<img
-					className="activity-log-banner__intro-image"
-					src={ activityImage }
-					alt={ translate( 'Activity' ) }
-				/>
-				<div className="activity-log-banner__intro-description">
-					<CardHeading tagName="h1" size={ 24 }>
-						{ translate( 'Welcome to your site’s activity' ) }
-					</CardHeading>
-					{ this.renderCardContent() }
-				</div>
-			</DismissibleCard>
+			<Fragment>
+				<QuerySitePurchases siteId={ siteId } />
+
+				<DismissibleCard
+					preferenceName="activity-introduction-banner"
+					className="activity-log-banner__intro"
+					onClick={ this.recordDismiss }
+				>
+					<img
+						className="activity-log-banner__intro-image"
+						src={ activityImage }
+						alt={ translate( 'Activity' ) }
+					/>
+					<div className="activity-log-banner__intro-description">
+						<CardHeading tagName="h1" size={ 24 }>
+							{ translate( 'Welcome to your site’s activity' ) }
+						</CardHeading>
+						{ this.renderCardContent() }
+					</div>
+				</DismissibleCard>
+			</Fragment>
 		);
 	}
 }
 
 export default connect(
-	( state, { siteId } ) => ( {
-		siteId,
-		siteIsJetpack: isJetpackSite( state, siteId ),
-		siteIsOnFreePlan: isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ),
-		siteSlug: getSiteSlug( state, siteId ),
-	} ),
+	( state, { siteId } ) => {
+		const siteIsOnFreePlan = isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) );
+		const hasBackupPurchase = siteHasBackupProductPurchase( state, siteId );
+
+		return {
+			siteId,
+			siteIsJetpack: isJetpackSite( state, siteId ),
+			siteHasBackup: ! siteIsOnFreePlan || hasBackupPurchase,
+			siteSlug: getSiteSlug( state, siteId ),
+		};
+	},
 	{
 		recordTracksEvent,
 	}

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -6,7 +6,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, includes, isEmpty, isEqual, some } from 'lodash';
+import { find, get, includes, isEmpty, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,6 @@ import Filterbar from '../filterbar';
 import UpgradeBanner from '../activity-log-banner/upgrade-banner';
 import IntroBanner from '../activity-log-banner/intro-banner';
 import { isFreePlan } from 'lib/plans';
-import { isJetpackBackup } from 'lib/products-values';
 import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
@@ -44,7 +43,7 @@ import FormattedHeader from 'components/formatted-header';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import RewindUnavailabilityNotice from './rewind-unavailability-notice';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
+import { siteHasBackupProductPurchase } from 'state/purchases/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSiteSlug, getSiteTitle, isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
@@ -565,10 +564,6 @@ class ActivityLog extends Component {
 
 const emptyList = [];
 
-const hasBackupProduct = purchases => {
-	return some( purchases, purchase => purchase.active && isJetpackBackup( purchase ) );
-};
-
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
@@ -583,8 +578,7 @@ export default connect(
 		const siteIsOnFreePlan =
 			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
 			! isVipSite( state, siteId );
-		const purchases = getSitePurchases( state, siteId );
-		const siteHasNoLog = siteIsOnFreePlan && ! hasBackupProduct( purchases );
+		const siteHasNoLog = siteIsOnFreePlan && ! siteHasBackupProductPurchase( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 
 		return {

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -70,6 +70,13 @@ export const getByPurchaseId = ( state, purchaseId ) =>
 export const getSitePurchases = ( state, siteId ) =>
 	getPurchases( state ).filter( purchase => purchase.siteId === siteId );
 
+/**
+ * Whether a site has an active Jetpack backup purchase.
+ *
+ * @param   {object} state       global state
+ * @param   {number} siteId      the site id
+ * @returns {boolean} True if the site has an active Jetpack Backup purchase, false otherwise.
+ */
 export const siteHasBackupProductPurchase = ( state, siteId ) => {
 	return some(
 		getSitePurchases( state, siteId ),

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find } from 'lodash';
+import { get, find, some } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,6 +13,7 @@ import {
 	getIncludedDomainPurchaseAmount,
 	isDomainRegistration,
 	isDomainMapping,
+	isJetpackBackup,
 } from 'lib/products-values';
 import { getPlan, findPlansKeys } from 'lib/plans';
 import { TYPE_PERSONAL } from 'lib/plans/constants';
@@ -65,6 +66,13 @@ export const getByPurchaseId = ( state, purchaseId ) =>
  */
 export const getSitePurchases = ( state, siteId ) =>
 	getPurchases( state ).filter( purchase => purchase.siteId === siteId );
+
+export const siteHasBackupProductPurchase = ( state, siteId ) => {
+	return some(
+		getSitePurchases( state, siteId ),
+		purchase => purchase.active && isJetpackBackup( purchase )
+	);
+};
 
 /***
  * Returns a purchase object that corresponds to that subscription's included domain

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -21,8 +21,8 @@ import { getPlanRawPrice } from 'state/plans/selectors';
 /**
  * Return the list of purchases from state object
  *
- * @param {Object} state - current state object
- * @return {Array} Purchases
+ * @param   {object} state - current state object
+ * @returns {Array} Purchases
  */
 export const getPurchases = createSelector(
 	state => createPurchasesArray( state.purchases.data ),
@@ -31,9 +31,10 @@ export const getPurchases = createSelector(
 
 /**
  * Returns a list of Purchases associated with a User from the state using its userId
- * @param  {Object} state       global state
- * @param  {Number} userId      the user id
- * @return {Object} the matching purchases if there are some
+ *
+ * @param   {object} state       global state
+ * @param   {number} userId      the user id
+ * @returns {object} the matching purchases if there are some
  */
 export const getUserPurchases = ( state, userId ) =>
 	state.purchases.hasLoadedUserPurchasesFromServer &&
@@ -42,16 +43,17 @@ export const getUserPurchases = ( state, userId ) =>
 /**
  * Returns the server error for site or user purchases (if there is one)
  *
- * @param {Object} state - current state object
- * @return {Object} an error object from the server
+ * @param   {object} state - current state object
+ * @returns {object} an error object from the server
  */
 export const getPurchasesError = state => get( state, 'purchases.error', '' );
 
 /**
  * Returns a Purchase object from the state using its id
- * @param  {Object} state       global state
- * @param  {Number} purchaseId  the purchase id
- * @return {Object} the matching purchase if there is one
+ *
+ * @param   {object} state       global state
+ * @param   {number} purchaseId  the purchase id
+ * @returns {object} the matching purchase if there is one
  */
 export const getByPurchaseId = ( state, purchaseId ) =>
 	getPurchases( state )
@@ -60,9 +62,10 @@ export const getByPurchaseId = ( state, purchaseId ) =>
 
 /**
  * Returns a list of Purchases associated with a Site from the state using its siteId
- * @param  {Object} state       global state
- * @param  {Number} siteId      the site id
- * @return {Object} the matching purchases if there are some
+ *
+ * @param   {object} state       global state
+ * @param   {number} siteId      the site id
+ * @returns {object} the matching purchases if there are some
  */
 export const getSitePurchases = ( state, siteId ) =>
 	getPurchases( state ).filter( purchase => purchase.siteId === siteId );
@@ -74,16 +77,16 @@ export const siteHasBackupProductPurchase = ( state, siteId ) => {
 	);
 };
 
-/***
+/**
  * Returns a purchase object that corresponds to that subscription's included domain
  *
  * Even if a domain registration was purchased with the subscription, it will
  * not be returned if the domain product was paid for separately (eg: if it was
  * renewed on its own).
  *
- * @param  {Object} state  global state
- * @param  {Object} subscriptionPurchase  subscription purchase object
- * @return {Object} domain purchase if there is one, null if none found or not a subscription object passed
+ * @param   {object} state  global state
+ * @param   {object} subscriptionPurchase  subscription purchase object
+ * @returns {object} domain purchase if there is one, null if none found or not a subscription object passed
  */
 export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
 	if (
@@ -131,9 +134,10 @@ export const getDowngradePlanRawPrice = ( state, purchase ) => {
 
 /**
  * Does the user have any current purchases?
- * @param  {Object}  state       global state
- * @param  {Number}  userId      the user id
- * @return {Boolean} if the user currently has any purchases.
+ *
+ * @param   {object}  state       global state
+ * @param   {number}  userId      the user id
+ * @returns {boolean} if the user currently has any purchases.
  */
 export const isUserPaid = ( state, userId ) =>
 	state.purchases.hasLoadedUserPurchasesFromServer && 0 < getUserPurchases( state, userId ).length;

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	isFetchingSitePurchases,
 	isFetchingUserPurchases,
 	isUserPaid,
+	siteHasBackupProductPurchase,
 } from '../selectors';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
@@ -190,6 +191,43 @@ describe( 'selectors', () => {
 			expect( result ).toHaveLength( 2 );
 			expect( result[ 0 ].siteId ).toBe( 1234 );
 			expect( result[ 1 ].siteId ).toBe( 1234 );
+		} );
+	} );
+
+	describe( 'siteHasBackupProductPurchase', () => {
+		test( 'should return true if a site has a Jetpack Backup purchase, false otherwise', () => {
+			const state = {
+				purchases: {
+					data: [
+						{
+							ID: '81414',
+							blog_id: '1234',
+							active: true,
+							product_slug: 'jetpack_personal',
+						},
+						{
+							ID: '82867',
+							blog_id: '1234',
+							active: true,
+							product_slug: 'something',
+						},
+						{
+							ID: '105103',
+							blog_id: '123',
+							active: true,
+							product_slug: 'jetpack_backup_daily',
+						},
+					],
+					error: null,
+					isFetchingSitePurchases: true,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false,
+				},
+			};
+
+			expect( siteHasBackupProductPurchase( state, 1234 ) ).toBe( false );
+			expect( siteHasBackupProductPurchase( state, 123 ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
Currently, when displaying the Activity Log intro banner, we will check if the user is on a free plan or not, but we don't consider if a user has purchased a backup product. So in the case where a user has purchased a Backup product but is on free plan, we'll display the banner as if the AL is limited to 20 entries (when really it's not).

This PR fixes this issue by altering the logic to consider the products, too.

#### Changes proposed in this Pull Request

* State: Introduce a `siteHasBackupProductPurchase` selector with tests.
* Activity Log: Update Intro banner to take Backup product into consideration
* Activity Log: Use siteHasBackupProductPurchase selector instead of the obsolete `hasBackupProduct` helper (cc @seear - this can be considered a follow-up of this suggestion - https://github.com/Automattic/wp-calypso/pull/37602/files#r347285791)

#### Preview
Before:
![](https://cldup.com/PLl2lPy7KG.png)

After:
![](https://cldup.com/tIOGqkD_8N.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/activity-log/:site where `:site` is a Jetpack site on a Free plan, with a Jetpack Backup product purchased already.
* Verify that you can see the right wording in the banner.
* If the banner doesn't appear, you can clear your user preference from Calypso's devtools:

![](https://cldup.com/tUuohqwN7q.png)

* Verify the banner still appears properly for all plan/product scenarios, consistently with whether the AL is truncated or not (see #37602 if you need more details on how truncation works).