### PR TITLE
Add getAllStoredItems to lib/browser-storage

### DIFF
--- a/client/lib/browser-storage/bypass.ts
+++ b/client/lib/browser-storage/bypass.ts
@@ -3,6 +3,11 @@
  */
 import debugModule from 'debug';
 
+/**
+ * Internal dependencies
+ */
+import { StoredItems } from './types';
+
 const debug = debugModule( 'calypso:support-user' );
 
 // This module defines a series of methods which bypasse all persistent storage.
@@ -11,7 +16,20 @@ const debug = debugModule( 'calypso:support-user' );
 // a user's data while support-user is active, ensuring it does not contaminate
 // the original user, and vice versa.
 
-const memoryStore = new Map< string, any >();
+const memoryStore = new Map();
+
+export async function getAllStoredItems( pattern?: RegExp ): Promise< StoredItems > {
+	debug( 'browser-storage bypass', 'getAllStoredItems' );
+
+	// TODO: Replace below with Object.fromEntries when it's available (needs core-js@3).
+	const results: StoredItems = {};
+	for ( const [ key, value ] of memoryStore.entries() ) {
+		if ( ! pattern || pattern?.test( key ) ) {
+			results[ key ] = value;
+		}
+	}
+	return results;
+}
 
 export async function getStoredItem< T >( key: string ): Promise< T | undefined > {
 	debug( 'browser-storage bypass', 'getStoredItem', key );

--- a/client/lib/browser-storage/bypass.ts
+++ b/client/lib/browser-storage/bypass.ts
@@ -21,14 +21,14 @@ const memoryStore = new Map();
 export async function getAllStoredItems( pattern?: RegExp ): Promise< StoredItems > {
 	debug( 'browser-storage bypass', 'getAllStoredItems' );
 
-	// TODO: Replace below with Object.fromEntries when it's available (needs core-js@3).
-	const results: StoredItems = {};
-	for ( const [ key, value ] of memoryStore.entries() ) {
-		if ( ! pattern || pattern?.test( key ) ) {
-			results[ key ] = value;
-		}
+	// Return everything.
+	if ( ! pattern ) {
+		return Object.fromEntries( memoryStore.entries() );
 	}
-	return results;
+
+	// Return only the entries that match the pattern.
+	const entries = Array.from( memoryStore.entries() );
+	return Object.fromEntries( entries.filter( ( [ key ] ) => pattern.test( key ) ) );
 }
 
 export async function getStoredItem< T >( key: string ): Promise< T | undefined > {

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -86,14 +86,14 @@ function idbGetAll( pattern?: RegExp ): Promise< StoredItems > {
 				const getAll = transaction.objectStore( STORE_NAME ).openCursor();
 
 				const success = ( event: Event ) => {
-					const cursor = ( event?.target as EventTargetWithCursorResult )?.result;
+					const cursor = ( event.target as EventTargetWithCursorResult ).result;
 					if ( cursor ) {
 						const { primaryKey: key, value } = cursor;
 						if (
 							key &&
 							typeof key === 'string' &&
 							key !== SANITY_TEST_KEY &&
-							( ! pattern || pattern?.test( key ) )
+							( ! pattern || pattern.test( key ) )
 						) {
 							results[ key ] = value;
 						}

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -78,9 +78,9 @@ function idbGet< T >( key: string ): Promise< T | undefined > {
 type EventTargetWithCursorResult = EventTarget & { result: IDBCursorWithValue | null };
 
 function idbGetAll( pattern?: RegExp ): Promise< StoredItems > {
-	return new Promise( ( resolve, reject ) => {
-		getDB()
-			.then( db => {
+	return getDB().then(
+		db =>
+			new Promise( ( resolve, reject ) => {
 				const results: StoredItems = {};
 				const transaction = db.transaction( STORE_NAME, 'readonly' );
 				const getAll = transaction.objectStore( STORE_NAME ).openCursor();
@@ -109,8 +109,7 @@ function idbGetAll( pattern?: RegExp ): Promise< StoredItems > {
 				transaction.onabort = error;
 				transaction.onerror = error;
 			} )
-			.catch( err => reject( err ) );
-	} );
+	);
 }
 
 function idbSet< T >( key: string, value: T ): Promise< void > {

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -198,16 +198,16 @@ export async function getAllStoredItems( pattern?: RegExp ): Promise< StoredItem
 
 	const idbSupported = await supportsIDB();
 	if ( ! idbSupported ) {
-		const results: StoredItems = {};
-		for ( let i = 0; i < window.localStorage.length; i++ ) {
-			const key = window.localStorage.key( i );
-			if ( ! key || ( pattern && ! pattern?.test( key ) ) ) {
-				continue;
-			}
-			const valueString = window.localStorage.getItem( key ) ?? undefined;
-			results[ key ] = valueString !== undefined ? JSON.parse( valueString ) : undefined;
+		const entries = Object.entries( window.localStorage ).map( ( [ key, value ] ) => [
+			key,
+			value !== undefined ? JSON.parse( value ) : undefined,
+		] );
+
+		if ( ! pattern ) {
+			return Object.fromEntries( entries );
 		}
-		return results;
+
+		return Object.fromEntries( entries.filter( ( [ key ] ) => pattern.test( key ) ) );
 	}
 
 	return await idbGetAll( pattern );

--- a/client/lib/browser-storage/test/bypass.js
+++ b/client/lib/browser-storage/test/bypass.js
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	clearStorage,
+	setStoredItem,
+	getStoredItem,
+	getAllStoredItems,
+	bypassPersistentStorage,
+} from 'lib/browser-storage';
+
+describe( 'lib/browser-storage', () => {
+	describe( 'bypass', () => {
+		beforeEach( async () => {
+			await clearStorage();
+			bypassPersistentStorage( false );
+			await clearStorage();
+			bypassPersistentStorage( true );
+		} );
+
+		it( 'should not be able to retrieve persisted items when bypassing', async () => {
+			bypassPersistentStorage( false );
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+			bypassPersistentStorage( true );
+			expect( await getStoredItem( 'number' ) ).toBe( undefined );
+		} );
+
+		it( 'should not persist items when disabling and re-enabling bypassing', async () => {
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+			bypassPersistentStorage( false );
+			bypassPersistentStorage( true );
+			expect( await getStoredItem( 'number' ) ).toBe( undefined );
+		} );
+
+		it( 'should set and get a numeric item', async () => {
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+		} );
+
+		it( 'should set and get an object', async () => {
+			expect(
+				async () => await setStoredItem( 'object', { string: 'example', number: 42 } )
+			).not.toThrow();
+			expect( await getStoredItem( 'object' ) ).toEqual( { string: 'example', number: 42 } );
+		} );
+
+		it( 'should return undefined when fetching a missing item', async () => {
+			expect( await getStoredItem( 'missing' ) ).toBe( undefined );
+		} );
+
+		it( 'should clear the store correctly', async () => {
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+			expect( async () => await clearStorage() ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( undefined );
+		} );
+
+		it( 'should set and retrieve all items', async () => {
+			expect( async () => await setStoredItem( 'item1', 1 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item2', 2 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item3', 3 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'itemA', 'A' ) ).not.toThrow();
+
+			expect( await getAllStoredItems() ).toEqual( {
+				item1: 1,
+				item2: 2,
+				item3: 3,
+				itemA: 'A',
+			} );
+		} );
+
+		it( 'should set and retrieve all items that follow a pattern', async () => {
+			expect( async () => await setStoredItem( 'item1', 1 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item2', 2 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item3', 3 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'itemA', 'A' ) ).not.toThrow();
+
+			expect( await getAllStoredItems( /item\d/ ) ).toEqual( {
+				item1: 1,
+				item2: 2,
+				item3: 3,
+			} );
+		} );
+	} );
+} );

--- a/client/lib/browser-storage/test/indexed-db.js
+++ b/client/lib/browser-storage/test/indexed-db.js
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import 'fake-indexeddb/auto'; // Polyfill indexedDB for this set of tests.
+
+/**
+ * Internal dependencies
+ */
+import {
+	supportsIDB,
+	clearStorage,
+	setStoredItem,
+	getStoredItem,
+	getAllStoredItems,
+} from 'lib/browser-storage';
+
+describe( 'lib/browser-storage', () => {
+	describe( 'when indexedDB is supported', () => {
+		beforeEach( async () => {
+			await clearStorage();
+		} );
+
+		it( 'should detect that indexedDB is supported', async () => {
+			expect( await supportsIDB() ).toBeTruthy();
+		} );
+
+		it( 'should set and get a numeric item', async () => {
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+		} );
+
+		it( 'should set and get an object', async () => {
+			expect(
+				async () => await setStoredItem( 'object', { string: 'example', number: 42 } )
+			).not.toThrow();
+			expect( await getStoredItem( 'object' ) ).toEqual( { string: 'example', number: 42 } );
+		} );
+
+		it( 'should return undefined when fetching a missing item', async () => {
+			expect( await getStoredItem( 'missing' ) ).toBe( undefined );
+		} );
+
+		it( 'should clear the store correctly', async () => {
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+			expect( async () => await clearStorage() ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( undefined );
+		} );
+
+		it( 'should set and retrieve all items', async () => {
+			expect( async () => await setStoredItem( 'item1', 1 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item2', 2 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item3', 3 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'itemA', 'A' ) ).not.toThrow();
+
+			expect( await getAllStoredItems() ).toEqual( {
+				item1: 1,
+				item2: 2,
+				item3: 3,
+				itemA: 'A',
+			} );
+		} );
+
+		it( 'should set and retrieve all items that follow a pattern', async () => {
+			expect( async () => await setStoredItem( 'item1', 1 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item2', 2 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item3', 3 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'itemA', 'A' ) ).not.toThrow();
+
+			expect( await getAllStoredItems( /item\d/ ) ).toEqual( {
+				item1: 1,
+				item2: 2,
+				item3: 3,
+			} );
+		} );
+	} );
+} );

--- a/client/lib/browser-storage/test/local-storage.js
+++ b/client/lib/browser-storage/test/local-storage.js
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// No IndexedDB support, so the library will default to localStorage.
+
+/**
+ * Internal dependencies
+ */
+import {
+	supportsIDB,
+	clearStorage,
+	setStoredItem,
+	getStoredItem,
+	getAllStoredItems,
+} from 'lib/browser-storage';
+
+describe( 'lib/browser-storage', () => {
+	describe( 'when indexedDB is not supported and it falls back to localStorage', () => {
+		beforeEach( async () => {
+			await clearStorage();
+		} );
+
+		it( 'should detect that indexedDB is not supported', async () => {
+			expect( await supportsIDB() ).toBeFalsy();
+		} );
+
+		it( 'should set and get a numeric item', async () => {
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+		} );
+
+		it( 'should set and get an object', async () => {
+			expect(
+				async () => await setStoredItem( 'object', { string: 'example', number: 42 } )
+			).not.toThrow();
+			expect( await getStoredItem( 'object' ) ).toEqual( { string: 'example', number: 42 } );
+		} );
+
+		it( 'should return undefined when fetching a missing item', async () => {
+			expect( await getStoredItem( 'missing' ) ).toBe( undefined );
+		} );
+
+		it( 'should clear the store correctly', async () => {
+			expect( async () => await setStoredItem( 'number', 42 ) ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( 42 );
+			expect( async () => await clearStorage() ).not.toThrow();
+			expect( await getStoredItem( 'number' ) ).toBe( undefined );
+		} );
+
+		it( 'should set and retrieve all items', async () => {
+			expect( async () => await setStoredItem( 'item1', 1 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item2', 2 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item3', 3 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'itemA', 'A' ) ).not.toThrow();
+
+			expect( await getAllStoredItems() ).toEqual( {
+				item1: 1,
+				item2: 2,
+				item3: 3,
+				itemA: 'A',
+			} );
+		} );
+
+		it( 'should set and retrieve all items that follow a pattern', async () => {
+			expect( async () => await setStoredItem( 'item1', 1 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item2', 2 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'item3', 3 ) ).not.toThrow();
+			expect( async () => await setStoredItem( 'itemA', 'A' ) ).not.toThrow();
+
+			expect( await getAllStoredItems( /item\d/ ) ).toEqual( {
+				item1: 1,
+				item2: 2,
+				item3: 3,
+			} );
+		} );
+	} );
+} );

--- a/client/lib/browser-storage/types.ts
+++ b/client/lib/browser-storage/types.ts
@@ -1,3 +1,3 @@
 export interface StoredItems {
-	[ key: string ]: any;
+	[ key: string ]: unknown;
 }

--- a/client/lib/browser-storage/types.ts
+++ b/client/lib/browser-storage/types.ts
@@ -1,0 +1,3 @@
+export interface StoredItems {
+	[ key: string ]: any;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8949,6 +8949,12 @@
 			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
 			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
 		},
+		"base64-arraybuffer-es6": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.5.0.tgz",
+			"integrity": "sha512-UCIPaDJrNNj5jG2ZL+nzJ7czvZV/ZYX6LaIRgfVU1k1edJOQg7dkbiSKzwHkNp6aHEHER/PhlFBrMYnlvJJQEw==",
+			"dev": true
+		},
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -15401,6 +15407,16 @@
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
+		},
+		"fake-indexeddb": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-3.0.0.tgz",
+			"integrity": "sha512-VrnV9dJWlVWvd8hp9MMR+JS4RLC4ZmToSkuCg91ZwpYE5mSODb3n5VEaV62Hf3AusnbrPfwQhukU+rGZm5W8PQ==",
+			"dev": true,
+			"requires": {
+				"realistic-structured-clone": "^2.0.1",
+				"setimmediate": "^1.0.5"
+			}
 		},
 		"fast-average-color": {
 			"version": "4.3.0",
@@ -30265,6 +30281,26 @@
 			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.3.tgz",
 			"integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
 		},
+		"realistic-structured-clone": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-2.0.2.tgz",
+			"integrity": "sha512-5IEvyfuMJ4tjQOuKKTFNvd+H9GSbE87IcendSBannE28PTrbolgaVg5DdEApRKhtze794iXqVUFKV60GLCNKEg==",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.5.3",
+				"domexception": "^1.0.1",
+				"typeson": "^5.8.2",
+				"typeson-registry": "^1.0.0-alpha.20"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+					"dev": true
+				}
+			}
+		},
 		"realpath-native": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -35218,6 +35254,36 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
 			"integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
 			"dev": true
+		},
+		"typeson": {
+			"version": "5.18.1",
+			"resolved": "https://registry.npmjs.org/typeson/-/typeson-5.18.1.tgz",
+			"integrity": "sha512-4cVDwf4tT+9hpeQk22/ioQJXL8lN3AYlzJfJLBpB0MDPG7CGpbvxR0HBkQ6qp9T72/yzryP6k2HSVdxd3jF5qg==",
+			"dev": true
+		},
+		"typeson-registry": {
+			"version": "1.0.0-alpha.33",
+			"resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.33.tgz",
+			"integrity": "sha512-q0jMkVizN10rzPtPcwkUC+pAOlA4iq4tl/GJ0iHDuMCnK3HxaN26bR/SczedswPBt0Pd+c0GjXZDDK+Cn2pgwg==",
+			"dev": true,
+			"requires": {
+				"base64-arraybuffer-es6": "0.5.0",
+				"typeson": "5.18.1",
+				"whatwg-url": "7.1.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
+			}
 		},
 		"ua-parser-js": {
 			"version": "0.7.21",

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
 		"eslint-plugin-react": "7.17.0",
 		"eslint-plugin-wpcalypso": "file:./packages/eslint-plugin-wpcalypso",
 		"exports-loader": "0.7.0",
+		"fake-indexeddb": "3.0.0",
 		"glob": "7.1.6",
 		"globby": "10.0.1",
 		"gzip-size": "5.1.1",


### PR DESCRIPTION
Since I'm still waiting on feedback in #37883, I decided to move forward with implementing the new functionality in `lib/browser-storage` in preparation. If it's not needed, I can drop the PR. If it is needed, then it's already done 🙂 

#### Changes proposed in this Pull Request

* Add `getAllStoredItems` to `lib/browser-storage`
* Fix some lint issues

#### Testing instructions

No testing instructions. This is new functionality that's not being used anywhere yet.
