### PR TITLE
Update/bpb set transformed name

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
@@ -4,6 +4,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
 /* eslint-enable import/no-extraneous-dependencies */
 
 /**
@@ -11,7 +12,22 @@ import { __ } from '@wordpress/i18n';
  */
 import { settings } from './newspack-homepage-articles/blocks/homepage-articles/index';
 
-registerBlockType( 'a8c/blog-posts', {
+/**
+ * Block name in the A8C\FSE context.
+ */
+const blockName = 'a8c/blog-posts';
+
+function setBlockTransformationName( name ) {
+	return name !== 'newspack-blocks/homepage-articles' ? name : blockName;
+}
+
+addFilter(
+	'blocks.transforms_from_name',
+	'set-transformed-block-name',
+	setBlockTransformationName
+);
+
+registerBlockType( blockName, {
 	...settings,
 	title: __( 'Blog Posts', 'full-site-editing' ),
 	category: 'layout',

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/index.js
@@ -5,9 +5,14 @@ import { Path, SVG } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { __, _x } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import edit from './edit';
 
 /**
@@ -66,15 +71,18 @@ export const settings = {
 					postsToShow,
 					categories,
 				} ) => {
-					return createBlock( 'newspack-blocks/homepage-articles', {
-						showExcerpt: displayPostContent,
-						showDate: displayPostDate,
-						postLayout,
-						columns,
-						postsToShow,
-						showAuthor: false,
-						categories: categories ? [ categories ] : [],
-					} );
+					return createBlock(
+						applyFilters( 'blocks.transforms_from_name', 'newspack-blocks/homepage-articles' ),
+						{
+							showExcerpt: displayPostContent,
+							showDate: displayPostDate,
+							postLayout,
+							columns,
+							postsToShow,
+							showAuthor: false,
+							categories: categories ? [ categories ] : [],
+						}
+					);
 				},
 			},
 		],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**It depends on https://github.com/Automattic/newspack-blocks/pull/272/.**

This PR handles the bug which happens when it transforms from the `core/latest-posts` to `a8b/blog-posts`.

#### Testing instructions

1) Apply these changes
2) Create a `Latest Post Block`

<img src="https://user-images.githubusercontent.com/77539/70556137-3cd1c180-1b4e-11ea-9615-41e891425beb.png" width="400px" />

<img src="https://user-images.githubusercontent.com/77539/70556152-43f8cf80-1b4e-11ea-95d2-1e77bd53d9c0.png" width="400px" />

3) Transforms the block to `Blog Posts Block`

<img src="https://user-images.githubusercontent.com/77539/70556183-57a43600-1b4e-11ea-8154-d84386d4e5fe.png" width="400px" />

You should get the transformed block without errors.