### PR TITLE
Update atomic eligibility copy for unlaunched and private sites

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
+import { identity, map } from 'lodash';
 import React from 'react';
 
 /**
@@ -219,5 +219,8 @@ function isHardBlockingHoldType(
 ): hold is keyof ReturnType< typeof getBlockingMessages > {
 	return blockingMessages.hasOwnProperty( hold );
 }
+
+export const hasBlockingHold = ( holds: string[] ) =>
+	holds.some( hold => isHardBlockingHoldType( hold, getBlockingMessages( identity ) ) );
 
 export default localize( HoldList );

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -37,13 +37,13 @@ function getHoldMessages(
 			supportUrl: null,
 		},
 		SITE_PRIVATE: {
-			title: isUnlaunched ? translate( 'Launch your site' ) : translate( 'Make site public' ),
+			title: isUnlaunched ? translate( 'Launch your site' ) : translate( 'Make site visible' ),
 			description: isUnlaunched
 				? translate(
 						"This creates the basic layer the fancier stuff is built on. Don't worry, you can share this with everyone only when you're ready."
 				  )
 				: translate(
-						"Change's your site's Privacy settings to \"Hidden\". Don't worry, you can share this with everyone only when you're ready."
+						"Your site will be visible to everyone, but we ask search engines to not index your site. Don't worry, you can share this with everyone only when you're ready."
 				  ),
 			supportUrl: isUnlaunched
 				? null

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -10,7 +10,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import SectionHeader from 'components/section-header';
+import CardHeading from 'components/card-heading';
 import { localizeUrl } from 'lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
@@ -101,23 +101,20 @@ function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
 }
 
 interface ExternalProps {
+	context: string | null;
 	holds: string[];
 	isPlaceholder: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( translate );
 
 	return (
 		<div>
-			<SectionHeader
-				label={ translate( 'Please resolve this issue:', 'Please resolve these issues:', {
-					count: holds.length,
-				} ) }
-			/>
 			<Card className="eligibility-warnings__hold-list">
+				<CardHeading>{ getCardHeading( context, translate ) }</CardHeading>
 				{ isPlaceholder && (
 					<div>
 						<div className="eligibility-warnings__hold">
@@ -134,18 +131,17 @@ export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<Gridicon icon="notice-outline" size={ 24 } />
+								<Gridicon icon="checkmark-circle" size={ 24 } />
 								<div className="eligibility-warnings__message">
-									<span className="eligibility-warnings__message-title">
+									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
-									</span>
-									:&nbsp;
-									<span className="eligibility-warnings__message-description">
+									</div>
+									<div className="eligibility-warnings__message-description">
 										{ holdMessages[ hold ].description }
-									</span>
+									</div>
 								</div>
 								{ holdMessages[ hold ].supportUrl && (
-									<div className="eligibility-warnings__action">
+									<div className="eligibility-warnings__hold-action">
 										<Button
 											compact
 											href={ holdMessages[ hold ].supportUrl }
@@ -162,6 +158,17 @@ export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
 		</div>
 	);
 };
+
+function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
+	switch ( context ) {
+		case 'plugins':
+			return translate( "To install plugins, you'll need a couple things:" );
+		case 'themes':
+			return translate( "To install themes, you'll need a couple things:" );
+		default:
+			return translate( "To continue, you'll need a couple things:" );
+	}
+}
 
 function isKnownHoldType(
 	hold: string,

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
@@ -139,8 +139,8 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 						) }
 					</Notice>
 				) }
-			<Card
-				className={ classNames( 'eligibility-warnings__hold-list', {
+			<div
+				className={ classNames( {
 					'eligibility-warnings__hold-list-dim': blockingHold,
 				} ) }
 				data-testid="HoldList-Card"
@@ -190,7 +190,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 							</div>
 						)
 					) }
-			</Card>
+			</div>
 		</>
 	);
 };

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -18,7 +18,11 @@ import { localizeUrl } from 'lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
 // TODO: update supportUrls and maybe create similar mapping for warnings
-function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
+function getHoldMessages(
+	context: string | null,
+	isUnlaunched: boolean,
+	translate: LocalizeProps[ 'translate' ]
+) {
 	return {
 		NO_BUSINESS_PLAN: {
 			title: translate( 'Upgrade to a Business plan' ),
@@ -33,11 +37,17 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 			supportUrl: null,
 		},
 		SITE_PRIVATE: {
-			title: translate( 'Public site needed' ),
-			description: translate(
-				'Change your site\'s Privacy settings to "Public" or "Hidden" (not "Private.")'
-			),
-			supportUrl: localizeUrl( 'https://en.support.wordpress.com/settings/privacy-settings/' ),
+			title: isUnlaunched ? translate( 'Launch your site' ) : translate( 'Public site needed' ),
+			description: isUnlaunched
+				? translate(
+						"This creates the basic layer the fancier stuff is built on. Don't worry, you can share this with everyone only when you're ready."
+				  )
+				: translate(
+						'Change your site\'s Privacy settings to "Public" or "Hidden" (not "Private.")'
+				  ),
+			supportUrl: isUnlaunched
+				? null
+				: localizeUrl( 'https://en.support.wordpress.com/settings/privacy-settings/' ),
 		},
 		NON_ADMIN_USER: {
 			title: translate( 'Site administrator only' ),
@@ -117,12 +127,13 @@ interface ExternalProps {
 	context: string | null;
 	holds: string[];
 	isPlaceholder: boolean;
+	isUnlaunched: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
-	const holdMessages = getHoldMessages( context, translate );
+export const HoldList = ( { context, holds, isPlaceholder, isUnlaunched, translate }: Props ) => {
+	const holdMessages = getHoldMessages( context, isUnlaunched, translate );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( h => isHardBlockingHoldType( h, blockingMessages ) );

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -116,16 +116,20 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 interface ExternalProps {
 	context: string | null;
 	holds: string[];
+	isIndented: boolean;
 	isPlaceholder: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isIndented, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( context, translate );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( h => isHardBlockingHoldType( h, blockingMessages ) );
+	const messageClassName = classNames( 'eligibility-warnings__message ', {
+		'eligibility-warnings__message--indented': isIndented,
+	} );
 
 	return (
 		<>
@@ -171,8 +175,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<Gridicon icon="chevron-right" size={ 24 } />
-								<div className="eligibility-warnings__message">
+								<div className={ messageClassName }>
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
 									</div>

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -166,7 +166,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<Gridicon icon="checkmark-circle" size={ 24 } />
+								<Gridicon icon="chevron-right" size={ 24 } />
 								<div className="eligibility-warnings__message">
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
@@ -198,11 +198,11 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins, you'll need a couple things:" );
+			return translate( "To install plugins, you'll need a couple of things:" );
 		case 'themes':
-			return translate( "To install themes, you'll need a couple things:" );
+			return translate( "To install themes, you'll need a couple of things:" );
 		default:
-			return translate( "To continue, you'll need a couple things:" );
+			return translate( "To continue, you'll need a couple of things:" );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -31,6 +31,13 @@ function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
 			),
 			supportUrl: null,
 		},
+		NO_BUSINESS_PLAN: {
+			title: translate( 'Upgrade to a Business plan' ),
+			description: translate(
+				"You'll also get to install custom themes, have more storage, and access live support."
+			),
+			supportUrl: null,
+		},
 		NO_JETPACK_SITES: {
 			title: translate( 'Not available for Jetpack sites' ),
 			description: translate( 'Try using a different site.' ),

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -198,11 +198,11 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins, you'll need a couple of things:" );
+			return translate( "To install plugins, you'll need to:" );
 		case 'themes':
-			return translate( "To install themes, you'll need a couple of things:" );
+			return translate( "To install themes, you'll need to:" );
 		default:
-			return translate( "To continue, you'll need a couple of things:" );
+			return translate( "To continue, you'll need to:" );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -76,7 +76,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 		},
 		TRANSFER_ALREADY_EXISTS: {
 			message: translate(
-				'Installation in progress. Just a minute! Please wait until the installation is finisehd, then try again.'
+				'Installation in progress. Just a minute! Please wait until the installation is finished, then try again.'
 			),
 			status: null,
 			contactUrl: null,
@@ -100,7 +100,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 		},
 		NO_SSL_CERTIFICATE: {
 			message: translate(
-				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browing on your site using "HTTPS".'
+				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
 			),
 			status: null,
 			contactUrl: null,

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -18,13 +18,18 @@ import { localizeUrl } from 'lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
 // TODO: update supportUrls and maybe create similar mapping for warnings
-function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
+function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {
 			title: translate( 'Upgrade to a Business plan' ),
-			description: translate(
-				"You'll also get to install custom themes, have more storage, and access live support."
-			),
+			description:
+				context === 'themes'
+					? translate(
+							"You'll also get to install custom plugins, have more storage, and access live support."
+					  )
+					: translate(
+							"You'll also get to install custom themes, have more storage, and access live support."
+					  ),
 			supportUrl: null,
 		},
 		SITE_PRIVATE: {
@@ -69,7 +74,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
 			message: translate(
-				'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+				'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
 			),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
@@ -117,7 +122,7 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
-	const holdMessages = getHoldMessages( translate );
+	const holdMessages = getHoldMessages( context, translate );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( h => isHardBlockingHoldType( h, blockingMessages ) );
@@ -201,6 +206,8 @@ function getCardHeading( context: string | null, translate: LocalizeProps[ 'tran
 			return translate( "To install plugins you'll need to:" );
 		case 'themes':
 			return translate( "To install themes you'll need to:" );
+		case 'hosting':
+			return translate( "To activate hosting access you'll need to:" );
 		default:
 			return translate( "To continue you'll need to" + ':' );
 	}

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -198,11 +198,11 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins, you'll need to:" );
+			return translate( "To install plugins you'll need to:" );
 		case 'themes':
-			return translate( "To install themes, you'll need to:" );
+			return translate( "To install themes you'll need to:" );
 		default:
-			return translate( "To continue, you'll need to:" );
+			return translate( "To continue you'll need to" + ':' );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -116,20 +116,16 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 interface ExternalProps {
 	context: string | null;
 	holds: string[];
-	isIndented: boolean;
 	isPlaceholder: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { context, holds, isIndented, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( context, translate );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( h => isHardBlockingHoldType( h, blockingMessages ) );
-	const messageClassName = classNames( 'eligibility-warnings__message ', {
-		'eligibility-warnings__message--indented': isIndented,
-	} );
 
 	return (
 		<>
@@ -175,7 +171,7 @@ export const HoldList = ( { context, holds, isIndented, isPlaceholder, translate
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<div className={ messageClassName }>
+								<div className="eligibility-warnings__message">
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
 									</div>

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'components/gridicon';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
+import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { localizeUrl } from 'lib/i18n-utils';
@@ -138,8 +139,17 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 						) }
 					</Notice>
 				) }
-			<Card className="eligibility-warnings__hold-list">
-				<CardHeading>{ getCardHeading( context, translate ) }</CardHeading>
+			<Card
+				className={ classNames( 'eligibility-warnings__hold-list', {
+					'eligibility-warnings__hold-list-dim': blockingHold,
+				} ) }
+				data-testid="HoldList-Card"
+			>
+				<CardHeading>
+					<span className="eligibility-warnings__hold-heading">
+						{ getCardHeading( context, translate ) }
+					</span>
+				</CardHeading>
 				{ isPlaceholder && (
 					<div>
 						<div className="eligibility-warnings__hold">
@@ -169,6 +179,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 									<div className="eligibility-warnings__hold-action">
 										<Button
 											compact
+											disabled={ !! blockingHold }
 											href={ holdMessages[ hold ].supportUrl }
 											rel="noopener noreferrer"
 										>

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -37,13 +37,13 @@ function getHoldMessages(
 			supportUrl: null,
 		},
 		SITE_PRIVATE: {
-			title: isUnlaunched ? translate( 'Launch your site' ) : translate( 'Public site needed' ),
+			title: isUnlaunched ? translate( 'Launch your site' ) : translate( 'Make site public' ),
 			description: isUnlaunched
 				? translate(
 						"This creates the basic layer the fancier stuff is built on. Don't worry, you can share this with everyone only when you're ready."
 				  )
 				: translate(
-						'Change your site\'s Privacy settings to "Public" or "Hidden" (not "Private.")'
+						"Change's your site's Privacy settings to \"Hidden\". Don't worry, you can share this with everyone only when you're ready."
 				  ),
 			supportUrl: isUnlaunched
 				? null

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { filter, get, includes, noop } from 'lodash';
+import { get, includes, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 
@@ -53,12 +53,8 @@ export const EligibilityWarnings = ( {
 	siteSlug,
 	translate,
 }: Props ) => {
-	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
-
-	const listHolds = filter(
-		get( eligibilityData, 'eligibilityHolds', [] ),
-		hold => ! includes( [ 'NO_BUSINESS_PLAN', 'NOT_USING_CUSTOM_DOMAIN' ], hold )
-	);
+	const warnings = eligibilityData.eligibilityWarnings || [];
+	const listHolds = eligibilityData.eligibilityHolds || [];
 
 	const classes = classNames( 'eligibility-warnings', {
 		'eligibility-warnings__placeholder': isPlaceholder,

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -48,6 +48,8 @@ export const EligibilityWarnings = ( {
 		'eligibility-warnings__placeholder': isPlaceholder,
 	} );
 
+	const showWarnings = warnings.length > 0 && ! hasBlockingHold( listHolds );
+
 	return (
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
@@ -57,7 +59,12 @@ export const EligibilityWarnings = ( {
 			/>
 			<CompactCard>
 				{ ( isPlaceholder || listHolds.length > 0 ) && (
-					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
+					<HoldList
+						context={ context }
+						holds={ listHolds }
+						isPlaceholder={ isPlaceholder }
+						isIndented={ showWarnings }
+					/>
 				) }
 
 				{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
@@ -69,7 +76,7 @@ export const EligibilityWarnings = ( {
 					</div>
 				) }
 			</CompactCard>
-			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
+			{ showWarnings && (
 				<CompactCard className="eligibility-warnings__warnings-card">
 					<WarningList context={ context } warnings={ warnings } />
 				</CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -71,7 +71,7 @@ export const EligibilityWarnings = ( {
 			</CompactCard>
 			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
 				<CompactCard className="eligibility-warnings__warnings-card">
-					<WarningList warnings={ warnings } />
+					<WarningList context={ context } warnings={ warnings } />
 				</CompactCard>
 			) }
 			<CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -208,7 +208,9 @@ function mergeProps(
 		context = 'hosting';
 	}
 
-	const onCancel = () => dispatchProps.trackCancel( { context } );
+	const onCancel = () => {
+		dispatchProps.trackCancel( { context } );
+	};
 	const onProceed = () => {
 		ownProps.onProceed();
 		dispatchProps.trackProceed( { context } );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -17,6 +17,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { Button, CompactCard } from '@automattic/components';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import HoldList, { hasBlockingHold } from './hold-list';
 import WarningList from './warning-list';
@@ -39,6 +40,7 @@ export const EligibilityWarnings = ( {
 	eligibilityData,
 	isEligible,
 	isPlaceholder,
+	isUnlaunched,
 	onProceed,
 	recordCtaClick,
 	siteId,
@@ -70,10 +72,9 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
-
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<CompactCard>
-					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
+					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } isUnlaunched={ isUnlaunched } />
 				</CompactCard>
 			) }
 
@@ -145,12 +146,14 @@ const mapStateToProps = ( state: object ) => {
 	const siteId = getSelectedSiteId( state );
 	const eligibilityData = getEligibility( state, siteId );
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
+	const isUnlaunched = siteId !== null && isUnlaunchedSite( state, siteId );
 	const dataLoaded = !! eligibilityData.lastUpdate;
 
 	return {
 		eligibilityData,
 		isEligible,
 		isPlaceholder: ! dataLoaded,
+		isUnlaunched,
 		siteId,
 	};
 };

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -17,7 +17,7 @@ import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { Button, Card } from '@automattic/components';
 import QueryEligibility from 'components/data/query-atat-eligibility';
-import HoldList from './hold-list';
+import HoldList, { hasBlockingHold } from './hold-list';
 import WarningList from './warning-list';
 
 /**
@@ -57,10 +57,12 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
+			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
+				<WarningList warnings={ warnings } />
+			) }
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 			) }
-			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
 			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
 				<Card className="eligibility-warnings__no-conflicts">

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -60,53 +60,56 @@ export const EligibilityWarnings = ( {
 			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
 				<WarningList warnings={ warnings } />
 			) }
-			{ ( isPlaceholder || listHolds.length > 0 ) && (
-				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
-			) }
 
-			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
-				<Card className="eligibility-warnings__no-conflicts">
-					<Gridicon icon="thumbs-up" size={ 24 } />
-					<span>
-						{ translate( 'This site is eligible to install plugins and upload themes.' ) }
-					</span>
-				</Card>
-			) }
+			<Card>
+				{ ( isPlaceholder || listHolds.length > 0 ) && (
+					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
+				) }
 
-			<Card className="eligibility-warnings__confirm-box">
-				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && (
-						<>
-							{ translate( 'Please clear all issues above to proceed.' ) }
-							&nbsp;
-						</>
-					) }
-					{ isEligible && warnings.length > 0 && (
-						<>
-							{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
-							&nbsp;
-						</>
-					) }
-					{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
-						components: {
-							a: (
-								<a
-									href="https://wordpress.com/help/contact"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</div>
-				<div className="eligibility-warnings__confirm-buttons">
-					<Button href={ backUrl } onClick={ onCancel }>
-						{ translate( 'Cancel' ) }
-					</Button>
+				{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
+					<div className="eligibility-warnings__no-conflicts">
+						<Gridicon icon="thumbs-up" size={ 24 } />
+						<span>
+							{ translate( 'This site is eligible to install plugins and upload themes.' ) }
+						</span>
+					</div>
+				) }
 
-					<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
-						{ translate( 'Proceed' ) }
-					</Button>
+				<div className="eligibility-warnings__confirm-box">
+					<div className="eligibility-warnings__confirm-text">
+						{ ! isEligible && (
+							<>
+								{ translate( 'Please clear all issues above to proceed.' ) }
+								&nbsp;
+							</>
+						) }
+						{ isEligible && warnings.length > 0 && (
+							<>
+								{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
+								&nbsp;
+							</>
+						) }
+						{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
+							components: {
+								a: (
+									<a
+										href="https://wordpress.com/help/contact"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</div>
+					<div className="eligibility-warnings__confirm-buttons">
+						<Button href={ backUrl } onClick={ onCancel }>
+							{ translate( 'Cancel' ) }
+						</Button>
+
+						<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
+							{ translate( 'Proceed' ) }
+						</Button>
+					</div>
 				</div>
 			</Card>
 		</div>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -105,7 +105,7 @@ export const EligibilityWarnings = ( {
 			{ businessUpsellBanner }
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
-				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } />
+				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 			) }
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -15,7 +15,7 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { Button, Card } from '@automattic/components';
+import { Button, CompactCard } from '@automattic/components';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import HoldList, { hasBlockingHold } from './hold-list';
 import WarningList from './warning-list';
@@ -55,11 +55,7 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
-			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
-				<WarningList warnings={ warnings } />
-			) }
-
-			<Card>
+			<CompactCard>
 				{ ( isPlaceholder || listHolds.length > 0 ) && (
 					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 				) }
@@ -72,7 +68,13 @@ export const EligibilityWarnings = ( {
 						</span>
 					</div>
 				) }
-
+			</CompactCard>
+			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
+				<CompactCard className="eligibility-warnings__warnings-card">
+					<WarningList warnings={ warnings } />
+				</CompactCard>
+			) }
+			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
 					<Button
 						primary={ true }
@@ -82,7 +84,7 @@ export const EligibilityWarnings = ( {
 						{ getProceedButtonText( listHolds, translate ) }
 					</Button>
 				</div>
-			</Card>
+			</CompactCard>
 		</div>
 	);
 };

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -44,8 +44,8 @@
 	align-items: flex-start;
 	margin-bottom: 16px;
 
-	&:last-child {
-		margin-bottom: 0;
+	&:first-of-type {
+		padding-top: 6px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,5 +1,3 @@
-
-
 .eligibility-warnings {
 	margin-top: 16px;
 	font-size: 14px;
@@ -57,7 +55,11 @@
 	}
 }
 
-.eligibility-warnings__hold .gridicon,
+.eligibility-warnings__hold .gridicon {
+	color: var( --color-neutral-10 );
+	flex-shrink: 0;
+}
+
 .eligibility-warnings__warning > .gridicon {
 	color: var( --color-error );
 	flex-shrink: 0;
@@ -77,13 +79,18 @@
 	}
 }
 
-.eligibility-warnings__action a {
+.eligibility-warnings__action a,
+.eligibility-warnings__hold-action a {
 	.gridicons-help-outline {
 		color: var( --color-neutral-light );
 	}
 	&:hover .gridicons-help-outline {
 		color: var( --color-primary );
 	}
+}
+
+.eligibility-warnings__hold-action {
+	align-self: center;
 }
 
 .eligibility-warnings__no-conflicts.card {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -124,3 +124,8 @@
 		margin-left: 16px;
 	}
 }
+
+.eligibility-warnings__hold-list-dim .eligibility-warnings__hold-heading,
+.eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
+	opacity: 0.2;
+}

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -33,13 +33,15 @@
 	}
 }
 
-.eligibility-warnings__hold {
+.eligibility-warnings__hold,
+.eligibility-warnings__warning {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
 }
 
-.eligibility-warnings__hold {
+.eligibility-warnings__hold,
+.eligibility-warnings__warning {
 	align-items: flex-start;
 	margin-bottom: 16px;
 
@@ -48,9 +50,17 @@
 	}
 }
 
+.eligibility-warnings__hold .gridicon,
+.eligibility-warnings__warning .gridicon {
+	flex-shrink: 0;
+}
+
 .eligibility-warnings__hold .gridicon {
 	color: var( --color-neutral-10 );
-	flex-shrink: 0;
+}
+
+.eligibility-warnings__warning .gridicon {
+	color: var( --color-warning-10 );
 }
 
 .eligibility-warnings__message {
@@ -64,6 +74,10 @@
 
 	.eligibility-warnings__message-description {
 		color: var( --color-text-subtle );
+	}
+
+	&--indented {
+		margin-left: 24px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -3,6 +3,16 @@
 	font-size: 14px;
 }
 
+.eligibility-warnings--with-indent {
+	.eligibility-warnings__message {
+		padding: 0 16px;
+		margin-left: 24px;
+	}
+	.gridicon + .eligibility-warnings__message {
+		margin-left: 0;
+	}
+}
+
 .eligibility-warnings__placeholder {
 	@include placeholder();
 
@@ -66,7 +76,7 @@
 .eligibility-warnings__message {
 	flex-grow: 1;
 	line-height: 24px;
-	padding: 0 16px;
+	padding: 0;
 
 	.eligibility-warnings__message-title {
 		font-weight: 600;
@@ -74,10 +84,6 @@
 
 	.eligibility-warnings__message-description {
 		color: var( --color-text-subtle );
-	}
-
-	&--indented {
-		margin-left: 24px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -114,7 +114,3 @@
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
 	opacity: 0.2;
 }
-
-.eligibility-warnings__confirm-buttons {
-	padding-left: 40px;
-}

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -38,15 +38,13 @@
 }
 
 .eligibility-warnings__hold,
-.eligibility-warnings__warning,
 .eligibility-warnings__confirm-box.card {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
 }
 
-.eligibility-warnings__hold,
-.eligibility-warnings__warning {
+.eligibility-warnings__hold {
 	align-items: flex-start;
 	margin-bottom: 16px;
 
@@ -57,11 +55,6 @@
 
 .eligibility-warnings__hold .gridicon {
 	color: var( --color-neutral-10 );
-	flex-shrink: 0;
-}
-
-.eligibility-warnings__warning > .gridicon {
-	color: var( --color-error );
 	flex-shrink: 0;
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -20,7 +20,7 @@
 	}
 
 	.button,
-	.eligibility-warnings__confirm-box {
+	.eligibility-warnings__confirm-buttons {
 		display: none;
 	}
 }
@@ -33,8 +33,7 @@
 	}
 }
 
-.eligibility-warnings__hold,
-.eligibility-warnings__confirm-box {
+.eligibility-warnings__hold {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
@@ -97,24 +96,11 @@
 	}
 }
 
-.eligibility-warnings__confirm-box {
-	flex-wrap: wrap;
-	justify-content: flex-end;
-
-	.eligibility-warnings__confirm-text {
-		color: var( --color-text-subtle );
-		flex-basis: 60%;
-		flex-grow: 1;
-		font-style: italic;
-		padding: 8px 0;
-	}
-
-	.button {
-		margin-left: 16px;
-	}
-}
-
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold-heading,
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
 	opacity: 0.2;
+}
+
+.eligibility-warnings__confirm-buttons {
+	padding-left: 40px;
 }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -25,10 +25,6 @@
 	}
 }
 
-.eligibility-warnings .card {
-	margin: 0;
-}
-
 .eligibility-warnings .banner {
 	margin-bottom: 16px;
 	.banner__icon-circle {
@@ -38,7 +34,7 @@
 }
 
 .eligibility-warnings__hold,
-.eligibility-warnings__confirm-box.card {
+.eligibility-warnings__confirm-box {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
@@ -86,7 +82,7 @@
 	align-self: center;
 }
 
-.eligibility-warnings__no-conflicts.card {
+.eligibility-warnings__no-conflicts {
 	align-items: center;
 	display: flex;
 

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import React, { ReactChild } from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import EligibilityWarnings from '..';
+
+function renderWithStore( element: ReactChild, initialState: object ) {
+	const store = createStore( state => state, initialState );
+	return {
+		...render( <Provider store={ store }>{ element }</Provider> ),
+		store,
+	};
+}
+
+function createState( { holds = [], siteId = 1 }: { holds?: string[]; siteId?: number } = {} ) {
+	return {
+		automatedTransfer: {
+			[ siteId ]: {
+				eligibility: {
+					eligibilityHolds: holds,
+					lastUpdate: 1,
+				},
+			},
+		},
+		currentUser: { capabilities: { [ siteId ]: {} } },
+		sites: { items: { [ siteId ]: {} } },
+		ui: { selectedSiteId: siteId },
+	};
+}
+
+describe( '<EligibilityWarnings>', () => {
+	it( 'renders error notice when AT has been blocked by a sticker', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER' ],
+		} );
+
+		const { container } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		const notice = container.querySelector( '.notice.is-error' );
+
+		expect( notice ).toBeVisible();
+		expect( notice ).toHaveTextContent( /This site is not currently eligible/ );
+	} );
+
+	it( 'only renders a single notice when multible hard blocking holds exist', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER', 'SITE_GRAYLISTED' ],
+		} );
+
+		const { container } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		expect( container.querySelectorAll( '.notice' ).length ).toBe( 1 );
+	} );
+
+	it( 'dimly renders the hold card when AT has been blocked by a sticker', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER', 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ],
+		} );
+
+		const { getByTestId, getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		expect( getByTestId( 'HoldList-Card' ) ).toHaveClass( 'eligibility-warnings__hold-list-dim' );
+		expect( getByText( 'Help' ) ).toHaveAttribute( 'disabled' );
+	} );
+} );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -40,6 +40,7 @@ function createState( {
 				},
 			},
 		},
+		sites: { items: { [ siteId ]: {} } },
 		ui: { selectedSiteId: siteId },
 	};
 }

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -86,6 +86,7 @@ describe( '<EligibilityWarnings>', () => {
 
 		expect( getByTestId( 'HoldList-Card' ) ).toHaveClass( 'eligibility-warnings__hold-list-dim' );
 		expect( getByText( 'Help' ) ).toHaveAttribute( 'disabled' );
+		expect( getByText( 'Upgrade and continue' ) ).toBeDisabled();
 	} );
 
 	it( 'renders warning notices when the API returns warnings', () => {
@@ -134,5 +135,42 @@ describe( '<EligibilityWarnings>', () => {
 		);
 
 		expect( container.querySelectorAll( '.notice.is-warning' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'calls onProceed prop when clicking "Upgrade and continue"', () => {
+		const state = createState( {
+			holds: [ 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ],
+		} );
+
+		const handleProceed = jest.fn();
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ handleProceed } />,
+			state
+		);
+
+		fireEvent.click( getByText( 'Upgrade and continue' ) );
+
+		expect( handleProceed ).toHaveBeenCalled();
+	} );
+
+	it( `disables the "Continue" button if holds can't be handled automatically`, () => {
+		const state = createState( {
+			holds: [ 'NON_ADMIN_USER', 'SITE_PRIVATE' ],
+		} );
+
+		const handleProceed = jest.fn();
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ handleProceed } />,
+			state
+		);
+
+		const continueButton = getByText( 'Continue' );
+
+		expect( continueButton ).toBeDisabled();
+
+		fireEvent.click( continueButton );
+		expect( handleProceed ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -96,7 +96,7 @@ describe( '<EligibilityWarnings>', () => {
 				{
 					name: 'Warning 2',
 					description: 'Describes warning 2',
-					supportUrl: 'http://example.com/',
+					supportUrl: 'https://helpme.com',
 				},
 			],
 		} );
@@ -113,9 +113,7 @@ describe( '<EligibilityWarnings>', () => {
 		expect( notices[ 1 ] ).toBeVisible();
 		expect( notices[ 1 ] ).toHaveTextContent( 'Describes warning 2' );
 
-		fireEvent.click( getByLabelText( 'Help' ) );
-
-		expect( window.location.href ).toBe( 'https://example.com/' );
+		expect( getByLabelText( 'Help' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
 	} );
 
 	it( "doesn't render warnings when there are blocking holds", () => {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -101,19 +101,17 @@ describe( '<EligibilityWarnings>', () => {
 			],
 		} );
 
-		const { container, getByLabelText } = renderWithStore(
+		const { getByText } = renderWithStore(
 			<EligibilityWarnings backUrl="" onProceed={ noop } />,
 			state
 		);
 
-		const notices = container.querySelectorAll( '.notice.is-warning' );
+		expect( getByText( 'Warning 1' ) ).toBeVisible();
+		expect( getByText( 'Describes warning 1' ) ).toBeVisible();
+		expect( getByText( 'Warning 2' ) ).toBeVisible();
+		expect( getByText( 'Describes warning 2' ) ).toBeVisible();
 
-		expect( notices[ 0 ] ).toBeVisible();
-		expect( notices[ 0 ] ).toHaveTextContent( 'Describes warning 1' );
-		expect( notices[ 1 ] ).toBeVisible();
-		expect( notices[ 1 ] ).toHaveTextContent( 'Describes warning 2' );
-
-		expect( getByLabelText( 'Help' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
+		expect( getByText( 'Learn more.' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
 	} );
 
 	it( "doesn't render warnings when there are blocking holds", () => {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -35,8 +35,6 @@ function createState( { holds = [], siteId = 1 }: { holds?: string[]; siteId?: n
 				},
 			},
 		},
-		currentUser: { capabilities: { [ siteId ]: {} } },
-		sites: { items: { [ siteId ]: {} } },
 		ui: { selectedSiteId: siteId },
 	};
 }

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -32,7 +32,7 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 
 		{ map( warnings, ( { name, description, supportUrl }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
-				<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+				<div className="eligibility-warnings__message">
 					<span className="eligibility-warnings__message-title">{ name }</span>
 					:&nbsp;
 					<span className="eligibility-warnings__message-description">
@@ -48,7 +48,7 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 		) ) }
 
 		<div className="eligibility-warnings__warning">
-			<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+			<div className="eligibility-warnings__message">
 				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
 				:&nbsp;
 				<span className="eligibility-warnings__message-description">

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -25,8 +25,8 @@ export const WarningList = ( { translate, warnings }: Props ) => (
 			<div className="eligibility-warnings__message">
 				<span className="eligibility-warnings__message-description">
 					{ translate(
-						"This feature isn't (yet) compatible with Plugin uploads and will be disabled:",
-						"These features aren't (yet) compatible with Plugin uploads and will be disabled:",
+						"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
+						"These features aren't (yet) compatible with plugin uploads and will be disabled:",
 						{
 							count: warnings.length,
 							args: warnings.length,

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,12 +3,14 @@
  */
 import React from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
+import { map } from 'lodash';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import ExternalLink from 'components/external-link';
+import ActionPanelLink from 'components/action-panel/link';
 
 interface ExternalProps {
 	warnings: import('state/automated-transfer/selectors').EligibilityWarning[];
@@ -17,20 +19,54 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { translate, warnings }: Props ) => (
-	<>
-		{ warnings.map( ( { description, supportUrl }, index ) => (
-			<Notice status="is-warning" key={ index } text={ description } showDismiss={ false }>
-				{ supportUrl && (
-					<NoticeAction
-						icon="help-outline"
-						aria-label={ translate( 'Help' ) }
-						href={ supportUrl }
-						external
-					/>
-				) }
-			</Notice>
+	<div>
+		<div className="eligibility-warnings__warning">
+			<Gridicon icon="notice-outline" size={ 24 } />
+			<div className="eligibility-warnings__message">
+				<span className="eligibility-warnings__message-description">
+					{ translate(
+						"This feature isn't (yet) compatible with Plugin uploads and will be disabled:",
+						"These features aren't (yet) compatible with Plugin uploads and will be disabled:",
+						{
+							count: warnings.length,
+							args: warnings.length,
+						}
+					) }
+				</span>
+			</div>
+		</div>
+
+		{ map( warnings, ( { name, description, supportUrl }, index ) => (
+			<div className="eligibility-warnings__warning" key={ index }>
+				<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+					<span className="eligibility-warnings__message-title">{ name }</span>
+					:&nbsp;
+					<span className="eligibility-warnings__message-description">
+						{ description }{ ' ' }
+						{ supportUrl && (
+							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+								{ translate( 'Learn more.' ) }
+							</ExternalLink>
+						) }
+					</span>
+				</div>
+			</div>
 		) ) }
-	</>
+
+		<div className="eligibility-warnings__warning">
+			<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
+				:&nbsp;
+				<span className="eligibility-warnings__message-description">
+					{ translate( '{{a}}Contact support{{/a}} for help.', {
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					} ) }
+				</span>
+			</div>
+		</div>
+	</div>
 );
 
 export default localize( WarningList );

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -13,25 +13,19 @@ import ExternalLink from 'components/external-link';
 import ActionPanelLink from 'components/action-panel/link';
 
 interface ExternalProps {
+	context: string | null;
 	warnings: import('state/automated-transfer/selectors').EligibilityWarning[];
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const WarningList = ( { translate, warnings }: Props ) => (
+export const WarningList = ( { context, translate, warnings }: Props ) => (
 	<div>
 		<div className="eligibility-warnings__warning">
 			<Gridicon icon="notice-outline" size={ 24 } />
 			<div className="eligibility-warnings__message">
 				<span className="eligibility-warnings__message-description">
-					{ translate(
-						"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
-						"These features aren't (yet) compatible with plugin uploads and will be disabled:",
-						{
-							count: warnings.length,
-							args: warnings.length,
-						}
-					) }
+					{ getWarningDescription( context, warnings.length, translate ) }
 				</span>
 			</div>
 		</div>
@@ -68,5 +62,46 @@ export const WarningList = ( { translate, warnings }: Props ) => (
 		</div>
 	</div>
 );
+
+function getWarningDescription(
+	context: string | null,
+	warningCount: number,
+	translate: LocalizeProps[ 'translate' ]
+) {
+	switch ( context ) {
+		case 'plugins':
+			return translate(
+				"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
+				"These features aren't (yet) compatible with plugin uploads and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
+
+		case 'themes':
+			return translate(
+				"This feature isn't (yet) compatible with theme uploads and will be disabled:",
+				"These features aren't (yet) compatible with theme uploads and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
+
+		case 'hosting':
+			return translate(
+				"This feature isn't (yet) compatible with hosting access and will be disabled:",
+				"These features aren't (yet) compatible with hosting access and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
+
+		default:
+			return null;
+	}
+}
 
 export default localize( WarningList );

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,15 +3,12 @@
  */
 import React from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
-import ExternalLink from 'components/external-link';
-import SectionHeader from 'components/section-header';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 interface ExternalProps {
 	warnings: import('state/automated-transfer/selectors').EligibilityWarning[];
@@ -20,37 +17,20 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { translate, warnings }: Props ) => (
-	<div>
-		<SectionHeader
-			label={ translate(
-				"By proceeding you'll lose %d feature:",
-				"By proceeding you'll lose these %d features:",
-				{
-					count: warnings.length,
-					args: warnings.length,
-				}
-			) }
-		/>
-		<Card className="eligibility-warnings__warning-list">
-			{ map( warnings, ( { name, description, supportUrl }, index ) => (
-				<div className="eligibility-warnings__warning" key={ index }>
-					<Gridicon icon="cross-small" size={ 24 } />
-					<div className="eligibility-warnings__message">
-						<span className="eligibility-warnings__message-title">{ name }</span>
-						:&nbsp;
-						<span className="eligibility-warnings__message-description">{ description }</span>
-					</div>
-					{ supportUrl && (
-						<div className="eligibility-warnings__action">
-							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-								<Gridicon icon="help-outline" size={ 24 } />
-							</ExternalLink>
-						</div>
-					) }
-				</div>
-			) ) }
-		</Card>
-	</div>
+	<>
+		{ warnings.map( ( { description, supportUrl }, index ) => (
+			<Notice status="is-warning" key={ index } text={ description } showDismiss={ false }>
+				{ supportUrl && (
+					<NoticeAction
+						icon="help-outline"
+						aria-label={ translate( 'Help' ) }
+						href={ supportUrl }
+						external
+					/>
+				) }
+			</Notice>
+		) ) }
+	</>
 );
 
 export default localize( WarningList );

--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -15,6 +15,7 @@ export default class extends React.Component {
 	static displayName = 'NoticeAction';
 
 	static propTypes = {
+		'aria-label': PropTypes.string,
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		external: PropTypes.bool,
@@ -27,6 +28,7 @@ export default class extends React.Component {
 
 	render() {
 		const attributes = {
+			'aria-label': this.props[ 'aria-label' ],
 			className: 'notice__action',
 			href: this.props.href,
 			onClick: this.props.onClick,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -74,6 +74,7 @@ export const FEATURE_BASIC_DESIGN = 'basic-design';
 export const FEATURE_ADVANCED_DESIGN = 'advanced-design';
 export const FEATURE_GOOGLE_ANALYTICS = 'google-analytics';
 export const FEATURE_GOOGLE_MY_BUSINESS = 'google-my-business';
+export const FEATURE_SFTP = 'sftp';
 export const FEATURE_LIVE_CHAT_SUPPORT = 'live-chat-support';
 export const FEATURE_NO_ADS = 'no-adverts';
 export const FEATURE_VIDEO_UPLOADS = 'video-upload';

--- a/client/state/selectors/is-unlaunched-site.js
+++ b/client/state/selectors/is-unlaunched-site.js
@@ -7,9 +7,9 @@ import getRawSite from 'state/selectors/get-raw-site';
 /**
  * Returns true if the site is unlaunched
  *
- * @param {Object} state Global state tree
- * @param {Object} siteId Site ID
- * @return {Boolean} True if site is unlaunched
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} True if site is unlaunched
  */
 export default function isUnlaunchedSite( state, siteId ) {
 	const site = getRawSite( state, siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of the #38141, this PR only includes wording changes for telling the user their site must be launched. Just to keep the wording changes easier to review. The bigger style changes are in #38277

* Change message shown for _unlaunched_ site with `SITE_PRIVATE` hold.
* Change message shown for _launched_ site with `SITE_PRIVATE` hold.

*Message for unlaunched site*
<img width="653" alt="Screenshot 2019-12-11 at 10 14 40 AM" src="https://user-images.githubusercontent.com/1500769/70569949-d0af9600-1bff-11ea-8748-1472c597a6b4.png">

*Message for launched private site*
<img width="695" alt="Screenshot 2019-12-11 at 10 26 24 AM" src="https://user-images.githubusercontent.com/1500769/70570480-da85c900-1c00-11ea-9cbe-3d81fbaf899c.png">
The help link goes to https://en.support.wordpress.com/settings/privacy-settings/, which is currently what production does. The button will probably be removed as part of #38141 since proceeding will change the setting for the user.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Choose a simple site to test that's unlaunched
  * Go to plugins, click upload plugin
  * Should see message that site must be launched
* Choose a simple simple site that's launched but private
  * Go to plugins, click upload plugin
  * Should see message that site must be made public