### PR TITLE
Fix Themes Showcase loading on selected tiers.

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -74,6 +74,7 @@ class ThemeShowcase extends React.Component {
 				this.props.loggedOutComponent ||
 				this.props.search ||
 				this.props.filter ||
+				this.props.tier ||
 				this.props.hasShowcaseOpened
 			),
 		};
@@ -107,9 +108,9 @@ class ThemeShowcase extends React.Component {
 	};
 
 	componentDidMount() {
-		const { search, filter, hasShowcaseOpened, themesBookmark } = this.props;
+		const { search, filter, tier, hasShowcaseOpened, themesBookmark } = this.props;
 		// Open showcase on state if we open here with query override.
-		if ( ( search || filter ) && ! hasShowcaseOpened ) {
+		if ( ( search || filter || tier ) && ! hasShowcaseOpened ) {
 			this.props.openThemesShowcase();
 		}
 		// Scroll to bookmark if applicable.
@@ -129,7 +130,11 @@ class ThemeShowcase extends React.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.search !== this.props.search || prevProps.filter !== this.props.filter ) {
+		if (
+			prevProps.search !== this.props.search ||
+			prevProps.filter !== this.props.filter ||
+			prevProps.tier !== this.props.tier
+		) {
 			this.scrollToSearchInput();
 		}
 	}
@@ -266,7 +271,7 @@ class ThemeShowcase extends React.Component {
 		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
 		const { isShowcaseOpen } = this.state;
-		const isQueried = this.props.search || this.props.filter;
+		const isQueried = this.props.search || this.props.filter || this.props.tier;
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -248,7 +248,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
 		}
 
 		// if query is default, filter out recommended themes
-		if ( ! query.search && ! query.filter ) {
+		if ( ! ( query.search || query.filter || query.tier ) ) {
 			const recommendedThemes = state.themes.recommendedThemes.themes;
 			const themeIds = flatMap( recommendedThemes, theme => {
 				return theme.id;

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -247,7 +247,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
 			return null;
 		}
 
-		// if query is default, filter out recommended themes
+		// If query is default, filter out recommended themes.
 		if ( ! ( query.search || query.filter || query.tier ) ) {
 			const recommendedThemes = state.themes.recommendedThemes.themes;
 			const themeIds = flatMap( recommendedThemes, theme => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added `tier` to the various query checks for Themes Showcase conditions.

This will allow users to load `wordpress.com/themes/free` without having the results hidden below Recommended Themes and behind the "More Themes" button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Load to `calypso.localhost:3000/themes/free` and `calypso.localhost:3000/themes/premium`
* Verify that Recommended Themes are not visible and that the tier results are visible by default.
* Smoke test search functionality and reloading behavior around my-sites/themes.

Fixes #38327
