### PR TITLE
[SIGNUP]: clear progress state after flow completion

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -342,6 +342,8 @@ class Signup extends React.Component {
 
 		debug( `Logging you in to "${ destination }"` );
 
+		this.signupFlowController.reset();
+
 		if ( ! this.state.controllerHasReset ) {
 			this.setState( { controllerHasReset: true } );
 		}
@@ -349,14 +351,12 @@ class Signup extends React.Component {
 		if ( userIsLoggedIn ) {
 			// don't use page.js for external URLs (eg redirect to new site after signup)
 			if ( /^https?:\/\//.test( destination ) ) {
-				this.signupFlowController.reset();
 				return ( window.location.href = destination );
 			}
 
 			// deferred in case the user is logged in and the redirect triggers a dispatch
 			defer( () => {
 				debug( `Redirecting you to "${ destination }"` );
-				this.signupFlowController.reset();
 				window.location.href = destination;
 			} );
 		}
@@ -364,7 +364,6 @@ class Signup extends React.Component {
 		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || dependencies.oauth2_client_id ) ) {
 			debug( `Handling oauth login` );
 			oauthToken.setToken( dependencies.bearer_token );
-			this.signupFlowController.reset();
 			window.location.href = destination;
 			return;
 		}


### PR DESCRIPTION
After the signup flow is complete, we redirect the user to the final destination based on their login state. 

If the signup progress state is not cleared, then any attempt to create a new site will result in the user seeing the site creation loading page.

![add-new-site](https://user-images.githubusercontent.com/8658164/70439970-0b42f280-1a89-11ea-9a26-9b5342b4a9ca.gif)

This is _no bueno_.

#### Changes proposed in this Pull Request

On new signups, the app doesn't know if the user is logged in until after they've created a site and arrived at the destination. That's why the `isLoggedIn` check fails.

This patch resets the controller under all conditions. Specifically it resets the controller when the user isn't logged in and the login method is not `oauth` (regular login).

Related PR: #36047

## Testing instructions

1. Sign up for a new account at https://wordpress.com/start, ending up at URL: https://wordpress.com/home/SITE_ADDRESS
2. In the sidebar, select "Add new site."
3. Under "Create a shiny new WordPress.com site" select "Start Now."

Expectations:

With no BSOD to hinder your progress, you should be able to create a site.

Fixes #38287
