### PR TITLE
[SIGNUP]: Add default value for suggestedTheme in site vertical reducer

### DIFF
--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -21,6 +21,7 @@ const initialState = {
 	parentId: '',
 	slug: '',
 	preview: '',
+	suggestedTheme: '',
 };
 
 // TODO:

--- a/client/state/signup/steps/site-vertical/schema.js
+++ b/client/state/signup/steps/site-vertical/schema.js
@@ -20,5 +20,8 @@ export const siteVerticalSchema = {
 		slug: {
 			type: 'string',
 		},
+		suggestedTheme: {
+			type: 'string',
+		},
 	},
 };


### PR DESCRIPTION
## Changes proposed in this Pull Request

Since we added `suggestedTheme` [to the site vertical object](https://github.com/Automattic/wp-calypso/commit/3195870a615e185e85ed1a89321669058556ff64), its corresponding schema definition object is whining.

<img width="1183" alt="Screen Shot 2019-12-11 at 12 42 53 pm" src="https://user-images.githubusercontent.com/6458278/70584368-fa26ec80-1c14-11ea-95bd-613c6fd8e026.png">

Let's silence it.

In this PR, we're adding a default property `suggestedTheme` to the siteVertical step state reducer.

Furthermore,  we'll add it to the schema definition object.

##  Testing instructions

1. Fire up http://calypso.localhost:3000/, and preserve your browser console logs!
2. Create a **Business > Real Estate Agent** site, or another combo that doesn't return a suggested theme.

SILENCE!
