### PR TITLE
G Suite: Fix infinite API calls made when account users are requested

### DIFF
--- a/client/components/data/query-gsuite-users/index.jsx
+++ b/client/components/data/query-gsuite-users/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -12,12 +12,18 @@ import { getGSuiteUsers } from 'state/gsuite-users/actions';
 import isRequestingGSuiteUsers from 'state/selectors/is-requesting-gsuite-users';
 
 const QueryGSuiteUsers = ( { siteId, request, isRequesting } ) => {
+	const prevIsRequestingRef = useRef();
+	const [ loaded, setLoaded ] = useState( false );
 	useEffect( () => {
+		prevIsRequestingRef.current = isRequesting;
 		if ( ! isRequesting ) {
 			request( siteId );
 		}
-	}, [ siteId, request, isRequesting ] );
-
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ siteId, request, loaded ] );
+	if ( prevIsRequestingRef.current && ! isRequesting ) {
+		setLoaded( true );
+	}
 	return null;
 };
 

--- a/client/components/data/query-gsuite-users/index.jsx
+++ b/client/components/data/query-gsuite-users/index.jsx
@@ -12,18 +12,17 @@ import { getGSuiteUsers } from 'state/gsuite-users/actions';
 import isRequestingGSuiteUsers from 'state/selectors/is-requesting-gsuite-users';
 
 const request = siteId => ( dispatch, getState ) => {
-	const isRequesting = isRequestingGSuiteUsers( getState(), siteId );
-	if ( ! isRequesting ) {
+	if ( ! isRequestingGSuiteUsers( getState(), siteId ) ) {
 		dispatch( getGSuiteUsers( siteId ) );
 	}
 };
 
-const QueryGSuiteUsers = ( { siteId } ) => {
+export default function QueryGSuiteUsers( { siteId } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
 		dispatch( request( siteId ) );
-	}, [ siteId, dispatch ] );
+	}, [ dispatch, siteId ] );
 
 	return null;
 };
@@ -31,5 +30,3 @@ const QueryGSuiteUsers = ( { siteId } ) => {
 QueryGSuiteUsers.propTypes = {
 	siteId: PropTypes.number.isRequired,
 };
-
-export default QueryGSuiteUsers;

--- a/client/components/data/query-gsuite-users/index.jsx
+++ b/client/components/data/query-gsuite-users/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,21 +11,19 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getGSuiteUsers } from 'state/gsuite-users/actions';
 import isRequestingGSuiteUsers from 'state/selectors/is-requesting-gsuite-users';
 
+const request = siteId => ( dispatch, getState ) => {
+	const isRequesting = isRequestingGSuiteUsers( getState(), siteId );
+	if ( ! isRequesting ) {
+		dispatch( getGSuiteUsers( siteId ) );
+	}
+};
+
 const QueryGSuiteUsers = ( { siteId } ) => {
 	const dispatch = useDispatch();
-	const isRequesting = useSelector( state => isRequestingGSuiteUsers( state, siteId ) );
-	const prevIsRequesting = useRef( isRequesting );
 
 	useEffect( () => {
-		if ( ! ( isRequesting || prevIsRequesting.current ) ) {
-			dispatch( getGSuiteUsers( siteId ) );
-		}
-		return () => {
-			if ( isRequesting ) {
-				prevIsRequesting.current = true;
-			}
-		};
-	} );
+		dispatch( request( siteId ) );
+	}, [ siteId, dispatch ] );
 
 	return null;
 };


### PR DESCRIPTION
Summary
-
This is a fix for the [Email](https://wordpress.com/emails) page, where there is an infinite set of GET API requests made to the [/google-apps](/sites/:site-id/google-apps) endpoint to fetch the set of available G Suite users for the site.

Additionally Redux's `connect` is ditched in favour of Redux's hooks that work with functional components. 

#### Testing instructions ( Before )

![screenshot](https://user-images.githubusercontent.com/277661/70605474-e1114200-1bfa-11ea-9dba-87eb16a4314b.png)
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Startup your dev server i.e. http://calypso.localhost:3000
* Ensure that you have eligible G Suite domains
  - At least one domain with users
  - At least one domain without users
* Nagivate to the `Email` page: http://calypso.localhost:3000/email
* Bring up/activate your browser's **Dev console** so that you can observe console logs
* Enable debug for requests  by running : `localStorage.setItem('debug','wpcom-proxy-request')`. You may need to refresh the page
* Optionally filter the console by applying `/request\(.*/google-apps/` to the filter input.
* Observe the unending calls to the `/sites/:site-id/google-apps` endpoint

#### Testing instructions ( After )

<img width="1181" alt="Screenshot 2019-12-11 at 9 56 46 AM" src="https://user-images.githubusercontent.com/277661/70606371-9c86a600-1bfc-11ea-8629-7603856e02f0.png">

* Checkout this branch : `git checkout fix/gsuite-infinite-api-calls-on-query-users`
* Refresh the page and confirm that the infinite calls have ceased.
* Navigate away from the `Email` page
* Come back to the `Email` 
* Confirm from the console that the request to `/sites/:site-id/google-apps` was made only once
* Switch to another site while on the `Email` page
* Confirm that requests were sent once to the `google-apps` endpoint
* Navigate to the `Domains` management page
* Attempt to access the users page for the domain with users.
* Confirm that requests were sent once to the `google-apps` endpoint
* Attempt to purchase G Suite for the domain without users.
* Confirm that requests were sent once to the `google-apps` endpoint


