### PR TITLE
Reader: fix scrolling problems in streams

### DIFF
--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -47,71 +47,53 @@ class ScrollHelper {
 		return height;
 	}
 
-	forEachInRow( index, callback, context ) {
-		if ( typeof callback !== 'function' ) {
-			return;
-		}
+	forEachInRow( index, callback ) {
+		const { itemsPerRow } = this.props;
 
-		if ( context ) {
-			callback = callback.bind( context );
-		}
+		const firstIndexInRow = index - ( index % itemsPerRow );
+		const lastIndexInRow = Math.min( firstIndexInRow + itemsPerRow, this.props.items.length ) - 1;
 
-		const firstIndexInRow = index - ( index % this.props.itemsPerRow ),
-			lastIndexInRow =
-				Math.min( firstIndexInRow + this.props.itemsPerRow, this.props.items.length ) - 1;
 		for ( let i = firstIndexInRow; i <= lastIndexInRow; i++ ) {
 			callback( this.props.items[ i ], i );
 		}
 	}
 
 	storeRowItemHeights( fromDirection, index ) {
-		this.forEachInRow(
-			index,
-			function( item ) {
-				const itemKey = this.props.getItemRef( item );
-				const itemBounds = this.boundsForRef( itemKey );
-				let height;
+		this.forEachInRow( index, item => {
+			const itemKey = this.props.getItemRef( item );
+			const itemBounds = this.boundsForRef( itemKey );
+			let height;
 
-				if ( itemBounds ) {
-					if ( 'bottom' === fromDirection ) {
-						height = this.containerBottom - this.bottomPlaceholderHeight - itemBounds.top;
-					} else {
-						height = itemBounds.bottom - ( this.containerTop + this.topPlaceholderHeight );
-					}
+			if ( itemBounds ) {
+				if ( 'bottom' === fromDirection ) {
+					height = this.containerBottom - this.bottomPlaceholderHeight - itemBounds.top;
 				} else {
-					height = this.props.guessedItemHeight;
+					height = itemBounds.bottom - ( this.containerTop + this.topPlaceholderHeight );
 				}
+			} else {
+				height = this.props.guessedItemHeight;
+			}
 
-				this.itemHeights[ itemKey ] = height;
-			},
-			this
-		);
+			this.itemHeights[ itemKey ] = height;
+		} );
 	}
 
 	deleteRowItemHeights( index ) {
-		this.forEachInRow(
-			index,
-			item => {
-				const itemKey = this.props.getItemRef( item );
-				delete this.itemHeights[ itemKey ];
-			},
-			this
-		);
+		this.forEachInRow( index, item => {
+			const itemKey = this.props.getItemRef( item );
+			delete this.itemHeights[ itemKey ];
+		} );
 	}
 
 	getRowHeight( index ) {
 		let maxHeight = 0;
 
-		this.forEachInRow(
-			index,
-			item => {
-				const itemKey = this.props.getItemRef( item ),
-					height = this.storedItemHeight( itemKey );
+		this.forEachInRow( index, item => {
+			const itemKey = this.props.getItemRef( item );
+			const height = this.storedItemHeight( itemKey );
 
-				maxHeight = Math.max( maxHeight, height );
-			},
-			this
-		);
+			maxHeight = Math.max( maxHeight, height );
+		} );
 
 		return maxHeight;
 	}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -365,6 +365,7 @@ class ReaderStream extends React.Component {
 		return (
 			<PostLifecycle
 				key={ itemKey }
+				ref={ itemKey /* The ref is stored into `InfiniteList`'s `this.ref` map */ }
 				isSelected={ isSelected }
 				handleClick={ showPost }
 				postKey={ postKey }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -97,6 +97,8 @@ class ReaderStream extends React.Component {
 		forcePlaceholders: false,
 	};
 
+	listRef = React.createRef();
+
 	componentDidUpdate( { selectedPostKey, streamKey } ) {
 		if ( streamKey !== this.props.streamKey ) {
 			this.props.resetCardExpansions();
@@ -222,7 +224,10 @@ class ReaderStream extends React.Component {
 	};
 
 	getVisibleItemIndexes() {
-		return this._list && this._list.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } );
+		return (
+			this.listRef.current &&
+			this.listRef.current.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } )
+		);
 	}
 
 	selectNextItem = () => {
@@ -329,8 +334,8 @@ class ReaderStream extends React.Component {
 		// if ( this.props.recommendationsStore ) {
 		// 	shufflePosts( this.props.recommendationsStore.id );
 		// }
-		if ( this._list ) {
-			this._list.scrollToTop();
+		if ( this.listRef.current ) {
+			this.listRef.current.scrollToTop();
 		}
 	};
 
@@ -410,7 +415,7 @@ class ReaderStream extends React.Component {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			body = (
 				<InfiniteList
-					ref={ c => ( this._list = c ) }
+					ref={ this.listRef }
 					className="reader__content"
 					items={ items }
 					lastPage={ lastPage }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -117,7 +117,7 @@ class ReaderStream extends React.Component {
 	}
 
 	_popstate = () => {
-		if ( this.props.selectedPostKey && history.scrollRestoration !== 'manual' ) {
+		if ( this.props.selectedPostKey && window.history.scrollRestoration !== 'manual' ) {
 			this.scrollToSelectedPost( false );
 		}
 	};
@@ -157,8 +157,8 @@ class ReaderStream extends React.Component {
 		KeyboardShortcuts.on( 'like-selection', this.toggleLikeOnSelectedPost );
 		KeyboardShortcuts.on( 'go-to-top', this.goToTop );
 		window.addEventListener( 'popstate', this._popstate );
-		if ( 'scrollRestoration' in history ) {
-			history.scrollRestoration = 'manual';
+		if ( 'scrollRestoration' in window.history ) {
+			window.history.scrollRestoration = 'manual';
 		}
 	}
 
@@ -170,8 +170,8 @@ class ReaderStream extends React.Component {
 		KeyboardShortcuts.off( 'like-selection', this.toggleLikeOnSelectedPost );
 		KeyboardShortcuts.off( 'go-to-top', this.goToTop );
 		window.removeEventListener( 'popstate', this._popstate );
-		if ( 'scrollRestoration' in history ) {
-			history.scrollRestoration = 'auto';
+		if ( 'scrollRestoration' in window.history ) {
+			window.history.scrollRestoration = 'auto';
 		}
 	}
 

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -103,5 +103,8 @@ export default connect(
 	} ),
 	null,
 	null,
-	{ areOwnPropsEqual: compareProps( { ignore: [ 'handleClick' ] } ) }
+	{
+		forwardRef: true,
+		areOwnPropsEqual: compareProps( { ignore: [ 'handleClick' ] } ),
+	}
 )( PostLifecycle );


### PR DESCRIPTION
Fixes #37901.

Was caused by me removing a ref on `PostLifecycle` component in #37553. Here's a quote of the very unwise comment I made there:

> **Unneeded refs in Reader Stream:**
`PostLifecycle` is a connect-ed component without `forwardRef`, and yet we're passing a ref to it. It's never used though, so I simply removed it.

I didn't realize then that the ref is used internally by `InfiniteList`, and is used to measure the list item pixel dimensions. If the refs are not set, items are assumed to have a "guessed" height of 600px. Which is almost never true and leads to buggy scrolling experience.

See the commit message in https://github.com/Automattic/wp-calypso/commit/df0faf80276035c241fe521146a0a09da580d7fb for more technical details and suggestions to improve that part of `InfiniteList` API.

The https://github.com/Automattic/wp-calypso/commit/df0faf80276035c241fe521146a0a09da580d7fb commit is the one that fixes the bug -- add back the `PostLifecycle` ref and add `forwardRef` flag to `PostLifecycle`'s `connect` wrapper so that it forwards the ref to the wrapped component.

The remaining commits are janitorial drive-by fixes:
- fix lint errors by converting references to `history` to `window.history`
- use `React.createRef` to manage a ref to the `InfiniteList`
- modernize and simplify the `forEachInRow` method in `InfiniteList`

Each change is a small isolated commit and shouldn't be difficult to review and test.

@kristarella @pento can you check (on calypso.live) that this patch indeed fixes the weird scroll behavior? The bug shouldn't be browser-specific at all, although the bug report mentions Firefox and others.