### PR TITLE
Fix the way that Button and Compact Card are imported into the TimelineEvent component

### DIFF
--- a/client/components/timeline/README.md
+++ b/client/components/timeline/README.md
@@ -13,6 +13,10 @@ A `Timeline` expects its children to be a flat list of `TimelineEvent`:
 
 The date to show for the timeline item.
 
+### `dateFormat { string }`
+
+The format for the dates shown in the timeline.
+
 ### `detail { string }`
 
 The detail message to show below the date.

--- a/client/components/timeline/timeline-event.jsx
+++ b/client/components/timeline/timeline-event.jsx
@@ -8,8 +8,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
-import CompactCard from 'components/card/compact';
+import { Button, CompactCard } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import { withLocalizedMoment } from 'components/localized-moment';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch the import for Button and CompactCard to use `from '@automattic/components'`

#### Testing instructions

Make sure that Calypso builds correctly and that you can see the component on http://calypso.localhost:3000/devdocs/design/timeline

I added the Timeline component in: https://github.com/Automattic/wp-calypso/pull/38278 and didn't realize there was a "New Component" label at the time, so I'm adding it here. 😞 
