### PR TITLE
Update product card options alignment and appearance

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -213,11 +213,10 @@
 }
 
 .product-card__options-label {
-	margin: 8px 0;
-	padding: 6px 0;
+	margin: 16px 0 0;
 	font-size: 14px;
+	text-align: center;
 	color: var( --color-text-subtle );
-	border-bottom: 1px solid var( --color-border-subtle );
 
 	@include breakpoint( '>960px' ) {
 		flex: 0 0 100%;
@@ -232,12 +231,17 @@
 
 // We need a higher specificity here to override .form-label styles
 .product-card__option.form-label {
-	margin: 16px 0 0;
-	padding: 8px 0;
+	margin: 24px 0;
 
 	@include breakpoint( '>960px' ) {
-		flex: 0 0 40%;
+		flex: 0 0 50%;
 		align-items: flex-start;
+		margin-bottom: 8px;
+
+		& + & {
+			padding-left: 20px;
+			border-left: 1px solid var( --color-border-subtle );
+		}
 	}
 }
 
@@ -245,6 +249,10 @@
 	margin-left: 8px;
 	flex-grow: 1;
 	flex-wrap: wrap;
+
+	@include breakpoint( '>960px' ) {
+		margin-left: 4px;
+	}
 }
 
 .product-card__option-name {

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -223,18 +223,14 @@
 	}
 }
 
-.product-card__option,
-.product-card__option-description {
-	display: flex;
-	align-items: center;
-}
-
 // We need a higher specificity here to override .form-label styles
 .product-card__option.form-label {
+	display: flex;
+	flex-flow: row nowrap;
+	align-items: center;
 	margin: 24px 0;
 
 	@include breakpoint( '>960px' ) {
-		flex: 0 0 50%;
 		align-items: flex-start;
 		margin-bottom: 8px;
 
@@ -246,17 +242,20 @@
 }
 
 .product-card__option-description {
-	margin-left: 8px;
+	display: flex;
+	flex-flow: row wrap;
 	flex-grow: 1;
-	flex-wrap: wrap;
+	margin-left: 8px;
 
 	@include breakpoint( '>960px' ) {
 		margin-left: 4px;
+		flex-flow: column nowrap;
 	}
 }
 
 .product-card__option-name {
 	flex-grow: 1;
+	margin-right: 10px;
 	font-size: 16px;
 	font-weight: 700;
 

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -131,6 +131,6 @@ export const JETPACK_PRODUCTS = [
 		optionDescriptions: {
 			...JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
 		},
-		optionsLabel: translate( 'Backup Options:' ),
+		optionsLabel: translate( 'Select a backup option:' ),
 	},
 ];


### PR DESCRIPTION
As part of the work related to p1HpG7-87V-p2, this PR centers the `ProductCard` options heading, updates its wording and removes the bottom border.

Also, a vertical separator between options is added as part of this PR.

Lastly, some minor padding/margin adjustments in the options area are made here so that it all looks good.

**Calypso - before**
<img width="541" alt="Screenshot 2019-12-11 at 17 26 08" src="https://user-images.githubusercontent.com/478735/70639965-86e4a100-1c3b-11ea-9edd-cd6142b20e43.png">

**Calypso - after**
<img width="544" alt="Screenshot 2019-12-11 at 17 25 34" src="https://user-images.githubusercontent.com/478735/70639978-8b10be80-1c3b-11ea-9865-6a52e676fb18.png">

**Jetpack Connect - before**
<img width="514" alt="Screenshot 2019-12-11 at 17 26 14" src="https://user-images.githubusercontent.com/478735/70639889-69173c00-1c3b-11ea-9901-bfb35a87fb2b.png">

**Jetpack Connect - after**
<img width="509" alt="Screenshot 2019-12-11 at 17 25 45" src="https://user-images.githubusercontent.com/478735/70639932-77655800-1c3b-11ea-9d09-12e5e3bf07ee.png">


Those updates apply to Jetpack Connect flow as well.

#### Changes proposed in this Pull Request

* Update product card options alignment, wording and appearance

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/plans/ and select a Jetpack site having no Jetpack Backup product
* Confirm that the changes mentioned in this PR description are done and there are no regressions. 
* Go to Jetpack Connect flow: http://calypso.localhost:3000/jetpack/connect/store
* Confirm that the changes mentioned in this PR description are done to the Jetpack connect flow as well and there are no regressions.

Fixes #
