### PR TITLE
ButtonGroup: Use Jest instead of Chai and sinon

### DIFF
--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -13,13 +13,13 @@ import { Button } from '@automattic/components';
 describe( 'ButtonGroup', () => {
 	let ButtonGroup, consoleErrorSpy;
 
-	beforeEach( () => {
+	beforeAll( () => {
 		consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation();
 
 		ButtonGroup = require( '../index' );
 	} );
 
-	afterEach( () => {
+	afterAll( () => {
 		consoleErrorSpy.mockRestore();
 	} );
 

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -25,7 +24,7 @@ describe( 'ButtonGroup', () => {
 
 	test( 'should have ButtonGroup class', () => {
 		const buttonGroup = shallow( <ButtonGroup /> );
-		assert.equal( 1, buttonGroup.find( '.button-group' ).length );
+		expect( buttonGroup.find( '.button-group' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should contains the same number of .button nodes than <Button>s it receives', () => {
@@ -35,12 +34,12 @@ describe( 'ButtonGroup', () => {
 				<Button>test2</Button>
 			</ButtonGroup>
 		);
-		assert.equal( 2, buttonGroup.find( Button ).length );
+		expect( buttonGroup.find( Button ) ).toHaveLength( 2 );
 	} );
 
 	test( 'should get the busy `is-busy` class when passed the `busy` prop', () => {
 		const buttonGroup = shallow( <ButtonGroup busy /> );
-		assert.equal( 1, buttonGroup.find( '.is-busy' ).length );
+		expect( buttonGroup.find( '.is-busy' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should throw an error if any of the children is not a <Button>', () => {

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -8,20 +8,9 @@ import React from 'react';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+import ButtonGroup from '..';
 
 describe( 'ButtonGroup', () => {
-	let ButtonGroup, consoleErrorSpy;
-
-	beforeAll( async () => {
-		consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation();
-
-		ButtonGroup = ( await import( '../index' ) ).default;
-	} );
-
-	afterAll( () => {
-		consoleErrorSpy.mockRestore();
-	} );
-
 	test( 'should have ButtonGroup class', () => {
 		const buttonGroup = shallow( <ButtonGroup /> );
 		expect( buttonGroup.find( '.button-group' ) ).toHaveLength( 1 );
@@ -43,6 +32,8 @@ describe( 'ButtonGroup', () => {
 	} );
 
 	test( 'should throw an error if any of the children is not a <Button>', () => {
+		const consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation();
+
 		shallow(
 			<ButtonGroup>
 				<div id="test">test</div>
@@ -52,5 +43,6 @@ describe( 'ButtonGroup', () => {
 		expect( consoleErrorSpy ).toHaveBeenCalledWith(
 			expect.stringContaining( 'All children elements should be a Button.' )
 		);
+		consoleErrorSpy.mockRestore();
 	} );
 } );

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -4,27 +4,23 @@
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
-
 import { Button } from '@automattic/components';
 
 describe( 'ButtonGroup', () => {
-	let sandbox, ButtonGroup;
+	let ButtonGroup, consoleErrorSpy;
 
 	beforeEach( () => {
-		sandbox = sinon.createSandbox();
-		sandbox.stub( console, 'error' );
-		sandbox.stub( console, 'log' );
+		consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation();
 
 		ButtonGroup = require( '../index' );
 	} );
 
 	afterEach( () => {
-		sandbox.restore();
+		consoleErrorSpy.mockRestore();
 	} );
 
 	test( 'should have ButtonGroup class', () => {
@@ -54,8 +50,8 @@ describe( 'ButtonGroup', () => {
 			</ButtonGroup>
 		);
 
-		/* eslint-disable no-console */
-		sinon.assert.calledWithMatch( console.error, 'All children elements should be a Button.' );
-		/* eslint-enable no-console */
+		expect( consoleErrorSpy ).toHaveBeenCalledWith(
+			expect.stringContaining( 'All children elements should be a Button.' )
+		);
 	} );
 } );

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -13,10 +13,10 @@ import { Button } from '@automattic/components';
 describe( 'ButtonGroup', () => {
 	let ButtonGroup, consoleErrorSpy;
 
-	beforeAll( () => {
+	beforeAll( async () => {
 		consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation();
 
-		ButtonGroup = require( '../index' );
+		ButtonGroup = ( await import( '../index' ) ).default;
 	} );
 
 	afterAll( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

ButtonGroup: Refactor test a bit to use native Jest functionality rather than Chai and sinon dependencies. 

Found while working on #38308.

#### Testing instructions

```
npm run test-client client/components/button-group/test/index.js
```

Passes?