### PR TITLE
Filter out system font from Google Font requests

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
@@ -78,7 +78,7 @@ class Global_Styles {
 	 */
 	private $plugin_name = 'jetpack-global-styles';
 
-	const VERSION = '1909241817';
+	const VERSION = '1912111747';
 
 	const SYSTEM_FONT     = '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif';
 	const AVAILABLE_FONTS = [
@@ -385,8 +385,9 @@ class Global_Styles {
 		 * - only the selected ones for the frontend
 		 */
 		$font_list = [];
-		// We want $font_list to only contain valid Google Font values, not things like 'unset'.
-		$font_values = array_diff( $this->get_font_values( $data['font_options'] ), [ 'unset' ] );
+		// We want $font_list to only contain valid Google Font values,
+		// so we filter out things like 'unset' on the system font.
+		$font_values = array_diff( $this->get_font_values( $data['font_options'] ), [ 'unset', self::SYSTEM_FONT ] );
 		if ( true === $only_selected_fonts ) {
 			foreach ( [ 'font_base', 'font_base_default', 'font_headings', 'font_headings_default' ] as $key ) {
 				if ( in_array( $data[ $key ], $font_values, true ) ) {
@@ -396,13 +397,16 @@ class Global_Styles {
 		} else {
 			$font_list = $font_values;
 		}
-		$font_list_str = '';
-		foreach ( $font_list as $font ) {
-			// Some fonts lack italic variants,
-			// the API will return only the regular and bold CSS for those.
-			$font_list_str = $font_list_str . $font . ':regular,bold,italic,bolditalic|';
+
+		if ( count( $font_list ) > 0 ) {
+			$font_list_str = '';
+			foreach ( $font_list as $font ) {
+				// Some fonts lack italic variants,
+				// the API will return only the regular and bold CSS for those.
+				$font_list_str = $font_list_str . $font . ':regular,bold,italic,bolditalic|';
+			}
+			$result = $result . "@import url('https://fonts.googleapis.com/css?family=" . $font_list_str . "');";
 		}
-		$result = $result . "@import url('https://fonts.googleapis.com/css?family=" . $font_list_str . "');";
 
 		/*
 		 * Add the CSS custom properties.

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
@@ -78,7 +78,7 @@ class Global_Styles {
 	 */
 	private $plugin_name = 'jetpack-global-styles';
 
-	const VERSION = '1912111747';
+	const VERSION = '1909241817';
 
 	const SYSTEM_FONT     = '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif';
 	const AVAILABLE_FONTS = [


### PR DESCRIPTION
This filter out the system fonts from being requested at Google Fonts.

#### Testing instructions (for a dotorg site)

* Build the Full Site Editing plugin and copy it within the `wp-content/plugins` directory of a test site.
* In the `functions.php` file of your active theme, add:

```php
add_theme_support(
       'jetpack-global-styles',
       [
               'enqueue_experimental_styles' => true,
               'enable_theme_default' => true,
               'font_base' => 'serif',
               'font_headings' => 'sans-serif',
       ]
);
```
* Activate the FSE plugin and go to the block editor. You should see the Global Styles sidebar's button in the right-top corner.
* Go to the front of your site and check that the request at `fonts.googleapis.com` triggers a 400 error. [1]
* Apply this patch.
* Go to the front end of your site and check that the request status at `fonts.googleapis.com` is 200. Check also that fonts work as expected.

#### Testing instructions (for a WordPress.com simple site)

In case you'd rather test in a WordPress.com simple site: 

* In your sandbox, select [one of the themes that have support for Global Styles](https://wordpress.com/themes/filter/global-styles) (hint: any of the Template-First Themes).
* Go to the block editor. You should see the Global Styles sidebar's button in the right-top corner.
* Go to the front of your site and check that the request at `fonts.googleapis.com` triggers a 400 error. [1]
* Apply this patch in your sandbox.
* Go to the front end of your site and check that the request status at `fonts.googleapis.com` is 200. Check also that fonts work as expected.

---

[1] If this is the first time you use Global Styles in your site, this is enough. Another way to test it is by selecting the "System Font" in the Global Styles sidebar (see step prior).
