### PR TITLE
G Suite: Remove A/B test introduced for discount

### DIFF
--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -50,71 +50,44 @@ const GSuitePrice = ( { currencyCode, product } ) => {
 	const annualPrice = getAnnualPrice( cost, currencyCode );
 	const monthlyPrice = getMonthlyPrice( cost, currencyCode );
 
-	if ( abtest( 'gsuitePrice' ) === 'discount' ) {
-		const isDiscounted = hasValidDiscount( product );
-
-		return (
-			<div className="gsuite-price">
-				<h4 className="gsuite-price__monthly-price">
-					{ translate( '{{strong}}%(price)s{{/strong}} per user/month', {
-						args: {
-							price: monthlyPrice,
-						},
-						components: {
-							strong: <strong />,
-						},
-						comment: "Monthly price per user formatted with the currency (e.g. '$8.40')",
-					} ) }
-				</h4>
-
-				<h5 className={ classNames( {
-					'gsuite-price__annual-price': true,
-					'discounted': isDiscounted
-				} ) }>
-					{ translate( '%(price)s billed annually', {
-						args: {
-							price: annualPrice,
-						},
-						comment: "Annual price formatted with the currency (e.g. '$99.99')"
-					} ) }
-				</h5>
-
-				{ isDiscounted && (
-					<Badge type="success">
-						{ translate( '%(price)s for your first year', {
-							args: {
-								price: getAnnualPrice( product.sale_cost, currencyCode ),
-							},
-							comment: "Discounted annual price formatted with the currency (e.g. '$80')"
-						} ) }
-					</Badge>
-				) }
-			</div>
-		);
-	}
+	const isDiscounted = hasValidDiscount( product );
 
 	return (
 		<div className="gsuite-price">
-			<h4 className="gsuite-price__price-per-user-per-month">
-				<span>
-					{ translate( '{{strong}}%(price)s{{/strong}} per user / month', {
-						components: {
-							strong: <strong />,
-						},
-						args: {
-							price: monthlyPrice,
-						},
-					} ) }
-				</span>
+			<h4 className="gsuite-price__monthly-price">
+				{ translate( '{{strong}}%(price)s{{/strong}} per user/month', {
+					args: {
+						price: monthlyPrice,
+					},
+					components: {
+						strong: <strong />,
+					},
+					comment: "Monthly price per user formatted with the currency (e.g. '$8.40')",
+				} ) }
 			</h4>
 
-			<h5 className="gsuite-price__price-per-user-per-year">
-				{ translate( '%(price)s billed yearly', {
+			<h5 className={ classNames( {
+				'gsuite-price__annual-price': true,
+				'discounted': isDiscounted
+			} ) }>
+				{ translate( '%(price)s billed annually', {
 					args: {
 						price: annualPrice,
 					},
+					comment: "Annual price formatted with the currency (e.g. '$99.99')"
 				} ) }
 			</h5>
+
+			{ isDiscounted && (
+				<Badge type="success">
+					{ translate( '%(price)s for your first year', {
+						args: {
+							price: getAnnualPrice( product.sale_cost, currencyCode ),
+						},
+						comment: "Discounted annual price formatted with the currency (e.g. '$80')"
+					} ) }
+				</Badge>
+			) }
 		</div>
 	);
 };

--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -9,7 +9,6 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Badge from 'components/badge';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
 
@@ -24,7 +23,7 @@ import './style.scss';
  * @param {object} product - G Suite product
  * @returns {boolean} - true if a discount can be applied, false otherwise
  */
-const hasValidDiscount = ( product ) => {
+const hasDiscount = product => {
 	if (
 		! product ||
 		! product.sale_cost ||
@@ -50,7 +49,7 @@ const GSuitePrice = ( { currencyCode, product } ) => {
 	const annualPrice = getAnnualPrice( cost, currencyCode );
 	const monthlyPrice = getMonthlyPrice( cost, currencyCode );
 
-	const isDiscounted = hasValidDiscount( product );
+	const isDiscounted = hasDiscount( product );
 
 	return (
 		<div className="gsuite-price">
@@ -66,15 +65,17 @@ const GSuitePrice = ( { currencyCode, product } ) => {
 				} ) }
 			</h4>
 
-			<h5 className={ classNames( {
-				'gsuite-price__annual-price': true,
-				'discounted': isDiscounted
-			} ) }>
+			<h5
+				className={ classNames( {
+					'gsuite-price__annual-price': true,
+					discounted: isDiscounted,
+				} ) }
+			>
 				{ translate( '%(price)s billed annually', {
 					args: {
 						price: annualPrice,
 					},
-					comment: "Annual price formatted with the currency (e.g. '$99.99')"
+					comment: "Annual price formatted with the currency (e.g. '$99.99')",
 				} ) }
 			</h5>
 
@@ -84,7 +85,7 @@ const GSuitePrice = ( { currencyCode, product } ) => {
 						args: {
 							price: getAnnualPrice( product.sale_cost, currencyCode ),
 						},
-						comment: "Discounted annual price formatted with the currency (e.g. '$80')"
+						comment: "Discounted annual price formatted with the currency (e.g. '$80')",
 					} ) }
 				</Badge>
 			) }

--- a/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
@@ -5,19 +5,17 @@ exports[`GSuitePrice renders correctly 1`] = `
   className="gsuite-price"
 >
   <h4
-    className="gsuite-price__price-per-user-per-month"
+    className="gsuite-price__monthly-price"
   >
-    <span>
-      <strong>
-        €6,40
-      </strong>
-       per user / month
-    </span>
+    <strong>
+      €6,40
+    </strong>
+     per user/month
   </h4>
   <h5
-    className="gsuite-price__price-per-user-per-year"
+    className="gsuite-price__annual-price"
   >
-    €76 billed yearly
+    €76 billed annually
   </h5>
 </div>
 `;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,13 +123,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	gsuitePrice: {
-		datestamp: '20191125',
-		variations: {
-			discount: 0,
-			control: 100,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -181,7 +181,7 @@ exports[`GSuitePurchaseCta renders correctly 1`] = `
         <strong>
           No setup or software required.
         </strong>
-
+         
         <a
           className="gsuite-learn-more__link"
           href="https://en.support.wordpress.com/adding-g-suite-to-your-site"

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -40,19 +40,17 @@ exports[`GSuitePurchaseCta renders correctly 1`] = `
           className="gsuite-price"
         >
           <h4
-            className="gsuite-price__price-per-user-per-month"
+            className="gsuite-price__monthly-price"
           >
-            <span>
-              <strong>
-                €6,40
-              </strong>
-               per user / month
-            </span>
+            <strong>
+              €6,40
+            </strong>
+             per user/month
           </h4>
           <h5
-            className="gsuite-price__price-per-user-per-year"
+            className="gsuite-price__annual-price"
           >
-            €76 billed yearly
+            €76 billed annually
           </h5>
         </div>
         <button
@@ -183,7 +181,7 @@ exports[`GSuitePurchaseCta renders correctly 1`] = `
         <strong>
           No setup or software required.
         </strong>
-         
+
         <a
           className="gsuite-learn-more__link"
           href="https://en.support.wordpress.com/adding-g-suite-to-your-site"


### PR DESCRIPTION
This pull request removes the A/B test introduced in https://github.com/Automattic/wp-calypso/pull/37919. We no longer need it since the new strings have been translated, and coupons are handled server-side. Here is how the `Email` page should look like now:

Without discount | With discount
----- | -----
![02](https://user-images.githubusercontent.com/594356/69556401-ea68a080-0fa4-11ea-8514-5fafc11f3989.png) | ![03](https://user-images.githubusercontent.com/594356/69556402-eb013700-0fa4-11ea-8218-8cf668795ccb.png)

#### Testing instructions

1. Run `git checkout remove/gsuite-discount-test` and start your server, or open a [live branch](https://calypso.live/?branch=remove/gsuite-discount-test)
2. Log in to an account that has a site with a domain but without G Suite
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Assert that the pricing block is displayed as in the screenshots above
5. Sandbox the store to access a valid coupon
6. Refresh the page
7. Assert that the pricing block is displayed as in the screenshots above