### PR TITLE
Migration: Redirect migrate path to root when disabled

### DIFF
--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -11,6 +11,13 @@ import SectionMigrate from 'my-sites/migrate/section-migrate';
 import getSiteId from 'state/selectors/get-site-id';
 import { isEnabled } from 'config';
 
+export function ensureFeatureFlag( context, next ) {
+	if ( isEnabled( 'tools/migrate' ) ) {
+		return next();
+	}
+	page.redirect( '/' );
+}
+
 export function migrateSite( context, next ) {
 	if ( isEnabled( 'tools/migrate' ) ) {
 		const sourceSiteId =
@@ -21,4 +28,9 @@ export function migrateSite( context, next ) {
 	}
 
 	page.redirect( '/' );
+}
+
+export function setSiteSelectionHeader( context, next ) {
+	context.getSiteSelectionHeaderText = () => 'Select a site to import into';
+	next();
 }

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -2,22 +2,23 @@
  * External dependencies
  */
 import page from 'page';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { migrateSite } from 'my-sites/migrate/controller';
+import {
+	ensureFeatureFlag,
+	migrateSite,
+	setSiteSelectionHeader,
+} from 'my-sites/migrate/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'my-sites/controller';
 
 export default function() {
 	page(
 		'/migrate',
-		( context, next ) => {
-			context.getSiteSelectionHeaderText = () => i18n.translate( 'Select a site to migrate to' );
-			next();
-		},
+		ensureFeatureFlag,
+		setSiteSelectionHeader,
 		siteSelection,
 		navigation,
 		sites,
@@ -27,6 +28,7 @@ export default function() {
 
 	page(
 		'/migrate/:site_id',
+		ensureFeatureFlag,
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/migrate' ),
@@ -37,6 +39,7 @@ export default function() {
 
 	page(
 		'/migrate/from/:sourceSiteId/to/:site_id',
+		ensureFeatureFlag,
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/migrate' ),


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Redirects the `/migrate` path to `/` when the feature-flag `tools/migrate` is disabled

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that navigating to `/migrate?flags=+tools/migrate` renders the site selector
* Verify that navigating to `/migrate?flags=-tools/migrate` redirects you to `/`
* Verify that navigating to any other `/migrate/*` path with the feature-flag disabled also redirects you to `/`

