### PR TITLE
FSE - Fix close button centration. 

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
@@ -27,6 +27,10 @@
 		font-size: 13px;
 	}
 
+	.dashicons-arrow-left-alt2 {
+		margin-left: -7px;
+	}
+
 	@media ( max-width: 599px ) {
 		margin-left: -2px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Subtract some margin from the left of the dashicon to horizontally balance the close button.

Alternatively, we could add margin to the right of the label.  However this way we don't take up more space than we need to.  If others feel the button looks a bit "cramped," we can look at the alternate approach.

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR in the FSE Plugin.
* Navigate to the editor.
* Verify the button is "centered"

**BEFORE**
![Screen Shot 2019-12-11 at 1 23 44 PM](https://user-images.githubusercontent.com/28742426/70649119-7d970c80-1c1a-11ea-9863-79bf95a26045.png)
![Screen Shot 2019-12-11 at 1 23 35 PM](https://user-images.githubusercontent.com/28742426/70649126-8091fd00-1c1a-11ea-940e-6b2d66d81292.png)

**AFTER**
![Screen Shot 2019-12-11 at 1 22 40 PM](https://user-images.githubusercontent.com/28742426/70649132-8556b100-1c1a-11ea-8029-336cbb12315b.png)
![Screen Shot 2019-12-11 at 1 23 00 PM](https://user-images.githubusercontent.com/28742426/70649135-87207480-1c1a-11ea-8481-d7e6cb594e5f.png)

Fixes #37741