### PR TITLE
removed icon from spt sidebar panel

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -57,7 +57,7 @@ registerPlugin( 'page-templates-sidebar', {
 				name="Template Modal Opener"
 				title={ __( 'Page Layout' ) }
 				className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
-				icon="admin-page"
+				icon="none"
 			>
 				<SidebarTemplatesPlugin
 					isFrontPage={ isFrontPage }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Icon from SPT Sidebar Plugin in editor.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR and FSE.
* Navigate to page editor.
* Verify SPT document sidebar panel has no icon.

**BEFORE**
![Screen Shot 2019-12-11 at 4 16 30 PM](https://user-images.githubusercontent.com/28742426/70661913-3ec18080-1c33-11ea-8982-6221d91a225e.png)

**AFTER**
![Screen Shot 2019-12-11 at 4 23 55 PM](https://user-images.githubusercontent.com/28742426/70661921-42ed9e00-1c33-11ea-9b1c-d062da22e02c.png)


Fixes #38358
