### PR TITLE
Hosting: Remove feature flag for hosting/all-sites

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { Card } from '@automattic/components';
 import Main from 'components/main';
 import SiteSelector from 'components/site-selector';
@@ -49,13 +48,8 @@ class Sites extends Component {
 				return false;
 			}
 
-			// Hosting routes apply to all Atomic sites.
-			if ( site.options.is_automated_transfer ) {
-				return true;
-			}
-
-			// hosting/all-sites allows Simple sites, so they can be exposed to upgrade notices.
-			return isEnabled( 'hosting/all-sites' );
+			// allow both Atomic sites and Simple sites, so they can be exposed to upgrade notices.
+			return true;
 		}
 
 		return site;

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -8,7 +8,6 @@ import isVipSite from 'state/selectors/is-vip-site';
 import getRawSite from 'state/selectors/get-raw-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import canCurrentUser from 'state/selectors/can-current-user';
-import isSiteOnAtomicPlan from 'state/selectors/is-site-on-atomic-plan';
 
 /**
  * TODO: this selector should be backed by an API response instead
@@ -40,9 +39,5 @@ export default function canSiteViewAtomicHosting( state ) {
 		return false;
 	}
 
-	if ( isEnabled( 'hosting/all-sites' ) ) {
-		return true;
-	}
-
-	return isSiteOnAtomicPlan( state, siteId );
+	return true;
 }


### PR DESCRIPTION
### Summary

This PR removes the feature flag shielding the Hosting Configuration section from Simple sites.

<hr>

### Screenshots

To recap expected states:

**Hosting Panel when access is activated on an Atomic site:**
<img width="1098" alt="Screen Shot 2019-12-11 at 4 58 13 PM" src="https://user-images.githubusercontent.com/8892849/70664347-3d468700-1c38-11ea-99b9-09266dff8a44.png">

**Hosting Panel with upgrade banner on a Simple site:**
<img width="1120" alt="Screen Shot 2019-12-11 at 4 58 00 PM" src="https://user-images.githubusercontent.com/8892849/70664359-42a3d180-1c38-11ea-8f8b-1d044f5f427e.png">

<hr>

### Testing

This should not change any functionality, besides removing the development flag and no longer encapsulating the existing Upgrade banner/visibility to Simple Sites for the panel.

*  Startup a local Calypso development environment with this branch and  `npm start` without setting any feature flags.
* Make sure that you can view the Hosting Configuration section using a Simple Site.
* Ensure there are no regressions.

<hr>

This is a followup to #36489 in preparation to flip the switch.