### PR TITLE
Clear user when an account is successfully closed (marked for deletion)

### DIFF
--- a/client/state/account/actions.js
+++ b/client/state/account/actions.js
@@ -1,9 +1,12 @@
 /**
  * Internal dependencies
  */
+import userFactory from 'lib/user';
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'state/action-types';
 
 import 'state/data-layer/wpcom/me/account/close';
+
+const user = userFactory();
 
 export function closeAccount() {
 	return {
@@ -12,7 +15,10 @@ export function closeAccount() {
 }
 
 export function closeAccountSuccess() {
-	return {
-		type: ACCOUNT_CLOSE_SUCCESS,
+	return async dispatch => {
+		await user.clear();
+		dispatch( {
+			type: ACCOUNT_CLOSE_SUCCESS,
+		} );
 	};
 }

--- a/client/state/account/test/actions.js
+++ b/client/state/account/test/actions.js
@@ -4,6 +4,10 @@
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'state/action-types';
 import { closeAccount, closeAccountSuccess } from 'state/account/actions';
 
+jest.mock( 'lib/user', () => () => {
+	return { clear: jest.fn() };
+} );
+
 describe( 'actions', () => {
 	describe( '#closeAccount', () => {
 		test( 'should return an action when an account is closed', () => {
@@ -15,9 +19,10 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#closeAccountSuccess', () => {
-		test( 'should return an action when an account is closed successfully', () => {
-			const action = closeAccountSuccess();
-			expect( action ).toEqual( {
+		test( 'should dispatch an action when an account is closed successfully', async () => {
+			const spy = jest.fn();
+			await closeAccountSuccess()( spy );
+			expect( spy ).toHaveBeenCalledWith( {
 				type: ACCOUNT_CLOSE_SUCCESS,
 			} );
 		} );

--- a/client/state/data-layer/wpcom/me/account/close/test/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/test/index.js
@@ -11,6 +11,10 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { closeAccount } from 'state/account/actions';
 import { ACCOUNT_CLOSE_SUCCESS } from 'state/action-types';
 
+jest.mock( 'lib/user', () => () => {
+	return { clear: jest.fn() };
+} );
+
 describe( 'account-close', () => {
 	describe( 'requestAccountClose', () => {
 		test( 'should dispatch a HTTP request', () => {
@@ -39,14 +43,13 @@ describe( 'account-close', () => {
 	} );
 
 	describe( 'receiveAccountCloseSuccess', () => {
-		test( 'should fire a success action', () => {
-			const result = receiveAccountCloseSuccess();
+		test( 'should dispatch a success action', async () => {
+			const spy = jest.fn();
+			await receiveAccountCloseSuccess()( spy );
 
-			expect( result ).toEqual(
-				expect.objectContaining( {
-					type: ACCOUNT_CLOSE_SUCCESS,
-				} )
-			);
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_CLOSE_SUCCESS,
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
This PR fixes an issue where if a user creates an account but doesn't complete site signup, then navigates to `/` and then decides to delete their account at `/me/account/close`, their signup state still remains. If they navigate to `/start` they will be stuck in the same signup flow they were in before, and unable to reach the `user` step. The only way to reset signup is to clear their cache, or log in and log out with another user account. If the user proceeds to try to complete signup, they will get stuck.

The fix proposes calling `user.clear()` when a request to close an account is successful, similar to what we do when we log out a user.

#### Before

After deleting an account and navigating back to `/`, this is what happens when a user clicks on Get Started:

![delete-user-before](https://user-images.githubusercontent.com/14988353/70689242-d09abd80-1d07-11ea-9aa4-a7d26a1d6440.gif)

If they proceed to try to complete signup they'll run into a bunch of errors:

![image](https://user-images.githubusercontent.com/14988353/70689223-bfea4780-1d07-11ea-81f7-9e6c52379848.png)

#### After

Here's a more complete demonstration of the issue resolved, going from creating a user account, navigating to delete the user account, and then navigating back to `/start`:

![delete-user](https://user-images.githubusercontent.com/14988353/70689276-edcf8c00-1d07-11ea-8772-6751a6791d2f.gif)

#### Changes proposed in this Pull Request

* Call `user.clear()` to clear out the current user and signup state when an account is closed (marked for deletion)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an incognito window
* Go to `/start` and create a new user account but don't complete signup
* Navigate to `/me/account/close`
* In the console, look at `state.account` and the `isClosed` property should be `false`
* Delete this newly created account
* In the console, look at `state.account` and the `isClosed` property should be `true`
* Navigate to `/start`
* You should now be on the `user` step of signup
* In the console, look at `state.account` and the `isClosed` property should be `false`
* Create another new account and complete signup as normal, and confirm that your site is created

Fixes https://github.com/Automattic/zelda-private/issues/259
