### PR TITLE
Fix: Missing "Credit applied" badge on atomic sites

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -289,18 +289,21 @@ export class PlanFeaturesHeader extends Component {
 			currentSitePlan,
 			discountPrice,
 			isJetpack,
+			isSiteAT,
 			planType,
 			rawPrice,
 			showPlanCreditsApplied,
 			translate,
 		} = this.props;
 
+		const isJetpackNotAtomic = isJetpack && ! isSiteAT;
+
 		if (
 			! showPlanCreditsApplied ||
 			! availableForPurchase ||
 			planMatches( planType, { type: TYPE_FREE } ) ||
 			planType === currentSitePlan.productSlug ||
-			isJetpack ||
+			isJetpackNotAtomic ||
 			! discountPrice ||
 			discountPrice >= rawPrice
 		) {

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -492,6 +492,8 @@ describe( 'PlanFeaturesHeader.renderCreditLabel()', () => {
 		rawPrice: 100,
 		discountPrice: 80,
 		translate: identity,
+		isJetpack: false,
+		isSiteAT: false,
 	};
 
 	test( 'Should display credit label for discounted higher-tier plans that are available for purchase', () => {
@@ -527,6 +529,27 @@ describe( 'PlanFeaturesHeader.renderCreditLabel()', () => {
 
 	test( 'Should not display credit label when discount price is higher than rawPrice', () => {
 		const instance = new PlanFeaturesHeader( { ...baseProps, discountPrice: 101 } );
+		expect( instance.renderCreditLabel() ).toBe( null );
+	} );
+
+	test( 'Should display credit label for atomic site on Business plan ', () => {
+		const instance = new PlanFeaturesHeader( {
+			...baseProps,
+			planType: PLAN_BUSINESS,
+			isJetpack: true,
+			isSiteAT: true,
+		} );
+		const wrapper = shallow( <span>{ instance.renderCreditLabel() }</span> );
+		expect( wrapper.find( '.plan-features__header-credit-label' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should not display credit label for Jetpack site ', () => {
+		const instance = new PlanFeaturesHeader( {
+			...baseProps,
+			planType: PLAN_JETPACK_PREMIUM,
+			isJetpack: true,
+			isSiteAT: false,
+		} );
 		expect( instance.renderCreditLabel() ).toBe( null );
 	} );
 } );

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -259,6 +259,8 @@ describe( 'PlanFeatures.renderCreditNotice', () => {
 			{ currencyCode: 'USD', planName: 'test-bundle', availableForPurchase: true },
 		],
 		showPlanCreditsApplied: true,
+		isJetpack: false,
+		isSiteAT: false,
 	};
 
 	const createInstance = props => {
@@ -308,5 +310,14 @@ describe( 'PlanFeatures.renderCreditNotice', () => {
 		const instance = createInstance( { ...baseProps, planCredits: 0 } );
 		const notice = instance.renderCreditNotice();
 		expect( notice ).toBe( null );
+	} );
+
+	test( 'Should display a credit notice for an atomic site on a Business plan', () => {
+		const instance = createInstance( { ...baseProps, isJetpack: true, isSiteAT: true } );
+		const notice = instance.renderCreditNotice();
+		expect( notice ).not.toBe( null );
+
+		const wrapper = shallow( notice );
+		expect( wrapper.find( '.plan-features__notice-credits' ).length ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In `/plans/{SITE_SLUG}` page, the "Credit applied" badge does not show for an atomic site on the Business plan. 
* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/38247, which fixed the missing pro-rated credits banner on atomic sites.

**BEFORE**(Missing "Credit applied" badge on atomic site)

<img width="2250" alt="Screenshot 2019-12-12 at 12 03 45 PM" src="https://user-images.githubusercontent.com/1269602/70690028-c06ce900-1cdb-11ea-884a-a4d3306f66eb.png">

**AFTER**

<img width="1065" alt="Screenshot 2019-12-12 at 12 34 54 PM" src="https://user-images.githubusercontent.com/1269602/70690052-d4184f80-1cdb-11ea-93ef-c98770c4f01e.png">




#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify all the following on the plans page at `/plans/{SITE_SLUG}`:

**Scenario 1**
* For a site on a free plan, verify the badge is not shown.
* Upgrade to Premium -verify badge is shown on all higher plans
* Upgrade to eCommerce - verify badge is not shown on any plan(because we are on the highest tier already, so there's nothing more to upgrade too).

**Scenario 2**

* For a site on a Business plan, verify badge is shown on the eCommerce plan
* Install a plugin on the site so that it goes atomic while continuing to be on the Business plan
* Verify that the badge still shows(without this patch it wouldn't have shown).

