### PR TITLE
Do not show "Your Plan" badge in the plans step of signup flow

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -42,7 +42,16 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderPlansHeader() {
-		const { newPlan, bestValue, planType, popular, selectedPlan, title, translate } = this.props;
+		const {
+			newPlan,
+			bestValue,
+			planType,
+			popular,
+			selectedPlan,
+			isInSignup,
+			title,
+			translate,
+		} = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isCurrent = this.isPlanCurrent();
@@ -57,7 +66,7 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getPlanFeaturesPrices() }
 					{ this.getBillingTimeframe() }
 				</div>
-				{ isCurrent && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+				{ isCurrent && ! isInSignup && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
 				{ planLevelsMatch( selectedPlan, planType ) && ! isCurrent && (
 					<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
 				) }

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -46,6 +46,8 @@ export class PlanFeaturesHeader extends Component {
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isCurrent = this.isPlanCurrent();
+		console.log( 'iscurrent is' );
+		console.log( isCurrent );
 
 		return (
 			<header className={ headerClasses }>
@@ -88,7 +90,7 @@ export class PlanFeaturesHeader extends Component {
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
 		return (
-			<>
+			<span>
 				<header className={ headerClasses }>
 					<h4 className="plan-features__header-title">{ title }</h4>
 					<div className="plan-features__audience">{ audience }</div>
@@ -106,7 +108,7 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
 					{ this.getIntervalDiscount() }
 				</div>
-			</>
+			</span>
 		);
 	}
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -42,12 +42,19 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderPlansHeader() {
-		const { newPlan, bestValue, planType, popular, selectedPlan, title, translate } = this.props;
+		const {
+			newPlan,
+			bestValue,
+			planType,
+			popular,
+			selectedPlan,
+			isInSignup,
+			title,
+			translate,
+		} = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isCurrent = this.isPlanCurrent();
-		console.log( 'iscurrent is' );
-		console.log( isCurrent );
 
 		return (
 			<header className={ headerClasses }>
@@ -59,7 +66,7 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getPlanFeaturesPrices() }
 					{ this.getBillingTimeframe() }
 				</div>
-				{ isCurrent && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+				{ ! isInSignup && isCurrent && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
 				{ planLevelsMatch( selectedPlan, planType ) && ! isCurrent && (
 					<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
 				) }
@@ -83,7 +90,6 @@ export class PlanFeaturesHeader extends Component {
 			selectedPlan,
 			title,
 			audience,
-			isInSignup,
 			translate,
 		} = this.props;
 
@@ -100,9 +106,6 @@ export class PlanFeaturesHeader extends Component {
 					{ popular && ! selectedPlan && <PlanPill>{ translate( 'Popular' ) }</PlanPill> }
 					{ newPlan && ! selectedPlan && <PlanPill>{ translate( 'New' ) }</PlanPill> }
 					{ bestValue && ! selectedPlan && <PlanPill>{ translate( 'Best Value' ) }</PlanPill> }
-					{ this.isPlanCurrent() && ! isInSignup && (
-						<PlanPill>{ translate( 'Your Plan' ) }</PlanPill>
-					) }
 				</header>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -42,16 +42,7 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderPlansHeader() {
-		const {
-			newPlan,
-			bestValue,
-			planType,
-			popular,
-			selectedPlan,
-			isInSignup,
-			title,
-			translate,
-		} = this.props;
+		const { newPlan, bestValue, planType, popular, selectedPlan, title, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isCurrent = this.isPlanCurrent();
@@ -66,7 +57,7 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getPlanFeaturesPrices() }
 					{ this.getBillingTimeframe() }
 				</div>
-				{ isCurrent && ! isInSignup && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+				{ isCurrent && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
 				{ planLevelsMatch( selectedPlan, planType ) && ! isCurrent && (
 					<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
 				) }
@@ -90,6 +81,7 @@ export class PlanFeaturesHeader extends Component {
 			selectedPlan,
 			title,
 			audience,
+			isInSignup,
 			translate,
 		} = this.props;
 
@@ -106,7 +98,9 @@ export class PlanFeaturesHeader extends Component {
 					{ popular && ! selectedPlan && <PlanPill>{ translate( 'Popular' ) }</PlanPill> }
 					{ newPlan && ! selectedPlan && <PlanPill>{ translate( 'New' ) }</PlanPill> }
 					{ bestValue && ! selectedPlan && <PlanPill>{ translate( 'Best Value' ) }</PlanPill> }
-					{ this.isPlanCurrent() && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+					{ this.isPlanCurrent() && ! isInSignup && (
+						<PlanPill>{ translate( 'Your Plan' ) }</PlanPill>
+					) }
 				</header>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
@@ -26,7 +30,7 @@ jest.mock( 'i18n-calypso', () => ( {
  * External dependencies
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { identity } from 'lodash';
 
 /**
@@ -34,6 +38,7 @@ import { identity } from 'lodash';
  */
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import { PlanFeaturesHeader } from '../header';
+import PlanPill from 'components/plans/plan-pill';
 import {
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
@@ -99,6 +104,34 @@ describe( 'PlanFeaturesHeader.getDiscountTooltipMessage()', () => {
 			);
 		} );
 	} );
+} );
+
+describe( 'PlanFeaturesHeader.renderPlansHeaderNoTabs()', () => {
+	[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ].forEach( productSlug => {
+		test( `Should render "Your Plan" plan pill for paid plans (${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isJetpack: false,
+				isPlaceholder: false,
+				currentSitePlan: { productSlug: PLAN_PREMIUM },
+				planType: productSlug,
+			};
+			// const pfh = mount( <PlanFeaturesHeader { ...myProps } />);
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			// const pfh = shallow( comp.renderPlansHeaderNoTabs() );
+			const pfh = shallow( comp.renderPlansHeaderNoTabs() );
+			console.log( pfh.html() );
+
+			expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( true );
+		} );
+	} );
+
+	// test( `Should not render "Your Plan" plan pill for free plan (${ productSlug })`, () => {
+	// 	const myProps = { ...props, isJetpack: false, planType: PLAN_FREE };
+	// 	const pfh = mount( <PlanFeaturesHeader { ...myProps } />);
+
+	// 	expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( false );
+	// } );
 } );
 
 describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -112,7 +112,7 @@ describe( 'PlanFeaturesHeader.renderPlansHeaderNoTabs()', () => {
 			const myProps = {
 				...props,
 				isPlaceholder: false,
-				currentSitePlan: { productSlug: productSlug },
+				currentSitePlan: { productSlug },
 				planType: PLAN_PREMIUM,
 				popular: false,
 				newPlan: false,
@@ -128,7 +128,7 @@ describe( 'PlanFeaturesHeader.renderPlansHeaderNoTabs()', () => {
 			const myProps = {
 				...props,
 				isPlaceholder: false,
-				currentSitePlan: { productSlug: productSlug },
+				currentSitePlan: { productSlug },
 				planType: PLAN_PREMIUM,
 				popular: true,
 				newPlan: false,
@@ -149,7 +149,7 @@ describe( 'PlanFeaturesHeader.renderPlansHeader()', () => {
 				...props,
 				isPlaceholder: false,
 				isInSignup: false,
-				currentSitePlan: { productSlug: productSlug },
+				currentSitePlan: { productSlug },
 				planType: productSlug,
 			};
 			const comp = new PlanFeaturesHeader( { ...myProps } );
@@ -166,7 +166,7 @@ describe( 'PlanFeaturesHeader.renderPlansHeader()', () => {
 				...props,
 				isPlaceholder: false,
 				isInSignup: false,
-				currentSitePlan: { productSlug: productSlug },
+				currentSitePlan: { productSlug },
 				planType: PLAN_PREMIUM,
 				popular: true,
 			};
@@ -185,7 +185,7 @@ describe( 'PlanFeaturesHeader.renderPlansHeader()', () => {
 				...props,
 				isPlaceholder: false,
 				isInSignup: true,
-				currentSitePlan: { productSlug: productSlug },
+				currentSitePlan: { productSlug },
 				planType: PLAN_PREMIUM,
 			};
 			// const pfh = mount( <PlanFeaturesHeader { ...myProps } />);
@@ -220,7 +220,7 @@ describe( 'PlanFeaturesHeader.renderPlansHeader()', () => {
 				...props,
 				isPlaceholder: false,
 				isInSignup: false,
-				currentSitePlan: { productSlug: productSlug },
+				currentSitePlan: { productSlug },
 				planType: productSlug,
 				popular: false,
 				newPlan: false,

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -30,7 +30,7 @@ jest.mock( 'i18n-calypso', () => ( {
  * External dependencies
  */
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { identity } from 'lodash';
 
 /**
@@ -108,30 +108,166 @@ describe( 'PlanFeaturesHeader.getDiscountTooltipMessage()', () => {
 
 describe( 'PlanFeaturesHeader.renderPlansHeaderNoTabs()', () => {
 	[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ].forEach( productSlug => {
-		test( `Should render "Your Plan" plan pill for paid plans (${ productSlug })`, () => {
+		test( `Should not render "Your Plan" plan pill (${ productSlug })`, () => {
 			const myProps = {
 				...props,
-				isJetpack: false,
 				isPlaceholder: false,
-				currentSitePlan: { productSlug: PLAN_PREMIUM },
+				currentSitePlan: { productSlug: productSlug },
+				planType: PLAN_PREMIUM,
+				popular: false,
+				newPlan: false,
+				bestValue: false,
+			};
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			const pfh = shallow( comp.renderPlansHeaderNoTabs() );
+
+			expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( false );
+		} );
+
+		test( `Should render "Popular" plan pill (${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isPlaceholder: false,
+				currentSitePlan: { productSlug: productSlug },
+				planType: PLAN_PREMIUM,
+				popular: true,
+				newPlan: false,
+				bestValue: false,
+			};
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			const pfh = shallow( comp.renderPlansHeaderNoTabs() );
+
+			expect( pfh.contains( <PlanPill>Popular</PlanPill> ) ).toBe( true );
+		} );
+	} );
+} );
+
+describe( 'PlanFeaturesHeader.renderPlansHeader()', () => {
+	[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ].forEach( productSlug => {
+		test( `Should render "Your Plan" plan pill and no other plan pills for a paid plan in /plans page (${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isPlaceholder: false,
+				isInSignup: false,
+				currentSitePlan: { productSlug: productSlug },
 				planType: productSlug,
+			};
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			const pfh = shallow( comp.renderPlansHeader() );
+
+			expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( true );
+
+			[ 'New', 'Popular', 'Best Value' ].forEach( planPillLabel => {
+				expect( pfh.contains( <PlanPill>${ planPillLabel }</PlanPill> ) ).toBe( false );
+			} );
+		} );
+		test( `Should render "Your Plan" plan pill only, even if plan is Popular (${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isPlaceholder: false,
+				isInSignup: false,
+				currentSitePlan: { productSlug: productSlug },
+				planType: PLAN_PREMIUM,
+				popular: true,
+			};
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			const pfh = shallow( comp.renderPlansHeader() );
+
+			expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( true );
+
+			[ 'New', 'Popular', 'Best Value' ].forEach( planPillLabel => {
+				expect( pfh.contains( <PlanPill>${ planPillLabel }</PlanPill> ) ).toBe( false );
+			} );
+		} );
+
+		test( `Should not render "Your Plan" plan pill in Signup flow (${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isPlaceholder: false,
+				isInSignup: true,
+				currentSitePlan: { productSlug: productSlug },
+				planType: PLAN_PREMIUM,
 			};
 			// const pfh = mount( <PlanFeaturesHeader { ...myProps } />);
 			const comp = new PlanFeaturesHeader( { ...myProps } );
-			// const pfh = shallow( comp.renderPlansHeaderNoTabs() );
-			const pfh = shallow( comp.renderPlansHeaderNoTabs() );
-			console.log( pfh.html() );
+			const pfh = shallow( comp.renderPlansHeader() );
 
-			expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( true );
+			expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( false );
+		} );
+
+		test( `Should render "Popular" plan pill in Signup flow (${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isPlaceholder: false,
+				isInSignup: true,
+				planType: PLAN_PREMIUM,
+				popular: true,
+			};
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			const pfh = shallow( comp.renderPlansHeader() );
+
+			expect( pfh.contains( <PlanPill>Popular</PlanPill> ) ).toBe( true );
+
+			[ 'New', 'Your Plan', 'Best Value' ].forEach( planPillLabel => {
+				expect( pfh.contains( <PlanPill>${ planPillLabel }</PlanPill> ) ).toBe( false );
+			} );
 		} );
 	} );
 
-	// test( `Should not render "Your Plan" plan pill for free plan (${ productSlug })`, () => {
-	// 	const myProps = { ...props, isJetpack: false, planType: PLAN_FREE };
-	// 	const pfh = mount( <PlanFeaturesHeader { ...myProps } />);
+	[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ].forEach( productSlug => {
+		test( `Should render "Your Plan" plan pill only even if plan is Best Value in /plans page(${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isPlaceholder: false,
+				isInSignup: false,
+				currentSitePlan: { productSlug: productSlug },
+				planType: productSlug,
+				popular: false,
+				newPlan: false,
+				bestValue: true,
+			};
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			const pfh = shallow( comp.renderPlansHeader() );
 
-	// 	expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( false );
-	// } );
+			expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( true );
+
+			[ 'New', 'Popular', 'Best Value' ].forEach( planPillLabel => {
+				expect( pfh.contains( <PlanPill>${ planPillLabel }</PlanPill> ) ).toBe( false );
+			} );
+		} );
+
+		test( `Should render "Best Value" plan pill if in signup flow(${ productSlug })`, () => {
+			const myProps = {
+				...props,
+				isPlaceholder: false,
+				isInSignup: true,
+				planType: productSlug,
+				popular: false,
+				newPlan: false,
+				bestValue: true,
+			};
+			const comp = new PlanFeaturesHeader( { ...myProps } );
+			const pfh = shallow( comp.renderPlansHeader() );
+
+			expect( pfh.contains( <PlanPill>Best Value</PlanPill> ) ).toBe( true );
+
+			[ 'New', 'Popular', 'Your Plan' ].forEach( planPillLabel => {
+				expect( pfh.contains( <PlanPill>${ planPillLabel }</PlanPill> ) ).toBe( false );
+			} );
+		} );
+	} );
+
+	[ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM ].forEach(
+		productSlug => {
+			test( `Should not render "Your Plan" plan pill if currently on the free plan`, () => {
+				const myProps = { ...props, isInSignup: false, planType: productSlug };
+				const comp = new PlanFeaturesHeader( { ...myProps } );
+				const pfh = shallow( comp.renderPlansHeader() );
+
+				expect( pfh.contains( <PlanPill>Your Plan</PlanPill> ) ).toBe( false );
+			} );
+		}
+	);
 } );
 
 describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
@@ -158,7 +294,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 		test( `Should render InfoPopover for non-jetpack sites (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( {
 				...myProps,
-				isSiteJetpack: false,
+				isJetpack: false,
 				planType: productSlug,
 			} );
 			const tf = shallow( comp.getBillingTimeframe() );
@@ -168,7 +304,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 		test( `Should render InfoPopover for AT sites (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( {
 				...myProps,
-				isSiteJetpack: true,
+				isJetpack: true,
 				isSiteAT: true,
 				planType: productSlug,
 			} );
@@ -179,7 +315,7 @@ describe( 'PlanFeaturesHeader.getBillingTimeframe()', () => {
 		test( `Should render InfoPopover when hideMonthly is true (${ productSlug })`, () => {
 			const comp = new PlanFeaturesHeader( {
 				...myProps,
-				isSiteJetpack: true,
+				isJetpack: true,
 				hideMonthly: true,
 				planType: productSlug,
 			} );

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -188,7 +188,6 @@ describe( 'PlanFeaturesHeader.renderPlansHeader()', () => {
 				currentSitePlan: { productSlug },
 				planType: PLAN_PREMIUM,
 			};
-			// const pfh = mount( <PlanFeaturesHeader { ...myProps } />);
 			const comp = new PlanFeaturesHeader( { ...myProps } );
 			const pfh = shallow( comp.renderPlansHeader() );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As described in https://github.com/Automattic/wp-calypso/issues/36712#issuecomment-544423842, the "Your Plan" badge appears in the plans step of the signup flow if the user goes through "Add new site" while another site on his account is on a paid plan. This PR removes that label. 
* Technical details:
`renderPlansHeader()` is used to render /plans page in Calypso.
`renderPlansHeaderNoTabs()` is used to render the plans step in signup flow /start/plans

In this PR, we remove the "Your Plan" badge rendering line from `renderPlansHeaderNoTabs()`. 


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through signup flow and verify that in the plans step, "Popular" badge is shown. 
* On an existing site on a paid plan, click "Add new site" and go through the signup flow. Verify that "Your Plan" badge does not show in the plans step of the signup flow.
* On a paid plan account, verify that "Your Plan" badge is shown in /plans page in Calypso. Verify this for both a wpcom site and Jetpack site(use https://jurassic.ninja to setup a Jetpack site).
* On a free plan account, verify that the /plans page in Calypso does not show the Your Plan badge but instead shows the Popular plan badge(verify for both wpcom and Jetpack sites).

Fixes https://github.com/Automattic/wp-calypso/issues/36712
