### PR TITLE
WPCOM Block Editor: Remove disable-nux-tour

### DIFF
--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -18,7 +18,6 @@ There are two environments the block editor integration supports:
 
 ### Common utilities
 
-- `disable-nux-tour.js`: Disable the pop-up tooltip tour that is displayed on first use.
 - `rich-text.js`: Extensions for the Rich Text toolbar with the Calypso buttons missing on Core (i.e. underline, justify).
 - `fix-block-invalidation-errors.js`: (Atomic/Simple) Performs block attempt block recovery on editor load if validation errors are detected.
 - `switch-to-classic.js`: Append a button to the "More tools" menu for switching to the classic editor.

--- a/apps/wpcom-block-editor/src/common/disable-nux-tour.js
+++ b/apps/wpcom-block-editor/src/common/disable-nux-tour.js
@@ -1,7 +1,0 @@
-/**
- * External dependencies
- */
-import { dispatch } from '@wordpress/data';
-import '@wordpress/nux'; //ensure nux store loads
-
-dispatch( 'core/nux' ).disableTips();

--- a/apps/wpcom-block-editor/src/common/index.js
+++ b/apps/wpcom-block-editor/src/common/index.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import './disable-nux-tour';
 import './fix-block-invalidation-errors';
 import './reorder-block-categories';
 import './rich-text';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `disable-nux-tour` override from the WPCOM Block Editor integration.

We were disabling it for several reasons: it was on a per-site basis, so users with many sites would get annoyed by it; it had wonky positioning on WPCOM because of its forced fullscreen mode.

Core Gutenberg recently [changed the NUX](https://github.com/WordPress/gutenberg/pull/18041) from `DotTip` (tooltips relatively positioned to their container element) to a `WelcomeGuide` ("multi-step" modal with text and images).

Eventually WPCOM will have a fully customized Welcome Guide instead of Core's, but for now, reenabling the vanilla Core NUX is better than nothing. 🙂 

<img width="779" alt="Screenshot 2019-12-12 at 12 19 01" src="https://user-images.githubusercontent.com/2070010/70711524-a8946580-1cd9-11ea-8953-5f2b195baf34.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Pre-requisites:

- Apply D36655 (twin diff of this PR).
- Sandbox `widgets.wp.com`.
- Pre-sandbox a new site.

Test:

- Create a new site with the pre-sandboxed URL on Horizon (https://horizon.wordpress.com/jetpack/new).
This is because the new Core NUX is available starting from Gutenberg 7.1.0, which as of today is not in WPCOM Production yet.
- Open the block editor.
- Make sure the Welcome Guide shows up.
- Close the Welcome Guide and reload the editor.
- Make sure the Welcome Guide doesn't show up anymore. It can be triggered again in the editor's More menu (ellipsis icon).

Part of #38299