### PR TITLE
Framework: Remove fontfaceobserver dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13377,11 +13377,6 @@
 				}
 			}
 		},
-		"fontfaceobserver": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
-			"integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
 		"filesize": "6.0.1",
 		"flag-icon-css": "3.4.5",
 		"flux": "3.1.3",
-		"fontfaceobserver": "2.1.0",
 		"fuse.js": "3.4.6",
 		"get-video-id": "3.1.4",
 		"gfm-code-blocks": "1.0.0",


### PR DESCRIPTION
In #30163 we started using the `fontfaceobserver` package but in #32135 we removed the last instance where we used it. Since it's no longer used, I suggest that we remove it completely from our dependencies.

#### Changes proposed in this Pull Request

* Remove `fontfaceobserver` because it's no longer used.

#### Testing instructions

* Checkout this branch.
* Run `npm install` and `npm run build`.
* Verify `fontfaceobserver` is used nowhere.
