### PR TITLE
Gutenboarding: Remove logo from header

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -90,9 +90,6 @@ const Header: FunctionComponent< Props > = ( {
 					</Button>
 				</div>
 				<div className="gutenboarding__header-group">
-					<Icon icon="wordpress-alt" color="#066188" />
-				</div>
-				<div className="gutenboarding__header-group">
 					{ currentDomain ? (
 						<DomainPickerButton
 							className="gutenboarding__header-domain-picker-button"


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* remove WordPress logo from header

#### Testing instructions
W logo should no longer be displayed in header