### PR TITLE
Components: Add TemplateSelector component

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -36,7 +36,6 @@ import { Steps } from './types';
 import './stores/domain-suggestions';
 import './stores/verticals-templates';
 import './style.scss';
-import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
 
 const stepCompleted: Record< Steps, ( state: OnboardingState ) => boolean > = {
 	[ Steps.IntentGathering ]: ( { siteVertical } ) => !! siteVertical,

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
  * Internal dependencies
  */
 import { SiteVertical } from '../../stores/onboard/types';
-import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control';
+import { TemplateSelector } from '@automattic/components';
 
 export default () => {
 	const siteVertical = useSelect(
@@ -28,7 +28,7 @@ export default () => {
 		<div
 			className="page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
 		>
-			<TemplateSelectorControl
+			<TemplateSelector
 				label={ NO__( 'Layout', 'full-site-editing' ) }
 				templates={ homepageTemplates }
 				blocksByTemplates={ {} /* Unneeded, since we're setting `useDynamicPreview` to `false` */ }

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -8,3 +8,4 @@ export { default as Ribbon } from './ribbon';
 export { default as RootChild } from './root-child';
 export { default as ScreenReaderText } from './screen-reader-text';
 export { default as Suggestions } from './suggestions';
+export { default as TemplateSelector } from './template-selector';

--- a/packages/components/src/template-selector/index.js
+++ b/packages/components/src/template-selector/index.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { isEmpty, isArray, noop, map } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+// import { withInstanceId, compose } from '@wordpress/compose';
+import { BaseControl } from '@wordpress/components';
+// import { memo } from '@wordpress/element';
+
+import './style.scss';
+
+/**
+ * Internal dependencies
+ */
+import TemplateSelectorItem from './item';
+import replacePlaceholders from './utils/replace-placeholders';
+
+export const TemplateSelector = ( {
+	label,
+	className,
+	help,
+	instanceId,
+	templates = [],
+	blocksByTemplates = {},
+	useDynamicPreview = false,
+	onTemplateSelect = noop,
+	siteInformation = {},
+	selectedTemplate,
+	handleTemplateConfirmation = noop,
+} ) => {
+	if ( isEmpty( templates ) || ! isArray( templates ) ) {
+		return null;
+	}
+
+	if ( true === useDynamicPreview && isEmpty( blocksByTemplates ) ) {
+		return null;
+	}
+
+	const id = `template-selector-${ instanceId }`;
+
+	return (
+		<BaseControl
+			label={ label }
+			id={ id }
+			help={ help }
+			className={ classnames( className, 'template-selector' ) }
+		>
+			<ul className="template-selector__options" data-testid="template-selector-options">
+				{ map( templates, ( { slug, title, preview, previewAlt } ) => (
+					<li key={ `${ id }-${ slug }` } className="template-selector__template">
+						<TemplateSelectorItem
+							id={ id }
+							value={ slug }
+							label={ replacePlaceholders( title, siteInformation ) }
+							help={ help }
+							onSelect={ onTemplateSelect }
+							staticPreviewImg={ preview }
+							staticPreviewImgAlt={ previewAlt }
+							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }
+							useDynamicPreview={ useDynamicPreview }
+							isSelected={ slug === selectedTemplate }
+							handleTemplateConfirmation={ handleTemplateConfirmation }
+						/>
+					</li>
+				) ) }
+			</ul>
+		</BaseControl>
+	);
+};
+
+//export default compose( memo, withInstanceId )( TemplateSelector );
+export default TemplateSelector;

--- a/packages/components/src/template-selector/index.js
+++ b/packages/components/src/template-selector/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 // import { withInstanceId, compose } from '@wordpress/compose';
-import { BaseControl } from '@wordpress/components';
+// import { BaseControl } from '@wordpress/components';
 // import { memo } from '@wordpress/element';
 
 import './style.scss';
@@ -44,7 +44,7 @@ export const TemplateSelector = ( {
 	const id = `template-selector-${ instanceId }`;
 
 	return (
-		<BaseControl
+		<div
 			label={ label }
 			id={ id }
 			help={ help }
@@ -69,7 +69,7 @@ export const TemplateSelector = ( {
 					</li>
 				) ) }
 			</ul>
-		</BaseControl>
+		</div>
 	);
 };
 

--- a/packages/components/src/template-selector/item.js
+++ b/packages/components/src/template-selector/item.js
@@ -16,7 +16,6 @@ const TemplateSelectorItem = props => {
 		staticPreviewImgAlt = '',
 		blocks = [],
 		isSelected,
-		handleTemplateConfirmation,
 	} = props;
 
 	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
@@ -38,19 +37,8 @@ const TemplateSelectorItem = props => {
 
 	const labelId = `label-${ id }-${ value }`;
 
-	/**
-	 * Determines (based on whether the large preview is able to be visible at the
-	 * current breakpoint) whether or not the Template selection UI interaction model
-	 * should be select _and_ confirm or simply a single "tap to confirm".
-	 */
 	const handleLabelClick = () => {
-		const largeTplPreviewVisible = window.matchMedia( '(min-width: 660px)' ).matches;
-		// In both cases set the template as being selected
 		onSelect( value );
-		// Confirm the template when large preview isn't visible
-		if ( ! largeTplPreviewVisible ) {
-			handleTemplateConfirmation( value );
-		}
 	};
 
 	return (

--- a/packages/components/src/template-selector/item.js
+++ b/packages/components/src/template-selector/item.js
@@ -26,7 +26,7 @@ const TemplateSelectorItem = props => {
 		return null;
 	}
 
-	// Define static or dynamic preview.
+	// Define preview.
 	const innerPreview = (
 		<img
 			className="template-selector__item-media"

--- a/packages/components/src/template-selector/item.js
+++ b/packages/components/src/template-selector/item.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { isNil, isEmpty } from 'lodash';
+import classnames from 'classnames';
+
+const TemplateSelectorItem = props => {
+	const {
+		id,
+		value,
+		onSelect,
+		label,
+		useDynamicPreview = false,
+		staticPreviewImg,
+		staticPreviewImgAlt = '',
+		blocks = [],
+		isSelected,
+		handleTemplateConfirmation,
+	} = props;
+
+	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
+		return null;
+	}
+
+	if ( useDynamicPreview && ( isNil( blocks ) || isEmpty( blocks ) ) ) {
+		return null;
+	}
+
+	// Define static or dynamic preview.
+	const innerPreview = (
+		<img
+			className="template-selector__item-media"
+			src={ staticPreviewImg }
+			alt={ staticPreviewImgAlt }
+		/>
+	);
+
+	const labelId = `label-${ id }-${ value }`;
+
+	/**
+	 * Determines (based on whether the large preview is able to be visible at the
+	 * current breakpoint) whether or not the Template selection UI interaction model
+	 * should be select _and_ confirm or simply a single "tap to confirm".
+	 */
+	const handleLabelClick = () => {
+		const largeTplPreviewVisible = window.matchMedia( '(min-width: 660px)' ).matches;
+		// In both cases set the template as being selected
+		onSelect( value );
+		// Confirm the template when large preview isn't visible
+		if ( ! largeTplPreviewVisible ) {
+			handleTemplateConfirmation( value );
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			className={ classnames( 'template-selector__item-label', {
+				'is-selected': isSelected,
+			} ) }
+			value={ value }
+			onClick={ handleLabelClick }
+			aria-labelledby={ `${ id } ${ labelId }` }
+		>
+			<div className="template-selector__item-preview-wrap">{ innerPreview }</div>
+			<span className="template-selector__item-template-title" id={ labelId }>
+				{ label }
+			</span>
+		</button>
+	);
+};
+
+export default TemplateSelectorItem;

--- a/packages/components/src/template-selector/style.scss
+++ b/packages/components/src/template-selector/style.scss
@@ -1,0 +1,136 @@
+$template-selector-border-color: #e2e4e7;
+$template-selector-border-color-selected: #555d66;
+$template-selector-border-color-active: #00a0d2;
+$template-selector-border-color-hover: #c9c9ca;
+$template-selector-empty-background: #fff;
+$template-selector-modal-offset-bottom: 25px;
+$template-selector-modal-offset-right: 32px;
+$template-selector-blank-template-mobile-height: 70px;
+
+.template-selector__options {
+	display: grid;
+	// stylelint-disable-next-line unit-whitelist
+	grid-template-columns: 1fr;
+	grid-gap: 1.75em;
+
+	@media screen and ( min-width: 660px ) {
+		margin-top: 0;
+		// stylelint-disable unit-whitelist
+		grid-template-columns: repeat(
+			auto-fit,
+			minmax( 110px, 1fr )
+		); // allow grid to take over number of cols on large screens
+		// stylelint-enable unit-whitelist
+	}
+}
+
+.template-selector__option {
+	margin-bottom: 4px;
+}
+
+.template-selector__item-label {
+	display: block;
+	width: 100%;
+	font-size: 14px;
+	text-align: center;
+	border: solid 2px $template-selector-border-color;
+	border-radius: 6px;
+	cursor: pointer;
+	appearance: none;
+	padding: 0;
+	overflow: hidden;
+	background-color: #fff;
+	position: relative;
+	transform: translateZ( 0 ); // Fix for Safari rounded border overflow (1/2).
+
+	.template-selector__item-template-title {
+		width: 100%;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		height: 40px;
+		line-height: 40px;
+		background-color: #fff;
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 1px #fff, 0 0 0 3px $template-selector-border-color-active;
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+	}
+
+	&:hover {
+		border: solid 2px $template-selector-border-color-hover;
+	}
+
+	&.is-selected {
+		border: solid 2px $template-selector-border-color-selected;
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+		outline-offset: -2px;
+
+		&:focus {
+			box-shadow: 0 0 0 1px #fff, 0 0 0 3px $template-selector-border-color-active;
+			border: solid 2px $template-selector-border-color-selected;
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 4px solid transparent;
+			outline-offset: -4px;
+		}
+	}
+}
+
+.template-selector__item-preview-wrap {
+	width: 100%;
+	display: block;
+	margin: 0 auto;
+	background: $template-selector-empty-background;
+	border-radius: 0;
+	overflow: hidden;
+	height: 0;
+	padding-top: 100%; // Aspect radio boxes. It will take the 100% of width.
+	box-sizing: content-box;
+	position: relative;
+	pointer-events: none;
+	opacity: 1;
+	transform: translateZ( 0 ); // Fix for Safari rounded border overflow (2/2).
+
+	@media screen and ( max-width: 659px ) {
+		padding-top: 120%;
+	}
+
+	&.is-rendering {
+		opacity: 0.5;
+	}
+
+	.block-editor-block-list__layout,
+	.block-editor-block-list__block {
+		padding: inherit;
+	}
+}
+
+.template-selector__item-media {
+	width: 100%;
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+// Blank template
+.template-selector__template:first-child {
+	.template-selector__item-preview-wrap {
+		@media screen and ( max-width: 659px ) {
+			padding-top: 0%;
+			height: $template-selector-blank-template-mobile-height;
+		}
+	}
+	.template-selector__item-template-title {
+		@media screen and ( max-width: 659px ) {
+			height: $template-selector-blank-template-mobile-height;
+			line-height: $template-selector-blank-template-mobile-height;
+		}
+	}
+}

--- a/packages/components/src/template-selector/utils/replace-placeholders.js
+++ b/packages/components/src/template-selector/utils/replace-placeholders.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { _x } from '@wordpress/i18n';
+
+const PLACEHOLDER_DEFAULTS = {
+	Address: _x( '123 Main St', 'default address', 'full-site-editing' ),
+	Phone: _x( '555-555-5555', 'default phone number', 'full-site-editing' ),
+	CompanyName: _x( 'Your Company Name', 'default company name', 'full-site-editing' ),
+	Vertical: _x( 'Business', 'default vertical name', 'full-site-editing' ),
+};
+
+const KEY_MAP = {
+	CompanyName: 'title',
+	Address: 'address',
+	Phone: 'phone',
+	Vertical: 'vertical',
+};
+
+const replacePlaceholders = ( pageContent, siteInformation = {} ) => {
+	if ( ! pageContent ) {
+		return '';
+	}
+
+	return pageContent.replace( /{{(\w+)}}/g, ( match, placeholder ) => {
+		const defaultValue = PLACEHOLDER_DEFAULTS[ placeholder ];
+		const key = KEY_MAP[ placeholder ];
+		return siteInformation[ key ] || defaultValue || placeholder;
+	} );
+};
+
+export default replacePlaceholders;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WIP, extracting FSE's `TemplateSelectorControl` into `@automattic/components`, so we can reuse it (and style it) for Gutenboarding.

#### Testing instructions

- `http://calypso.localhost:3000/gutenboarding`
- Fill in vertical and site title, then click 'Next'
- Click on some template item, verify it's marked as selected