### PR TITLE
SPT: Move handleTemplateConfirmation up the component hierarchy

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -32,7 +32,6 @@ export const TemplateSelectorControl = ( {
 	onTemplateSelect = noop,
 	siteInformation = {},
 	selectedTemplate,
-	handleTemplateConfirmation = noop,
 } ) => {
 	if ( isEmpty( templates ) || ! isArray( templates ) ) {
 		return null;
@@ -68,7 +67,6 @@ export const TemplateSelectorControl = ( {
 							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }
 							useDynamicPreview={ useDynamicPreview }
 							isSelected={ slug === selectedTemplate }
-							handleTemplateConfirmation={ handleTemplateConfirmation }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -25,7 +25,6 @@ const TemplateSelectorItem = props => {
 		staticPreviewImgAlt = '',
 		blocks = [],
 		isSelected,
-		handleTemplateConfirmation,
 	} = props;
 
 	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
@@ -51,19 +50,8 @@ const TemplateSelectorItem = props => {
 
 	const labelId = `label-${ id }-${ value }`;
 
-	/**
-	 * Determines (based on whether the large preview is able to be visible at the
-	 * current breakpoint) whether or not the Template selection UI interaction model
-	 * should be select _and_ confirm or simply a single "tap to confirm".
-	 */
 	const handleLabelClick = () => {
-		const largeTplPreviewVisible = window.matchMedia( '(min-width: 660px)' ).matches;
-		// In both cases set the template as being selected
 		onSelect( value );
-		// Confirm the template when large preview isn't visible
-		if ( ! largeTplPreviewVisible ) {
-			handleTemplateConfirmation( value );
-		}
 	};
 
 	return (

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -181,13 +181,13 @@ class PageTemplateModal extends Component {
 	};
 
 	previewTemplate = slug => {
+		this.setState( { previewedTemplate: slug } );
+
 		/**
 		 * Determines (based on whether the large preview is able to be visible at the
 		 * current breakpoint) whether or not the Template selection UI interaction model
 		 * should be select _and_ confirm or simply a single "tap to confirm".
 		 */
-		this.setState( { previewedTemplate: slug } );
-
 		const largeTplPreviewVisible = window.matchMedia( '(min-width: 660px)' ).matches;
 		// Confirm the template when large preview isn't visible
 		if ( ! largeTplPreviewVisible ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -180,7 +180,20 @@ class PageTemplateModal extends Component {
 		}
 	};
 
-	previewTemplate = slug => this.setState( { previewedTemplate: slug } );
+	previewTemplate = slug => {
+		/**
+		 * Determines (based on whether the large preview is able to be visible at the
+		 * current breakpoint) whether or not the Template selection UI interaction model
+		 * should be select _and_ confirm or simply a single "tap to confirm".
+		 */
+		this.setState( { previewedTemplate: slug } );
+
+		const largeTplPreviewVisible = window.matchMedia( '(min-width: 660px)' ).matches;
+		// Confirm the template when large preview isn't visible
+		if ( ! largeTplPreviewVisible ) {
+			this.handleConfirmation( slug );
+		}
+	};
 
 	closeModal = event => {
 		// Check to see if the Blur event occurred on the buttons inside of the Modal.
@@ -238,7 +251,6 @@ class PageTemplateModal extends Component {
 				useDynamicPreview={ false }
 				siteInformation={ this.props.siteInformation }
 				selectedTemplate={ this.state.previewedTemplate }
-				handleTemplateConfirmation={ this.handleConfirmation }
 			/>
 		</fieldset>
 	);

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -36,7 +36,6 @@ export default () => {
 				useDynamicPreview={ false }
 				siteInformation={ undefined }
 				selectedTemplate={ previewedTemplate }
-				// handleTemplateConfirmation={ this.handleConfirmation }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`handleTemplateConfirmation` is a somewhat redundant prop on both `TemplateSelectorControl` and `TemplateSelectorItem`, since there's already `onSelect`. Furthermore, the current check in `TemplateSelectorItem` (whether to invoke it or not upon template selection) relies on `window` and thus breaks encapsulation.

This PR moves aforementioned logic to the 'consumer' component, `PageTemplateModal`. This should also make it easier to isolate `TemplateSelectorControl` (see #38378).

#### Testing instructions

Test Starter Page Templates on a screen that's less wide than 660px. Verify that clicking on one of the templates readily creates a new page, based on that template (rather than just highlighting it as selected).