### PR TITLE
Add a few more missing localizedMoment HOCs/hooks.

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -10,6 +10,7 @@ import { getCurrencyObject } from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
+import { withLocalizedMoment } from 'components/localized-moment';
 import analytics from 'lib/analytics';
 import { canRemoveFromCart } from 'lib/cart-values';
 import { getIncludedDomain } from 'lib/cart-values/cart-items';
@@ -355,4 +356,4 @@ export class CartItem extends React.Component {
 
 export default connect( state => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
-} ) )( localize( CartItem ) );
+} ) )( localize( withLocalizedMoment( CartItem ) ) );

--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import { connect } from 'react-redux';
 
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import CardHeading from 'components/card-heading';
+import { useLocalizedMoment } from 'components/localized-moment';
 import getLastGoodRewindBackup from 'state/selectors/get-last-good-rewind-backup';
 import { requestRewindBackups } from 'state/rewind/backups/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -19,14 +20,10 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  */
 import './style.scss';
 
-const SiteBackupCard = ( {
-	disabled,
-	lastGoodBackup,
-	moment,
-	requestBackups,
-	siteId,
-	translate,
-} ) => {
+const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	const hasRetrievedLastBackup = lastGoodBackup !== null;
 	const [ isLoading, setIsLoading ] = useState( false );
 
@@ -36,7 +33,7 @@ const SiteBackupCard = ( {
 			requestBackups( siteId );
 			setIsLoading( true );
 		}
-	}, [ disabled, isLoading, lastGoodBackup, siteId ] );
+	}, [ disabled, hasRetrievedLastBackup, isLoading, lastGoodBackup, requestBackups, siteId ] );
 
 	useEffect( () => {
 		if ( hasRetrievedLastBackup ) {
@@ -92,4 +89,4 @@ export default connect(
 	{
 		requestBackups: requestRewindBackups,
 	}
-)( localize( SiteBackupCard ) );
+)( SiteBackupCard );

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -17,6 +17,7 @@ import Month from './month';
 import { Card } from '@automattic/components';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
+import { withLocalizedMoment } from 'components/localized-moment';
 import { getSiteOption } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteStatsPostStreakData } from 'state/stats/lists/selectors';
@@ -219,4 +220,4 @@ const mapStateToProps = state => {
 
 export default connect( mapStateToProps, null, null, {
 	areStatePropsEqual: compareProps( { deep: [ 'query' ] } ),
-} )( localize( PostTrends ) );
+} )( localize( withLocalizedMoment( PostTrends ) ) );


### PR DESCRIPTION
This PR is one of many slowly working towards removing the `moment` export from `i18n-calypso`.

The components in this PR were depending on `i18n-calypso`'s `moment` prop, which we're trying to get rid of, and replace with `components/localized-moment`. I thought I had taken care of all of them in #37367, but it looks like I missed a few (or perhaps they're newly added?)

#### Changes proposed in this Pull Request

* Use `withLocalizedMoment` HOC instead of relying on the `moment` prop from the `localize` HOC
* Use `useTranslate` and `useLocalizedMoment` hooks in `SiteBackupCard`

#### Testing instructions

No specific testing instructions, as the changes should be trivial to review from code inspection alone.