### PR TITLE
WPCOM Block Editor: Fix incorrect editor position on mobile

### DIFF
--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -15,21 +15,10 @@
 	}
 }
 
-@media ( min-width: 782px ) {
-	.edit-post-layout__content {
-		position: fixed;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		top: 88px;
-		min-height: calc( 100% - 88px );
-		height: auto;
-		margin-left: 160px;
-	}
-
-	body.is-fullscreen-mode .edit-post-layout__content {
-		top: 56px;
-		position: fixed;
+body.is-fullscreen-mode {
+	.edit-post-editor-regions,
+	.components-editor-notices__dismissible {
+		top: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/WordPress/gutenberg/pull/18686 changed how the editor is positioned on mobile.
In Core the admin bar is always visible, even in fullscreen mode.

In WPCOM, instead, the admin bar is never visible, so we don't need the `top` offset for it.

This PR sets `top: 0` to the elements affected by the changes in Gutenberg 7.1.0 (at least those that I've noticed).

I've also removed a couple of rules that aren't applicable anymore, as `.edit-post-layout__content` has been recently removed.

| Before | After |
| - | - |
| <img width="403" alt="Screenshot 2019-12-12 at 18 36 04" src="https://user-images.githubusercontent.com/2070010/70739653-3dfe1c80-1d0f-11ea-89bc-871dc798adcb.png"> | <img width="400" alt="Screenshot 2019-12-12 at 18 36 14" src="https://user-images.githubusercontent.com/2070010/70739660-422a3a00-1d0f-11ea-9be9-038fb0f924f4.png"> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Pre-requisites:

- Apply D36681-code (the twin diff of this PR).
- Sandbox `widgets.wp.com`.
- Pre-sandbox a new site.

Test:

- In Calypso, edit a page in the block editor.
- Resize the browser down to a mobile width.
- Make sure the editor's top bar and notifications are stuck to the top.