### PR TITLE
Customer Home: Update checklist bullets to look less clickable

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -223,7 +223,7 @@
 				width: 5px;
 				height: 5px;
 				border-color: var( --color-neutral-20 );
-				background: var( --color-neutral-20 );
+				background: var( --color-surface );
 				top: 21px;
 				left: 16px;
 
@@ -232,7 +232,14 @@
 				}
 			}
 
+			.checklist__task.is-collapsed .checklist__task-icon {
+				border-color: var( --color-neutral-20 );
+				background: var( --color-surface );
+			}
+
 			.checklist__task.is-completed .checklist__task-icon {
+				border-color: var( --color-neutral-10 );
+				background: var( --color-neutral-10 );
 				top: 15px;
 				left: 16px;
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -220,10 +220,10 @@
 			}
 
 			.checklist__task-icon {
-				border-radius: 5px;
 				width: 5px;
 				height: 5px;
-				background: var( --color-neutral-5 );
+				border-color: var( --color-neutral-20 );
+				background: var( --color-neutral-20 );
 				top: 21px;
 				left: 16px;
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -213,11 +213,41 @@
 
 			&-completed-title {
 				margin-top: 24px;
-			}
-		}
 
-		.checklist__task::before {
-			display: none;
+				@include breakpoint( '480px-660px' ) {
+					margin-left: 24px;
+				}
+			}
+
+			.checklist__task-icon {
+				border-radius: 5px;
+				width: 5px;
+				height: 5px;
+				background: var( --color-neutral-5 );
+				top: 21px;
+				left: 16px;
+
+				@include breakpoint( '>480px' ) {
+					left: 24px;
+				}
+			}
+
+			.checklist__task.is-completed .checklist__task-icon {
+				top: 15px;
+				left: 16px;
+
+				@include breakpoint( '>480px' ) {
+					left: 24px;
+				}
+			}
+
+			.checklist__task.is-completed .gridicons-checkmark {
+				display: none;
+			}
+
+			.checklist__task::before {
+				display: none;
+			}
 		}
 	}
 	&__layout-col {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The large, hollow circle icons looked like clickable checkboxes on a checklist. This PR turns them into smaller, closed circles, to act more like bullet points.
* This should not have an effect on the Jetpack checklist, since the styles live in Customer Home's SCSS

**Before**

<img width="737" alt="Screen Shot 2019-12-12 at 2 20 29 PM" src="https://user-images.githubusercontent.com/2124984/70741988-92db6c00-1cea-11ea-9a8f-2fca34568aff.png">

**After**

<img width="729" alt="Screen Shot 2019-12-12 at 3 38 17 PM" src="https://user-images.githubusercontent.com/2124984/70747419-f5863500-1cf5-11ea-9cc6-122fca349875.png">

#### Testing instructions

* Switch to this PR
* Create a new site from `/start`; finish signup and you'll land on Customer Home
* Note the new styles; check for visual bugs, make sure you can still complete tasks and launch your site.