### PR TITLE
build: Use the latest npm instead of bundled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN        bash /tmp/env-config.sh
 
 
 # Install our package manager
-ARG npm_version=6.13.4
-ENV NPM_VERSION $npm_version
+ENV NPM_VERSION 6.13.4
 
 RUN npm install -g npm@$NPM_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer="Automattic"
 
 WORKDIR    /calypso
 
-
 ENV        CONTAINER 'docker'
 ENV        NODE_PATH=/calypso/server:/calypso/client
 ENV        PROGRESS=true
@@ -20,6 +19,13 @@ ENV        PROGRESS=true
 #   such as the apt and npm mirrors
 COPY       ./env-config.sh /tmp/env-config.sh
 RUN        bash /tmp/env-config.sh
+
+
+# Install our package manager
+ARG npm_version=6.13.4
+ENV NPM_VERSION $npm_version
+
+RUN npm install -g npm@$NPM_VERSION
 
 # Build a node_modules layer
 #

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
 	},
 	"engines": {
 		"node": "^10.16.3",
-		"npm": "^6.9.0"
+		"npm": "^6.13.4"
 	},
 	"scripts": {
 		"preanalyze-bundles": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=true PROGRESS=1 NODE_ARGS=--max_old_space_size=8192 npm run -s build-client-evergreen",


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* The npm that ships with Node has [a security issue that can allow bin pinning](https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli). 
* Force our docker container to use a non-vulnerable npm@6.13.4

#### Testing instructions

* Verify that docker is now using npm@6.13.4


Not quite sure what to do about Circle CI yet. @sirreal any thoughts? New cachable thing? 
