### PR TITLE
Gutenberg: autofix block validation issues on editor load

### DIFF
--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -20,9 +20,10 @@ There are two environments the block editor integration supports:
 
 - `disable-nux-tour.js`: Disable the pop-up tooltip tour that is displayed on first use.
 - `rich-text.js`: Extensions for the Rich Text toolbar with the Calypso buttons missing on Core (i.e. underline, justify).
+- `fix-block-invalidation-errors.js`: (Atomic/Simple) Performs block attempt block recovery on editor load if validation errors are detected.
 - `switch-to-classic.js`: Append a button to the "More tools" menu for switching to the classic editor.
 - `tracking`: Adds analytics around specific user actions for Simple, Jetpack and Atomic sites.
-- `reorder-block-categories`: Moves Jetpack and CoBlocks Block Categories below Core Categories
+- `reorder-block-categories`: (Atomic/Simple) Moves Jetpack and CoBlocks Block Categories below Core Categories
 - `unregister-experimental-blocks`: Removes some experimental blocks from the Gutenberg Plugin.
 
 ### Calypso utilities

--- a/apps/wpcom-block-editor/src/common/fix-block-invalidation-errors.js
+++ b/apps/wpcom-block-editor/src/common/fix-block-invalidation-errors.js
@@ -1,0 +1,40 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+/**
+ * External dependencies
+ */
+import { select, dispatch, subscribe } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+
+// Very fragile checks, we'll replace with proper common bundle splitting in https://github.com/Automattic/wp-calypso/issues/34476
+const isSimpleSite = !! window.wpcomGutenberg.pluginVersion;
+const isAtomicSite = window._currentSiteType === 'atomic';
+
+if ( isAtomicSite || isSimpleSite ) {
+	const unsubscribe = subscribe( () => {
+		const isCleanNewPost = select( 'core/editor' ).isCleanNewPost();
+
+		if ( isCleanNewPost ) {
+			unsubscribe();
+		}
+
+		const blocks = select( 'core/editor' ).getBlocks();
+
+		if ( blocks.length === 0 ) {
+			return;
+		}
+
+		unsubscribe();
+
+		//If any blocks have validation issues auto-fix them for now, until core is less strict.
+		select( 'core/editor' )
+			.getBlocks()
+			.filter( block => ! block.isValid )
+			.forEach( ( { clientId, name, attributes, innerBlocks } ) => {
+				dispatch( 'core/editor' ).replaceBlock(
+					clientId,
+					createBlock( name, attributes, innerBlocks )
+				);
+			} );
+	} );
+}

--- a/apps/wpcom-block-editor/src/common/index.js
+++ b/apps/wpcom-block-editor/src/common/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import './disable-nux-tour';
+import './fix-block-invalidation-errors';
 import './reorder-block-categories';
 import './rich-text';
 import './style.scss';


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/37230

This PR attempts to auto-fix block-invalidation errors once on load.

### Context

When a block parses HTML markup, it also tries to validate the data by re-serializing and comparing the result. Unfortunately blocks currently compare with an _exact_ string match. Even a small whitespace for change for completely equivalent markup/styling, is enough to cause the following scary error:

<img width="685" alt="Screen Shot 2019-10-31 at 10 21 49 AM" src="https://user-images.githubusercontent.com/1270189/67970464-4881ae00-fbc8-11e9-956f-da38e919206c.png">

Traditionally WP allows manipulation of content from a variety of filters/customizations from 3rd party code, so this is a very easy case to fall into, especially if older customizations are not Gutenberg aware.

Most folks don't understand what this warning means, so let's try auto-applying the most common want, which is block-recovery. Or just make my blocks work.

### Testing Instructions

- Make sure you have a post that will render with a block invalidation error. (Try manually editing in code view, and publish, even whitespace will do the trick)
- Apply the paired diff: D36698-code
- Reload the post in the editor
- We should see some errors in console about block invalidation, but blocks should render okay

| Before            | After                |
| ------------- | ------------- |
| <img width="1245" alt="Screen Shot 2019-12-12 at 4 31 11 PM" src="https://user-images.githubusercontent.com/1270189/70759943-e1920180-1cfc-11ea-8951-2909b9f69a48.png"> | <img width="1130" alt="Screen Shot 2019-12-12 at 4 21 28 PM" src="https://user-images.githubusercontent.com/1270189/70759525-81e72680-1cfb-11ea-88b0-b05402668de0.png"> |
