### PR TITLE
Reader: update the reader link from `/` to `/read`

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -157,7 +157,7 @@ export class ReaderSidebar extends React.Component {
 								label={ translate( 'Followed Sites' ) }
 								onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
 								materialIcon="check_circle"
-								link="/"
+								link="/read"
 							/>
 
 							<SidebarItem


### PR DESCRIPTION
## Changes proposed in this Pull Request

Hi interesting people!

A while back in https://github.com/Automattic/wp-calypso/pull/37547 we updated Reader links from `/` to `/read`.


For context see:

p58i-89H-p2
EPIC Issue: Automattic/zelda-private#173
Calypso PR: Automattic/wp-calypso#37547

This PR updates a further Reader link in the Reader **Streams** menu to `/read`

<img width="404" alt="Screen Shot 2019-12-13 at 11 17 42 am" src="https://user-images.githubusercontent.com/6458278/70759503-b52cc280-1d9a-11ea-9b12-d078b827f76e.png">

## Testing instructions

1. Fire up the branch and head to http://calypso.localhost:3000/read
2. Check that the **Followed Sites** link in the left-hand-side **Streams** menu links to `/read`
3. Check that you're getting the best deal from your energy provider. You could save $100s!

