### PR TITLE
composite-checkout: Restore Button imports

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/credit-card.js
@@ -7,7 +7,7 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import Button from '../../components/button';
 import { useLocalize, sprintf } from '../../lib/localize';
 import joinClasses from '../../lib/join-classes';
 import { usePaymentData, useLineItems, renderDisplayValueMarkdown } from '../../public-api';

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -7,7 +7,7 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
 import { useDispatch, useSelect, usePaymentData } from '../../lib/registry';
 import { useCheckoutHandlers, useCheckoutRedirects, useLineItems } from '../../public-api';

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -12,7 +12,7 @@ import { LeftColumn, RightColumn } from '../styled-components/ie-fallback';
  */
 import Field from '../../components/field';
 import GridRow from '../../components/grid-row';
-import { Button } from '@automattic/components';
+import Button from '../../components/button';
 import {
 	useStripe,
 	createStripePaymentMethod,


### PR DESCRIPTION
This reverts the changes made to composite-checkout by #38308 which
accidentally replaced the local Button component imports with the Button
component from `@automattic/components`.

#### Testing instructions

- Run `npm run composite-checkout-demo`.
- Verify that the buttons in the form work as expected, notably the "Continue" buttons and the "Pay" button for Paypal and the second Credit Card payment method.
