### PR TITLE
Fix `_superProps` in Tracks events.

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -81,7 +81,7 @@ if ( typeof window !== 'undefined' ) {
 function getUrlParameter( name ) {
 	name = name.replace( /[[]/g, '\\[' ).replace( /[\]]/g, '\\]' );
 	const regex = new RegExp( '[\\?&]' + name + '=([^&#]*)' );
-	const results = regex.exec( location.search );
+	const results = regex.exec( window.location.search );
 	return results === null ? '' : decodeURIComponent( results[ 1 ].replace( /\+/g, ' ' ) );
 }
 
@@ -97,7 +97,7 @@ function createRandomId( randomBytesLength = 9 ) {
 		randomBytes = times( randomBytesLength, () => Math.floor( Math.random() * 256 ) );
 	}
 
-	return btoa( String.fromCharCode.apply( String, randomBytes ) );
+	return window.btoa( String.fromCharCode.apply( String, randomBytes ) );
 }
 
 function checkForBlockedTracks() {
@@ -212,7 +212,7 @@ const analytics = {
 
 			if ( config( 'mc_analytics_enabled' ) ) {
 				const uriComponent = buildQuerystring( group, name );
-				new Image().src =
+				new window.Image().src =
 					document.location.protocol +
 					'//pixel.wp.com/g.gif?v=wpcom-no-pv' +
 					uriComponent +
@@ -231,7 +231,7 @@ const analytics = {
 
 			if ( config( 'mc_analytics_enabled' ) ) {
 				const uriComponent = buildQuerystringNoPrefix( group, name );
-				new Image().src =
+				new window.Image().src =
 					document.location.protocol +
 					'//pixel.wp.com/g.gif?v=wpcom' +
 					uriComponent +
@@ -598,7 +598,7 @@ const analytics = {
 				);
 
 				const imgUrl = statsdTimingUrl( featureSlug, eventType, duration );
-				new Image().src = imgUrl;
+				new window.Image().src = imgUrl;
 			}
 		},
 
@@ -611,7 +611,7 @@ const analytics = {
 				);
 
 				const imgUrl = statsdCountingUrl( featureSlug, eventType, increment );
-				new Image().src = imgUrl;
+				new window.Image().src = imgUrl;
 			}
 		},
 	},

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -186,7 +186,7 @@ if ( typeof window !== 'undefined' ) {
 const analytics = {
 	initialize: function( currentUser, superProps ) {
 		// Update super props.
-		if ( 'object' === typeof superProps ) {
+		if ( 'function' === typeof superProps ) {
 			initializeDebug( 'superProps', superProps );
 			_superProps = superProps;
 		}


### PR DESCRIPTION
_superProps is a function, not an object.
Fixes: p4qSXL-3kr-p2

Open calypso.live link and run these in console to enable analytics:
https://calypso.live/?branch=fix/superprops

```
document.cookie = 'flags=gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
document.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
```

Now refresh page and filter Network tab by `calypso_page_view`.
- Confirm these props exist:

![Screen Shot 2019-12-13 at 02 30 31](https://user-images.githubusercontent.com/1563559/70778994-948c4a80-1d51-11ea-95b8-2265ecf089c7.png)
