### PR TITLE
Gutenboarding: Update Template Selector Styling

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -78,7 +78,7 @@ export function Gutenboard() {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="block-editor__container">
+		<div className="gutenboarding block-editor__container">
 			<SlotFillProvider>
 				<DropZoneProvider>
 					<div

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -36,7 +36,6 @@ import { Steps } from './types';
 import './stores/domain-suggestions';
 import './stores/verticals-templates';
 import './style.scss';
-import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
 
 const stepCompleted: Record< Steps, ( state: OnboardingState ) => boolean > = {
 	[ Steps.IntentGathering ]: ( { siteVertical } ) => !! siteVertical,

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { SiteVertical } from '../../stores/onboard/types';
 import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control';
 
-import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
+import './style.scss';
 
 interface DesignSelectorProps {
 	className: string;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -3,8 +3,7 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import React, { FunctionComponent, useState } from 'react';
-import classNames from 'classnames';
+import React, { useState } from 'react';
 
 /**
  * Internal dependencies
@@ -14,11 +13,7 @@ import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/f
 
 import './style.scss';
 
-interface DesignSelectorProps {
-	className: string;
-}
-
-const DesignSelector: FunctionComponent< DesignSelectorProps > = ( { className } ) => {
+export default () => {
 	const siteVertical = useSelect(
 		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical
 	);
@@ -32,7 +27,9 @@ const DesignSelector: FunctionComponent< DesignSelectorProps > = ( { className }
 
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (
-		<div className={ classNames( 'page-template-modal__list', className ) }>
+		<div
+			className="page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
+		>
 			<TemplateSelectorControl
 				label={ NO__( 'Layout', 'full-site-editing' ) }
 				templates={ homepageTemplates }
@@ -45,5 +42,3 @@ const DesignSelector: FunctionComponent< DesignSelectorProps > = ( { className }
 		</div>
 	);
 };
-
-export default DesignSelector;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -3,7 +3,8 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import React, { useState } from 'react';
+import React, { FunctionComponent, useState } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,7 +14,11 @@ import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/f
 
 import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
 
-export default () => {
+interface DesignSelectorProps {
+	className: string;
+}
+
+const DesignSelector: FunctionComponent< DesignSelectorProps > = ( { className } ) => {
 	const siteVertical = useSelect(
 		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical
 	);
@@ -27,9 +32,7 @@ export default () => {
 
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (
-		<div
-			className="page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
-		>
+		<div className={ classNames( 'page-template-modal__list', className ) }>
 			<TemplateSelectorControl
 				label={ NO__( 'Layout', 'full-site-editing' ) }
 				templates={ homepageTemplates }
@@ -42,3 +45,5 @@ export default () => {
 		</div>
 	);
 };
+
+export default DesignSelector;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -28,7 +28,7 @@ export default () => {
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (
 		<div
-			className="page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
+			className="onboarding-block__design-selector page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
 		>
 			<TemplateSelectorControl
 				label={ NO__( 'Layout', 'full-site-editing' ) }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -28,17 +28,25 @@ export default () => {
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (
 		<div
-			className="onboarding-block__design-selector page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
+			className="onboarding-block__design-selector" // eslint-disable-line wpcalypso/jsx-classname-namespace
 		>
-			<TemplateSelectorControl
-				label={ NO__( 'Layout', 'full-site-editing' ) }
-				templates={ homepageTemplates }
-				blocksByTemplates={ {} /* Unneeded, since we're setting `useDynamicPreview` to `false` */ }
-				onTemplateSelect={ setPreviewedTemplate }
-				useDynamicPreview={ false }
-				siteInformation={ undefined }
-				selectedTemplate={ previewedTemplate }
-			/>
+			<h1>{ NO__( 'Choose a starting design for your site' ) }</h1>
+			<h2>{ NO__( "You'll be able to customize your new site in hundreds of ways." ) }</h2>
+			<div
+				className=" page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
+			>
+				<TemplateSelectorControl
+					label={ NO__( 'Layout', 'full-site-editing' ) }
+					templates={ homepageTemplates }
+					blocksByTemplates={
+						{} /* Unneeded, since we're setting `useDynamicPreview` to `false` */
+					}
+					onTemplateSelect={ setPreviewedTemplate }
+					useDynamicPreview={ false }
+					siteInformation={ undefined }
+					selectedTemplate={ previewedTemplate }
+				/>
+			</div>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -11,6 +11,8 @@ import React, { useState } from 'react';
 import { SiteVertical } from '../../stores/onboard/types';
 import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control';
 
+import '../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
+
 export default () => {
 	const siteVertical = useSelect(
 		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ as NO__ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
 import React, { useState } from 'react';
 
@@ -23,7 +24,17 @@ export default () => {
 			select( 'automattic/verticals/templates' ).getTemplates( siteVertical.id )
 		) ?? [];
 
-	const homepageTemplates = templates.filter( template => template.category === 'home' );
+	// The templates' preview URLs come with a hard-wired size param (`?w=332`)
+	// that isn't high-res enough for our purposes. Thus, we override it here.
+	// TODO: Maybe add a `srcset` to `TemplateSelectorItem`.
+	const templatesWithResizedThumbnails = templates.map( template => ( {
+		...template,
+		preview: addQueryArgs( template.preview, { w: 960 / 2 } ),
+	} ) );
+
+	const homepageTemplates = templatesWithResizedThumbnails.filter(
+		template => template.category === 'home'
+	);
 
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -2,6 +2,7 @@
 @import '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
 
 .onboarding-block__design-selector {
+	margin: 0 auto;
 	max-width: 960px;
 
 	h1 {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -2,6 +2,10 @@
 @import '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
 
 .onboarding-block__design-selector {
+	max-width: 960px;
+}
+
+.onboarding-block__design-selector {
 	.template-selector-control__options {
 		@media screen and ( min-width: 660px ) {
 			margin-top: 0;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -22,6 +22,8 @@
 	}
 
 	.template-selector-control__options {
+		grid-gap: 4.5em;
+
 		@media screen and ( min-width: 660px ) {
 			margin-top: 0;
 			// stylelint-disable unit-whitelist

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -1,0 +1,13 @@
+// FIXME: Extract Template Selector component and styling into `@automattic/components` (see #38378)
+@import '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss';
+
+.onboarding-block__design-selector {
+	.template-selector-control__options {
+		@media screen and ( min-width: 660px ) {
+			margin-top: 0;
+			// stylelint-disable unit-whitelist
+			grid-template-columns: repeat( 2, 1fr );
+			// stylelint-enable unit-whitelist
+		}
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -4,6 +4,22 @@
 .onboarding-block__design-selector {
 	max-width: 960px;
 
+	h1 {
+		color: #23282d;
+		font-size: 2em;
+		font-weight: bold;
+		margin-bottom: 0.25em;
+		text-align: center;
+	}
+
+	h2,
+	h3 {
+		color: #23282d;
+		font-size: 1.3em;
+		margin-bottom: 3em;
+		text-align: center;
+	}
+
 	.template-selector-control__options {
 		@media screen and ( min-width: 660px ) {
 			margin-top: 0;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -3,9 +3,7 @@
 
 .onboarding-block__design-selector {
 	max-width: 960px;
-}
 
-.onboarding-block__design-selector {
 	.template-selector-control__options {
 		@media screen and ( min-width: 660px ) {
 			margin-top: 0;

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -59,7 +59,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = ( {
 				</div>
 			);
 		case Steps.DesignSelection:
-			return <DesignSelector />;
+			return <DesignSelector className="onboarding-block__design-selector" />;
 	}
 
 	return null;

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -59,7 +59,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = ( {
 				</div>
 			);
 		case Steps.DesignSelection:
-			return <DesignSelector className="onboarding-block__design-selector" />;
+			return <DesignSelector />;
 	}
 
 	return null;

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -17,6 +17,12 @@ $admin-sidebar-width-collapsed: 0;
 	max-width: 1100px; // Overrides default $content-width
 }
 
+.gutenboarding {
+	.edit-post-layout__content {
+		overflow-y: scroll;
+	}
+}
+
 /**
  * Hide the block UI with CSS overrides
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WIP.

- [x] Centered 960px
- [x] 2 columns
- [ ] No template captions
- [x] High-res thumbnails 
- [x] Enable scrolling
- [x] Heading
- [ ] Keep verticalized background from intent gathering step

#### Mockup

![Design picker](https://user-images.githubusercontent.com/96308/70797714-3e5dec80-1dcf-11ea-95b3-47547fa136e1.png)

#### Current Status

![image](https://user-images.githubusercontent.com/96308/70814855-8ba18480-1df6-11ea-968d-9218b6f15111.png)

#### Testing instructions

`http://calypso.localhost:3000/gutenboarding`

Fill in verticals and site title, click next.