### PR TITLE
Disable "multiple" support for the Blog Posts block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
@@ -31,4 +31,8 @@ registerBlockType( blockName, {
 	...settings,
 	title: __( 'Blog Posts', 'full-site-editing' ),
 	category: 'layout',
+	supports: {
+		...settings.supports,
+		multiple: false,
+	},
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable "multiple" support for the Blog Posts block.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check-out this branch,
2. Build FSE plugin (`npx lerna run dev --scope='@automattic/full-site-editing' --stream`),
3. Activate it,
4. In the editor add a Blog Posts block,
5. You should not be able to add another one (it should be greyed-out).

Fixes #38404
