### PR TITLE
Site Migration: Only show valid destination sites. 

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -52,10 +52,10 @@ class SectionMigrate extends Component {
 		return isTargetSiteJetpack ? targetSiteImportAdminUrl : `/import/${ targetSiteSlug }`;
 	};
 
-	jetpackSiteFilter = sourceSite => {
+	automatedTransferFilter = sourceSite => {
 		const { targetSiteId } = this.props;
 
-		return sourceSite.jetpack && sourceSite.ID !== targetSiteId;
+		return sourceSite.options.is_automated_transfer && sourceSite.ID !== targetSiteId;
 	};
 
 	resetMigration = () => {
@@ -401,7 +401,7 @@ class SectionMigrate extends Component {
 					<SiteSelector
 						className="migrate__source-site"
 						onSiteSelect={ this.setSourceSiteId }
-						filter={ this.jetpackSiteFilter }
+						filter={ this.automatedTransferFilter }
 					/>
 					<div className="migrate__import-instead">
 						Don't see it? You can still{ ' ' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This diff updates how we filter sites in the migration destination screen.

#### Testing instructions

Apply diff
Go to the start migration 
Make sure the listed sites are only valid WordPress.com Business sites.