### PR TITLE
Gutenboarding: Transition bg color

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -50,7 +50,7 @@
 }
 
 .onboarding-block__background::before {
-	background: $white;
+	background-color: $white;
 	content: '';
 	position: absolute;
 	top: 0;
@@ -58,7 +58,7 @@
 	bottom: 0;
 	left: 0;
 	opacity: 0.7;
-	transition: opacity 1s linear;
+	transition: opacity 1s linear, background-color 250ms linear;
 }
 .onboarding-block__background-fade-enter {
 	&.onboarding-block__background::before {
@@ -99,7 +99,7 @@
 			}
 		}
 		.onboarding-block__background::before {
-			background: $dark-gray-900;
+			background-color: $dark-gray-900;
 		}
 		.components-button.is-link.onboarding-block__question-skip {
 			color: $light-gray-500;

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -1,5 +1,8 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 
+// This should match the timeout used in the component.
+$onboarding-block-css-transition-duration: 750ms;
+
 .onboarding-block__acquire-intent {
 	display: flex;
 	justify-content: center;
@@ -10,6 +13,16 @@
 	top: 20%;
 	left: 0%;
 	width: 100%;
+
+	.onboarding-block__question-answered,
+	.onboarding-block__question-input,
+	.onboarding-block__question-input::placeholder,
+	.onboarding-block__question,
+	.onboarding-block__questions-heading,
+	.onboarding-block__question-skip {
+		transition: $onboarding-block-css-transition-duration color linear
+			$onboarding-block-css-transition-duration;
+	}
 }
 
 .onboarding-block__questions {
@@ -58,7 +71,9 @@
 	bottom: 0;
 	left: 0;
 	opacity: 0.7;
-	transition: opacity 1s linear, background-color 250ms linear;
+	transition: opacity $onboarding-block-css-transition-duration linear,
+		background-color $onboarding-block-css-transition-duration linear
+			$onboarding-block-css-transition-duration;
 }
 .onboarding-block__background-fade-enter {
 	&.onboarding-block__background::before {
@@ -74,7 +89,7 @@
 .onboarding-block__background-fade-enter,
 .onboarding-block__background-fade-exit,
 .onboarding-block__background-fade-enter-done {
-	transition: opacity 1s linear;
+	transition: opacity $onboarding-block-css-transition-duration linear;
 }
 
 @media ( prefers-color-scheme: dark ) {

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -20,7 +20,7 @@ $onboarding-block-css-transition-duration: 750ms;
 	.onboarding-block__question,
 	.onboarding-block__questions-heading,
 	.onboarding-block__question-skip {
-		transition: $onboarding-block-css-transition-duration color linear
+		transition: $onboarding-block-css-transition-duration color linear // @TODO: replace with opacity transition as described in https://github.com/Automattic/wp-calypso/pull/38412/files#r358123862
 			$onboarding-block-css-transition-duration;
 	}
 }
@@ -72,7 +72,7 @@ $onboarding-block-css-transition-duration: 750ms;
 	left: 0;
 	opacity: 0.7;
 	transition: opacity $onboarding-block-css-transition-duration linear,
-		background-color $onboarding-block-css-transition-duration linear
+		background-color $onboarding-block-css-transition-duration linear // @TODO: replace with opacity transition
 			$onboarding-block-css-transition-duration;
 }
 .onboarding-block__background-fade-enter {

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -54,7 +54,7 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { id,
 		<SwitchTransition mode="in-out">
 			<CSSTransition
 				key={ imageUrl || 'empty' }
-				timeout={ 1000 }
+				timeout={ 750 }
 				classNames="onboarding-block__background-fade"
 			>
 				<div


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A small visual tweak to soften an abrupt background color change.

##### Before
![before](https://user-images.githubusercontent.com/841763/70815394-ac091900-1dcd-11ea-8b51-cacf8220d16c.gif)

##### After
![after](https://user-images.githubusercontent.com/841763/70815402-ae6b7300-1dcd-11ea-8f27-8d7706208634.gif)

#### Testing instructions

* Visit `/gutenboarding` and pick a vertical.
