### PR TITLE
Show mapped domain notice when status is reported as transferrable.

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -221,6 +221,7 @@ class MapDomainStep extends React.Component {
 					AVAILABLE,
 					AVAILABILITY_CHECK_ERROR,
 					MAPPABLE,
+					MAPPED,
 					NOT_REGISTRABLE,
 					UNKNOWN,
 				} = domainAvailability;
@@ -243,8 +244,10 @@ class MapDomainStep extends React.Component {
 					site = get( this.props, 'selectedSite.slug', null );
 				}
 
+				const noticeStatus = MAPPED === mappableStatus ? mappableStatus : status;
+
 				const maintenanceEndTime = get( result, 'maintenance_end_time', null );
-				const { message, severity } = getAvailabilityNotice( domain, status, {
+				const { message, severity } = getAvailabilityNotice( domain, noticeStatus, {
 					site,
 					maintenanceEndTime,
 				} );

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -244,10 +244,10 @@ class MapDomainStep extends React.Component {
 					site = get( this.props, 'selectedSite.slug', null );
 				}
 
-				const noticeStatus = MAPPED === mappableStatus ? mappableStatus : status;
+				const availabilityStatus = MAPPED === mappableStatus ? mappableStatus : status;
 
 				const maintenanceEndTime = get( result, 'maintenance_end_time', null );
-				const { message, severity } = getAvailabilityNotice( domain, noticeStatus, {
+				const { message, severity } = getAvailabilityNotice( domain, availabilityStatus, {
 					site,
 					maintenanceEndTime,
 				} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For domains that have a mappable status of `mapped_domain`, we should always show the notice that the domain is already mapped even if the domain is transferable.

#### Testing instructions

Hack the back end to return the following:
```
domain_name: "your-examnple-domain-name.com"
mappable: "mapped_domain"
status: "transferrable"
supports_privacy: true
```

Go to the mapping page (ex.: http://calypso.localhost:3000/domains/add/mapping/a8ctest.com)

Type in a domain and make sure that you see the error notice saying: "This domain is already mapped to a WordPress.com site."

<img width="1438" alt="Screen Shot 2019-12-13 at 12 14 33 PM" src="https://user-images.githubusercontent.com/1379730/70818728-71d65200-1da2-11ea-855b-93448400c42e.png">


Make sure that mapping still works for un-mapped, registered domains that are both transferrable and non-transferrable.

Also make sure that you see the mapped notice from the domain search page:

<img width="1438" alt="Screen Shot 2019-12-13 at 12 14 11 PM" src="https://user-images.githubusercontent.com/1379730/70818646-405d8680-1da2-11ea-94ac-a96a38ef9fae.png">

And make sure that when you see the mapped notice from domain search, that the "Yes, I own this domain" link takes you directly to the transfer page (if the domain is transferrable).