### PR TITLE
Composite checkout: Fix spacing

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -94,16 +94,13 @@ const LineItemUI = styled( WPLineItem )`
 	flex-wrap: wrap;
 	justify-content: space-between;
 	font-weight: ${( { theme, total } ) => ( total ? theme.weights.bold : theme.weights.normal )};
-	color: ${( { theme, total } ) => ( total ? theme.colors.textColorDark : 'inherit' )};
+	color: ${( { theme, total } ) => ( total ? theme.colors.textColorDark : theme.colors.textColor )};
 	font-size: ${( { total } ) => ( total ? '1.2em' : '1em' )};
 	padding: ${( { total, isSummaryVisible } ) => ( isSummaryVisible || total ? 0 : '24px 0' )};
 	border-bottom: ${( { theme, total, isSummaryVisible } ) =>
 		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
 	position: relative;
 	margin-right: 30px;
-	:first-of-type {
-		padding-top: 10px;
-	}
 
 	:first-of-type button {
 		top: -3px;
@@ -154,7 +151,6 @@ function DeleteIcon( { uniqueID, product } ) {
 			width="25"
 			height="24"
 			viewBox="0 0 25 24"
-			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 			aria-labelledby={ uniqueID }
 		>
@@ -242,6 +238,10 @@ const WPOrderReviewListItems = styled.li`
 	padding: 0;
 	display: block;
 	list-style: none;
+
+	:first-of-type .checkout-line-item {
+		padding-top: 10px;
+	}
 `;
 
 function PlanTermOptions() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a spacing issue in the order review of the new checkout.

**Before**
![image](https://user-images.githubusercontent.com/6981253/70815609-ccb87b00-1d9b-11ea-851e-c1d62b74968b.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/70815649-dcd05a80-1d9b-11ea-8765-e59afdc55128.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get calypso running locally.
* Add a product to cart and go to checkout
* Add `?flags=composite-checkout-wpcom` to the url when you're in checkout. 
* Make your way to the review step and ensure the spacing doesn't look off. 
