### PR TITLE
Gutenboarding: "next" when siteTitle is set

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -51,7 +51,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = ( {
 						{ siteVertical && (
 							<div className="onboarding-block__footer">
 								<Button className="onboarding-block__question-skip" isLink>
-									{ NO__( "Don't know yet" ) } →
+									{ siteTitle ? NO__( 'Next' ) : NO__( "Don't know yet" ) } →
 								</Button>
 							</div>
 						) }

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -51,7 +51,8 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = ( {
 						{ siteVertical && (
 							<div className="onboarding-block__footer">
 								<Button className="onboarding-block__question-skip" isLink>
-									{ siteTitle ? NO__( 'Next' ) : NO__( "Don't know yet" ) } →
+									{ /* @TODO: add transitions and correct action */ }
+									{ siteTitle ? NO__( 'Continue' ) : NO__( "Don't know yet" ) } →{ ' ' }
 								</Button>
 							</div>
 						) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change "Don't know yet" to "next" when a site title is provided

##### Before
![before](https://user-images.githubusercontent.com/841763/70816869-ae20a700-1dd0-11ea-9169-3da9992924af.gif)

##### After
![after](https://user-images.githubusercontent.com/841763/70816877-b0830100-1dd0-11ea-9441-cf9f7db7f5db.gif)

#### Testing instructions


* Visit `/guetnboarding`, pick a vertical and add a title. When the title is filled, the text at the bottom should say "next"

Fixes #
