### PR TITLE
G Suite: Prevent prices and discount from wrapping

### DIFF
--- a/client/components/gsuite/gsuite-features/style.scss
+++ b/client/components/gsuite/gsuite-features/style.scss
@@ -23,7 +23,8 @@
 .gsuite-features__list {
 	box-sizing: border-box;
 	justify-content: space-between;
-	margin: 1em 0;
+	margin-left: 1.5em;
+	margin-top: 1em;
 
 	.gsuite-features__feature {
 		margin-bottom: 2em;
@@ -40,7 +41,10 @@
 	display: flex;
 	flex-basis: 50%;
 	justify-content: flex-start;
-	margin-bottom: 1em;
+
+	&:not(:last-of-type) {
+		margin-bottom: 1em;
+	}
 }
 .gsuite-features__feature {
 	.gsuite-features__feature-header {

--- a/client/components/gsuite/gsuite-features/style.scss
+++ b/client/components/gsuite/gsuite-features/style.scss
@@ -1,6 +1,6 @@
 .gsuite-features__grid {
 	box-sizing: border-box;
-	justify-content: justify-content;
+	justify-content: space-between;
 	margin: 1em 0;
 
 	@include breakpoint( '>960px' ) {
@@ -22,7 +22,7 @@
 }
 .gsuite-features__list {
 	box-sizing: border-box;
-	justify-content: justify-content;
+	justify-content: space-between;
 	margin: 1em 0;
 
 	.gsuite-features__feature {

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -1,3 +1,7 @@
+.gsuite-price {
+	margin-bottom: 1.5em;
+}
+
 .gsuite-price__monthly-price {
 	font-size: 18px;
 	font-weight: 500;

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -1,7 +1,3 @@
-.gsuite-price {
-	margin-bottom: 1.5em;
-}
-
 .gsuite-price__monthly-price {
 	font-size: 18px;
 	font-weight: 500;

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/product-details.jsx
@@ -21,22 +21,24 @@ function GSuiteUpsellProductDetails( { currencyCode, domain, product, productSlu
 	return (
 		<div className="gsuite-upsell-card__product-details">
 			<div className="gsuite-upsell-card__product-intro">
-				<div className="gsuite-upsell-card__product-name">
-					{ /* Intentionally not translated as it is a brand name and Google keeps it in English */ }
-					<span className="gsuite-upsell-card__product-logo">G Suite</span>
+				<div className="gsuite-upsell-card__product-presentation">
+					<div className="gsuite-upsell-card__product-name">
+						{ /* Intentionally not translated as it is a brand name and Google keeps it in English */ }
+						<span className="gsuite-upsell-card__product-logo">G Suite</span>
+					</div>
+
+					<p>
+						{ translate(
+							"We've teamed up with Google to offer you email, storage, docs, calendars, " +
+								'and more, integrated with your site.'
+						) }
+					</p>
 				</div>
 
-				<p>
-					{ translate(
-						"We've teamed up with Google to offer you email, storage, docs, calendars, " +
-							'and more, integrated with your site.'
-					) }
-				</p>
-
-				<GSuitePrice product={ product } currencyCode={ currencyCode } />
+				<GSuiteCompactFeatures domainName={ domain } productSlug={ productSlug } type={ 'list' } />
 			</div>
 
-			<GSuiteCompactFeatures domainName={ domain } productSlug={ productSlug } type={ 'list' } />
+			<GSuitePrice product={ product } currencyCode={ currencyCode } />
 		</div>
 	);
 }

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/style.scss
@@ -1,14 +1,19 @@
 .gsuite-upsell-card__product-details {
+	margin-bottom: 1.5em;
+}
+
+.gsuite-upsell-card__product-intro {
+	@include breakpoint( '<960px' ) {
+		margin-bottom: 1em;
+	}
+
 	@include breakpoint( '>960px' ) {
 		display: flex;
 	}
 }
 
-.gsuite-upsell-card__product-intro {
-	@include breakpoint( '>960px' ) {
-		max-width: 350px;
-		margin-right: 50px;
-	}
+.gsuite-upsell-card__product-presentation {
+	flex-basis: 55%;
 }
 
 .gsuite-upsell-card__product-name {


### PR DESCRIPTION
This pull request seeks to fix alignment issues on the `Upsell` pages in certain languages where prices and discount would be displayed on more than two lines:

Before | After
------ | -----
![BEFORE](https://user-images.githubusercontent.com/594356/70816407-b9bf9e00-1dcf-11ea-89f7-df1c5697842b.png) | ![AFTER](https://user-images.githubusercontent.com/594356/70816417-bdebbb80-1dcf-11ea-9691-630d413671c9.png)

#### Testing instructions

You should test those changes in different languages, and browser widths:

1. Run `git checkout fix/gsuite-discount-display` and start your server, or open a [live branch](https://calypso.live/?branch=fix/gsuite-discount-display)
2. Sandbox the store to enable the discount
3. Log into an account that has a site with a domain but not G Suite
4. Open the [`Email` page](http://calypso.localhost:3000/me/email)
5. Asserts that everything looks like before
6. Navigate to the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
7. Select a domain to access the `Upsell` page
8. Asserts that the price block is displayed on a single line now

/cc @fditrapani 