### PR TITLE
Recurring Payments <==> Mailchimp integration

### DIFF
--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -27,6 +27,7 @@ const MailchimpSettings = ( {
 	mailchimpLists,
 	mailchimpListId,
 	membershipsConnectedAccountId,
+	membershipsMailchimpListId,
 	isJetpack,
 	isJetpackConnectionBroken,
 	isJetpackTooOld,
@@ -162,26 +163,29 @@ const MailchimpSettings = ( {
 						</option>
 					) ) }
 			</select>
-			{ membershipsConnectedAccountId && mailchimpLists && mailchimpLists.length && (
-				<div>
-					<p>
-						{ translate(
-							'Your site has also enabled Recurring Payments. Do you want your Recurring Payments subscribers to be added to a Mailchimp list?'
-						) }
-					</p>
-					<select value={ mailchimpListId } onChange={ chooseMembershipsList }>
-						<option key="none" value={ 0 }>
-							{ translate( 'Do not connect Recurring Payments with Mailchimp' ) }
-						</option>
-						{ mailchimpLists &&
-							mailchimpLists.map( list => (
-								<option key={ list.id } value={ list.id }>
-									{ list.name }
-								</option>
-							) ) }
-					</select>
-				</div>
-			) }
+			{ !! membershipsConnectedAccountId &&
+				!! mailchimpListId &&
+				!! mailchimpLists &&
+				mailchimpLists.length > 0 && (
+					<div>
+						<p>
+							{ translate(
+								'Your site has also enabled Recurring Payments. Do you want your Recurring Payments subscribers to be added to a Mailchimp list?'
+							) }
+						</p>
+						<select value={ membershipsMailchimpListId } onChange={ chooseMembershipsList }>
+							<option key="none" value={ 0 }>
+								{ translate( 'Do not connect Recurring Payments with Mailchimp' ) }
+							</option>
+							{ mailchimpLists &&
+								mailchimpLists.map( list => (
+									<option key={ list.id } value={ list.id }>
+										{ list.name }
+									</option>
+								) ) }
+						</select>
+					</div>
+				) }
 			{ common }
 		</div>
 	);

--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -65,9 +65,11 @@ const MailchimpSettings = ( {
 			{
 				memberships_subscribers_list: event.target.value,
 			},
-			translate( 'New Recurring Payments subscribers will be saved to the %s Mailchimp list', {
-				args: list.name,
-			} )
+			parseInt( event.target.value )
+				? translate( 'New Recurring Payments subscribers will be saved to the %s Mailchimp list', {
+						args: list.name,
+				  } )
+				: translate( 'New Recurring Payments subscribers will not be shared with Mailchimp' )
 		);
 	};
 	const common = (
@@ -152,7 +154,11 @@ const MailchimpSettings = ( {
 					showDismiss={ false }
 				/>
 			) }
-			<select value={ mailchimpListId } onChange={ chooseMailchimpList }>
+			<select
+				className="sharing-service__mailchimp-select" // eslint-disable-line wpcalypso/jsx-classname-namespace
+				value={ mailchimpListId }
+				onChange={ chooseMailchimpList }
+			>
 				<option key="none" value={ 0 }>
 					{ translate( 'Do not save subscribers to Mailchimp for this site' ) }
 				</option>
@@ -170,10 +176,26 @@ const MailchimpSettings = ( {
 					<div>
 						<p>
 							{ translate(
-								'Your site has also enabled Recurring Payments. Do you want your Recurring Payments subscribers to be added to a Mailchimp list?'
+								'Your site has also enabled {{a}}Recurring Payments{{/a}}.{{br/}}Do you want your Recurring Payments subscribers to be added to a Mailchimp list?',
+								{
+									components: {
+										a: (
+											<a
+												href={ `/earn/payments/${ siteSlug }` }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+										br: <br />,
+									},
+								}
 							) }
 						</p>
-						<select value={ membershipsMailchimpListId } onChange={ chooseMembershipsList }>
+						<select
+							className="sharing-service__mailchimp-select" // eslint-disable-line wpcalypso/jsx-classname-namespace
+							value={ membershipsMailchimpListId }
+							onChange={ chooseMembershipsList }
+						>
 							<option key="none" value={ 0 }>
 								{ translate( 'Do not connect Recurring Payments with Mailchimp' ) }
 							</option>

--- a/client/my-sites/marketing/connections/services-group.scss
+++ b/client/my-sites/marketing/connections/services-group.scss
@@ -7,3 +7,7 @@
 	padding: 0;
 	list-style: none;
 }
+
+.sharing-service__mailchimp-select {
+	margin-bottom: 12px;
+}


### PR DESCRIPTION
This diff allows for integrating Recurring Payments with Mailchimp - effectively enabling paid newsletters.
If Recurring Payments is set up on the site, additional mailchimp options shows up to select a list where recurring payments subscribers will be saved

<img width="1059" alt="Zrzut ekranu 2019-12-13 o 18 56 13" src="https://user-images.githubusercontent.com/3775068/70821054-67d04580-1dda-11ea-8f23-786d8f50f4aa.png">



#### Testing instructions

You need a Stripe account AND a Mailchimp account. If you are sandboxing store, than you only need 

1. Pick a site with Recurring Payments enabled (in http://calypso.localhost:3000/earn/payments/ )
2. Go to http://calypso.localhost:3000/marketing/connections/
3. Connect Mailchimp account
4. Pick a mailchimp list right there in the mailchimp setup
5. Pick a second (or the same list) to save your recurring payments subscribers.

Now, when it's set up, log in to `wpsh` on your sandbox

Run this:
```
require_lib('mailchimp');
MailchimpApi::membership_purchase( <YOUR SITE ID>, (object)['user_email' => 'artur.piszek+test1@automattic.com'], 0)
```

After this, `artur.piszek+test1@automattic.com` will be on your list.

