### PR TITLE
Themes Showcase - Fix bug stopping pagination requests.

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -66,6 +66,13 @@ class ThemesSelection extends Component {
 		showUploadButton: true,
 	};
 
+	componentDidMount() {
+		// Create "buffer zone" to prevent overscrolling too early bugging pagination requests.
+		if ( ! this.props.recommendedThemes ) {
+			this.props.incrementPage();
+		}
+	}
+
 	recordSearchResultsClick = ( themeId, resultsRank, action ) => {
 		// TODO do we need different query if from RecommendedThemes?
 		const { query, filterString } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an `incrementPage` request on `componentDidMount` for the themes-selection component.

This change is intended to create a larger "buffer" of themes in the window making it more difficult to "overscroll" too early and bug out the pagination component from requesting more pages.  Some more notes on this bug can be found on the issue #38410.  

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Run this PR.
* Navigate to the Themes Showcase.
* Scroll down and click "More Themes".
* Scroll down more immediately.
* Verify pagination requests continue as expected.

NOTE:  This may be a bit difficult to test as the original issue is hard to consistently recreate in a reasonable manner.  These changes intend to make this even more difficult to recreate, however this bug can always be triggered through scrolling too far down while pagination requests are occurring. 
 Test with a "reasonable" scrolling speed that would be used by someone actually browsing themes.  Please compare against the current behavior on dotcom to see if this makes a reasonable difference in preventing the pagination bug.

Fixes #38410
