### PR TITLE
fix(security): Make the password change success notification persistent

### DIFF
--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -20,7 +20,7 @@ import { getSocialServiceFromClientId } from 'lib/login';
 export function password( context, next ) {
 	if ( context.query && context.query.updated === 'password' ) {
 		notices.success( i18n.translate( 'Your password was saved successfully.' ), {
-			displayOnNextPage: true,
+			persistent: true,
 		} );
 
 		page.replace( window.location.pathname );


### PR DESCRIPTION
Instead of showing a transient notification, make the password change notification persistent and require the user to dismiss it. This allows the notification to show up immediately after the page load.
