### PR TITLE
Fix/missing delayed notices

### DIFF
--- a/client/notices/index.js
+++ b/client/notices/index.js
@@ -177,6 +177,7 @@ const notices = {
 				list[ noticeObject.container ].push( noticeObject );
 			} );
 			delayedNotices = [];
+			changed = true;
 		}
 
 		if ( changed ) {

--- a/client/notices/index.js
+++ b/client/notices/index.js
@@ -19,13 +19,14 @@ let delayedNotices = [];
 const notices = {
 	/**
 	 * Creates a new notice
+	 *
 	 * @private
 	 *
-	 * @param {String} text The text of the notices
-	 * @param {Object} options Options for the notice
-	 * @param {String} status The status
+	 * @param {string} text The text of the notices
+	 * @param {object} options Options for the notice
+	 * @param {string} status The status
 	 *
-	 * @return {object} notice
+	 * @returns {object} notice
 	 */
 	new: function( text, options, status ) {
 		// Set container
@@ -72,12 +73,13 @@ const notices = {
 
 	/**
 	 * Helper function for creating a new "Success" notice
+	 *
 	 * @public
 	 *
-	 * @param {String} text The text of the notices
-	 * @param {Object} options Options for the notice
+	 * @param {string} text The text of the notices
+	 * @param {object} options Options for the notice
 	 *
-	 * @return {object} notice
+	 * @returns {object} notice
 	 */
 	success: function( text, options ) {
 		options = options || {};
@@ -86,12 +88,13 @@ const notices = {
 
 	/**
 	 * Helper function for creating a new "Error" notice
+	 *
 	 * @public
 	 *
-	 * @param {String} text The text of the notices
-	 * @param {Object} options Options for the notice
+	 * @param {string} text The text of the notices
+	 * @param {object} options Options for the notice
 	 *
-	 * @return {object} notice
+	 * @returns {object} notice
 	 */
 	error: function( text, options ) {
 		options = options || {};
@@ -100,12 +103,13 @@ const notices = {
 
 	/**
 	 * Helper function for creating a new general "Info" notice
+	 *
 	 * @public
 	 *
-	 * @param {String} text The text of the notices
-	 * @param {Object} options Options for the notice
+	 * @param {string} text The text of the notices
+	 * @param {object} options Options for the notice
 	 *
-	 * @return {object} notice
+	 * @returns {object} notice
 	 */
 	info: function( text, options ) {
 		options = options || {};
@@ -114,12 +118,13 @@ const notices = {
 
 	/**
 	 * Helper function for creating a new general "Info" notice
+	 *
 	 * @public
 	 *
-	 * @param {String} text The text of the notices
-	 * @param {Object} options Options for the notice
+	 * @param {string} text The text of the notices
+	 * @param {object} options Options for the notice
 	 *
-	 * @return {object} notice
+	 * @returns {object} notice
 	 */
 	warning: function( text, options ) {
 		options = options || {};
@@ -133,6 +138,7 @@ const notices = {
 
 	/**
 	 * Removes a specific notice when you click its `X` button
+	 *
 	 * @param  {object} notice The data that was originally used to create the notice
 	 */
 	removeNotice: function( notice ) {
@@ -151,8 +157,9 @@ const notices = {
 
 	/**
 	 * Callback handler to clear notices when a user leaves current page
+	 *
 	 * @public
-	 * @param {Object} context The page context
+	 * @param {object} context The page context
 	 * @param {Function} next The continuation
 	 */
 	clearNoticesOnNavigation: function( context, next ) {
@@ -188,6 +195,7 @@ const notices = {
 
 	/**
 	 * Clear all notices at once for a given container
+	 *
 	 * @public
 	 *
 	 * @param  {string} container DOM ID of notices container to clear


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show delayed notices on page navigation again

#### Testing instructions

* Emit a delayed notice by trying some code that looks like
```
import { success } from 'notices';
success( 'next', { displayOnNextPage: true } );
page.replace( window.location.pathname );
```

Discovered while working on https://github.com/Automattic/wp-calypso/pull/38431
