### PR TITLE
composite-checkout: Hook up paypal transactions

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -288,10 +288,6 @@ function useCreatePaymentMethods() {
 	const paypalMethod = useMemo(
 		() =>
 			createPayPalMethod( {
-				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,
-				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-				getPhoneNumber: () => select( 'wpcom' )?.getContactInfo?.()?.phoneNumber?.value,
-				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 				registerStore: registerStore,
 				submitTransaction: submitData =>
 					makePayPalExpressRequest( {
@@ -299,6 +295,10 @@ function useCreatePaymentMethods() {
 						siteId: select( 'wpcom' )?.getSiteId?.(),
 						domainDetails: getDomainDetails(),
 						couponId: null, // TODO: get couponId
+						country: select( 'wpcom' )?.getContactInfo?.()?.country?.value,
+						postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+						subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+						phoneNumber: select( 'wpcom' )?.getContactInfo?.()?.phoneNumber?.value,
 					} ),
 			} ),
 		[]

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -112,9 +112,10 @@ function formatDataForPayPalExpressEndpoint( {
 			subdivisionCode,
 			phoneNumber,
 			couponId,
-			items,
+			items: items.filter( item => item.type !== 'tax' ),
 		} ),
 		domainDetails,
+		country,
 		postalCode,
 	};
 }

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -253,6 +253,7 @@ function useCreatePaymentMethods() {
 	const paypalMethod = useMemo(
 		() =>
 			createPayPalMethod( {
+				getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
 				registerStore: registerStore,
 				makePayPalExpressRequest: mockPayPalExpressRequest,
 			} ),

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -9,7 +9,6 @@ import {
 	createApplePayMethod,
 	createExistingCardMethod,
 } from '@automattic/composite-checkout';
-import { mockPayPalExpressRequest } from '@automattic/composite-checkout-wpcom';
 import { useTranslate } from 'i18n-calypso';
 import debugFactory from 'debug';
 import { useSelector } from 'react-redux';
@@ -122,6 +121,10 @@ export function createCartFromLineItems( {
 			},
 		},
 	};
+}
+
+async function makePayPalExpressRequest( transactionData ) {
+	return wpcom.paypalExpressUrl( transactionData );
 }
 
 function getDomainDetails() {
@@ -260,7 +263,7 @@ function useCreatePaymentMethods() {
 				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 				getDomainDetails,
 				registerStore: registerStore,
-				makePayPalExpressRequest: mockPayPalExpressRequest,
+				makePayPalExpressRequest,
 			} ),
 		[]
 	);

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -288,14 +288,18 @@ function useCreatePaymentMethods() {
 	const paypalMethod = useMemo(
 		() =>
 			createPayPalMethod( {
-				getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
 				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,
 				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 				getPhoneNumber: () => select( 'wpcom' )?.getContactInfo?.()?.phoneNumber?.value,
 				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-				getDomainDetails,
 				registerStore: registerStore,
-				submitTransaction: submitData => makePayPalExpressRequest( submitData ),
+				submitTransaction: submitData =>
+					makePayPalExpressRequest( {
+						...submitData,
+						siteId: select( 'wpcom' )?.getSiteId?.(),
+						domainDetails: getDomainDetails(),
+						couponId: null, // TODO: get couponId
+					} ),
 			} ),
 		[]
 	);

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -295,7 +295,7 @@ function useCreatePaymentMethods() {
 				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 				getDomainDetails,
 				registerStore: registerStore,
-				makePayPalExpressRequest,
+				submitTransaction: submitData => makePayPalExpressRequest( submitData ),
 			} ),
 		[]
 	);

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -90,6 +90,35 @@ function formatDataForTransactionsEndpoint( {
 	};
 }
 
+function formatDataForPayPalExpressEndpoint( {
+	successUrl,
+	cancelUrl,
+	siteId,
+	country,
+	postalCode,
+	subdivisionCode,
+	phoneNumber,
+	couponId,
+	items,
+	domainDetails,
+} ) {
+	return {
+		successUrl,
+		cancelUrl,
+		cart: createCartFromLineItems( {
+			siteId,
+			country,
+			postalCode,
+			subdivisionCode,
+			phoneNumber,
+			couponId,
+			items,
+		} ),
+		domainDetails,
+		postalCode,
+	};
+}
+
 // Create cart object as required by the WPCOM transactions endpoint '/me/transactions/': WPCOM_JSON_API_Transactions_Endpoint
 export function createCartFromLineItems( {
 	siteId,
@@ -124,7 +153,9 @@ export function createCartFromLineItems( {
 }
 
 async function makePayPalExpressRequest( transactionData ) {
-	return wpcom.paypalExpressUrl( transactionData );
+	const formattedTransactionData = formatDataForPayPalExpressEndpoint( transactionData );
+	debug( 'sending paypal transaction', formattedTransactionData );
+	return wpcom.paypalExpressUrl( formattedTransactionData );
 }
 
 function getDomainDetails() {

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -254,6 +254,11 @@ function useCreatePaymentMethods() {
 		() =>
 			createPayPalMethod( {
 				getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
+				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,
+				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+				getPhoneNumber: () => select( 'wpcom' )?.getContactInfo?.()?.phoneNumber?.value,
+				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+				getDomainDetails,
 				registerStore: registerStore,
 				makePayPalExpressRequest: mockPayPalExpressRequest,
 			} ),

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -109,7 +109,7 @@ test( 'When we enter checkout, the line items and total are rendered', async () 
 				availablePaymentMethods={ [
 					createPayPalMethod( {
 						registerStore: registerStore,
-						makePayPalExpressRequest: mockPayPalExpressRequest,
+						submitTransaction: mockPayPalExpressRequest,
 					} ),
 				] }
 				registry={ registry }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -234,7 +234,7 @@ Creates a [Payment Method](#payment-methods) object for an existing credit card.
 Creates a [Payment Method](#payment-methods) object. Requires passing an object with the following properties:
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
-- `makePayPalExpressRequest: async object => string`. An async function that sends the request to the endpoint to get the redirect url.
+- `submitTransaction: async object => string`. An async function that sends the request to the endpoint to get the redirect url.
 
 ### createStripeMethod
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -234,7 +234,7 @@ Creates a [Payment Method](#payment-methods) object for an existing credit card.
 Creates a [Payment Method](#payment-methods) object. Requires passing an object with the following properties:
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
-- `makePayPalExpressRequest: async ?object => object`. An async function that sends the request to the endpoint to get the redirect url.
+- `makePayPalExpressRequest: async object => string`. An async function that sends the request to the endpoint to get the redirect url.
 
 ### createStripeMethod
 
@@ -242,7 +242,7 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
 - `fetchStripeConfiguration: async ?object => object`. An async function that fetches the stripe configuration (we use Stripe for Apple Pay).
-- `submitTransaction: async ?object => object`. An async function that sends the request to the endpoint.
+- `submitTransaction: async object => object`. An async function that sends the request to the endpoint.
 - `getCountry: () => string`. A function that returns the country to use for the transaction.
 - `getPostalCode: () => string`. A function that returns the postal code for the transaction.
 - `getSubdivisionCode: () => string`. A function that returns the subdivision code for the transaction.

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -104,7 +104,10 @@ const applePayMethod = isApplePayAvailable()
 	  } )
 	: null;
 
-const paypalMethod = createPayPalMethod( { registerStore, makePayPalExpressRequest } );
+const paypalMethod = createPayPalMethod( {
+	registerStore,
+	submitTransaction: makePayPalExpressRequest,
+} );
 
 export function isApplePayAvailable() {
 	// Our Apple Pay implementation uses the Payment Request API, so check that first.

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -17,14 +17,7 @@ import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 const debug = debugFactory( 'composite-checkout:paypal' );
 
-export function createPayPalMethod( {
-	registerStore,
-	submitTransaction,
-	getCountry,
-	getPostalCode,
-	getSubdivisionCode,
-	getPhoneNumber,
-} ) {
+export function createPayPalMethod( { registerStore, submitTransaction } ) {
 	registerStore( 'paypal', {
 		controls: {
 			PAYPAL_TRANSACTION_SUBMIT( action ) {
@@ -32,10 +25,6 @@ export function createPayPalMethod( {
 				return submitTransaction( {
 					successUrl,
 					cancelUrl,
-					country: getCountry(),
-					postalCode: getPostalCode(),
-					subdivisionCode: getSubdivisionCode(),
-					phoneNumber: getPhoneNumber(),
 					items,
 				} );
 			},

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -13,7 +13,6 @@ import { useDispatch, useSelect } from '../../lib/registry';
 import { useMessages, useCheckoutRedirects, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
-import { createCartFromLineItems } from './transactions-endpoint';
 
 export function createPayPalMethod( {
 	registerStore,
@@ -29,22 +28,18 @@ export function createPayPalMethod( {
 		controls: {
 			PAYPAL_TRANSACTION_SUBMIT( action ) {
 				const { items, successUrl, cancelUrl } = action.payload;
-				const dataForApi = {
+				return makePayPalExpressRequest( {
 					successUrl,
 					cancelUrl,
-					cart: createCartFromLineItems( {
-						siteId: getSiteId(),
-						country: getCountry(),
-						postalCode: getPostalCode(),
-						subdivisionCode: getSubdivisionCode(),
-						phoneNumber: getPhoneNumber(),
-						couponId: null, // TODO: get couponId
-						items,
-					} ),
+					siteId: getSiteId(),
+					country: getCountry(),
+					postalCode: getPostalCode(),
+					subdivisionCode: getSubdivisionCode(),
+					phoneNumber: getPhoneNumber(),
+					couponId: null, // TODO: get couponId
+					items,
 					domainDetails: getDomainDetails(),
-					'postal-code': getPostalCode(),
-				};
-				return makePayPalExpressRequest( dataForApi );
+				} );
 			},
 		},
 		actions: {

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -19,7 +19,7 @@ const debug = debugFactory( 'composite-checkout:paypal' );
 
 export function createPayPalMethod( {
 	registerStore,
-	makePayPalExpressRequest,
+	submitTransaction,
 	getSiteId,
 	getCountry,
 	getPostalCode,
@@ -31,7 +31,7 @@ export function createPayPalMethod( {
 		controls: {
 			PAYPAL_TRANSACTION_SUBMIT( action ) {
 				const { items, successUrl, cancelUrl } = action.payload;
-				return makePayPalExpressRequest( {
+				return submitTransaction( {
 					successUrl,
 					cancelUrl,
 					siteId: getSiteId(),

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -20,12 +20,10 @@ const debug = debugFactory( 'composite-checkout:paypal' );
 export function createPayPalMethod( {
 	registerStore,
 	submitTransaction,
-	getSiteId,
 	getCountry,
 	getPostalCode,
 	getSubdivisionCode,
 	getPhoneNumber,
-	getDomainDetails,
 } ) {
 	registerStore( 'paypal', {
 		controls: {
@@ -34,14 +32,11 @@ export function createPayPalMethod( {
 				return submitTransaction( {
 					successUrl,
 					cancelUrl,
-					siteId: getSiteId(),
 					country: getCountry(),
 					postalCode: getPostalCode(),
 					subdivisionCode: getSubdivisionCode(),
 					phoneNumber: getPhoneNumber(),
-					couponId: null, // TODO: get couponId
 					items,
-					domainDetails: getDomainDetails(),
 				} );
 			},
 		},

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -13,6 +13,7 @@ import { useDispatch, useSelect } from '../../lib/registry';
 import { useMessages, useCheckoutRedirects, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+import { createCartFromLineItems } from './transactions-endpoint';
 
 export function createPayPalMethod( {
 	registerStore,
@@ -223,36 +224,4 @@ function PaypalLogo( { className } ) {
 			</defs>
 		</svg>
 	);
-}
-
-// TODO: this is duplicated in stripe-credit-card-fields also
-function createCartFromLineItems( {
-	siteId,
-	couponId,
-	items,
-	country,
-	postalCode,
-	subdivisionCode,
-} ) {
-	const currency = items.reduce( ( firstValue, item ) => firstValue || item.amount.currency, null );
-	return {
-		blog_id: siteId,
-		coupon: couponId || '',
-		currency: currency || '',
-		temporary: false,
-		extra: [],
-		products: items.map( item => ( {
-			product_id: item.id,
-			meta: '', // TODO: get this for domains, etc
-			currency: item.amount.currency,
-			volume: 1,
-		} ) ),
-		tax: {
-			location: {
-				country_code: country,
-				postal_code: postalCode,
-				subdivision_code: subdivisionCode,
-			},
-		},
-	};
 }

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -14,7 +14,7 @@ import { useMessages, useCheckoutRedirects, useLineItems } from '../../public-ap
 import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
-export function createPayPalMethod( { registerStore, makePayPalExpressRequest } ) {
+export function createPayPalMethod( { registerStore, makePayPalExpressRequest, getSiteId } ) {
 	registerStore( 'paypal', {
 		controls: {
 			PAYPAL_TRANSACTION_SUBMIT( action ) {
@@ -27,7 +27,7 @@ export function createPayPalMethod( { registerStore, makePayPalExpressRequest } 
 					domainDetails,
 					postalCode,
 				} = action.payload;
-				const siteId = ''; // TODO: get site id
+				const siteId = getSiteId();
 				const couponId = null; // TODO: get couponId
 				const dataForApi = {
 					successUrl,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This hooks up PayPal transactions in much the same way that #38095 hooks up Stripe transactions.

#### Testing instructions

First make sure you have a sandboxed PayPal account. It must be using an `@automattic.com` email address. [Instructions for creating one are here](https://developer.paypal.com/docs/classic/lifecycle/sandbox/accounts/#create-and-manage-sandbox-accounts).

- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`
- Add a plan to your cart and visit checkout.
- Choose the "PayPal" payment method and fill out the form.
- Press "Pay".
- Verify that you are redirected to a PayPal page. The URL should begin with `sandbox.paypal`.
- Log in to PayPal and pay for the purchase using your special sandboxed account.
- Verify that you are redirected to a "thank you" page (you may see a "pending" page briefly).
- Verify that the product is successfully purchased and exists on your account.