### PR TITLE
Earn: Hide Badge for New Users

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import React, { FunctionComponent, Fragment } from 'react';
 import page from 'page';
 import { get, compact } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ import QueryMembershipsSettings from 'components/data/query-memberships-settings
 import QueryWordadsStatus from 'components/data/query-wordads-status';
 import { FEATURE_WORDADS_INSTANT, FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentUserDate } from 'state/current-user/selectors';
 
 /**
  * Image dependencies
@@ -60,6 +62,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	trackUpgrade,
 	trackLearnLink,
 	trackCtaButton,
+	userDate,
 } ) => {
 	const translate = useTranslate();
 
@@ -151,7 +154,8 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			badge: translate( 'New' ),
+			badge:
+				moment( userDate ).diff( moment( '2019-11-26 00:00:00' ) ) < 0 ? translate( 'New' ) : null,
 			image: {
 				path: recurringImage,
 			},
@@ -298,6 +302,7 @@ export default connect< ConnectedProps, {}, {} >(
 			isAtomicSite: isSiteAutomatedTransfer( state, site.ID ),
 			hasWordAds: hasFeature( state, site.ID, FEATURE_WORDADS_INSTANT ),
 			hasSimplePayments: hasFeature( state, site.ID, FEATURE_SIMPLE_PAYMENTS ),
+			userDate: getCurrentUserDate( state ),
 			hasConnectedAccount: !! get(
 				state,
 				[ 'memberships', 'settings', site.ID, 'connectedAccountId' ],

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import Gridicon from 'components/gridicon';
 import { format as formatUrl, parse as parseUrl } from 'url';
 import { memoize } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import { memoize } from 'lodash';
 import { isEnabled } from 'config';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import Badge from 'components/badge';
 import ExternalLink from 'components/external-link';
 import JetpackLogo from 'components/jetpack-logo';
 import Sidebar from 'layout/sidebar';
@@ -27,7 +29,7 @@ import SiteMenu from './site-menu';
 import StatsSparkline from 'blocks/stats-sparkline';
 import ToolsMenu from './tools-menu';
 import { isFreeTrial, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, getCurrentUserDate } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -63,7 +65,7 @@ import {
 	SIDEBAR_SECTION_MANAGE,
 } from './constants';
 import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosting';
-import Badge from 'components/badge';
+
 /**
  * Style dependencies
  */
@@ -219,7 +221,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const { path, translate } = this.props;
+		const { path, translate, userDate } = this.props;
 
 		return (
 			<SidebarItem
@@ -230,7 +232,9 @@ export class MySitesSidebar extends Component {
 				tipTarget="earn"
 				expandSection={ this.expandToolsSection }
 			>
-				<Badge type="info">{ translate( 'New' ) }</Badge>
+				{ moment( userDate ).diff( moment( '2019-11-26 00:00:00' ) ) < 0 && (
+					<Badge type="info">{ translate( 'New' ) }</Badge>
+				) }
 			</SidebarItem>
 		);
 	}
@@ -814,6 +818,7 @@ function mapStateToProps( state ) {
 		canUserUseAds: canCurrentUserUseAds( state, siteId ),
 		canUserUpgradeSite: canCurrentUserUpgradeSite( state, siteId ),
 		currentUser,
+		userDate: getCurrentUserDate( state ),
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		hasJetpackSites: hasJetpackSites( state ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For new users (users registered after 26th November, the day that #37912 was merged), hide the "New" badge for the Earn section

Let me know if that date should be changed!

#### Testing instructions

There's two things to check. Firstly, verify that it doesn't appear in the sidebar for new users, and secondly `/earn/site`. They should appear for older users.

<img width="254" alt="Screenshot 2019-12-15 at 14 29 40" src="https://user-images.githubusercontent.com/43215253/70864152-58bad600-1f47-11ea-8361-a4e4dc2410fe.png">

cc @shaunandrews, @davemart-in, @artpi

Fixes #38293
