### PR TITLE
Update from unlimited to 200 GB in "Video and audio posts" card.

### DIFF
--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -20,13 +20,13 @@ function getDescription( plan, translate ) {
 	if ( isWpComBusinessPlan( plan ) ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload as much media as you want, ' +
-				'directly to your site — the Business Plan has unlimited storage.'
+				'directly to your site — the Business Plan has 200 GB storage.'
 		);
 	}
 	if ( isWpComEcommercePlan( plan ) ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload as much media as you want, ' +
-				'directly to your site — the Ecommerce Plan has unlimited storage.'
+				'directly to your site — the Ecommerce Plan has 200 GB storage.'
 		);
 	}
 

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -19,13 +19,13 @@ import videoImage from 'assets/images/illustrations/video-hosting.svg';
 function getDescription( plan, translate ) {
 	if ( isWpComBusinessPlan( plan ) ) {
 		return translate(
-			'Enrich your posts and pages with video or audio. Upload as much media as you want, ' +
+			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the Business Plan has 200 GB storage.'
 		);
 	}
 	if ( isWpComEcommercePlan( plan ) ) {
 		return translate(
-			'Enrich your posts and pages with video or audio. Upload as much media as you want, ' +
+			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the Ecommerce Plan has 200 GB storage.'
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update from unlimited, to more accurately saying, "200 GB" in the "Video and audio posts" card.

#### Testing instructions

https://calypso.live/?branch=fix/200-gb-audio-video
Go to: `/plans/my-plan/`

- Review the "Video and audio posts" card on the `/plans/my-plan/` page.
- Review on test sites that are on different plans.
- Confirm that it reads "200 GB" for Business and eCommerce plans.

![Screen Shot 2019-12-15 at 23 22 40](https://user-images.githubusercontent.com/1563559/70879045-f804bb00-1f91-11ea-9866-b083905eba65.png)

