### PR TITLE
Make site public directly from <EligibilityWarnings>

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
+import { identity, map } from 'lodash';
 import React from 'react';
 
 /**
@@ -219,5 +219,8 @@ function isHardBlockingHoldType(
 ): hold is keyof ReturnType< typeof getBlockingMessages > {
 	return blockingMessages.hasOwnProperty( hold );
 }
+
+export const hasBlockingHold = ( holds: string[] ) =>
+	holds.some( hold => isHardBlockingHoldType( hold, getBlockingMessages( identity ) ) );
 
 export default localize( HoldList );

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -10,7 +10,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import SectionHeader from 'components/section-header';
+import CardHeading from 'components/card-heading';
 import { localizeUrl } from 'lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
@@ -101,23 +101,20 @@ function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
 }
 
 interface ExternalProps {
+	context: string | null;
 	holds: string[];
 	isPlaceholder: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( translate );
 
 	return (
 		<div>
-			<SectionHeader
-				label={ translate( 'Please resolve this issue:', 'Please resolve these issues:', {
-					count: holds.length,
-				} ) }
-			/>
 			<Card className="eligibility-warnings__hold-list">
+				<CardHeading>{ getCardHeading( context, translate ) }</CardHeading>
 				{ isPlaceholder && (
 					<div>
 						<div className="eligibility-warnings__hold">
@@ -134,18 +131,17 @@ export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<Gridicon icon="notice-outline" size={ 24 } />
+								<Gridicon icon="checkmark-circle" size={ 24 } />
 								<div className="eligibility-warnings__message">
-									<span className="eligibility-warnings__message-title">
+									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
-									</span>
-									:&nbsp;
-									<span className="eligibility-warnings__message-description">
+									</div>
+									<div className="eligibility-warnings__message-description">
 										{ holdMessages[ hold ].description }
-									</span>
+									</div>
 								</div>
 								{ holdMessages[ hold ].supportUrl && (
-									<div className="eligibility-warnings__action">
+									<div className="eligibility-warnings__hold-action">
 										<Button
 											compact
 											href={ holdMessages[ hold ].supportUrl }
@@ -162,6 +158,17 @@ export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
 		</div>
 	);
 };
+
+function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
+	switch ( context ) {
+		case 'plugins':
+			return translate( "To install plugins, you'll need a couple things:" );
+		case 'themes':
+			return translate( "To install themes, you'll need a couple things:" );
+		default:
+			return translate( "To continue, you'll need a couple things:" );
+	}
+}
 
 function isKnownHoldType(
 	hold: string,

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
@@ -139,8 +139,8 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 						) }
 					</Notice>
 				) }
-			<Card
-				className={ classNames( 'eligibility-warnings__hold-list', {
+			<div
+				className={ classNames( {
 					'eligibility-warnings__hold-list-dim': blockingHold,
 				} ) }
 				data-testid="HoldList-Card"
@@ -190,7 +190,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 							</div>
 						)
 					) }
-			</Card>
+			</div>
 		</>
 	);
 };

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -31,6 +31,13 @@ function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
 			),
 			supportUrl: null,
 		},
+		NO_BUSINESS_PLAN: {
+			title: translate( 'Upgrade to a Business plan' ),
+			description: translate(
+				"You'll also get to install custom themes, have more storage, and access live support."
+			),
+			supportUrl: null,
+		},
 		NO_JETPACK_SITES: {
 			title: translate( 'Not available for Jetpack sites' ),
 			description: translate( 'Try using a different site.' ),

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -76,7 +76,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 		},
 		TRANSFER_ALREADY_EXISTS: {
 			message: translate(
-				'Installation in progress. Just a minute! Please wait until the installation is finisehd, then try again.'
+				'Installation in progress. Just a minute! Please wait until the installation is finished, then try again.'
 			),
 			status: null,
 			contactUrl: null,
@@ -100,7 +100,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 		},
 		NO_SSL_CERTIFICATE: {
 			message: translate(
-				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browing on your site using "HTTPS".'
+				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
 			),
 			status: null,
 			contactUrl: null,

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'components/gridicon';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
+import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { localizeUrl } from 'lib/i18n-utils';
@@ -138,8 +139,17 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 						) }
 					</Notice>
 				) }
-			<Card className="eligibility-warnings__hold-list">
-				<CardHeading>{ getCardHeading( context, translate ) }</CardHeading>
+			<Card
+				className={ classNames( 'eligibility-warnings__hold-list', {
+					'eligibility-warnings__hold-list-dim': blockingHold,
+				} ) }
+				data-testid="HoldList-Card"
+			>
+				<CardHeading>
+					<span className="eligibility-warnings__hold-heading">
+						{ getCardHeading( context, translate ) }
+					</span>
+				</CardHeading>
 				{ isPlaceholder && (
 					<div>
 						<div className="eligibility-warnings__hold">
@@ -169,6 +179,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 									<div className="eligibility-warnings__hold-action">
 										<Button
 											compact
+											disabled={ !! blockingHold }
 											href={ holdMessages[ hold ].supportUrl }
 											rel="noopener noreferrer"
 										>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { filter, get, includes, noop } from 'lodash';
+import { get, includes, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 
@@ -53,12 +53,8 @@ export const EligibilityWarnings = ( {
 	siteSlug,
 	translate,
 }: Props ) => {
-	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
-
-	const listHolds = filter(
-		get( eligibilityData, 'eligibilityHolds', [] ),
-		hold => ! includes( [ 'NO_BUSINESS_PLAN', 'NOT_USING_CUSTOM_DOMAIN' ], hold )
-	);
+	const warnings = eligibilityData.eligibilityWarnings || [];
+	const listHolds = eligibilityData.eligibilityHolds || [];
 
 	const classes = classNames( 'eligibility-warnings', {
 		'eligibility-warnings__placeholder': isPlaceholder,

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -61,7 +61,7 @@ export const EligibilityWarnings = ( {
 			}
 		} else if ( listHolds.includes( 'SITE_PRIVATE' ) ) {
 			const response = await saveSiteSettings( siteId, { blog_public: 0 } );
-			if ( response?.updated?.blog_public !== 0 ) {
+			if ( response?.updated?.blog_public !== '0' ) {
 				return;
 			}
 		}

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -208,7 +208,9 @@ function mergeProps(
 		context = 'hosting';
 	}
 
-	const onCancel = () => dispatchProps.trackCancel( { context } );
+	const onCancel = () => {
+		dispatchProps.trackCancel( { context } );
+	};
 	const onProceed = () => {
 		ownProps.onProceed();
 		dispatchProps.trackProceed( { context } );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -54,7 +54,9 @@ export const EligibilityWarnings = ( {
 
 	const handleContinueClick = async () => {
 		if ( isUnlaunched ) {
-			await launchSite( siteId );
+			if ( ! ( await launchSite( siteId ) ) ) {
+				return;
+			}
 		} else if ( listHolds.includes( 'SITE_PRIVATE' ) ) {
 			//
 		}

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -17,7 +17,7 @@ import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { Button, Card } from '@automattic/components';
 import QueryEligibility from 'components/data/query-atat-eligibility';
-import HoldList from './hold-list';
+import HoldList, { hasBlockingHold } from './hold-list';
 import WarningList from './warning-list';
 
 /**
@@ -57,10 +57,12 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
+			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
+				<WarningList warnings={ warnings } />
+			) }
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 			) }
-			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
 			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
 				<Card className="eligibility-warnings__no-conflicts">

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -60,53 +60,56 @@ export const EligibilityWarnings = ( {
 			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
 				<WarningList warnings={ warnings } />
 			) }
-			{ ( isPlaceholder || listHolds.length > 0 ) && (
-				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
-			) }
 
-			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
-				<Card className="eligibility-warnings__no-conflicts">
-					<Gridicon icon="thumbs-up" size={ 24 } />
-					<span>
-						{ translate( 'This site is eligible to install plugins and upload themes.' ) }
-					</span>
-				</Card>
-			) }
+			<Card>
+				{ ( isPlaceholder || listHolds.length > 0 ) && (
+					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
+				) }
 
-			<Card className="eligibility-warnings__confirm-box">
-				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && (
-						<>
-							{ translate( 'Please clear all issues above to proceed.' ) }
-							&nbsp;
-						</>
-					) }
-					{ isEligible && warnings.length > 0 && (
-						<>
-							{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
-							&nbsp;
-						</>
-					) }
-					{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
-						components: {
-							a: (
-								<a
-									href="https://wordpress.com/help/contact"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</div>
-				<div className="eligibility-warnings__confirm-buttons">
-					<Button href={ backUrl } onClick={ onCancel }>
-						{ translate( 'Cancel' ) }
-					</Button>
+				{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
+					<div className="eligibility-warnings__no-conflicts">
+						<Gridicon icon="thumbs-up" size={ 24 } />
+						<span>
+							{ translate( 'This site is eligible to install plugins and upload themes.' ) }
+						</span>
+					</div>
+				) }
 
-					<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
-						{ translate( 'Proceed' ) }
-					</Button>
+				<div className="eligibility-warnings__confirm-box">
+					<div className="eligibility-warnings__confirm-text">
+						{ ! isEligible && (
+							<>
+								{ translate( 'Please clear all issues above to proceed.' ) }
+								&nbsp;
+							</>
+						) }
+						{ isEligible && warnings.length > 0 && (
+							<>
+								{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
+								&nbsp;
+							</>
+						) }
+						{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
+							components: {
+								a: (
+									<a
+										href="https://wordpress.com/help/contact"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</div>
+					<div className="eligibility-warnings__confirm-buttons">
+						<Button href={ backUrl } onClick={ onCancel }>
+							{ translate( 'Cancel' ) }
+						</Button>
+
+						<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
+							{ translate( 'Proceed' ) }
+						</Button>
+					</div>
 				</div>
 			</Card>
 		</div>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -105,7 +105,7 @@ export const EligibilityWarnings = ( {
 			{ businessUpsellBanner }
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
-				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } />
+				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 			) }
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -17,6 +17,7 @@ import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { launchSite as launchSiteActionCreator } from 'state/sites/launch/actions';
+import { saveSiteSettings as saveSiteSettingsActionCreator } from 'state/site-settings/actions';
 import { Button, Card } from '@automattic/components';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import HoldList, { hasBlockingHold } from './hold-list';
@@ -42,6 +43,7 @@ export const EligibilityWarnings = ( {
 	isUnlaunched,
 	launchSite,
 	onProceed,
+	saveSiteSettings,
 	siteId,
 	translate,
 }: Props ) => {
@@ -58,7 +60,10 @@ export const EligibilityWarnings = ( {
 				return;
 			}
 		} else if ( listHolds.includes( 'SITE_PRIVATE' ) ) {
-			//
+			const response = await saveSiteSettings( siteId, { blog_public: 0 } );
+			if ( response?.updated?.blog_public !== 0 ) {
+				return;
+			}
 		}
 
 		onProceed();
@@ -143,6 +148,7 @@ const mapDispatchToProps = {
 	trackProceed: ( eventProperties = {} ) =>
 		recordTracksEvent( 'calypso_automated_transfer_eligibilty_click_proceed', eventProperties ),
 	launchSite: launchSiteActionCreator,
+	saveSiteSettings: saveSiteSettingsActionCreator,
 };
 
 function mergeProps(

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -44,8 +44,8 @@
 	align-items: flex-start;
 	margin-bottom: 16px;
 
-	&:last-child {
-		margin-bottom: 0;
+	&:first-of-type {
+		padding-top: 6px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,5 +1,3 @@
-
-
 .eligibility-warnings {
 	margin-top: 16px;
 	font-size: 14px;
@@ -57,7 +55,11 @@
 	}
 }
 
-.eligibility-warnings__hold .gridicon,
+.eligibility-warnings__hold .gridicon {
+	color: var( --color-neutral-10 );
+	flex-shrink: 0;
+}
+
 .eligibility-warnings__warning > .gridicon {
 	color: var( --color-error );
 	flex-shrink: 0;
@@ -77,13 +79,18 @@
 	}
 }
 
-.eligibility-warnings__action a {
+.eligibility-warnings__action a,
+.eligibility-warnings__hold-action a {
 	.gridicons-help-outline {
 		color: var( --color-neutral-light );
 	}
 	&:hover .gridicons-help-outline {
 		color: var( --color-primary );
 	}
+}
+
+.eligibility-warnings__hold-action {
+	align-self: center;
 }
 
 .eligibility-warnings__no-conflicts.card {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -124,3 +124,8 @@
 		margin-left: 16px;
 	}
 }
+
+.eligibility-warnings__hold-list-dim .eligibility-warnings__hold-heading,
+.eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
+	opacity: 0.2;
+}

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -38,15 +38,13 @@
 }
 
 .eligibility-warnings__hold,
-.eligibility-warnings__warning,
 .eligibility-warnings__confirm-box.card {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
 }
 
-.eligibility-warnings__hold,
-.eligibility-warnings__warning {
+.eligibility-warnings__hold {
 	align-items: flex-start;
 	margin-bottom: 16px;
 
@@ -57,11 +55,6 @@
 
 .eligibility-warnings__hold .gridicon {
 	color: var( --color-neutral-10 );
-	flex-shrink: 0;
-}
-
-.eligibility-warnings__warning > .gridicon {
-	color: var( --color-error );
 	flex-shrink: 0;
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -20,7 +20,7 @@
 	}
 
 	.button,
-	.eligibility-warnings__confirm-box {
+	.eligibility-warnings__confirm-buttons {
 		display: none;
 	}
 }
@@ -33,8 +33,7 @@
 	}
 }
 
-.eligibility-warnings__hold,
-.eligibility-warnings__confirm-box {
+.eligibility-warnings__hold {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
@@ -97,24 +96,11 @@
 	}
 }
 
-.eligibility-warnings__confirm-box {
-	flex-wrap: wrap;
-	justify-content: flex-end;
-
-	.eligibility-warnings__confirm-text {
-		color: var( --color-text-subtle );
-		flex-basis: 60%;
-		flex-grow: 1;
-		font-style: italic;
-		padding: 8px 0;
-	}
-
-	.button {
-		margin-left: 16px;
-	}
-}
-
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold-heading,
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
 	opacity: 0.2;
+}
+
+.eligibility-warnings__confirm-buttons {
+	padding-left: 40px;
 }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -25,10 +25,6 @@
 	}
 }
 
-.eligibility-warnings .card {
-	margin: 0;
-}
-
 .eligibility-warnings .banner {
 	margin-bottom: 16px;
 	.banner__icon-circle {
@@ -38,7 +34,7 @@
 }
 
 .eligibility-warnings__hold,
-.eligibility-warnings__confirm-box.card {
+.eligibility-warnings__confirm-box {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
@@ -86,7 +82,7 @@
 	align-self: center;
 }
 
-.eligibility-warnings__no-conflicts.card {
+.eligibility-warnings__no-conflicts {
 	align-items: center;
 	display: flex;
 

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -138,9 +138,14 @@ describe( '<EligibilityWarnings>', () => {
 		expect( container.querySelectorAll( '.notice.is-warning' ) ).toHaveLength( 0 );
 	} );
 
-	it( 'calls onProceed prop when clicking "Upgrade and continue"', () => {
+	it( 'calls onProceed prop when clicking "Upgrade and continue"', async () => {
+		jest
+			.spyOn( wpcom.req, 'post' )
+			.mockImplementationOnce( () => Promise.resolve( { updated: { blog_public: '0' } } ) );
+
 		const state = createState( {
 			holds: [ 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ],
+			isUnlaunched: false,
 		} );
 
 		const handleProceed = jest.fn();
@@ -152,7 +157,7 @@ describe( '<EligibilityWarnings>', () => {
 
 		fireEvent.click( getByText( 'Upgrade and continue' ) );
 
-		expect( handleProceed ).toHaveBeenCalled();
+		await wait( () => expect( handleProceed ).toHaveBeenCalled() );
 	} );
 
 	it( `disables the "Continue" button if holds can't be handled automatically`, () => {
@@ -267,7 +272,7 @@ describe( '<EligibilityWarnings>', () => {
 
 		const post = jest.spyOn( wpcom.req, 'post' ).mockImplementationOnce( () => {
 			return new Promise( resolve => {
-				completePostRequest = () => resolve( { updated: { blog_public: 0 } } );
+				completePostRequest = () => resolve( { updated: { blog_public: '0' } } );
 			} );
 		} );
 

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import React, { ReactChild } from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import EligibilityWarnings from '..';
+
+function renderWithStore( element: ReactChild, initialState: object ) {
+	const store = createStore( state => state, initialState );
+	return {
+		...render( <Provider store={ store }>{ element }</Provider> ),
+		store,
+	};
+}
+
+function createState( { holds = [], siteId = 1 }: { holds?: string[]; siteId?: number } = {} ) {
+	return {
+		automatedTransfer: {
+			[ siteId ]: {
+				eligibility: {
+					eligibilityHolds: holds,
+					lastUpdate: 1,
+				},
+			},
+		},
+		currentUser: { capabilities: { [ siteId ]: {} } },
+		sites: { items: { [ siteId ]: {} } },
+		ui: { selectedSiteId: siteId },
+	};
+}
+
+describe( '<EligibilityWarnings>', () => {
+	it( 'renders error notice when AT has been blocked by a sticker', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER' ],
+		} );
+
+		const { container } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		const notice = container.querySelector( '.notice.is-error' );
+
+		expect( notice ).toBeVisible();
+		expect( notice ).toHaveTextContent( /This site is not currently eligible/ );
+	} );
+
+	it( 'only renders a single notice when multible hard blocking holds exist', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER', 'SITE_GRAYLISTED' ],
+		} );
+
+		const { container } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		expect( container.querySelectorAll( '.notice' ).length ).toBe( 1 );
+	} );
+
+	it( 'dimly renders the hold card when AT has been blocked by a sticker', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER', 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ],
+		} );
+
+		const { getByTestId, getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		expect( getByTestId( 'HoldList-Card' ) ).toHaveClass( 'eligibility-warnings__hold-list-dim' );
+		expect( getByText( 'Help' ) ).toHaveAttribute( 'disabled' );
+	} );
+} );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -86,6 +86,7 @@ describe( '<EligibilityWarnings>', () => {
 
 		expect( getByTestId( 'HoldList-Card' ) ).toHaveClass( 'eligibility-warnings__hold-list-dim' );
 		expect( getByText( 'Help' ) ).toHaveAttribute( 'disabled' );
+		expect( getByText( 'Upgrade and continue' ) ).toBeDisabled();
 	} );
 
 	it( 'renders warning notices when the API returns warnings', () => {
@@ -134,5 +135,42 @@ describe( '<EligibilityWarnings>', () => {
 		);
 
 		expect( container.querySelectorAll( '.notice.is-warning' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'calls onProceed prop when clicking "Upgrade and continue"', () => {
+		const state = createState( {
+			holds: [ 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ],
+		} );
+
+		const handleProceed = jest.fn();
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ handleProceed } />,
+			state
+		);
+
+		fireEvent.click( getByText( 'Upgrade and continue' ) );
+
+		expect( handleProceed ).toHaveBeenCalled();
+	} );
+
+	it( `disables the "Continue" button if holds can't be handled automatically`, () => {
+		const state = createState( {
+			holds: [ 'NON_ADMIN_USER', 'SITE_PRIVATE' ],
+		} );
+
+		const handleProceed = jest.fn();
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ handleProceed } />,
+			state
+		);
+
+		const continueButton = getByText( 'Continue' );
+
+		expect( continueButton ).toBeDisabled();
+
+		fireEvent.click( continueButton );
+		expect( handleProceed ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -96,7 +96,7 @@ describe( '<EligibilityWarnings>', () => {
 				{
 					name: 'Warning 2',
 					description: 'Describes warning 2',
-					supportUrl: 'http://example.com/',
+					supportUrl: 'https://helpme.com',
 				},
 			],
 		} );
@@ -113,9 +113,7 @@ describe( '<EligibilityWarnings>', () => {
 		expect( notices[ 1 ] ).toBeVisible();
 		expect( notices[ 1 ] ).toHaveTextContent( 'Describes warning 2' );
 
-		fireEvent.click( getByLabelText( 'Help' ) );
-
-		expect( window.location.href ).toBe( 'https://example.com/' );
+		expect( getByLabelText( 'Help' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
 	} );
 
 	it( "doesn't render warnings when there are blocking holds", () => {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -35,8 +35,6 @@ function createState( { holds = [], siteId = 1 }: { holds?: string[]; siteId?: n
 				},
 			},
 		},
-		currentUser: { capabilities: { [ siteId ]: {} } },
-		sites: { items: { [ siteId ]: {} } },
 		ui: { selectedSiteId: siteId },
 	};
 }

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,15 +3,12 @@
  */
 import React from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
-import ExternalLink from 'components/external-link';
-import SectionHeader from 'components/section-header';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 interface ExternalProps {
 	warnings: import('state/automated-transfer/selectors').EligibilityWarning[];
@@ -20,37 +17,20 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { translate, warnings }: Props ) => (
-	<div>
-		<SectionHeader
-			label={ translate(
-				"By proceeding you'll lose %d feature:",
-				"By proceeding you'll lose these %d features:",
-				{
-					count: warnings.length,
-					args: warnings.length,
-				}
-			) }
-		/>
-		<Card className="eligibility-warnings__warning-list">
-			{ map( warnings, ( { name, description, supportUrl }, index ) => (
-				<div className="eligibility-warnings__warning" key={ index }>
-					<Gridicon icon="cross-small" size={ 24 } />
-					<div className="eligibility-warnings__message">
-						<span className="eligibility-warnings__message-title">{ name }</span>
-						:&nbsp;
-						<span className="eligibility-warnings__message-description">{ description }</span>
-					</div>
-					{ supportUrl && (
-						<div className="eligibility-warnings__action">
-							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-								<Gridicon icon="help-outline" size={ 24 } />
-							</ExternalLink>
-						</div>
-					) }
-				</div>
-			) ) }
-		</Card>
-	</div>
+	<>
+		{ warnings.map( ( { description, supportUrl }, index ) => (
+			<Notice status="is-warning" key={ index } text={ description } showDismiss={ false }>
+				{ supportUrl && (
+					<NoticeAction
+						icon="help-outline"
+						aria-label={ translate( 'Help' ) }
+						href={ supportUrl }
+						external
+					/>
+				) }
+			</Notice>
+		) ) }
+	</>
 );
 
 export default localize( WarningList );

--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -15,6 +15,7 @@ export default class extends React.Component {
 	static displayName = 'NoticeAction';
 
 	static propTypes = {
+		'aria-label': PropTypes.string,
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		external: PropTypes.bool,
@@ -27,6 +28,7 @@ export default class extends React.Component {
 
 	render() {
 		const attributes = {
+			'aria-label': this.props[ 'aria-label' ],
 			className: 'notice__action',
 			href: this.props.href,
 			onClick: this.props.onClick,

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -7,10 +7,16 @@ import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getSiteSlug, isCurrentPlanPaid } from 'state/sites/selectors';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 
-export const launchSite = siteId => ( {
-	type: SITE_LAUNCH,
-	siteId,
-} );
+export function launchSite( siteId ) {
+	return async ( dispatch, getState ) => {
+		await dispatch( {
+			type: SITE_LAUNCH,
+			siteId,
+		} );
+
+		return ! isUnlaunchedSite( getState(), siteId );
+	};
+}
 
 export const launchSiteOrRedirectToLaunchSignupFlow = siteId => ( dispatch, getState ) => {
 	if ( ! isUnlaunchedSite( getState(), siteId ) ) {
@@ -27,6 +33,6 @@ export const launchSiteOrRedirectToLaunchSignupFlow = siteId => ( dispatch, getS
 
 	const siteSlug = getSiteSlug( getState(), siteId );
 
-	// TODO: consider using the `page` library instead of calling using `location.href` here
-	location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
+	// TODO: consider using the `page` library instead of calling using `window.location.href` here
+	window.location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
 };

--- a/client/state/sites/launch/test/actions.js
+++ b/client/state/sites/launch/test/actions.js
@@ -6,12 +6,37 @@ import { launchSite } from 'state/sites/launch/actions';
 
 describe( 'actions', () => {
 	describe( '#launchSite', () => {
-		test( 'should return an action when a site is launched', () => {
-			const action = launchSite( 123 );
-			expect( action ).toEqual( {
+		test( 'should return a thunk action when a site is launched', () => {
+			const dispatch = jest.fn();
+			launchSite( 123 )( dispatch );
+			expect( dispatch ).toHaveBeenCalledWith( {
 				type: SITE_LAUNCH,
 				siteId: 123,
 			} );
+		} );
+
+		test( 'returns true if the site was launched', async () => {
+			const getState = () => ( {
+				sites: {
+					items: { '123': { launch_status: 'launched' } },
+				},
+			} );
+
+			const launched = await launchSite( 123 )( jest.fn(), getState );
+
+			expect( launched ).toBe( true );
+		} );
+
+		test( 'returns false if the site was not launched', async () => {
+			const getState = () => ( {
+				sites: {
+					items: { '123': { launch_status: 'unlaunched' } },
+				},
+			} );
+
+			const launched = await launchSite( 123 )( jest.fn(), getState );
+
+			expect( launched ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If a site is private or unlaunched, and doesn't need a plan upgrade, then clicking the "Continue" button should launch/un-private the site automatically.

This is part of #38141 

I've made it so that if a site is blocked from going Atomic because it's private, then clicking "Continue" will change the visibility setting to "Hidden" (not indexed), not "Public". Given they probably weren't in the mindset of making their site public, it seems like changing to "hidden" is the smallest change to the settings that will allow them to go Atomic.

This PR doesn't update the copy to make it clear whether a site is private or unlaunched, that's #38324 

* `<EligibilityWarnings>` component can automatically launch sites
* `<EligibilityWarnings>` component can automatically set site visibility to "hidden"
* `launchSite` selector returns a promise that resolves to `true` if the site was launched
* Changed unrelated `location.href` to `window.location.href` to silence eslint so I could commit

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an unlaunched site with a business plan
* View eligibility warnings by uploading plugin or theme, or change hosting settings
* The continue button should launch your site and proceed to the next page (e.g. plugin upload page)
* Create a site with a business plan, launch it, then set visibility settings to private
* View eligibility warnings by uploading plugin or theme, or change hosting settings
* The continue button should change the visibility setting to "hidden" and proceed to the next page (e.g. plugin upload page)