### PR TITLE
2019 Quick Start closure notice for Xmas and New Year

### DIFF
--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -12,7 +12,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 import { CompactCard as Card } from '@automattic/components';
 import { useLocalizedMoment } from 'components/localized-moment';
 
-const DATE_FORMAT = 'dddd, MMMM Do LT';
+const DATE_FORMAT = 'MMMM Do h:mm A z';
 
 const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
 	const translate = useTranslate();

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -12,7 +12,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 import { CompactCard as Card } from '@automattic/components';
 import { useLocalizedMoment } from 'components/localized-moment';
 
-const DATE_FORMAT = 'MMMM D h:mma z';
+const DATE_FORMAT = 'dddd, MMMM Do LT';
 
 const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
 	const translate = useTranslate();
@@ -29,7 +29,7 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
 
 	if ( currentDate.isBefore( closesAt ) ) {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Support sessions will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
+			'{{strong}}Note:{{/strong}} Quick Start sessions will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get to it as fast as we can. Thank you!',
 			{
@@ -46,7 +46,7 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
 		);
 	} else {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Support sessions are closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
+			'{{strong}}Note:{{/strong}} Quick Start sessions are closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get back to you as fast as we can. Thank you!',
 			{

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -23,11 +23,13 @@ class PrimaryHeader extends Component {
 					displayAt="2019-12-17 00:00Z"
 					closesAt="2019-12-24 00:00Z"
 					reopensAt="2019-12-26 07:00Z"
+					holidayName="Christmas"
 				/>
 				<ClosureNotice
 					displayAt="2019-12-26 00:00Z"
 					closesAt="2019-12-31 00:00Z"
 					reopensAt="2020-01-02 07:00Z"
+					holidayName="New Year's Day"
 				/>
 				<Card>
 					<img

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -8,6 +8,7 @@ import React, { Component, Fragment } from 'react';
  */
 import { Card } from '@automattic/components';
 import ClosureNotice from '../shared/closure-notice';
+import GMClosureNotice from '../shared/gm-closure-notice';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
 import { localize } from 'i18n-calypso';
@@ -19,6 +20,11 @@ class PrimaryHeader extends Component {
 
 		return (
 			<Fragment>
+				<GMClosureNotice
+					displayAt="2019-09-03 00:00Z"
+					closesAt="2019-09-10 00:00Z"
+					reopensAt="2019-09-19 04:00Z"
+				/>
 				<ClosureNotice
 					displayAt="2019-12-17 00:00Z"
 					closesAt="2019-12-24 00:00Z"

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -7,7 +7,7 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import ClosureNotice from '../shared/gm-closure-notice';
+import ClosureNotice from '../shared/closure-notice';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
 import { localize } from 'i18n-calypso';
@@ -26,7 +26,7 @@ class PrimaryHeader extends Component {
 					holidayName="Christmas"
 				/>
 				<ClosureNotice
-					displayAt="2019-12-26 00:00Z"
+					displayAt="2019-12-26 07:00Z"
 					closesAt="2019-12-31 00:00Z"
 					reopensAt="2020-01-02 07:00Z"
 					holidayName="New Year's Day"

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -7,7 +7,7 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import GMClosureNotice from '../shared/gm-closure-notice';
+import ClosureNotice from '../shared/gm-closure-notice';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
 import { localize } from 'i18n-calypso';
@@ -19,10 +19,15 @@ class PrimaryHeader extends Component {
 
 		return (
 			<Fragment>
-				<GMClosureNotice
-					displayAt="2019-09-03 00:00Z"
-					closesAt="2019-09-10 00:00Z"
-					reopensAt="2019-09-19 04:00Z"
+				<ClosureNotice
+					displayAt="2019-12-17 00:00Z"
+					closesAt="2019-12-24 00:00Z"
+					reopensAt="2019-12-26 07:00Z"
+				/>
+				<ClosureNotice
+					displayAt="2019-12-26 00:00Z"
+					closesAt="2019-12-31 00:00Z"
+					reopensAt="2020-01-02 07:00Z"
 				/>
 				<Card>
 					<img


### PR DESCRIPTION
#### Changes proposed in this Pull Request

_For additional context, check p58i-8mZ-p2_.

* Displays a closure notice banner on the Quick Start schedule session page for the upcoming Xmas and New Year holidays.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an account that has a Business plan, head to /me/concierge and select the Business plan site. 
* You should not be seeing any notices now

* Change your computer's date and time settings to the following and observe the effects:
    - Before 17th Dec 2019 00:00 UTC, you should not see any banner
    - Between 17th Dec 2019 00:00 UTC and 24th Dec 2019 00:00 UTC, you should see the following banner:
<img width="724" alt="Screenshot 2019-12-17 at 4 05 12 PM" src="https://user-images.githubusercontent.com/1269602/70901350-9d667000-2020-11ea-8257-f0d5527088ff.png" />
    
    - Between 24th Dec 2019 00:00 UTC and 26th Dec 2019 07:00 UTC, you should see the banner below:
<img width="728" alt="Screenshot 2019-12-24 at 4 05 49 PM" src="https://user-images.githubusercontent.com/1269602/70901438-cdae0e80-2020-11ea-932e-819daff8b5f0.png">

    * Between 26th Dec 2019 07:00 UTC and 31st Dec 2019 00:00 UTC, you should see:

<img width="723" alt="Screenshot 2019-12-26 at 12 32 29 PM" src="https://user-images.githubusercontent.com/1269602/70901509-ee766400-2020-11ea-82a2-34e88bd03c63.png">

    * Between 31st Dec 2019 00:00 UTC and 2nd Jan 2020 07:00 UTC, you should see:
  
<img width="724" alt="Screenshot 2019-12-31 at 12 32 50 PM" src="https://user-images.githubusercontent.com/1269602/70901594-1a91e500-2021-11ea-9d4d-78a0abe4f928.png">

    * After 2nd Jan 2020 07:00 UTC, you should not see any banner.

Fixes 762-gh-hg and 760-gh-hg
