### PR TITLE
Add type definitions for Jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3860,6 +3860,15 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
+		"@types/jest": {
+			"version": "24.0.23",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.23.tgz",
+			"integrity": "sha512-L7MBvwfNpe7yVPTXLn32df/EK+AMBFAFvZrRuArGs7npEWnlziUXK+5GMIUTI4NIuwok3XibsjXCs5HxviYXjg==",
+			"dev": true,
+			"requires": {
+				"jest-diff": "^24.3.0"
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
 		"@types/classnames": "2.2.9",
 		"@types/debug": "4.1.5",
 		"@types/fast-json-stable-stringify": "2.0.0",
+		"@types/jest": "24.0.23",
 		"@types/lodash": "4.14.149",
 		"@types/page": "1.8.0",
 		"@types/react": "16.9.16",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the type errors test files related to `describe`, `it`, `expect`, etc. It also improves auto-complete.

Installed version 24.x.x so it lines up with version 24.x.x of Jest.

* Add `@types/jest` as a `devDependency`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open TypeScript test file (e.g. `client/lib/interval/test/interval.tsx`)
* See type errors for `describe` and `it`
* `npm install`
* Type errors gone
