### PR TITLE
2019 Live Chat closure notice for Xmas and New Year

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -17,6 +17,7 @@ import Main from 'components/main';
 import { Card } from '@automattic/components';
 import Notice from 'components/notice';
 import HelpContactForm from 'me/help/help-contact-form';
+import LiveChatClosureNotice from 'me/help/live-chat-closure-notice';
 import GMClosureNotice from 'me/help/gm-closure-notice';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
 import HeaderCake from 'components/header-cake';
@@ -433,7 +434,7 @@ class HelpContact extends React.Component {
 	 * Before determining which variation to assign, certain async data needs to be in place.
 	 * This function helps assess whether we're ready to say which variation the user should see.
 	 *
-	 * @returns {Boolean} Whether all the data is present to determine the variation to show
+	 * @returns {boolean} Whether all the data is present to determine the variation to show
 	 */
 	hasDataToDetermineVariation = () => {
 		const ticketReadyOrError =
@@ -468,7 +469,8 @@ class HelpContact extends React.Component {
 
 	/**
 	 * Get the view for the contact page.
-	 * @return {object} A JSX object that should be rendered
+	 *
+	 * @returns {object} A JSX object that should be rendered
 	 */
 	getView = () => {
 		const { confirmation } = this.state;
@@ -529,14 +531,30 @@ class HelpContact extends React.Component {
 		return (
 			<div>
 				{ isUserAffectedByLiveChatClosure && (
-					<GMClosureNotice
-						compact={ compact }
-						displayAt="2019-08-31 00:00Z"
-						basicChatClosesAt="2019-09-07 00:00Z"
-						basicChatReopensAt="2019-09-23 04:00Z"
-						priorityChatClosesAt="2019-09-10 00:00Z"
-						priorityChatReopensAt="2019-09-19 04:00Z"
-					/>
+					<>
+						<LiveChatClosureNotice
+							holidayName="Christmas"
+							compact={ compact }
+							displayAt="2019-12-17 00:00Z"
+							closesAt="2019-12-24 00:00Z"
+							reopensAt="2019-12-26 07:00Z"
+						/>
+						<LiveChatClosureNotice
+							holidayName="New Year's Day"
+							compact={ compact }
+							displayAt="2019-12-26 07:00Z"
+							closesAt="2019-12-31 00:00Z"
+							reopensAt="2020-02-01 07:00Z"
+						/>
+						<GMClosureNotice
+							compact={ compact }
+							displayAt="2019-08-31 00:00Z"
+							basicChatClosesAt="2019-09-07 00:00Z"
+							basicChatReopensAt="2019-09-23 04:00Z"
+							priorityChatClosesAt="2019-09-10 00:00Z"
+							priorityChatReopensAt="2019-09-19 04:00Z"
+						/>
+					</>
 				) }
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (
 					<Notice

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -544,7 +544,7 @@ class HelpContact extends React.Component {
 							compact={ compact }
 							displayAt="2019-12-26 07:00Z"
 							closesAt="2019-12-31 00:00Z"
-							reopensAt="2020-02-01 07:00Z"
+							reopensAt="2020-01-02 07:00Z"
 						/>
 						<GMClosureNotice
 							compact={ compact }

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -18,7 +18,7 @@ import { useLocalizedMoment } from 'components/localized-moment';
  */
 import './style.scss';
 
-const DATE_FORMAT = 'MMMM D h:mma z';
+const DATE_FORMAT = 'MMMM Do h:mm A z';
 
 const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reopensAt } ) => {
 	const translate = useTranslate();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

_For additional context, please check p58i-8mZ-p2._

* Displays a closure notice banner on the /help/contact page and live chat interface for the upcoming Xmas and New Year holidays.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an account on a free plan, verify that the notice does not show in the inline help widget or /help/contact

* On any account that has a paid plan, verify the following on both the inline help widget and the /help/contact page by modifying your system's date/time settings:
    - Before 17th Dec 2019 00:00 UTC, you should not see any banner
    - Between 17th Dec 2019 00:00 UTC and 24th Dec 2019 00:00 UTC, you should see the following banner:
<img width="737" alt="Screenshot 2019-12-17 at 5 24 32 PM" src="https://user-images.githubusercontent.com/1269602/70905347-a4de4700-2029-11ea-9227-0fa121b32d39.png">
<img width="465" alt="Screenshot 2019-12-17 at 5 24 48 PM" src="https://user-images.githubusercontent.com/1269602/70905350-a740a100-2029-11ea-86dd-96052697ec48.png">

    - Between 24th Dec 2019 00:00 UTC and 26th Dec 2019 07:00 UTC, you should see the banner below:
<img width="1053" alt="Screenshot 2019-12-26 at 5 26 01 AM" src="https://user-images.githubusercontent.com/1269602/70905364-b0317280-2029-11ea-958a-4aab8912466a.png">

    - Between 26th Dec 2019 07:00 UTC and 31st Dec 2019 00:00 UTC, you should see:
<img width="1049" alt="Screenshot 2019-12-26 at 12 32 26 PM" src="https://user-images.githubusercontent.com/1269602/70905389-c17a7f00-2029-11ea-8981-8665cd42b26e.png">

    - Between 31st Dec 2019 00:00 UTC and 2nd Jan 2020 07:00 UTC, you should see:
<img width="1041" alt="Screenshot 2019-12-31 at 12 33 08 PM" src="https://user-images.githubusercontent.com/1269602/70905413-ce976e00-2029-11ea-8329-14d1a64996e4.png">
  
    - After 2nd Jan 2020 07:00 UTC, you should not see any banner.


Fixes 759-gh-hg and 761-gh-hg
