### PR TITLE
Adding Domain move paragraph test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -144,6 +144,7 @@ class RegisterDomainStep extends React.Component {
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
 		showTestCopy: PropTypes.bool,
+		showTestParagraph: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,
@@ -579,6 +580,10 @@ class RegisterDomainStep extends React.Component {
 		}
 
 		if ( this.props.showExampleSuggestions ) {
+			if ( this.props.showTestParagraph ) {
+				return this.renderFreeDomainExplainer();
+			}
+
 			return this.renderExampleSuggestions();
 		}
 
@@ -1227,7 +1232,10 @@ class RegisterDomainStep extends React.Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				showTestCopy={ this.props.showTestCopy }
 			>
-				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer() }
+				{ this.props.showTestCopy &&
+					hasResults &&
+					! this.props.showTestParagraph &&
+					this.renderFreeDomainExplainer() }
 
 				{ showTldFilterBar && (
 					<TldFilterBar

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,4 +123,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	domainStepMoveParagraph: {
+		datestamp: '20191216',
+		variations: {
+			variantMoveParagraph: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -128,6 +128,12 @@ class DomainsStep extends React.Component {
 		) {
 			this.showTestCopy = true;
 		}
+
+		this.showTestParagraph = false;
+
+		if ( this.showTestCopy && 'variantMoveParagraph' === abtest( 'domainStepMoveParagraph' ) ) {
+			this.showTestParagraph = true;
+		}
 	}
 
 	static getDerivedStateFromProps( nextProps ) {
@@ -463,6 +469,7 @@ class DomainsStep extends React.Component {
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
 				showTestCopy={ this.showTestCopy }
+				showTestParagraph={ this.showTestParagraph }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR introduces a new Domain step test. You can find more information here p8Eqe3-ZD

![image](https://user-images.githubusercontent.com/538790/70994839-55525680-20cf-11ea-84c6-b10d8edb8110.png)

![image](https://user-images.githubusercontent.com/538790/70995918-f4784d80-20d1-11ea-9307-4c391c5c02b5.png)



#### Testing instructions

* Go through the signup flow at /start
* If you are assigned to the `control` group of the `domainStepCopyUpdates` test, it means you're in the Holdout group, so you should not see the `domainStepCopyUpdates` from https://github.com/Automattic/wp-calypso/pull/37661 or this PR's `domainStepMoveParagraph` test either. Verify the following:
    - The domain step UI and copy remains the same as before (no copy updates, no explanation paragraph).
    - Complete signup and check the launch flow steps - they should remain unchanged

* If you are assigned to the `variantShowUpdates` group of the `domainStepCopyUpdates` test, you're eligible for this PR's `domainStepMoveParagraph` test.

    - If you're assigned to the `control` group of this PR's `domainStepMoveParagraph` test:
         * You should see the new copy for the Domains step, with the Free One-Year Domain explanation paragraph showing up only after you type some domain to search. 
    - If you're assigned to the `variantMoveParagraph` of this PR's `domainStepMoveParagraph` test:
        * The Free One-Year Domain explanation paragraph should show up before you type some domain to search, and disappear after in the search results screen (see screenshots above).
        * The rest should work as normal.


 Note: This test  _should not show_ in the site launch flow or in the Add domain page.

