### PR TITLE
Revert "build: Use the latest npm instead of bundled"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="Automattic"
 
 WORKDIR    /calypso
 
+
 ENV        CONTAINER 'docker'
 ENV        NODE_PATH=/calypso/server:/calypso/client
 ENV        PROGRESS=true
@@ -19,12 +20,6 @@ ENV        PROGRESS=true
 #   such as the apt and npm mirrors
 COPY       ./env-config.sh /tmp/env-config.sh
 RUN        bash /tmp/env-config.sh
-
-
-# Install our package manager
-ENV NPM_VERSION 6.13.4
-
-RUN npm install -g npm@$NPM_VERSION
 
 # Build a node_modules layer
 #

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
 	},
 	"engines": {
 		"node": "^10.16.3",
-		"npm": "^6.13.4"
+		"npm": "^6.9.0"
 	},
 	"scripts": {
 		"preanalyze-bundles": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=true PROGRESS=1 NODE_ARGS=--max_old_space_size=8192 npm run -s build-client-evergreen",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#38393

Production build failed