### PR TITLE
Gutenboarding: Drop FSE reuse/use MediaCard

### DIFF
--- a/client/landing/gutenboarding/components/card/README.md
+++ b/client/landing/gutenboarding/components/card/README.md
@@ -1,0 +1,97 @@
+# Card
+
+Card provides a flexible and extensible content container.
+
+## Usage
+
+```jsx
+import { Card, CardBody } from '@wordpress/components';
+
+const Example = () => (
+	<Card>
+		<CardBody>...</CardBody>
+	</Card>
+);
+```
+
+## Props
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`isBorderless` | `boolean` | `false` | Determines the border style of the card.
+`isElevated` | `boolean` | `false` | Determines the elevation style of the card.
+`size` | `string` | `medium` | Determines the amount of padding within the card.
+
+## Sub-Components
+
+This component provides a collection of sub-component that can be used to compose various interfaces.
+
+-   [`<CardBody />`](./docs/body.md)
+-   [`<CardDivider />`](./docs/divider.md)
+-   [`<CardFooter />`](./docs/footer.md)
+-   [`<CardHeader />`](./docs/header.md)
+-   [`<CardMedia />`](./docs/media.md)
+
+### Sub-Components Example
+
+```jsx
+import {
+	Card,
+	CardBody,
+	CardDivider,
+	CardFooter,
+	CardHeader,
+	CardMedia
+} from '@wordpress/components';
+
+const Example = () => (
+	<Card>
+		<CardHeader>
+			...
+		</CardHeader>
+		<CardBody>
+			...
+		<CardBody>
+		<CardDivider />
+		<CardBody>
+			...
+		<CardBody>
+		<CardMedia>
+			<img src="..." />
+		</CardMedia>
+		<CardHeader>
+			...
+		</CardHeader>
+	</Card>
+);
+```
+
+### Context
+
+`<Card />`'s sub-components are connected to `<Card />` using [Context](https://reactjs.org/docs/context.html). Certain props like `size` and `variant` are passed through to the sub-components.
+
+In the following example, the `<CardBody />` will render with a size of `small`:
+
+```jsx
+import { Card, CardBody } from '@wordpress/components';
+
+const Example = () => (
+	<Card size="small">
+		<CardBody>...</CardBody>
+	</Card>
+);
+```
+
+These sub-components are designed to be flexible. The Context props can be overridden by the sub-component(s) as required. In the following example, the last `<CardBody />` will render it's specified size:
+
+```jsx
+import { Card, CardBody } from '@wordpress/components';
+
+const Example = () => (
+	<Card size="small">
+		<CardBody>...</CardBody>
+		<CardBody>...</CardBody>
+		<CardBody size="large">...</CardBody>
+	</Card>
+);
+```

--- a/client/landing/gutenboarding/components/card/README.md
+++ b/client/landing/gutenboarding/components/card/README.md
@@ -1,3 +1,10 @@
+# THIS IS TEMPORARY
+
+This is an unreleased component copied from
+[`@wordpress/components`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/card).
+
+_It should not be heavily modified, it will be replaced with the published component soon._
+
 # Card
 
 Card provides a flexible and extensible content container.
@@ -16,21 +23,21 @@ const Example = () => (
 
 ## Props
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`isBorderless` | `boolean` | `false` | Determines the border style of the card.
-`isElevated` | `boolean` | `false` | Determines the elevation style of the card.
-`size` | `string` | `medium` | Determines the amount of padding within the card.
+| Name           | Type      | Default  | Description                                       |
+| -------------- | --------- | -------- | ------------------------------------------------- |
+| `isBorderless` | `boolean` | `false`  | Determines the border style of the card.          |
+| `isElevated`   | `boolean` | `false`  | Determines the elevation style of the card.       |
+| `size`         | `string`  | `medium` | Determines the amount of padding within the card. |
 
 ## Sub-Components
 
 This component provides a collection of sub-component that can be used to compose various interfaces.
 
--   [`<CardBody />`](./docs/body.md)
--   [`<CardDivider />`](./docs/divider.md)
--   [`<CardFooter />`](./docs/footer.md)
--   [`<CardHeader />`](./docs/header.md)
--   [`<CardMedia />`](./docs/media.md)
+- [`<CardBody />`](./docs/body.md)
+- [`<CardDivider />`](./docs/divider.md)
+- [`<CardFooter />`](./docs/footer.md)
+- [`<CardHeader />`](./docs/header.md)
+- [`<CardMedia />`](./docs/media.md)
 
 ### Sub-Components Example
 

--- a/client/landing/gutenboarding/components/card/body.js
+++ b/client/landing/gutenboarding/components/card/body.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { BodyUI } from './styles/card-styles';
+import { useCardContext } from './context';
+
+export const defaultProps = {
+	isShady: false,
+	size: 'medium',
+};
+
+export function CardBody( props ) {
+	const { className, isShady, ...additionalProps } = props;
+	const mergedProps = { ...defaultProps, ...useCardContext(), ...props };
+	const { size } = mergedProps;
+
+	const classes = classnames(
+		'components-card__body',
+		isShady && 'is-shady',
+		size && `is-size-${ size }`,
+		className
+	);
+
+	return <BodyUI { ...additionalProps } className={ classes } />;
+}
+
+export default CardBody;

--- a/client/landing/gutenboarding/components/card/context.js
+++ b/client/landing/gutenboarding/components/card/context.js
@@ -1,0 +1,7 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+export const CardContext = createContext( {} );
+export const useCardContext = () => useContext( CardContext );

--- a/client/landing/gutenboarding/components/card/context.js
+++ b/client/landing/gutenboarding/components/card/context.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { createContext, useContext } from '@wordpress/element';
 

--- a/client/landing/gutenboarding/components/card/divider.js
+++ b/client/landing/gutenboarding/components/card/divider.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { DividerUI } from './styles/card-styles';
+
+export function CardDivider( props ) {
+	const { className, ...additionalProps } = props;
+
+	const classes = classnames( 'components-card__divider', className );
+
+	return (
+		<DividerUI { ...additionalProps } children={ null } className={ classes } role="separator" />
+	);
+}
+
+export default CardDivider;

--- a/client/landing/gutenboarding/components/card/footer.js
+++ b/client/landing/gutenboarding/components/card/footer.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { FooterUI } from './styles/card-styles';
+import { useCardContext } from './context';
+
+export const defaultProps = {
+	isBorderless: false,
+	isShady: false,
+	size: 'medium',
+};
+
+export function CardFooter( props ) {
+	const { className, isShady, ...additionalProps } = props;
+	const mergedProps = { ...defaultProps, ...useCardContext(), ...props };
+	const { isBorderless, size } = mergedProps;
+
+	const classes = classnames(
+		'components-card__footer',
+		isBorderless && 'is-borderless',
+		isShady && 'is-shady',
+		size && `is-size-${ size }`,
+		className
+	);
+
+	return <FooterUI { ...additionalProps } className={ classes } />;
+}
+
+export default CardFooter;

--- a/client/landing/gutenboarding/components/card/header.js
+++ b/client/landing/gutenboarding/components/card/header.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { HeaderUI } from './styles/card-styles';
+import { useCardContext } from './context';
+
+export const defaultProps = {
+	isBorderless: false,
+	isShady: false,
+	size: 'medium',
+};
+
+export function CardHeader( props ) {
+	const { className, isShady, ...additionalProps } = props;
+	const mergedProps = { ...defaultProps, ...useCardContext(), ...props };
+	const { isBorderless, size } = mergedProps;
+
+	const classes = classnames(
+		'components-card__header',
+		isBorderless && 'is-borderless',
+		isShady && 'is-shady',
+		size && `is-size-${ size }`,
+		className
+	);
+
+	return <HeaderUI { ...additionalProps } className={ classes } />;
+}
+
+export default CardHeader;

--- a/client/landing/gutenboarding/components/card/index.js
+++ b/client/landing/gutenboarding/components/card/index.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { CardContext } from './context';
+import { CardUI } from './styles/card-styles';
+
+export const defaultProps = {
+	isBorderless: false,
+	isElevated: false,
+	size: 'medium',
+};
+
+export function Card( props ) {
+	const { className, isBorderless, isElevated, size, ...additionalProps } = props;
+	const { Provider } = CardContext;
+
+	const contextProps = {
+		isBorderless,
+		isElevated,
+		size,
+	};
+
+	const classes = classnames(
+		'components-card',
+		isBorderless && 'is-borderless',
+		isElevated && 'is-elevated',
+		size && `is-size-${ size }`,
+		className
+	);
+
+	return (
+		<Provider value={ contextProps }>
+			<CardUI { ...additionalProps } className={ classes } />
+		</Provider>
+	);
+}
+
+Card.defaultProps = defaultProps;
+
+export default Card;

--- a/client/landing/gutenboarding/components/card/media.js
+++ b/client/landing/gutenboarding/components/card/media.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { MediaUI } from './styles/card-styles';
+
+export function CardMedia( props ) {
+	const { className, ...additionalProps } = props;
+
+	const classes = classnames( 'components-card__media', className );
+
+	return <MediaUI { ...additionalProps } className={ classes } />;
+}
+
+export default CardMedia;

--- a/client/landing/gutenboarding/components/card/styles/card-styles.js
+++ b/client/landing/gutenboarding/components/card/styles/card-styles.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import { HorizontalRule } from '@wordpress/components';
+
+export const styleProps = {
+	borderColor: color( 'lightGray.500' ),
+	borderRadius: '3px',
+	backgroundShady: color( 'lightGray.200' ),
+};
+
+const { borderColor, borderRadius, backgroundShady } = styleProps;
+
+export const CardUI = styled.div`
+	background: ${color( 'white' )};
+	box-sizing: border-box;
+	border-radius: ${borderRadius};
+	border: 1px solid ${borderColor};
+
+	${handleBorderless};
+
+	&.is-elevated {
+		box-shadow: 0px 1px 3px 0px rgba( 0, 0, 0, 0.2 ), 0px 1px 1px 0px rgba( 0, 0, 0, 0.14 ),
+			0px 2px 1px -1px rgba( 0, 0, 0, 0.12 );
+	}
+`;
+
+export const HeaderUI = styled.div`
+	border-bottom: 1px solid ${borderColor};
+	border-top-left-radius: ${borderRadius};
+	border-top-right-radius: ${borderRadius};
+	box-sizing: border-box;
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	${headerFooterSizes};
+	${handleBorderless};
+	${handleShady};
+`;
+
+export const MediaUI = styled.div`
+	box-sizing: border-box;
+	overflow: hidden;
+
+	& > img,
+	& > iframe {
+		display: block;
+		height: auto;
+		max-width: 100%;
+		width: 100%;
+	}
+
+	&:first-of-type {
+		border-top-left-radius: ${borderRadius};
+		border-top-right-radius: ${borderRadius};
+	}
+
+	&:last-of-type {
+		border-bottom-left-radius: ${borderRadius};
+		border-bottom-right-radius: ${borderRadius};
+	}
+`;
+
+export const BodyUI = styled.div`
+	box-sizing: border-box;
+
+	${bodySize};
+	${handleShady};
+`;
+
+export const FooterUI = styled.div`
+	border-top: 1px solid ${borderColor};
+	border-bottom-left-radius: ${borderRadius};
+	border-bottom-right-radius: ${borderRadius};
+	box-sizing: border-box;
+
+	&:first-of-type {
+		border-top: none;
+	}
+
+	${headerFooterSizes};
+	${handleBorderless};
+	${handleShady};
+`;
+
+export const DividerUI = styled( HorizontalRule )`
+	all: unset;
+	border-top: 1px solid ${borderColor};
+	box-sizing: border-box;
+	display: block;
+	height: 0;
+	width: 100%;
+`;
+
+export function bodySize() {
+	return `
+		&.is-size {
+			&-large {
+				padding: 28px;
+			}
+			&-medium {
+				padding: 20px;
+			}
+			&-small {
+				padding: 12px;
+			}
+			&-extraSmall {
+				padding: 8px;
+			}
+		}
+	`;
+}
+
+export function headerFooterSizes() {
+	return `
+		&.is-size {
+			&-large {
+				padding: 20px 28px;
+			}
+			&-medium {
+				padding: 12px 20px;
+			}
+			&-small {
+				padding: 8px 12px;
+			}
+			&-extraSmall {
+				padding: 4px 8px;
+			}
+		}
+	`;
+}
+
+export function handleBorderless() {
+	return `
+		&.is-borderless {
+			border: none;
+		}
+	`;
+}
+
+export function handleShady() {
+	return `
+		&.is-shady {
+			background: ${ backgroundShady };
+		}
+	`;
+}
+
+// hack around https://github.com/WordPress/gutenberg/blob/master/packages/components/src/utils/colors.js
+function color( value ) {
+	switch ( value ) {
+		case 'lightGray.500':
+			return '#e2e4e7';
+		case 'lightGray.200':
+			return '#f3f4f5';
+		case 'white':
+			return '#fff';
+	}
+	return '#000';
+}

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -105,7 +105,7 @@ export function Gutenboard() {
 							value={ [ onboardingBlock.current ] }
 							settings={ { templateLock: 'all' } }
 						>
-							<div className="edit-post-layout__content">
+							<div className="gutenboard__edit-post-layout-content edit-post-layout__content ">
 								<div
 									className="edit-post-visual-editor editor-styles-wrapper"
 									role="region"

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { __ as NO__ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import React, { useState } from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -11,7 +11,8 @@ import React, { useState } from 'react';
 import { Card } from '../../components/card';
 import { CardMedia } from '../../components/card/media';
 import { SiteVertical } from '../../stores/onboard/types';
-import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control';
+
+import './style.scss';
 
 export default () => {
 	const siteVertical = useSelect(
@@ -25,25 +26,23 @@ export default () => {
 
 	const homepageTemplates = templates.filter( template => template.category === 'home' );
 
-	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
+	const [ selectedDesign, setSelectedDesign ] = useState< string | undefined >();
 	return (
-		<div>
+		<div className="design-selector">
 			{ homepageTemplates.map( t => (
-				<Card key={ t.slug } isElevated onClick={ () => setPreviewedTemplate( t.slug ) }>
+				<Card
+					className={ classnames( 'design-selector__design-option', {
+						'is-selected': t.slug === selectedDesign,
+					} ) }
+					key={ t.slug }
+					isElevated
+					onClick={ () => setSelectedDesign( t.slug ) }
+				>
 					<CardMedia>
 						<img alt={ t.title } src={ t.preview } />
 					</CardMedia>
 				</Card>
 			) ) }
-			<TemplateSelectorControl
-				label={ NO__( 'Layout', 'full-site-editing' ) }
-				templates={ homepageTemplates }
-				blocksByTemplates={ {} /* Unneeded, since we're setting `useDynamicPreview` to `false` */ }
-				onTemplateSelect={ setPreviewedTemplate }
-				useDynamicPreview={ false }
-				siteInformation={ undefined }
-				selectedTemplate={ previewedTemplate }
-			/>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -29,17 +29,17 @@ export default () => {
 	const [ selectedDesign, setSelectedDesign ] = useState< string | undefined >();
 	return (
 		<div className="design-selector">
-			{ homepageTemplates.map( t => (
+			{ homepageTemplates.map( template => (
 				<Card
 					className={ classnames( 'design-selector__design-option', {
-						'is-selected': t.slug === selectedDesign,
+						'is-selected': template.slug === selectedDesign,
 					} ) }
-					key={ t.slug }
+					key={ template.slug }
 					isElevated
-					onClick={ () => setSelectedDesign( t.slug ) }
+					onClick={ () => setSelectedDesign( template.slug ) }
 				>
 					<CardMedia>
-						<img alt={ t.title } src={ t.preview } />
+						<img alt={ template.title } src={ template.preview } />
 					</CardMedia>
 				</Card>
 			) ) }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -8,6 +8,8 @@ import React, { useState } from 'react';
 /**
  * Internal dependencies
  */
+import { Card } from '../../components/card';
+import { CardMedia } from '../../components/card/media';
 import { SiteVertical } from '../../stores/onboard/types';
 import { TemplateSelectorControl } from '../../../../../apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control';
 
@@ -25,9 +27,14 @@ export default () => {
 
 	const [ previewedTemplate, setPreviewedTemplate ] = useState< string | null >( null );
 	return (
-		<div
-			className="page-template-modal__list" // eslint-disable-line wpcalypso/jsx-classname-namespace
-		>
+		<div>
+			{ homepageTemplates.map( t => (
+				<Card key={ t.slug } isElevated onClick={ () => setPreviewedTemplate( t.slug ) }>
+					<CardMedia>
+						<img alt={ t.title } src={ t.preview } />
+					</CardMedia>
+				</Card>
+			) ) }
 			<TemplateSelectorControl
 				label={ NO__( 'Layout', 'full-site-editing' ) }
 				templates={ homepageTemplates }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -1,0 +1,18 @@
+.design-selector {
+	display: grid;
+	grid-gap: 4.5em;
+
+	@include breakpoint( '>660px' ) {
+		// stylelint-disable unit-whitelist
+		grid-template-columns: repeat( 2, 1fr );
+		// stylelint-enable unit-whitelist
+	}
+}
+
+.design-selector__design-option {
+	transition: transform 100ms ease-in-out;
+
+	&.is-selected {
+		transform: scale( 1.1 );
+	}
+}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -13,6 +13,10 @@ $admin-sidebar-width-collapsed: 0;
 @import '~@wordpress/block-editor/src/style.scss';
 @import '~@wordpress/format-library/src/style.scss';
 
+.gutenboard__edit-post-layout-content {
+	position: static;
+}
+
 .wp-block {
 	max-width: 1100px; // Overrides default $content-width
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes dependence on sibling monorepo app's components (FSE plugin)
* Pulls in unpublished `Card` from `@wordpress/components` (mostly simple copy)
* Fixes an issue where a `position: fixed` from Gutenberg styles breaks the block editor's overflow (no scrolling)
* Uses simple grid layout from #38403 (props @ockham)
* Implements very simple list layout designs from API + `MediaCard` component.
* Adds simple selected design visual feedback for demonstration

Closes #38403 (supersedes)


#### Demo

![demo](https://user-images.githubusercontent.com/841763/70933379-2dfe7980-203c-11ea-9241-9594297ff7bc.gif)


#### Testing instructions

* Go to `/gutenboarding` on (calypso.live or dev branch)
* Pass the first screen (select a vertical and site title) and click "Next"
* Play with the design picker ✨ 

