### PR TITLE
Currency Formatting: Add logic to put symbol on right

### DIFF
--- a/packages/format-currency/src/currencies.js
+++ b/packages/format-currency/src/currencies.js
@@ -268,6 +268,7 @@ export const CURRENCIES = {
 		grouping: '.',
 		decimal: ',',
 		precision: 2,
+		symbolPosition: 'right',
 	},
 	FJD: {
 		symbol: 'FJ$',
@@ -978,6 +979,7 @@ export function getCurrencyDefaults( code ) {
 		grouping: ',',
 		decimal: '.',
 		precision: 2,
+		symbolPosition: 'left',
 	};
 
 	return CURRENCIES[ code ] || defaultCurrency;

--- a/packages/format-currency/src/index.js
+++ b/packages/format-currency/src/index.js
@@ -13,22 +13,26 @@ export { CURRENCIES } from './currencies';
 
 /**
  * Formats money with a given currency code
- * @param   {Number}     number              number to format
- * @param   {String}     code                currency code e.g. 'USD'
- * @param   {Object}     options             options object
- * @param   {String}     options.decimal     decimal symbol e.g. ','
- * @param   {String}     options.grouping    thousands separator
- * @param   {Number}     options.precision   decimal digits
- * @param   {String}     options.symbol      currency symbol e.g. 'A$'
- * @param   {Boolean}    options.stripZeros  whether to remove trailing zero cents
- * @returns {?String}                        A formatted string.
+ * @param   {Number}     number                 number to format
+ * @param   {String}     code                   currency code e.g. 'USD'
+ * @param   {Object}     options                options object
+ * @param   {String}     options.decimal        decimal symbol e.g. ','
+ * @param   {String}     options.grouping       thousands separator
+ * @param   {Number}     options.precision      decimal digits
+ * @param   {String}     options.symbol         currency symbol e.g. 'A$'
+ * @param   {Boolean}    options.stripZeros     whether to remove trailing zero cents
+ * @param   {String}     options.symbolPosition position of symbol, either right or left
+ * @returns {?String}                           A formatted string.
  */
 export default function formatCurrency( number, code, options = {} ) {
 	const currencyDefaults = getCurrencyDefaults( code );
 	if ( ! currencyDefaults || isNaN( number ) ) {
 		return null;
 	}
-	const { decimal, grouping, precision, symbol } = { ...currencyDefaults, ...options };
+	const { decimal, grouping, precision, symbol, symbolPosition } = {
+		...currencyDefaults,
+		...options,
+	};
 	const sign = number < 0 ? '-' : '';
 	let value = numberFormat( Math.abs( number ), {
 		decimals: precision,
@@ -40,6 +44,9 @@ export default function formatCurrency( number, code, options = {} ) {
 		value = stripZeros( value, decimal );
 	}
 
+	if ( 'right' === symbolPosition ) {
+		return `${ sign }${ value }${ symbol }`;
+	}
 	return `${ sign }${ symbol }${ value }`;
 }
 

--- a/packages/format-currency/src/index.js
+++ b/packages/format-currency/src/index.js
@@ -12,17 +12,18 @@ export { getCurrencyDefaults };
 export { CURRENCIES } from './currencies';
 
 /**
- * Formats money with a given currency code
- * @param   {Number}     number                 number to format
- * @param   {String}     code                   currency code e.g. 'USD'
- * @param   {Object}     options                options object
- * @param   {String}     options.decimal        decimal symbol e.g. ','
- * @param   {String}     options.grouping       thousands separator
- * @param   {Number}     options.precision      decimal digits
- * @param   {String}     options.symbol         currency symbol e.g. 'A$'
- * @param   {Boolean}    options.stripZeros     whether to remove trailing zero cents
- * @param   {String}     options.symbolPosition position of symbol, either right or left
- * @returns {?String}                           A formatted string.
+ * Formats money with a given currency code.
+ *
+ * @param   {number}     number                 number to format
+ * @param   {string}     code                   currency code e.g. 'USD'
+ * @param   {object}     options                options object
+ * @param   {string}     options.decimal        decimal symbol e.g. ','
+ * @param   {string}     options.grouping       thousands separator
+ * @param   {number}     options.precision      decimal digits
+ * @param   {string}     options.symbol         currency symbol e.g. 'A$'
+ * @param   {boolean}    options.stripZeros     whether to remove trailing zero cents
+ * @param   {string}     options.symbolPosition position of symbol, either right or left
+ * @returns {?string}                           A formatted string.
  */
 export default function formatCurrency( number, code, options = {} ) {
 	const currencyDefaults = getCurrencyDefaults( code );
@@ -52,14 +53,15 @@ export default function formatCurrency( number, code, options = {} ) {
 
 /**
  * Returns a formatted price object.
- * @param   {Number}     number              number to format
- * @param   {String}     code                currency code e.g. 'USD'
- * @param   {Object}     options             options object
- * @param   {String}     options.decimal     decimal symbol e.g. ','
- * @param   {String}     options.grouping    thousands separator
- * @param   {Number}     options.precision   decimal digits
- * @param   {String}     options.symbol      currency symbol e.g. 'A$'
- * @returns {?String}                        A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
+ *
+ * @param   {number}     number              number to format
+ * @param   {string}     code                currency code e.g. 'USD'
+ * @param   {object}     options             options object
+ * @param   {string}     options.decimal     decimal symbol e.g. ','
+ * @param   {string}     options.grouping    thousands separator
+ * @param   {number}     options.precision   decimal digits
+ * @param   {string}     options.symbol      currency symbol e.g. 'A$'
+ * @returns {?string}                        A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
  */
 export function getCurrencyObject( number, code, options = {} ) {
 	const currencyDefaults = getCurrencyDefaults( code );
@@ -92,10 +94,11 @@ export function getCurrencyObject( number, code, options = {} ) {
 }
 
 /**
- * Remove trailing zero cents
- * @param {String}  number  formatted number
- * @param {String}  decimal decimal symbol
- * @returns {String}
+ * Remove trailing zero cents.
+ *
+ * @param {string}  number  formatted number
+ * @param {string}  decimal decimal symbol
+ * @returns {string}
  */
 
 function stripZeros( number, decimal ) {

--- a/packages/format-currency/test/index.js
+++ b/packages/format-currency/test/index.js
@@ -20,10 +20,10 @@ describe( 'formatCurrency', () => {
 		expect( money2 ).toBe( '$0' );
 
 		const money3 = formatCurrency( 0, 'EUR' );
-		expect( money3 ).toBe( '€0,00' );
+		expect( money3 ).toBe( '0,00€' );
 
 		const money4 = formatCurrency( 0, 'EUR', { stripZeros: true } );
-		expect( money4 ).toBe( '€0' );
+		expect( money4 ).toBe( '0€' );
 	} );
 	test( 'handles negative values', () => {
 		const money = formatCurrency( -1234.56789, 'USD' );
@@ -49,15 +49,20 @@ describe( 'formatCurrency', () => {
 
 	test( 'returns no trailing zero cents when stripZeros set to true (EUR)', () => {
 		const money = formatCurrency( 9800900, 'EUR', { precision: 2 } );
-		expect( money ).toBe( '€9.800.900,00' );
+		expect( money ).toBe( '9.800.900,00€' );
 
 		// Trailing zero cents should be removed.
 		const money2 = formatCurrency( 9800900, 'EUR', { precision: 2, stripZeros: true } );
-		expect( money2 ).toBe( '€9.800.900' );
+		expect( money2 ).toBe( '9.800.900€' );
 
 		// It should not strip non-zero cents.
 		const money3 = formatCurrency( 9800900.32, 'EUR', { precision: 2, stripZeros: true } );
-		expect( money3 ).toBe( '€9.800.900,32' );
+		expect( money3 ).toBe( '9.800.900,32€' );
+	} );
+
+	test( 'puts symbols on the right for specific languages', () => {
+		const money = formatCurrency( 9800900, 'EUR', { precision: 2 } );
+		expect( money ).toBe( '9.800.900,00€' );
 	} );
 
 	describe( 'supported currencies', () => {
@@ -75,7 +80,7 @@ describe( 'formatCurrency', () => {
 		} );
 		test( 'EUR', () => {
 			const money = formatCurrency( 9800900.32, 'EUR' );
-			expect( money ).toBe( '€9.800.900,32' );
+			expect( money ).toBe( '9.800.900,32€' );
 		} );
 		test( 'GBP', () => {
 			const money = formatCurrency( 9800900.32, 'GBP' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds ability for `format-currency` package to put symbols on right.

#### Testing instructions

* Load a page that displays USD and check symbol is on left
* Load a page that displays EUR and check symbol is on right

Fixes #38325 
