### PR TITLE
Checklist: Temporarily disable for Atomic sites

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -592,7 +592,7 @@ const connectHome = connect(
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
 
 		return {
-			displayChecklist: !! ( hasChecklistData && ! isChecklistComplete ),
+			displayChecklist: !! ( ! isAtomic && hasChecklistData && ! isChecklistComplete ),
 			site: getSelectedSite( state ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
In #38289, we enabled the Onboarding Checklist for Atomic sites (in practice, just for Business sites).

Unfortunately, if sites go Atomic prior to completing the "Update Your Homepage" task, it becomes impossible to complete.

See D36812-code for more info.

#### Changes proposed in this Pull Request

* Set the `displayChecklist` prop to false when the selected site is Atomic

#### Testing instructions

* Browse to `/home` for a new Business site that's gone Atomic
  * You should not see the checklist
* Browse to `/home` for a new WPCOM simple site
  * You should see the checklist
