### PR TITLE
[SIGNUP]: A/B test an alternative default logged-in landing page

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -124,10 +124,16 @@ const loggedInMiddleware = currentUser => {
 	}
 
 	page( '/', context => {
-		let redirectPath = 'variant' === abtest( 'redirectToCustomerHome' ) ? '/home' : '/read';
+		const { primarySiteSlug } = currentUser.get();
+		let redirectPath =
+			primarySiteSlug && 'variant' === abtest( 'redirectToCustomerHome' )
+				? `/home/${ primarySiteSlug }`
+				: '/read';
+
 		if ( context.querystring ) {
 			redirectPath += `?${ context.querystring }`;
 		}
+
 		page.redirect( redirectPath );
 	} );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -20,7 +20,7 @@ import { ReduxWrappedLayout } from 'controller';
 import notices from 'notices';
 import { getToken } from 'lib/oauth-token';
 import emailVerification from 'components/email-verification';
-import { getSavedVariations } from 'lib/abtest'; // used by error logger
+import { abtest, getSavedVariations } from 'lib/abtest'; // used by error logger
 import accessibleFocus from 'lib/accessible-focus';
 import Logger from 'lib/catch-js-errors';
 import { bindState as bindWpLocaleState } from 'lib/wp/localization';
@@ -124,7 +124,7 @@ const loggedInMiddleware = currentUser => {
 	}
 
 	page( '/', context => {
-		let redirectPath = '/read';
+		let redirectPath = 'variant' === abtest( 'redirectToCustomerHome' ) ? '/home' : '/read';
 		if ( context.querystring ) {
 			redirectPath += `?${ context.querystring }`;
 		}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -147,4 +147,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	redirectToCustomerHome: {
+		datestamp: '20191220',
+		variations: {
+			variant: 10,
+			control: 90,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -154,6 +154,6 @@ export default {
 			control: 90,
 		},
 		defaultVariation: 'control',
-		allowExistingUsers: true,
+		allowExistingUsers: false,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -148,7 +148,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	redirectToCustomerHome: {
-		datestamp: '20191220',
+		datestamp: '20200117',
 		variations: {
 			variant: 10,
 			control: 90,


### PR DESCRIPTION
This PR follows up on #37547 

## Changes proposed in this Pull Request

This PR A/B tests an alternative default logged-in landing page. 

We'll redirect 10% of users to `/home` (the variant). The remaining 90% will be redirected to the default: `/read`

Background p58i-89H-p2

EPIC https://github.com/Automattic/zelda-private/issues/173

Fixes https://github.com/Automattic/zelda-private/issues/232 

⚠️ ~This PR should only be merged once Jetpack has been released on January 14, 2020 https://github.com/Automattic/jetpack/pull/14214~

Jetpack 8.1 has been released: https://github.com/Automattic/jetpack/milestone/141?closed=1

## Testing instructions

### The variant

1. Fire up the branch
2. Head to http://calypso.localhost:3000/log-in
3. From the A/B list, select `'variant'` for `redirectToCustomerHome`
4. You should be prompted to select a site to open **My Home**
5. For sites with a home section, you should be redirected to that site's home page. For older sites with no home section, you'll be taken to that site's stats page.

<img width="757" alt="Screen Shot 2020-01-17 at 2 56 42 pm" src="https://user-images.githubusercontent.com/6458278/72583222-a016f680-3939-11ea-9f9a-1a22ab0edde3.png">


### The control

1. Fire up the branch
2. Head to http://calypso.localhost:3000/log-in
3. From the A/B list, select `'control'` for `redirectToCustomerHome`
4. You should be redirected to the Reader


