### PR TITLE
Composite checkout: fix delete button opacity

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/button.js
+++ b/packages/composite-checkout-wpcom/src/components/button.js
@@ -83,13 +83,13 @@ const CallToAction = styled.button`
 `;
 
 function getImageFilter( { buttonType, buttonState } ) {
-	return `grayscale( ${ buttonState && buttonState.includes( 'primary' ) ? 0 : 100 } ) invert( ${
+	return `grayscale( ${ buttonState === 'disabled' ? 100 : 0 } ) invert( ${
 		buttonState === 'primary' && buttonType === 'apple-pay' ? '100%' : 0
 	} );`;
 }
 
 function getImageOpacity( { buttonState } ) {
-	return buttonState && buttonState.includes( 'primary' ) ? 1 : '0.5';
+	return buttonState === 'disabled' ? 0.5 : '1';
 }
 
 function getBorderWeight( { buttonState } ) {

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -124,6 +124,7 @@ const CheckoutModalTitle = styled.h1`
 	font-weight: ${props => props.theme.weights.normal};
 	font-size: 24px;
 	color: ${props => props.theme.colors.textColor};
+	line-height: 1.3;
 `;
 
 const CheckoutModalCopy = styled.p`


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a colour issue with the delete button icon and makes a minor tweak to the line-height of the modal title. 

Before:
![image](https://user-images.githubusercontent.com/6981253/70963251-edabf500-2055-11ea-905e-b80b639f8f4b.png)

After:
![image](https://user-images.githubusercontent.com/6981253/70963277-ff8d9800-2055-11ea-93bf-4dc6d1e6ac71.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get calypso running locally or use the calypso live link.
* Make your way to checkout and then add this query string at the end `?flags=composite-checkout-wpcom`
* switch to the paypal payment method (verify that the paypal logo looks disabled)
* Continue through to the review step and hover over the trashcan icon to confirm that it turns red.

