### PR TITLE
Build: Add typescript asset types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
 				"@babel/preset-env": "7.7.6",
 				"@babel/preset-react": "7.7.4",
 				"@babel/preset-typescript": "7.7.4",
+				"@types/webpack-env": "1.14.1",
 				"@wordpress/babel-plugin-import-jsx-pragma": "2.3.0",
 				"@wordpress/browserslist-config": "2.6.0",
 				"@wordpress/dependency-extraction-webpack-plugin": "2.1.0",
@@ -263,6 +264,7 @@
 				"@emotion/styled": "10.0.23",
 				"@wordpress/data": "^4.9.2",
 				"@wordpress/i18n": "3.7.0",
+				"debug": "4.1.1",
 				"emotion-theming": "10.0.19",
 				"interpolate-components": "1.1.1",
 				"prop-types": "^15.7.2",
@@ -587,7 +589,8 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
 		},
 		"@babel/helper-regex": {
 			"version": "7.5.5",
@@ -844,6 +847,7 @@
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
 			"integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -1440,6 +1444,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
 			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"dev": true,
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
@@ -1752,6 +1757,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
 			"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+			"dev": true,
 			"requires": {
 				"@jest/source-map": "^24.9.0",
 				"chalk": "^2.0.1",
@@ -1762,6 +1768,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -1771,7 +1778,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -1779,6 +1787,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
 			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
 				"@jest/reporters": "^24.9.0",
@@ -1814,6 +1823,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -1823,12 +1833,14 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -1839,6 +1851,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
 			"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+			"dev": true,
 			"requires": {
 				"@jest/fake-timers": "^24.9.0",
 				"@jest/transform": "^24.9.0",
@@ -1850,6 +1863,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
 			"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"jest-message-util": "^24.9.0",
@@ -1860,6 +1874,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
 			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+			"dev": true,
 			"requires": {
 				"@jest/environment": "^24.9.0",
 				"@jest/test-result": "^24.9.0",
@@ -1888,6 +1903,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -1897,12 +1913,14 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -1910,6 +1928,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
 			"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
 				"graceful-fs": "^4.1.15",
@@ -1919,7 +1938,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -1927,6 +1947,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
 			"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+			"dev": true,
 			"requires": {
 				"@jest/console": "^24.9.0",
 				"@jest/types": "^24.9.0",
@@ -1937,6 +1958,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
 			"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+			"dev": true,
 			"requires": {
 				"@jest/test-result": "^24.9.0",
 				"jest-haste-map": "^24.9.0",
@@ -1948,6 +1970,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
 			"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
 				"@jest/types": "^24.9.0",
@@ -1971,6 +1994,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -1980,17 +2004,20 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
 					"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -2003,6 +2030,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
 			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^1.1.1",
@@ -3716,6 +3744,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
 			"integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -3728,6 +3757,7 @@
 			"version": "7.6.1",
 			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
 			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -3736,6 +3766,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
 			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -3745,6 +3776,7 @@
 			"version": "7.0.8",
 			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
 			"integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
@@ -3806,12 +3838,14 @@
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
+			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+			"dev": true
 		},
 		"@types/istanbul-lib-report": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
 			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "*"
 			}
@@ -3820,6 +3854,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
 			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
@@ -3916,7 +3951,8 @@
 		"@types/stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
 		},
 		"@types/testing-library__dom": {
 			"version": "6.10.0",
@@ -4165,6 +4201,7 @@
 			"version": "13.0.3",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
 			"integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
@@ -4172,7 +4209,8 @@
 		"@types/yargs-parser": {
 			"version": "13.1.0",
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
+			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
+			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "2.10.0",
@@ -5118,7 +5156,8 @@
 		"abab": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+			"dev": true
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -5148,6 +5187,7 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
 			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
@@ -5430,7 +5470,8 @@
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-filter": {
 			"version": "1.0.0",
@@ -5624,7 +5665,8 @@
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
 		},
 		"async": {
 			"version": "2.6.3",
@@ -5777,6 +5819,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
 			"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+			"dev": true,
 			"requires": {
 				"@jest/transform": "^24.9.0",
 				"@jest/types": "^24.9.0",
@@ -5791,6 +5834,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -5800,7 +5844,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -5866,6 +5911,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
 			"integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"find-up": "^3.0.0",
@@ -5877,6 +5923,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
 			"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+			"dev": true,
 			"requires": {
 				"@types/babel__traverse": "^7.0.6"
 			}
@@ -5906,6 +5953,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
 			"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
 				"babel-plugin-jest-hoist": "^24.9.0"
@@ -6256,12 +6304,14 @@
 		"browser-process-hrtime": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
 		},
 		"browser-resolve": {
 			"version": "1.11.3",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
 			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
 			},
@@ -6269,7 +6319,8 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				}
 			}
 		},
@@ -6375,6 +6426,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
 			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
 			}
@@ -6682,6 +6734,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
 			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+			"dev": true,
 			"requires": {
 				"rsvp": "^4.8.4"
 			}
@@ -7721,7 +7774,8 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"coa": {
 			"version": "2.0.2",
@@ -8752,18 +8806,20 @@
 				"icss-utils": "^4.1.1",
 				"loader-utils": "^1.2.3",
 				"normalize-path": "^3.0.0",
+				"postcss": "^7.0.23",
 				"postcss-modules-extract-imports": "^2.0.0",
 				"postcss-modules-local-by-default": "^3.0.2",
-				"postcss-modules-scope": "^2.1.0",
+				"postcss-modules-scope": "^2.1.1",
 				"postcss-modules-values": "^3.0.0",
-				"postcss-value-parser": "^4.0.0",
-				"schema-utils": "^2.0.0"
+				"postcss-value-parser": "^4.0.2",
+				"schema-utils": "^2.6.0"
 			},
 			"dependencies": {
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8774,6 +8830,7 @@
 							"version": "5.5.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
 							"requires": {
 								"has-flag": "^3.0.0"
 							}
@@ -8783,12 +8840,14 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "7.0.24",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
 					"integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
@@ -8808,12 +8867,14 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9190,12 +9251,14 @@
 		"cssom": {
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+			"dev": true
 		},
 		"cssstyle": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
 			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
 			}
@@ -9320,6 +9383,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
@@ -9446,7 +9510,8 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"deepmerge": {
 			"version": "1.5.2",
@@ -9719,7 +9784,8 @@
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
 		},
 		"detect-node": {
 			"version": "2.0.4",
@@ -9744,7 +9810,8 @@
 		"diff-sequences": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
+			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -9871,6 +9938,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
 			"requires": {
 				"webidl-conversions": "^4.0.2"
 			}
@@ -10449,6 +10517,7 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
 			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -10460,12 +10529,14 @@
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -11195,7 +11266,8 @@
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.6.1",
@@ -11259,7 +11331,8 @@
 		"exec-sh": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
-			"integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A=="
+			"integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
+			"dev": true
 		},
 		"execa": {
 			"version": "0.7.0",
@@ -11325,7 +11398,8 @@
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
@@ -11393,6 +11467,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
 			"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"ansi-styles": "^3.2.0",
@@ -11661,7 +11736,8 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fast-luhn": {
 			"version": "1.0.4",
@@ -11707,6 +11783,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
 			"integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+			"dev": true,
 			"requires": {
 				"bser": "2.1.1"
 			}
@@ -12910,7 +12987,8 @@
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
 		},
 		"gud": {
 			"version": "1.0.0",
@@ -13357,6 +13435,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
 			"requires": {
 				"whatwg-encoding": "^1.0.1"
 			}
@@ -14486,7 +14565,8 @@
 		"is-generator-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+			"dev": true
 		},
 		"is-git-clean": {
 			"version": "1.1.0",
@@ -14833,7 +14913,8 @@
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
 		},
 		"is-yarn-global": {
 			"version": "0.3.0",
@@ -14872,12 +14953,14 @@
 		"istanbul-lib-coverage": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
+			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+			"dev": true
 		},
 		"istanbul-lib-instrument": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
 			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+			"dev": true,
 			"requires": {
 				"@babel/generator": "^7.4.0",
 				"@babel/parser": "^7.4.3",
@@ -14891,7 +14974,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -14899,6 +14983,7 @@
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
 			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "^2.0.5",
 				"make-dir": "^2.1.0",
@@ -14909,6 +14994,7 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -14919,6 +15005,7 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
 			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
 				"istanbul-lib-coverage": "^2.0.5",
@@ -14931,6 +15018,7 @@
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -14938,7 +15026,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -14946,6 +15035,7 @@
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
 			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+			"dev": true,
 			"requires": {
 				"handlebars": "^4.1.2"
 			}
@@ -14964,6 +15054,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -14973,7 +15064,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"jest-cli": {
 					"version": "24.9.0",
@@ -14999,22 +15091,7 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-					"requires": {
-						"@jest/core": "^24.9.0",
-						"@jest/test-result": "^24.9.0",
-						"@jest/types": "^24.9.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"import-local": "^2.0.0",
-						"is-ci": "^2.0.0",
-						"jest-config": "^24.9.0",
-						"jest-util": "^24.9.0",
-						"jest-validate": "^24.9.0",
-						"prompts": "^2.0.1",
-						"realpath-native": "^1.1.0",
-						"yargs": "^13.3.0"
-					}
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
 				}
 			}
 		},
@@ -15022,6 +15099,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
 			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"execa": "^1.0.0",
@@ -15032,6 +15110,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -15044,6 +15123,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
 						"get-stream": "^4.0.0",
@@ -15058,6 +15138,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -15065,12 +15146,14 @@
 				"path-key": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
 				},
 				"pump": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -15080,6 +15163,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
@@ -15087,12 +15171,14 @@
 				"shebang-regex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
 				},
 				"which": {
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -15103,6 +15189,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
 			"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
 				"@jest/test-sequencer": "^24.9.0",
@@ -15127,6 +15214,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -15136,7 +15224,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -15144,6 +15233,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
 			"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"diff-sequences": "^24.9.0",
@@ -15155,6 +15245,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -15164,7 +15255,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -15172,6 +15264,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
 			"integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+			"dev": true,
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
@@ -15180,6 +15273,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
 			"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
@@ -15192,6 +15286,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -15201,7 +15296,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -15218,6 +15314,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
 			"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+			"dev": true,
 			"requires": {
 				"@jest/environment": "^24.9.0",
 				"@jest/fake-timers": "^24.9.0",
@@ -15231,6 +15328,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
 			"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+			"dev": true,
 			"requires": {
 				"@jest/environment": "^24.9.0",
 				"@jest/fake-timers": "^24.9.0",
@@ -15263,12 +15361,14 @@
 		"jest-get-type": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
+			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+			"dev": true
 		},
 		"jest-haste-map": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
 			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
@@ -15288,6 +15388,7 @@
 					"version": "1.2.9",
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
 					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"nan": "^2.12.1",
@@ -15298,24 +15399,28 @@
 							"version": "1.1.1",
 							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+							"dev": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
 							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
 							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"delegates": "^1.0.0",
@@ -15326,12 +15431,14 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+							"dev": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
@@ -15342,36 +15449,42 @@
 							"version": "1.1.1",
 							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
 							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
 							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+							"dev": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+							"dev": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+							"dev": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"ms": "^2.1.1"
@@ -15381,24 +15494,28 @@
 							"version": "0.6.0",
 							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
 							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
 							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -15408,12 +15525,14 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"aproba": "^1.0.3",
@@ -15430,6 +15549,7 @@
 							"version": "7.1.3",
 							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
@@ -15444,12 +15564,14 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
 							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"safer-buffer": ">= 2.1.2 < 3"
@@ -15459,6 +15581,7 @@
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"minimatch": "^3.0.4"
@@ -15468,6 +15591,7 @@
 							"version": "1.0.6",
 							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"once": "^1.3.0",
@@ -15478,18 +15602,21 @@
 							"version": "2.0.3",
 							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+							"dev": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
 							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
@@ -15499,12 +15626,14 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
@@ -15514,12 +15643,14 @@
 							"version": "0.0.8",
 							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+							"dev": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -15530,6 +15661,7 @@
 							"version": "1.2.1",
 							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
 							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -15539,6 +15671,7 @@
 							"version": "0.5.1",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
@@ -15548,12 +15681,14 @@
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
 							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"debug": "^4.1.0",
@@ -15565,6 +15700,7 @@
 							"version": "0.12.0",
 							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"detect-libc": "^1.0.2",
@@ -15583,6 +15719,7 @@
 							"version": "4.0.1",
 							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"abbrev": "1",
@@ -15593,12 +15730,14 @@
 							"version": "1.0.6",
 							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
 							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
 							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
 							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"ignore-walk": "^3.0.1",
@@ -15609,6 +15748,7 @@
 							"version": "4.1.2",
 							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
@@ -15621,18 +15761,21 @@
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+							"dev": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
 							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
 							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"wrappy": "1"
@@ -15642,18 +15785,21 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
 							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
@@ -15664,18 +15810,21 @@
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
 							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"deep-extend": "^0.6.0",
@@ -15688,6 +15837,7 @@
 									"version": "1.2.0",
 									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+									"dev": true,
 									"optional": true
 								}
 							}
@@ -15696,6 +15846,7 @@
 							"version": "2.3.6",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -15711,6 +15862,7 @@
 							"version": "2.6.3",
 							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"glob": "^7.1.3"
@@ -15720,42 +15872,49 @@
 							"version": "5.1.2",
 							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
 							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
 							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
 							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
 							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -15767,6 +15926,7 @@
 							"version": "1.1.1",
 							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -15776,6 +15936,7 @@
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
@@ -15785,12 +15946,14 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
 							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
 							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"chownr": "^1.1.1",
@@ -15806,12 +15969,14 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
 							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"string-width": "^1.0.2 || 2"
@@ -15821,12 +15986,14 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+							"dev": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -15837,6 +16004,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
 			"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
 				"@jest/environment": "^24.9.0",
@@ -15860,6 +16028,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -15869,7 +16038,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -15890,6 +16060,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
 			"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+			"dev": true,
 			"requires": {
 				"jest-get-type": "^24.9.0",
 				"pretty-format": "^24.9.0"
@@ -15899,6 +16070,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
 			"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-diff": "^24.9.0",
@@ -15910,6 +16082,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -15919,7 +16092,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -15927,6 +16101,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
 			"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@jest/test-result": "^24.9.0",
@@ -15942,6 +16117,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -15951,7 +16127,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -15959,6 +16136,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
 			"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0"
 			}
@@ -15966,17 +16144,20 @@
 		"jest-pnp-resolver": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ=="
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
-			"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA=="
+			"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+			"dev": true
 		},
 		"jest-resolve": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
 			"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"browser-resolve": "^1.11.3",
@@ -15989,6 +16170,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -15998,7 +16180,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -16006,6 +16189,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
 			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
@@ -16016,6 +16200,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
 			"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
 				"@jest/environment": "^24.9.0",
@@ -16042,6 +16227,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -16051,7 +16237,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -16059,6 +16246,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
 			"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
 				"@jest/environment": "^24.9.0",
@@ -16089,6 +16277,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -16098,19 +16287,22 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
 		"jest-serializer": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
-			"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ=="
+			"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
+			"dev": true
 		},
 		"jest-snapshot": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
 			"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
 				"@jest/types": "^24.9.0",
@@ -16131,6 +16323,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -16140,12 +16333,14 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -16153,6 +16348,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
 			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+			"dev": true,
 			"requires": {
 				"@jest/console": "^24.9.0",
 				"@jest/fake-timers": "^24.9.0",
@@ -16172,6 +16368,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -16181,12 +16378,14 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -16194,6 +16393,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
 			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"camelcase": "^5.3.1",
@@ -16207,6 +16407,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -16216,7 +16417,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -16224,6 +16426,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
 			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+			"dev": true,
 			"requires": {
 				"@jest/test-result": "^24.9.0",
 				"@jest/types": "^24.9.0",
@@ -16238,6 +16441,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -16247,7 +16451,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -16255,6 +16460,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
 			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+			"dev": true,
 			"requires": {
 				"merge-stream": "^2.0.0",
 				"supports-color": "^6.1.0"
@@ -16264,6 +16470,7 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -16374,6 +16581,7 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
 			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
 				"acorn": "^5.5.3",
@@ -16406,17 +16614,20 @@
 				"acorn": {
 					"version": "5.7.3",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+					"dev": true
 				},
 				"parse5": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+					"dev": true
 				},
 				"whatwg-url": {
 					"version": "6.5.0",
 					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
 					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"dev": true,
 					"requires": {
 						"lodash.sortby": "^4.7.0",
 						"tr46": "^1.0.1",
@@ -16427,6 +16638,7 @@
 					"version": "5.2.2",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
 					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+					"dev": true,
 					"requires": {
 						"async-limiter": "~1.0.0"
 					}
@@ -16567,7 +16779,8 @@
 		"kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true
 		},
 		"known-css-properties": {
 			"version": "0.11.0",
@@ -16594,7 +16807,8 @@
 		"left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
 		},
 		"lerna": {
 			"version": "3.18.4",
@@ -16623,12 +16837,14 @@
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -17134,6 +17350,7 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
 			"requires": {
 				"tmpl": "1.0.x"
 			}
@@ -17389,7 +17606,8 @@
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"merge2": {
 			"version": "1.3.0",
@@ -18036,7 +18254,8 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"ncp": {
 			"version": "2.0.0",
@@ -18237,7 +18456,8 @@
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",
@@ -18313,12 +18533,14 @@
 		"node-modules-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
 		},
 		"node-notifier": {
 			"version": "5.4.3",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
 			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
 				"is-wsl": "^1.1.0",
@@ -18331,6 +18553,7 @@
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -18764,42 +18987,13 @@
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
-				},
 				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
-					}
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-					"dev": true
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -18817,12 +19011,6 @@
 					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 					"dev": true
 				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
 				"invert-kv": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -18837,18 +19025,6 @@
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
 				},
 				"lcid": {
 					"version": "1.0.0",
@@ -18869,16 +19045,6 @@
 						"path-exists": "^3.0.0"
 					}
 				},
-				"lru-cache": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
 				"mem": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -18888,41 +19054,9 @@
 						"mimic-fn": "^1.0.0"
 					}
 				},
-				"mimic-fn": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-					"dev": true
-				},
 				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"npm-run-path": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-					"dev": true,
-					"requires": {
-						"path-key": "^2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"os-locale": {
 					"version": "2.1.0",
@@ -18934,12 +19068,6 @@
 						"lcid": "^1.0.0",
 						"mem": "^1.1.0"
 					}
-				},
-				"p-finally": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
@@ -18956,29 +19084,9 @@
 						"p-limit": "^1.1.0"
 					}
 				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
 				"path-key": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-					"dev": true
-				},
-				"pseudomap": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-					"dev": true
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-					"dev": true
+					"version": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
@@ -18986,17 +19094,10 @@
 					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true
-				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
@@ -19004,14 +19105,7 @@
 				"shebang-regex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 				},
 				"string-width": {
 					"version": "1.0.2",
@@ -19033,26 +19127,13 @@
 						"ansi-regex": "^2.0.0"
 					}
 				},
-				"strip-eof": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-					"dev": true
-				},
 				"which": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
@@ -19068,12 +19149,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
 					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				},
 				"yargs": {
@@ -19445,7 +19520,8 @@
 		"nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -19676,6 +19752,7 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
 			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.6",
@@ -19823,6 +19900,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
@@ -20308,6 +20386,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
 			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"dev": true,
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
 			}
@@ -20346,7 +20425,8 @@
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
 		},
 		"portfinder": {
 			"version": "1.0.25",
@@ -23529,7 +23609,8 @@
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"prepend-http": {
 			"version": "2.0.0",
@@ -23555,6 +23636,7 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
 			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"ansi-regex": "^4.0.0",
@@ -23634,6 +23716,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
 			"integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
+			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.3"
@@ -24640,6 +24723,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
 			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+			"dev": true,
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
@@ -25295,6 +25379,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
 			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.15"
 			}
@@ -25303,6 +25388,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
 			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.3",
 				"stealthy-require": "^1.1.1",
@@ -25513,7 +25599,8 @@
 		"rsvp": {
 			"version": "4.8.5",
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+			"dev": true
 		},
 		"rtlcss": {
 			"version": "2.4.0",
@@ -25606,6 +25693,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
 			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+			"dev": true,
 			"requires": {
 				"@cnakazawa/watch": "^1.0.3",
 				"anymatch": "^2.0.0",
@@ -25622,6 +25710,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -25634,6 +25723,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
 						"get-stream": "^4.0.0",
@@ -25648,6 +25738,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -25655,12 +25746,14 @@
 				"path-key": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
 				},
 				"pump": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -25670,6 +25763,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
@@ -25677,12 +25771,14 @@
 				"shebang-regex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
 				},
 				"which": {
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -25965,7 +26061,8 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"scheduler": {
 			"version": "0.18.0",
@@ -26262,7 +26359,8 @@
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
 		},
 		"showdown": {
 			"version": "1.9.1",
@@ -26351,7 +26449,8 @@
 		"sisteransi": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-			"integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig=="
+			"integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
+			"dev": true
 		},
 		"slash": {
 			"version": "2.0.0",
@@ -27010,7 +27109,8 @@
 		"stack-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
 		},
 		"stackframe": {
 			"version": "1.1.0",
@@ -27109,7 +27209,8 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
 		},
 		"store": {
 			"version": "2.0.12",
@@ -27241,6 +27342,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
 			"requires": {
 				"astral-regex": "^1.0.0",
 				"strip-ansi": "^4.0.0"
@@ -27249,12 +27351,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -28053,7 +28157,8 @@
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true
 		},
 		"table": {
 			"version": "5.4.6",
@@ -28383,6 +28488,7 @@
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
 			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3",
 				"minimatch": "^3.0.4",
@@ -28394,6 +28500,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
 					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
 						"read-pkg": "^3.0.0"
@@ -28447,7 +28554,8 @@
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
@@ -28559,7 +28667,8 @@
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
 		},
 		"to-array": {
 			"version": "0.1.4",
@@ -28928,6 +29037,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -29682,6 +29792,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
 			}
@@ -29696,6 +29807,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
 			"requires": {
 				"makeerror": "1.0.x"
 			}
@@ -30444,6 +30556,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
 			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
@@ -30456,7 +30569,8 @@
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
 		},
 		"whatwg-url": {
 			"version": "7.1.0",
@@ -30675,7 +30789,8 @@
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
 		},
 		"wordwrap": {
 			"version": "0.0.3",
@@ -30886,7 +31001,8 @@
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
 		},
 		"xmlhttprequest-ssl": {
 			"version": "1.5.5",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -44,6 +44,7 @@
 		"@babel/preset-env": "7.7.6",
 		"@babel/preset-react": "7.7.4",
 		"@babel/preset-typescript": "7.7.4",
+		"@types/webpack-env": "1.14.1",
 		"@wordpress/babel-plugin-import-jsx-pragma": "2.3.0",
 		"@wordpress/browserslist-config": "2.6.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "2.1.0",
@@ -54,9 +55,9 @@
 		"caniuse-api": "3.0.0",
 		"css-loader": "3.2.1",
 		"duplicate-package-checker-webpack-plugin": "3.0.0",
-		"enzyme": "3.10.0",
 		"enzyme-adapter-react-16": "1.15.1",
 		"enzyme-to-json": "3.4.3",
+		"enzyme": "3.10.0",
 		"file-loader": "4.2.0",
 		"jest-config": "24.9.0",
 		"jest-enzyme": "7.1.2",
@@ -69,9 +70,9 @@
 		"terser-webpack-plugin": "2.2.1",
 		"thread-loader": "2.1.3",
 		"typescript": "3.7.3",
-		"webpack": "4.41.2",
 		"webpack-cli": "3.3.10",
 		"webpack-filter-warnings-plugin": "1.2.1",
-		"webpack-rtl-plugin": "2.0.0"
+		"webpack-rtl-plugin": "2.0.0",
+		"webpack": "4.41.2"
 	}
 }

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -55,9 +55,9 @@
 		"caniuse-api": "3.0.0",
 		"css-loader": "3.2.1",
 		"duplicate-package-checker-webpack-plugin": "3.0.0",
+		"enzyme": "3.10.0",
 		"enzyme-adapter-react-16": "1.15.1",
 		"enzyme-to-json": "3.4.3",
-		"enzyme": "3.10.0",
 		"file-loader": "4.2.0",
 		"jest-config": "24.9.0",
 		"jest-enzyme": "7.1.2",
@@ -70,9 +70,9 @@
 		"terser-webpack-plugin": "2.2.1",
 		"thread-loader": "2.1.3",
 		"typescript": "3.7.3",
+		"webpack": "4.41.2",
 		"webpack-cli": "3.3.10",
 		"webpack-filter-warnings-plugin": "1.2.1",
-		"webpack-rtl-plugin": "2.0.0",
-		"webpack": "4.41.2"
+		"webpack-rtl-plugin": "2.0.0"
 	}
 }

--- a/packages/calypso-build/tsconfig.json
+++ b/packages/calypso-build/tsconfig.json
@@ -14,7 +14,8 @@
 		// Import non-ES modules as default imports.
 		"esModuleInterop": true,
 		"skipLibCheck": false,
-		"module": "esnext"
-	},
-	"types": [ "webpack-env" ]
+		"module": "esnext",
+		"typeRoots": [ "./typings", "**/node_modules/@types" ],
+		"types": [ "webpack-env", "calypso-assets" ]
+	}
 }

--- a/packages/calypso-build/typings/calypso-assets/index.d.ts
+++ b/packages/calypso-build/typings/calypso-assets/index.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Declare assets provided by webpack file-loader
+ */
+
+declare module '*.gif' {
+	const url: string;
+	export default url;
+}
+declare module '*.jpeg' {
+	const url: string;
+	export default url;
+}
+declare module '*.jpg' {
+	const url: string;
+	export default url;
+}
+declare module '*.png' {
+	const url: string;
+	export default url;
+}
+declare module '*.svg' {
+	const url: string;
+	export default url;
+}


### PR DESCRIPTION
Calypso's build includes a file-loader. Make TypeScript aware of the file loader modules.
Also fixes `webpack-env` types declaration that was included in the wrong part of tsconfig and moves `webpack-env` type dependency to `calypso-build`.

This should remove many of the following type of errors on the [typecheck job](https://circleci.com/api/v1.1/project/github/Automattic/wp-calypso/545630/output/103/0?file=true&allocation-id=5df89c9405990913006b5278-0-build%2F2AAC3182):

```
client/components/credit-card/stored-card.tsx:22:35 - error TS2307: Cannot find module 'assets/images/upgrades/cc-diners.svg'.
```

#### Testing instructions

* Fewer erros in `typecheck` job.
  - [Master currently "Found 234 errors."](https://app.circleci.com/jobs/github/Automattic/wp-calypso/545630)
  - [This branch "Found 210 errors."](https://app.circleci.com/jobs/github/Automattic/wp-calypso/545733)
