### PR TITLE
Add return type string to numberFormat type dec

### DIFF
--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -74,8 +74,8 @@ declare namespace i18nCalypso {
 		thousandsSep?: string;
 	}
 
-	export function numberFormat( number: number, numberOfDecimalPlaces: number );
-	export function numberFormat( number: number, options: NumberFormatOptions );
+	export function numberFormat( number: number, numberOfDecimalPlaces: number ): string;
+	export function numberFormat( number: number, options: NumberFormatOptions ): string;
 
 	export interface LocalizeProps {
 		locale: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes some type errors reported in the [typecheck job](https://app.circleci.com/jobs/github/Automattic/wp-calypso/545861) by adding return type `string` to `numberFormat`.

Here's the implementation, verify it returns a string:

https://github.com/Automattic/wp-calypso/blob/665109f7b8665b036823dee0090337dc03776ead/packages/i18n-calypso/src/number-format.js#L13-L30

#### Testing instructions

* Fewer errors in the `typecheck` job:
  - [234 `master`](https://app.circleci.com/jobs/github/Automattic/wp-calypso/545861)
  - [232 branch](https://app.circleci.com/jobs/github/Automattic/wp-calypso/545895) 
