### PR TITLE
Gutenboarding: Add page selector

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent, MouseEventHandler, CSSProperties } from 'react';
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '../../components/card';
+import { CardMedia } from '../../components/card/media';
+import { Template } from '../../stores/verticals-templates/types';
+
+const gridWidth = 960;
+const srcSet = ( src: string, widths: number[] ) =>
+	widths.map( width => addQueryArgs( src, { w: width } ) + ` ${ width }w` ).join( ', ' );
+
+interface Props {
+	isSelected?: boolean;
+	design: Template;
+	onClick: MouseEventHandler< HTMLDivElement >;
+	style?: CSSProperties;
+}
+const DeisgnCard: FunctionComponent< Props > = ( { design, onClick, isSelected, style } ) => (
+	<Card
+		className={ classnames( 'design-selector__design-option', { 'is-selected': isSelected } ) }
+		isElevated
+		onClick={ onClick }
+		style={ style }
+	>
+		<CardMedia>
+			<img
+				width={ 480 }
+				height={ 360 }
+				alt={ design.title }
+				src={ removeQueryArgs( design.preview, 'w' ) }
+				srcSet={ srcSet( design.preview, [ gridWidth / 2, gridWidth / 4 ] ) }
+			/>
+		</CardMedia>
+	</Card>
+);
+
+export default DeisgnCard;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -58,7 +58,11 @@ const DesignSelector: FunctionComponent = () => {
 
 	return (
 		<div className={ classnames( 'design-selector', { 'has-selected-design': selectedDesign } ) }>
-			<div className="design-selector__header-container" onClick={ () => resetState() }>
+			<div
+				className="design-selector__header-container"
+				onClick={ () => resetState() }
+				aria-hidden={ hasSelectedDesign ? 'true' : undefined }
+			>
 				<h1 className="design-selector__title">
 					{ NO__( 'Choose a starting design for your site' ) }
 				</h1>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -100,7 +100,7 @@ const DesignSelector: FunctionComponent = () => {
 			</CSSTransition>
 
 			<CSSTransition in={ hasSelectedDesign } timeout={ transitionTiming } unmountOnExit>
-				<div className="page-selector__grid-container">
+				<div className="page-layout-selector__container">
 					<PageLayoutSelector
 						selectedDesign={ selectedDesign }
 						selectedLayouts={ selectedLayouts }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -85,7 +85,7 @@ const DesignSelector: FunctionComponent = () => {
 								style={
 									selectedDesign?.slug === design.slug
 										? {
-												transform: `translate3d( 0, calc( -100vh + ${ -cp + 10 }px ), 0 )`,
+												transform: `translate3d( 0, calc( -100vh + ${ -( cp ?? 0 ) + 10 }px ), 0 )`,
 										  }
 										: undefined
 								}

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -14,7 +14,7 @@ import { partition } from 'lodash';
  */
 import { SiteVertical } from '../../stores/onboard/types';
 import { Template } from '../../stores/verticals-templates/types';
-import DeisgnCard from './design-card';
+import DesignCard from './design-card';
 
 import './style.scss';
 
@@ -78,7 +78,7 @@ const DesignSelector: FunctionComponent = () => {
 				>
 					<div className="design-selector__grid">
 						{ designs.map( design => (
-							<DeisgnCard
+							<DesignCard
 								key={ design.slug }
 								design={ design }
 								isSelected={ design.slug === selectedDesign?.slug }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { __ as NO__, sprintf } from '@wordpress/i18n';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { Template } from '../../stores/verticals-templates/types';
+import Card from '../../components/card';
+import CardMedia from '../../components/card/media';
+import { removeQueryArgs } from '@wordpress/url';
+import { Icon } from '@wordpress/components';
+
+interface Props {
+	selectedDesign: Template | undefined;
+	selectedLayouts: Set< Template[ 'slug' ] >;
+	selectLayout: ( t: Template ) => void;
+	templates: Template[];
+}
+
+const PageLayoutSelector: FunctionComponent< Props > = ( {
+	selectedDesign,
+	selectedLayouts,
+	selectLayout,
+	templates,
+} ) => (
+	<div className="page-layout-selector">
+		<div className="page-layout-selector__content">
+			<h1 className="page-layout-selector__title">
+				{ selectedDesign
+					? sprintf( NO__( 'Select the pages you want to use with %s:' ), selectedDesign.title )
+					: null }
+			</h1>
+			<div className="page-layout-selector__grid">
+				{ templates.map( template => (
+					<Card
+						className={ classnames( 'page-layout-selector__item', {
+							'is-selected': selectedLayouts.has( template.slug ),
+						} ) }
+						onClick={ () => selectLayout( template ) }
+						key={ template.slug }
+					>
+						<div className="page-layout-selector__selected-indicator">
+							<Icon icon="yes" size={ 24 } />
+						</div>
+						<CardMedia>
+							<img alt={ template.description } src={ removeQueryArgs( template.preview, 'w' ) } />
+						</CardMedia>
+					</Card>
+				) ) }
+			</div>
+		</div>
+	</div>
+);
+
+export default PageLayoutSelector;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -4,7 +4,9 @@ $design-selector-transition-timing: 250ms;
 
 $design-selector-max-width: 1100px;
 $design-selector-header-height: 60px;
-$design-selector-header-vertical-shift: 60px + 50px;
+// We'll use this height to move the heading up out of the viewport.
+// Gutenberg editor adds 50px
+$design-selector-header-vertical-shift: $design-selector-header-height + 50px;
 $deisgn-selector-selection-space: 175px;
 
 @mixin design-selector-show {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -67,7 +67,7 @@ $deisgn-selector-selection-space: 175px;
 	@include design-selector-show();
 }
 
-.page-selector__grid-container {
+.page-layout-selector__container {
 	position: absolute;
 	top: $design-selector-header-vertical-shift + $deisgn-selector-selection-space;
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -1,5 +1,31 @@
 @import '~@wordpress/base-styles/colors';
 
+$design-selector-transition-timing: 250ms;
+
+$design-selector-max-width: 1100px;
+$design-selector-header-height: 60px;
+$design-selector-header-vertical-shift: 60px + 50px;
+$deisgn-selector-selection-space: 175px;
+
+@mixin design-selector-show {
+	transform: translate3d( 0, 0, 0 );
+}
+@mixin design-selector-hide {
+	transform: translate3d( 0, 100vh, 0 );
+}
+
+@mixin design-selector-transition {
+	transition: $design-selector-transition-timing transform ease-out;
+}
+
+.design-selector {
+	@include design-selector-transition();
+	transform: translate3d( 0, 0, 0 );
+	&.has-selected-design {
+		transform: translate3d( 0, -( $design-selector-header-vertical-shift ), 0 );
+	}
+}
+
 .design-selector__title {
 	color: $dark-gray-800;
 	font-size: 2em;
@@ -15,19 +41,119 @@
 	text-align: center;
 }
 
+.design-selector__grid-container {
+	position: absolute;
+	margin-top: 1em;
+
+	&.exit,
+	&.exit-done {
+		overflow-y: hidden;
+		height: 100vh;
+
+		.design-selector__grid {
+			@include design-selector-hide();
+		}
+	}
+}
 .design-selector__grid {
+	@include design-selector-transition();
 	display: grid;
 	grid-gap: 4.5em;
 
 	@include breakpoint( '>660px' ) {
-		grid-template-columns: repeat( 2, 1fr );
+		grid-template-columns: 1fr 1fr;
+	}
+
+	@include design-selector-show();
+}
+
+.page-selector__grid-container {
+	position: absolute;
+	top: $design-selector-header-vertical-shift + $deisgn-selector-selection-space;
+
+	&,
+	&.enter,
+	&.exit-active.exit-active, // duplicate selector to override `.exit` below
+	&.exit-done {
+		.page-layout-selector {
+			@include design-selector-hide();
+		}
+	}
+
+	&.exit,
+	&.enter-active,
+	&.enter-done {
+		.page-layout-selector {
+			@include design-selector-show();
+			transform: translate3d( 0, 0, 0 );
+		}
+	}
+}
+.page-layout-selector {
+	@include design-selector-transition();
+	background: $white;
+	box-shadow: gray 0 0 12px; // use a sass variable
+	padding: 2em 4em;
+}
+
+.design-selector__header-container {
+	height: $design-selector-header-height;
+}
+
+.page-layout-selector__title {
+	font-weight: bold;
+	margin-bottom: 1em;
+	font-size: 1.3em;
+}
+
+.page-layout-selector__grid {
+	display: grid;
+	grid-gap: 0.75em;
+	@include breakpoint( '>660px' ) {
+		grid-template-columns: 1fr 1fr 1fr;
 	}
 }
 
-.design-selector__design-option {
-	transition: transform 100ms ease-in-out;
+.page-layout-selector__item {
+	position: relative;
+	overflow: hidden;
+	padding: 2px;
 
 	&.is-selected {
-		transform: scale( 1.1 );
+		border: 3px solid $blue-medium-focus;
+		padding: 0;
+		.page-layout-selector__selected-indicator {
+			top: -2px;
+			right: -2px;
+			transform: translate3d( 0, 0, 0 );
+		}
 	}
+}
+
+.page-layout-selector__selected-indicator {
+	$size: 24px; // should match icon size
+	$full-size: floor( $size * 1.66 );
+
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: $full-size;
+	height: $full-size;
+
+	text-align: right;
+	color: $white;
+	background: linear-gradient(
+		to bottom left,
+		$blue-medium-focus,
+		$blue-medium-focus 50%,
+		transparent 51% /* 1% difference helps prevent a rough edge */
+	);
+
+	transition: 80ms transform linear;
+	transform: translate3d( $size, -$size, 0 );
+}
+
+.design-selector__design-option {
+	transform: translate3d( 0, 0, 0 );
+	@include design-selector-transition();
 }


### PR DESCRIPTION
Implements a page selector in the Gutenboarding flow.

MT: paObgF-Sa-p2
Design: paObgF-RB-p2 and paObgF-RB-p2#comment-2026

## Screens

![demo](https://user-images.githubusercontent.com/841763/71254745-343a7180-232c-11ea-8f39-e163c0108186.gif)


## Testing

Visit it at [`/gutenboarding`](https://calypso.live/gutenboarding?branch=gutenboarding/add-page-selector)

## Next steps
- Keyboard navigation (tab/rover, esc handling…)
- Visual polish
- Update `@wordpress/components` dependency and use `Card` directly.
- Use css-in-js to avoid duplicated css/js variables
- Add the background to the page selector