### PR TITLE
Domains: Add abtest for domain suggestions using hints vs. not using hints

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -133,5 +133,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 		localeExceptions: [ 'en' ],
+	domainSuggestionsWithHints: {
+		datestamp: '20191217',
+		variations: {
+			variation2_front: 0,
+			variation3_front: 50,
+			variation4_front: 50,
+		},
+		defaultVariation: 'variation2_front',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,7 +138,8 @@ export default {
 		variations: {
 			variation2_front: 0,
 			variation3_front: 50,
-			variation4_front: 50,
+			variation4_front: 25,
+			variation5_front: 25,
 		},
 		defaultVariation: 'variation2_front',
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -133,8 +133,9 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 		localeExceptions: [ 'en' ],
+	},
 	domainSuggestionsWithHints: {
-		datestamp: '20191217',
+		datestamp: '20191220',
 		variations: {
 			variation2_front: 0,
 			variation3_front: 50,

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,3 +1,11 @@
-export const getSuggestionsVendor = () => {
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+
+export const getSuggestionsVendor = ( isSignup = false ) => {
+	if ( isSignup ) {
+		return abtest( 'domainSuggestionsWithHints' );
+	}
 	return 'variation2_front';
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -474,7 +474,7 @@ class DomainsStep extends React.Component {
 				showTestParagraph={ this.showTestParagraph }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor() }
+				vendor={ getSuggestionsVendor( true ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }


### PR DESCRIPTION
We want to test how well domain suggestions compare when we pass hints to the suggestion provider vs. when not doing that. In order to do that I've introduced three new vendor variants - `variation3_front`, `variation4_front` and `variation5_front` and added an abtest called `domainSuggestionsWithHints` that is active only in NUX.

depends on: D36842-code
see: p99Zz8-Ps-p2

#### Changes proposed in this Pull Request

* introduce a new abtest

#### Testing instructions

* start from `/start`, then check if using different variations will pass different `vendor` down the `/domains/suggestions` REST API endpoint.
