### PR TITLE
Jetpack Backup: Fix Credentials and AL wording based on currently supported product

### DIFF
--- a/client/state/selectors/site-supports-realtime-backup.js
+++ b/client/state/selectors/site-supports-realtime-backup.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSitePlanSlug } from 'state/sites/plans/selectors';
+import { getSitePurchases } from 'state/purchases/selectors';
+import { planHasFeature } from 'lib/plans';
+import {
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+} from 'lib/products-values/constants';
+
+/**
+ * Module variables
+ */
+const productSlugs = [ PRODUCT_JETPACK_BACKUP_REALTIME, PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ];
+
+/**
+ * True if the site supports Jetpack Real-time Backup, false otherwise.
+ *
+ * A site supports Jetpack Real-time Backup if either is true:
+ * - it has an active Jetpack Backup Real-time purchase
+ * - its current plan includes real time backups as a feature
+ *
+ * @param   {object}  state  Global state tree
+ * @param   {number}  siteId ID of the site
+ * @returns {boolean}        Whether site supports Jetpack Real-time Backup
+ */
+export default function siteSupportsRealtimeBackup( state, siteId ) {
+	const currentPlanSlug = getSitePlanSlug( state, siteId );
+	const purchases = getSitePurchases( state, siteId );
+
+	const currentPlanSupportsRealtimeBackup = some( productSlugs, productSlug =>
+		planHasFeature( currentPlanSlug, productSlug )
+	);
+	const hasActiveRealtimeBackupProduct = some(
+		purchases,
+		purchase =>
+			purchase.active && some( productSlugs, productSlug => productSlug === purchase.productSlug )
+	);
+
+	return currentPlanSupportsRealtimeBackup || hasActiveRealtimeBackupProduct;
+}

--- a/client/state/selectors/test/site-supports-realtime-backup.js
+++ b/client/state/selectors/test/site-supports-realtime-backup.js
@@ -56,7 +56,7 @@ describe( 'siteSupportsRealtimeBackup()', () => {
 			purchases: {
 				data: [
 					{
-						active: false,
+						active: true,
 						blog_id: siteId,
 						product_slug: PRODUCT_JETPACK_BACKUP_DAILY,
 					},

--- a/client/state/selectors/test/site-supports-realtime-backup.js
+++ b/client/state/selectors/test/site-supports-realtime-backup.js
@@ -3,6 +3,12 @@
  */
 import siteSupportsRealtimeBackup from 'state/selectors/site-supports-realtime-backup';
 import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+} from 'lib/plans/constants';
+import {
 	PRODUCT_JETPACK_BACKUP_DAILY,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
@@ -136,7 +142,7 @@ describe( 'siteSupportsRealtimeBackup()', () => {
 						data: [
 							{
 								currentPlan: true,
-								productSlug: 'jetpack_premium',
+								productSlug: PLAN_JETPACK_PREMIUM,
 							},
 						],
 					},
@@ -159,7 +165,7 @@ describe( 'siteSupportsRealtimeBackup()', () => {
 						data: [
 							{
 								currentPlan: true,
-								productSlug: 'jetpack_premium_monthly',
+								productSlug: PLAN_JETPACK_PREMIUM_MONTHLY,
 							},
 						],
 					},
@@ -182,7 +188,7 @@ describe( 'siteSupportsRealtimeBackup()', () => {
 						data: [
 							{
 								currentPlan: true,
-								productSlug: 'jetpack_business',
+								productSlug: PLAN_JETPACK_BUSINESS,
 							},
 						],
 					},
@@ -205,7 +211,7 @@ describe( 'siteSupportsRealtimeBackup()', () => {
 						data: [
 							{
 								currentPlan: true,
-								productSlug: 'jetpack_business_monthly',
+								productSlug: PLAN_JETPACK_BUSINESS_MONTHLY,
 							},
 						],
 					},

--- a/client/state/selectors/test/site-supports-realtime-backup.js
+++ b/client/state/selectors/test/site-supports-realtime-backup.js
@@ -1,0 +1,218 @@
+/**
+ * Internal dependencies
+ */
+import siteSupportsRealtimeBackup from 'state/selectors/site-supports-realtime-backup';
+import {
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+} from 'lib/products-values/constants';
+
+describe( 'siteSupportsRealtimeBackup()', () => {
+	test( 'should return false when no data is available', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [],
+			},
+			sites: {
+				plans: {},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+	} );
+
+	test( 'should return false when there is an inactive real time backup purchase for that site', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [
+					{
+						active: false,
+						blog_id: siteId,
+						product_slug: PRODUCT_JETPACK_BACKUP_REALTIME,
+					},
+				],
+			},
+			sites: {
+				plans: {},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+	} );
+
+	test( 'should return false when there is a yearly daily backup purchase for that site', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [
+					{
+						active: false,
+						blog_id: siteId,
+						product_slug: PRODUCT_JETPACK_BACKUP_DAILY,
+					},
+				],
+			},
+			sites: {
+				plans: {},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+	} );
+
+	test( 'should return false when there is a monthly daily backup purchase for that site', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [
+					{
+						active: true,
+						blog_id: siteId,
+						product_slug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+					},
+				],
+			},
+			sites: {
+				plans: {},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+	} );
+
+	test( 'should return true when there is a yearly real time backup purchase for that site', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [
+					{
+						active: true,
+						blog_id: siteId,
+						product_slug: PRODUCT_JETPACK_BACKUP_REALTIME,
+					},
+				],
+			},
+			sites: {
+				plans: {},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+	} );
+
+	test( 'should return true when there is a monthly real time backup purchase for that site', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [
+					{
+						active: true,
+						blog_id: siteId,
+						product_slug: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+					},
+				],
+			},
+			sites: {
+				plans: {},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+	} );
+
+	test( 'should return false when site is on a Jetpack Premium yearly plan', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [],
+			},
+			sites: {
+				plans: {
+					[ siteId ]: {
+						data: [
+							{
+								currentPlan: true,
+								productSlug: 'jetpack_premium',
+							},
+						],
+					},
+				},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+	} );
+
+	test( 'should return false when site is on a Jetpack Premium monthly plan', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [],
+			},
+			sites: {
+				plans: {
+					[ siteId ]: {
+						data: [
+							{
+								currentPlan: true,
+								productSlug: 'jetpack_premium_monthly',
+							},
+						],
+					},
+				},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+	} );
+
+	test( 'should return true when site is on a Jetpack Professional yearly plan', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [],
+			},
+			sites: {
+				plans: {
+					[ siteId ]: {
+						data: [
+							{
+								currentPlan: true,
+								productSlug: 'jetpack_business',
+							},
+						],
+					},
+				},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+	} );
+
+	test( 'should return true when site is on a Jetpack Professional monthly plan', () => {
+		const siteId = 123456;
+		const state = {
+			purchases: {
+				data: [],
+			},
+			sites: {
+				plans: {
+					[ siteId ]: {
+						data: [
+							{
+								currentPlan: true,
+								productSlug: 'jetpack_business_monthly',
+							},
+						],
+					},
+				},
+			},
+		};
+
+		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+	} );
+} );

--- a/client/state/selectors/test/site-supports-realtime-backup.js
+++ b/client/state/selectors/test/site-supports-realtime-backup.js
@@ -50,175 +50,111 @@ describe( 'siteSupportsRealtimeBackup()', () => {
 		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
 	} );
 
-	test( 'should return false when there is a yearly daily backup purchase for that site', () => {
+	test( 'should return false when there is a daily backup purchase for that site', () => {
 		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [
-					{
-						active: true,
-						blog_id: siteId,
-						product_slug: PRODUCT_JETPACK_BACKUP_DAILY,
-					},
-				],
-			},
-			sites: {
-				plans: {},
-			},
-		};
+		const dailyBackupProductSlugs = [
+			PRODUCT_JETPACK_BACKUP_DAILY,
+			PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+		];
 
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
-	} );
+		dailyBackupProductSlugs.map( productSlug => {
+			const state = {
+				purchases: {
+					data: [
+						{
+							active: true,
+							blog_id: siteId,
+							product_slug: productSlug,
+						},
+					],
+				},
+				sites: {
+					plans: {},
+				},
+			};
 
-	test( 'should return false when there is a monthly daily backup purchase for that site', () => {
-		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [
-					{
-						active: true,
-						blog_id: siteId,
-						product_slug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-					},
-				],
-			},
-			sites: {
-				plans: {},
-			},
-		};
-
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+			expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+		} );
 	} );
 
 	test( 'should return true when there is a yearly real time backup purchase for that site', () => {
 		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [
-					{
-						active: true,
-						blog_id: siteId,
-						product_slug: PRODUCT_JETPACK_BACKUP_REALTIME,
-					},
-				],
-			},
-			sites: {
-				plans: {},
-			},
-		};
+		const realtimeBackupProductSlugs = [
+			PRODUCT_JETPACK_BACKUP_REALTIME,
+			PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+		];
 
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
-	} );
+		realtimeBackupProductSlugs.map( productSlug => {
+			const state = {
+				purchases: {
+					data: [
+						{
+							active: true,
+							blog_id: siteId,
+							product_slug: productSlug,
+						},
+					],
+				},
+				sites: {
+					plans: {},
+				},
+			};
 
-	test( 'should return true when there is a monthly real time backup purchase for that site', () => {
-		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [
-					{
-						active: true,
-						blog_id: siteId,
-						product_slug: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
-					},
-				],
-			},
-			sites: {
-				plans: {},
-			},
-		};
-
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+			expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+		} );
 	} );
 
 	test( 'should return false when site is on a Jetpack Premium yearly plan', () => {
 		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [],
-			},
-			sites: {
-				plans: {
-					[ siteId ]: {
-						data: [
-							{
-								currentPlan: true,
-								productSlug: PLAN_JETPACK_PREMIUM,
-							},
-						],
+		const premiumPlanSlugs = [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
+
+		premiumPlanSlugs.map( productSlug => {
+			const state = {
+				purchases: {
+					data: [],
+				},
+				sites: {
+					plans: {
+						[ siteId ]: {
+							data: [
+								{
+									currentPlan: true,
+									productSlug: productSlug,
+								},
+							],
+						},
 					},
 				},
-			},
-		};
+			};
 
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
-	} );
-
-	test( 'should return false when site is on a Jetpack Premium monthly plan', () => {
-		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [],
-			},
-			sites: {
-				plans: {
-					[ siteId ]: {
-						data: [
-							{
-								currentPlan: true,
-								productSlug: PLAN_JETPACK_PREMIUM_MONTHLY,
-							},
-						],
-					},
-				},
-			},
-		};
-
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+			expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( false );
+		} );
 	} );
 
 	test( 'should return true when site is on a Jetpack Professional yearly plan', () => {
 		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [],
-			},
-			sites: {
-				plans: {
-					[ siteId ]: {
-						data: [
-							{
-								currentPlan: true,
-								productSlug: PLAN_JETPACK_BUSINESS,
-							},
-						],
+		const professionalPlanSlugs = [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
+
+		professionalPlanSlugs.map( productSlug => {
+			const state = {
+				purchases: {
+					data: [],
+				},
+				sites: {
+					plans: {
+						[ siteId ]: {
+							data: [
+								{
+									currentPlan: true,
+									productSlug: productSlug,
+								},
+							],
+						},
 					},
 				},
-			},
-		};
+			};
 
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
-	} );
-
-	test( 'should return true when site is on a Jetpack Professional monthly plan', () => {
-		const siteId = 123456;
-		const state = {
-			purchases: {
-				data: [],
-			},
-			sites: {
-				plans: {
-					[ siteId ]: {
-						data: [
-							{
-								currentPlan: true,
-								productSlug: PLAN_JETPACK_BUSINESS_MONTHLY,
-							},
-						],
-					},
-				},
-			},
-		};
-
-		expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+			expect( siteSupportsRealtimeBackup( state, siteId ) ).toBe( true );
+		} );
 	} );
 } );


### PR DESCRIPTION
Previously, we were saying "in real time" in both the AL and the credentials screen. However, if the user has a daily backup product, this is no longer accurate. This PR is fixing the wording to reflect the currently supported product/plan.

#### Changes proposed in this Pull Request

* Introduce a new `siteSupportsRealtimeBackup` selector with tests.
* Activity Log: Fix wording depending on the supported backup.
* Settings: Fix credentials wording depending on the supported backup.

#### Preview

Activity Log - with a Daily Backup product
![](https://cldup.com/yYuk3nNkjo.png)

Activity Log - with a Realtime Backup product
![](https://cldup.com/E-IV88W9MH.png)

Security Settings - with a Daily Backup product
![](https://cldup.com/GdTgj6h6K2.png)

Security Settings - with a Realtime Backup product
![](https://cldup.com/rtFCF1uVBc.png)

#### Testing instructions

* Checkout this branch.
* Create 2 JN sites and connect them. Let's call them site X and site Y.
* Buy a daily backup for site X, buy a realtime backup for site Y.
* You'll be prompted to add credentials. If you aren't, you can do it at http://calypso.localhost:3000/settings/security/:site
* Add credentials for each of the sites.
* Take a look at the credentials section. Verify it says:
  * `Your site is being backed up every day and regularly scanned for security threats.` for site X.
  * `Your site is being backed up in real time and regularly scanned for security threats.` for site Y.
* Go to Activity: http://calypso.localhost:3000/activity-log/:site
* Take a look at the top nudge, verify it ends with:
  * `...After this initial backup, we'll save future changes every day.`
  * `...After this initial backup, we'll save future changes in real time.`
* Verify tests pass: `npm run test-client client/state/selectors/test/site-supports-realtime-backup.js`

Fixes #38395
