### PR TITLE
Themes Showcase - gate incrementPage pagination 'fix' behind empty query requirement

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -68,7 +68,8 @@ class ThemesSelection extends Component {
 
 	componentDidMount() {
 		// Create "buffer zone" to prevent overscrolling too early bugging pagination requests.
-		if ( ! this.props.recommendedThemes ) {
+		const { query, recommendedThemes } = this.props;
+		if ( ! recommendedThemes && ! query.search && ! query.filter && ! query.tier ) {
 			this.props.incrementPage();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restricts changes from last weeks PR #38419 to only take place on empty query.

This empty query check makes sense in the context that the pagination bug we were fixing is primarily triggered through opening "More Themes".  Since the showcase is open by default when query params are present, we do not need this 'fix' to run when that is the case.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Navigate to themes showcase.
* Open the "more themes" section, verify pagination works as expected on scrolling.
* Search a specific theme name like 'Maywood'
* Click to view info.
* Click "back" to return to the showcase.
* Verify the showcase is not blinking and acting 'crazy'

Fixes #38478