### PR TITLE
composite-checkout: Inject country selection menu

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -283,10 +283,15 @@ function CountrySelectMenu( {
 	errorMessage,
 	currentValue,
 	countriesList,
+	selectorIdPrefix,
 } ) {
-	const countrySelectorId = 'country-selector';
-	const countrySelectorLabelId = 'country-selector-label';
-	const countrySelectorDescriptionId = 'country-selector-description';
+    const idPrefix = selectorIdPrefix
+        ? selectorIdPrefix + '__country-selector'
+        : 'country-selector';
+
+	const countrySelectorId = idPrefix;
+	const countrySelectorLabelId = idPrefix + '-label';
+	const countrySelectorDescriptionId = idPrefix + '-description';
 
 	return (
 		<FormFieldAnnotation


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Inject Calypso's country selection form field into composite checkout and use it in the billing details component.

<img width="554" alt="Screen Shot 2020-01-15 at 4 24 23 PM" src="https://user-images.githubusercontent.com/2036909/72473069-e2aec680-37b3-11ea-8c41-2b216fd471c7.png">

#### Testing instructions

* Sandbox the store.
* Start local calypso with composite checkout enabled: `ENABLE_FEATURES=composite-checkout-wpcom npm start`
* Complete the form.
* Test the behavior of the country field (drop down menu, populated with country names).
* Complete the purchase and verify that the receipt is correct.
* Repeat the above test with a .live domain.
