### PR TITLE
Purchases: Add print media query for receipts

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -427,6 +427,10 @@ textarea.billing-history__billing-details-editable {
 		padding: 0;
 		margin: 0;
 	}
+
+	body {
+		font-family: -apple-system, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	}
 }
 
 .billing-history__transactions-header-select-dropdown {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `BlinkMacSystemFont` from the list of fonts on the body when printing. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Using Chrome browser:
1. Go to Me > Manage Purchases > Billing History
2. Pick a recent purchase and click on “View Receipt”
3. Click on 'Print Receipt'.  Without this patch you should see strange characters all over the page, with the fix applied you should see the nicely formatted receipt.

Fixes #37549 
