### PR TITLE
Remove "New" badge from Earn link in sidebar

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -63,7 +63,6 @@ import {
 	SIDEBAR_SECTION_MANAGE,
 } from './constants';
 import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosting';
-import Badge from 'components/badge';
 /**
  * Style dependencies
  */
@@ -229,9 +228,7 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackEarnClick }
 				tipTarget="earn"
 				expandSection={ this.expandToolsSection }
-			>
-				<Badge type="info">{ translate( 'New' ) }</Badge>
-			</SidebarItem>
+			/>
 		);
 	}
 


### PR DESCRIPTION
Based on feedback from @artpi [this badge is no longer needed](https://github.com/Automattic/wp-calypso/pull/38440#issuecomment-566457633).

**Before**

![before](https://user-images.githubusercontent.com/5634774/71027935-4624d600-20da-11ea-8747-1d0042bf1862.png)

**After**

![after](https://user-images.githubusercontent.com/5634774/71027850-137add80-20da-11ea-81f8-68f5898a014f.png)

Fixes #38293

Removes the need for #38440 (cc @Aurorum)
