### PR TITLE
composite-checkout: Add form status

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -42,11 +42,16 @@ export function CompositeCheckout( {
 	showInfoMessage,
 	showSuccessMessage,
 } ) {
-	const { items, tax, total, removeItem, addItem, changePlanLength, errors } = useShoppingCart(
-		siteSlug,
-		setCart,
-		getCart
-	);
+	const {
+		items,
+		tax,
+		total,
+		removeItem,
+		addItem,
+		changePlanLength,
+		errors,
+		isLoading,
+	} = useShoppingCart( siteSlug, setCart, getCart );
 	const { registerStore } = registry;
 	useWpcomStore( registerStore );
 
@@ -74,6 +79,7 @@ export function CompositeCheckout( {
 			failureRedirectUrl={ failureRedirectUrl }
 			paymentMethods={ availablePaymentMethods }
 			registry={ registry }
+			isLoading={ isLoading }
 		>
 			<WPCheckout
 				removeItem={ removeItem }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -58,8 +58,6 @@ export function CompositeCheckout( {
 	const errorMessages = useMemo( () => errors.map( error => error.message ), [ errors ] );
 	useDisplayErrors( errorMessages, showErrorMessage );
 
-	// TODO: record stats
-
 	useAddProductToCart( planSlug, isJetpackNotAtomic, addItem );
 
 	const itemsForCheckout = items.length ? [ ...items, tax ] : [];

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -34,6 +34,7 @@ const debug = debugFactory( 'composite-checkout-wpcom:shopping-cart-manager' );
  *     * removeItem: callback for removing an item from the cart
  */
 export interface ShoppingCartManager {
+	isLoading: boolean;
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem;
 	total: CheckoutCartTotal;
@@ -197,6 +198,7 @@ export function useShoppingCart(
 	};
 
 	return {
+		isLoading: cacheStatus === 'fresh',
 		items: cart.items,
 		tax: cart.tax,
 		total: cart.total,

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -110,6 +110,18 @@ Each payment method is an object with the following properties:
 
 Within the components, the Hook `usePaymentMethod()` will return an object of the above form with the key of the currently selected payment method or null if none is selected. To retrieve all the payment methods and their properties, the Hook `useAllPaymentMethods()` will return an array that contains them all.
 
+## Line Items
+
+Each item is an object with the following properties:
+
+- `id: string`. A unique identifier for this line item within the array of line items. Do not use the product id; never assume that only one instance of a particular product is present.
+- `type: string`. Not used internally but can be used to organize line items (eg: `tax` for a VAT line item).
+- `label: string`. The displayed title of the line item.
+- `subLabel?: string`. An optional subtitle for the line item.
+- `amount: { currency: string, value: number, displayValue: string }`. The price of the line item. For line items without a price, set value to 0 and displayValue to an empty string.
+
+The `displayValue` property can use limited Markdown formatting, including the `~~` characters for strike-through text. When rendering `displayValue`, the property should be passed through the `renderDisplayValueMarkdown()` helper.
+
 ## Data Stores
 
 Each Payment Method or component can create a Redux-like data store by using the `registerStore` function. Code can then access that data by using `dispatch`, `select`, and `subscribe`. These functions can be accessed by calling the `useRegistry` hook. Components can most easily use the data with the `useDispatch` and `useSelect` hooks. Read the [@wordpress/data](https://wordpress.org/gutenberg/handbook/packages/packages-data/) docs to learn more about the details of this system.
@@ -144,33 +156,22 @@ Renders its `children` prop and acts as a React Context provider. All of checkou
 
 It has the following props.
 
-- locale: string (required)
-- items: array (required)
-- total: object (required)
-- theme: object (optional)
-- onPaymentComplete: function (required)
-- showErrorMessage: function (required)
-- showInfoMessage: function (required)
-- showSuccessMessage: function (required)
-- onEvent: function
-- successRedirectUrl: string (required)
-- failureRedirectUrl: string (required)
-- paymentMethods: array (required)
-- registry: object (optional)
-
-The line items must be passed to `Checkout` using the required `items` array prop. Each item is an object of the form `{ label: string, subLabel: string, id: string, type: string, amount: { currency: string, value: int, displayValue: string } }`. All the properties are required except for `subLabel`, and `id` must be unique. The `type` property is not used internally but can be used to organize the line items.
-
-If any event in the form causes the line items to change (for example, deleting something during the review step), the `items` array should not be mutated. It is incumbent on the parent component to create a modified line item list and then update `Checkout`.
+- `locale: string`. A [BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
+- `items: object[]`. An array of [line item objects](#line-items) that will be displayed in the form.
+- `total: object`. A [line item object](#line-items) with the final total to be paid.
+- `theme?: object`. A [theme object](#styles-and-themes).
+- `onPaymentComplete: () => null`. A function to call for non-redirect payment methods when payment is successful.
+- `showErrorMessage: (string) => null`. A function that will display a message with an "error" type.
+- `showInfoMessage: (string) => null`. A function that will display a message with an "info" type.
+- `showSuccessMessage: (string) => null`. A function that will display a message with a "success" type.
+- `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
+- `successRedirectUrl: string`. The url to load if using a redirect payment method and it succeeds.
+- `failureRedirectUrl: string`. The url to load if using a redirect payment method and it fails.
+- `paymentMethods: object[]`: An array of [Payment Method objects](#payment-methods).
+- `registry?: object`. An object returned by [createRegistry](#createRegistry). If not provided, a default registry will be created.
+- `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder.
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
-
-The `displayValue` property of both the items and the total can use limited Markdown formatting, including the `~~` characters for strike-through text. If customizing this component, the property should be passed through the `renderDisplayValueMarkdown()` helper.
-
-`paymentMethods` is an array of Payment Method objects.
-
-`registry` is an object returned by `createRegistry`. If not provided, a default registry will be created.
-
-`onEvent` is an optional callback that will be called for all sorts of events in the code and can be used for all sorts of things. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action) which will always be an object that has at least the `type` property and possibly also the `payload` property.
 
 ### CheckoutReviewOrder
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -14,7 +14,6 @@ import {
 	createStripeMethod,
 	createPayPalMethod,
 	createApplePayMethod,
-	createCreditCardMethod,
 	useIsStepActive,
 	usePaymentData,
 	getDefaultPaymentMethodStep,
@@ -93,8 +92,6 @@ const stripeMethod = createStripeMethod( {
 	fetchStripeConfiguration,
 	sendStripeTransaction,
 } );
-
-const creditCardMethod = createCreditCardMethod();
 
 const applePayMethod = isApplePayAvailable()
 	? createApplePayMethod( {
@@ -315,9 +312,7 @@ function MyCheckout() {
 			failureRedirectUrl={ failureRedirectUrl }
 			registry={ registry }
 			isLoading={ isLoading }
-			paymentMethods={ [ applePayMethod, creditCardMethod, stripeMethod, paypalMethod ].filter(
-				Boolean
-			) }
+			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
 		>
 			<Checkout steps={ steps } />
 		</CheckoutProvider>

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -295,6 +295,12 @@ function MyCheckout() {
 	}, [] );
 	const total = useMemo( () => getTotal( items ), [ items ] );
 
+	// This simulates loading the data
+	const [ isLoading, setIsLoading ] = useState( true );
+	useEffect( () => {
+		setTimeout( () => setIsLoading( false ), 1500 );
+	}, [] );
+
 	return (
 		<CheckoutProvider
 			locale={ 'en' }
@@ -308,6 +314,7 @@ function MyCheckout() {
 			successRedirectUrl={ successRedirectUrl }
 			failureRedirectUrl={ failureRedirectUrl }
 			registry={ registry }
+			isLoading={ isLoading }
 			paymentMethods={ [ applePayMethod, creditCardMethod, stripeMethod, paypalMethod ].filter(
 				Boolean
 			) }

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -74,8 +74,8 @@ async function sendStripeTransaction( data ) {
 	};
 }
 
-async function makePayPalExpressRequest() {
-	// return this.wpcom.req.post( '/me/paypal-express-url', data );
+async function makePayPalExpressRequest( data ) {
+	window.console.log( 'Processing paypal transaction with data', data );
 	return window.location.href;
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -46,22 +46,7 @@ export const CheckoutProvider = props => {
 		paymentMethods ? paymentMethods[ 0 ].id : null
 	);
 
-	const [ formStatus, dispatchFormStatus ] = useReducer(
-		formStatusReducer,
-		isLoading ? 'loading' : 'ready'
-	);
-	const setFormStatus = useCallback( payload => {
-		if ( typeof payload === 'function' ) {
-			return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE_WITH_FUNCTION', payload } );
-		}
-		return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE', payload } );
-	}, [] );
-	useEffect( () => {
-		const newStatus = isLoading ? 'loading' : 'ready';
-		debug( `isLoading has changed to ${ isLoading }; setting form status to ${ newStatus }` );
-		setFormStatus( newStatus );
-	}, [ isLoading, setFormStatus ] );
-	debug( `form status is ${ formStatus }` );
+	const [ formStatus, setFormStatus ] = useFormStatusManager( isLoading );
 
 	// Remove undefined and duplicate CheckoutWrapper properties
 	const wrappers = [
@@ -199,6 +184,26 @@ export const useCheckoutRedirects = () => {
 
 export function useFormStatus() {
 	const { formStatus, setFormStatus } = useContext( CheckoutContext );
+	return [ formStatus, setFormStatus ];
+}
+
+function useFormStatusManager( isLoading ) {
+	const [ formStatus, dispatchFormStatus ] = useReducer(
+		formStatusReducer,
+		isLoading ? 'loading' : 'ready'
+	);
+	const setFormStatus = useCallback( payload => {
+		if ( typeof payload === 'function' ) {
+			return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE_WITH_FUNCTION', payload } );
+		}
+		return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE', payload } );
+	}, [] );
+	useEffect( () => {
+		const newStatus = isLoading ? 'loading' : 'ready';
+		debug( `isLoading has changed to ${ isLoading }; setting form status to ${ newStatus }` );
+		setFormStatus( newStatus );
+	}, [ isLoading, setFormStatus ] );
+	debug( `form status is ${ formStatus }` );
 	return [ formStatus, setFormStatus ];
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useContext, useEffect, useState, useRef } from 'react';
+import React, { useReducer, useCallback, useContext, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
@@ -46,17 +46,15 @@ export const CheckoutProvider = props => {
 		paymentMethods ? paymentMethods[ 0 ].id : null
 	);
 
-	const [ formStatus, setFormStatusActual ] = useState( isLoading ? 'loading' : 'ready' );
-	const setFormStatus = useCallback( value => {
-		if ( typeof value === 'function' ) {
-			return setFormStatusActual( currentValue => {
-				const newValue = value( currentValue );
-				debug( 'setting form status to', newValue );
-				return newValue;
-			} );
+	const [ formStatus, dispatchFormStatus ] = useReducer(
+		formStatusReducer,
+		isLoading ? 'loading' : 'ready'
+	);
+	const setFormStatus = useCallback( payload => {
+		if ( typeof payload === 'function' ) {
+			return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE_WITH_FUNCTION', payload } );
 		}
-		debug( 'setting form status', value );
-		return setFormStatusActual( value );
+		return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE', payload } );
 	}, [] );
 	useEffect( () => {
 		const newStatus = isLoading ? 'loading' : 'ready';
@@ -202,4 +200,28 @@ export const useCheckoutRedirects = () => {
 export function useFormStatus() {
 	const { formStatus, setFormStatus } = useContext( CheckoutContext );
 	return [ formStatus, setFormStatus ];
+}
+
+function formStatusReducer( state, action ) {
+	switch ( action.type ) {
+		case 'FORM_STATUS_CHANGE':
+			validateStatus( action.payload );
+			debug( 'setting form status to', action.payload );
+			return action.payload;
+		case 'FORM_STATUS_CHANGE_WITH_FUNCTION': {
+			const newStatus = action.payload( state );
+			validateStatus( newStatus );
+			debug( 'setting form status to', newStatus );
+			return newStatus;
+		}
+		default:
+			return state;
+	}
+}
+
+function validateStatus( status ) {
+	const validStatuses = [ 'loading', 'ready', 'submitting' ];
+	if ( ! validStatuses.includes( status ) ) {
+		throw new Error( `Invalid form status '${ status }'` );
+	}
 }

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -69,7 +69,7 @@ export const CheckoutProvider = props => {
 		showSuccessMessage,
 		successRedirectUrl,
 		failureRedirectUrl,
-		onEvent,
+		onEvent: onEvent || ( () => {} ),
 		formStatus,
 		setFormStatus,
 	};

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useContext, useState, useRef } from 'react';
+import React, { useContext, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
@@ -39,11 +39,20 @@ export const CheckoutProvider = props => {
 		paymentMethods,
 		registry,
 		onEvent,
+		isLoading,
 		children,
 	} = props;
 	const [ paymentMethodId, setPaymentMethodId ] = useState(
 		paymentMethods ? paymentMethods[ 0 ].id : null
 	);
+
+	const [ formStatus, setFormStatus ] = useState( isLoading ? 'loading' : 'ready' );
+	useEffect( () => {
+		const newStatus = isLoading ? 'loading' : 'ready';
+		debug( `isLoading has changed to ${ isLoading }; setting form status to ${ newStatus }` );
+		setFormStatus( newStatus );
+	}, [ isLoading ] );
+	debug( `form status is ${ formStatus }` );
 
 	// Remove undefined and duplicate CheckoutWrapper properties
 	const wrappers = [
@@ -66,6 +75,8 @@ export const CheckoutProvider = props => {
 		successRedirectUrl,
 		failureRedirectUrl,
 		onEvent,
+		formStatus,
+		setFormStatus,
 	};
 
 	// This error message cannot be translated because translation hasn't loaded yet.
@@ -105,6 +116,7 @@ CheckoutProvider.propTypes = {
 	successRedirectUrl: PropTypes.string.isRequired,
 	failureRedirectUrl: PropTypes.string.isRequired,
 	onEvent: PropTypes.func,
+	isLoading: PropTypes.bool,
 };
 
 function CheckoutProviderPropValidator( { propsToValidate } ) {
@@ -175,3 +187,8 @@ export const useCheckoutRedirects = () => {
 	}
 	return { successRedirectUrl, failureRedirectUrl };
 };
+
+export function useFormStatus() {
+	const { formStatus, setFormStatus } = useContext( CheckoutContext );
+	return [ formStatus, setFormStatus ];
+}

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useContext, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useContext, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
@@ -46,12 +46,23 @@ export const CheckoutProvider = props => {
 		paymentMethods ? paymentMethods[ 0 ].id : null
 	);
 
-	const [ formStatus, setFormStatus ] = useState( isLoading ? 'loading' : 'ready' );
+	const [ formStatus, setFormStatusActual ] = useState( isLoading ? 'loading' : 'ready' );
+	const setFormStatus = useCallback( value => {
+		if ( typeof value === 'function' ) {
+			return setFormStatusActual( currentValue => {
+				const newValue = value( currentValue );
+				debug( 'setting form status to', newValue );
+				return newValue;
+			} );
+		}
+		debug( 'setting form status', value );
+		return setFormStatusActual( value );
+	}, [] );
 	useEffect( () => {
 		const newStatus = isLoading ? 'loading' : 'ready';
 		debug( `isLoading has changed to ${ isLoading }; setting form status to ${ newStatus }` );
 		setFormStatus( newStatus );
-	}, [ isLoading ] );
+	}, [ isLoading, setFormStatus ] );
 	debug( `form status is ${ formStatus }` );
 
 	// Remove undefined and duplicate CheckoutWrapper properties

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -62,7 +62,7 @@ function useRegisterCheckoutStore() {
 		},
 		controls: {
 			STEP_NUMBER_CHANGE_EVENT( action ) {
-				onEvent && onEvent( action );
+				onEvent( action );
 				saveStepNumberToUrl( action.payload );
 			},
 		},

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -31,7 +31,8 @@ import {
 	getDefaultOrderReviewStep,
 } from './default-steps';
 import { validateSteps } from '../lib/validation';
-import { useEvents, useFormStatus } from './checkout-provider';
+import { useEvents } from './checkout-provider';
+import { useFormStatus } from '../lib/form-status';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -130,7 +130,8 @@ export default function Checkout( { steps, className } ) {
 	} );
 	const isThereAnotherNumberedStep = !! nextStep && nextStep.hasStepNumber;
 	const isThereAnIncompleteStep = !! annotatedSteps.find( step => ! step.isComplete );
-	const isCheckoutInProgress = isThereAnIncompleteStep || isThereAnotherNumberedStep;
+	const isCheckoutInProgress =
+		isThereAnIncompleteStep || isThereAnotherNumberedStep || formStatus !== 'ready';
 
 	if ( formStatus === 'loading' ) {
 		return (

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -14,6 +14,7 @@ import { useLocalize, sprintf } from '../lib/localize';
 import CheckoutStep from './checkout-step';
 import CheckoutNextStepButton from './checkout-next-step-button';
 import CheckoutSubmitButton from './checkout-submit-button';
+import LoadingContent from './loading-content';
 import {
 	usePrimarySelect,
 	usePrimaryDispatch,
@@ -30,7 +31,7 @@ import {
 	getDefaultOrderReviewStep,
 } from './default-steps';
 import { validateSteps } from '../lib/validation';
-import { useEvents } from './checkout-provider';
+import { useEvents, useFormStatus } from './checkout-provider';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 
@@ -80,6 +81,7 @@ export default function Checkout( { steps, className } ) {
 	const localize = useLocalize();
 	const [ paymentData ] = usePaymentData();
 	const activePaymentMethod = usePaymentMethod();
+	const [ formStatus ] = useFormStatus();
 
 	// Re-render if any store changes; that way isComplete can rely on any data
 	useRenderOnStoreUpdate();
@@ -129,6 +131,19 @@ export default function Checkout( { steps, className } ) {
 	const isThereAnotherNumberedStep = !! nextStep && nextStep.hasStepNumber;
 	const isThereAnIncompleteStep = !! annotatedSteps.find( step => ! step.isComplete );
 	const isCheckoutInProgress = isThereAnIncompleteStep || isThereAnotherNumberedStep;
+
+	if ( formStatus === 'loading' ) {
+		return (
+			<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
+				<MainContent
+					className={ joinClasses( [ className, 'checkout__content' ] ) }
+					isCheckoutInProgress={ isCheckoutInProgress }
+				>
+					<LoadingContent />
+				</MainContent>
+			</Container>
+		);
+	}
 
 	return (
 		<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>

--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function LoadingContent() {
+	// TODO: fill this in and style it
+	return <div>Loading...</div>;
+}

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 
 /**
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
  */
 import { useLocalize } from '../lib/localize';
 import Button from './button';
+import { useFormStatus } from '../lib/form-status';
 
 // The react-stripe-elements PaymentRequestButtonElement cannot have its
 // paymentRequest updated once it has been rendered, so this is a custom one.
@@ -21,19 +22,19 @@ export default function PaymentRequestButton( {
 	disabledReason,
 } ) {
 	const localize = useLocalize();
-	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ formStatus, setFormStatus ] = useFormStatus();
 	const onClick = event => {
 		event.persist();
 		event.preventDefault();
-		setIsSubmitting( true );
-		paymentRequest.on( 'cancel', () => setIsSubmitting( false ) );
+		setFormStatus( 'submitting' );
+		paymentRequest.on( 'cancel', () => setFormStatus( 'ready' ) );
 		paymentRequest.show();
 	};
 	if ( ! paymentRequest ) {
 		disabled = true;
 	}
 
-	if ( isSubmitting ) {
+	if ( formStatus === 'submitting' ) {
 		return (
 			<Button disabled fullWidth>
 				{ localize( 'Completing your purchase', { context: 'Loading state on /checkout' } ) }

--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { useReducer, useCallback, useContext, useEffect } from 'react';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import CheckoutContext from '../lib/checkout-context';
+
+const debug = debugFactory( 'composite-checkout:form-status' );
+
+export function useFormStatus() {
+	const { formStatus, setFormStatus } = useContext( CheckoutContext );
+	return [ formStatus, setFormStatus ];
+}
+
+export function useFormStatusManager( isLoading ) {
+	const [ formStatus, dispatchFormStatus ] = useReducer(
+		formStatusReducer,
+		isLoading ? 'loading' : 'ready'
+	);
+	const setFormStatus = useCallback( payload => {
+		if ( typeof payload === 'function' ) {
+			return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE_WITH_FUNCTION', payload } );
+		}
+		return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE', payload } );
+	}, [] );
+	useEffect( () => {
+		const newStatus = isLoading ? 'loading' : 'ready';
+		debug( `isLoading has changed to ${ isLoading }; setting form status to ${ newStatus }` );
+		setFormStatus( newStatus );
+	}, [ isLoading, setFormStatus ] );
+	debug( `form status is ${ formStatus }` );
+	return [ formStatus, setFormStatus ];
+}
+
+function formStatusReducer( state, action ) {
+	switch ( action.type ) {
+		case 'FORM_STATUS_CHANGE':
+			validateStatus( action.payload );
+			debug( 'setting form status to', action.payload );
+			return action.payload;
+		case 'FORM_STATUS_CHANGE_WITH_FUNCTION': {
+			const newStatus = action.payload( state );
+			validateStatus( newStatus );
+			debug( 'setting form status to', newStatus );
+			return newStatus;
+		}
+		default:
+			return state;
+	}
+}
+
+function validateStatus( status ) {
+	const validStatuses = [ 'loading', 'ready', 'submitting' ];
+	if ( ! validStatuses.includes( status ) ) {
+		throw new Error( `Invalid form status '${ status }'` );
+	}
+}

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -16,7 +16,7 @@ import {
 	useCheckoutRedirects,
 	useLineItems,
 } from '../../public-api';
-import { useFormStatus } from '../../components/checkout-provider';
+import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 export function createPayPalMethod( { registerStore, makePayPalExpressRequest } ) {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -43,7 +43,7 @@ import { SummaryLine, SummaryDetails } from '../styled-components/summary-detail
 import CreditCardFields, { CVVImage } from './credit-card-fields';
 import Spinner from '../../components/spinner';
 import ErrorMessage from '../../components/error-message';
-import { useFormStatus } from '../../components/checkout-provider';
+import { useFormStatus } from '../form-status';
 
 export function createStripeMethod( {
 	getSiteId,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -43,6 +43,7 @@ import { SummaryLine, SummaryDetails } from '../styled-components/summary-detail
 import CreditCardFields, { CVVImage } from './credit-card-fields';
 import Spinner from '../../components/spinner';
 import ErrorMessage from '../../components/error-message';
+import { useFormStatus } from '../../components/checkout-provider';
 
 export function createStripeMethod( {
 	getSiteId,
@@ -617,6 +618,7 @@ function StripePayButton( { disabled } ) {
 	const transactionAuthData = useSelect( select => select( 'stripe' ).getTransactionAuthData() );
 	const { beginStripeTransaction } = useDispatch( 'stripe' );
 	const name = useSelect( select => select( 'stripe' ).getCardholderName() );
+	const [ formStatus, setFormStatus ] = useFormStatus();
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
@@ -649,10 +651,10 @@ function StripePayButton( { disabled } ) {
 		localize,
 	] );
 
-	const buttonString = sprintf(
-		localize( 'Pay %s' ),
-		renderDisplayValueMarkdown( total.amount.displayValue )
-	);
+	const buttonString =
+		formStatus === 'submitting'
+			? localize( 'Processing...' )
+			: sprintf( localize( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
 	return (
 		<Button
 			disabled={ disabled }
@@ -667,6 +669,7 @@ function StripePayButton( { disabled } ) {
 					successUrl: successRedirectUrl,
 					cancelUrl: failureRedirectUrl,
 					beginStripeTransaction,
+					setFormStatus,
 				} )
 			}
 			buttonState={ disabled ? 'disabled' : 'primary' }
@@ -701,8 +704,10 @@ async function submitStripePayment( {
 	successUrl,
 	cancelUrl,
 	beginStripeTransaction,
+	setFormStatus,
 } ) {
 	try {
+		setFormStatus( 'submitting' );
 		beginStripeTransaction( {
 			stripe,
 			name,
@@ -713,6 +718,7 @@ async function submitStripePayment( {
 			cancelUrl,
 		} );
 	} catch ( error ) {
+		setFormStatus( 'ready' );
 		showErrorMessage( error );
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new state to the checkout form which keeps the current "form status", which is one of `loading`, `ready`, or `submitting`. That status is then used to replace the form with a loading indicator, to display the form normally, or to display a disabled form that reads "Processing..." respectively.

Note: Right now the loading state looks quite poor. This will be replaced in a future PR (cc @fditrapani).

#### Testing instructions

- Run `npm run composite-checkout-demo`.
- Visit the demo form and verify that it shows a loading state for 1.5 seconds before displaying the form.
- Choose the credit card payment method. Fill out the form using the Stripe test card `4242 4242 4242 4242`. Press the "Pay" button. Verify that the button becomes disabled and now reads "Processing".
- Reload the form and repeat the last step with the PayPal payment method.
- Reload the form and repeat the last step with the Apple Pay payment method. This will require setting up https locally and then disabling the `canMakePayment` guard on line 95 of `packages/composite-checkout/src/lib/payment-methods/apple-pay.js`.