### PR TITLE
Creates Product Expiration component

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -5,7 +5,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
-import { find, findKey, flowRight as compose, includes, isEmpty, map, invoke } from 'lodash';
+import { find, findKey, flowRight as compose, includes, isEmpty, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -19,6 +19,7 @@ import ProductCardOptions from 'components/product-card/options';
 import ProductCardPromoNudge from 'components/product-card/promo-nudge';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
+import ProductExpiration from 'components/product-expiration';
 import { extractProductSlugs, filterByProductSlugs } from './utils';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -176,22 +177,14 @@ export class ProductSelector extends Component {
 			return null;
 		}
 
-		if ( purchase.autoRenew && purchase.autoRenewDateMoment ) {
-			return translate( 'Set to auto-renew on %s.', {
-				args: invoke( purchase, 'autoRenewDateMoment.format', 'LL' ),
-			} );
-		}
-
-		// Show purchase date if still refundable.
-		if ( purchase.isRefundable && purchase.subscribedMoment ) {
-			return translate( 'Purchased on %s.', {
-				args: invoke( purchase, 'subscribedMoment.format', 'LL' ),
-			} );
-		}
-
-		return translate( 'Expires on %s.', {
-			args: invoke( purchase, 'expiryMoment.format', 'LL' ),
-		} );
+		return (
+			<ProductExpiration
+				expiryDateMoment={ purchase.expiryMoment }
+				purchaseDateMoment={ purchase.subscribedMoment }
+				isRefundable={ purchase.isRefundable }
+				translate={ translate }
+			/>
+		);
 	}
 
 	getDescriptionByProduct( product ) {

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -182,7 +182,6 @@ export class ProductSelector extends Component {
 				expiryDateMoment={ purchase.expiryMoment }
 				purchaseDateMoment={ purchase.subscribedMoment }
 				isRefundable={ purchase.isRefundable }
-				translate={ translate }
 			/>
 		);
 	}

--- a/client/components/product-expiration/README.md
+++ b/client/components/product-expiration/README.md
@@ -1,0 +1,30 @@
+Product Expiration
+==================
+
+`ProductExpiration` is a React component designed to display a product's expiration or renewal dates in a consistent way to users.
+
+At minimum, it requires an expiry date to display when the product will renew.
+
+### Properties
+
+#### `dateFormat { string } - default 'LL'`
+This controls the formatting of the date format, which is passed to a localized `moment.format`.
+
+#### `expiryDateMoment { moment }`
+This is the expiration date as a `moment` instance, and is required for display.
+
+#### `isRefundable { boolean } - default false`
+Controls whether the product is currently in the refund window, which changes the display to the purchase date, if provided.
+
+#### `purchaseDateMoment { moment } - optional`
+Optional purchase date, used only when `isRefundable` provided.
+
+### `ProductExpiration` Usage
+
+```jsx
+const expiryDateMoment = moment( product.expiry );
+<ProductExpiration
+	expiryDateMoment={ expiryDateMoment }
+	isRefundable={ product.isRefundable }
+/>
+```

--- a/client/components/product-expiration/README.md
+++ b/client/components/product-expiration/README.md
@@ -19,7 +19,7 @@ Controls whether the product is currently in the refund window, which changes th
 #### `purchaseDateMoment { moment } - optional`
 Optional purchase date, used only when `isRefundable` provided.
 
-### `ProductExpiration` Usage
+### Usage
 
 ```jsx
 const expiryDateMoment = moment( product.expiry );

--- a/client/components/product-expiration/docs/example.tsx
+++ b/client/components/product-expiration/docs/example.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import ProductExpiration from '../index';
+
+function ProductExpirationExample() {
+	return (
+		<>
+			<h3>Product still refundable</h3>
+			<p>
+				<ProductExpiration
+					purchaseDateMoment={ moment() }
+					expiryDateMoment={ moment() }
+					isRefundable
+				/>
+			</p>
+			<h3>Product previously expired</h3>
+			<p>
+				<ProductExpiration expiryDateMoment={ moment( new Date( 0 ) ) } />
+			</p>
+			<h3>Product subscription expires in future</h3>
+			<p>
+				<ProductExpiration expiryDateMoment={ moment().add( 1, 'day' ) } />
+			</p>
+		</>
+	);
+}
+ProductExpirationExample.displayName = 'ProductExpiration';
+
+export default ProductExpirationExample;

--- a/client/components/product-expiration/docs/example.tsx
+++ b/client/components/product-expiration/docs/example.tsx
@@ -13,21 +13,30 @@ import ProductExpiration from '../index';
 function ProductExpirationExample() {
 	return (
 		<>
-			<h3>Product still refundable</h3>
 			<p>
-				<ProductExpiration
-					purchaseDateMoment={ moment() }
-					expiryDateMoment={ moment() }
-					isRefundable
-				/>
+				Product still refundable:
+				<br />
+				<em>
+					<ProductExpiration
+						purchaseDateMoment={ moment() }
+						expiryDateMoment={ moment() }
+						isRefundable
+					/>
+				</em>
 			</p>
-			<h3>Product previously expired</h3>
 			<p>
-				<ProductExpiration expiryDateMoment={ moment( new Date( 0 ) ) } />
+				Product previously expired:
+				<br />
+				<em>
+					<ProductExpiration expiryDateMoment={ moment( new Date( 0 ) ) } />
+				</em>
 			</p>
-			<h3>Product subscription expires in future</h3>
 			<p>
-				<ProductExpiration expiryDateMoment={ moment().add( 1, 'day' ) } />
+				Product subscription expires in future:
+				<br />
+				<em>
+					<ProductExpiration expiryDateMoment={ moment().add( 1, 'day' ) } />
+				</em>
 			</p>
 		</>
 	);

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -4,33 +4,33 @@
 import React from 'react';
 
 interface Moment {
+	diff: ( date: Date ) => number;
+	format: ( dateFormat: string ) => string;
 	isValid: () => boolean;
-	format: ( arg0: string ) => string;
-	diff: ( arg0: Date ) => number;
 }
 
-export interface Props {
-	expiryDateMoment: Moment;
-	purchaseDateMoment: Moment;
-	isRefundable: boolean;
+interface Props {
 	dateFormat: string;
+	expiryDateMoment: Moment;
+	isRefundable: boolean;
+	purchaseDateMoment: Moment;
 	translate: ( arg0: string, arg1: object ) => string;
 }
 
 class ProductExpiration extends React.PureComponent< Props > {
 	static defaultProps = {
-		expiryDateMoment: null,
-		purchaseDateMoment: null,
-		isRefundable: false,
 		dateFormat: 'LL',
+		expiryDateMoment: null,
+		isRefundable: false,
+		purchaseDateMoment: null,
 	};
 
 	render() {
 		const {
-			expiryDateMoment,
-			purchaseDateMoment,
-			isRefundable,
 			dateFormat,
+			expiryDateMoment,
+			isRefundable,
+			purchaseDateMoment,
 			translate,
 		} = this.props;
 

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -2,19 +2,15 @@
  * External dependencies
  */
 import React from 'react';
-
-interface Moment {
-	diff: ( date: Date ) => number;
-	format: ( dateFormat: string ) => string;
-	isValid: () => boolean;
-}
+import { translate as translateType } from 'i18n-calypso/types';
+import { Moment } from 'moment';
 
 interface Props {
 	dateFormat: string;
 	expiryDateMoment: Moment;
 	isRefundable: boolean;
 	purchaseDateMoment: Moment;
-	translate: ( arg0: string, arg1: object ) => string;
+	translate: typeof translateType;
 }
 
 class ProductExpiration extends React.PureComponent< Props > {

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -35,7 +35,7 @@ export class ProductExpiration extends React.PureComponent< Props > {
 		// Return the subscription date if we don't have the expiry date or the plan is refundable.
 		if ( ! expiryDateMoment || isRefundable ) {
 			if ( purchaseDateMoment && purchaseDateMoment.isValid() ) {
-				return translate( 'Purchased on %s.', { args: purchaseDateMoment.format( dateFormat ) } );
+				return translate( 'Purchased on %s', { args: purchaseDateMoment.format( dateFormat ) } );
 			}
 			return null;
 		}
@@ -47,11 +47,11 @@ export class ProductExpiration extends React.PureComponent< Props > {
 
 		// If the expiry date is in the past, show the expiration date.
 		if ( expiryDateMoment.diff( new Date() ) < 0 ) {
-			return translate( 'Expired on %s.', { args: expiryDateMoment.format( dateFormat ) } );
+			return translate( 'Expired on %s', { args: expiryDateMoment.format( dateFormat ) } );
 		}
 
 		// Lastly, return the renewal date.
-		return translate( 'Renews on %s.', { args: expiryDateMoment.format( dateFormat ) } );
+		return translate( 'Renews on %s', { args: expiryDateMoment.format( dateFormat ) } );
 	}
 }
 

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+interface Moment {
+	isValid: () => boolean;
+	format: ( arg0: string ) => string;
+	diff: ( arg0: Date ) => number;
+}
+
+export interface Props {
+	expiryDateMoment: Moment;
+	purchaseDateMoment: Moment;
+	isRefundable: boolean;
+	dateFormat: string;
+	translate: ( arg0: string, arg1: object ) => string;
+}
+
+class ProductExpiration extends React.PureComponent< Props > {
+	static defaultProps = {
+		expiryDateMoment: null,
+		purchaseDateMoment: null,
+		isRefundable: false,
+		dateFormat: 'LL',
+	};
+
+	render() {
+		const {
+			expiryDateMoment,
+			purchaseDateMoment,
+			isRefundable,
+			dateFormat,
+			translate,
+		} = this.props;
+
+		// Return null if we don't have any dates.
+		if ( ! expiryDateMoment && ! purchaseDateMoment ) {
+			return null;
+		}
+
+		// Return the subscription date if we don't have the expiry date or the plan is refundable.
+		if ( ! expiryDateMoment || isRefundable ) {
+			if ( purchaseDateMoment.isValid() ) {
+				return translate( 'Purchased on %s.', { args: purchaseDateMoment.format( dateFormat ) } );
+			}
+			return null;
+		}
+
+		// Return null if date is not parsable.
+		if ( ! expiryDateMoment.isValid() ) {
+			return null;
+		}
+
+		// If the expiry date is in the past, show the expiration date.
+		if ( expiryDateMoment.diff( new Date() ) < 0 ) {
+			return translate( 'Expired on %s.', { args: expiryDateMoment.format( dateFormat ) } );
+		}
+
+		// Lastly, return the renewal date.
+		return translate( 'Renews on %s.', { args: expiryDateMoment.format( dateFormat ) } );
+	}
+}
+
+export default ProductExpiration;

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -2,18 +2,17 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as translateType } from 'i18n-calypso/types';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import { Moment } from 'moment';
 
-interface Props {
+interface Props extends LocalizeProps {
 	dateFormat: string;
 	expiryDateMoment: Moment;
 	isRefundable: boolean;
 	purchaseDateMoment: Moment;
-	translate: typeof translateType;
 }
 
-class ProductExpiration extends React.PureComponent< Props > {
+export class ProductExpiration extends React.PureComponent< Props > {
 	static defaultProps = {
 		dateFormat: 'LL',
 		expiryDateMoment: null,
@@ -58,4 +57,4 @@ class ProductExpiration extends React.PureComponent< Props > {
 	}
 }
 
-export default ProductExpiration;
+export default localize( ProductExpiration );

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -6,18 +6,16 @@ import { localize, LocalizeProps } from 'i18n-calypso';
 import { Moment } from 'moment';
 
 interface Props extends LocalizeProps {
-	dateFormat: string;
+	dateFormat?: string;
 	expiryDateMoment: Moment;
-	isRefundable: boolean;
-	purchaseDateMoment: Moment;
+	isRefundable?: boolean;
+	purchaseDateMoment?: Moment;
 }
 
 export class ProductExpiration extends React.PureComponent< Props > {
 	static defaultProps = {
 		dateFormat: 'LL',
-		expiryDateMoment: null,
 		isRefundable: false,
-		purchaseDateMoment: null,
 	};
 
 	render() {
@@ -36,7 +34,7 @@ export class ProductExpiration extends React.PureComponent< Props > {
 
 		// Return the subscription date if we don't have the expiry date or the plan is refundable.
 		if ( ! expiryDateMoment || isRefundable ) {
-			if ( purchaseDateMoment.isValid() ) {
+			if ( purchaseDateMoment && purchaseDateMoment.isValid() ) {
 				return translate( 'Purchased on %s.', { args: purchaseDateMoment.format( dateFormat ) } );
 			}
 			return null;

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import ProductExpiration from '../index';
+import { translate } from 'i18n-calypso';
+
+describe( 'ProductExpiration', () => {
+	it( 'should return null if not provided dates', () => {
+		const wrapper = shallow( <ProductExpiration /> );
+		expect( wrapper.isEmptyRender() ).toEqual( true );
+	} );
+
+	it( 'should return the purchase date when refundable', () => {
+		const date = moment( new Date( 2009, 10, 10 ) );
+		const wrapper = shallow(
+			<ProductExpiration purchaseDateMoment={ date } translate={ translate } isRefundable />
+		);
+		expect( wrapper.text() ).toEqual( 'Purchased on November 10, 2009.' );
+	} );
+
+	it( 'should return the expiry date in past tense when date is in past', () => {
+		const date = moment( new Date( 2009, 10, 10 ) );
+		const wrapper = shallow(
+			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
+		);
+		expect( wrapper.text() ).toEqual( 'Expired on November 10, 2009.' );
+	} );
+
+	it( 'should return the renewal date in when the date is in the future', () => {
+		const date = moment( new Date( 2100, 10, 10 ) );
+		const wrapper = shallow(
+			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
+		);
+		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100.' );
+	} );
+
+	it( 'should return null when provided an invalid expiry date', () => {
+		const date = moment( NaN );
+		const wrapper = shallow(
+			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
+		);
+		expect( wrapper.isEmptyRender() ).toEqual( true );
+	} );
+
+	it( 'should return null when provided an invalid purchase date and no expiry date', () => {
+		const date = moment( NaN );
+		const wrapper = shallow(
+			<ProductExpiration purchaseDateMoment={ date } translate={ translate } />
+		);
+		expect( wrapper.isEmptyRender() ).toEqual( true );
+	} );
+} );

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -4,16 +4,16 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import moment from 'moment';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import ProductExpiration from '../index';
-import { translate } from 'i18n-calypso';
+import { ProductExpiration } from '../index';
 
 describe( 'ProductExpiration', () => {
 	it( 'should return null if not provided dates', () => {
-		const wrapper = shallow( <ProductExpiration /> );
+		const wrapper = shallow( <ProductExpiration translate={ translate } /> );
 		expect( wrapper.isEmptyRender() ).toEqual( true );
 	} );
 

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -22,7 +22,7 @@ describe( 'ProductExpiration', () => {
 		const wrapper = shallow(
 			<ProductExpiration purchaseDateMoment={ date } translate={ translate } isRefundable />
 		);
-		expect( wrapper.text() ).toEqual( 'Purchased on November 10, 2009.' );
+		expect( wrapper.text() ).toEqual( 'Purchased on November 10, 2009' );
 	} );
 
 	it( 'should return the expiry date in past tense when date is in past', () => {
@@ -30,7 +30,7 @@ describe( 'ProductExpiration', () => {
 		const wrapper = shallow(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( wrapper.text() ).toEqual( 'Expired on November 10, 2009.' );
+		expect( wrapper.text() ).toEqual( 'Expired on November 10, 2009' );
 	} );
 
 	it( 'should return the renewal date in when the date is in the future', () => {
@@ -38,7 +38,7 @@ describe( 'ProductExpiration', () => {
 		const wrapper = shallow(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100.' );
+		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100' );
 	} );
 
 	it( 'should return null when provided an invalid expiry date', () => {

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -90,6 +90,7 @@ import PlansSkipButton from 'components/plans/plans-skip-button/docs/example';
 import PodcastIndicator from 'components/podcast-indicator/docs/example';
 import Popovers from 'components/popover/docs/example';
 import ProductCard from 'components/product-card/docs/example';
+import ProductExpiration from 'components/product-expiration/docs/example';
 import ProductIcon from '@automattic/components/src/product-icon/docs/example';
 import ProgressBar from '@automattic/components/src/progress-bar/docs/example';
 import PromoSection from 'components/promo-section/docs/example';
@@ -257,6 +258,7 @@ class DesignAssets extends React.Component {
 					<PlansSkipButton readmeFilePath="plans/plans-skip-button" />
 					<PodcastIndicator readmeFilePath="podcast-indicator" />
 					<Popovers readmeFilePath="popover" />
+					<ProductExpiration readmeFilePath="product-expiration" />
 					<ProgressBar readmeFilePath="/packages/components/src/progress-bar" />
 					<PromoSection readmeFilePath="promo-section" />
 					<PromoCard readmeFilePath="promo-section/promo-card" />

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -72,6 +72,7 @@ function createPurchaseObject( purchase ) {
 		siteId: Number( purchase.blog_id ),
 		siteName: purchase.blogname,
 		subscribedDate: purchase.subscribed_date,
+		subscribedMoment: purchase.subscribed_date ? i18n.moment( purchase.subscribed_date ) : null,
 		subscriptionStatus: purchase.subscription_status,
 		tagLine: purchase.tag_line,
 		taxAmount: purchase.tax_amount,

--- a/client/my-sites/plans/current-plan/my-plan-card/index.jsx
+++ b/client/my-sites/plans/current-plan/my-plan-card/index.jsx
@@ -48,7 +48,7 @@ MyPlanCard.propTypes = {
 	action: PropTypes.oneOfType( [ PropTypes.node, PropTypes.element ] ),
 	isError: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
-	details: PropTypes.string,
+	details: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ),
 	product: PropTypes.string,
 	tagline: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
 	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -125,8 +125,6 @@ class PurchasesListing extends Component {
 	}
 
 	getExpirationInfo( purchase ) {
-		const { translate } = this.props;
-
 		// No expiration date for free plan or partner site.
 		if ( this.isFreePlan( purchase ) || isPartnerPurchase( purchase ) ) {
 			return null;
@@ -137,7 +135,6 @@ class PurchasesListing extends Component {
 				expiryDateMoment={ purchase.expiryMoment }
 				purchaseDateMoment={ purchase.subscribedMoment }
 				isRefundable={ purchase.isRefundable }
-				translate={ translate }
 			/>
 		);
 	}

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -138,6 +138,13 @@ class PurchasesListing extends Component {
 			} );
 		}
 
+		// Show purchase date if still refundable.
+		if ( purchase.isRefundable && purchase.subscribedMoment ) {
+			return translate( 'Purchased on %s.', {
+				args: invoke( purchase, 'subscribedMoment.format', 'LL' ),
+			} );
+		}
+
 		return translate( 'Expires on %s.', {
 			args: invoke( purchase, 'expiryMoment.format', 'LL' ),
 		} );

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -5,7 +5,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, invoke, isEmpty } from 'lodash';
+import { find, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +23,7 @@ import MyPlanCard from './my-plan-card';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
+import ProductExpiration from 'components/product-expiration';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { managePurchase } from 'me/purchases/paths';
 import { getPlan } from 'lib/plans';
@@ -131,23 +132,14 @@ class PurchasesListing extends Component {
 			return null;
 		}
 
-		// Show auto-renew information if it is enabled.
-		if ( purchase.autoRenew && purchase.autoRenewDateMoment ) {
-			return translate( 'Set to auto-renew on %s.', {
-				args: invoke( purchase, 'autoRenewDateMoment.format', 'LL' ),
-			} );
-		}
-
-		// Show purchase date if still refundable.
-		if ( purchase.isRefundable && purchase.subscribedMoment ) {
-			return translate( 'Purchased on %s.', {
-				args: invoke( purchase, 'subscribedMoment.format', 'LL' ),
-			} );
-		}
-
-		return translate( 'Expires on %s.', {
-			args: invoke( purchase, 'expiryMoment.format', 'LL' ),
-		} );
+		return (
+			<ProductExpiration
+				expiryDateMoment={ purchase.expiryMoment }
+				purchaseDateMoment={ purchase.subscribedMoment }
+				isRefundable={ purchase.isRefundable }
+				translate={ translate }
+			/>
+		);
 	}
 
 	getActionButton( purchase ) {

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -117,6 +117,7 @@ describe( 'selectors', () => {
 				renewMoment: null,
 				siteName: undefined,
 				subscribedDate: undefined,
+				subscribedMoment: null,
 				subscriptionStatus: undefined,
 				tagLine: undefined,
 				taxAmount: undefined,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Centralizes display of product expiration in component

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy JP Backup for a site
* Visit the site plan page and view product expiration
* Click on Plans and view product expiration
* Adjust product data to be refundable and watch text change

Should show purchase date when still refundable, and expiration otherwise.

Fixes 1143508703416848-as-1151698080758463

#### Screenshots

My Plan (expires)
<img width="1062" alt="Screen Shot 2019-12-17 at 1 08 38 PM" src="https://user-images.githubusercontent.com/1760168/71033121-c18b8500-20e4-11ea-9879-4efa4c8fa10d.png">

My Plan (still refundable)
<img width="1049" alt="Screen Shot 2019-12-17 at 1 07 57 PM" src="https://user-images.githubusercontent.com/1760168/71033138-c8b29300-20e4-11ea-8506-8823b957b717.png">

Plans (expires)
<img width="549" alt="Screen Shot 2019-12-17 at 1 26 12 PM" src="https://user-images.githubusercontent.com/1760168/71033400-3b237300-20e5-11ea-80ba-7863c25dea27.png">

Plans (still refundable)
<img width="561" alt="Screen Shot 2019-12-17 at 1 26 04 PM" src="https://user-images.githubusercontent.com/1760168/71033303-1929f080-20e5-11ea-9836-f06cff0c97b0.png">