### PR TITLE
WIP - Media Modal inserting temporary urls from google images

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -219,7 +219,8 @@ export class EditorMediaModal extends Component {
 			);
 			if (
 				itemsWithTransientId.length === 1 &&
-				MediaUtils.getMimePrefix( itemsWithTransientId[ 0 ] ) === 'image'
+				MediaUtils.getMimePrefix( itemsWithTransientId[ 0 ] ) === 'image' &&
+				this.state.source !== 'google_photos'
 			) {
 				this.copyExternal( itemsWithTransientId, this.state.source );
 				this.props.onClose( {
@@ -239,6 +240,10 @@ export class EditorMediaModal extends Component {
 				: undefined;
 			this.props.onClose( value );
 		}
+	};
+
+	isTransientSelected = () => {
+		return this.props.mediaLibrarySelectedItems.some( item => item.transient );
 	};
 
 	setDetailSelectedIndex = index => {
@@ -499,7 +504,9 @@ export class EditorMediaModal extends Component {
 			let label = this.props.translate( 'Insert' );
 			if (
 				selectedItems.length > 1 ||
-				( selectedItems.length === 1 && MediaUtils.getMimePrefix( selectedItems[ 0 ] ) !== 'image' )
+				( selectedItems.length === 1 &&
+					MediaUtils.getMimePrefix( selectedItems[ 0 ] ) !== 'image' ) ||
+				this.state.source === 'google_photos'
 			) {
 				label = this.props.translate( 'Copy to media library' );
 			}
@@ -532,7 +539,7 @@ export class EditorMediaModal extends Component {
 				action: 'confirm',
 				label: this.props.labels.confirm || this.props.translate( 'Insert' ),
 				isPrimary: true,
-				disabled: isDisabled || 0 === selectedItems.length,
+				disabled: isDisabled || 0 === selectedItems.length || this.isTransientSelected(),
 				onClick: this.confirmSelection,
 			} );
 		}


### PR DESCRIPTION
NOTE - Discussion and Testing for this issue has been moved to #38488 

### Changes proposed in this Pull Request

* Prevent media-modal from adding images as "hotlinks" from google-photos.

Currently, when the media-modal is viewing external media sources (such as google-photos), if 1 image is selected it will give the option to "Insert" the image while if multiple are selected it will give the option to "Copy to media library."  

**Currently**
![current](https://user-images.githubusercontent.com/28742426/71039793-061e1d00-20f3-11ea-96ec-0709646fa58c.gif)

When "insert" is used in this case of google-photos, the image is added with the temporary google images url that expires after an hour.  This prompts us to make the first change:

1. Remove 'insert' as an option from google photo's altogether, and force the step of 'Copy to media library' when used in this case.

Now, if this photo that is being uploaded to the media library is then inserted while the upload is in progress, it will once again insert it with the temporary google photo's URL and not update it to the appropriate URL from our media library.  This prompts the second change:

2. Disable the "Insert" button on the media modal if an image pending upload is selected as part of the media to insert.  This will then enable itself once the upload is complete (or once deselected), allowing the user to then "Insert" the media with the proper URL.

**Updated Behavior**
![updated](https://user-images.githubusercontent.com/28742426/71040017-99575280-20f3-11ea-8179-138ba0f48e49.gif)


#### Lingering Question:
Why is there a special case to "Insert" rather than "Copy to media library" if only 1 image is selected?  Should this special case behavior be removed altogether?

In the other case of external media in this modal, the "free photos library", it still prompts us to `Copy to media library' if more than 1 image is selected.  But if 1 image is selected, it just inserts this without copying the media to our library.  If we are concerned with copying the media to our library to guarantee our user never loses the image selected for their site, the amount of images selected should not influence that decision.

Should we ALWAYS copy external media from this modal to our library before inserting it onto the user's site, regardless of the source or amount of images selected?  If that is the case we could just get rid of the special case logic and [do something like in this alternative PR.](https://github.com/Automattic/wp-calypso/pull/38488) #38488 . Which would force the free media library to "Copy to media library" for single image selections as well.

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR
* Navigate to edit a page.
* Add a gallery block and select the Media Library.
* Try to add images from google photos.
* Verify having 1 image selected will copy the item to the media library instead of inserting it.
* Verify you are unable to "Insert" while the image is still selected and uploading into the library.
* Verify inserted images URLs correspond to the media library and not google images.
* Repeat the above for an Atomic or Jetpack site. 

Fixes #34593