### PR TITLE
composite-checkout: Sync url to step number

### DIFF
--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -302,13 +302,18 @@ function getStepNumberFromUrl() {
 }
 
 function saveStepNumberToUrl( stepNumber ) {
-	if ( window.history?.pushState && window.location?.hash ) {
-		window.history.pushState(
-			null,
-			null,
-			window.location.href.replace( window.location.hash, `#step${ stepNumber }` )
-		);
+	if ( ! window.history?.pushState ) {
+		return;
 	}
+	const newHash = `#step${ stepNumber }`;
+	if ( window.location.hash === newHash ) {
+		return;
+	}
+	const newUrl = window.location.hash
+		? window.location.href.replace( window.location.hash, newHash )
+		: window.location.href + newHash;
+	debug( 'updating url to', newUrl );
+	window.history.pushState( null, null, newUrl );
 }
 
 function useChangeStepNumberForUrl() {

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -34,10 +34,10 @@ import { useEvents } from './checkout-provider';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 
-function useRegisterCheckoutStore( { urlStepNumber = 1 } ) {
+function useRegisterCheckoutStore() {
 	const onEvent = useEvents();
 	useRegisterPrimaryStore( {
-		reducer( state = { stepNumber: urlStepNumber, paymentData: {} }, action ) {
+		reducer( state = { stepNumber: getStepNumberFromUrl(), paymentData: {} }, action ) {
 			switch ( action.type ) {
 				case 'STEP_NUMBER_SET':
 					return { ...state, stepNumber: action.payload };
@@ -76,8 +76,7 @@ function useRegisterCheckoutStore( { urlStepNumber = 1 } ) {
 }
 
 export default function Checkout( { steps, className } ) {
-	const urlStepNumber = getStepNumberFromUrl();
-	useRegisterCheckoutStore( { urlStepNumber } );
+	useRegisterCheckoutStore();
 	const localize = useLocalize();
 	const [ paymentData ] = usePaymentData();
 	const activePaymentMethod = usePaymentMethod();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a url hash for each step in the checkout form (eg: `/checkout/#step2`). When the page loads or when this hash changes, the form will display the appropriate step. This allows for the browser's back button to navigate between steps.

**Question for reviewers:** when might we want to override this behavior? If you reload the form, all the fields will be empty and the steps will therefore be invalid. Should we still remain on the current step? Perhaps we should only allow jumping to a step if all the previous steps are marked as complete?

#### Testing instructions

- Run `npm run composite-checkout-demo`.
- Visit the demo site and begin completing the form.
- When you get to step 3, press the back button in your browser. Verify that you are returned to step 2.
- Press the forward button in the browser and verify that you are returned to step 3.
- Reload the page. Verify that you remain on step 3 (note that the form fields will now be empty; this is expected).
- Press the back button two times and verify that you are returned to step 1.
