### PR TITLE
Update chromedriver version in e2e tests

### DIFF
--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -982,9 +982,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "12.12.11",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-			"integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ=="
+			"version": "12.12.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
+			"integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA=="
 		},
 		"@xmpp/client-core": {
 			"version": "0.3.0",
@@ -2369,9 +2369,9 @@
 			"dev": true
 		},
 		"chromedriver": {
-			"version": "77.0.0",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-77.0.0.tgz",
-			"integrity": "sha512-mZa1IVx4HD8rDaItWbnS470mmypgiWsDiu98r0NkiT4uLm3qrANl4vOU6no6vtWtLQiW5kt1POcIbjeNpsLbXA==",
+			"version": "79.0.0",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-79.0.0.tgz",
+			"integrity": "sha512-DO29C7ntJfzu6q1vuoWwCON8E9x5xzopt7Q41A7Dr7hBKcdNpGw1l9DTt9b+l1qviOWiJLGsD+jHw21ptEHubA==",
 			"requires": {
 				"del": "^4.1.1",
 				"extract-zip": "^1.6.7",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "7.3.1",
 		"asana-phrase": "0.0.8",
 		"cached-path-relative": ">=1.0.2",
-		"chromedriver": "^77.0.0",
+		"chromedriver": "^79.0.0",
 		"concurrently": "^3.6.1",
 		"config": "1.28.0",
 		"cryptiles": ">=4.1.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the chromedriver version to 79 to match with https://github.com/Automattic/wp-calypso/pull/37622

Thanks @stephanethomas for [pointing it out](https://github.com/Automattic/wp-calypso/pull/37622#discussion_r359375418).
