### PR TITLE
Fix: Domain step test should exclude users who are going through the /start/{PLAN} flows

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -123,7 +123,7 @@ class DomainsStep extends React.Component {
 		this.showTestCopy = false;
 
 		// Do not assign user to the test if either in the launch flow or in /start/{PLAN_SLUG} flow
-		if ( false !== this.props.shouldShowDomainTestCopy && ! props.cartItem ) {
+		if ( false !== this.props.shouldShowDomainTestCopy && ! props.isPlanStepFulfilled ) {
 			if (
 				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' ) ||
 				'variantShowUpdates' === abtest( 'nonEnglishDomainStepCopyUpdates' )
@@ -730,7 +730,7 @@ export default connect(
 			vertical: getVerticalForDomainSuggestions( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 			isSitePreviewVisible: isSitePreviewVisible( state ),
-			cartItem: ownProps.signupDependencies.cartItem,
+			isPlanStepFulfilled: get( ownProps.signupDependencies, 'cartItem', false ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -122,7 +122,8 @@ class DomainsStep extends React.Component {
 
 		this.showTestCopy = false;
 
-		if ( false !== this.props.shouldShowDomainTestCopy ) {
+		// Do not assign user to the test if either in the launch flow or in /start/{PLAN_SLUG} flow
+		if ( false !== this.props.shouldShowDomainTestCopy && ! props.cartItem ) {
 			if (
 				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' ) ||
 				'variantShowUpdates' === abtest( 'nonEnglishDomainStepCopyUpdates' )
@@ -729,6 +730,7 @@ export default connect(
 			vertical: getVerticalForDomainSuggestions( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 			isSitePreviewVisible: isSitePreviewVisible( state ),
+			cartItem: ownProps.signupDependencies.cartItem,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For users who go through the plan specific flows - `/start/personal`, `/start/premium`, `/start/business` and `/start/ecommerce` - we will exclude these users from the domain step test that was introduced with https://github.com/Automattic/wp-calypso/pull/37661.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In `en` locale, go through the following flows and verify that you don't get assigned to the `domainStepCopyUpdates` test(by checking `localstorage.ABTests;` in your browser console when you're in the domain step):
/start/personal 
/start/premium
/start/business
/start/ecommerce
* In `en` locale, go through the main signup flow /start and verify things work normally i.e you should get assigned to the `domainStepCopyUpdates` test.

Fixes https://github.com/Automattic/wp-calypso/issues/38495
