### PR TITLE
Composite checkout: Add coupon field events

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -121,7 +121,7 @@ function handleFormSubmit(
 		setIsCouponApplied( true );
 		onEvent( {
 			type: 'a8c_checkout_add_coupon',
-			payload: { coupon: couponFieldValue, client_id: 'WordPress.com' },
+			payload: { coupon: couponFieldValue },
 		} );
 
 		if ( couponAdded ) {
@@ -133,7 +133,7 @@ function handleFormSubmit(
 
 	onEvent( {
 		type: 'a8c_checkout_add_coupon_error',
-		payload: { type: 'Invalid code', client_id: 'WordPress.com' },
+		payload: { type: 'Invalid code' },
 	} );
 	setHasCouponError( true );
 }

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -119,7 +119,10 @@ function handleFormSubmit(
 	//TODO: Validate coupon field and replace condition in the following if statement
 	if ( couponFieldValue === 'Add' ) {
 		setIsCouponApplied( true );
-		onEvent( { type: 'calypso_checkout_add_coupon', payload: { coupon: couponFieldValue } } );
+		onEvent( {
+			type: 'a8c_checkout_add_coupon',
+			payload: { coupon: couponFieldValue, client_id: 'WordPress.com' },
+		} );
 
 		if ( couponAdded ) {
 			couponAdded();
@@ -128,6 +131,9 @@ function handleFormSubmit(
 		return;
 	}
 
-	onEvent( { type: 'calypso_checkout_add_coupon_error', payload: { type: 'Invalid code' } } );
+	onEvent( {
+		type: 'a8c_checkout_add_coupon_error',
+		payload: { type: 'Invalid code', client_id: 'WordPress.com' },
+	} );
 	setHasCouponError( true );
 }

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
+import { useEvents } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import Button from './button';
 
 export default function Coupon( { id, couponAdded, className, isCouponFieldVisible } ) {
 	const translate = useTranslate();
+	const onEvent = useEvents();
 	const [ isApplyButtonActive, setIsApplyButtonActive ] = useState( false );
 	const [ couponFieldValue, setCouponFieldValue ] = useState( '' );
 	const [ hasCouponError, setHasCouponError ] = useState( false );
@@ -34,7 +36,8 @@ export default function Coupon( { id, couponAdded, className, isCouponFieldVisib
 					couponFieldValue,
 					setHasCouponError,
 					couponAdded,
-					setIsCouponApplied
+					setIsCouponApplied,
+					onEvent
 				);
 			} }
 		>
@@ -108,13 +111,15 @@ function handleFormSubmit(
 	couponFieldValue,
 	setHasCouponError,
 	couponAdded,
-	setIsCouponApplied
+	setIsCouponApplied,
+	onEvent
 ) {
 	event.preventDefault();
 
 	//TODO: Validate coupon field and replace condition in the following if statement
 	if ( couponFieldValue === 'Add' ) {
 		setIsCouponApplied( true );
+		onEvent( { type: 'calypso_checkout_add_coupon', payload: { coupon: couponFieldValue } } );
 
 		if ( couponAdded ) {
 			couponAdded();
@@ -123,5 +128,6 @@ function handleFormSubmit(
 		return;
 	}
 
+	onEvent( { type: 'calypso_checkout_add_coupon_error', payload: { type: 'Invalid code' } } );
 	setHasCouponError( true );
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -129,6 +129,5 @@ function handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent ) {
 	setIsCouponFieldVisible( true );
 	onEvent( {
 		type: 'a8c_checkout_add_coupon_button_clicked',
-		payload: { location: 'order-summary', client_id: 'WordPress.com' },
 	} );
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -3,7 +3,12 @@
  */
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
-import { useLineItems, useTotal, renderDisplayValueMarkdown } from '@automattic/composite-checkout';
+import {
+	useLineItems,
+	useTotal,
+	renderDisplayValueMarkdown,
+	useEvents,
+} from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -15,6 +20,7 @@ import Coupon from './coupon';
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();
 	const [ items ] = useLineItems();
+	const onEvent = useEvents();
 	//TODO: tie the default coupon field visibility based on whether there is a coupon in the cart
 	const [ isCouponFieldVisible, setIsCouponFieldVisible ] = useState( false );
 	const [ hasCouponBeenApplied, setHasCouponBeenApplied ] = useState( false );
@@ -35,7 +41,7 @@ export default function WPCheckoutOrderSummary() {
 					<AddCouponButton
 						buttonState="text-button"
 						onClick={ () => {
-							setIsCouponFieldVisible( true );
+							handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent );
 						} }
 					>
 						{ translate( 'Add a coupon' ) }
@@ -47,7 +53,7 @@ export default function WPCheckoutOrderSummary() {
 				id="order-summary-coupon"
 				isCouponFieldVisible={ isCouponFieldVisible }
 				couponAdded={ () => {
-					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
+					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied, onEvent );
 				} }
 			/>
 		</React.Fragment>
@@ -117,4 +123,9 @@ const AddCouponButton = styled( Button )`
 function handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied ) {
 	setIsCouponFieldVisible( false );
 	setHasCouponBeenApplied( true );
+}
+
+function handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent ) {
+	setIsCouponFieldVisible( true );
+	onEvent( { type: 'ADD_COUPON_BUTTON_CLICKED', payload: { location: 'order-summary' } } );
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -127,5 +127,8 @@ function handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied ) {
 
 function handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent ) {
 	setIsCouponFieldVisible( true );
-	onEvent( { type: 'ADD_COUPON_BUTTON_CLICKED', payload: { location: 'order-summary' } } );
+	onEvent( {
+		type: 'a8c_checkout_add_coupon_button_clicked',
+		payload: { location: 'order-summary', client_id: 'WordPress.com' },
+	} );
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -53,7 +53,7 @@ export default function WPCheckoutOrderSummary() {
 				id="order-summary-coupon"
 				isCouponFieldVisible={ isCouponFieldVisible }
 				couponAdded={ () => {
-					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied, onEvent );
+					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
 				} }
 			/>
 		</React.Fragment>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds events to measure user coupon field interactions. 

#### Testing instructions
* Get calypso running locally.
* Add a product to the cart and go to checkout. 
* Add `?flags=composite-checkout-wpcom` to the checkout URL.
* Click on the "Add a coupon" button to make sure the coupon field displays. 
* Enter "Add" and click apply to make sure the form submits. (The field should disappear after you submit the form)
