### PR TITLE
Live chat closure: Header to indicate the upcoming closure

### DIFF
--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -12,7 +12,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 import { CompactCard as Card } from '@automattic/components';
 import { useLocalizedMoment } from 'components/localized-moment';
 
-const DATE_FORMAT = 'MMMM Do h:mm A z';
+const DATE_FORMAT = 'LLL';
 
 const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
 	const translate = useTranslate();

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -29,13 +29,13 @@ class PrimaryHeader extends Component {
 					displayAt="2019-12-17 00:00Z"
 					closesAt="2019-12-24 00:00Z"
 					reopensAt="2019-12-26 07:00Z"
-					holidayName="Christmas"
+					holidayName={ translate( 'Christmas' ) }
 				/>
 				<ClosureNotice
 					displayAt="2019-12-26 07:00Z"
 					closesAt="2019-12-31 00:00Z"
 					reopensAt="2020-01-02 07:00Z"
-					holidayName="New Year's Day"
+					holidayName={ translate( "New Year's Day" ) }
 				/>
 				<Card>
 					<img

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -18,6 +18,10 @@ class PrimaryHeader extends Component {
 	render() {
 		const { translate } = this.props;
 
+		const xmasHolidayName = translate( 'Christmas', {
+			context: 'Holiday name',
+		} );
+
 		return (
 			<Fragment>
 				<GMClosureNotice
@@ -29,7 +33,7 @@ class PrimaryHeader extends Component {
 					displayAt="2019-12-17 00:00Z"
 					closesAt="2019-12-24 00:00Z"
 					reopensAt="2019-12-26 07:00Z"
-					holidayName={ translate( 'Christmas' ) }
+					holidayName={ xmasHolidayName }
 				/>
 				<ClosureNotice
 					displayAt="2019-12-26 07:00Z"

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -533,14 +533,14 @@ class HelpContact extends React.Component {
 				{ isUserAffectedByLiveChatClosure && (
 					<>
 						<LiveChatClosureNotice
-							holidayName="Christmas"
+							holidayName={ translate( 'Christmas' ) }
 							compact={ compact }
 							displayAt="2019-12-17 00:00Z"
 							closesAt="2019-12-24 00:00Z"
 							reopensAt="2019-12-26 07:00Z"
 						/>
 						<LiveChatClosureNotice
-							holidayName="New Year's Day"
+							holidayName={ translate( "New Year's Day" ) }
 							compact={ compact }
 							displayAt="2019-12-26 07:00Z"
 							closesAt="2019-12-31 00:00Z"

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -528,12 +528,16 @@ class HelpContact extends React.Component {
 		const isUserAffectedByLiveChatClosure =
 			supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
+		const xmasHolidayName = translate( 'Christmas', {
+			context: 'Holiday name',
+		} );
+
 		return (
 			<div>
 				{ isUserAffectedByLiveChatClosure && (
 					<>
 						<LiveChatClosureNotice
-							holidayName={ translate( 'Christmas' ) }
+							holidayName={ xmasHolidayName }
 							compact={ compact }
 							displayAt="2019-12-17 00:00Z"
 							closesAt="2019-12-24 00:00Z"

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -18,7 +18,7 @@ import { useLocalizedMoment } from 'components/localized-moment';
  */
 import './style.scss';
 
-const DATE_FORMAT = 'LLL z';
+const DATE_FORMAT = 'LLL';
 
 const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reopensAt } ) => {
 	const translate = useTranslate();

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -31,13 +31,13 @@ const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reo
 		return null;
 	}
 
-	const heading = translate( 'Live chat closed for %(holidayName)s', {
-		args: { holidayName },
-	} );
-
-	let message;
+	let heading, message;
 
 	if ( currentDate.isBefore( closesAt ) ) {
+		heading = translate( 'Live chat will be closed for %(holidayName)s', {
+			args: { holidayName },
+		} );
+
 		message = translate(
 			'Live chat will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
 				'You’ll be able to reach us by email and we’ll get back to you as fast as we can. Thank you!',
@@ -50,6 +50,10 @@ const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reo
 			}
 		);
 	} else {
+		heading = translate( 'Live chat closed for %(holidayName)s', {
+			args: { holidayName },
+		} );
+
 		message = translate(
 			'Live chat is closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
 				'You can reach us by email below and we’ll get back to you as fast as we can. Thank you!',

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -18,7 +18,7 @@ import { useLocalizedMoment } from 'components/localized-moment';
  */
 import './style.scss';
 
-const DATE_FORMAT = 'MMMM Do h:mm A z';
+const DATE_FORMAT = 'LLL z';
 
 const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reopensAt } ) => {
 	const translate = useTranslate();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up to https://github.com/Automattic/wp-calypso/pull/38448, before the closure date, the live chat interface's header says that live chat is closed, when in fact it should say that the closure date is in the future.

<img width="1051" alt="Screenshot 2019-12-19 at 1 02 33 AM" src="https://user-images.githubusercontent.com/1269602/71117014-48cb1c80-21fb-11ea-85ec-1a97b18223cd.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* WIP

Fixes #
