### PR TITLE
Customer Home: Update language to be clearer after purchase.

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -134,7 +134,7 @@ class Home extends Component {
 	};
 
 	getChecklistSubHeaderText = () => {
-		const { checklistMode, currentTheme, translate, user, siteHasPaidPlan } = this.props;
+		const { checklistMode, currentTheme, translate, user } = this.props;
 
 		switch ( checklistMode ) {
 			case 'gsuite':
@@ -175,13 +175,9 @@ class Home extends Component {
 				return translate( 'Make sure you share it with everyone and show it off.' );
 
 			default:
-				if ( siteHasPaidPlan ) {
-					return translate(
-						'Next, use this quick list of setup tasks to get your site ready to share.'
-					);
-				}
-
-				return translate( 'Next, use this quick list of setup tasks to get it ready to share.' );
+				return translate(
+					'Next, use this quick list of setup tasks to get your site ready to share.'
+				);
 		}
 	};
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -134,7 +134,7 @@ class Home extends Component {
 	};
 
 	getChecklistSubHeaderText = () => {
-		const { checklistMode, currentTheme, translate, user } = this.props;
+		const { checklistMode, currentTheme, translate, user, siteHasPaidPlan } = this.props;
 
 		switch ( checklistMode ) {
 			case 'gsuite':
@@ -175,6 +175,12 @@ class Home extends Component {
 				return translate( 'Make sure you share it with everyone and show it off.' );
 
 			default:
+				if ( siteHasPaidPlan ) {
+					return translate(
+						'Next, use this quick list of setup tasks to get your site ready to share.'
+					);
+				}
+
 				return translate( 'Next, use this quick list of setup tasks to get it ready to share.' );
 		}
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The current purchase flow for a new site ends on Customer Home with the heading "Thank you for your purchase!" and "Next, use this quick list of setup tasks to get it ready to share."
* It's unclear what "it" refers to in this case, and "get your purchase ready to share" doesn't make sense. This PR updates it to "get your site ready to share".

**Before**

<img width="949" alt="Screen Shot 2019-12-18 at 4 58 39 PM" src="https://user-images.githubusercontent.com/2124984/71127132-704cc580-21b8-11ea-913b-2c0b5ffd8856.png">


**After**

<img width="942" alt="Screen Shot 2019-12-18 at 4 58 22 PM" src="https://user-images.githubusercontent.com/2124984/71127143-793d9700-21b8-11ea-914c-c1934392fefa.png">

#### Testing instructions

* Switch to this PR
* Create a new site from `/start/`; use a free account.
* Land on Customer Home and note the heading and description.
* Create another new site from `/start`, this time with a paid plan. 
* Once again, land on Customer Home and check the heading and description for language tweaks.
