### PR TITLE
Migration: Move polling to progress page; update error handling

### DIFF
--- a/client/my-sites/migrate/migrate-button.jsx
+++ b/client/my-sites/migrate/migrate-button.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { Button } from '@automattic/components';
+
+class MigrateButton extends Component {
+	state = {
+		busy: false,
+	};
+
+	handleClick = () => {
+		if ( this.state.busy ) {
+			return;
+		}
+
+		this.setState( { busy: true }, this.props.onClick );
+	};
+
+	render() {
+		return (
+			<Button primary busy={ this.state.busy } onClick={ this.handleClick }>
+				Migrate site
+			</Button>
+		);
+	}
+}
+
+export default MigrateButton;

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -73,7 +73,7 @@ class SectionMigrate extends Component {
 			page( `/migrate/${ targetSiteSlug }` );
 			/**
 			 * Note this migrationStatus is local, thus the setState vs setMigrationState.
-			 * Call to updateFromAPI will update non-local state.
+			 * Call to updateFromAPI will update both local and non-local state.
 			 */
 			this.setState( { migrationStatus: 'inactive' }, this.updateFromAPI );
 		} );

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -7,17 +7,18 @@ import { connect } from 'react-redux';
 import page from 'page';
 import { get, isEmpty, includes } from 'lodash';
 import moment from 'moment';
+import { Button, Card, CompactCard, ProgressBar } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import { Button, Card, CompactCard, ProgressBar } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
+import MigrateButton from './migrate-button';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Site from 'blocks/site';
 import SiteSelector from 'components/site-selector';
@@ -47,6 +48,12 @@ class SectionMigrate extends Component {
 		this.updateFromAPI();
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( this.props.targetSiteId !== prevProps.targetSiteId ) {
+			this.updateFromAPI();
+		}
+	}
+
 	getImportHref = () => {
 		const { isTargetSiteJetpack, targetSiteImportAdminUrl, targetSiteSlug } = this.props;
 
@@ -62,9 +69,13 @@ class SectionMigrate extends Component {
 	resetMigration = () => {
 		const { targetSiteId, targetSiteSlug } = this.props;
 
-		wpcom.resetMigration( targetSiteId ).then( () => {
+		wpcom.resetMigration( targetSiteId ).finally( () => {
 			page( `/migrate/${ targetSiteSlug }` );
-			this.updateFromAPI();
+			/**
+			 * Note this migrationStatus is local, thus the setState vs setMigrationState.
+			 * Call to updateFromAPI will update non-local state.
+			 */
+			this.setState( { migrationStatus: 'inactive' }, this.updateFromAPI );
 		} );
 	};
 
@@ -86,9 +97,10 @@ class SectionMigrate extends Component {
 			return;
 		}
 
-		this.setMigrationState( { migrationStatus: 'backing-up', startTime: '' } );
-
-		wpcom.startMigration( sourceSiteId, targetSiteId ).then( () => this.updateFromAPI() );
+		wpcom
+			.startMigration( sourceSiteId, targetSiteId )
+			.then( () => this.updateFromAPI() )
+			.catch( () => this.setMigrationState( { migrationStatus: 'error' } ) );
 	};
 
 	updateFromAPI = () => {
@@ -235,9 +247,7 @@ class SectionMigrate extends Component {
 							</li>
 						</ul>
 					</div>
-					<Button primary onClick={ this.startMigration }>
-						Migrate site
-					</Button>
+					<MigrateButton onClick={ this.startMigration } />
 					<Button className="migrate__cancel" href={ backHref }>
 						Cancel
 					</Button>
@@ -281,6 +291,7 @@ class SectionMigrate extends Component {
 
 		return (
 			<>
+				<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
 				<Card className="migrate__pane">
 					<img
 						className="migrate__illustration"
@@ -453,7 +464,6 @@ class SectionMigrate extends Component {
 
 		return (
 			<Main>
-				<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
 				<DocumentHead title="Migrate" />
 				<SidebarNavigation />
 				{ migrationElement }


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Only poll the endpoint for changes on the progress screen
* Set error locally when the API to start migration returns an error
* Create a `MigrateButton` component, which is busy until the result of the API request is shown
* Update the status from the API when the `targetSiteId` prop changes
* Reset local error when resetting migration

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Setup source and target sites using the instructions found on pbkcP4-6z-p2
* Open your network inspector
* Start a migration from `/migrate`, and verify that before pressing "Migrate site" the endpoint for migration status isn't polled. It should be hit once, initially, when the component loads, and then again every 10 seconds after the migration is started
* Start a new migration to a simple site by manually visiting `/migrate/:simpleSiteSlug`. The API should error when starting the migration, and you should see an error page (not yet complete). You should be able to start over from that error page by acknowledging the message.

