### PR TITLE
composite-checkout: Add redirect when payment complete

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
 	createRegistry,
 	createPayPalMethod,
@@ -210,26 +210,30 @@ export default function CompositeCheckoutContainer( {
 		state => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
 	);
 
-	const onPaymentComplete = () => {
-		debug( 'success' );
+	const onPaymentComplete = useCallback( () => {
+		debug( 'payment completed successfully' );
+		// TODO: redirect to the pending page
 		notices.success( translate( 'Your purchase was successful!' ) );
-	};
+	}, [ translate ] );
 
-	const showErrorMessage = error => {
-		debug( 'error', error );
-		const message = error && error.toString ? error.toString() : error;
-		notices.error( message || translate( 'An error occurred during your purchase.' ) );
-	};
+	const showErrorMessage = useCallback(
+		error => {
+			debug( 'error', error );
+			const message = error && error.toString ? error.toString() : error;
+			notices.error( message || translate( 'An error occurred during your purchase.' ) );
+		},
+		[ translate ]
+	);
 
-	const showInfoMessage = message => {
+	const showInfoMessage = useCallback( message => {
 		debug( 'info', message );
 		notices.info( message );
-	};
+	}, [] );
 
-	const showSuccessMessage = message => {
+	const showSuccessMessage = useCallback( message => {
 		debug( 'success', message );
 		notices.success( message );
-	};
+	}, [] );
 
 	return (
 		<CompositeCheckout

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -12,6 +12,7 @@ import { mockPayPalExpressRequest } from '@automattic/composite-checkout-wpcom';
 import { useTranslate } from 'i18n-calypso';
 import debugFactory from 'debug';
 import { useSelector } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -212,9 +213,9 @@ export default function CompositeCheckoutContainer( {
 
 	const onPaymentComplete = useCallback( () => {
 		debug( 'payment completed successfully' );
-		// TODO: redirect to the pending page
-		notices.success( translate( 'Your purchase was successful!' ) );
-	}, [ translate ] );
+		// TODO: determine which thank-you page to visit
+		page.redirect( `/checkout/thank-you/${ siteId }/` );
+	}, [ siteId ] );
 
 	const showErrorMessage = useCallback(
 		error => {

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -110,7 +110,7 @@ Each payment method is an object with the following properties:
 
 Within the components, the Hook `usePaymentMethod()` will return an object of the above form with the key of the currently selected payment method or null if none is selected. To retrieve all the payment methods and their properties, the Hook `useAllPaymentMethods()` will return an array that contains them all.
 
-When the `submitButton` component has been clicked, it should use `setFormStatus` (see [useFormStatus](#useFormStatus)) to change the status to 'submitting'. If there is a problem, it should change the status back to 'ready' and display an appropriate error using [useMessages](#useMessages). If the payment is successful, it should change the status to 'complete', which will cause [Checkout](#Checkout) to call `onPaymentComplete` (see [CheckoutProvider](#CheckoutProvider)).
+When the `submitButton` component has been clicked, it should use the functions provided by [useFormStatus](#useFormStatus) to change the status to 'submitting'. If there is a problem, it should change the status back to 'ready' and display an appropriate error using [useMessages](#useMessages). If the payment is successful, it should change the status to 'complete', which will cause [Checkout](#Checkout) to call `onPaymentComplete` (see [CheckoutProvider](#CheckoutProvider)).
 
 ## Line Items
 
@@ -281,7 +281,15 @@ A React Hook that will return the `onEvent` callback as passed to `CheckoutProvi
 
 ### useFormStatus
 
-A React Hook that will return a two-element array where the first element is the `formStatus` (one of 'loading', 'ready', 'submitting', or 'complete') and the second element is `setFormStatus` which can be used to change the status. Only works within [CheckoutProvider](#CheckoutProvider).
+A React Hook that will return an object with the following properties:
+
+- `formStatus: string`. The current status of the form; one of 'loading', 'ready', 'submitting', or 'complete'.
+- `setFormReady: () => void`. Function to change the form status to 'ready'.
+- `setFormLoading: () => void`. Function to change the form status to 'loading'.
+- `setFormSubmitting: () => void`. Function to change the form status to 'submitting'.
+- `setFormComplete: () => void`. Function to change the form status to 'complete'. Note that this will trigger `onPaymentComplete` from [CheckoutProvider](#CheckoutProvider).
+
+Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useIsStepActive
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -27,7 +27,7 @@ It's also possible to build an entirely custom form using the other components e
 
 Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the functions [createStripeMethod](#createstripemethod), [createApplePayMethod](#createapplepaymethod), and [createPayPalMethod](#createpaypalmethod).
 
-Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [usePaymentComplete](#usePaymentComplete), [useMessages](#useMessages), [useCheckoutRedirects](#useCheckoutRedirects), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentData](#usePaymentData), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
+Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [useMessages](#useMessages), [useCheckoutRedirects](#useCheckoutRedirects), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentData](#usePaymentData), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
 
 The [Checkout](#checkout) component creates the form itself. That component displays a series of steps which are passed in as [Step objects](#steps). While you can create these objects manually, the package provides three pre-defined steps that can be created by using the functions [getDefaultOrderSummaryStep](#getDefaultOrderSummaryStep), [getDefaultPaymentMethodStep](#getDefaultPaymentMethodStep), and [getDefaultOrderReviewStep](#getDefaultOrderReviewStep).
 
@@ -290,10 +290,6 @@ A React Hook that will return a two element array where the first element is the
 ### useMessages
 
 A React Hook that will return an object containing the `showErrorMessage`, `showInfoMessage`, and `showSuccessMessage` callbacks as passed to `CheckoutProvider`. Only works within [CheckoutProvider](#CheckoutProvider).
-
-### usePaymentComplete
-
-A React Hook that will return the `onPaymentComplete` callback as passed to `CheckoutProvider`. Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### usePaymentData
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -102,7 +102,7 @@ Each payment method is an object with the following properties:
 - `id: string`. A unique id.
 - `label: React.ReactNode`. A component that displays that payment method selection button which can be as simple as the name and an icon.
 - `activeContent: React.ReactNode`. A component that displays that payment method (this can return null or something like a credit card form).
-- `submitButton: React.Component`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. When disabled, it will be provided with the `disabled` prop and must disable the button.
+- `submitButton: React.ReactNode`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. When disabled, it will be provided with the `disabled` prop and must disable the button.
 - `inactiveContent: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
 - `CheckoutWrapper?: React.Component`. A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).
 - `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -110,7 +110,7 @@ Each payment method is an object with the following properties:
 
 Within the components, the Hook `usePaymentMethod()` will return an object of the above form with the key of the currently selected payment method or null if none is selected. To retrieve all the payment methods and their properties, the Hook `useAllPaymentMethods()` will return an array that contains them all.
 
-When the `submitButton` component has been clicked, it should use `setFormStatus` (see [useFormStatus](#useFormStatus)) to change the status to 'submitting'. If there is a problem, it should change the status back to 'ready' and display an appropriate error using [useMessages](#useMessages). If the payment is successful, it should change the status to 'provisioning', which will cause [Checkout](#Checkout) to render its `provisioningContent`.
+When the `submitButton` component has been clicked, it should use `setFormStatus` (see [useFormStatus](#useFormStatus)) to change the status to 'submitting'. If there is a problem, it should change the status back to 'ready' and display an appropriate error using [useMessages](#useMessages). If the payment is successful, it should change the status to 'complete', which will cause [Checkout](#Checkout) to call `onPaymentComplete` (see [CheckoutProvider](#CheckoutProvider)).
 
 ## Line Items
 
@@ -141,9 +141,6 @@ While the `Checkout` component takes care of most everything, there are many sit
 The main component in this package. It has the following props.
 
 - `steps: array`. See the [Steps](#steps) section above for more details.
-- `provisioningContent: React.ReactNode`. The component to display after the payment method is complete.
-
-The provisioningContent component should display a "pending" message and poll for full payment completion. When the provisioning is complete, it should use `setFormStatus` (see [useFormStatus](#useFormStatus)) to change the status to 'complete', which will cause `onPaymentComplete` to be called.
 
 ### CheckoutNextStepButton
 
@@ -284,7 +281,7 @@ A React Hook that will return the `onEvent` callback as passed to `CheckoutProvi
 
 ### useFormStatus
 
-A React Hook that will return a two-element array where the first element is the `formStatus` (one of 'loading', 'ready', 'submitting', 'provisioning', or 'complete') and the second element is `setFormStatus` which can be used to change the status. Only works within [CheckoutProvider](#CheckoutProvider).
+A React Hook that will return a two-element array where the first element is the `formStatus` (one of 'loading', 'ready', 'submitting', or 'complete') and the second element is `setFormStatus` which can be used to change the status. Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useIsStepActive
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -110,6 +110,8 @@ Each payment method is an object with the following properties:
 
 Within the components, the Hook `usePaymentMethod()` will return an object of the above form with the key of the currently selected payment method or null if none is selected. To retrieve all the payment methods and their properties, the Hook `useAllPaymentMethods()` will return an array that contains them all.
 
+When the `submitButton` component has been clicked, it should use `setFormStatus` (see [useFormStatus](#useFormStatus)) to change the status to 'submitting'. If there is a problem, it should change the status back to 'ready' and display an appropriate error using [useMessages](#useMessages). If the payment is successful, it should change the status to 'provisioning', which will cause [Checkout](#Checkout) to render its `provisioningContent`.
+
 ## Line Items
 
 Each item is an object with the following properties:

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -27,7 +27,7 @@ It's also possible to build an entirely custom form using the other components e
 
 Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the functions [createStripeMethod](#createstripemethod), [createApplePayMethod](#createapplepaymethod), and [createPayPalMethod](#createpaypalmethod).
 
-Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [useMessages](#useMessages), [useCheckoutRedirects](#useCheckoutRedirects), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentData](#usePaymentData), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
+Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [useFormStatus](#useFormStatus), [useMessages](#useMessages), [useCheckoutRedirects](#useCheckoutRedirects), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentData](#usePaymentData), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
 
 The [Checkout](#checkout) component creates the form itself. That component displays a series of steps which are passed in as [Step objects](#steps). While you can create these objects manually, the package provides three pre-defined steps that can be created by using the functions [getDefaultOrderSummaryStep](#getDefaultOrderSummaryStep), [getDefaultPaymentMethodStep](#getDefaultPaymentMethodStep), and [getDefaultOrderReviewStep](#getDefaultOrderReviewStep).
 
@@ -138,9 +138,10 @@ While the `Checkout` component takes care of most everything, there are many sit
 
 The main component in this package. It has the following props.
 
-- steps: array
+- `steps: array`. See the [Steps](#steps) section above for more details.
+- `provisioningContent: React.ReactNode`. The component to display after the payment method is complete.
 
-See the [Steps](#steps) section above for more details.
+The provisioningContent component should display a "pending" message and poll for full payment completion. When the provisioning is complete, it should use `setFormStatus` (see [useFormStatus](#useFormStatus)) to change the status to 'complete', which will cause `onPaymentComplete` to be called.
 
 ### CheckoutNextStepButton
 
@@ -278,6 +279,10 @@ A React Hook that will return all the bound action creators for a [Data store](#
 ### useEvents
 
 A React Hook that will return the `onEvent` callback as passed to `CheckoutProvider`. Only works within [CheckoutProvider](#CheckoutProvider).
+
+### useFormStatus
+
+A React Hook that will return a two-element array where the first element is the `formStatus` (one of 'loading', 'ready', 'submitting', 'provisioning', or 'complete') and the second element is `setFormStatus` which can be used to change the status. Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useIsStepActive
 

--- a/packages/composite-checkout/demo/complete.html
+++ b/packages/composite-checkout/demo/complete.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-	<title>Checkout Demo</title>
+	<title>Checkout Demo Complete</title>
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<style>
@@ -18,11 +18,8 @@
 </head>
 
 <body>
-	<div id="root"></div>
-	<noscript>
-		You need to enable JavaScript to run this app.
-	</noscript>
-	<script src="../dist/bundle.js"></script>
+	<h1>Your payment is complete!</h1>
 </body>
 
 </html>
+

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -17,7 +17,6 @@ import {
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
-	useFormStatus,
 	useIsStepActive,
 	usePaymentData,
 } from '../src/public-api';
@@ -61,6 +60,8 @@ const showSuccessMessage = message => {
 };
 
 async function fetchStripeConfiguration() {
+	// This simulates the network request time
+	await asyncTimeout( 2000 );
 	return {
 		public_key: stripeKey,
 		js_url: 'https://js.stripe.com/v3/',
@@ -69,6 +70,8 @@ async function fetchStripeConfiguration() {
 
 async function sendStripeTransaction( data ) {
 	window.console.log( 'Processing stripe transaction with data', data );
+	// This simulates the transaction and provisioning time
+	await asyncTimeout( 2000 );
 	return {
 		success: true,
 	};
@@ -76,6 +79,8 @@ async function sendStripeTransaction( data ) {
 
 async function makePayPalExpressRequest( data ) {
 	window.console.log( 'Processing paypal transaction with data', data );
+	// This simulates the transaction and provisioning time
+	await asyncTimeout( 2000 );
 	return window.location.href;
 }
 
@@ -246,17 +251,6 @@ function AdditionalFields() {
 	);
 }
 
-function ProvisioningContent() {
-	const [ , setFormStatus ] = useFormStatus();
-	// This simulates provisioning
-	useEffect( () => {
-		setTimeout( () => {
-			setFormStatus( 'complete' );
-		}, 1500 );
-	}, [ setFormStatus ] );
-	return <div>Please wait...</div>;
-}
-
 const steps = [
 	getDefaultOrderSummaryStep(),
 	{
@@ -310,8 +304,6 @@ function MyCheckout() {
 		setTimeout( () => setIsLoading( false ), 1500 );
 	}, [] );
 
-	const provisioningContent = <ProvisioningContent />;
-
 	return (
 		<CheckoutProvider
 			locale={ 'en' }
@@ -328,7 +320,7 @@ function MyCheckout() {
 			isLoading={ isLoading }
 			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
 		>
-			<Checkout steps={ steps } provisioningContent={ provisioningContent } />
+			<Checkout steps={ steps } />
 		</CheckoutProvider>
 	);
 }
@@ -339,6 +331,11 @@ function formatValueForCurrency( currency, value ) {
 	}
 	const floatValue = value / 100;
 	return '$' + floatValue.toString();
+}
+
+// Simulate network request time
+async function asyncTimeout( timeout ) {
+	return new Promise( resolve => setTimeout( resolve, timeout ) );
 }
 
 ReactDOM.render( <MyCheckout />, document.getElementById( 'root' ) );

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -39,9 +39,13 @@ const initialItems = [
 	},
 ];
 
-const onPaymentComplete = () => window.alert( 'Payment succeeded!' );
-const onEvent = event => window.console.log( 'Event', event );
+const successRedirectUrl = '/complete.html';
+const failureRedirectUrl = window.location.href;
 
+const onPaymentComplete = () => {
+	window.location.href = successRedirectUrl;
+};
+const onEvent = event => window.console.log( 'Event', event );
 const showErrorMessage = error => {
 	console.log( 'Error:', error ); /* eslint-disable-line no-console */
 	window.alert( 'There was a problem with your payment: ' + error );
@@ -54,10 +58,6 @@ const showSuccessMessage = message => {
 	console.log( 'Success:', message ); /* eslint-disable-line no-console */
 	window.alert( message );
 };
-
-// These are used only for redirect payment methods
-const successRedirectUrl = window.location.href;
-const failureRedirectUrl = window.location.href;
 
 async function fetchStripeConfiguration() {
 	return {

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -10,15 +10,16 @@ import ReactDOM from 'react-dom';
 import {
 	Checkout,
 	CheckoutProvider,
+	createApplePayMethod,
+	createPayPalMethod,
 	createRegistry,
 	createStripeMethod,
-	createPayPalMethod,
-	createApplePayMethod,
+	getDefaultOrderReviewStep,
+	getDefaultOrderSummaryStep,
+	getDefaultPaymentMethodStep,
+	useFormStatus,
 	useIsStepActive,
 	usePaymentData,
-	getDefaultPaymentMethodStep,
-	getDefaultOrderSummaryStep,
-	getDefaultOrderReviewStep,
 } from '../src/public-api';
 
 const stripeKey = 'pk_test_zIh4nRbVgmaetTZqoG4XKxWT';
@@ -245,6 +246,17 @@ function AdditionalFields() {
 	);
 }
 
+function ProvisioningContent() {
+	const [ , setFormStatus ] = useFormStatus();
+	// This simulates provisioning
+	useEffect( () => {
+		setTimeout( () => {
+			setFormStatus( 'complete' );
+		}, 1500 );
+	}, [ setFormStatus ] );
+	return <div>Please wait...</div>;
+}
+
 const steps = [
 	getDefaultOrderSummaryStep(),
 	{
@@ -298,6 +310,8 @@ function MyCheckout() {
 		setTimeout( () => setIsLoading( false ), 1500 );
 	}, [] );
 
+	const provisioningContent = <ProvisioningContent />;
+
 	return (
 		<CheckoutProvider
 			locale={ 'en' }
@@ -314,7 +328,7 @@ function MyCheckout() {
 			isLoading={ isLoading }
 			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
 		>
-			<Checkout steps={ steps } />
+			<Checkout steps={ steps } provisioningContent={ provisioningContent } />
 		</CheckoutProvider>
 	);
 }

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useContext, useState, useRef } from 'react';
+import React, { useContext, useMemo, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
@@ -59,20 +59,35 @@ export const CheckoutProvider = props => {
 	const registryRef = useRef( registry );
 	registryRef.current = registryRef.current || createRegistry();
 
-	const value = {
-		allPaymentMethods: paymentMethods,
-		paymentMethodId,
-		setPaymentMethodId,
-		onPaymentComplete,
-		showErrorMessage,
-		showInfoMessage,
-		showSuccessMessage,
-		successRedirectUrl,
-		failureRedirectUrl,
-		onEvent: onEvent || ( () => {} ),
-		formStatus,
-		setFormStatus,
-	};
+	const value = useMemo(
+		() => ( {
+			allPaymentMethods: paymentMethods,
+			paymentMethodId,
+			setPaymentMethodId,
+			onPaymentComplete,
+			showErrorMessage,
+			showInfoMessage,
+			showSuccessMessage,
+			successRedirectUrl,
+			failureRedirectUrl,
+			onEvent: onEvent || ( () => {} ),
+			formStatus,
+			setFormStatus,
+		} ),
+		[
+			failureRedirectUrl,
+			formStatus,
+			onEvent,
+			onPaymentComplete,
+			paymentMethodId,
+			paymentMethods,
+			setFormStatus,
+			showErrorMessage,
+			showInfoMessage,
+			showSuccessMessage,
+			successRedirectUrl,
+		]
+	);
 
 	// This error message cannot be translated because translation hasn't loaded yet.
 	const errorMessage = 'Sorry, there was an error loading this page';

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -151,14 +151,6 @@ function PaymentMethodWrapperProvider( { children, wrappers } ) {
 	}, children );
 }
 
-export function usePaymentComplete() {
-	const { onPaymentComplete } = useContext( CheckoutContext );
-	if ( ! onPaymentComplete ) {
-		throw new Error( 'usePaymentComplete can only be used inside a CheckoutProvider' );
-	}
-	return onPaymentComplete;
-}
-
 export function useEvents() {
 	const { onEvent } = useContext( CheckoutContext );
 	if ( ! onEvent ) {

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useContext, useMemo, useState, useRef } from 'react';
+import React, { useContext, useEffect, useMemo, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
@@ -142,21 +142,35 @@ function CheckoutProviderPropValidator( { propsToValidate } ) {
 		failureRedirectUrl,
 		paymentMethods,
 	} = propsToValidate;
-	debug( 'propsToValidate', propsToValidate );
+	useEffect( () => {
+		debug( 'propsToValidate', propsToValidate );
 
-	validateArg( locale, 'CheckoutProvider missing required prop: locale' );
-	validateArg( total, 'CheckoutProvider missing required prop: total' );
-	validateTotal( total );
-	validateArg( items, 'CheckoutProvider missing required prop: items' );
-	validateLineItems( items );
-	validateArg( paymentMethods, 'CheckoutProvider missing required prop: paymentMethods' );
-	validatePaymentMethods( paymentMethods );
-	validateArg( onPaymentComplete, 'CheckoutProvider missing required prop: onPaymentComplete' );
-	validateArg( showErrorMessage, 'CheckoutProvider missing required prop: showErrorMessage' );
-	validateArg( showInfoMessage, 'CheckoutProvider missing required prop: showInfoMessage' );
-	validateArg( showSuccessMessage, 'CheckoutProvider missing required prop: showSuccessMessage' );
-	validateArg( successRedirectUrl, 'CheckoutProvider missing required prop: successRedirectUrl' );
-	validateArg( failureRedirectUrl, 'CheckoutProvider missing required prop: failureRedirectUrl' );
+		validateArg( locale, 'CheckoutProvider missing required prop: locale' );
+		validateArg( total, 'CheckoutProvider missing required prop: total' );
+		validateTotal( total );
+		validateArg( items, 'CheckoutProvider missing required prop: items' );
+		validateLineItems( items );
+		validateArg( paymentMethods, 'CheckoutProvider missing required prop: paymentMethods' );
+		validatePaymentMethods( paymentMethods );
+		validateArg( onPaymentComplete, 'CheckoutProvider missing required prop: onPaymentComplete' );
+		validateArg( showErrorMessage, 'CheckoutProvider missing required prop: showErrorMessage' );
+		validateArg( showInfoMessage, 'CheckoutProvider missing required prop: showInfoMessage' );
+		validateArg( showSuccessMessage, 'CheckoutProvider missing required prop: showSuccessMessage' );
+		validateArg( successRedirectUrl, 'CheckoutProvider missing required prop: successRedirectUrl' );
+		validateArg( failureRedirectUrl, 'CheckoutProvider missing required prop: failureRedirectUrl' );
+	}, [
+		failureRedirectUrl,
+		items,
+		locale,
+		onPaymentComplete,
+		paymentMethods,
+		propsToValidate,
+		showErrorMessage,
+		showInfoMessage,
+		showSuccessMessage,
+		successRedirectUrl,
+		total,
+	] );
 	return null;
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -151,6 +151,14 @@ function PaymentMethodWrapperProvider( { children, wrappers } ) {
 	}, children );
 }
 
+export function usePaymentComplete() {
+	const { onPaymentComplete } = useContext( CheckoutContext );
+	if ( ! onPaymentComplete ) {
+		throw new Error( 'usePaymentComplete can only be used inside a CheckoutProvider' );
+	}
+	return onPaymentComplete;
+}
+
 export function useEvents() {
 	const { onEvent } = useContext( CheckoutContext );
 	if ( ! onEvent ) {

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -138,6 +138,7 @@ export default function Checkout( { steps, className } ) {
 
 	useEffect( () => {
 		if ( formStatus === 'complete' ) {
+			debug( "form status is complete so I'm calling onPaymentComplete" );
 			onPaymentComplete();
 		}
 	}, [ formStatus, onPaymentComplete ] );

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -136,6 +136,12 @@ export default function Checkout( { steps, className } ) {
 	const isCheckoutInProgress =
 		isThereAnIncompleteStep || isThereAnotherNumberedStep || formStatus !== 'ready';
 
+	useEffect( () => {
+		if ( formStatus === 'complete' ) {
+			onPaymentComplete();
+		}
+	}, [ formStatus, onPaymentComplete ] );
+
 	if ( formStatus === 'loading' ) {
 		return (
 			<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
@@ -147,10 +153,6 @@ export default function Checkout( { steps, className } ) {
 				</MainContent>
 			</Container>
 		);
-	}
-
-	if ( formStatus === 'complete' ) {
-		onPaymentComplete();
 	}
 
 	return (

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -83,7 +83,7 @@ export default function Checkout( { steps, className } ) {
 	const localize = useLocalize();
 	const [ paymentData ] = usePaymentData();
 	const activePaymentMethod = usePaymentMethod();
-	const [ formStatus ] = useFormStatus();
+	const { formStatus } = useFormStatus();
 	const onPaymentComplete = usePaymentComplete();
 
 	// Re-render if any store changes; that way isComplete can rely on any data

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -32,7 +32,7 @@ import {
 	getDefaultOrderReviewStep,
 } from './default-steps';
 import { validateSteps } from '../lib/validation';
-import { useEvents } from './checkout-provider';
+import { useEvents, useCheckoutRedirects } from './checkout-provider';
 import { useFormStatus } from '../lib/form-status';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
@@ -84,6 +84,7 @@ export default function Checkout( { steps, className } ) {
 	const [ paymentData ] = usePaymentData();
 	const activePaymentMethod = usePaymentMethod();
 	const [ formStatus ] = useFormStatus();
+	const { successRedirectUrl } = useCheckoutRedirects();
 
 	// Re-render if any store changes; that way isComplete can rely on any data
 	useRenderOnStoreUpdate();
@@ -159,6 +160,10 @@ export default function Checkout( { steps, className } ) {
 				</MainContent>
 			</Container>
 		);
+	}
+
+	if ( formStatus === 'complete' ) {
+		window.location.href = successRedirectUrl;
 	}
 
 	return (

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -15,6 +15,7 @@ import CheckoutStep from './checkout-step';
 import CheckoutNextStepButton from './checkout-next-step-button';
 import CheckoutSubmitButton from './checkout-submit-button';
 import LoadingContent from './loading-content';
+import ProvisioningContent from './provisioning-content';
 import {
 	usePrimarySelect,
 	usePrimaryDispatch,
@@ -142,6 +143,19 @@ export default function Checkout( { steps, className } ) {
 					isCheckoutInProgress={ isCheckoutInProgress }
 				>
 					<LoadingContent />
+				</MainContent>
+			</Container>
+		);
+	}
+
+	if ( formStatus === 'provisioning' ) {
+		return (
+			<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
+				<MainContent
+					className={ joinClasses( [ className, 'checkout__content' ] ) }
+					isCheckoutInProgress={ isCheckoutInProgress }
+				>
+					<ProvisioningContent />
 				</MainContent>
 			</Container>
 		);

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -78,7 +78,7 @@ function useRegisterCheckoutStore() {
 	} );
 }
 
-export default function Checkout( { steps, provisioningContent, className } ) {
+export default function Checkout( { steps, className } ) {
 	useRegisterCheckoutStore();
 	const localize = useLocalize();
 	const [ paymentData ] = usePaymentData();
@@ -149,19 +149,6 @@ export default function Checkout( { steps, provisioningContent, className } ) {
 		);
 	}
 
-	if ( formStatus === 'provisioning' ) {
-		return (
-			<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
-				<MainContent
-					className={ joinClasses( [ className, 'checkout__content' ] ) }
-					isCheckoutInProgress={ isCheckoutInProgress }
-				>
-					{ provisioningContent }
-				</MainContent>
-			</Container>
-		);
-	}
-
 	if ( formStatus === 'complete' ) {
 		onPaymentComplete();
 	}
@@ -209,7 +196,6 @@ export default function Checkout( { steps, provisioningContent, className } ) {
 Checkout.propTypes = {
 	className: PropTypes.string,
 	steps: PropTypes.array,
-	provisioningContent: PropTypes.node.isRequired,
 };
 
 function CheckoutStepContainer( {

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -32,7 +32,7 @@ import {
 	getDefaultOrderReviewStep,
 } from './default-steps';
 import { validateSteps } from '../lib/validation';
-import { useEvents, useCheckoutRedirects } from './checkout-provider';
+import { useEvents, usePaymentComplete } from './checkout-provider';
 import { useFormStatus } from '../lib/form-status';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
@@ -84,7 +84,7 @@ export default function Checkout( { steps, className } ) {
 	const [ paymentData ] = usePaymentData();
 	const activePaymentMethod = usePaymentMethod();
 	const [ formStatus ] = useFormStatus();
-	const { successRedirectUrl } = useCheckoutRedirects();
+	const onPaymentComplete = usePaymentComplete();
 
 	// Re-render if any store changes; that way isComplete can rely on any data
 	useRenderOnStoreUpdate();
@@ -163,7 +163,7 @@ export default function Checkout( { steps, className } ) {
 	}
 
 	if ( formStatus === 'complete' ) {
-		window.location.href = successRedirectUrl;
+		onPaymentComplete();
 	}
 
 	return (

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -78,7 +78,7 @@ function useRegisterCheckoutStore() {
 	} );
 }
 
-export default function Checkout( { steps, className } ) {
+export default function Checkout( { steps, provisioningContent, className } ) {
 	useRegisterCheckoutStore();
 	const localize = useLocalize();
 	const [ paymentData ] = usePaymentData();
@@ -156,7 +156,7 @@ export default function Checkout( { steps, className } ) {
 					className={ joinClasses( [ className, 'checkout__content' ] ) }
 					isCheckoutInProgress={ isCheckoutInProgress }
 				>
-					<ProvisioningContent />
+					{ provisioningContent }
 				</MainContent>
 			</Container>
 		);
@@ -209,6 +209,7 @@ export default function Checkout( { steps, className } ) {
 Checkout.propTypes = {
 	className: PropTypes.string,
 	steps: PropTypes.array,
+	provisioningContent: PropTypes.node.isRequired,
 };
 
 function CheckoutStepContainer( {

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -22,12 +22,12 @@ export default function PaymentRequestButton( {
 	disabledReason,
 } ) {
 	const localize = useLocalize();
-	const [ formStatus, setFormStatus ] = useFormStatus();
+	const { formStatus, setFormReady, setFormSubmitting } = useFormStatus();
 	const onClick = event => {
 		event.persist();
 		event.preventDefault();
-		setFormStatus( 'submitting' );
-		paymentRequest.on( 'cancel', () => setFormStatus( 'ready' ) );
+		setFormSubmitting();
+		paymentRequest.on( 'cancel', setFormReady );
 		paymentRequest.show();
 	};
 	if ( ! paymentRequest ) {

--- a/packages/composite-checkout/src/components/provisioning-content.js
+++ b/packages/composite-checkout/src/components/provisioning-content.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function ProvisioningContent() {
+	// TODO: fill this in and style it
+	return <div>Please wait...</div>;
+}

--- a/packages/composite-checkout/src/components/provisioning-content.js
+++ b/packages/composite-checkout/src/components/provisioning-content.js
@@ -1,9 +1,0 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-export default function ProvisioningContent() {
-	// TODO: fill this in and style it
-	return <div>Please wait...</div>;
-}

--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useReducer, useCallback, useContext, useEffect } from 'react';
+import { useReducer, useMemo, useCallback, useContext, useEffect } from 'react';
 import debugFactory from 'debug';
 
 /**
@@ -13,7 +13,16 @@ const debug = debugFactory( 'composite-checkout:form-status' );
 
 export function useFormStatus() {
 	const { formStatus, setFormStatus } = useContext( CheckoutContext );
-	return [ formStatus, setFormStatus ];
+	return useMemo(
+		() => ( {
+			formStatus,
+			setFormLoading: setFormStatus( 'loading' ),
+			setFormReady: setFormStatus( 'ready' ),
+			setFormSubmitting: setFormStatus( 'submitting' ),
+			setFormComplete: setFormStatus( 'complete' ),
+		} ),
+		[ formStatus, setFormStatus ]
+	);
 }
 
 export function useFormStatusManager( isLoading ) {

--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -54,7 +54,7 @@ function formStatusReducer( state, action ) {
 }
 
 function validateStatus( status ) {
-	const validStatuses = [ 'loading', 'ready', 'submitting', 'provisioning', 'complete' ];
+	const validStatuses = [ 'loading', 'ready', 'submitting', 'complete' ];
 	if ( ! validStatuses.includes( status ) ) {
 		throw new Error( `Invalid form status '${ status }'` );
 	}

--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -16,10 +16,10 @@ export function useFormStatus() {
 	return useMemo(
 		() => ( {
 			formStatus,
-			setFormLoading: setFormStatus( 'loading' ),
-			setFormReady: setFormStatus( 'ready' ),
-			setFormSubmitting: setFormStatus( 'submitting' ),
-			setFormComplete: setFormStatus( 'complete' ),
+			setFormLoading: () => setFormStatus( 'loading' ),
+			setFormReady: () => setFormStatus( 'ready' ),
+			setFormSubmitting: () => setFormStatus( 'submitting' ),
+			setFormComplete: () => setFormStatus( 'complete' ),
 		} ),
 		[ formStatus, setFormStatus ]
 	);

--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -54,7 +54,7 @@ function formStatusReducer( state, action ) {
 }
 
 function validateStatus( status ) {
-	const validStatuses = [ 'loading', 'ready', 'submitting' ];
+	const validStatuses = [ 'loading', 'ready', 'submitting', 'provisioning', 'complete' ];
 	if ( ! validStatuses.includes( status ) ) {
 		throw new Error( `Invalid form status '${ status }'` );
 	}

--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -31,9 +31,6 @@ export function useFormStatusManager( isLoading ) {
 		isLoading ? 'loading' : 'ready'
 	);
 	const setFormStatus = useCallback( payload => {
-		if ( typeof payload === 'function' ) {
-			return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE_WITH_FUNCTION', payload } );
-		}
 		return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE', payload } );
 	}, [] );
 	useEffect( () => {
@@ -51,12 +48,6 @@ function formStatusReducer( state, action ) {
 			validateStatus( action.payload );
 			debug( 'setting form status to', action.payload );
 			return action.payload;
-		case 'FORM_STATUS_CHANGE_WITH_FUNCTION': {
-			const newStatus = action.payload( state );
-			validateStatus( newStatus );
-			debug( 'setting form status to', newStatus );
-			return newStatus;
-		}
 		default:
 			return state;
 	}

--- a/packages/composite-checkout/src/lib/line-items.js
+++ b/packages/composite-checkout/src/lib/line-items.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 
 /**
  * Internal dependencies
@@ -9,7 +9,7 @@ import React, { useContext } from 'react';
 import LineItemsContext from './line-items-context';
 
 export function LineItemsProvider( { items, total, children } ) {
-	const value = { items, total };
+	const value = useMemo( () => ( { items, total } ), [ items, total ] );
 	return <LineItemsContext.Provider value={ value }>{ children }</LineItemsContext.Provider>;
 }
 

--- a/packages/composite-checkout/src/lib/localize.js
+++ b/packages/composite-checkout/src/lib/localize.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useContext } from 'react';
+import React, { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { __, setLocaleData, sprintf } from '@wordpress/i18n';
 
@@ -10,9 +10,9 @@ import { __, setLocaleData, sprintf } from '@wordpress/i18n';
  */
 import LocalizeContext from './localize-context';
 
-export default function localizeFactory( locale ) {
+function useLocalizeFactory( locale ) {
 	setLocaleData( getLocaleDataForLocale( locale ) );
-	return text => __( text, 'default' );
+	return useCallback( text => __( text, 'default' ), [] );
 }
 
 export function useLocalize() {
@@ -27,7 +27,7 @@ export function LocalizeProvider( { locale, children } ) {
 	if ( ! locale ) {
 		throw new Error( 'LocalizeProvider requires locale' );
 	}
-	const localize = localizeFactory( locale );
+	const localize = useLocalizeFactory( locale );
 	return <LocalizeContext.Provider value={ localize }>{ children }</LocalizeContext.Provider>;
 }
 

--- a/packages/composite-checkout/src/lib/localize.js
+++ b/packages/composite-checkout/src/lib/localize.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useContext, useCallback } from 'react';
+import React, { useContext, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { __, setLocaleData, sprintf } from '@wordpress/i18n';
 
@@ -11,8 +11,12 @@ import { __, setLocaleData, sprintf } from '@wordpress/i18n';
 import LocalizeContext from './localize-context';
 
 function useLocalizeFactory( locale ) {
-	setLocaleData( getLocaleDataForLocale( locale ) );
-	return useCallback( text => __( text, 'default' ), [] );
+	const localize = useRef( text => text );
+	useEffect( () => {
+		setLocaleData( getLocaleDataForLocale( locale ) );
+		localize.current = text => __( text, 'default' );
+	}, [ locale ] );
+	return localize.current;
 }
 
 export function useLocalize() {

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -87,10 +87,10 @@ export function ApplePayLabel() {
 export function ApplePaySubmitButton( { disabled } ) {
 	const localize = useLocalize();
 	const paymentRequestOptions = usePaymentRequestOptions();
-	const [ , setFormStatus ] = useFormStatus();
+	const { setFormComplete } = useFormStatus();
 	const { paymentRequest, canMakePayment } = useStripePaymentRequest( {
 		paymentRequestOptions,
-		onSubmit: () => setFormStatus( 'complete' ),
+		onSubmit: setFormComplete,
 	} );
 
 	if ( ! canMakePayment ) {

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -90,7 +90,7 @@ export function ApplePaySubmitButton( { disabled } ) {
 	const [ , setFormStatus ] = useFormStatus();
 	const { paymentRequest, canMakePayment } = useStripePaymentRequest( {
 		paymentRequestOptions,
-		onSubmit: () => setFormStatus( 'provisioning' ),
+		onSubmit: () => setFormStatus( 'complete' ),
 	} );
 
 	if ( ! canMakePayment ) {

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -7,10 +7,11 @@ import React, { useState, useEffect, useMemo } from 'react';
  * Internal dependencies
  */
 import { StripeHookProvider, useStripe } from '../../lib/stripe';
-import { useLineItems, usePaymentComplete } from '../../public-api';
+import { useLineItems } from '../../public-api';
 import { useLocalize } from '../../lib/localize';
 import PaymentRequestButton from '../../components/payment-request-button';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+import { useFormStatus } from '../form-status';
 
 export function createApplePayMethod( { registerStore, fetchStripeConfiguration } ) {
 	const actions = {
@@ -85,11 +86,11 @@ export function ApplePayLabel() {
 
 export function ApplePaySubmitButton( { disabled } ) {
 	const localize = useLocalize();
-	const onPaymentComplete = usePaymentComplete();
 	const paymentRequestOptions = usePaymentRequestOptions();
+	const [ , setFormStatus ] = useFormStatus();
 	const { paymentRequest, canMakePayment } = useStripePaymentRequest( {
 		paymentRequestOptions,
-		onSubmit: onPaymentComplete,
+		onSubmit: () => setFormStatus( 'provisioning' ),
 	} );
 
 	if ( ! canMakePayment ) {

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -111,7 +111,7 @@ export function PaypalSubmitButton( { disabled } ) {
 	const [ paymentData ] = usePaymentData();
 	const { billing = {} } = paymentData;
 	useTransactionStatusHandler();
-	const [ formStatus ] = useFormStatus();
+	const { formStatus } = useFormStatus();
 
 	const onClick = () =>
 		submitPaypalPayment( {
@@ -141,7 +141,7 @@ function useTransactionStatusHandler() {
 	const { showErrorMessage } = useMessages();
 	const transactionStatus = useSelect( select => select( 'paypal' ).getTransactionStatus() );
 	const transactionError = useSelect( select => select( 'paypal' ).getTransactionError() );
-	const [ , setFormStatus ] = useFormStatus();
+	const { setFormReady, setFormSubmitting } = useFormStatus();
 
 	useEffect( () => {
 		if ( transactionStatus === 'redirecting' ) {
@@ -149,18 +149,24 @@ function useTransactionStatusHandler() {
 			return;
 		}
 		if ( transactionStatus === 'error' ) {
-			setFormStatus( 'ready' );
+			setFormReady();
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
 			return;
 		}
 		if ( transactionStatus === 'submitting' ) {
-			setFormStatus( 'submitting' );
+			setFormSubmitting();
 			return;
 		}
-		setFormStatus( status => ( status === 'submitting' ? 'ready' : status ) );
-	}, [ localize, showErrorMessage, transactionStatus, transactionError, setFormStatus ] );
+	}, [
+		localize,
+		showErrorMessage,
+		transactionStatus,
+		transactionError,
+		setFormReady,
+		setFormSubmitting,
+	] );
 }
 
 const ButtonPayPalIcon = styled( PaypalLogo )`

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -60,9 +60,9 @@ export function createPayPalMethod( { registerStore, makePayPalExpressRequest } 
 		reducer( state = {}, action ) {
 			switch ( action.type ) {
 				case 'PAYPAL_TRANSACTION_BEGIN':
-					return { ...state, paypalStatus: 'submitting', paypalExpressUrl: action.payload };
+					return { ...state, paypalStatus: 'submitting' };
 				case 'PAYPAL_TRANSACTION_END':
-					return { ...state, paypalStatus: 'complete', paypalExpressUrl: action.payload };
+					return { ...state, paypalStatus: 'redirecting', paypalExpressUrl: action.payload };
 				case 'PAYPAL_TRANSACTION_ERROR':
 					return { ...state, paypalStatus: 'error', paypalError: action.payload };
 			}
@@ -144,8 +144,8 @@ function useTransactionStatusHandler() {
 	const [ , setFormStatus ] = useFormStatus();
 
 	useEffect( () => {
-		if ( transactionStatus === 'complete' ) {
-			setFormStatus( 'provisioning' );
+		if ( transactionStatus === 'redirecting' ) {
+			// TODO: redirect to url
 			return;
 		}
 		if ( transactionStatus === 'error' ) {

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -10,12 +10,7 @@ import styled from '@emotion/styled';
 import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
 import { useDispatch, useSelect, usePaymentData } from '../../lib/registry';
-import {
-	useMessages,
-	usePaymentComplete,
-	useCheckoutRedirects,
-	useLineItems,
-} from '../../public-api';
+import { useMessages, useCheckoutRedirects, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
@@ -143,7 +138,6 @@ export function PaypalSubmitButton( { disabled } ) {
 
 function useTransactionStatusHandler() {
 	const localize = useLocalize();
-	const onPaymentComplete = usePaymentComplete();
 	const { showErrorMessage } = useMessages();
 	const transactionStatus = useSelect( select => select( 'paypal' ).getTransactionStatus() );
 	const transactionError = useSelect( select => select( 'paypal' ).getTransactionError() );
@@ -151,7 +145,7 @@ function useTransactionStatusHandler() {
 
 	useEffect( () => {
 		if ( transactionStatus === 'complete' ) {
-			onPaymentComplete();
+			setFormStatus( 'provisioning' );
 			return;
 		}
 		if ( transactionStatus === 'error' ) {
@@ -166,14 +160,7 @@ function useTransactionStatusHandler() {
 			return;
 		}
 		setFormStatus( status => ( status === 'submitting' ? 'ready' : status ) );
-	}, [
-		localize,
-		onPaymentComplete,
-		showErrorMessage,
-		transactionStatus,
-		transactionError,
-		setFormStatus,
-	] );
+	}, [ localize, showErrorMessage, transactionStatus, transactionError, setFormStatus ] );
 }
 
 const ButtonPayPalIcon = styled( PaypalLogo )`

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -616,7 +616,7 @@ function StripePayButton( { disabled } ) {
 	const transactionAuthData = useSelect( select => select( 'stripe' ).getTransactionAuthData() );
 	const { beginStripeTransaction } = useDispatch( 'stripe' );
 	const name = useSelect( select => select( 'stripe' ).getCardholderName() );
-	const [ formStatus, setFormStatus ] = useFormStatus();
+	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
@@ -624,10 +624,10 @@ function StripePayButton( { disabled } ) {
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
-			setFormStatus( 'ready' );
+			setFormReady();
 		}
 		if ( transactionStatus === 'complete' ) {
-			setFormStatus( 'complete' );
+			setFormComplete();
 		}
 		if ( transactionStatus === 'redirect' ) {
 			// TODO: notify user that we are going to redirect
@@ -637,12 +637,13 @@ function StripePayButton( { disabled } ) {
 				stripeConfiguration,
 				response: transactionAuthData,
 			} ).catch( error => {
-				setFormStatus( 'ready' );
+				setFormReady();
 				showErrorMessage( error.stripeError || error.message );
 			} );
 		}
 	}, [
-		setFormStatus,
+		setFormReady,
+		setFormComplete,
 		showErrorMessage,
 		transactionStatus,
 		transactionError,
@@ -669,7 +670,7 @@ function StripePayButton( { disabled } ) {
 					successUrl: successRedirectUrl,
 					cancelUrl: failureRedirectUrl,
 					beginStripeTransaction,
-					setFormStatus,
+					setFormSubmitting,
 				} )
 			}
 			buttonState={ disabled ? 'disabled' : 'primary' }
@@ -704,10 +705,11 @@ async function submitStripePayment( {
 	successUrl,
 	cancelUrl,
 	beginStripeTransaction,
-	setFormStatus,
+	setFormSubmitting,
+	setFormReady,
 } ) {
 	try {
-		setFormStatus( 'submitting' );
+		setFormSubmitting();
 		beginStripeTransaction( {
 			stripe,
 			name,
@@ -718,7 +720,7 @@ async function submitStripePayment( {
 			cancelUrl,
 		} );
 	} catch ( error ) {
-		setFormStatus( 'ready' );
+		setFormReady();
 		showErrorMessage( error );
 		return;
 	}

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -627,7 +627,7 @@ function StripePayButton( { disabled } ) {
 			setFormStatus( 'ready' );
 		}
 		if ( transactionStatus === 'complete' ) {
-			setFormStatus( 'provisioning' );
+			setFormStatus( 'complete' );
 		}
 		if ( transactionStatus === 'redirect' ) {
 			// TODO: notify user that we are going to redirect
@@ -637,6 +637,7 @@ function StripePayButton( { disabled } ) {
 				stripeConfiguration,
 				response: transactionAuthData,
 			} ).catch( error => {
+				setFormStatus( 'ready' );
 				showErrorMessage( error.stripeError || error.message );
 			} );
 		}

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -22,7 +22,6 @@ import {
 import {
 	useSelect,
 	useDispatch,
-	usePaymentComplete,
 	useMessages,
 	useLineItems,
 	useCheckoutRedirects,
@@ -610,7 +609,6 @@ function StripePayButton( { disabled } ) {
 	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage } = useMessages();
-	const onPaymentComplete = usePaymentComplete();
 	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
 	const { stripe, stripeConfiguration } = useStripe();
 	const transactionStatus = useSelect( select => select( 'stripe' ).getTransactionStatus() );
@@ -626,9 +624,10 @@ function StripePayButton( { disabled } ) {
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
+			setFormStatus( 'ready' );
 		}
 		if ( transactionStatus === 'complete' ) {
-			onPaymentComplete();
+			setFormStatus( 'provisioning' );
 		}
 		if ( transactionStatus === 'redirect' ) {
 			// TODO: notify user that we are going to redirect
@@ -642,7 +641,7 @@ function StripePayButton( { disabled } ) {
 			} );
 		}
 	}, [
-		onPaymentComplete,
+		setFormStatus,
 		showErrorMessage,
 		transactionStatus,
 		transactionError,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -27,7 +27,7 @@ import {
 	useCheckoutRedirects,
 	renderDisplayValueMarkdown,
 } from '../../public-api';
-import useLocalize, { sprintf } from '../localize';
+import { sprintf, useLocalize } from '../localize';
 import {
 	VisaLogo,
 	AmexLogo,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -4,7 +4,6 @@
 import {
 	CheckoutProvider,
 	useEvents,
-	usePaymentComplete,
 	useMessages,
 	useCheckoutRedirects,
 } from './components/checkout-provider';
@@ -71,7 +70,6 @@ export {
 	useIsStepActive,
 	useLineItems,
 	useMessages,
-	usePaymentComplete,
 	usePaymentData,
 	usePaymentMethod,
 	usePaymentMethodId,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -40,6 +40,7 @@ import {
 	getDefaultPaymentMethodStep,
 	getDefaultOrderReviewStep,
 } from './components/default-steps';
+import { useFormStatus } from './lib/form-status';
 
 // Re-export the public API
 export {
@@ -67,6 +68,7 @@ export {
 	useCheckoutRedirects,
 	useDispatch,
 	useEvents,
+	useFormStatus,
 	useIsStepActive,
 	useLineItems,
 	useMessages,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies checkout to add an additional form status. Previously there was `loading`, `ready`, and `submitting`. This adds `complete`. It also removes `usePaymentComplete` from the public API. Instead of calling `onPaymentComplete` directly when a Payment Method object finishes, it now changes the form status to `complete`. This will automatically trigger the `onPaymentComplete` callback.

Using this technique, this PR redirects to a "complete" page when the purchase is successful.

It also modifies the "jump-to-step" behavior added in #38493 so that it only jumps when all previous steps are complete.

#### Testing instructions

First test the demo.

- Run `npm run composite-checkout-demo`.
- Complete the form using the Credit card payment method (use the Stripe test card of `4242424242424242`) and press "Pay".
- Verify that there is a short pause during which the button is disabled, then the page should redirect to a "complete" page.

Then test Calypso.

- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`
- Add a plan to your cart (not a domain) and visit checkout.
- Complete the form using the Credit card payment method (use the Stripe test card of `4242424242424242`) and press "Pay".
- Verify that there is a short pause during which the button is disabled, then the page should redirect to a "complete" page.
