### PR TITLE
Popover: make the component SSR safe

### DIFF
--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -4,9 +4,6 @@ jest.mock( 'lib/abtest', () => ( {
 
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/user', () => ( {} ) );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
 jest.mock( 'components/banner', () => 'Banner' );
 
 jest.mock( 'i18n-calypso', () => ( {

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -400,7 +400,7 @@ function Popover( { isVisible = false, showDelay = 0, ...props } ) {
 // In case of a React component instance, we'll find the DOM element with `findDOMNode`.
 const PropTypeElement = PropTypes.oneOfType( [
 	PropTypes.instanceOf( Component ),
-	PropTypes.instanceOf( window.Element ),
+	PropTypes.instanceOf( typeof window !== 'undefined' ? window.Element : Object ),
 ] );
 
 Popover.propTypes = {

--- a/client/components/popover/util.js
+++ b/client/components/popover/util.js
@@ -54,7 +54,7 @@ function onViewportChange() {
 	_viewport = updateViewport();
 }
 
-const bindWindowListeners = () => {
+export function bindWindowListeners() {
 	if ( _windowEventsRefCount++ > 0 ) {
 		return;
 	}
@@ -63,9 +63,9 @@ const bindWindowListeners = () => {
 	// don't debounce these because they don't so any work that requires layout
 	window.addEventListener( 'resize', onViewportChange, true );
 	window.addEventListener( 'scroll', onViewportChange, true );
-};
+}
 
-const unbindWindowListeners = () => {
+export function unbindWindowListeners() {
 	if ( --_windowEventsRefCount > 0 ) {
 		return;
 	}
@@ -73,9 +73,9 @@ const unbindWindowListeners = () => {
 	debug( 'unbind handlers to `resize` and `scroll` events' );
 	window.removeEventListener( 'resize', onViewportChange, true );
 	window.removeEventListener( 'scroll', onViewportChange, true );
-};
+}
 
-const suggested = ( pos, el, target ) => {
+export function suggested( pos, el, target ) {
 	const viewport = getViewport();
 	const targetPosition = getBoundingClientRect( target );
 	const h = el.clientHeight;
@@ -100,7 +100,7 @@ const suggested = ( pos, el, target ) => {
 	}
 
 	return chooseSecondary( primary, pos1, el, target, w, h ) || pos;
-};
+}
 
 function choosePrimary( prefered, room ) {
 	// top, bottom, left, right in order of preference
@@ -189,7 +189,7 @@ function chooseSecondary( primary, prefered, el, target, w, h ) {
 	return bestPos;
 }
 
-function offset( pos, el, target, relativePosition ) {
+export function offset( pos, el, target, relativePosition ) {
 	const pad = 15;
 	const tipRect = getBoundingClientRect( el );
 
@@ -343,12 +343,10 @@ function _offset( box, doc ) {
  * @param {window.Element} el Element to be constained to viewport
  * @returns {number}    the best width
  */
-function constrainLeft( off, el ) {
+export function constrainLeft( off, el ) {
 	const viewport = getViewport();
 	const ew = getBoundingClientRect( el ).width;
 	off.left = Math.max( 0, Math.min( off.left, viewport.width - ew ) );
 
 	return off;
 }
-
-export { constrainLeft, bindWindowListeners, unbindWindowListeners, suggested, offset };

--- a/client/components/seo/preview-upgrade-nudge/test/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/test/index.jsx
@@ -5,9 +5,6 @@ jest.mock( 'lib/abtest', () => ( {
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( 'lib/analytics/track-component-view', () => 'TrackComponentView' );
-jest.mock( 'lib/user', () => ( {} ) );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
 jest.mock( 'components/banner', () => 'Banner' );
 
 jest.mock( 'i18n-calypso', () => ( {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
@@ -4,9 +4,6 @@ jest.mock( 'lib/abtest', () => ( {
 
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/user', () => () => {} );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -4,10 +4,6 @@ jest.mock( 'lib/abtest', () => ( {
 
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/user', () => ( {} ) );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
-jest.mock( 'components/info-popover', () => 'InfoPopover' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -5,10 +5,6 @@ jest.mock( 'lib/abtest', () => ( {
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/ad-tracking', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/user', () => () => {} );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
-jest.mock( 'components/info-popover', () => 'InfoPopover' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -7,7 +7,6 @@ jest.mock( 'react-redux', () => ( {
 } ) );
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'config', () => {
 	const fn = () => {};
 	fn.isEnabled = jest.fn( () => true );
@@ -18,8 +17,6 @@ jest.mock( 'components/data/query-plans', () => 'QueryPlans' );
 jest.mock( 'components/data/query-site-plans', () => 'QuerySitePlans' );
 jest.mock( 'components/data/cart', () => 'CartData' );
 jest.mock( 'blocks/payment-methods', () => 'PaymentMethods' );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
 jest.mock( 'my-sites/plan-features', () => 'PlanFeatures' );
 jest.mock( 'my-sites/plans-features-main/wpcom-faq', () => 'WpcomFAQ' );
 jest.mock( 'my-sites/plans-features-main/jetpack-faq', () => 'JetpackFAQ' );

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -4,7 +4,6 @@ jest.mock( 'lib/abtest', () => ( {
 
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'lib/translator-jumpstart', () => ( {} ) );
 jest.mock( 'lib/plugins/wporg-data/actions', () => ( {} ) );
 jest.mock( 'lib/plugins/wporg-data/list-store', () => ( {
@@ -17,8 +16,6 @@ jest.mock( 'state/ui/guided-tours/selectors', () => ( {} ) );
 jest.mock( 'my-sites/plugins/utils', () => ( {
 	getExtensionSettingsPath: () => '',
 } ) );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
 jest.mock( 'layout/guided-tours/positioning', () => 'Positioning' );
 jest.mock( 'layout/guided-tours/tours/main-tour', () => 'MainTour' );
 jest.mock( 'layout/masterbar/logged-in', () => 'LoggedIn' );

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -6,11 +6,7 @@ jest.mock( 'store', () => ( {
 	get: () => {},
 	User: () => {},
 } ) );
-jest.mock( 'components/language-picker', () => 'LanguagePicker' );
-jest.mock( 'components/popover', () => 'Popover' );
-jest.mock( 'components/info-popover', () => 'InfoPopover' );
 jest.mock( 'components/banner', () => 'Banner' );
-jest.mock( 'components/data/query-site-settings', () => 'QuerySiteSettings' );
 
 /**
  * External dependencies

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -13,9 +13,6 @@ import ThemeSheetComponent from '../main';
 import { createReduxStore } from 'state';
 import { receiveTheme, themeRequestFailure } from 'state/themes/actions';
 
-jest.mock( 'components/data/query-user-purchases', () => require( 'components/empty-component' ) );
-jest.mock( 'components/data/query-site-purchases', () => require( 'components/empty-component' ) );
-jest.mock( 'components/popover', () => require( 'components/empty-component' ) );
 jest.mock( 'lib/analytics', () => ( {} ) );
 jest.mock( 'lib/wp', () => ( {
 	undocumented: () => ( {

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -15,14 +15,10 @@ import { THEMES_REQUEST_FAILURE } from 'state/action-types';
 import { receiveThemes } from 'state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 
-jest.mock( 'components/popover', () => require( 'components/empty-component' ) );
 jest.mock( 'lib/abtest', () => ( { abtest: () => {} } ) );
 jest.mock( 'lib/analytics', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => require( 'components/empty-component' ) );
 jest.mock( 'my-sites/themes/theme-preview', () => require( 'components/empty-component' ) );
-
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'lib/user', () => () => {} );
 
 describe( 'logged-out', () => {
 	describe( 'when calling renderToString()', () => {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -16,7 +16,6 @@ import { EditorGroundControl } from '../';
 import { isSaveAvailableFn } from '../quick-save-buttons';
 
 jest.mock( 'blocks/site', () => require( 'components/empty-component' ) );
-jest.mock( 'components/popover', () => require( 'components/empty-component' ) );
 jest.mock( 'components/post-schedule', () => require( 'components/empty-component' ) );
 jest.mock( 'components/sticky-panel', () => require( 'components/empty-component' ) );
 jest.mock( 'post-editor/edit-post-status', () => require( 'components/empty-component' ) );

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -4,9 +4,6 @@ jest.mock( 'lib/abtest', () => ( {
 
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'lib/user', () => ( {} ) );
-jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/popover', () => 'Popover' );
 
 /**
  * External dependencies

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -138,10 +138,6 @@ const webpackConfig = {
 		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]user$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
-			/^components[/\\]popover$/,
-			'components/null-component'
-		), // Depends on BOM and interactions don't work without JS
-		new webpack.NormalModuleReplacementPlugin(
 			/^my-sites[/\\]themes[/\\]theme-upload$/,
 			'components/empty-component'
 		), // Depends on BOM


### PR DESCRIPTION
Another small step on the journey to make the `Popover` component behave well and prepare it for inclusion in `@automattic/components`.

Until now, the `Popover` component could not be loaded in a Node.js environment because the `components/popover/util` module tries to read the DOM viewport dimensions during its static initialization:
```js
let viewport = updateViewport();
```
That fails in an environment without DOM and you can't even load the module.

I changed that so that the DOM reads are done only when the viewport is needed for the first time.

Also, I updated the `bind/unbindWindowListeners` function to reference count the calls from multiple popovers (each `Popover` listens for viewport changes so that it can reposition itself). That fixes a bug where the viewport stopped updating when there are 2+ popovers, because the listeners was removed too soon.

**How to test:**
Verify that the Calypso server builds and correctly renders SSR pages.

In the `components/popover` module, I also had to guard the reference to `window.Element` when checking proptypes.

The net result is that we no longer need to alias the `components/popover` module to an empty component in the server-side webpack build (see the change in `webpack.config.node.js`).

And we don't need to mock `components/popover` in many Enzyme tests any more.