### PR TITLE
Wait for blocks when triggering the conversion prompt

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/tinymce.js
+++ b/apps/wpcom-block-editor/src/calypso/features/tinymce.js
@@ -8,7 +8,7 @@ import tinymce from 'tinymce/tinymce';
 /**
  * Internal dependencies
  */
-import { inIframe, sendMessage } from '../utils';
+import { inIframe, sendMessage } from '../../utils';
 
 function replaceMediaModalOnClassicBlocks() {
 	if ( ! inIframe() ) {

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -1,3 +1,9 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { select, subscribe } from '@wordpress/data';
+
 /**
  * Checks self and top to determine if we are being loaded in an iframe.
  * Can't use window.frameElement because we are being embedded from a different origin.
@@ -25,3 +31,27 @@ export function sendMessage( message ) {
 
 	window.parent.postMessage( { ...message, type: 'gutenbergIframeMessage' }, '*' );
 }
+
+/**
+ * Indicates if the block editor has been initialized with blocks.
+ *
+ * @returns {Promise} Promise that resolves when the editor has been initialized.
+ */
+export const isEditorReadyWithBlocks = async () => new Promise( resolve => {
+	const unsubscribe = subscribe( () => {
+		const isCleanNewPost = select( 'core/editor' ).isCleanNewPost();
+
+		if ( isCleanNewPost ) {
+			unsubscribe();
+			resolve( false );
+		}
+
+		const blocks = select( 'core/editor' ).getBlocks();
+
+		if ( blocks.length > 0 ) {
+			unsubscribe();
+			resolve( true );
+		}
+	} );
+} );
+

--- a/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
@@ -3,25 +3,21 @@
 /**
  * External dependencies
  */
-import { select, dispatch, subscribe } from '@wordpress/data';
+import { select, dispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
-const unsubscribe = subscribe( () => {
-	const isCleanNewPost = select( 'core/editor' ).isCleanNewPost();
+/**
+ * Internal dependencies
+ */
+import { isEditorReadyWithBlocks } from '../../utils';
 
-	if ( isCleanNewPost ) {
-		unsubscribe();
-	}
-
-	const blocks = select( 'core/editor' ).getBlocks();
-
-	if ( blocks.length === 0 ) {
+async function fixInvalidBlocks() {
+	const editorHasBlocks = await isEditorReadyWithBlocks();
+	if ( ! editorHasBlocks ) {
 		return;
 	}
 
-	unsubscribe();
-
-	//If any blocks have validation issues auto-fix them for now, until core is less strict.
+	// If any blocks have validation issues auto-fix them for now, until core is less strict.
 	select( 'core/editor' )
 		.getBlocks()
 		.filter( block => ! block.isValid )
@@ -31,4 +27,6 @@ const unsubscribe = subscribe( () => {
 				createBlock( name, attributes, innerBlocks )
 			);
 		} );
-} );
+}
+
+fixInvalidBlocks();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Seems we cannot rely on `getCurrentPost` for determining if the editor has been initialized and blocks has been added, so the convert to blocks dialog was not being displayed when a post has been created with the classic editor 

This PR replaces that check in favor of `isCleanNewPost` + `getBlocks` which apparently is more reliable.


<img width="788" alt="Screenshot 2019-12-19 at 12 00 16" src="https://user-images.githubusercontent.com/1233880/71168514-2cf56400-2257-11ea-9351-ccab62d0f643.png">


#### Testing instructions

* Apply D36950-code and sandbox `widgets.wp.com`.
* Switch to the classic editor.
* Publish a post.
* Switch to the block editor.
* Make sure the convert to blocks dialog is displayed when loading the previous post.
* Verify invalid blocks are still autofixed on editor loaded (https://github.com/Automattic/wp-calypso/pull/38397) 

Fixes #38489
