### PR TITLE
Gutenboarding: improve loading  styles

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -5,19 +5,6 @@
  *
  */
 
-.wpcom-site__logo {
-	fill: var( --color-neutral-10 );
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translate( -50%, -50% );
-
-	@include breakpoint( '>960px' ) {
-		width: 100px;
-		height: 100px;
-	}
-}
-
 .wpcom-site__global-noscript {
 	position: fixed;
 	bottom: 0;

--- a/client/assets/stylesheets/gutenboarding.scss
+++ b/client/assets/stylesheets/gutenboarding.scss
@@ -4,13 +4,23 @@
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined
-
+@import './shared/loading';
 @import './gutenberg-base-styles';
 
 // Gutenberg resets
 // Not an actual "CSS reset", but an opiniated base style for HTML elements in Gutenberg views.
 :root {
 	@include reset;
+}
+
+// Change loading logo's color while Calypso boots
+.wpcom-site__logo {
+	fill: $light-gray-500;
+}
+
+// Hide Calypso header while Calypso boots
+.masterbar {
+	display: none;
 }
 
 // Gutenberg default typography

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -1,0 +1,12 @@
+.wpcom-site__logo {
+	fill: var( --color-neutral-10 );
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+
+	@include breakpoint( '>960px' ) {
+		width: 100px;
+		height: 100px;
+	}
+}

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -10,4 +10,5 @@
 @import 'shared/forms'; // form styling
 
 // WordPress.com main styles for global layout and responsive styles
+@import './shared/loading';
 @import 'main';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Copied `.wpcom-site__logo` styles from Calypso main stylesheet to shared location
* Hide `.masterbar` which is shown only during the loading stage
* Apply different color to loading logo in Gutenboarding than in elsewhere

**Before**
<img width="1622" alt="Screenshot 2019-12-19 at 13 48 36" src="https://user-images.githubusercontent.com/87168/71171722-20790780-2267-11ea-9071-77f4ce999e56.png">

**After**
<img width="1621" alt="Screenshot 2019-12-19 at 13 48 12" src="https://user-images.githubusercontent.com/87168/71171704-1bb45380-2267-11ea-90d0-80398a45a30f.png">


#### Testing instructions

- Open `/gutenboarding` and observe different loading logo color than rest of Calypso and no masterbar visible while loading 
- Ensure rest of onboarding flow works just fine
- Open `/` and ensure everything stays the same