### PR TITLE
Tests: add jest-enzyme to test/client config

### DIFF
--- a/client/components/accordion/test/status.jsx
+++ b/client/components/accordion/test/status.jsx
@@ -5,20 +5,17 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Gridicon from 'components/gridicon';
 import React from 'react';
-import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import AccordionStatus from '../status';
+import Tooltip from 'components/tooltip';
 
 describe( 'AccordionStatus', () => {
-	let AccordionStatus, Tooltip;
-
-	beforeAll( () => {
-		AccordionStatus = require( '../status' );
-		Tooltip = require( 'components/tooltip' );
-	} );
-
 	test( 'should render with explicit props', () => {
 		const status = {
 			type: 'error',
@@ -28,55 +25,40 @@ describe( 'AccordionStatus', () => {
 		};
 		const wrapper = shallow( <AccordionStatus { ...status } /> );
 
-		expect( wrapper.find( 'a' ) )
-			.to.have.prop( 'href' )
-			.equal( 'https://wordpress.com' );
-		expect( wrapper.find( 'a' ) ).to.have.className( 'is-error' );
-		expect( wrapper.find( Gridicon ) )
-			.to.have.prop( 'icon' )
-			.equal( 'notice' );
-		expect( wrapper.find( Tooltip ) )
-			.to.have.prop( 'children' )
-			.equal( 'Warning!' );
-		expect( wrapper.find( Tooltip ) )
-			.to.have.prop( 'position' )
-			.equal( 'top left' );
+		expect( wrapper.find( 'a' ) ).toHaveProp( 'href', 'https://wordpress.com' );
+		expect( wrapper.find( 'a' ) ).toHaveClassName( 'is-error' );
+		expect( wrapper.find( Gridicon ) ).toHaveProp( 'icon', 'notice' );
+		expect( wrapper.find( Tooltip ) ).toHaveProp( 'children', 'Warning!' );
+		expect( wrapper.find( Tooltip ) ).toHaveProp( 'position', 'top left' );
 	} );
 
 	test( 'should render with default props', () => {
 		const wrapper = shallow( <AccordionStatus /> );
 
-		expect( wrapper.find( 'a' ) ).to.not.have.prop( 'href' );
-		expect( wrapper.find( 'a' ) ).to.have.className( 'is-info' );
-		expect( wrapper.find( Gridicon ) )
-			.to.have.prop( 'icon' )
-			.equal( 'info' );
-		expect( wrapper ).to.not.have.descendants( Tooltip );
+		expect( wrapper.find( 'a' ) ).toHaveProp( 'href', undefined );
+		expect( wrapper.find( 'a' ) ).toHaveClassName( 'is-info' );
+		expect( wrapper.find( Gridicon ) ).toHaveProp( 'icon', 'info' );
+		expect( wrapper ).not.toContainMatchingElement( Tooltip );
 	} );
 
 	test( 'should show tooltip on hover', () => {
 		const wrapper = shallow( <AccordionStatus text="Warning!" /> );
 
-		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.false;
-		expect( wrapper.find( Tooltip ) )
-			.to.have.prop( 'position' )
-			.equal( 'top' );
+		expect( wrapper.find( Tooltip ) ).toHaveProp( 'isVisible', false );
+		expect( wrapper.find( Tooltip ) ).toHaveProp( 'position', 'top' );
 
 		wrapper.find( 'a' ).simulate( 'mouseEnter' );
-
-		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.true;
+		expect( wrapper.find( Tooltip ) ).toHaveProp( 'isVisible', true );
 
 		wrapper.find( 'a' ).simulate( 'mouseLeave' );
-
-		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.false;
+		expect( wrapper.find( Tooltip ) ).toHaveProp( 'isVisible', false );
 	} );
 
 	test( 'should call onClick callback', () => {
-		const spy = sinon.spy();
+		const spy = jest.fn();
 		const wrapper = shallow( <AccordionStatus onClick={ spy } /> );
 
 		wrapper.find( 'a' ).simulate( 'click' );
-
-		expect( spy ).to.have.been.calledOnce;
+		expect( spy ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
 		"jest": "24.9.0",
 		"jest-docblock": "24.9.0",
 		"jest-emotion": "10.0.27",
+		"jest-enzyme": "7.1.2",
 		"jest-fetch-mock": "2.1.2",
 		"jest-junit": "9.0.0",
 		"lerna": "3.20.2",

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -35,6 +35,9 @@ jest.mock( 'enzyme', () => {
 		const chaiEnzyme = require.requireActual( 'chai-enzyme' );
 		chai.use( chaiEnzyme() );
 
+		// configure custom Enzyme matchers for Jest
+		require.requireActual( 'jest-enzyme' );
+
 		// configure enzyme 3 for React, from docs: http://airbnb.io/enzyme/docs/installation/index.html
 		const Adapter = require.requireActual( 'enzyme-adapter-react-16' );
 		actualEnzyme.configure( { adapter: new Adapter() } );


### PR DESCRIPTION
The `test/client` Jest config is not based on the `calypso-build` preset, and doesn't include the `jest-enzyme` package with custom matchers.

This PR adds setup of `jest-enzyme` and migrates one selected test, for the `AccordionStatus` component, from Chai to Jest asserts. This updated tests wouldn't work without the config update.
