### PR TITLE
UpsellNudge: Add UpsellNudge block to unify upsell nudges going forward

### DIFF
--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -11,9 +11,9 @@ import UpsellNudge from 'blocks/upsell-nudge';
 function myUpsell() {
 	return (
 		<UpsellNudge
-			eventName={ 'calypso_domain_upsell_nudge' }
-			buttonText={ translate( 'Upgrade' ) }
-			text={ translate( 'Free domain with a plan!' ) }
+			tracksImpressionName={ 'calypso_domain_upsell_nudge' }
+			callToAction={ translate( 'Upgrade' ) }
+			title={ translate( 'Free domain with a plan!' ) }
 			href={ '/plans' }
 			compact
 		/>
@@ -26,12 +26,15 @@ function myUpsell() {
 
 Name | Type | Default | Description
 ---- | ---- | ---- | ----
-`buttonText` | `string` | null | Message to show on the upsell call to action.
+`callToAction` | `string` | null | Message to show on the upsell call to action.
 `compact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
 `dismissPreferenceName` | `string` | empty | Enables dismiss functionality with this value as the event name
-`eventName` | `string` | null | Unique event name for tracking the nudge on impression, click, and dismiss, passed to `Banner` as a Tracks event property `cta_name`
-`eventProperties` | `object` | null | Additional event properties to track on click
 `href` | `string` | null | The URL/path that the user is taken to when clicked.
 `icon` | `string` | null | Optional reference to a Gridicon.
-`text` | `string` | null | Message to show on the upsell.
-`tracksEvent` | `string` | `calypso_upsell_nudge_click` | Unique event name to track when the nudge is clicked
+`title` | `string` | null | Message to show on the upsell.
+`tracksImpressionName` | `string` | | Unique event name to track when the nudge is viewed
+`tracksClickName` | `string` | | Unique event name to track when the nudge is clicked
+`tracksDismissName` | `string` |  | Unique event name to track when the nudge is dismissed
+`tracksImpressionProperties` | `object` | | Additional props to track when the nudge is viewed
+`tracksClickProperties` | `object` | | Additional props to track when the nudge is clicked
+`tracksDismissProperties` | `object` |  | Additional props to track when the nudge is dismissed

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -1,7 +1,7 @@
 UpsellNudge (JSX)
 ===
 
-`UpsellNudge` is used to display upsell nudges for plans, domains, services, and product features.
+`UpsellNudge` is a wrapper for the `Banner` component, used to display upsell nudges for plans, domains, services, and product features.
 
 ## Usage
 
@@ -16,7 +16,6 @@ function myUpsell() {
 			text={ translate( 'Free domain with a plan!' ) }
 			href={ '/plans' }
 			isCompact
-			showDismiss
 		/>
 	)
 }
@@ -27,12 +26,11 @@ function myUpsell() {
 
 Name | Type | Default | Description
 ---- | ---- | ---- | ----
+`buttonText` | `string` | 'Upgrade' | Message to show on the upsell call to action.
+`dismissPreferenceName` | `string` | empty | Enables a dismiss icon with this value as the event name
+`eventName` | `string` | null | Unique event name for tracking the nudge, passed as a Tracks event property
+`eventProperties` | `object` | null | Additional event properties to track
 `href` | `string` | null | The URL/path that the user is taken to when clicked.
-`onClick` | `func` | | Optional function to call when the action is clicked.
 `icon` | `string` | null | Optional reference to a Gridicon.
 `isCompact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
-`buttonText` | `string` | 'Upgrade' | Message to show on the upsell call to action.
 `text` | `string` | 'Free domain with a plan!' | Message to show on the upsell.
-`eventName` | `string` | null | Unique event name for tracking the nudge, passed as a Tracks event property
-`dismissPreferenceName` | `string` | empty | Enables a dismiss icon with this value as the event name
-`eventProperties` | `object` | null | Additional event properties to track

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -15,7 +15,7 @@ function myUpsell() {
 			buttonText={ translate( 'Upgrade' ) }
 			text={ translate( 'Free domain with a plan!' ) }
 			href={ '/plans' }
-			isCompact
+			compact
 		/>
 	)
 }
@@ -33,5 +33,5 @@ Name | Type | Default | Description
 `eventProperties` | `object` | null | Additional event properties to track on click
 `href` | `string` | null | The URL/path that the user is taken to when clicked.
 `icon` | `string` | null | Optional reference to a Gridicon.
-`isCompact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
+`compact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
 `text` | `string` | 'Free domain with a plan!' | Message to show on the upsell.

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -28,8 +28,9 @@ Name | Type | Default | Description
 ---- | ---- | ---- | ----
 `buttonText` | `string` | 'Upgrade' | Message to show on the upsell call to action.
 `dismissPreferenceName` | `string` | empty | Enables a dismiss icon with this value as the event name
-`eventName` | `string` | null | Unique event name for tracking the nudge, passed as a Tracks event property
-`eventProperties` | `object` | null | Additional event properties to track
+`tracksEvent` | `string` | `calypso_upsell_nudge_click` | Unique event name to track when the nudge is clicked
+`eventName` | `string` | null | Unique event name for tracking the nudge on impression, click, and dismiss, passed to `Banner` as a Tracks event property `cta_name`
+`eventProperties` | `object` | null | Additional event properties to track on click
 `href` | `string` | null | The URL/path that the user is taken to when clicked.
 `icon` | `string` | null | Optional reference to a Gridicon.
 `isCompact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -26,12 +26,12 @@ function myUpsell() {
 
 Name | Type | Default | Description
 ---- | ---- | ---- | ----
-`buttonText` | `string` | 'Upgrade' | Message to show on the upsell call to action.
-`dismissPreferenceName` | `string` | empty | Enables a dismiss icon with this value as the event name
-`tracksEvent` | `string` | `calypso_upsell_nudge_click` | Unique event name to track when the nudge is clicked
+`buttonText` | `string` | null | Message to show on the upsell call to action.
+`compact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
+`dismissPreferenceName` | `string` | empty | Enables dismiss functionality with this value as the event name
 `eventName` | `string` | null | Unique event name for tracking the nudge on impression, click, and dismiss, passed to `Banner` as a Tracks event property `cta_name`
 `eventProperties` | `object` | null | Additional event properties to track on click
 `href` | `string` | null | The URL/path that the user is taken to when clicked.
 `icon` | `string` | null | Optional reference to a Gridicon.
-`compact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
-`text` | `string` | 'Free domain with a plan!' | Message to show on the upsell.
+`text` | `string` | null | Message to show on the upsell.
+`tracksEvent` | `string` | `calypso_upsell_nudge_click` | Unique event name to track when the nudge is clicked

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -34,6 +34,5 @@ Name | Type | Default | Description
 `buttonText` | `string` | 'Upgrade' | Message to show on the upsell call to action.
 `text` | `string` | 'Free domain with a plan!' | Message to show on the upsell.
 `eventName` | `string` | null | Unique event name for tracking the nudge, passed as a Tracks event property
-`onDismissClick` | `func` |  | Optional function to run when showDismiss is true and the upsell is dismissed
-`showDismiss` | `bool` | false | Allow the upsell to be dismissed
+`dismissPreferenceName` | `string` | empty | Enables a dismiss icon with this value as the event name
 `eventProperties` | `object` | null | Additional event properties to track

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -1,0 +1,39 @@
+UpsellNudge (JSX)
+===
+
+`UpsellNudge` is used to display upsell nudges for plans, domains, services, and product features.
+
+## Usage
+
+```js
+import UpsellNudge from 'blocks/upsell-nudge';
+
+function myUpsell() {
+	return (
+		<UpsellNudge
+			eventName={ 'calypso_domain_upsell_nudge' }
+			buttonText={ translate( 'Upgrade' ) }
+			text={ translate( 'Free domain with a plan!' ) }
+			href={ '/plans' }
+			isCompact
+			showDismiss
+		/>
+	)
+}
+```
+
+### Props
+
+
+Name | Type | Default | Description
+---- | ---- | ---- | ----
+`href` | `string` | null | The URL/path that the user is taken to when clicked.
+`onClick` | `func` | | Optional function to call when the action is clicked.
+`icon` | `string` | null | Optional reference to a Gridicon.
+`isCompact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
+`buttonText` | `string` | 'Upgrade' | Message to show on the upsell call to action.
+`text` | `string` | 'Free domain with a plan!' | Message to show on the upsell.
+`eventName` | `string` | null | Unique event name for tracking the nudge, passed as a Tracks event property
+`onDismissClick` | `func` |  | Optional function to run when showDismiss is true and the upsell is dismissed
+`showDismiss` | `bool` | false | Allow the upsell to be dismissed
+`eventProperties` | `object` | null | Additional event properties to track

--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -15,6 +15,7 @@ function myUpsell() {
 			callToAction={ translate( 'Upgrade' ) }
 			title={ translate( 'Free domain with a plan!' ) }
 			href={ '/plans' }
+			showIcon={ true }
 			compact
 		/>
 	)
@@ -28,9 +29,10 @@ Name | Type | Default | Description
 ---- | ---- | ---- | ----
 `callToAction` | `string` | null | Message to show on the upsell call to action.
 `compact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
-`dismissPreferenceName` | `string` | empty | Enables dismiss functionality with this value as the event name
+`dismissPreferenceName` | `string` | empty | Enables dismiss functionality, using this value as the dismiss event name.
 `href` | `string` | null | The URL/path that the user is taken to when clicked.
 `icon` | `string` | null | Optional reference to a Gridicon.
+`showIcon` | `bool` | `false` | Show an icon next to the title.
 `title` | `string` | null | Message to show on the upsell.
 `tracksImpressionName` | `string` | | Unique event name to track when the nudge is viewed
 `tracksClickName` | `string` | | Unique event name to track when the nudge is clicked

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -73,7 +73,7 @@ export class UpsellNudge extends Component {
 			showDismiss,
 			translate,
 		} = this.props;
-		const classes = classnames( 'upsell-nudge', className, isCompact ? 'compact' : '' );
+		const classes = classnames( 'upsell-nudge', className, { 'is-compact': isCompact } );
 
 		return (
 			<div className={ classes }>

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -2,16 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Banner from 'components/banner';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
-import { navigate } from 'state/ui/actions';
 
 /**
  * Style dependencies
@@ -23,11 +19,17 @@ export const UpsellNudge = ( {
 	className,
 	compact = false,
 	dismissPreferenceName,
-	eventName,
 	href,
 	icon = false,
-	navigateAndTrack,
+	onClick,
+	onDismiss,
 	text,
+	tracksImpressionName,
+	tracksClickName,
+	tracksDismissName,
+	tracksImpressionProperties,
+	tracksClickProperties,
+	tracksDismissProperties,
 } ) => {
 	const classes = classnames( 'upsell-nudge', className );
 
@@ -36,32 +38,20 @@ export const UpsellNudge = ( {
 			className={ classes }
 			callToAction={ buttonText }
 			dismissPreferenceName={ dismissPreferenceName }
-			event={ eventName }
 			href={ href }
 			icon={ icon }
 			compact={ compact }
-			onClick={ navigateAndTrack }
+			onClick={ onClick }
+			onDismiss={ onDismiss }
 			title={ text }
+			tracksImpressionName={ tracksImpressionName }
+			tracksClickName={ tracksClickName }
+			tracksDismissName={ tracksDismissName }
+			tracksImpressionProperties={ tracksImpressionProperties }
+			tracksClickProperties={ tracksClickProperties }
+			tracksDismissProperties={ tracksDismissProperties }
 		/>
 	);
 };
 
-const mapDispatchToProps = (
-	dispatch,
-	{ tracksEvent = 'calypso_upsell_nudge_click', href, eventName, eventProperties }
-) => {
-	return {
-		navigateAndTrack: () =>
-			dispatch(
-				withAnalytics(
-					recordTracksEvent( tracksEvent, {
-						cta_name: eventName,
-						...eventProperties,
-					} ),
-					navigate( href )
-				)
-			),
-	};
-};
-
-export default connect( null, mapDispatchToProps )( localize( UpsellNudge ) );
+export default UpsellNudge;

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -21,11 +21,11 @@ import './style.scss';
 export const UpsellNudge = ( {
 	buttonText,
 	className,
+	compact = false,
 	dismissPreferenceName,
 	eventName,
 	href,
 	icon = false,
-	compact = false,
 	navigateAndTrack,
 	text,
 } ) => {

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export class UpsellNudge extends Component {
+	static defaultProps = {
+		className: '',
+	};
+
+	static propTypes = {
+		className: PropTypes.string,
+		eventName: PropTypes.string,
+		eventProperties: PropTypes.object,
+		buttonText: PropTypes.string,
+		icon: PropTypes.string,
+		href: PropTypes.string,
+		text: PropTypes.string,
+		onClick: PropTypes.func,
+		onDismissClick: PropTypes.func,
+		showDismiss: PropTypes.bool,
+		isCompact: PropTypes.bool,
+		track: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	onClick = e => {
+		const { eventName, eventProperties, track, onClick } = this.props;
+		track( 'calypso_upsell_nudge_button_click', { event_name: eventName, ...eventProperties } );
+		if ( onClick ) {
+			onClick( e );
+		}
+	};
+
+	onDismissClick = e => {
+		const { eventName, eventProperties, track, onDismissClick } = this.props;
+		track( 'calypso_upsell_nudge_button_dismiss_click', {
+			event_name: eventName,
+			...eventProperties,
+		} );
+		if ( onDismissClick ) {
+			onDismissClick( e );
+		}
+	};
+
+	render() {
+		const {
+			className,
+			eventName,
+			eventProperties,
+			buttonText,
+			href,
+			icon,
+			text,
+			isCompact,
+			showDismiss,
+			translate,
+		} = this.props;
+		const classes = classnames( 'upsell-nudge', className, isCompact ? 'compact' : '' );
+
+		return (
+			<div className={ classes }>
+				<TrackComponentView
+					eventName="calypso_upsell_nudge_impression"
+					eventProperties={ { event_name: eventName, ...eventProperties } }
+				/>
+				{ icon && (
+					<Gridicon className="upsell-nudge__icon" icon={ icon } size={ isCompact ? 18 : 36 } />
+				) }
+				<span className="upsell-nudge__content">
+					<span className="upsell-nudge__text">{ text }</span>
+				</span>
+				{ buttonText && (
+					<Button
+						className="upsell-nudge__button"
+						compact={ isCompact }
+						primary
+						onClick={ this.onClick }
+						href={ href }
+					>
+						{ buttonText }
+					</Button>
+				) }
+				{ showDismiss && (
+					<span className="upsell-nudge__dismiss">
+						<Button
+							className="upsell-nudge__dismiss-button"
+							onClick={ this.onDismissClick }
+							aria-label={ translate( 'Dismiss' ) }
+							compact
+							borderless
+						>
+							<Gridicon
+								className="upsell-nudge__dismiss-icon"
+								icon={ isCompact ? 'cross-small' : 'cross' }
+								size={ 18 }
+							/>
+						</Button>
+					</span>
+				) }
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = null;
+const mapDispatchToProps = { track: recordTracksEvent };
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( UpsellNudge ) );

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -6,13 +6,11 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
-import TrackComponentView from 'lib/analytics/track-component-view';
+import Banner from 'components/banner';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -28,17 +26,15 @@ export class UpsellNudge extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		eventName: PropTypes.string,
-		eventProperties: PropTypes.object,
+		/*eventProperties: PropTypes.object, @TODO: We may want to be able to assign eventProperties to Tracks events */
+		dismissPreferenceName: PropTypes.string,
 		buttonText: PropTypes.string,
-		icon: PropTypes.string,
+		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		href: PropTypes.string,
 		text: PropTypes.string,
 		onClick: PropTypes.func,
-		onDismissClick: PropTypes.func,
-		showDismiss: PropTypes.bool,
 		isCompact: PropTypes.bool,
 		track: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
 	};
 
 	onClick = e => {
@@ -49,77 +45,31 @@ export class UpsellNudge extends Component {
 		}
 	};
 
-	onDismissClick = e => {
-		const { eventName, eventProperties, track, onDismissClick } = this.props;
-		track( 'calypso_upsell_nudge_button_dismiss_click', {
-			event_name: eventName,
-			...eventProperties,
-		} );
-		if ( onDismissClick ) {
-			onDismissClick( e );
-		}
-	};
-
 	render() {
 		const {
 			className,
+			dismissPreferenceName,
 			eventName,
-			eventProperties,
 			buttonText,
 			href,
 			icon,
 			text,
 			isCompact,
-			showDismiss,
-			translate,
 		} = this.props;
-		const classes = classnames( 'upsell-nudge', className, { 'is-compact': isCompact } );
+		const classes = classnames( 'upsell-nudge', className );
 
 		return (
-			<div className={ classes }>
-				<TrackComponentView
-					eventName="calypso_upsell_nudge_impression"
-					eventProperties={ { event_name: eventName, ...eventProperties } }
-				/>
-				{ icon && (
-					<Gridicon className="upsell-nudge__icon" icon={ icon } size={ isCompact ? 18 : 24 } />
-				) }
-				<span className="upsell-nudge__content">
-					<span className="upsell-nudge__text">
-						<a href={ href } onClick={ this.onClick }>
-							{ text }
-						</a>
-					</span>
-				</span>
-				{ buttonText && (
-					<Button
-						className="upsell-nudge__button"
-						compact={ isCompact }
-						primary
-						onClick={ this.onClick }
-						href={ href }
-					>
-						{ buttonText }
-					</Button>
-				) }
-				{ showDismiss && (
-					<span className="upsell-nudge__dismiss">
-						<Button
-							className="upsell-nudge__dismiss-button"
-							onClick={ this.onDismissClick }
-							aria-label={ translate( 'Dismiss' ) }
-							compact
-							borderless
-						>
-							<Gridicon
-								className="upsell-nudge__dismiss-icon"
-								icon={ isCompact ? 'cross-small' : 'cross' }
-								size={ 18 }
-							/>
-						</Button>
-					</span>
-				) }
-			</div>
+			<Banner
+				className={ classes }
+				callToAction={ buttonText }
+				dismissPreferenceName={ dismissPreferenceName }
+				event={ eventName }
+				href={ href }
+				icon={ icon }
+				isCompact={ isCompact }
+				onClick={ this.onClick }
+				title={ text }
+			/>
 		);
 	}
 }

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -14,10 +14,10 @@ import Banner from 'components/banner';
  */
 import './style.scss';
 
-export const UpsellNudge = ( { className, ...props } ) => {
+export const UpsellNudge = ( { className, showIcon = false, ...props } ) => {
 	const classes = classnames( 'upsell-nudge', className );
 
-	return <Banner { ...props } className={ classes } />;
+	return <Banner { ...props } showIcon={ showIcon } className={ classes } />;
 };
 
 export default UpsellNudge;

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -23,7 +23,6 @@ export const UpsellNudge = ( {
 	className,
 	dismissPreferenceName,
 	eventName,
-	/* eventProperties, @TODO: We may want to add support for this to Banner */
 	href,
 	icon,
 	compact,
@@ -48,13 +47,16 @@ export const UpsellNudge = ( {
 };
 
 const mapStateToProps = null;
-const mapDispatchToProps = ( dispatch, { href, eventName, eventProperties } ) => {
+const mapDispatchToProps = (
+	dispatch,
+	{ tracksEvent = 'calypso_upsell_nudge_click', href, eventName, eventProperties }
+) => {
 	return {
 		navigateAndTrack: () =>
 			dispatch(
 				withAnalytics(
-					recordTracksEvent( 'calypso_upsell_nudge_click', {
-						event_name: eventName,
+					recordTracksEvent( tracksEvent, {
+						cta_name: eventName,
 						...eventProperties,
 					} ),
 					navigate( href )

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -46,7 +46,6 @@ export const UpsellNudge = ( {
 	);
 };
 
-const mapStateToProps = null;
 const mapDispatchToProps = (
 	dispatch,
 	{ tracksEvent = 'calypso_upsell_nudge_click', href, eventName, eventProperties }
@@ -65,4 +64,4 @@ const mapDispatchToProps = (
 	};
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( UpsellNudge ) );
+export default connect( null, mapDispatchToProps )( localize( UpsellNudge ) );

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -14,44 +14,10 @@ import Banner from 'components/banner';
  */
 import './style.scss';
 
-export const UpsellNudge = ( {
-	buttonText,
-	className,
-	compact = false,
-	dismissPreferenceName,
-	href,
-	icon = false,
-	onClick,
-	onDismiss,
-	text,
-	tracksImpressionName,
-	tracksClickName,
-	tracksDismissName,
-	tracksImpressionProperties,
-	tracksClickProperties,
-	tracksDismissProperties,
-} ) => {
+export const UpsellNudge = ( { className, ...props } ) => {
 	const classes = classnames( 'upsell-nudge', className );
 
-	return (
-		<Banner
-			className={ classes }
-			callToAction={ buttonText }
-			dismissPreferenceName={ dismissPreferenceName }
-			href={ href }
-			icon={ icon }
-			compact={ compact }
-			onClick={ onClick }
-			onDismiss={ onDismiss }
-			title={ text }
-			tracksImpressionName={ tracksImpressionName }
-			tracksClickName={ tracksClickName }
-			tracksDismissName={ tracksDismissName }
-			tracksImpressionProperties={ tracksImpressionProperties }
-			tracksClickProperties={ tracksClickProperties }
-			tracksDismissProperties={ tracksDismissProperties }
-		/>
-	);
+	return <Banner { ...props } className={ classes } />;
 };
 
 export default UpsellNudge;

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -24,8 +24,8 @@ export const UpsellNudge = ( {
 	dismissPreferenceName,
 	eventName,
 	href,
-	icon,
-	compact,
+	icon = false,
+	compact = false,
 	navigateAndTrack,
 	text,
 } ) => {

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -19,53 +18,34 @@ import { navigate } from 'state/ui/actions';
  */
 import './style.scss';
 
-export class UpsellNudge extends Component {
-	static defaultProps = {
-		className: '',
-	};
+export const UpsellNudge = ( {
+	buttonText,
+	className,
+	dismissPreferenceName,
+	eventName,
+	/* eventProperties, @TODO: We may want to add support for this to Banner */
+	href,
+	icon,
+	isCompact,
+	navigateAndTrack,
+	text,
+} ) => {
+	const classes = classnames( 'upsell-nudge', className );
 
-	static propTypes = {
-		className: PropTypes.string,
-		eventName: PropTypes.string,
-		/*eventProperties: PropTypes.object, @TODO: We may want to be able to assign eventProperties to Tracks events */
-		dismissPreferenceName: PropTypes.string,
-		buttonText: PropTypes.string,
-		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
-		href: PropTypes.string,
-		text: PropTypes.string,
-		onClick: PropTypes.func,
-		isCompact: PropTypes.bool,
-	};
-
-	render() {
-		const {
-			className,
-			dismissPreferenceName,
-			eventName,
-			buttonText,
-			href,
-			icon,
-			navigateAndTrack,
-			text,
-			isCompact,
-		} = this.props;
-		const classes = classnames( 'upsell-nudge', className );
-
-		return (
-			<Banner
-				className={ classes }
-				callToAction={ buttonText }
-				dismissPreferenceName={ dismissPreferenceName }
-				event={ eventName }
-				href={ href }
-				icon={ icon }
-				isCompact={ isCompact }
-				onClick={ navigateAndTrack }
-				title={ text }
-			/>
-		);
-	}
-}
+	return (
+		<Banner
+			className={ classes }
+			callToAction={ buttonText }
+			dismissPreferenceName={ dismissPreferenceName }
+			event={ eventName }
+			href={ href }
+			icon={ icon }
+			isCompact={ isCompact }
+			onClick={ navigateAndTrack }
+			title={ text }
+		/>
+	);
+};
 
 const mapStateToProps = null;
 const mapDispatchToProps = ( dispatch, { href, eventName, eventProperties } ) => {

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -86,7 +86,9 @@ export class UpsellNudge extends Component {
 				) }
 				<span className="upsell-nudge__content">
 					<span className="upsell-nudge__text">
-						<a href={ href }>{ text }</a>
+						<a href={ href } onClick={ this.onClick }>
+							{ text }
+						</a>
 					</span>
 				</span>
 				{ buttonText && (

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -11,7 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Banner from 'components/banner';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { navigate } from 'state/ui/actions';
 
 /**
  * Style dependencies
@@ -34,15 +35,6 @@ export class UpsellNudge extends Component {
 		text: PropTypes.string,
 		onClick: PropTypes.func,
 		isCompact: PropTypes.bool,
-		track: PropTypes.func.isRequired,
-	};
-
-	onClick = e => {
-		const { eventName, eventProperties, track, onClick } = this.props;
-		track( 'calypso_upsell_nudge_button_click', { event_name: eventName, ...eventProperties } );
-		if ( onClick ) {
-			onClick( e );
-		}
 	};
 
 	render() {
@@ -53,6 +45,7 @@ export class UpsellNudge extends Component {
 			buttonText,
 			href,
 			icon,
+			navigateAndTrack,
 			text,
 			isCompact,
 		} = this.props;
@@ -67,7 +60,7 @@ export class UpsellNudge extends Component {
 				href={ href }
 				icon={ icon }
 				isCompact={ isCompact }
-				onClick={ this.onClick }
+				onClick={ navigateAndTrack }
 				title={ text }
 			/>
 		);
@@ -75,6 +68,19 @@ export class UpsellNudge extends Component {
 }
 
 const mapStateToProps = null;
-const mapDispatchToProps = { track: recordTracksEvent };
+const mapDispatchToProps = ( dispatch, { href, eventName, eventProperties } ) => {
+	return {
+		navigateAndTrack: () =>
+			dispatch(
+				withAnalytics(
+					recordTracksEvent( 'calypso_upsell_nudge_click', {
+						event_name: eventName,
+						...eventProperties,
+					} ),
+					navigate( href )
+				)
+			),
+	};
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( UpsellNudge ) );

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -82,10 +82,12 @@ export class UpsellNudge extends Component {
 					eventProperties={ { event_name: eventName, ...eventProperties } }
 				/>
 				{ icon && (
-					<Gridicon className="upsell-nudge__icon" icon={ icon } size={ isCompact ? 18 : 36 } />
+					<Gridicon className="upsell-nudge__icon" icon={ icon } size={ isCompact ? 18 : 24 } />
 				) }
 				<span className="upsell-nudge__content">
-					<span className="upsell-nudge__text">{ text }</span>
+					<span className="upsell-nudge__text">
+						<a href={ href }>{ text }</a>
+					</span>
 				</span>
 				{ buttonText && (
 					<Button

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -26,7 +26,7 @@ export const UpsellNudge = ( {
 	/* eventProperties, @TODO: We may want to add support for this to Banner */
 	href,
 	icon,
-	isCompact,
+	compact,
 	navigateAndTrack,
 	text,
 } ) => {
@@ -40,7 +40,7 @@ export const UpsellNudge = ( {
 			event={ eventName }
 			href={ href }
 			icon={ icon }
-			isCompact={ isCompact }
+			compact={ compact }
 			onClick={ navigateAndTrack }
 			title={ text }
 		/>

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,17 +1,18 @@
 .upsell-nudge {
-	border-left: 4px solid var( --color-accent );
+	border-left: 8px solid var( --color-accent );
 	background-color: var( --color-neutral-80 );
 	color: var( --color-text-inverted );
 	display: flex;
 	align-items: center;
+	padding: 0.5em 1em;
+
+	a {
+		color: var( --color-text-inverted );
+	}
 
 	&__content {
 		padding: 1em;
 		margin-right: auto;
-	}
-
-	&__icon {
-		margin-right: 1em;
 	}
 
 	&__dismiss {
@@ -28,6 +29,7 @@
 	}
 
 	&.compact {
+		border-left-width: 4px;
 		font-size: 12px;
 		padding: 8px;
 
@@ -37,7 +39,7 @@
 
 		.upsell-nudge__icon {
 			margin-top: -2px;
-			margin-right: 0.5em;
+			margin-right: 0.25em;
 		}
 
 		.upsell-nudge__dismiss {

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -21,6 +21,10 @@
 			.dismissible-card__close-icon {
 				margin-left: 0.25em;
 			}
+			.banner__content {
+				padding-top: 0;
+				padding-bottom: 0;
+			}
 		}
 	}
 

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -4,14 +4,15 @@
 	color: var( --color-text-inverted );
 	display: flex;
 	align-items: center;
-	padding: 0.5em 1em;
+	margin-bottom: 1.5em;
+	padding: 0.5em 1.5em;
 
 	a {
 		color: var( --color-text-inverted );
 	}
 
 	&__content {
-		padding: 1em;
+		padding: 1em 1em 1em 0;
 		margin-right: auto;
 	}
 
@@ -26,11 +27,13 @@
 	&__button {
 		margin-left: auto;
 		overflow: visible;
+		white-space: nowrap;
 	}
 
 	&.compact {
 		border-left-width: 4px;
 		font-size: 12px;
+		margin-bottom: 0;
 		padding: 8px;
 
 		.upsell-nudge__content {

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -28,7 +28,7 @@
 				margin-right: 0.25em;
 			}
 			.dismissible-card__close-icon {
-				margin-left: 0.55em;
+				margin-left: 0.25em;
 				width: 16px;
 				height: 16px;
 			}

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,0 +1,47 @@
+.upsell-nudge {
+	border-left: 4px solid var( --color-accent );
+	background-color: var( --color-neutral-80 );
+	color: var( --color-text-inverted );
+	display: flex;
+	align-items: center;
+
+	&__content {
+		padding: 1em;
+		margin-right: auto;
+	}
+
+	&__icon {
+		margin-right: 1em;
+	}
+
+	&__dismiss {
+		margin-left: 1em;
+	}
+
+	&__dismiss-icon {
+		fill: var( --color-text-inverted );
+	}
+
+	&__button {
+		margin-left: auto;
+		overflow: visible;
+	}
+
+	&.compact {
+		font-size: 12px;
+		padding: 8px;
+
+		.upsell-nudge__content {
+			padding: 5px;
+		}
+
+		.upsell-nudge__icon {
+			margin-top: -2px;
+			margin-right: 0.5em;
+		}
+
+		.upsell-nudge__dismiss {
+			margin-left: 0.5em;
+		}
+	}
+}

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -22,8 +22,7 @@
 				margin-left: 0.25em;
 			}
 			.banner__content {
-				padding-top: 0;
-				padding-bottom: 0;
+				padding: 0 0 0 8px;
 			}
 		}
 	}

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -24,7 +24,8 @@
 		}
 	}
 
-	&.banner.card .banner__icon-circle {
+	&.banner.card .banner__icon-circle,
+	&.banner.card .banner__icon {
 		width: auto;
 		height: auto;
 		color: var( --color-text-inverted );

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,47 +1,75 @@
 .upsell-nudge {
-	border-left: 8px solid var( --color-accent );
-	background-color: var( --color-neutral-80 );
-	color: var( --color-text-inverted );
-	display: flex;
-	align-items: center;
-	margin-bottom: 1.5em;
-	padding: 0.5em 1.5em;
+	&.banner.card {
+		border-left: 8px solid var( --color-accent );
+		background-color: var( --color-neutral-80 );
+		color: var( --color-text-inverted );
+		display: flex;
+		align-items: center;
+		margin-bottom: 1.5em;
+		padding: 0.5em 1.5em;
 
-	a {
+		a {
+			color: var( --color-text-inverted );
+		}
+
+		&.is-compact {
+			border-left-width: 4px;
+			font-size: 12px;
+			margin-bottom: 0;
+			padding: 8px;
+
+			.banner__content {
+				padding: 5px;
+			}
+			.banner__title {
+				font-size: 12px;
+			}
+			.banner__icon-circle {
+				margin-right: 0.25em;
+			}
+			.dismissible-card__close-icon {
+				margin-left: 0.55em;
+				width: 16px;
+				height: 16px;
+			}
+		}
+	}
+
+	&.banner.card .banner__icon-circle {
+		width: auto;
+		height: auto;
+		color: var( --color-text-inverted );
+		border-radius: 0;
+		background: none;
+		padding: 0;
+	}
+
+	.banner__content {
+		padding: 1em 1em 1em 0;
+		margin-right: auto;
 		color: var( --color-text-inverted );
 	}
 
-}
-.upsell-nudge__content {
-	padding: 1em 1em 1em 0;
-	margin-right: auto;
-}
-.upsell-nudge__dismiss {
-	margin-left: 1em;
-}
-.upsell-nudge__dismiss-icon {
-	fill: var( --color-text-inverted );
-}
-.upsell-nudge__button {
-	margin-left: auto;
-	overflow: visible;
-	white-space: nowrap;
-}
-
-.upsell-nudge.is-compact {
-	border-left-width: 4px;
-	font-size: 12px;
-	margin-bottom: 0;
-	padding: 8px;
-
-	.upsell-nudge__content {
-		padding: 5px;
+	.banner__title {
+		color: var( --color-text-inverted );
+		font-weight: normal;
 	}
-	.upsell-nudge__icon {
-		margin-top: -2px;
-		margin-right: 0.25em;
+
+	.banner__action {
+		margin-left: auto;
+		margin-right: 0;
 	}
-	.upsell-nudge__dismiss {
-		margin-left: 0.5em;
+
+	.dismissible-card__close-icon {
+		fill: var( --color-text-inverted );
+		margin-left: 1em;
+		position: relative;
+		top: auto;
+		right: auto;
+		order: 2;
+	}
+
+	&.is-dismissible .banner__action {
+		margin-top: 0;
 	}
 }

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -7,6 +7,8 @@
 		align-items: center;
 
 		a {
+			border: none;
+			box-shadow: none;
 			color: var( --color-text-inverted );
 		}
 
@@ -46,8 +48,8 @@
 	}
 
 	.banner__action {
+		margin-top: 3px;
 		margin-left: auto;
-		margin-right: -5px;
 	}
 
 	.dismissible-card__close-icon {

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,36 +1,23 @@
 .upsell-nudge {
 	&.banner.card {
-		border-left: 8px solid var( --color-accent );
+		border-left-color: var( --color-accent );
 		background-color: var( --color-neutral-80 );
 		color: var( --color-text-inverted );
 		display: flex;
 		align-items: center;
-		margin-bottom: 1.5em;
-		padding: 0.5em 1.5em;
 
 		a {
 			color: var( --color-text-inverted );
 		}
 
 		&.is-compact {
-			border-left-width: 4px;
-			font-size: 12px;
 			margin-bottom: 0;
-			padding: 8px;
 
-			.banner__content {
-				padding: 5px;
-			}
-			.banner__title {
-				font-size: 12px;
-			}
 			.banner__icon-circle {
 				margin-right: 0.25em;
 			}
 			.dismissible-card__close-icon {
 				margin-left: 0.25em;
-				width: 16px;
-				height: 16px;
 			}
 		}
 	}
@@ -49,7 +36,6 @@
 	}
 
 	.banner__content {
-		padding: 1em 1em 1em 0;
 		margin-right: auto;
 		color: var( --color-text-inverted );
 	}
@@ -61,12 +47,13 @@
 
 	.banner__action {
 		margin-left: auto;
-		margin-right: 0;
+		margin-right: -5px;
 	}
 
 	.dismissible-card__close-icon {
 		fill: var( --color-text-inverted );
 		margin-left: 1em;
+		margin-top: 0;
 		position: relative;
 		top: auto;
 		right: auto;
@@ -74,6 +61,10 @@
 	}
 
 	&.is-dismissible .banner__action {
-		margin-top: 0;
+		margin-right: 0;
+
+		@include breakpoint( '>480px' ) {
+			margin-top: 0;
+		}
 	}
 }

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -15,11 +15,13 @@
 		&.is-compact {
 			margin-bottom: 0;
 
-			.banner__icon-circle {
+			.banner__icon-circle,
+			.banner__icon {
+				margin-top: -2px;
 				margin-right: 0.25em;
 			}
 			.dismissible-card__close-icon {
-				margin-left: 0.25em;
+				margin-left: 0.75em;
 			}
 			.banner__content {
 				padding: 0 0 0 8px;
@@ -52,25 +54,25 @@
 	}
 
 	.banner__action {
-		margin-top: 3px;
+		margin-top: 5px;
 		margin-left: auto;
 	}
 
 	.dismissible-card__close-icon {
 		fill: var( --color-text-inverted );
 		margin-left: 1em;
-		margin-top: 0;
-		position: relative;
-		top: auto;
-		right: auto;
 		order: 2;
-	}
-
-	&.is-dismissible .banner__action {
-		margin-right: 0;
 
 		@include breakpoint( '>480px' ) {
 			margin-top: 0;
+			position: relative;
+			top: auto;
+			right: auto;
 		}
+	}
+
+	&.is-dismissible .banner__action {
+		margin-top: 3px;
+		margin-right: 0;
 	}
 }

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -11,42 +11,37 @@
 		color: var( --color-text-inverted );
 	}
 
-	&__content {
-		padding: 1em 1em 1em 0;
-		margin-right: auto;
+}
+.upsell-nudge__content {
+	padding: 1em 1em 1em 0;
+	margin-right: auto;
+}
+.upsell-nudge__dismiss {
+	margin-left: 1em;
+}
+.upsell-nudge__dismiss-icon {
+	fill: var( --color-text-inverted );
+}
+.upsell-nudge__button {
+	margin-left: auto;
+	overflow: visible;
+	white-space: nowrap;
+}
+
+.upsell-nudge.is-compact {
+	border-left-width: 4px;
+	font-size: 12px;
+	margin-bottom: 0;
+	padding: 8px;
+
+	.upsell-nudge__content {
+		padding: 5px;
 	}
-
-	&__dismiss {
-		margin-left: 1em;
+	.upsell-nudge__icon {
+		margin-top: -2px;
+		margin-right: 0.25em;
 	}
-
-	&__dismiss-icon {
-		fill: var( --color-text-inverted );
-	}
-
-	&__button {
-		margin-left: auto;
-		overflow: visible;
-		white-space: nowrap;
-	}
-
-	&.compact {
-		border-left-width: 4px;
-		font-size: 12px;
-		margin-bottom: 0;
-		padding: 8px;
-
-		.upsell-nudge__content {
-			padding: 5px;
-		}
-
-		.upsell-nudge__icon {
-			margin-top: -2px;
-			margin-right: 0.25em;
-		}
-
-		.upsell-nudge__dismiss {
-			margin-left: 0.5em;
-		}
+	.upsell-nudge__dismiss {
+		margin-left: 0.5em;
 	}
 }

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -53,6 +53,10 @@
 		font-weight: normal;
 	}
 
+	.banner__description {
+		color: var( --color-text-inverted );
+	}
+
 	.banner__action {
 		margin-top: 5px;
 		margin-left: auto;

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -44,6 +44,10 @@
 		padding: 0;
 	}
 
+	&.banner.card .card__link-indicator {
+		fill: var( --color-text-inverted );
+	}
+
 	.banner__content {
 		padding: 1em 1em 1em 0;
 		margin-right: auto;

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,7 +13,6 @@ import { get, reject, transform } from 'lodash';
 /**
  * Internal dependencies
  */
-import UpsellNudge from 'blocks/upsell-nudge';
 import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -81,21 +80,20 @@ export class SiteNotice extends React.Component {
 			return null;
 		}
 
+		const eventName = 'calypso_domain_credit_reminder_impression';
 		const eventProperties = { cta_name: 'current_site_domain_notice' };
 		const { translate } = this.props;
 
 		return (
-			<UpsellNudge
-				callToAction={ translate( 'Claim' ) }
-				event="calypso_domain_credit_reminder_impression"
-				href={ `/domains/add/${ this.props.site.slug }` }
-				tracksImpressionName="calypso_domain_credit_reminder_impression"
-				tracksImpressionProperties={ eventProperties }
-				tracksClickName="calypso_domain_credit_reminder_click"
-				tracksClickProperties={ eventProperties }
-				compact
-				title={ translate( 'Free domain available' ) }
-			/>
+			<Notice compact title={ translate( 'Free domain available' ) }>
+				<NoticeAction
+					onClick={ this.props.clickClaimDomainNotice }
+					href={ `/domains/add/${ this.props.site.slug }` }
+				>
+					{ translate( 'Claim' ) }
+					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+				</NoticeAction>
+			</Notice>
 		);
 	}
 
@@ -280,6 +278,12 @@ export default connect(
 	},
 	dispatch => {
 		return {
+			clickClaimDomainNotice: () =>
+				dispatch(
+					recordTracksEvent( 'calypso_domain_credit_reminder_click', {
+						cta_name: 'current_site_domain_notice',
+					} )
+				),
 			clickDomainUpsellGo: () =>
 				dispatch(
 					recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,6 +13,7 @@ import { get, reject, transform } from 'lodash';
 /**
  * Internal dependencies
  */
+import UpsellNudge from 'blocks/upsell-nudge';
 import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -80,25 +81,21 @@ export class SiteNotice extends React.Component {
 			return null;
 		}
 
-		const eventName = 'calypso_domain_credit_reminder_impression';
 		const eventProperties = { cta_name: 'current_site_domain_notice' };
 		const { translate } = this.props;
 
 		return (
-			<Notice
-				isCompact
-				status="is-success"
-				icon="info-outline"
-				text={ translate( 'Free domain available' ) }
-			>
-				<NoticeAction
-					onClick={ this.props.clickClaimDomainNotice }
-					href={ `/domains/add/${ this.props.site.slug }` }
-				>
-					{ translate( 'Claim' ) }
-					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-				</NoticeAction>
-			</Notice>
+			<UpsellNudge
+				callToAction={ translate( 'Claim' ) }
+				event="calypso_domain_credit_reminder_impression"
+				href={ `/domains/add/${ this.props.site.slug }` }
+				tracksImpressionName="calypso_domain_credit_reminder_impression"
+				tracksImpressionProperties={ eventProperties }
+				tracksClickName="calypso_domain_credit_reminder_click"
+				tracksClickProperties={ eventProperties }
+				compact
+				title={ translate( 'Free domain available' ) }
+			/>
 		);
 	}
 
@@ -283,12 +280,6 @@ export default connect(
 	},
 	dispatch => {
 		return {
-			clickClaimDomainNotice: () =>
-				dispatch(
-					recordTracksEvent( 'calypso_domain_credit_reminder_click', {
-						cta_name: 'current_site_domain_notice',
-					} )
-				),
 			clickDomainUpsellGo: () =>
 				dispatch(
 					recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -85,7 +85,12 @@ export class SiteNotice extends React.Component {
 		const { translate } = this.props;
 
 		return (
-			<Notice compact title={ translate( 'Free domain available' ) }>
+			<Notice
+				isCompact
+				status="is-success"
+				icon="info-outline"
+				text={ translate( 'Free domain available' ) }
+			>
 				<NoticeAction
 					onClick={ this.props.clickClaimDomainNotice }
 					href={ `/domains/add/${ this.props.site.slug }` }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an `UpsellNudge` block to replace the use of `SidebarBanner` and `Notice` components in the sidebar.
* This is a wrapper for `Banner`, to restyle it to match the new nudges we're proposing for the sidebar. See #38733 for changes made to `Banner` to add support for a new compact style.
* Eventually we hope to consolidate all upsell nudges to use this block.

Example implementation:
<img width="289" alt="Screen Shot 2020-01-13 at 4 46 24 PM" src="https://user-images.githubusercontent.com/2124984/72294979-a6992b80-3624-11ea-8e76-5e573744b7c9.png">

#### Testing instructions

* Switch to this PR
* Check to make sure the new block does not break anything. It isn't implemented yet, but it should not break existing uses of `Banner`.