### PR TITLE
Customer Home: Fix positioning of checklist complete notice

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -32,6 +32,13 @@
 		@include grid-column( 1, 12 );
 	}
 
+	&__main .banner.card {
+		@include grid-column( 1, 12 );
+		@include grid-row( 2, 1 );
+		margin-left: 0;
+		margin-right: 0;
+	}
+
 	&__page-heading {
 		@include grid-row( 1, 1 );
 		@include breakpoint( '>1040px' ) {
@@ -199,7 +206,7 @@
 		padding-bottom: 12px;
 	}
 	&__layout {
-		@include grid-row( 2, 1 );
+		@include grid-row( 3, 1 );
 		@include breakpoint( '>1040px' ) {
 			@include grid-column( 1, 12 );
 			@include display-grid;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When you complete the checklist *after* site launch by skipping the mobile apps download step, you get an inline notice about having completed the checklist. The placement of this notice was broken when I shipped #38121 
* This PR aligns that notice correctly with the rest of the grid.

**Before**

![image](https://user-images.githubusercontent.com/2124984/71194855-b78b9280-225a-11ea-82ec-2fa31029f95d.png)

**After**

<img width="1089" alt="Screen Shot 2019-12-19 at 12 18 53 PM" src="https://user-images.githubusercontent.com/2124984/71194710-70050680-225a-11ea-8319-ac1f1da2a265.png">


#### Testing instructions

* Switch to this PR
* Create a new site with a new user account from `/start`
* Confirm your email address and launch your site
* Complete all other checklist tasks *except* the mobile apps download step
* "Skip" the mobile apps download
* Note the notice that appears at the top of the page; it should look like the After step above.