### PR TITLE
Earn: Remove Badge by Recurring Payments

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -151,7 +151,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		return {
 			title,
 			body,
-			badge: translate( 'New' ),
 			image: {
 				path: recurringImage,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This just simply removes the "New" badge.

#38483, didn't cover this, but let me know if it should stay and the approach in #38440 should be used instead. 

#### Testing instructions

Visit the Earn page and verify the badge next to "Collect recurring payments" is gone 

<img width="434" alt="Screenshot 2019-12-19 at 18 15 23" src="https://user-images.githubusercontent.com/43215253/71198460-bcb50580-228b-11ea-8c0e-1ed13c9f5850.png">

cc @davemart-in 
