### PR TITLE
Composite checkout: add events for billing field errors

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -53,7 +53,7 @@ export function CompositeCheckout( {
 		isLoading,
 	} = useShoppingCart( siteSlug, setCart, getCart );
 	const { registerStore } = registry;
-	useWpcomStore( registerStore );
+	useWpcomStore( registerStore, handleCheckoutEvent );
 
 	const errorMessages = useMemo( () => errors.map( error => error.message ), [ errors ] );
 	useDisplayErrors( errorMessages, showErrorMessage );

--- a/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
+++ b/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
@@ -6,7 +6,6 @@ import { useRef } from 'react';
 export function useWpcomStore( registerStore, onEvent ) {
 	// Only register once
 	const registerComplete = useRef();
-
 	if ( registerComplete.current ) {
 		return;
 	}

--- a/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
+++ b/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
@@ -3,9 +3,10 @@
  */
 import { useRef } from 'react';
 
-export function useWpcomStore( registerStore ) {
+export function useWpcomStore( registerStore, onEvent ) {
 	// Only register once
 	const registerComplete = useRef();
+
 	if ( registerComplete.current ) {
 		return;
 	}
@@ -92,6 +93,16 @@ export function useWpcomStore( registerStore ) {
 			},
 
 			setContactField( key, field ) {
+				if ( ! field.isValid ) {
+					onEvent( {
+						type: 'a8c_checkout_error',
+						payload: {
+							type: 'Field error',
+							field: key,
+						},
+					} );
+				}
+
 				return { type: 'CONTACT_SET_FIELD', payload: { key, field } };
 			},
 			setVatId( payload ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds event tracking every time an error is thrown on a billing detail field. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get Calypso running locally. 
* Add a product to your cart and make your way to checkout. 
* Add the following query string to your url: `?flags=composite-checkout-wpcom`
* Enable debugging mode by typing this in your DevTools console and refreshing the screen `localStorage.setItem('debug', 'calypso:composite-checkout')`.
* Pick a payment method
* Enter something into one of the billing fields and then remove it. 
* You should see an event pop up in the console called `a8c_checkout_error` with the type `Field error` in the payload. 
