### PR TITLE
Reader: fix double-encoded entities in post title

### DIFF
--- a/client/lib/post-normalizer/rule-decode-entities.js
+++ b/client/lib/post-normalizer/rule-decode-entities.js
@@ -20,6 +20,9 @@ export default function decodeEntities( post, fields = DEFAULT_FIELDS ) {
 		}
 	} );
 
+	// Sometimes titles are double-encoded, so run again to be sure
+	post.title = decode( post.title );
+
 	if ( post.parent && post.parent.title ) {
 		post.parent.title = decode( post.parent.title );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sometimes in Reader we see undecoded entities like this in post titles (often x-post titles):

<img width="763" alt="Screen Shot 2019-12-20 at 09 33 28" src="https://user-images.githubusercontent.com/17325/71210504-e31d8400-2311-11ea-9e07-9eb453ec5869.png">

This happens when the entity has been double-encoded, and the first pass of `decodeEntities` didn't do the trick.

This PR adds a second pass of `decodeEntities` for the post title only.

(Ultimately it would be nice to fix this in the API, but this is an effective band-aid for now.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure all post titles display without undecoded entities in your Reader feed:

<img width="572" alt="Screen Shot 2019-12-20 at 10 07 50" src="https://user-images.githubusercontent.com/17325/71210481-d9941c00-2311-11ea-9022-b75217d7e83f.png">

Fixes https://github.com/Automattic/wp-calypso/issues/37829.
