### PR TITLE
Quick Start session dashboard: Wrap strings in translate()

### DIFF
--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -98,18 +98,22 @@ class AppointmentInfo extends Component {
 						<>
 							<br />
 							<FormSettingExplanation>
-								Note: You have two free sessions with your plan. If you are unable to attend a
-								session, you may cancel or reschedule it at least one hour in advance so that it
-								does not count towards your session total.
+								{ translate(
+									'Note: You have two free sessions with your plan. If you are unable to attend a ' +
+										'session, you may cancel or reschedule it at least one hour in advance so that it ' +
+										'does not count towards your session total.'
+								) }
 							</FormSettingExplanation>
 						</>
 					) : (
 						<>
 							<br />
 							<FormSettingExplanation>
-								Note: You have 30 days from the date of purchase to cancel an unused Quick Start
-								session and receive a refund. Please note, if you miss a scheduled session twice,
-								the purchase will be cancelled without a refund.
+								{ translate(
+									'Note: You have 30 days from the date of purchase to cancel an unused Quick Start ' +
+										'session and receive a refund. Please note, if you miss a scheduled session twice, ' +
+										'the purchase will be cancelled without a refund.'
+								) }
 							</FormSettingExplanation>
 						</>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A couple of strings are missing the translate() call, so this PR just wraps those strings to be translatable.

Screenshots:

<img width="756" alt="Screenshot 2019-12-20 at 11 17 21 AM" src="https://user-images.githubusercontent.com/1269602/71233147-ae61fa80-231a-11ea-8731-41f3dfb51733.png">


<img width="725" alt="Screenshot 2019-12-20 at 11 18 47 AM" src="https://user-images.githubusercontent.com/1269602/71233161-b4f07200-231a-11ea-902a-3743f7bc2ec8.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Book a Quick Start session and visit your session dashboard at /me/concierge/{SITE_SLUG}
* Verify that the dashboard renders in en locale, and in non-en locales with appropriate translations of all strings. 
