### PR TITLE
Stylelint: allow fr units for CSS grids

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -22,7 +22,7 @@
 
 		"unit-case": "lower",
 		"unit-no-unknown": true,
-		"unit-whitelist": [ "px", "%", "deg", "ms", "em", "vh", "vw", "rem", "s" ],
+		"unit-whitelist": [ "%", "deg", "em", "fr", "ms", "px", "rem", "s", "vh", "vw" ],
 
 		"value-list-comma-space-after": "always-single-line",
 		"value-list-comma-space-before": "never",

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -135,18 +135,15 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 .template-selector-control__options {
 	display: grid;
-	// stylelint-disable-next-line unit-whitelist
 	grid-template-columns: 1fr;
 	grid-gap: 1.75em;
 
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		margin-top: 0;
-		// stylelint-disable unit-whitelist
 		grid-template-columns: repeat(
 			auto-fit,
 			minmax( 110px, 1fr )
 		); // allow grid to take over number of cols on large screens
-		// stylelint-enable unit-whitelist
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -20,9 +20,7 @@
 	grid-gap: 4.5em;
 
 	@include breakpoint( '>660px' ) {
-		// stylelint-disable unit-whitelist
 		grid-template-columns: repeat( 2, 1fr );
-		// stylelint-enable unit-whitelist
 	}
 }
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -23,7 +23,6 @@
 	&__main {
 		@include breakpoint( '>1040px' ) {
 			@include display-grid;
-			// stylelint-disable-next-line unit-whitelist
 			@include grid-template-columns( 12, 24px, 1fr );
 		}
 	}
@@ -210,7 +209,6 @@
 		@include breakpoint( '>1040px' ) {
 			@include grid-column( 1, 12 );
 			@include display-grid;
-			// stylelint-disable-next-line unit-whitelist
 			@include grid-template-columns( 12, 24px, 1fr );
 			grid-gap: 24px;
 		}


### PR DESCRIPTION
`fr` units are used in CSS grids:

> The new `fr` unit represents a fraction of the available space in the grid container. The next grid definition would create three equal width tracks that grow and shrink according to the available space.

via https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout

We used this unit quite heavily now in `client/landing/gutenboarding/*`

Related reading:
- https://caniuse.com/#feat=css-grid 
- https://rachelandrew.co.uk/archives/2017/07/04/is-it-really-safe-to-start-using-css-grid-layout/
- p1576230223377600-slack-luna

#### Changes proposed in this Pull Request

* Add `fr` unit to the allowed list
* Alphabetize the list 🤓
* Removed some `stylelint-disable` lines

#### Testing instructions

- You can write scss like this without Stylelint complaining: `grid-template-columns: 1fr 1fr 1fr;`
