### PR TITLE
Start transpiling the Chalk dependency

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,7 @@ const nodeModulesToTranspile = [
 	// In some cases we do want prefix style matching (lodash. for lodash.assign)
 	'@github/webauthn-json/',
 	'acorn-jsx/',
+	'chalk/',
 	'd3-array/',
 	'd3-scale/',
 	'debug/',
@@ -75,7 +76,7 @@ const nodeModulesToTranspile = [
 	'react-spring/',
 	'regenerate-unicode-properties/',
 	'regexpu-core/',
-	'striptags',
+	'striptags/',
 	'unicode-match-property-ecmascript/',
 	'unicode-match-property-value-ecmascript/',
 ];


### PR DESCRIPTION
It ships untranspiled ES6 code. Should fix #38527 and the desktop build.
