### PR TITLE
Theme Support Page: Update the Premium Theme Forum URL

### DIFF
--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -507,12 +507,11 @@ export function getThemeDemoUrl( state, themeId, siteId ) {
  *
  * @param  {Object}  state   Global state tree
  * @param  {String}  themeId Theme ID
- * @param  {String}  siteId  Site ID
- * @return {?String}         Theme forum URL
+ * @returns {?String}        Theme forum URL
  */
 export function getThemeForumUrl( state, themeId ) {
 	if ( isThemePremium( state, themeId ) ) {
-		return '//premium-themes.forums.wordpress.com/forum/' + themeId;
+		return '//premium-themes.forums.wordpress.com/' + themeId;
 	}
 	if ( isWpcomTheme( state, themeId ) ) {
 		return '//en.forums.wordpress.com/forum/themes';
@@ -729,12 +728,12 @@ export function getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ) {
 
 /**
  * Returns the price string to display for a given theme on a given site:
- * @TODO Add tests!
+ * TODO Add tests!
  *
  * @param  {Object}  state   Global state tree
  * @param  {string}  themeId Theme ID
  * @param  {Number}  siteId  Site ID
- * @return {String}          Price
+ * @returns {String}          Price
  */
 export function getPremiumThemePrice( state, themeId, siteId ) {
 	if ( ! isThemePremium( state, themeId ) || isPremiumThemeAvailable( state, themeId, siteId ) ) {
@@ -761,7 +760,7 @@ export function getPremiumThemePrice( state, themeId, siteId ) {
  * @param {Object} state   Global state tree
  * @param {String} themeId An identifier for the theme - like
  *                         `independent-publisher-2` or `maywood`.
- * @return {Boolean} True if the theme should be edited with gutenberg.
+ * @returns {Boolean} True if the theme should be edited with gutenberg.
  */
 export function isThemeGutenbergFirst( state, themeId ) {
 	const theme = getTheme( state, 'wpcom', themeId );


### PR DESCRIPTION
On https://wordpress.com/theme/port/support, the

> Have a question about this theme? Visit Forum

goes to the wrong theme forum. Currently it points to https://premium-themes.forums.wordpress.com/forum/port which redirects to https://premium-themes.forums.wordpress.com/forum/the-theme-foundry/portfolio/ instead of https://premium-themes.forums.wordpress.com/forum/themetrust/port/ 

Since the link https://premium-themes.forums.wordpress.com/port correctly redirects to https://premium-themes.forums.wordpress.com/forum/themetrust/port/ we'll change it to that.

#### Changes proposed in this Pull Request

* Change the target URL of premium themes.

#### Testing instructions

Load up https://calypso.live/?branch=fix/premium-theme-forum-url and visit a few theme Support URLs and make sure that they still point to the correct forums. Examples:

* https://premium-themes.forums.wordpress.com/port
* https://premium-themes.forums.wordpress.com/portfolio
