### PR TITLE
Disable Plan Downgrades in Remove Plan Flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -77,13 +77,21 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	getAllSurveySteps = () => {
-		const { purchase, isChatAvailable, isChatActive, precancellationChatAvailable } = this.props;
+		const {
+			purchase,
+			isChatAvailable,
+			isChatActive,
+			precancellationChatAvailable,
+			downgradeClick,
+		} = this.props;
+		const downgradePossible = !! downgradeClick;
 
 		return stepsForProductAndSurvey(
 			this.state,
 			purchase,
 			isChatAvailable || isChatActive,
-			precancellationChatAvailable
+			precancellationChatAvailable,
+			downgradePossible
 		);
 	};
 

--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -29,7 +29,8 @@ export default function stepsForProductAndSurvey(
 	survey,
 	product,
 	canChat,
-	precancellationChatAvailable
+	precancellationChatAvailable,
+	downgradePossible
 ) {
 	if ( survey && survey.questionOneRadio === 'couldNotInstall' ) {
 		if ( includesProduct( BUSINESS_PLANS, product ) && abtest( 'ATPromptOnCancel' ) === 'show' ) {
@@ -42,7 +43,7 @@ export default function stepsForProductAndSurvey(
 	}
 
 	if ( survey && survey.questionOneRadio === 'onlyNeedFree' ) {
-		if ( includesProduct( PREMIUM_PLANS, product ) ) {
+		if ( includesProduct( PREMIUM_PLANS, product ) && downgradePossible ) {
 			return [ steps.INITIAL_STEP, steps.DOWNGRADE_STEP, steps.FINAL_STEP ];
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Plan Downgrades are embedded in the marketing cancellation survey. There are two flows that trigger the same survey and they don't use the same code or the same approach. The remove
flow doesn't have the downgradeClick callback available.

I'm disabling the downgrades in that flow. Fixing it would require a significant refactoring that I may be able to do during the next planned iteration of downgrades and seems to be a relatively low priority given the difficulty to reproduce the error.

In order to see the remove plan button, a user has to:
- Have an expiring Premium subscription
- The auto-renew needs to be turned off

#### Testing instructions

1. With the Store Sandbox enabled, buy a Premium plan
2. With Store Admin, change the expiration to be in the next 2-3 days and turn off the Auto-renew
3. Hardcode on the server Store_Subscription::is_refundable to return false
4. Go to /me/purchases and click on the plan
5. You need to see the Remove button at the bottom, click that
6. In the survey, check that the plan is too expensive
7. Continue and finish the cancelation

There should be no errors.
*

Fixes #38542
