### PR TITLE
Remove node's url from lib/i18n-utils.

### DIFF
--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -12,4 +12,4 @@ export { default as isHttps } from './is-https';
 export { addSchemeIfMissing, setUrlScheme } from './scheme-utils';
 export { decodeURIIfValid, decodeURIComponentIfValid } from './decode-utils';
 export { default as format } from './format';
-export { getUrlParts } from './url-parts';
+export { getUrlParts, getUrlFromParts } from './url-parts';

--- a/client/lib/url/url-parts.ts
+++ b/client/lib/url/url-parts.ts
@@ -24,6 +24,20 @@ interface UrlParts {
 	password: string;
 }
 
+interface OptionalUrlParts {
+	protocol?: string;
+	host?: string;
+	hostname?: string;
+	port?: string;
+	origin?: string;
+	pathname?: string;
+	hash?: string;
+	search?: string;
+	searchParams?: URLSearchParams;
+	username?: string;
+	password?: string;
+}
+
 type UrlPartKey = keyof UrlParts;
 
 const EMPTY_URL: Readonly< UrlParts > = Object.freeze( {
@@ -99,4 +113,33 @@ export function getUrlParts( url: URLString | URL ): UrlParts {
 	}
 
 	return pathParts;
+}
+
+/**
+ * Returns a URL object built from the provided URL parts.
+ *
+ * @param parts the provided URL parts.
+ *
+ * @returns the generated URL object.
+ */
+export function getUrlFromParts( parts: OptionalUrlParts ): URL {
+	if ( ! parts?.protocol ) {
+		throw new Error( 'getUrlFromParts: protocol missing.' );
+	}
+
+	if ( ! parts.host && ! parts.hostname ) {
+		throw new Error( 'getUrlFromParts: host missing.' );
+	}
+
+	const result = new URL( BASE_URL );
+
+	// Apply 'host' first, since it includes both hostname and port.
+	result.host = parts.host ?? result.host;
+
+	for ( const part of URL_PART_KEYS ) {
+		if ( part !== 'host' && part !== 'origin' && part !== 'searchParams' ) {
+			result[ part ] = parts[ part ] ?? result[ part ];
+		}
+	}
+	return result;
 }


### PR DESCRIPTION
Also adds a new `getUrlFromParts` method  to `lib/url`.

#### Changes proposed in this Pull Request

* Adds new `getUrlFromParts` method  to `lib/url`.
* Remove usage of `node`'s deprecated `url` module from `lib/i18n-utils`.
* Drive-by lint fixes.

#### Testing instructions

Ensure that the unit tests for `lib/i18n-utils` continue to work correctly.
