### PR TITLE
Calypso Site Preview: Simplify site preview toolbar by hiding URL on smaller breakpoints

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -276,6 +276,7 @@ export class WebPreviewContent extends Component {
 					{ ...this.props }
 					showExternal={ this.props.previewUrl ? this.props.showExternal : false }
 					showDeviceSwitcher={ this.props.showDeviceSwitcher && isWithinBreakpoint( '>660px' ) }
+					showUrl={ this.props.showUrl && isWithinBreakpoint( '>960px' ) }
 					selectSeoPreview={ this.selectSEO }
 					isLoading={ this.state.isLoadingSubpage }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the URL in the Calypso site preview on smaller breakpoints. This gives everything room to breathe on smaller devices.

**375px Before**
<img width="373" alt="Screen Shot 2019-12-20 at 3 41 48 PM" src="https://user-images.githubusercontent.com/448298/71291067-7de08780-233f-11ea-8e39-c7e1fa8b8382.png">

**375px After**
<img width="375" alt="Screen Shot 2019-12-20 at 3 41 38 PM" src="https://user-images.githubusercontent.com/448298/71291083-8a64e000-233f-11ea-8661-7403d751c3a2.png">

**768px Before**
<img width="768" alt="Screen Shot 2019-12-20 at 3 41 24 PM" src="https://user-images.githubusercontent.com/448298/71291102-98b2fc00-233f-11ea-8e85-b59ad25f5de3.png">

**768px After**
<img width="767" alt="Screen Shot 2019-12-20 at 3 40 52 PM" src="https://user-images.githubusercontent.com/448298/71291098-93ee4800-233f-11ea-841a-cdb6f4ab603c.png">
 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally or using the calypso.live link
* Click the site card in the sidebar to view the site preview
* Resize the browser window
* Make sure the URL is hidden below `960px` and shows on higher breakpoints

Fixes #38099
