### PR TITLE
i18n: New function hasLocalizedText & usage in EligibilityWarnings component

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
+import { identity, map } from 'lodash';
 import React from 'react';
 
 /**
@@ -219,5 +219,8 @@ function isHardBlockingHoldType(
 ): hold is keyof ReturnType< typeof getBlockingMessages > {
 	return blockingMessages.hasOwnProperty( hold );
 }
+
+export const hasBlockingHold = ( holds: string[] ) =>
+	holds.some( hold => isHardBlockingHoldType( hold, getBlockingMessages( identity ) ) );
 
 export default localize( HoldList );

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { localize, LocalizeProps } from 'i18n-calypso';
+import i18n, { localize, LocalizeProps } from 'i18n-calypso';
+const hasTranslation = ( message: string ) => i18n.hasTranslation( message );
 import { identity, map } from 'lodash';
 import React from 'react';
 
@@ -21,15 +22,32 @@ import { localizeUrl } from 'lib/i18n-utils';
 function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: translate( 'Upgrade to a Business plan' ),
-			description:
-				context === 'themes'
+			title: hasTranslation( 'Upgrade to a Business plan' )
+				? translate( 'Upgrade to a Business plan' )
+				: translate( 'Upgrade to Business' ),
+			description: ( function() {
+				if ( context === 'themes' ) {
+					return hasTranslation(
+						"You'll also get to install custom plugins, have more storage, and access live support."
+					)
+						? translate(
+								"You'll also get to install custom plugins, have more storage, and access live support."
+						  )
+						: translate(
+								'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+						  );
+				}
+
+				return hasTranslation(
+					"You'll also get to install custom themes, have more storage, and access live support."
+				)
 					? translate(
-							"You'll also get to install custom plugins, have more storage, and access live support."
+							"You'll also get to install custom themes, have more storage, and access live support."
 					  )
 					: translate(
-							"You'll also get to install custom themes, have more storage, and access live support."
-					  ),
+							'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+					  );
+			} )(),
 			supportUrl: null,
 		},
 		SITE_PRIVATE: {
@@ -73,9 +91,15 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
-			message: translate(
+			message: hasTranslation(
 				'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
-			),
+			)
+				? translate(
+						'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
+				  )
+				: translate(
+						'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+				  ),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},
@@ -97,16 +121,26 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			contactUrl: null,
 		},
 		SITE_GRAYLISTED: {
-			message: translate(
+			message: hasTranslation(
 				"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
-			),
+			)
+				? hasTranslation(
+						"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
+				  )
+				: translate( "Contact us to review your site's standing and resolve the dispute." ),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://en.support.wordpress.com/suspended-blogs/' ),
 		},
 		NO_SSL_CERTIFICATE: {
-			message: translate(
+			message: hasTranslation(
 				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
-			),
+			)
+				? hasTranslation(
+						'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
+				  )
+				: translate(
+						'Hold tight! We are setting up a digital certificate to allow secure browsing on your site, using "HTTPS". Please try again in a few minutes.\''
+				  ),
 			status: null,
 			contactUrl: null,
 		},
@@ -200,15 +234,24 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 };
 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
+	const defaultCopy = translate( 'Please clear all issues above to proceed.' );
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins you'll need to:" );
+			return hasTranslation( "To install plugins you'll need to:" )
+				? translate( "To install plugins you'll need to:" )
+				: defaultCopy;
 		case 'themes':
-			return translate( "To install themes you'll need to:" );
+			return hasTranslation( "To install themes you'll need to:" )
+				? translate( "To install plugins you'll need to:" )
+				: defaultCopy;
 		case 'hosting':
-			return translate( "To activate hosting access you'll need to:" );
+			return hasTranslation( "To activate hosting access you'll need to:" )
+				? translate( "To activate hosting access you'll need to:" )
+				: defaultCopy;
 		default:
-			return translate( "To continue you'll need to" + ':' );
+			return hasTranslation( "To continue you'll need to:" )
+				? translate( "To continue you'll need to:" )
+				: defaultCopy;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -10,7 +10,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import SectionHeader from 'components/section-header';
+import CardHeading from 'components/card-heading';
 import { localizeUrl } from 'lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
@@ -101,23 +101,20 @@ function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
 }
 
 interface ExternalProps {
+	context: string | null;
 	holds: string[];
 	isPlaceholder: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( translate );
 
 	return (
 		<div>
-			<SectionHeader
-				label={ translate( 'Please resolve this issue:', 'Please resolve these issues:', {
-					count: holds.length,
-				} ) }
-			/>
 			<Card className="eligibility-warnings__hold-list">
+				<CardHeading>{ getCardHeading( context, translate ) }</CardHeading>
 				{ isPlaceholder && (
 					<div>
 						<div className="eligibility-warnings__hold">
@@ -134,18 +131,17 @@ export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<Gridicon icon="notice-outline" size={ 24 } />
+								<Gridicon icon="checkmark-circle" size={ 24 } />
 								<div className="eligibility-warnings__message">
-									<span className="eligibility-warnings__message-title">
+									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
-									</span>
-									:&nbsp;
-									<span className="eligibility-warnings__message-description">
+									</div>
+									<div className="eligibility-warnings__message-description">
 										{ holdMessages[ hold ].description }
-									</span>
+									</div>
 								</div>
 								{ holdMessages[ hold ].supportUrl && (
-									<div className="eligibility-warnings__action">
+									<div className="eligibility-warnings__hold-action">
 										<Button
 											compact
 											href={ holdMessages[ hold ].supportUrl }
@@ -162,6 +158,17 @@ export const HoldList = ( { holds, isPlaceholder, translate }: Props ) => {
 		</div>
 	);
 };
+
+function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
+	switch ( context ) {
+		case 'plugins':
+			return translate( "To install plugins, you'll need a couple things:" );
+		case 'themes':
+			return translate( "To install themes, you'll need a couple things:" );
+		default:
+			return translate( "To continue, you'll need a couple things:" );
+	}
+}
 
 function isKnownHoldType(
 	hold: string,

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -3,7 +3,6 @@
  */
 import classNames from 'classnames';
 import i18n, { localize, LocalizeProps } from 'i18n-calypso';
-const hasTranslation = ( message: string ) => i18n.hasTranslation( message );
 import { identity, map } from 'lodash';
 import React from 'react';
 
@@ -21,12 +20,12 @@ import { localizeUrl } from 'lib/i18n-utils';
 function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: hasTranslation( 'Upgrade to a Business plan' )
+			title: i18n.hasLocalizedText( 'Upgrade to a Business plan' )
 				? translate( 'Upgrade to a Business plan' )
 				: translate( 'Upgrade to Business' ),
 			description: ( function() {
 				if ( context === 'themes' ) {
-					return hasTranslation(
+					return i18n.hasLocalizedText(
 						"You'll also get to install custom plugins, have more storage, and access live support."
 					)
 						? translate(
@@ -37,7 +36,7 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 						  );
 				}
 
-				return hasTranslation(
+				return i18n.hasLocalizedText(
 					"You'll also get to install custom themes, have more storage, and access live support."
 				)
 					? translate(
@@ -98,7 +97,7 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
-			message: hasTranslation(
+			message: i18n.hasLocalizedText(
 				'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
 			)
 				? translate(
@@ -128,10 +127,10 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			contactUrl: null,
 		},
 		SITE_GRAYLISTED: {
-			message: hasTranslation(
+			message: i18n.hasLocalizedText(
 				"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
 			)
-				? hasTranslation(
+				? i18n.hasLocalizedText(
 						"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
 				  )
 				: translate( "Contact us to review your site's standing and resolve the dispute." ),
@@ -139,10 +138,10 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			contactUrl: localizeUrl( 'https://en.support.wordpress.com/suspended-blogs/' ),
 		},
 		NO_SSL_CERTIFICATE: {
-			message: hasTranslation(
+			message: i18n.hasLocalizedText(
 				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
 			)
-				? hasTranslation(
+				? i18n.hasLocalizedText(
 						'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
 				  )
 				: translate(
@@ -244,15 +243,15 @@ function getCardHeading( context: string | null, translate: LocalizeProps[ 'tran
 	const defaultCopy = translate( "To continue you'll need to:" );
 	switch ( context ) {
 		case 'plugins':
-			return hasTranslation( "To install plugins you'll need to:" )
+			return i18n.hasLocalizedText( "To install plugins you'll need to:" )
 				? translate( "To install plugins you'll need to:" )
 				: defaultCopy;
 		case 'themes':
-			return hasTranslation( "To install themes you'll need to:" )
+			return i18n.hasLocalizedText( "To install themes you'll need to:" )
 				? translate( "To install plugins you'll need to:" )
 				: defaultCopy;
 		case 'hosting':
-			return hasTranslation( "To activate hosting access you'll need to:" )
+			return i18n.hasLocalizedText( "To activate hosting access you'll need to:" )
 				? translate( "To activate hosting access you'll need to:" )
 				: defaultCopy;
 		default:

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
@@ -139,8 +139,8 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 						) }
 					</Notice>
 				) }
-			<Card
-				className={ classNames( 'eligibility-warnings__hold-list', {
+			<div
+				className={ classNames( {
 					'eligibility-warnings__hold-list-dim': blockingHold,
 				} ) }
 				data-testid="HoldList-Card"
@@ -190,7 +190,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 							</div>
 						)
 					) }
-			</Card>
+			</div>
 		</>
 	);
 };

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -116,16 +116,20 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 interface ExternalProps {
 	context: string | null;
 	holds: string[];
+	isIndented: boolean;
 	isPlaceholder: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isIndented, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( context, translate );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( h => isHardBlockingHoldType( h, blockingMessages ) );
+	const messageClassName = classNames( 'eligibility-warnings__message ', {
+		'eligibility-warnings__message--indented': isIndented,
+	} );
 
 	return (
 		<>
@@ -171,8 +175,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<Gridicon icon="chevron-right" size={ 24 } />
-								<div className="eligibility-warnings__message">
+								<div className={ messageClassName }>
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
 									</div>

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -166,7 +166,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<Gridicon icon="checkmark-circle" size={ 24 } />
+								<Gridicon icon="chevron-right" size={ 24 } />
 								<div className="eligibility-warnings__message">
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
@@ -198,11 +198,11 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins, you'll need a couple things:" );
+			return translate( "To install plugins, you'll need a couple of things:" );
 		case 'themes':
-			return translate( "To install themes, you'll need a couple things:" );
+			return translate( "To install themes, you'll need a couple of things:" );
 		default:
-			return translate( "To continue, you'll need a couple things:" );
+			return translate( "To continue, you'll need a couple of things:" );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -31,6 +31,13 @@ function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
 			),
 			supportUrl: null,
 		},
+		NO_BUSINESS_PLAN: {
+			title: translate( 'Upgrade to a Business plan' ),
+			description: translate(
+				"You'll also get to install custom themes, have more storage, and access live support."
+			),
+			supportUrl: null,
+		},
 		NO_JETPACK_SITES: {
 			title: translate( 'Not available for Jetpack sites' ),
 			description: translate( 'Try using a different site.' ),

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -198,11 +198,11 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins, you'll need a couple of things:" );
+			return translate( "To install plugins, you'll need to:" );
 		case 'themes':
-			return translate( "To install themes, you'll need a couple of things:" );
+			return translate( "To install themes, you'll need to:" );
 		default:
-			return translate( "To continue, you'll need a couple of things:" );
+			return translate( "To continue, you'll need to:" );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -241,7 +241,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 };
 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
-	const defaultCopy = translate( 'Please clear all issues above to proceed.' );
+	const defaultCopy = translate( "To continue you'll need to:" );
 	switch ( context ) {
 		case 'plugins':
 			return hasTranslation( "To install plugins you'll need to:" )
@@ -256,9 +256,7 @@ function getCardHeading( context: string | null, translate: LocalizeProps[ 'tran
 				? translate( "To activate hosting access you'll need to:" )
 				: defaultCopy;
 		default:
-			return hasTranslation( "To continue you'll need to:" )
-				? translate( "To continue you'll need to:" )
-				: defaultCopy;
+			return defaultCopy;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -87,6 +87,14 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 	};
 }
 
+/**
+ * This function defines how we should communicate each type of blocking hold the public-api returns.
+ * Blocking holds are "hard stops" - if we detect any, we know the Atomic Transfer won't be possible and so we
+ * should short-circuit any eligibility checks and just communicate the problem.
+ *
+ * @param {Function} translate Translate fn
+ * @returns {object} Dictionary of blocking holds and their corresponding messages
+ */
 function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
@@ -261,6 +269,15 @@ function isKnownHoldType(
 	return holdMessages.hasOwnProperty( hold );
 }
 
+/**
+ * This checks if hold coming from API is blocking (@see getBlockingMessages);
+ * For example, if we detect BLOCKED_ATOMIC_TRANSFER, we should block the path forward and direct the user
+ * to our support.
+ *
+ * @param {string} hold Specific hold we want to check
+ * @param {object} blockingMessages List of all holds we consider blocking
+ * @returns {boolean} Is {hold} blocking or not
+ */
 function isHardBlockingHoldType(
 	hold: string,
 	blockingMessages: ReturnType< typeof getBlockingMessages >

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -76,7 +76,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 		},
 		TRANSFER_ALREADY_EXISTS: {
 			message: translate(
-				'Installation in progress. Just a minute! Please wait until the installation is finisehd, then try again.'
+				'Installation in progress. Just a minute! Please wait until the installation is finished, then try again.'
 			),
 			status: null,
 			contactUrl: null,
@@ -100,7 +100,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 		},
 		NO_SSL_CERTIFICATE: {
 			message: translate(
-				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browing on your site using "HTTPS".'
+				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
 			),
 			status: null,
 			contactUrl: null,

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -18,13 +18,18 @@ import { localizeUrl } from 'lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
 // TODO: update supportUrls and maybe create similar mapping for warnings
-function getHoldMessages( translate: LocalizeProps[ 'translate' ] ) {
+function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {
 			title: translate( 'Upgrade to a Business plan' ),
-			description: translate(
-				"You'll also get to install custom themes, have more storage, and access live support."
-			),
+			description:
+				context === 'themes'
+					? translate(
+							"You'll also get to install custom plugins, have more storage, and access live support."
+					  )
+					: translate(
+							"You'll also get to install custom themes, have more storage, and access live support."
+					  ),
 			supportUrl: null,
 		},
 		SITE_PRIVATE: {
@@ -69,7 +74,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
 			message: translate(
-				'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
+				'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
 			),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
@@ -117,7 +122,7 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
-	const holdMessages = getHoldMessages( translate );
+	const holdMessages = getHoldMessages( context, translate );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( h => isHardBlockingHoldType( h, blockingMessages ) );
@@ -201,6 +206,8 @@ function getCardHeading( context: string | null, translate: LocalizeProps[ 'tran
 			return translate( "To install plugins you'll need to:" );
 		case 'themes':
 			return translate( "To install themes you'll need to:" );
+		case 'hosting':
+			return translate( "To activate hosting access you'll need to:" );
 		default:
 			return translate( "To continue you'll need to" + ':' );
 	}

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -198,11 +198,11 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	switch ( context ) {
 		case 'plugins':
-			return translate( "To install plugins, you'll need to:" );
+			return translate( "To install plugins you'll need to:" );
 		case 'themes':
-			return translate( "To install themes, you'll need to:" );
+			return translate( "To install themes you'll need to:" );
 		default:
-			return translate( "To continue, you'll need to:" );
+			return translate( "To continue you'll need to" + ':' );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -116,20 +116,16 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 interface ExternalProps {
 	context: string | null;
 	holds: string[];
-	isIndented: boolean;
 	isPlaceholder: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const HoldList = ( { context, holds, isIndented, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const holdMessages = getHoldMessages( context, translate );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( h => isHardBlockingHoldType( h, blockingMessages ) );
-	const messageClassName = classNames( 'eligibility-warnings__message ', {
-		'eligibility-warnings__message--indented': isIndented,
-	} );
 
 	return (
 		<>
@@ -175,7 +171,7 @@ export const HoldList = ( { context, holds, isIndented, isPlaceholder, translate
 					map( holds, hold =>
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
-								<div className={ messageClassName }>
+								<div className="eligibility-warnings__message">
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
 									</div>

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -18,7 +18,6 @@ import NoticeAction from 'components/notice/notice-action';
 import { localizeUrl } from 'lib/i18n-utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
-// TODO: update supportUrls and maybe create similar mapping for warnings
 function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'components/gridicon';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
+import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { localizeUrl } from 'lib/i18n-utils';
@@ -138,8 +139,17 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 						) }
 					</Notice>
 				) }
-			<Card className="eligibility-warnings__hold-list">
-				<CardHeading>{ getCardHeading( context, translate ) }</CardHeading>
+			<Card
+				className={ classNames( 'eligibility-warnings__hold-list', {
+					'eligibility-warnings__hold-list-dim': blockingHold,
+				} ) }
+				data-testid="HoldList-Card"
+			>
+				<CardHeading>
+					<span className="eligibility-warnings__hold-heading">
+						{ getCardHeading( context, translate ) }
+					</span>
+				</CardHeading>
 				{ isPlaceholder && (
 					<div>
 						<div className="eligibility-warnings__hold">
@@ -169,6 +179,7 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 									<div className="eligibility-warnings__hold-action">
 										<Button
 											compact
+											disabled={ !! blockingHold }
 											href={ holdMessages[ hold ].supportUrl }
 											rel="noopener noreferrer"
 										>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { filter, get, includes, noop } from 'lodash';
+import { get, includes, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 
@@ -53,12 +53,8 @@ export const EligibilityWarnings = ( {
 	siteSlug,
 	translate,
 }: Props ) => {
-	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
-
-	const listHolds = filter(
-		get( eligibilityData, 'eligibilityHolds', [] ),
-		hold => ! includes( [ 'NO_BUSINESS_PLAN', 'NOT_USING_CUSTOM_DOMAIN' ], hold )
-	);
+	const warnings = eligibilityData.eligibilityWarnings || [];
+	const listHolds = eligibilityData.eligibilityHolds || [];
 
 	const classes = classNames( 'eligibility-warnings', {
 		'eligibility-warnings__placeholder': isPlaceholder,

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -48,6 +48,8 @@ export const EligibilityWarnings = ( {
 		'eligibility-warnings__placeholder': isPlaceholder,
 	} );
 
+	const showWarnings = warnings.length > 0 && ! hasBlockingHold( listHolds );
+
 	return (
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
@@ -57,7 +59,12 @@ export const EligibilityWarnings = ( {
 			/>
 			<CompactCard>
 				{ ( isPlaceholder || listHolds.length > 0 ) && (
-					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
+					<HoldList
+						context={ context }
+						holds={ listHolds }
+						isPlaceholder={ isPlaceholder }
+						isIndented={ showWarnings }
+					/>
 				) }
 
 				{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
@@ -69,7 +76,7 @@ export const EligibilityWarnings = ( {
 					</div>
 				) }
 			</CompactCard>
-			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
+			{ showWarnings && (
 				<CompactCard className="eligibility-warnings__warnings-card">
 					<WarningList context={ context } warnings={ warnings } />
 				</CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -71,7 +71,7 @@ export const EligibilityWarnings = ( {
 			</CompactCard>
 			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
 				<CompactCard className="eligibility-warnings__warnings-card">
-					<WarningList warnings={ warnings } />
+					<WarningList context={ context } warnings={ warnings } />
 				</CompactCard>
 			) }
 			<CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize, LocalizeProps } from 'i18n-calypso';
+import i18n, { localize, LocalizeProps } from 'i18n-calypso';
+const hasTranslation = ( message: string ) => i18n.hasTranslation( message );
 import { includes, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
@@ -54,8 +55,6 @@ export const EligibilityWarnings = ( {
 	} );
 
 	const logEventAndProceed = () => {
-		// We removed <Banner /> Component which logged this event on upsell click.
-		// We want to keep tracking the data in the same way, so let's fake the banner click here
 		recordCtaClick( feature );
 		onProceed();
 	};
@@ -110,23 +109,33 @@ function getSiteIsEligibleMessage(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ]
 ) {
+	const defaultCopy = translate( 'This site is eligible to install plugins and upload themes.' );
 	switch ( context ) {
 		case 'plugins':
 		case 'themes':
-			return translate( 'This site is eligible to install plugins and upload themes.' );
+			return hasTranslation( 'This site is eligible to install plugins and upload themes.' )
+				? translate( 'This site is eligible to install plugins and upload themes.' )
+				: defaultCopy;
 		case 'hosting':
-			return translate( 'This site is eligible to activate hosting access.' );
+			return hasTranslation( 'This site is eligible to activate hosting access.' )
+				? translate( 'This site is eligible to activate hosting access.' )
+				: defaultCopy;
 		default:
-			return translate( 'This site is eligible to continue.' );
+			return hasTranslation( 'This site is eligible to continue.' )
+				? translate( 'This site is eligible to continue.' )
+				: defaultCopy;
 	}
 }
 
 function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'translate' ] ) {
+	const defaultCopy = translate( 'Proceed' );
 	if ( holds.includes( 'NO_BUSINESS_PLAN' ) ) {
-		return translate( 'Upgrade and continue' );
+		return hasTranslation( 'Upgrade and continue' )
+			? translate( 'Upgrade and continue' )
+			: defaultCopy;
 	}
 
-	return translate( 'Continue' );
+	return hasTranslation( 'Continue' ) ? translate( 'Continue' ) : defaultCopy;
 }
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {
@@ -172,7 +181,7 @@ function mergeProps(
 	ownProps: ExternalProps
 ) {
 	let context: string | null = null;
-	let feature: string | null = null;
+	let feature = '';
 	if ( includes( ownProps.backUrl, 'plugins' ) ) {
 		context = 'plugins';
 		feature = FEATURE_UPLOAD_PLUGINS;

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -208,7 +208,9 @@ function mergeProps(
 		context = 'hosting';
 	}
 
-	const onCancel = () => dispatchProps.trackCancel( { context } );
+	const onCancel = () => {
+		dispatchProps.trackCancel( { context } );
+	};
 	const onProceed = () => {
 		ownProps.onProceed();
 		dispatchProps.trackProceed( { context } );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import i18n, { localize, LocalizeProps } from 'i18n-calypso';
-const hasTranslation = ( message: string ) => i18n.hasTranslation( message );
 import { includes, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
@@ -119,15 +118,15 @@ function getSiteIsEligibleMessage(
 	switch ( context ) {
 		case 'plugins':
 		case 'themes':
-			return hasTranslation( 'This site is eligible to install plugins and upload themes.' )
+			return i18n.hasLocalizedText( 'This site is eligible to install plugins and upload themes.' )
 				? translate( 'This site is eligible to install plugins and upload themes.' )
 				: defaultCopy;
 		case 'hosting':
-			return hasTranslation( 'This site is eligible to activate hosting access.' )
+			return i18n.hasLocalizedText( 'This site is eligible to activate hosting access.' )
 				? translate( 'This site is eligible to activate hosting access.' )
 				: defaultCopy;
 		default:
-			return hasTranslation( 'This site is eligible to continue.' )
+			return i18n.hasLocalizedText( 'This site is eligible to continue.' )
 				? translate( 'This site is eligible to continue.' )
 				: defaultCopy;
 	}
@@ -136,12 +135,12 @@ function getSiteIsEligibleMessage(
 function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'translate' ] ) {
 	const defaultCopy = translate( 'Proceed' );
 	if ( holds.includes( 'NO_BUSINESS_PLAN' ) ) {
-		return hasTranslation( 'Upgrade and continue' )
+		return i18n.hasLocalizedText( 'Upgrade and continue' )
 			? translate( 'Upgrade and continue' )
 			: defaultCopy;
 	}
 
-	return hasTranslation( 'Continue' ) ? translate( 'Continue' ) : defaultCopy;
+	return i18n.hasLocalizedText( 'Continue' ) ? translate( 'Continue' ) : defaultCopy;
 }
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -8,6 +8,7 @@ const hasTranslation = ( message: string ) => i18n.hasTranslation( message );
 import { includes, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -58,7 +59,8 @@ export const EligibilityWarnings = ( {
 	const logEventAndProceed = () => {
 		recordCtaClick( feature );
 		if ( siteRequiresUpgrade( listHolds ) ) {
-            page.redirect(`/checkout/${siteSlug}/business`);
+			page.redirect( `/checkout/${ siteSlug }/business` );
+			return;
 		}
 		onProceed();
 	};
@@ -144,8 +146,7 @@ function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'trans
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {
 	const canHandleHoldsAutomatically =
-		holds.length <= 2 &&
-		holds.every( hold => [ 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ].includes( hold ) );
+		holds.length <= 2 && holds.every( hold => [ 'NO_BUSINESS_PLAN' ].includes( hold ) );
 
 	return ! canHandleHoldsAutomatically && ! isEligible;
 }

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -17,7 +17,7 @@ import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { Button, Card } from '@automattic/components';
 import QueryEligibility from 'components/data/query-atat-eligibility';
-import HoldList from './hold-list';
+import HoldList, { hasBlockingHold } from './hold-list';
 import WarningList from './warning-list';
 
 /**
@@ -57,10 +57,12 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
+			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
+				<WarningList warnings={ warnings } />
+			) }
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 			) }
-			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
 			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
 				<Card className="eligibility-warnings__no-conflicts">

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -60,53 +60,56 @@ export const EligibilityWarnings = ( {
 			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
 				<WarningList warnings={ warnings } />
 			) }
-			{ ( isPlaceholder || listHolds.length > 0 ) && (
-				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
-			) }
 
-			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
-				<Card className="eligibility-warnings__no-conflicts">
-					<Gridicon icon="thumbs-up" size={ 24 } />
-					<span>
-						{ translate( 'This site is eligible to install plugins and upload themes.' ) }
-					</span>
-				</Card>
-			) }
+			<Card>
+				{ ( isPlaceholder || listHolds.length > 0 ) && (
+					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
+				) }
 
-			<Card className="eligibility-warnings__confirm-box">
-				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && (
-						<>
-							{ translate( 'Please clear all issues above to proceed.' ) }
-							&nbsp;
-						</>
-					) }
-					{ isEligible && warnings.length > 0 && (
-						<>
-							{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
-							&nbsp;
-						</>
-					) }
-					{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
-						components: {
-							a: (
-								<a
-									href="https://wordpress.com/help/contact"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</div>
-				<div className="eligibility-warnings__confirm-buttons">
-					<Button href={ backUrl } onClick={ onCancel }>
-						{ translate( 'Cancel' ) }
-					</Button>
+				{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
+					<div className="eligibility-warnings__no-conflicts">
+						<Gridicon icon="thumbs-up" size={ 24 } />
+						<span>
+							{ translate( 'This site is eligible to install plugins and upload themes.' ) }
+						</span>
+					</div>
+				) }
 
-					<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
-						{ translate( 'Proceed' ) }
-					</Button>
+				<div className="eligibility-warnings__confirm-box">
+					<div className="eligibility-warnings__confirm-text">
+						{ ! isEligible && (
+							<>
+								{ translate( 'Please clear all issues above to proceed.' ) }
+								&nbsp;
+							</>
+						) }
+						{ isEligible && warnings.length > 0 && (
+							<>
+								{ translate( 'If you proceed you will no longer be able to use these features. ' ) }
+								&nbsp;
+							</>
+						) }
+						{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
+							components: {
+								a: (
+									<a
+										href="https://wordpress.com/help/contact"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</div>
+					<div className="eligibility-warnings__confirm-buttons">
+						<Button href={ backUrl } onClick={ onCancel }>
+							{ translate( 'Cancel' ) }
+						</Button>
+
+						<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
+							{ translate( 'Proceed' ) }
+						</Button>
+					</div>
 				</div>
 			</Card>
 		</div>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -105,7 +105,7 @@ export const EligibilityWarnings = ( {
 			{ businessUpsellBanner }
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
-				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } />
+				<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 			) }
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -15,7 +15,7 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { Button, Card } from '@automattic/components';
+import { Button, CompactCard } from '@automattic/components';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import HoldList, { hasBlockingHold } from './hold-list';
 import WarningList from './warning-list';
@@ -55,11 +55,7 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
-			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
-				<WarningList warnings={ warnings } />
-			) }
-
-			<Card>
+			<CompactCard>
 				{ ( isPlaceholder || listHolds.length > 0 ) && (
 					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 				) }
@@ -72,7 +68,13 @@ export const EligibilityWarnings = ( {
 						</span>
 					</div>
 				) }
-
+			</CompactCard>
+			{ warnings.length > 0 && ! hasBlockingHold( listHolds ) && (
+				<CompactCard className="eligibility-warnings__warnings-card">
+					<WarningList warnings={ warnings } />
+				</CompactCard>
+			) }
+			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
 					<Button
 						primary={ true }
@@ -82,7 +84,7 @@ export const EligibilityWarnings = ( {
 						{ getProceedButtonText( listHolds, translate ) }
 					</Button>
 				</div>
-			</Card>
+			</CompactCard>
 		</div>
 	);
 };

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -44,8 +44,8 @@
 	align-items: flex-start;
 	margin-bottom: 16px;
 
-	&:last-child {
-		margin-bottom: 0;
+	&:first-of-type {
+		padding-top: 6px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,5 +1,3 @@
-
-
 .eligibility-warnings {
 	margin-top: 16px;
 	font-size: 14px;
@@ -57,7 +55,11 @@
 	}
 }
 
-.eligibility-warnings__hold .gridicon,
+.eligibility-warnings__hold .gridicon {
+	color: var( --color-neutral-10 );
+	flex-shrink: 0;
+}
+
 .eligibility-warnings__warning > .gridicon {
 	color: var( --color-error );
 	flex-shrink: 0;
@@ -77,13 +79,18 @@
 	}
 }
 
-.eligibility-warnings__action a {
+.eligibility-warnings__action a,
+.eligibility-warnings__hold-action a {
 	.gridicons-help-outline {
 		color: var( --color-neutral-light );
 	}
 	&:hover .gridicons-help-outline {
 		color: var( --color-primary );
 	}
+}
+
+.eligibility-warnings__hold-action {
+	align-self: center;
 }
 
 .eligibility-warnings__no-conflicts.card {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -124,3 +124,8 @@
 		margin-left: 16px;
 	}
 }
+
+.eligibility-warnings__hold-list-dim .eligibility-warnings__hold-heading,
+.eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
+	opacity: 0.2;
+}

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -33,13 +33,15 @@
 	}
 }
 
-.eligibility-warnings__hold {
+.eligibility-warnings__hold,
+.eligibility-warnings__warning {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
 }
 
-.eligibility-warnings__hold {
+.eligibility-warnings__hold,
+.eligibility-warnings__warning {
 	align-items: flex-start;
 	margin-bottom: 16px;
 
@@ -48,9 +50,17 @@
 	}
 }
 
+.eligibility-warnings__hold .gridicon,
+.eligibility-warnings__warning .gridicon {
+	flex-shrink: 0;
+}
+
 .eligibility-warnings__hold .gridicon {
 	color: var( --color-neutral-10 );
-	flex-shrink: 0;
+}
+
+.eligibility-warnings__warning .gridicon {
+	color: var( --color-warning-10 );
 }
 
 .eligibility-warnings__message {
@@ -64,6 +74,10 @@
 
 	.eligibility-warnings__message-description {
 		color: var( --color-text-subtle );
+	}
+
+	&--indented {
+		margin-left: 24px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -3,6 +3,16 @@
 	font-size: 14px;
 }
 
+.eligibility-warnings--with-indent {
+	.eligibility-warnings__message {
+		padding: 0 16px;
+		margin-left: 24px;
+	}
+	.gridicon + .eligibility-warnings__message {
+		margin-left: 0;
+	}
+}
+
 .eligibility-warnings__placeholder {
 	@include placeholder();
 
@@ -66,7 +76,7 @@
 .eligibility-warnings__message {
 	flex-grow: 1;
 	line-height: 24px;
-	padding: 0 16px;
+	padding: 0;
 
 	.eligibility-warnings__message-title {
 		font-weight: 600;
@@ -74,10 +84,6 @@
 
 	.eligibility-warnings__message-description {
 		color: var( --color-text-subtle );
-	}
-
-	&--indented {
-		margin-left: 24px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -114,7 +114,3 @@
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
 	opacity: 0.2;
 }
-
-.eligibility-warnings__confirm-buttons {
-	padding-left: 40px;
-}

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -38,15 +38,13 @@
 }
 
 .eligibility-warnings__hold,
-.eligibility-warnings__warning,
 .eligibility-warnings__confirm-box.card {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
 }
 
-.eligibility-warnings__hold,
-.eligibility-warnings__warning {
+.eligibility-warnings__hold {
 	align-items: flex-start;
 	margin-bottom: 16px;
 
@@ -57,11 +55,6 @@
 
 .eligibility-warnings__hold .gridicon {
 	color: var( --color-neutral-10 );
-	flex-shrink: 0;
-}
-
-.eligibility-warnings__warning > .gridicon {
-	color: var( --color-error );
 	flex-shrink: 0;
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -20,7 +20,7 @@
 	}
 
 	.button,
-	.eligibility-warnings__confirm-box {
+	.eligibility-warnings__confirm-buttons {
 		display: none;
 	}
 }
@@ -33,8 +33,7 @@
 	}
 }
 
-.eligibility-warnings__hold,
-.eligibility-warnings__confirm-box {
+.eligibility-warnings__hold {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
@@ -97,24 +96,11 @@
 	}
 }
 
-.eligibility-warnings__confirm-box {
-	flex-wrap: wrap;
-	justify-content: flex-end;
-
-	.eligibility-warnings__confirm-text {
-		color: var( --color-text-subtle );
-		flex-basis: 60%;
-		flex-grow: 1;
-		font-style: italic;
-		padding: 8px 0;
-	}
-
-	.button {
-		margin-left: 16px;
-	}
-}
-
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold-heading,
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
 	opacity: 0.2;
+}
+
+.eligibility-warnings__confirm-buttons {
+	padding-left: 40px;
 }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -25,10 +25,6 @@
 	}
 }
 
-.eligibility-warnings .card {
-	margin: 0;
-}
-
 .eligibility-warnings .banner {
 	margin-bottom: 16px;
 	.banner__icon-circle {
@@ -38,7 +34,7 @@
 }
 
 .eligibility-warnings__hold,
-.eligibility-warnings__confirm-box.card {
+.eligibility-warnings__confirm-box {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
@@ -86,7 +82,7 @@
 	align-self: center;
 }
 
-.eligibility-warnings__no-conflicts.card {
+.eligibility-warnings__no-conflicts {
 	align-items: center;
 	display: flex;
 

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import React, { ReactChild } from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import EligibilityWarnings from '..';
+
+function renderWithStore( element: ReactChild, initialState: object ) {
+	const store = createStore( state => state, initialState );
+	return {
+		...render( <Provider store={ store }>{ element }</Provider> ),
+		store,
+	};
+}
+
+function createState( { holds = [], siteId = 1 }: { holds?: string[]; siteId?: number } = {} ) {
+	return {
+		automatedTransfer: {
+			[ siteId ]: {
+				eligibility: {
+					eligibilityHolds: holds,
+					lastUpdate: 1,
+				},
+			},
+		},
+		currentUser: { capabilities: { [ siteId ]: {} } },
+		sites: { items: { [ siteId ]: {} } },
+		ui: { selectedSiteId: siteId },
+	};
+}
+
+describe( '<EligibilityWarnings>', () => {
+	it( 'renders error notice when AT has been blocked by a sticker', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER' ],
+		} );
+
+		const { container } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		const notice = container.querySelector( '.notice.is-error' );
+
+		expect( notice ).toBeVisible();
+		expect( notice ).toHaveTextContent( /This site is not currently eligible/ );
+	} );
+
+	it( 'only renders a single notice when multible hard blocking holds exist', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER', 'SITE_GRAYLISTED' ],
+		} );
+
+		const { container } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		expect( container.querySelectorAll( '.notice' ).length ).toBe( 1 );
+	} );
+
+	it( 'dimly renders the hold card when AT has been blocked by a sticker', () => {
+		const state = createState( {
+			holds: [ 'BLOCKED_ATOMIC_TRANSFER', 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ],
+		} );
+
+		const { getByTestId, getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
+			state
+		);
+
+		expect( getByTestId( 'HoldList-Card' ) ).toHaveClass( 'eligibility-warnings__hold-list-dim' );
+		expect( getByText( 'Help' ) ).toHaveAttribute( 'disabled' );
+	} );
+} );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -86,6 +86,7 @@ describe( '<EligibilityWarnings>', () => {
 
 		expect( getByTestId( 'HoldList-Card' ) ).toHaveClass( 'eligibility-warnings__hold-list-dim' );
 		expect( getByText( 'Help' ) ).toHaveAttribute( 'disabled' );
+		expect( getByText( 'Upgrade and continue' ) ).toBeDisabled();
 	} );
 
 	it( 'renders warning notices when the API returns warnings', () => {
@@ -134,5 +135,42 @@ describe( '<EligibilityWarnings>', () => {
 		);
 
 		expect( container.querySelectorAll( '.notice.is-warning' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'calls onProceed prop when clicking "Upgrade and continue"', () => {
+		const state = createState( {
+			holds: [ 'NO_BUSINESS_PLAN', 'SITE_PRIVATE' ],
+		} );
+
+		const handleProceed = jest.fn();
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ handleProceed } />,
+			state
+		);
+
+		fireEvent.click( getByText( 'Upgrade and continue' ) );
+
+		expect( handleProceed ).toHaveBeenCalled();
+	} );
+
+	it( `disables the "Continue" button if holds can't be handled automatically`, () => {
+		const state = createState( {
+			holds: [ 'NON_ADMIN_USER', 'SITE_PRIVATE' ],
+		} );
+
+		const handleProceed = jest.fn();
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ handleProceed } />,
+			state
+		);
+
+		const continueButton = getByText( 'Continue' );
+
+		expect( continueButton ).toBeDisabled();
+
+		fireEvent.click( continueButton );
+		expect( handleProceed ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -96,7 +96,7 @@ describe( '<EligibilityWarnings>', () => {
 				{
 					name: 'Warning 2',
 					description: 'Describes warning 2',
-					supportUrl: 'http://example.com/',
+					supportUrl: 'https://helpme.com',
 				},
 			],
 		} );
@@ -113,9 +113,7 @@ describe( '<EligibilityWarnings>', () => {
 		expect( notices[ 1 ] ).toBeVisible();
 		expect( notices[ 1 ] ).toHaveTextContent( 'Describes warning 2' );
 
-		fireEvent.click( getByLabelText( 'Help' ) );
-
-		expect( window.location.href ).toBe( 'https://example.com/' );
+		expect( getByLabelText( 'Help' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
 	} );
 
 	it( "doesn't render warnings when there are blocking holds", () => {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -101,19 +101,17 @@ describe( '<EligibilityWarnings>', () => {
 			],
 		} );
 
-		const { container, getByLabelText } = renderWithStore(
+		const { getByText } = renderWithStore(
 			<EligibilityWarnings backUrl="" onProceed={ noop } />,
 			state
 		);
 
-		const notices = container.querySelectorAll( '.notice.is-warning' );
+		expect( getByText( 'Warning 1' ) ).toBeVisible();
+		expect( getByText( 'Describes warning 1' ) ).toBeVisible();
+		expect( getByText( 'Warning 2' ) ).toBeVisible();
+		expect( getByText( 'Describes warning 2' ) ).toBeVisible();
 
-		expect( notices[ 0 ] ).toBeVisible();
-		expect( notices[ 0 ] ).toHaveTextContent( 'Describes warning 1' );
-		expect( notices[ 1 ] ).toBeVisible();
-		expect( notices[ 1 ] ).toHaveTextContent( 'Describes warning 2' );
-
-		expect( getByLabelText( 'Help' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
+		expect( getByText( 'Learn more.' ) ).toHaveAttribute( 'href', 'https://helpme.com' );
 	} );
 
 	it( "doesn't render warnings when there are blocking holds", () => {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -35,8 +35,6 @@ function createState( { holds = [], siteId = 1 }: { holds?: string[]; siteId?: n
 				},
 			},
 		},
-		currentUser: { capabilities: { [ siteId ]: {} } },
-		sites: { items: { [ siteId ]: {} } },
 		ui: { selectedSiteId: siteId },
 	};
 }

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -32,7 +32,7 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 
 		{ map( warnings, ( { name, description, supportUrl }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
-				<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+				<div className="eligibility-warnings__message">
 					<span className="eligibility-warnings__message-title">{ name }</span>
 					:&nbsp;
 					<span className="eligibility-warnings__message-description">
@@ -48,7 +48,7 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 		) ) }
 
 		<div className="eligibility-warnings__warning">
-			<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+			<div className="eligibility-warnings__message">
 				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
 				:&nbsp;
 				<span className="eligibility-warnings__message-description">

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -25,8 +25,8 @@ export const WarningList = ( { translate, warnings }: Props ) => (
 			<div className="eligibility-warnings__message">
 				<span className="eligibility-warnings__message-description">
 					{ translate(
-						"This feature isn't (yet) compatible with Plugin uploads and will be disabled:",
-						"These features aren't (yet) compatible with Plugin uploads and will be disabled:",
+						"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
+						"These features aren't (yet) compatible with plugin uploads and will be disabled:",
 						{
 							count: warnings.length,
 							args: warnings.length,

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,12 +3,14 @@
  */
 import React from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
+import { map } from 'lodash';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import ExternalLink from 'components/external-link';
+import ActionPanelLink from 'components/action-panel/link';
 
 interface ExternalProps {
 	warnings: import('state/automated-transfer/selectors').EligibilityWarning[];
@@ -17,20 +19,54 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { translate, warnings }: Props ) => (
-	<>
-		{ warnings.map( ( { description, supportUrl }, index ) => (
-			<Notice status="is-warning" key={ index } text={ description } showDismiss={ false }>
-				{ supportUrl && (
-					<NoticeAction
-						icon="help-outline"
-						aria-label={ translate( 'Help' ) }
-						href={ supportUrl }
-						external
-					/>
-				) }
-			</Notice>
+	<div>
+		<div className="eligibility-warnings__warning">
+			<Gridicon icon="notice-outline" size={ 24 } />
+			<div className="eligibility-warnings__message">
+				<span className="eligibility-warnings__message-description">
+					{ translate(
+						"This feature isn't (yet) compatible with Plugin uploads and will be disabled:",
+						"These features aren't (yet) compatible with Plugin uploads and will be disabled:",
+						{
+							count: warnings.length,
+							args: warnings.length,
+						}
+					) }
+				</span>
+			</div>
+		</div>
+
+		{ map( warnings, ( { name, description, supportUrl }, index ) => (
+			<div className="eligibility-warnings__warning" key={ index }>
+				<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+					<span className="eligibility-warnings__message-title">{ name }</span>
+					:&nbsp;
+					<span className="eligibility-warnings__message-description">
+						{ description }{ ' ' }
+						{ supportUrl && (
+							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+								{ translate( 'Learn more.' ) }
+							</ExternalLink>
+						) }
+					</span>
+				</div>
+			</div>
 		) ) }
-	</>
+
+		<div className="eligibility-warnings__warning">
+			<div className="eligibility-warnings__message eligibility-warnings__message--indented">
+				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
+				:&nbsp;
+				<span className="eligibility-warnings__message-description">
+					{ translate( '{{a}}Contact support{{/a}} for help.', {
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					} ) }
+				</span>
+			</div>
+		</div>
+	</div>
 );
 
 export default localize( WarningList );

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { localize, LocalizeProps } from 'i18n-calypso';
+import i18n, { localize, LocalizeProps } from 'i18n-calypso';
+const hasTranslation = ( message: string ) => i18n.hasTranslation( message );
 import { map } from 'lodash';
 import Gridicon from 'components/gridicon';
 
@@ -49,14 +50,24 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 
 		<div className="eligibility-warnings__warning">
 			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
+				<span className="eligibility-warnings__message-title">
+					{ hasTranslation( 'Questions?' )
+						? translate( 'Questions?' )
+						: translate( 'Any Questions?' ) }
+				</span>
 				:&nbsp;
 				<span className="eligibility-warnings__message-description">
-					{ translate( '{{a}}Contact support{{/a}} for help.', {
-						components: {
-							a: <ActionPanelLink href="/help/contact" />,
-						},
-					} ) }
+					{ hasTranslation( '{{a}}Contact support{{/a}} for help.' ) ? (
+						translate( '{{a}}Contact support{{/a}} for help.', {
+							components: {
+								a: <ActionPanelLink href="/help/contact" />,
+							},
+						} )
+					) : (
+						<ActionPanelLink href="/help/contact">
+							{ translate( 'Contact support' ) }
+						</ActionPanelLink>
+					) }
 				</span>
 			</div>
 		</div>
@@ -68,36 +79,56 @@ function getWarningDescription(
 	warningCount: number,
 	translate: LocalizeProps[ 'translate' ]
 ) {
+	const defaultCopy = translate(
+		"By proceeding you'll lose %d feature:",
+		"By proceeding you'll lose these %d features:",
+		{
+			count: warningCount,
+			args: warningCount,
+		}
+	);
 	switch ( context ) {
 		case 'plugins':
-			return translate(
-				"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
-				"These features aren't (yet) compatible with plugin uploads and will be disabled:",
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+			return hasTranslation(
+				"This feature isn't (yet) compatible with plugin uploads and will be disabled:"
+			)
+				? translate(
+						"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
+						"These features aren't (yet) compatible with plugin uploads and will be disabled:",
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  )
+				: defaultCopy;
 
 		case 'themes':
-			return translate(
-				"This feature isn't (yet) compatible with theme uploads and will be disabled:",
-				"These features aren't (yet) compatible with theme uploads and will be disabled:",
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+			return hasTranslation(
+				"This feature isn't (yet) compatible with theme uploads and will be disabled:"
+			)
+				? translate(
+						"This feature isn't (yet) compatible with theme uploads and will be disabled:",
+						"These features aren't (yet) compatible with theme uploads and will be disabled:",
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  )
+				: defaultCopy;
 
 		case 'hosting':
-			return translate(
-				"This feature isn't (yet) compatible with hosting access and will be disabled:",
-				"These features aren't (yet) compatible with hosting access and will be disabled:",
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+			return hasTranslation(
+				"This feature isn't (yet) compatible with hosting access and will be disabled:"
+			)
+				? translate(
+						"This feature isn't (yet) compatible with hosting access and will be disabled:",
+						"These features aren't (yet) compatible with hosting access and will be disabled:",
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  )
+				: defaultCopy;
 
 		default:
 			return null;

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import i18n, { localize, LocalizeProps } from 'i18n-calypso';
-const hasTranslation = ( message: string ) => i18n.hasTranslation( message );
 import { map } from 'lodash';
 import Gridicon from 'components/gridicon';
 
@@ -51,13 +50,13 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 		<div className="eligibility-warnings__warning">
 			<div className="eligibility-warnings__message">
 				<span className="eligibility-warnings__message-title">
-					{ hasTranslation( 'Questions?' )
+					{ i18n.hasLocalizedText( 'Questions?' )
 						? translate( 'Questions?' )
 						: translate( 'Any Questions?' ) }
 				</span>
 				:&nbsp;
 				<span className="eligibility-warnings__message-description">
-					{ hasTranslation( '{{a}}Contact support{{/a}} for help.' ) ? (
+					{ i18n.hasLocalizedText( '{{a}}Contact support{{/a}} for help.' ) ? (
 						translate( '{{a}}Contact support{{/a}} for help.', {
 							components: {
 								a: <ActionPanelLink href="/help/contact" />,
@@ -89,7 +88,7 @@ function getWarningDescription(
 	);
 	switch ( context ) {
 		case 'plugins':
-			return hasTranslation(
+			return i18n.hasLocalizedText(
 				"This feature isn't (yet) compatible with plugin uploads and will be disabled:"
 			)
 				? translate(
@@ -103,7 +102,7 @@ function getWarningDescription(
 				: defaultCopy;
 
 		case 'themes':
-			return hasTranslation(
+			return i18n.hasLocalizedText(
 				"This feature isn't (yet) compatible with theme uploads and will be disabled:"
 			)
 				? translate(
@@ -117,7 +116,7 @@ function getWarningDescription(
 				: defaultCopy;
 
 		case 'hosting':
-			return hasTranslation(
+			return i18n.hasLocalizedText(
 				"This feature isn't (yet) compatible with hosting access and will be disabled:"
 			)
 				? translate(

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -13,25 +13,19 @@ import ExternalLink from 'components/external-link';
 import ActionPanelLink from 'components/action-panel/link';
 
 interface ExternalProps {
+	context: string | null;
 	warnings: import('state/automated-transfer/selectors').EligibilityWarning[];
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const WarningList = ( { translate, warnings }: Props ) => (
+export const WarningList = ( { context, translate, warnings }: Props ) => (
 	<div>
 		<div className="eligibility-warnings__warning">
 			<Gridicon icon="notice-outline" size={ 24 } />
 			<div className="eligibility-warnings__message">
 				<span className="eligibility-warnings__message-description">
-					{ translate(
-						"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
-						"These features aren't (yet) compatible with plugin uploads and will be disabled:",
-						{
-							count: warnings.length,
-							args: warnings.length,
-						}
-					) }
+					{ getWarningDescription( context, warnings.length, translate ) }
 				</span>
 			</div>
 		</div>
@@ -68,5 +62,46 @@ export const WarningList = ( { translate, warnings }: Props ) => (
 		</div>
 	</div>
 );
+
+function getWarningDescription(
+	context: string | null,
+	warningCount: number,
+	translate: LocalizeProps[ 'translate' ]
+) {
+	switch ( context ) {
+		case 'plugins':
+			return translate(
+				"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
+				"These features aren't (yet) compatible with plugin uploads and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
+
+		case 'themes':
+			return translate(
+				"This feature isn't (yet) compatible with theme uploads and will be disabled:",
+				"These features aren't (yet) compatible with theme uploads and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
+
+		case 'hosting':
+			return translate(
+				"This feature isn't (yet) compatible with hosting access and will be disabled:",
+				"These features aren't (yet) compatible with hosting access and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
+
+		default:
+			return null;
+	}
+}
 
 export default localize( WarningList );

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,15 +3,12 @@
  */
 import React from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map } from 'lodash';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
-import ExternalLink from 'components/external-link';
-import SectionHeader from 'components/section-header';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 interface ExternalProps {
 	warnings: import('state/automated-transfer/selectors').EligibilityWarning[];
@@ -20,37 +17,20 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { translate, warnings }: Props ) => (
-	<div>
-		<SectionHeader
-			label={ translate(
-				"By proceeding you'll lose %d feature:",
-				"By proceeding you'll lose these %d features:",
-				{
-					count: warnings.length,
-					args: warnings.length,
-				}
-			) }
-		/>
-		<Card className="eligibility-warnings__warning-list">
-			{ map( warnings, ( { name, description, supportUrl }, index ) => (
-				<div className="eligibility-warnings__warning" key={ index }>
-					<Gridicon icon="cross-small" size={ 24 } />
-					<div className="eligibility-warnings__message">
-						<span className="eligibility-warnings__message-title">{ name }</span>
-						:&nbsp;
-						<span className="eligibility-warnings__message-description">{ description }</span>
-					</div>
-					{ supportUrl && (
-						<div className="eligibility-warnings__action">
-							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-								<Gridicon icon="help-outline" size={ 24 } />
-							</ExternalLink>
-						</div>
-					) }
-				</div>
-			) ) }
-		</Card>
-	</div>
+	<>
+		{ warnings.map( ( { description, supportUrl }, index ) => (
+			<Notice status="is-warning" key={ index } text={ description } showDismiss={ false }>
+				{ supportUrl && (
+					<NoticeAction
+						icon="help-outline"
+						aria-label={ translate( 'Help' ) }
+						href={ supportUrl }
+						external
+					/>
+				) }
+			</Notice>
+		) ) }
+	</>
 );
 
 export default localize( WarningList );

--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -15,6 +15,7 @@ export default class extends React.Component {
 	static displayName = 'NoticeAction';
 
 	static propTypes = {
+		'aria-label': PropTypes.string,
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		external: PropTypes.bool,
@@ -27,6 +28,7 @@ export default class extends React.Component {
 
 	render() {
 		const attributes = {
+			'aria-label': this.props[ 'aria-label' ],
 			className: 'notice__action',
 			href: this.props.href,
 			onClick: this.props.onClick,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -74,6 +74,7 @@ export const FEATURE_BASIC_DESIGN = 'basic-design';
 export const FEATURE_ADVANCED_DESIGN = 'advanced-design';
 export const FEATURE_GOOGLE_ANALYTICS = 'google-analytics';
 export const FEATURE_GOOGLE_MY_BUSINESS = 'google-my-business';
+export const FEATURE_SFTP = 'sftp';
 export const FEATURE_LIVE_CHAT_SUPPORT = 'live-chat-support';
 export const FEATURE_NO_ADS = 'no-adverts';
 export const FEATURE_VIDEO_UPLOADS = 'video-upload';

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -194,8 +194,8 @@ export function isBestValue( plan ) {
 /**
  * Return estimated duration of given PLAN_TERM in days
  *
- * @param {String} term TERM_ constant
- * @return {Number} Term duration
+ * @param {string} term TERM_ constant
+ * @returns {number} Term duration
  */
 export function getTermDuration( term ) {
 	switch ( term ) {

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -2,9 +2,9 @@
 
 This lib enables translations, exposing three public methods:
 
-* [.translate()](#translate-method)
-* [.moment()](#moment-method)
-* [.numberFormat()](#numberformat-method)
+- [.translate()](#translate-method)
+- [.moment()](#moment-method)
+- [.numberFormat()](#numberformat-method)
 
 It also provides a React higher-order component named [localize()](#localize) and a React hook name [useTranslate()](#react-hook). Wrapping your component in `localize()` will give it the aforementioned functions as props, and calling the `useTranslate()` hook will return the `translate()` function. This is the suggested way of using `i18n-calypso` methods with React components.
 
@@ -29,10 +29,10 @@ Finally, this lib exposes some utility methods for your React application:
 
 The following attributes can be set in the options object to alter the translation type. The attributes can be combined as needed for a particular case.
 
-* **options.args** [string, array, or object] arguments you would pass into sprintf to be run against the text for string substitution. [See docs](http://www.diveintojavascript.com/projects/javascript-sprintf)
-* **options.components** [object] markup must be added as React components and not with string substitution. See [mixing strings and markup](#mixing-strings-and-markup).
-* **options.comment** [string] comment that will be shown to the translator for anything that may need to be explained about the translation.
-* **options.context** [string] provides the ability for the translator to provide a different translation for the same text in two locations (_dependent on context_). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
+- **options.args** [string, array, or object] arguments you would pass into sprintf to be run against the text for string substitution. [See docs](http://www.diveintojavascript.com/projects/javascript-sprintf)
+- **options.components** [object] markup must be added as React components and not with string substitution. See [mixing strings and markup](#mixing-strings-and-markup).
+- **options.comment** [string] comment that will be shown to the translator for anything that may need to be explained about the translation.
+- **options.context** [string] provides the ability for the translator to provide a different translation for the same text in two locations (_dependent on context_). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
 
 ## Usage
 
@@ -66,10 +66,10 @@ var example = i18n.translate( 'foo' );
 
 // do concatenate long strings with the + operator
 var translation = i18n.translate(
-    'I am the very model of a modern Major-General, ' +
-    'I\'ve information vegetable, animal, and mineral, ' +
-    'I know the kings of England, and I quote the fights historical ' +
-    'from Marathon to Waterloo, in order categorical.'
+	'I am the very model of a modern Major-General, ' +
+		"I've information vegetable, animal, and mineral, " +
+		'I know the kings of England, and I quote the fights historical ' +
+		'from Marathon to Waterloo, in order categorical.'
 );
 ```
 
@@ -80,22 +80,22 @@ The `translate()` method uses sprintf interpolation for string substitution ([se
 ```js
 // named arguments (preferred approach)
 i18n.translate( 'My %(thing)s has %(number)d corners', {
-    args: {
-        thing: 'hat',
-        number: 3
-    }
+	args: {
+		thing: 'hat',
+		number: 3,
+	},
 } );
 // 'My hat has 3 corners'
 
 // argument array
 i18n.translate( 'My %s has %d corners', {
-    args: [ 'hat', 3 ]
+	args: [ 'hat', 3 ],
 } );
 // 'My hat has 3 corners'
 
 // single substitution
 i18n.translate( 'My %s has 3 corners', {
-    args: 'hat'
+	args: 'hat',
 } );
 // 'My hat has 3 corners'
 ```
@@ -111,61 +111,52 @@ Instead we use the [interpolate-components module](https://github.com/Automattic
 ```js
 // self-closing component syntax
 var example = i18n.translate( 'My hat has {{hatInput/}} corners', {
-        components: {
-            hatInput: <input name="hatInput" type="text" />
-        }
-    } );
+	components: {
+		hatInput: <input name="hatInput" type="text" />,
+	},
+} );
 
 // component that wraps part of the string
 var example2 = i18n.translate( 'I feel {{em}}very{{/em}} strongly about this.', {
-        components: {
-            em: <em />
-        }
-    } );
+	components: {
+		em: <em />,
+	},
+} );
 
 // components can nest
 var example3 = i18n.translate( '{{a}}{{icon/}}click {{em}}here{{/em}}{{/a}} to see examples.', {
-        components: {
-            a: <a href="#" />,
-            em: <em />,
-            icon: <Icon size="huge" />
-        }
-    } );
-
-
+	components: {
+		a: <a href="#" />,
+		em: <em />,
+		icon: <Icon size="huge" />,
+	},
+} );
 ```
 
 ### Pluralization
 
 You must specify both the singular and plural variants of a string when it contains plurals. If the string uses placeholders that will be replaced with actual values, then both the plural and singular strings should include those placeholders. It might seem redundant, but it is necessary for languages where a singular version may be used for counts other than 1.
 
-
 ```js
-
 // An example where the translated string does not have
 // a number represented directly, but still depends on it
 var numHats = howManyHats(), // returns integer
-    content = i18n.translate(
-    	'My hat has three corners.',
-    	'My hats have three corners.',
-    	{
-            count: numHats
-        }
-    );
+	content = i18n.translate( 'My hat has three corners.', 'My hats have three corners.', {
+		count: numHats,
+	} );
 
 // An example where the translated string includes the actual number it depends on
 var numDays = daysUntilExpiration(), // returns integer
-    content = i18n.translate(
-        'Your subscription will expire in %(numberOfDays)d day.',
-        'Your subscription will expire in %(numberOfDays)d days.',
-        {
-            count: numDays,
-            args: {
-                numberOfDays: numDays
-            }
-        }
-    );
-
+	content = i18n.translate(
+		'Your subscription will expire in %(numberOfDays)d day.',
+		'Your subscription will expire in %(numberOfDays)d days.',
+		{
+			count: numDays,
+			args: {
+				numberOfDays: numDays,
+			},
+		}
+	);
 ```
 
 ### More translate() Examples
@@ -176,39 +167,38 @@ var content = i18n.translate( 'My hat has three corners.' );
 
 // sprintf-style string substitution
 var city = getCity(), // returns string
-    zip = getZip(), // returns string
-    content = i18n.translate( 'Your city is %(city)s, your zip is %(zip)s.', {
-        args: {
-            city: city,
-            zip: zip
-        }
-    } );
+	zip = getZip(), // returns string
+	content = i18n.translate( 'Your city is %(city)s, your zip is %(zip)s.', {
+		args: {
+			city: city,
+			zip: zip,
+		},
+	} );
 
 // Mixing strings and markup
 // NOTE: This will return a React component, not a string
 var component = i18n.translate( 'I bought my hat in {{country/}}.', {
-        components: {
-            country: <input name="someName" type="text" />
-        }
-    } );
+	components: {
+		country: <input name="someName" type="text" />,
+	},
+} );
 
 // Mixing strings with markup that has nested content
 var component = i18n.translate( 'My hat has {{link}}three{{/link}} corners', {
-        components: {
-            link: <a href="#three" />
-        }
-    } );
+	components: {
+		link: <a href="#three" />,
+	},
+} );
 
 // add a comment to the translator
 var content = i18n.translate( 'g:i:s a', {
-        comment: 'draft saved date format, see http://php.net/date'
-    } );
+	comment: 'draft saved date format, see http://php.net/date',
+} );
 
 // providing context
 var content = i18n.translate( 'post', {
-        context: 'verb'
-    } );
-
+	context: 'verb',
+} );
 ```
 
 See the [test cases](test/test.jsx) for more example usage.
@@ -218,14 +208,14 @@ See the [test cases](test/test.jsx) for more example usage.
 This module includes an instantiation of `moment.js` to allow for internationalization of dates and times. We generate a momentjs locale file as part of loading a locale and automatically update the moment instance to use the correct locale and translations. You can use `moment()` from within any component like this:
 
 ```js
-var thisMagicMoment = i18n.moment( "2014-07-18T14:59:09-07:00" ).format( 'LLLL' );
+var thisMagicMoment = i18n.moment( '2014-07-18T14:59:09-07:00' ).format( 'LLLL' );
 ```
 
 And you can use it from outside of React like this.
 
 ```js
 var i18n = require( 'i18n-calypso' );
-var thisMagicMoment = i18n.moment( "2014-07-18T14:59:09-07:00" ).format( 'LLLL' );
+var thisMagicMoment = i18n.moment( '2014-07-18T14:59:09-07:00' ).format( 'LLLL' );
 ```
 
 ## numberFormat Method
@@ -239,7 +229,7 @@ The numberFormat method is also available to format numbers using the loaded loc
 // locale-formatted numbers
 i18n.numberFormat( 2500.25 ); // '2.500'
 i18n.numberFormat( 2500.1, 2 ); // '2.500,10'
-i18n.numberFormat( 2500.33, { decimals: 3, thousandsSep: '*', decPoint: '@'} ); // '2*500@330'
+i18n.numberFormat( 2500.33, { decimals: 3, thousandsSep: '*', decPoint: '@' } ); // '2*500@330'
 ```
 
 ## hasTranslation Method
@@ -247,6 +237,7 @@ i18n.numberFormat( 2500.33, { decimals: 3, thousandsSep: '*', decPoint: '@'} ); 
 Using the method `hasTranslation` you can check whether a translation for a given string exists. As the `translate()` function will always return screen text that can be displayed (will supply the source text if no translation exists), it is unsuitable to determine whether text is translated. Other factors are optional [key hashing](#key-hashing) as well as purposeful translation to the source text.
 
 ### Usage
+
 ```js
 var i18n = require( 'i18n-calypso' );
 i18n.hasTranslation( 'This has been translated' ); // true
@@ -272,7 +263,6 @@ var label = i18n.hasLocalizedText( 'Some string that may not yet be translated' 
 
 The mixin has been removed from this distribution. Please use version 1 of `i18n-calypso` if you need to use the mixin.
 
-
 ## Localize
 
 `localize` is a higher-order component which, when invoked as a function with a component,
@@ -292,11 +282,7 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 
 function Greeting( { translate, className } ) {
-	return (
-		<h1 className={ className }>
-			{ translate( 'Hello!' ) }
-		</h1>
-	);
+	return <h1 className={ className }>{ translate( 'Hello!' ) }</h1>;
 }
 
 export default localize( Greeting );
@@ -310,10 +296,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import Greeting from './greeting';
 
-render(
-	<Greeting className="greeting" />,
-	document.body
-);
+render( <Greeting className="greeting" />, document.body );
 ```
 
 ## React Hook
@@ -324,9 +307,11 @@ resulting component is also reactive, i.e., it gets rerendered when the `i18n` l
 and the state emitter emits a `change` event.
 
 The `useTranslate` hook returns the `translate` function:
+
 ```jsx
 const translate = useTranslate();
 ```
+
 The function can be called to return a localized value of a string, and it also exposes a
 `localeSlug` property whose value is a string with the current locale slug.
 
@@ -337,13 +322,9 @@ import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 
 function Greeting( { className } ) {
-  const translate = useTranslate();
-  debug( 'using translate with locale:', translate.localeSlug );
-	return (
-		<h1 className={ className }>
-			{ translate( 'Hello!' ) }
-		</h1>
-	);
+	const translate = useTranslate();
+	debug( 'using translate with locale:', translate.localeSlug );
+	return <h1 className={ className }>{ translate( 'Hello!' ) }</h1>;
 }
 
 export default Greeting;
@@ -416,13 +397,23 @@ In order to reduce file-size, i18n-calypso allows the usage of hashed keys for l
 #### Example
 
 Instead of providing the full English text, like here:
+
 ```json
-{"":{"localeSlug":"de"},"Please enter a valid email address.":["","Bitte gib eine gültige E-Mail-Adresse ein."]}
+{
+	"": { "localeSlug": "de" },
+	"Please enter a valid email address.": [ "", "Bitte gib eine gültige E-Mail-Adresse ein." ]
+}
 ```
+
 just the hash is used for lookup, resulting in a shorter file.
+
 ```json
-{"":{"localeSlug":"de","key-hash":"sha1-1"},"d":["","Bitte gib eine gültige E-Mail-Adresse ein."]}
+{
+	"": { "localeSlug": "de", "key-hash": "sha1-1" },
+	"d": [ "", "Bitte gib eine gültige E-Mail-Adresse ein." ]
+}
 ```
+
 The generator of the jed file would usually try to choose the smallest hash length at which no hash collisions occur. In the above example a hash length of 1 (`d` short for `d2306dd8970ff616631a3501791297f31475e416`) is enough because there is only one string.
 
 Note that when generating the jed file, all possible strings need to be taken into consideration for the collision calculation, as otherwise an untranslated source string would be provided with the wrong translation.

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -8,9 +8,10 @@ This lib enables translations, exposing three public methods:
 
 It also provides a React higher-order component named [localize()](#localize) and a React hook name [useTranslate()](#react-hook). Wrapping your component in `localize()` will give it the aforementioned functions as props, and calling the `useTranslate()` hook will return the `translate()` function. This is the suggested way of using `i18n-calypso` methods with React components.
 
-Finally, this lib exposes a utility method for your React application:
+Finally, this lib exposes some utility methods for your React application:
 
-* [.hasTranslation()](#hastranslation-method)
+- [.hasTranslation()](#hastranslation-method)
+- [.hasLocalizedText()](#haslocalizedtext-method)
 
 ## Translate Method
 
@@ -250,6 +251,21 @@ Using the method `hasTranslation` you can check whether a translation for a give
 var i18n = require( 'i18n-calypso' );
 i18n.hasTranslation( 'This has been translated' ); // true
 i18n.hasTranslation( 'Not translation exists' ); // false
+```
+
+## hasLocalizedText Method
+
+Using the method `hasLocalizedText`, you can check if the string is usable in the selected locale.
+If the locale is the default, this will always return true.
+If the locale is not the default, returns the value of `this.hasTranslation` for the input.
+
+### Usage
+
+```js
+var i18n = require( 'i18n-calypso' );
+var label = i18n.hasLocalizedText( 'Some string that may not yet be translated' )
+	? translate( 'Some string that may not yet be translated in the current locale' )
+	: translate( "Some string that we're confident is translated" );
 ```
 
 ## Mixin

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -353,6 +353,25 @@ I18N.prototype.hasTranslation = function() {
 };
 
 /**
+ * If the locale is the default, this will always return true.
+ * If the locale is not the default, returns the value of `this.hasTranslation` for the input.
+ *
+ * @returns {boolean} whether localized text exists
+ */
+I18N.prototype.hasLocalizedText = function() {
+	return this.isDefaultLocale() || this.hasTranslation( normalizeTranslateArguments( arguments ) );
+};
+
+/**
+ * Does the instance's localeSlug match the default
+ *
+ * @returns {boolean} Whether the i18n instance matches the default locale
+ */
+I18N.prototype.isDefaultLocale = function() {
+	return this.state.localeSlug === this.defaultLocaleSlug;
+};
+
+/**
  * Exposes single translation method.
  * See sibling README
  *

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import ReactDomServer from 'react-dom/server';
 
 /**
@@ -13,8 +14,9 @@ import i18n, { numberFormat, translate } from '../src';
 /**
  * Pass in a react-generated html string to remove react-specific attributes
  * to make it easier to compare to expected html structure
+ *
  * @param  {string} string React-generated html string
- * @return {string}        html with react attributes removed
+ * @returns {string}        html with react attributes removed
  */
 function stripReactAttributes( string ) {
 	return string.replace( /\sdata-(reactid|react-checksum)="[^"]+"/g, '' );
@@ -285,6 +287,53 @@ describe( 'I18n', function() {
 			expect( translate( 'simple' ) ).toBe( 'implesa' );
 			expect( translate( 'red' ) ).toBe( 'edra' );
 			expect( translate( 'grey' ) ).toBe( 'reyga' );
+		} );
+	} );
+
+	describe( 'hasTranslation()', function() {
+		it( 'should return true for a simple translation', function() {
+			expect( i18n.hasTranslation( 'test1' ) ).toBe( true );
+		} );
+
+		it( 'should return false for a string without translation', function() {
+			expect(
+				i18n.hasTranslation(
+					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'
+				)
+			).toBe( false );
+		} );
+
+		it( 'should return false for a simple translation when using default locale', function() {
+			i18n.configure();
+			expect( i18n.hasTranslation( 'test1' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'hasLocalizedText', function() {
+		it( 'should return true for a simple translation', function() {
+			expect( i18n.hasLocalizedText( 'test1' ) ).toBe( true );
+		} );
+
+		it( 'should return false for a string without translation', function() {
+			expect(
+				i18n.hasLocalizedText(
+					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'
+				)
+			).toBe( false );
+		} );
+
+		it( 'should return true for a simple translation when using default locale', function() {
+			i18n.configure();
+			expect( i18n.hasLocalizedText( 'test1' ) ).toBe( true );
+		} );
+
+		it( 'should return true for a string without translation when using default locale', function() {
+			i18n.configure();
+			expect(
+				i18n.hasLocalizedText(
+					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'
+				)
+			).toBe( true );
 		} );
 	} );
 } );

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -68,6 +68,8 @@ declare namespace i18nCalypso {
 
 	export function hasTranslation( original: string ): boolean;
 
+	export function hasLocalizedText( original: string ): boolean;
+
 	export interface NumberFormatOptions {
 		decimals?: number;
 		decPoint?: string;


### PR DESCRIPTION
NOTE: This is based off the branch in #38277. It should be merged there prior to it landing.

The usage of `hasTranslation` in the parent branch did not yield the correct results when the locale was set to the default (`en`).  Since `hasTranslation` returns false across the board when using the default locale, it can't allow the application code to vary as intended.

This adds a mechanism to the `i18n-calypso` package to do the type of conditional check we're doing in the parent branch.

#### Changes proposed in this Pull Request

* New function `i18n.hasLocalizedText`
* Type definition for `i18n.hasLocalizedText`
* Tests for `i18n.hasLocalizedText`
* Tests for `i18n.hasTranslation` while we're at it
* Lint fixes for i18n-calypso test file
* Document `i18n.hasLocalizedText` in the README
* Format `packages/i18n-calypso/README.md` with prettier
* Use hasLocalizedText throughout eligibility-warnings component

#### Testing instructions

##### Manual Testing

* Follow test instructions in #38277
  * English locales should get the newer "preferred" text
  * Non-english locales should get the fallback text

##### Automated Testing

* Validate the intent and implementation of the test code in this PR
* Run `npm run test-packages packages/i18n-calypso*`
  * All tests should pass
