### PR TITLE
[i18n] Make hasTranslation aware of current locale

### DIFF
--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "i18n JavaScript library on top of Tannin originally used in Calypso",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -349,7 +349,18 @@ I18N.prototype.addTranslations = function( localeData ) {
  * @returns {boolean} whether a translation exists
  */
 I18N.prototype.hasTranslation = function() {
-	return !! getTranslation( this, normalizeTranslateArguments( arguments ) );
+	return (
+		this.isDefaultLocale() || !! getTranslation( this, normalizeTranslateArguments( arguments ) )
+	);
+};
+
+/**
+ * Does the instance's localeSlug match the default
+ *
+ * @returns {boolean} Whether the i18n instance matches the default locale
+ */
+I18N.prototype.isDefaultLocale = function() {
+	return this.state.localeSlug === this.defaultLocaleSlug;
 };
 
 /**

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import ReactDomServer from 'react-dom/server';
 
 /**
@@ -13,8 +14,9 @@ import i18n, { numberFormat, translate } from '../src';
 /**
  * Pass in a react-generated html string to remove react-specific attributes
  * to make it easier to compare to expected html structure
+ *
  * @param  {string} string React-generated html string
- * @return {string}        html with react attributes removed
+ * @returns {string}        html with react attributes removed
  */
 function stripReactAttributes( string ) {
 	return string.replace( /\sdata-(reactid|react-checksum)="[^"]+"/g, '' );
@@ -285,6 +287,34 @@ describe( 'I18n', function() {
 			expect( translate( 'simple' ) ).toBe( 'implesa' );
 			expect( translate( 'red' ) ).toBe( 'edra' );
 			expect( translate( 'grey' ) ).toBe( 'reyga' );
+		} );
+	} );
+
+	describe( 'hasTranslation()', function() {
+		it( 'should return true for a simple translation', function() {
+			expect( i18n.hasTranslation( 'test1' ) ).toBe( true );
+		} );
+
+		it( 'should return false for a string without translation', function() {
+			expect(
+				i18n.hasTranslation(
+					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'
+				)
+			).toBe( false );
+		} );
+
+		it( 'should return true for a simple translation when using default locale', function() {
+			i18n.configure();
+			expect( i18n.hasTranslation( 'test1' ) ).toBe( true );
+		} );
+
+		it( 'should return true for a string without translation when using default locale', function() {
+			i18n.configure();
+			expect(
+				i18n.hasTranslation(
+					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'
+				)
+			).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Problem:**

* When user has locale set to default locale...
* ... and `hasTranslation` is called...
* ....it returns false, even though passing the input through `translate()` would return a valid result (the input itself

This PR makes `hasTranslation` aware of current defaultLocale so it may return true in the case described above.

#### Considerations

`i18n-calypso` README says (https://www.npmjs.com/package/i18n-calypso#hastranslation-method):

> Using the method hasTranslation you can check whether a translation for a given string exists. As the translate() function will always return screen text that can be displayed (will supply the source text if no translation exists), it is unsuitable to determine whether text is translated.

Does it mean the behavior we are fixing in this PR is intentional? If so, then let's move forward with https://github.com/Automattic/wp-calypso/pull/38565 instead.

Also - this is breaking BC. I wasn't able to use any usages of `hasTranslation()` in this or related repos so it may not be a problem - but I want to make it clear here.

#### Testing instructions

There are no usages of `hasTranslation()` in entire wp-calypso repo, so the only way to test it is to check automated tests introduced in this PR, confirm they pass and make sense.

