### PR TITLE
DesignCard: Fix typo in local component name

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
@@ -22,7 +22,7 @@ interface Props {
 	onClick: MouseEventHandler< HTMLDivElement >;
 	style?: CSSProperties;
 }
-const DeisgnCard: FunctionComponent< Props > = ( { design, onClick, isSelected, style } ) => (
+const DesignCard: FunctionComponent< Props > = ( { design, onClick, isSelected, style } ) => (
 	<Card
 		className={ classnames( 'design-selector__design-option', { 'is-selected': isSelected } ) }
 		isElevated
@@ -41,4 +41,4 @@ const DeisgnCard: FunctionComponent< Props > = ( { design, onClick, isSelected, 
 	</Card>
 );
 
-export default DeisgnCard;
+export default DesignCard;


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Rename local component variable name from `DeisgnCard` to `DesignCard`

#### Testing instructions

* No behavior changes expected