### PR TITLE
Change word "plugins" to "themes" in heading copy

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -249,7 +249,7 @@ function getCardHeading( context: string | null, translate: LocalizeProps[ 'tran
 				: defaultCopy;
 		case 'themes':
 			return hasLocalizedText( "To install themes you'll need to:" )
-				? translate( "To install plugins you'll need to:" )
+				? translate( "To install themes you'll need to:" )
 				: defaultCopy;
 		case 'hosting':
 			return hasLocalizedText( "To activate hosting access you'll need to:" )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes a single word in a heading copy for Eligibility warnings component. It should say "themes" and now it says "plugins"

#### Testing instructions

* On a free, public site go to `/themes/upload/`, confirm the header says `To install themes you'll need to:`

