### PR TITLE
Eslint: Set JSDoc mode to 'typescript'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,9 @@ module.exports = {
 		react: {
 			version: reactVersion,
 		},
+		jsdoc: {
+			mode: 'typescript',
+		},
 	},
 	rules: {
 		// REST API objects include underscores


### PR DESCRIPTION
This allows the `@template` tag name which is useful for Calypso.

See https://github.com/gajus/eslint-plugin-jsdoc#mode