### PR TITLE
Framework: Remove gfm-code-blocks dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14872,19 +14872,6 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"gfm-code-block-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gfm-code-block-regex/-/gfm-code-block-regex-1.0.0.tgz",
-			"integrity": "sha1-u4PH1ihOa1ty+gIZilisDSViFdI="
-		},
-		"gfm-code-blocks": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gfm-code-blocks/-/gfm-code-blocks-1.0.0.tgz",
-			"integrity": "sha1-YU0hBZuETGu8nViMCJslxOi8zw0=",
-			"requires": {
-				"gfm-code-block-regex": "^1.0.0"
-			}
-		},
 		"git-diff-tree": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/git-diff-tree/-/git-diff-tree-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
 		"fontfaceobserver": "2.1.0",
 		"fuse.js": "3.4.6",
 		"get-video-id": "3.1.4",
-		"gfm-code-blocks": "1.0.0",
 		"globalthis": "1.0.0",
 		"globby": "10.0.1",
 		"gridicons": "3.3.1",


### PR DESCRIPTION
In #26367 we started using the `gfm-code-blocks` package but in #32026 we removed the last instance where we used it. Since it's no longer used, I suggest that we remove it completely from our dependencies.

#### Changes proposed in this Pull Request

* Remove `gfm-code-blocks` because it's no longer used.

#### Testing instructions

* Checkout this branch.
* Run `npm install` and `npm run build`.
* Verify `gfm-code-blocks` is used nowhere.
