### PR TITLE
Gutenboarding: persist vertical background

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -43,6 +43,13 @@ $deisgn-selector-selection-space: 175px;
 	text-align: center;
 }
 
+@media ( prefers-color-scheme: dark ) {
+	.design-selector__subtitle,
+	.design-selector__title {
+		color: $white;
+	}
+}
+
 .design-selector__grid-container {
 	position: absolute;
 	margin-top: 1em;

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -27,44 +27,44 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 	const [ hasBackground, setHasBackground ] = useState( false );
 
 	return (
-		<Switch>
-			<Route exact path={ Step.IntentGathering }>
-				<div
-					className={ classNames( 'onboarding-block__acquire-intent', {
-						'has-background': hasBackground && siteVertical,
-					} ) }
-				>
-					{ ( hasBackground || siteVertical ) && (
-						<VerticalBackground id={ siteVertical?.id } onLoad={ () => setHasBackground( true ) } />
-					) }
-					<div className="onboarding-block__questions">
-						<h2 className="onboarding-block__questions-heading">
-							{ ! siteVertical &&
-								! siteTitle &&
-								NO__( "Let's set up your website – it takes only a moment." ) }
-						</h2>
-						<StepperWizard
-							stepComponents={ [ VerticalSelect, ( siteVertical || siteTitle ) && SiteTitle ] }
-						/>
-						{ siteVertical && (
-							<div className="onboarding-block__footer">
-								<Link
-									to={ Step.DesignSelection }
-									className="onboarding-block__question-skip"
-									isLink
-								>
-									{ /* @TODO: add transitions and correct action */ }
-									{ siteTitle ? NO__( 'Continue' ) : NO__( "Don't know yet" ) } →
-								</Link>
-							</div>
-						) }
+		<>
+			<VerticalBackground id={ siteVertical?.id } onLoad={ () => setHasBackground( true ) } />
+			<Switch>
+				<Route exact path={ Step.IntentGathering }>
+					<div
+						className={ classNames( 'onboarding-block__acquire-intent', {
+							'has-background': hasBackground && siteVertical,
+						} ) }
+					>
+						<div className="onboarding-block__questions">
+							<h2 className="onboarding-block__questions-heading">
+								{ ! siteVertical &&
+									! siteTitle &&
+									NO__( "Let's set up your website – it takes only a moment." ) }
+							</h2>
+							<StepperWizard
+								stepComponents={ [ VerticalSelect, ( siteVertical || siteTitle ) && SiteTitle ] }
+							/>
+							{ siteVertical && (
+								<div className="onboarding-block__footer">
+									<Link
+										to={ Step.DesignSelection }
+										className="onboarding-block__question-skip"
+										isLink
+									>
+										{ /* @TODO: add transitions and correct action */ }
+										{ siteTitle ? NO__( 'Continue' ) : NO__( "Don't know yet" ) } →
+									</Link>
+								</div>
+							) }
+						</div>
 					</div>
-				</div>
-			</Route>
-			<Route exact path={ Step.DesignSelection }>
-				{ ! siteVertical ? <Redirect to={ Step.IntentGathering } /> : <DesignSelector /> }
-			</Route>
-		</Switch>
+				</Route>
+				<Route exact path={ Step.DesignSelection }>
+					{ ! siteVertical ? <Redirect to={ Step.IntentGathering } /> : <DesignSelector /> }
+				</Route>
+			</Switch>
+		</>
 	);
 };
 

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -20,7 +20,8 @@ $onboarding-block-css-transition-duration: 750ms;
 	.onboarding-block__question,
 	.onboarding-block__questions-heading,
 	.onboarding-block__question-skip {
-		transition: $onboarding-block-css-transition-duration color linear // @TODO: replace with opacity transition as described in https://github.com/Automattic/wp-calypso/pull/38412/files#r358123862
+		// @TODO: replace with opacity transition as described in https://github.com/Automattic/wp-calypso/pull/38412/files#r358123862
+		transition: $onboarding-block-css-transition-duration color linear
 			$onboarding-block-css-transition-duration;
 	}
 }
@@ -57,7 +58,8 @@ $onboarding-block-css-transition-duration: 750ms;
 	position: fixed;
 	top: 0;
 	bottom: 0;
-	width: 100%;
+	left: 0;
+	right: 0;
 	background-size: cover;
 	z-index: -1;
 }
@@ -72,7 +74,8 @@ $onboarding-block-css-transition-duration: 750ms;
 	left: 0;
 	opacity: 0.7;
 	transition: opacity $onboarding-block-css-transition-duration linear,
-		background-color $onboarding-block-css-transition-duration linear // @TODO: replace with opacity transition
+		// @TODO: replace with opacity transition
+			background-color $onboarding-block-css-transition-duration linear
 			$onboarding-block-css-transition-duration;
 }
 .onboarding-block__background-fade-enter {

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -64,7 +64,7 @@ $onboarding-block-css-transition-duration: 750ms;
 	z-index: -1;
 }
 
-.onboarding-block__background::before {
+.onboarding-block__background.has-background::before {
 	background-color: $white;
 	content: '';
 	position: absolute;

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -77,7 +77,11 @@ $onboarding-block-css-transition-duration: 750ms;
 		// @TODO: replace with opacity transition
 			background-color $onboarding-block-css-transition-duration linear
 			$onboarding-block-css-transition-duration;
+	@media ( prefers-color-scheme: dark ) {
+		background-color: $dark-gray-900;
+	}
 }
+
 .onboarding-block__background-fade-enter {
 	&.onboarding-block__background::before {
 		opacity: 0.8;
@@ -115,9 +119,6 @@ $onboarding-block-css-transition-duration: 750ms;
 			.onboarding-block__question-answered {
 				color: $blue-medium-highlight;
 			}
-		}
-		.onboarding-block__background::before {
-			background-color: $dark-gray-900;
 		}
 		.components-button.is-link.onboarding-block__question-skip {
 			color: $light-gray-500;

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -57,7 +57,7 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onL
 				preloadImage.onerror = null;
 			};
 		}
-		return setImageUrl( undefined );
+		setImageUrl( undefined );
 	}, [ siteVertical, onLoad ] );
 
 	return (

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -57,6 +57,7 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onL
 				preloadImage.onerror = null;
 			};
 		}
+		return setImageUrl( undefined );
 	}, [ siteVertical, onLoad ] );
 
 	return (

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -4,6 +4,7 @@
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { SwitchTransition, CSSTransition } from 'react-transition-group';
 import { useSelect } from '@wordpress/data';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ export interface VerticalBackgroundProps {
 
 const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onLoad } ) => {
 	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
-	const [ imageUrl, setImageUrl ] = useState< string | null >( null );
+	const [ imageUrl, setImageUrl ] = useState< string | undefined >();
 
 	// Prefetch the default image.
 	useEffect( () => void ( new window.Image().src = defaultImageUrl ), [] );
@@ -36,7 +37,6 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onL
 			};
 			// We get an esmodule wrapping the url here
 			const successHandler = ( { default: url }: { default: string } ) => {
-				preloadImage;
 				preloadImage.onload = () => {
 					setImageUrl( url );
 					onLoad();
@@ -62,12 +62,12 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onL
 	return (
 		<SwitchTransition mode="in-out">
 			<CSSTransition
-				key={ imageUrl || 'empty' }
+				key={ imageUrl || 'none' }
 				timeout={ 750 }
 				classNames="onboarding-block__background-fade"
 			>
 				<div
-					className="onboarding-block__background"
+					className={ classnames( 'onboarding-block__background', { 'has-background': imageUrl } ) }
 					style={ {
 						backgroundImage: imageUrl ? `url( ${ imageUrl } ) ` : 'none',
 					} }

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -3,6 +3,12 @@
  */
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { SwitchTransition, CSSTransition } from 'react-transition-group';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '../stores/onboard';
 
 /**
  * Calypso dependencies
@@ -14,41 +20,44 @@ export interface VerticalBackgroundProps {
 	onLoad: () => void;
 }
 
-const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { id, onLoad } ) => {
+const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onLoad } ) => {
+	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 	const [ imageUrl, setImageUrl ] = useState< string | null >( null );
 
 	// Prefetch the default image.
 	useEffect( () => void ( new window.Image().src = defaultImageUrl ), [] );
 
 	useEffect( () => {
-		const preloadImage = new window.Image();
-		const failureHandler = () => {
-			setImageUrl( defaultImageUrl );
-			onLoad();
-		};
-		// We get an esmodule wrapping the url here
-		const successHandler = ( { default: url }: { default: string } ) => {
-			preloadImage;
-			preloadImage.onload = () => {
-				setImageUrl( url );
+		if ( siteVertical ) {
+			const preloadImage = new window.Image();
+			const failureHandler = () => {
+				setImageUrl( defaultImageUrl );
 				onLoad();
 			};
-			preloadImage.onerror = failureHandler;
-			preloadImage.src = url;
-		};
-		import(
-			/**
-			 * Set eager mode because these are just image _paths_.
-			 */
-			/* webpackMode: "eager" */
-			/* webpackInclude: /\.jpg$/ */
-			`../../../../static/images/verticals/${ id }.jpg`
-		).then( successHandler, failureHandler );
-		return () => {
-			preloadImage.onload = null;
-			preloadImage.onerror = null;
-		};
-	}, [ id, onLoad ] );
+			// We get an esmodule wrapping the url here
+			const successHandler = ( { default: url }: { default: string } ) => {
+				preloadImage;
+				preloadImage.onload = () => {
+					setImageUrl( url );
+					onLoad();
+				};
+				preloadImage.onerror = failureHandler;
+				preloadImage.src = url;
+			};
+			import(
+				/**
+				 * Set eager mode because these are just image _paths_.
+				 */
+				/* webpackMode: "eager" */
+				/* webpackInclude: /\.jpg$/ */
+				`../../../../static/images/verticals/${ siteVertical.id }.jpg`
+			).then( successHandler, failureHandler );
+			return () => {
+				preloadImage.onload = null;
+				preloadImage.onerror = null;
+			};
+		}
+	}, [ siteVertical, onLoad ] );
 
 	return (
 		<SwitchTransition mode="in-out">
@@ -60,7 +69,7 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { id,
 				<div
 					className="onboarding-block__background"
 					style={ {
-						backgroundImage: imageUrl ? `url(${ imageUrl })` : 'none',
+						backgroundImage: imageUrl ? `url( ${ imageUrl } ) ` : 'none',
 					} }
 				/>
 			</CSSTransition>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Vertical background was only shown on acquire intent step. Apply the background to the design selector as well.

#### To do

- [x] Better dark theme color handling in design selector

#### Follow-up

- Better isolation of acquire-intent and design-selector components

#### Screens

##### Before

![before](https://user-images.githubusercontent.com/841763/71376020-6ebc3c80-25c0-11ea-97ec-7ebe69dcfa22.gif)

##### After

![after](https://user-images.githubusercontent.com/841763/71382639-0fb6f180-25d9-11ea-9e90-5b3e91b2b60d.gif)

#### Testing instructions

* Visit `/gutenboarding`
* No regressions
* Vertical background persists and looks appropriate on design selection

