### PR TITLE
Settings: AsyncLoad SEO Settings

### DIFF
--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'components/async-load';
 import notices from 'notices';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySiteSettings from 'components/data/query-site-settings';
@@ -18,7 +19,6 @@ import {
 	getPurchasesError,
 } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import SeoForm from './form';
 
 export class SeoSettings extends Component {
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -34,7 +34,7 @@ export class SeoSettings extends Component {
 			<div>
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
-				<SeoForm />
+				<AsyncLoad require="my-sites/site-settings/seo-settings/form" placeholder={ null } />
 			</div>
 		);
 	}


### PR DESCRIPTION
Reduces the marketing section size by about 30% by asynchronously loading the SEO settings.

#### Changes proposed in this Pull Request

* Settings: AsyncLoad SEO Settings

#### Testing instructions

* Go to http://calypso.localhost:3000/marketing/traffic/:site where `:site` is a Jetpack site.
* Verify SEO settings load correctly with no errors in the console.
