### PR TITLE
WooCommerce Login: Fix 2FA Button Alignment

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -647,19 +647,8 @@
 	.login__social,
 	.two-factor-authentication__actions {
 		border-top: 1px solid #e6e6e6;
-		margin: 0 -16px;
 		padding-top: 44px;
-		width: calc( 100% + ( #{$woo-form-whitespace} * 2 ) );
-
-		@include breakpoint( '>480px' ) {
-			margin: 0 -24px;
-			width: calc( 100% + ( #{$woo-form-whitespace-480} * 2 ) );
-		}
-
-		@include breakpoint( '>660px' ) {
-			margin: 0 -100px;
-			width: calc( 100% + ( #{$woo-form-whitespace-660} * 2 ) );
-		}
+		text-align: center;
 	}
 
 	.wp-login__links {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Centres the 2FA button on the WooCommerce login 

#### Testing instructions

Follow the instructions in #38580 and verify the buttons now appear centred.

**Before:**
<img width="778" alt="Screenshot 2019-12-24 at 07 36 59" src="https://user-images.githubusercontent.com/43215253/71400975-524fec80-2620-11ea-980d-c901fb79590b.png">

**After:**
<img width="756" alt="Screenshot 2019-12-24 at 07 35 58" src="https://user-images.githubusercontent.com/43215253/71400972-50862900-2620-11ea-83c5-cc335b29203e.png">

cc @arunsathiya, @scruffian, @ice9js 

Fixes #38580
