### PR TITLE
Gutenboarding: Improve a11y and lints

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
@@ -30,6 +30,7 @@ const DesignCard: FunctionComponent< Props > = ( {
 	style,
 } ) => (
 	<Card
+		as="button"
 		className={ classnames( 'design-selector__design-option', { 'is-selected': isSelected } ) }
 		isElevated
 		onClick={ onClick }
@@ -37,7 +38,7 @@ const DesignCard: FunctionComponent< Props > = ( {
 		aria-haspopup="dialog"
 		aria-controls={ dialogId }
 	>
-		<CardMedia>
+		<CardMedia as="span">
 			<img
 				width={ 480 }
 				height={ 360 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ as NO__ } from '@wordpress/i18n';
 import React, { FunctionComponent, MouseEventHandler, CSSProperties } from 'react';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
@@ -46,6 +47,11 @@ const DesignCard: FunctionComponent< Props > = ( {
 				src={ removeQueryArgs( design.preview, 'w' ) }
 				srcSet={ srcSet( design.preview, [ gridWidth / 2, gridWidth / 4 ] ) }
 			/>
+			<span className="design-selector__option-overlay">
+				<span className="design-selector__option-overlay-text">
+					{ NO__( 'Select this design' ) }
+				</span>
+			</span>
 		</CardMedia>
 	</Card>
 );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
@@ -20,13 +20,22 @@ interface Props {
 	design: import('@automattic/data-stores').VerticalsTemplates.Template;
 	onClick: MouseEventHandler< HTMLDivElement >;
 	style?: CSSProperties;
+	dialogId: string;
 }
-const DesignCard: FunctionComponent< Props > = ( { design, onClick, isSelected, style } ) => (
+const DesignCard: FunctionComponent< Props > = ( {
+	design,
+	dialogId,
+	isSelected,
+	onClick,
+	style,
+} ) => (
 	<Card
 		className={ classnames( 'design-selector__design-option', { 'is-selected': isSelected } ) }
 		isElevated
 		onClick={ onClick }
 		style={ style }
+		aria-haspopup="dialog"
+		aria-controls={ dialogId }
 	>
 		<CardMedia>
 			<img

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -117,19 +117,19 @@ const DesignSelector: FunctionComponent = () => {
 				/>
 			</Portal>
 
-			<CSSTransition
-				in={ hasSelectedDesign }
-				onEnter={ () => setIsDialogVisible( true ) }
-				onExited={ () => setIsDialogVisible( false ) }
-				timeout={ transitionTiming }
+			<Dialog
+				visible={ isDialogVisible }
+				baseId={ dialogId }
+				hide={ resetState }
+				aria-labelledby="page-layout-selector__title"
+				hideOnClickOutside
+				hideOnEsc
 			>
-				<Dialog
-					visible={ isDialogVisible }
-					baseId={ dialogId }
-					hide={ resetState }
-					aria-labelledby="page-layout-selector__title"
-					hideOnClickOutside
-					hideOnEsc
+				<CSSTransition
+					in={ hasSelectedDesign }
+					onEnter={ () => setIsDialogVisible( true ) }
+					onExited={ () => setIsDialogVisible( false ) }
+					timeout={ transitionTiming }
 				>
 					<div className="design-selector__page-layout-container">
 						<PageLayoutSelector
@@ -139,8 +139,8 @@ const DesignSelector: FunctionComponent = () => {
 							templates={ otherTemplates }
 						/>
 					</div>
-				</Dialog>
-			</CSSTransition>
+				</CSSTransition>
+			</Dialog>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -107,7 +107,7 @@ const DesignSelector: FunctionComponent = () => {
 			</CSSTransition>
 
 			<CSSTransition in={ hasSelectedDesign } timeout={ transitionTiming } unmountOnExit>
-				<div className="page-layout-selector__container">
+				<div className="design-selector__page-layout-container">
 					<PageLayoutSelector
 						selectedDesign={ selectedDesign }
 						selectedLayouts={ selectedLayouts }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { __ as NO__, sprintf } from '@wordpress/i18n';
+import { __ as NO__ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
 /**
@@ -23,17 +23,17 @@ interface Props {
 }
 
 const PageLayoutSelector: FunctionComponent< Props > = ( {
-	selectedDesign,
 	selectedLayouts,
 	selectLayout,
 	templates,
 } ) => (
 	<div className="page-layout-selector">
 		<div className="page-layout-selector__content">
-			<h1 className="page-layout-selector__title">
-				{ selectedDesign
-					? sprintf( NO__( 'Select the pages you want to use with %s:' ), selectedDesign.title )
-					: null }
+			<h1
+				/* ID for aria-labelledby */ id="page-layout-selector__title"
+				className="page-layout-selector__title"
+			>
+				{ NO__( "Select the pages you'd like to include:" ) }
 			</h1>
 			<div className="page-layout-selector__grid">
 				{ templates.map( template => (

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -38,16 +38,17 @@ const PageLayoutSelector: FunctionComponent< Props > = ( {
 			<div className="page-layout-selector__grid">
 				{ templates.map( template => (
 					<Card
+						as="button"
 						className={ classnames( 'page-layout-selector__item', {
 							'is-selected': selectedLayouts.has( template.slug ),
 						} ) }
 						onClick={ () => selectLayout( template ) }
 						key={ template.slug }
 					>
-						<div className="page-layout-selector__selected-indicator">
+						<span className="page-layout-selector__selected-indicator">
 							<Icon icon="yes" size={ 24 } />
-						</div>
-						<CardMedia>
+						</span>
+						<CardMedia as="span">
 							<img alt={ template.description } src={ removeQueryArgs( template.preview, 'w' ) } />
 						</CardMedia>
 					</Card>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -57,6 +57,7 @@ $deisgn-selector-selection-space: 175px;
 	&.exit,
 	&.exit-done {
 		overflow-y: hidden;
+		height: 100vh;
 
 		.design-selector__grid {
 			@include design-selector-hide();

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -125,7 +125,7 @@ $deisgn-selector-selection-space: 175px;
 
 .page-layout-selector__grid {
 	display: grid;
-	grid-gap: 0.75em;
+	grid-gap: 1.25em;
 	@include breakpoint( '>660px' ) {
 		grid-template-columns: 1fr 1fr 1fr;
 	}
@@ -135,6 +135,12 @@ $deisgn-selector-selection-space: 175px;
 	position: relative;
 	overflow: hidden;
 	padding: 2px;
+
+	&:hover,
+	&:focus {
+		border: 3px solid var( --color-neutral-dark );
+		padding: 0;
+	}
 
 	&.is-selected {
 		border: 3px solid $blue-medium-focus;
@@ -173,4 +179,31 @@ $deisgn-selector-selection-space: 175px;
 .design-selector__design-option {
 	transform: translate3d( 0, 0, 0 );
 	@include design-selector-transition();
+
+	.design-selector__option-overlay {
+		background-color: rgba( var( --color-primary-rgb ), 0.8 );
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 0;
+		transition: 400ms;
+
+		.design-selector__option-overlay-text {
+			font-size: 24px;
+			color: $white;
+			border-bottom: 2px solid $white;
+		}
+	}
+
+	&:hover,
+	&:focus {
+		.design-selector__design-option-overlay {
+			opacity: 1;
+		}
+	}
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -96,15 +96,15 @@ $deisgn-selector-selection-space: 175px;
 	transition-timing-function: ease-out;
 
 	&,
-	.enter > &,
-	.exit-active.exit-active > &, // duplicate selector to override `.exit` below
-	.exit-done > & {
+	&.enter,
+	&.exit-active.exit-active , // duplicate selector to override `.exit` below
+	&.exit-done {
 		@include design-selector-hide();
 	}
 
-	.exit > &,
-	.enter-active > &,
-	.enter-done > & {
+	&.exit,
+	&.enter-active,
+	&.enter-done {
 		@include design-selector-show();
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -76,7 +76,7 @@ $deisgn-selector-selection-space: 175px;
 	@include design-selector-show();
 }
 
-.page-layout-selector__container {
+.design-selector__page-layout-container {
 	position: absolute;
 	top: $design-selector-header-vertical-shift + $deisgn-selector-selection-space;
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -57,7 +57,7 @@ $deisgn-selector-selection-space: 175px;
 	&.exit,
 	&.exit-done {
 		overflow-y: hidden;
-		height: 100vh;
+		// height: 100vh;
 
 		.design-selector__grid {
 			@include design-selector-hide();
@@ -87,30 +87,31 @@ $deisgn-selector-selection-space: 175px;
 .design-selector__page-layout-container {
 	position: absolute;
 	top: $design-selector-header-vertical-shift + $deisgn-selector-selection-space;
+	width: 100%;
+	background: $white;
+	box-shadow: gray 0 0 12px; // use a sass variable
+	padding: 2em 4em;
+
+	@include design-selector-transition();
+	transition-timing-function: ease-out;
 
 	&,
 	.enter > &,
 	.exit-active.exit-active > &, // duplicate selector to override `.exit` below
 	.exit-done > & {
-		.page-layout-selector {
-			@include design-selector-hide();
-		}
+		@include design-selector-hide();
 	}
 
 	.exit > &,
 	.enter-active > &,
 	.enter-done > & {
-		.page-layout-selector {
-			@include design-selector-show();
-			transform: translate3d( 0, 0, 0 );
-		}
+		@include design-selector-show();
 	}
 }
+
 .page-layout-selector {
-	@include design-selector-transition();
-	background: $white;
-	box-shadow: gray 0 0 12px; // use a sass variable
-	padding: 2em 4em;
+	max-width: $design-selector-max-width;
+	margin: 0 auto;
 }
 
 .design-selector__header-container {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -137,12 +137,6 @@ $deisgn-selector-selection-space: 175px;
 	overflow: hidden;
 	padding: 2px;
 
-	&:hover,
-	&:focus {
-		border: 3px solid var( --color-neutral-dark );
-		padding: 0;
-	}
-
 	&.is-selected {
 		border: 3px solid $blue-medium-focus;
 		padding: 0;
@@ -150,6 +144,20 @@ $deisgn-selector-selection-space: 175px;
 			top: -2px;
 			right: -2px;
 			transform: translate3d( 0, 0, 0 );
+		}
+	}
+
+	&:hover,
+	&:focus {
+		border: 3px solid var( --color-neutral-dark );
+		padding: 0;
+		.page-layout-selector__selected-indicator {
+			background: linear-gradient(
+				to bottom left,
+				var( --color-neutral-dark ),
+				var( --color-neutral-dark ) 50%,
+				transparent 51% /* 1% difference helps prevent a rough edge */
+			);
 		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -57,7 +57,6 @@ $deisgn-selector-selection-space: 175px;
 	&.exit,
 	&.exit-done {
 		overflow-y: hidden;
-		// height: 100vh;
 
 		.design-selector__grid {
 			@include design-selector-hide();

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -202,7 +202,7 @@ $deisgn-selector-selection-space: 175px;
 
 	&:hover,
 	&:focus {
-		.design-selector__design-option-overlay {
+		.design-selector__option-overlay {
 			opacity: 1;
 		}
 	}

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -76,22 +76,30 @@ $deisgn-selector-selection-space: 175px;
 	@include design-selector-show();
 }
 
+.design-selector__page-layout-backdrop {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+}
+
 .design-selector__page-layout-container {
 	position: absolute;
 	top: $design-selector-header-vertical-shift + $deisgn-selector-selection-space;
 
 	&,
-	&.enter,
-	&.exit-active.exit-active, // duplicate selector to override `.exit` below
-	&.exit-done {
+	.enter > &,
+	.exit-active.exit-active > &, // duplicate selector to override `.exit` below
+	.exit-done > & {
 		.page-layout-selector {
 			@include design-selector-hide();
 		}
 	}
 
-	&.exit,
-	&.enter-active,
-	&.enter-done {
+	.exit > &,
+	.enter-active > &,
+	.enter-done > & {
 		.page-layout-selector {
 			@include design-selector-show();
 			transform: translate3d( 0, 0, 0 );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -88,7 +88,7 @@ $deisgn-selector-selection-space: 175px;
 	top: $design-selector-header-vertical-shift + $deisgn-selector-selection-space;
 	width: 100%;
 	background: $white;
-	box-shadow: gray 0 0 12px; // use a sass variable
+	box-shadow: $dark-gray-300 0 0 12px;
 	padding: 2em 4em;
 
 	@include design-selector-transition();

--- a/package-lock.json
+++ b/package-lock.json
@@ -6538,6 +6538,22 @@
 				"humanize-ms": "^1.2.1"
 			}
 		},
+		"aggregate-error": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+			"integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+				}
+			}
+		},
 		"airbnb-js-shims": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-2.2.1.tgz",
@@ -8099,6 +8115,11 @@
 				}
 			}
 		},
+		"body-scroll-lock": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-2.6.4.tgz",
+			"integrity": "sha512-NP08WsovlmxEoZP9pdlqrE+AhNaivlTrz9a0FF37BQsnOrpN48eNqivKkE7SYpM9N+YIPjsdVzfLAUQDBm6OQw=="
+		},
 		"bonjour": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
@@ -9606,6 +9627,11 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
+		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
 		},
 		"cli-boxes": {
 			"version": "2.2.0",
@@ -20296,6 +20322,75 @@
 				}
 			}
 		},
+		"minipass-collect": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
+		"minipass-flush": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
+		"minipass-pipeline": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+			"integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
 		"minizlib": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
@@ -22971,8 +23066,7 @@
 		"popper.js": {
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-			"integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==",
-			"dev": true
+			"integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
 		},
 		"portfinder": {
 			"version": "1.0.25",
@@ -27936,6 +28030,27 @@
 			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
 			"dev": true
 		},
+		"reakit": {
+			"version": "1.0.0-beta.14",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-beta.14.tgz",
+			"integrity": "sha512-/KRlHT7tACx3PVvnX1DOuJxlWnfdfbdoEOJKdVPR8X4a9hkLPOZnLRaCNWKwHTVR7tAuVxo0K+ySsMuxWiGGYw==",
+			"requires": {
+				"body-scroll-lock": "^2.6.4",
+				"popper.js": "^1.16.0",
+				"reakit-system": "^0.7.2",
+				"reakit-utils": "^0.7.3"
+			}
+		},
+		"reakit-system": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.7.2.tgz",
+			"integrity": "sha512-IY0NwVguy2Awp0DFRzsCBtSnn5gpHtfM3pvfi6Qcwv7Wkms6ZUWxsqFpwNJTMBfXqEBo9dDuIkpCBZivtezYzA=="
+		},
+		"reakit-utils": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.3.tgz",
+			"integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
+		},
 		"realpath-native": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -31766,9 +31881,207 @@
 			"integrity": "sha512-dNxivOXmDgZqrGxOttBH6B4xaxT4zNC+Xd+2K8jwGDMK5q2CZI+KZMA1AAnSRT+BTRvuzKsDx+fpxzPAmAMVcA==",
 			"dev": true,
 			"requires": {
+				"cacache": "^13.0.1",
+				"find-cache-dir": "^3.2.0",
 				"jest-worker": "^24.9.0",
+				"schema-utils": "^2.6.1",
 				"serialize-javascript": "^2.1.2",
+				"source-map": "^0.6.1",
+				"terser": "^4.4.3",
 				"webpack-sources": "^1.4.3"
+			},
+			"dependencies": {
+				"cacache": {
+					"version": "13.0.1",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
+					"integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.2",
+						"figgy-pudding": "^3.5.1",
+						"fs-minipass": "^2.0.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.2",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^5.1.1",
+						"minipass": "^3.0.0",
+						"minipass-collect": "^1.0.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.2",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"p-map": "^3.0.0",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.7.1",
+						"ssri": "^7.0.0",
+						"unique-filename": "^1.1.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.0",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"fs-minipass": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.0.0.tgz",
+					"integrity": "sha512-40Qz+LFXmd9tzYVnnBmZvFfvAADfUA14TXPK1s7IfElJTIZ97rA8w4Kin7Wt5JBrC3ShnnFJO/5vPjPEeJIq9A==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					},
+					"dependencies": {
+						"yallist": {
+							"version": "3.1.1",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+							"dev": true
+						}
+					}
+				},
+				"make-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"schema-utils": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
+					"integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"ssri": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+					"integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"minipass": "^3.1.1"
+					}
+				},
+				"terser": {
+					"version": "4.4.3",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
+					"integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
 			}
 		},
 		"test-exclude": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
 		]
 	},
 	"dependencies": {
-		"@automattic/data-stores": "file:./packages/data-stores",
 		"@automattic/color-studio": "2.2.0",
 		"@automattic/components": "file:./packages/components",
 		"@automattic/composite-checkout": "file:./packages/composite-checkout",
 		"@automattic/composite-checkout-wpcom": "file:./packages/composite-checkout-wpcom",
+		"@automattic/data-stores": "file:./packages/data-stores",
 		"@automattic/format-currency": "file:./packages/format-currency",
 		"@automattic/load-script": "file:./packages/load-script",
 		"@automattic/material-design-icons": "file:./packages/material-design-icons",
@@ -186,6 +186,7 @@
 		"react-stripe-elements": "4.0.2",
 		"react-transition-group": "4.3.0",
 		"react-virtualized": "9.21.2",
+		"reakit": "1.0.0-beta.14",
 		"redux": "4.0.4",
 		"redux-form": "8.2.6",
 		"redux-thunk": "2.3.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add and use Reakit to implement the page selector as a [`Dialog`](https://reakit.io/docs/dialog/). This should improve overall usability of the page selector.

This fixes some lint issues as well as simplifies some styling, for example the full-width page selector overlay. Click outside and <kbd>escape</kbd> close the page selector.


#### Screens

##### Before

![before](https://user-images.githubusercontent.com/841763/71415297-4897aa80-265b-11ea-9176-d7e7d89edb73.gif)

##### After

![after](https://user-images.githubusercontent.com/841763/71415302-4c2b3180-265b-11ea-93de-a3c1a1591ae0.gif)

#### Follow up

- <s>Use [Reakit `Rover`](https://reakit.io/docs/rover/) for tab access to designs and templates in the page selector.</s>
used `Card as="button"` for now.
- Move to css-in-JS which should help clarity and consistency across css/js. There are a lot of duplicated variables and logic right now.
- Transitions are likely to move to React Spring

#### Testing instructions

* Visit [`/gutenboarding`](https://calypso.live/?branch=gutenboarding/improve-a11y-and-lints).
* Complete the first step.
* Navigating between designs should work using keyboard (tabbing).
* On focus / hover over a design there should be a transparent overlay with text.
* Pick a design and verify click outside and <kbd>escape</kbd> work as expected.
* In page layout selector focus should be by default on the first item and tabbing should work.
* Focus should return to the design that was selected.
* Designs are improved (paObgF-RB-p2)
