### PR TITLE
Gutenboarding: Add loading placeholders for domain picker

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import DomainPicker, { Props as DomainPickerProps } from './list';
+import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
 
 /**
  * Style dependencies
@@ -51,7 +51,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				aria-expanded={ isDomainPopoverVisible }
 				aria-haspopup="menu"
 				aria-pressed={ isDomainPopoverVisible }
-				className={ classnames( 'domain-picker__button', className, {
+				className={ classnames( 'domain-picker-button', className, {
 					'is-open': isDomainPopoverVisible,
 				} ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -1,0 +1,9 @@
+.domain-picker-button {
+	.dashicon {
+		margin-left: 0.5em;
+		transition: transform 100ms ease-in-out;
+	}
+	&.is-open .dashicon {
+		transform: rotate( 180deg );
+	}
+}

--- a/client/landing/gutenboarding/components/domain-picker/index.ts
+++ b/client/landing/gutenboarding/components/domain-picker/index.ts
@@ -1,1 +1,0 @@
-export { default as DomainPickerButton } from './button';

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -64,21 +64,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		...queryParameters,
 	};
 
-	const { isLoading, suggestions } = useSelect(
+	const suggestions = useSelect(
 		select => {
 			if ( search ) {
-				return {
-					isLoading: select( DOMAIN_SUGGESTIONS_STORE ).isLoadingDomainSuggestions(
-						search,
-						searchOptions
-					),
-					suggestions: select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions(
-						search,
-						searchOptions
-					),
-				};
+				return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( search, searchOptions );
 			}
-			return {};
 		},
 		[ search, queryParameters ]
 	);
@@ -108,7 +98,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__recommended-header">{ NO__( 'Recommended' ) }</div>
-					{ ! suggestions?.length && isLoading
+					{ ! suggestions?.length
 						? times( searchOptions.quantity, i => (
 								<Button className="domain-picker__suggestion-item" key={ i }>
 									<span className="domain-picker__suggestion-item-name placeholder">

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -111,7 +111,12 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					{ ! suggestions?.length && isLoading
 						? times( searchOptions.quantity, i => (
 								<Button className="domain-picker__suggestion-item" key={ i }>
-									WordPress.com
+									<span className="domain-picker__suggestion-item-name placeholder">
+										example.wordpress.com
+									</span>
+									<span className="domain-picker__suggestion-action placeholder">
+										{ NO__( 'Select' ) }
+									</span>
 								</Button>
 						  ) )
 						: null }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -98,18 +98,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__recommended-header">{ NO__( 'Recommended' ) }</div>
-					{ ! suggestions?.length
-						? times( searchOptions.quantity, i => (
-								<Button className="domain-picker__suggestion-item" key={ i }>
-									<span className="domain-picker__suggestion-item-name placeholder">
-										example.wordpress.com
-									</span>
-									<span className="domain-picker__suggestion-action placeholder">
-										{ NO__( 'Select' ) }
-									</span>
-								</Button>
-						  ) )
-						: null }
 					{ suggestions?.length
 						? suggestions.map( suggestion => (
 								<Button
@@ -134,7 +122,16 @@ const DomainPicker: FunctionComponent< Props > = ( {
 									) }
 								</Button>
 						  ) )
-						: null }
+						: times( searchOptions.quantity, i => (
+								<Button className="domain-picker__suggestion-item" key={ i }>
+									<span className="domain-picker__suggestion-item-name placeholder">
+										example.wordpress.com
+									</span>
+									<span className="domain-picker__suggestion-action placeholder">
+										{ NO__( 'Select' ) }
+									</span>
+								</Button>
+						  ) ) }
 				</PanelRow>
 
 				<PanelRow className="domain-picker__has-domain domain-picker__panel-row">

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -21,6 +21,11 @@ import { times } from 'lodash';
 import { DomainSuggestions } from '@automattic/data-stores';
 import { selectorDebounce } from '../../constants';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
 export interface Props {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -2,6 +2,10 @@
 @import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 
+.domain-picker {
+	min-width: 22em;
+}
+
 .domain-picker__choose-domain-header {
 	font-weight: bold;
 	text-align: center;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -1,15 +1,5 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 
-.domain-picker__button {
-	.dashicon {
-		margin-left: 0.5em;
-		transition: transform 100ms ease-in-out;
-	}
-	&.is-open .dashicon {
-		transform: rotate( 180deg );
-	}
-}
-
 .domain-picker__choose-domain-header {
 	font-weight: bold;
 	text-align: center;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -1,4 +1,6 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
+@import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
+@import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 
 .domain-picker__choose-domain-header {
 	font-weight: bold;
@@ -20,10 +22,20 @@
 	margin-top: 18px;
 }
 
+.domain-picker__suggestion-item-name {
+	&.placeholder {
+		@include placeholder();
+	}
+}
+
 .domain-picker__suggestion-action {
 	color: var( --studio-blue-40 );
 	text-decoration: none;
 	margin-left: 20px;
+
+	&.placeholder {
+		@include placeholder( --studio-blue-30 );
+	}
 }
 
 .domain-picker__has-domain {

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -102,9 +102,11 @@ const Header: FunctionComponent< Props > = ( {
 					) : (
 						<>
 							{ siteTitleElement }
-							<span className="gutenboarding__header-domain-picker-button-domain placeholder">
-								example.wordpress.com
-							</span>
+							{ siteTitle ? (
+								<span className="gutenboarding__header-domain-picker-button-domain placeholder">
+									example.wordpress.com
+								</span>
+							) : null }
 						</>
 					) }
 				</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -13,7 +13,7 @@ import { useDebounce } from 'use-debounce';
 import { DomainSuggestions } from '@automattic/data-stores';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import './style.scss';
-import { DomainPickerButton } from '../domain-picker';
+import DomainPickerButton from '../domain-picker-button';
 import { selectorDebounce } from '../../constants';
 import Link from '../link';
 

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -6,6 +6,7 @@ import { Icon, IconButton } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
 import { useDebounce } from 'use-debounce';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -74,6 +75,16 @@ const Header: FunctionComponent< Props > = ( {
 		</span>
 	);
 
+	const domainElement = (
+		<span
+			className={ classnames( 'gutenboarding__header-domain-picker-button-domain', {
+				placeholder: siteTitle && ! currentDomain,
+			} ) }
+		>
+			{ siteTitle && currentDomain ? currentDomain.domain_name : 'example.wordpress.com' }
+		</span>
+	);
+
 	return (
 		<div
 			className="gutenboarding__header"
@@ -89,25 +100,19 @@ const Header: FunctionComponent< Props > = ( {
 					</Link>
 				</div>
 				<div className="gutenboarding__header-group">
-					{ currentDomain ? (
+					{ siteTitle ? (
 						<DomainPickerButton
 							className="gutenboarding__header-domain-picker-button"
 							defaultQuery={ siteTitle }
+							disabled={ ! currentDomain }
 							onDomainSelect={ setDomain }
 							queryParameters={ { vertical: siteVertical?.id } }
 						>
 							{ siteTitleElement }
-							<span>{ currentDomain.domain_name }</span>
+							{ domainElement }
 						</DomainPickerButton>
 					) : (
-						<>
-							{ siteTitleElement }
-							{ siteTitle ? (
-								<span className="gutenboarding__header-domain-picker-button-domain placeholder">
-									example.wordpress.com
-								</span>
-							) : null }
-						</>
+						siteTitleElement
 					) }
 				</div>
 			</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -78,10 +78,10 @@ const Header: FunctionComponent< Props > = ( {
 	const domainElement = (
 		<span
 			className={ classnames( 'gutenboarding__header-domain-picker-button-domain', {
-				placeholder: siteTitle && ! currentDomain,
+				placeholder: ! currentDomain,
 			} ) }
 		>
-			{ siteTitle && currentDomain ? currentDomain.domain_name : 'example.wordpress.com' }
+			{ currentDomain ? currentDomain.domain_name : 'example.wordpress.com' }
 		</span>
 	);
 

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -100,7 +100,12 @@ const Header: FunctionComponent< Props > = ( {
 							<span>{ currentDomain.domain_name }</span>
 						</DomainPickerButton>
 					) : (
-						siteTitleElement
+						<>
+							{ siteTitleElement }
+							<span className="gutenboarding__header-domain-picker-button-domain placeholder">
+								example.wordpress.com
+							</span>
+						</>
 					) }
 				</div>
 			</div>

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -57,6 +57,13 @@ $padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;
 		outline: 0;
 	}
 
+	&:disabled {
+		opacity: 1;
+		.gutenboarding__site-title {
+			color: black;
+		}
+	}
+
 	.gutenboarding__site-title {
 		padding: 0;
 	}

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -1,4 +1,6 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
+@import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
+@import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 
 // Copied from https://github.com/WordPress/gutenberg/blob/8c0c7b7267473b5c197dd3052e9707f75f4e6448/packages/edit-widgets/src/components/header/style.scss
 .gutenboarding__header {
@@ -66,6 +68,12 @@ $padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;
 	}
 	> .dashicon {
 		align-self: flex-end;
+	}
+}
+
+.gutenboarding__header-domain-picker-button-domain {
+	&.placeholder {
+		@include placeholder();
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add loading state placheolders to the domain picker button and list.

Fixes #37848.

#### Screencast

![domain-picker-loading](https://user-images.githubusercontent.com/96308/71441084-2fa9fa80-272a-11ea-984a-665c4a0620f4.gif)

#### Testing instructions

- Go to `http://calypso.localhost:3000/gutenboarding` (either in an incognito window, or run `localStorage.removeItem('WP_DATA')` in your browser console and reload)
- Enter a site vertical and title
- Observe the domain picker's behavior -- it should match the screencast ^
- Open the domain picker and search for a different domain
- Observe loading placeholders again