### PR TITLE
Jetpack: Remove obsolete isJetpackMinimumVersion checks

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -14,7 +14,6 @@ import { find, isNumber, pick, noop, get, isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import getSimplePayments from 'state/selectors/get-simple-payments';
 import QuerySimplePayments from 'components/data/query-simple-payments';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -39,7 +38,7 @@ import {
 	receiveUpdateProduct,
 	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
-import { PLAN_PREMIUM, FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
+import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
 import UpgradeNudge from 'blocks/upgrade-nudge';
 import TrackComponentView from 'lib/analytics/track-component-view';
@@ -50,7 +49,6 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
-import Banner from 'components/banner';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { DEFAULT_CURRENCY } from 'lib/simple-payments/constants';
 
@@ -143,7 +141,6 @@ class SimplePaymentsDialog extends Component {
 		editPaymentId: PropTypes.number,
 		onClose: PropTypes.func.isRequired,
 		onInsert: PropTypes.func.isRequired,
-		isJetpackNotSupported: PropTypes.bool,
 		canCurrentUserAddButtons: PropTypes.bool,
 	};
 
@@ -446,10 +443,8 @@ class SimplePaymentsDialog extends Component {
 		const {
 			showDialog,
 			siteId,
-			siteSlug,
 			paymentButtons,
 			currencyCode,
-			isJetpackNotSupported,
 			translate,
 			planHasSimplePaymentsFeature,
 			shouldQuerySitePlans,
@@ -463,28 +458,6 @@ class SimplePaymentsDialog extends Component {
 		const showNavigation =
 			activeTab === 'list' ||
 			( activeTab === 'form' && ! this.isDirectEdit() && ! isEmptyArray( paymentButtons ) );
-
-		if ( ! shouldQuerySitePlans && isJetpackNotSupported ) {
-			return this.renderEmptyDialog(
-				<EmptyContent
-					className="upgrade-jetpack"
-					illustration="/calypso/images/illustrations/illustration-jetpack.svg"
-					title={ translate( 'Upgrade Jetpack to use Simple Payments' ) }
-					illustrationWidth={ 600 }
-					action={
-						<Banner
-							icon="star"
-							title={ translate( 'Upgrade your Jetpack!' ) }
-							description={ translate( 'Simple Payments requires Jetpack version 5.2 or later.' ) }
-							feature={ FEATURE_SIMPLE_PAYMENTS }
-							plan={ PLAN_PREMIUM }
-							href={ '../../plugins/jetpack/' + siteSlug }
-						/>
-					}
-				/>,
-				true
-			);
-		}
 
 		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
 			return this.renderEmptyDialog(
@@ -606,12 +579,9 @@ export default connect( ( state, { siteId } ) => {
 
 	return {
 		siteId,
-		siteSlug: getSiteSlug( state, siteId ),
 		paymentButtons: getSimplePayments( state, siteId ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		shouldQuerySitePlans: getSitePlanSlug( state, siteId ) === null,
-		isJetpackNotSupported:
-			isJetpackSite( state, siteId ) && ! isJetpackMinimumVersion( state, siteId, '5.2' ),
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 		formIsValid: isProductFormValid( state ),
 		formIsDirty: isProductFormDirty( state ),

--- a/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/memberships.jsx
@@ -13,7 +13,6 @@ import { find, isNumber, pick, noop, get } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, isJetpackMinimumVersion, getSiteSlug } from 'state/sites/selectors';
 import getMemberships from 'state/selectors/get-memberships';
 import QueryMemberships from 'components/data/query-memberships';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -31,13 +30,12 @@ import wpcom from 'lib/wp';
 import accept from 'lib/accept';
 import { membershipProductFromApi } from 'state/data-layer/wpcom/sites/memberships/index.js';
 import { receiveUpdateProduct, receiveDeleteProduct } from 'state/memberships/product-list/actions';
-import { PLAN_PREMIUM, FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
+import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
 import UpgradeNudge from 'blocks/upgrade-nudge';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
-import Banner from 'components/banner';
 
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = a => Array.isArray( a ) && a.length === 0;
@@ -412,10 +410,8 @@ class MembershipsDialog extends Component {
 		const {
 			showDialog,
 			siteId,
-			siteSlug,
 			paymentButtons,
 			currencyCode,
-			isJetpackNotSupported,
 			translate,
 			planHasSimplePaymentsFeature,
 			shouldQuerySitePlans,
@@ -427,28 +423,6 @@ class MembershipsDialog extends Component {
 		const showNavigation =
 			activeTab === 'list' ||
 			( activeTab === 'form' && ! this.isDirectEdit() && ! isEmptyArray( paymentButtons ) );
-
-		if ( ! shouldQuerySitePlans && isJetpackNotSupported ) {
-			return this.renderEmptyDialog(
-				<EmptyContent
-					className="upgrade-jetpack"
-					illustration="/calypso/images/illustrations/illustration-jetpack.svg"
-					title={ translate( 'Upgrade Jetpack to use Simple Payments' ) }
-					illustrationWidth={ 600 }
-					action={
-						<Banner
-							icon="star"
-							title={ translate( 'Upgrade your Jetpack!' ) }
-							description={ translate( 'Simple Payments requires Jetpack version 5.2 or later.' ) }
-							feature={ FEATURE_SIMPLE_PAYMENTS }
-							plan={ PLAN_PREMIUM }
-							href={ '../../plugins/jetpack/' + siteSlug }
-						/>
-					}
-				/>,
-				true
-			);
-		}
 
 		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
 			return this.renderEmptyDialog(
@@ -527,12 +501,9 @@ export default connect( ( state, { siteId } ) => {
 
 	return {
 		siteId,
-		siteSlug: getSiteSlug( state, siteId ),
 		paymentButtons: getMemberships( state, siteId ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		shouldQuerySitePlans: getSitePlanSlug( state, siteId ) === null,
-		isJetpackNotSupported:
-			isJetpackSite( state, siteId ) && ! isJetpackMinimumVersion( state, siteId, '5.2' ),
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 		formIsValid: isProductFormValid( state ),
 		formIsDirty: isProductFormDirty( state ),

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -16,7 +16,6 @@ import ButtonGroup from 'components/button-group';
 import Count from 'components/count';
 import CommentNavigationTab from './comment-navigation-tab';
 import FormCheckbox from 'components/forms/form-checkbox';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import Search from 'components/search';
@@ -192,7 +191,6 @@ export class CommentNavigation extends Component {
 			hasSearch,
 			hasComments,
 			isBulkMode,
-			isCommentsTreeSupported,
 			isSelectedAll,
 			query,
 			selectedComments,
@@ -294,7 +292,7 @@ export class CommentNavigation extends Component {
 				</NavTabs>
 
 				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
-					{ isCommentsTreeSupported && hasComments && (
+					{ hasComments && (
 						<SegmentedControl compact className="comment-navigation__sort-buttons">
 							<SegmentedControl.Item
 								onClick={ setOrder( NEWEST_FIRST ) }
@@ -348,8 +346,6 @@ const mapStateToProps = ( state, { commentsPage, siteId } ) => {
 		visibleComments,
 		hasComments: visibleComments.length > 0,
 		hasPendingBulkAction: hasPendingCommentRequests( state ),
-		isCommentsTreeSupported:
-			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 	};
 };
 

--- a/client/my-sites/comments/comment-tree/index.jsx
+++ b/client/my-sites/comments/comment-tree/index.jsx
@@ -19,13 +19,11 @@ import CommentListHeader from 'my-sites/comments/comment-list/comment-list-heade
 import CommentNavigation from 'my-sites/comments/comment-navigation';
 import EmptyContent from 'components/empty-content';
 import Pagination from 'components/pagination';
-import QuerySiteCommentsList from 'components/data/query-site-comments-list';
 import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import getSiteCommentsTree from 'state/selectors/get-site-comments-tree';
 import isCommentsTreeInitialized from 'state/selectors/is-comments-tree-initialized';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { COMMENTS_PER_PAGE } from '../constants';
 
 const CommentTransition = props => (
@@ -143,7 +141,6 @@ export class CommentTree extends Component {
 
 	render() {
 		const {
-			isCommentsTreeSupported,
 			isLoading,
 			isPostView,
 			order,
@@ -170,15 +167,7 @@ export class CommentTree extends Component {
 		return (
 			<div className="comment-tree comment-list">
 				<QuerySiteSettings siteId={ siteId } />
-				{ ! isCommentsTreeSupported && (
-					<QuerySiteCommentsList
-						number={ 100 }
-						offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
-						siteId={ siteId }
-						status={ status }
-					/>
-				) }
-				{ isCommentsTreeSupported && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
+				<QuerySiteCommentsTree siteId={ siteId } status={ status } />
 				{ isPostView && <CommentListHeader postId={ postId } /> }
 				<CommentNavigation
 					commentsPage={ commentsPage }
@@ -204,10 +193,7 @@ export class CommentTree extends Component {
 								isBulkMode={ isBulkMode }
 								isPostView={ isPostView }
 								isSelected={ this.isCommentSelected( commentId ) }
-								refreshCommentData={
-									isCommentsTreeSupported &&
-									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
-								}
+								refreshCommentData={ ! this.hasCommentJustMovedBackToCurrentStatus( commentId ) }
 								toggleSelected={ this.toggleCommentSelected }
 								updateLastUndo={ this.updateLastUndo }
 							/>
@@ -259,8 +245,6 @@ const mapStateToProps = ( state, { postId, siteId, status } ) => {
 	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
 	return {
 		comments,
-		isCommentsTreeSupported:
-			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.5' ),
 		isLoading,
 		isPostView,
 		siteId,

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -33,7 +33,6 @@ import { editComment } from 'state/comments/actions';
 import { removeNotice, successNotice } from 'state/notices/actions';
 import getSiteComment from 'state/selectors/get-site-comment';
 import getSiteSetting from 'state/selectors/get-site-setting';
-import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentEdit extends Component {
@@ -126,11 +125,9 @@ export class CommentEdit extends Component {
 	render() {
 		const {
 			isAuthorRegistered,
-			isEditCommentSupported,
 			moment,
 			siteGmtOffset,
 			siteId,
-			siteSlug,
 			siteTimezone,
 			toggleEditMode,
 			translate,
@@ -157,7 +154,7 @@ export class CommentEdit extends Component {
 							</InfoPopover>
 						) }
 						<FormTextInput
-							disabled={ ! isEditCommentSupported || isAuthorRegistered }
+							disabled={ isAuthorRegistered }
 							id="author"
 							onChange={ this.setAuthorDisplayNameValue }
 							value={ authorDisplayName }
@@ -172,7 +169,7 @@ export class CommentEdit extends Component {
 							</InfoPopover>
 						) }
 						<FormTextInput
-							disabled={ ! isEditCommentSupported || isAuthorRegistered }
+							disabled={ isAuthorRegistered }
 							id="author_url"
 							onChange={ this.setAuthorUrlValue }
 							value={ authorUrl }
@@ -215,25 +212,11 @@ export class CommentEdit extends Component {
 
 					<CommentHtmlEditor
 						commentContent={ commentContent }
-						disabled={ ! isEditCommentSupported }
 						onChange={ this.setCommentContentValue }
 					/>
 
-					{ ! isEditCommentSupported && (
-						<p className="comment__edit-jetpack-update-notice">
-							<Gridicon icon="notice-outline" />
-							{ translate( 'Comment editing requires a newer version of Jetpack.' ) }
-							<a
-								className="comment__edit-jetpack-update-notice-link"
-								href={ `/plugins/jetpack/${ siteSlug }` }
-							>
-								{ translate( 'Update Now' ) }
-							</a>
-						</p>
-					) }
-
 					<div className="comment__edit-buttons">
-						<FormButton compact disabled={ ! isEditCommentSupported } onClick={ this.submitEdit }>
+						<FormButton compact onClick={ this.submitEdit }>
 							{ translate( 'Save' ) }
 						</FormButton>
 						<FormButton compact isPrimary={ false } onClick={ toggleEditMode } type="button">
@@ -248,8 +231,6 @@ export class CommentEdit extends Component {
 
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
-	const isEditCommentSupported =
-		! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' );
 	const comment = getSiteComment( state, siteId, commentId );
 	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
 
@@ -259,11 +240,9 @@ const mapStateToProps = ( state, { commentId } ) => {
 		commentContent: get( comment, 'raw_content' ),
 		commentDate: get( comment, 'date' ),
 		isAuthorRegistered: 0 !== get( comment, 'author.ID' ),
-		isEditCommentSupported,
 		postId: get( comment, 'post.ID' ),
 		siteGmtOffset: getSiteSetting( state, siteId, 'gmt_offset' ),
 		siteId,
-		siteSlug: getSiteSlug( state, siteId ),
 		siteTimezone: getSiteSetting( state, siteId, 'timezone_string' ),
 	};
 };

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,9 +20,6 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import FormattedHeader from 'components/formatted-header';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { preventWidows } from 'lib/formatting';
-import { updatePlugin } from 'state/plugins/installed/actions';
-import { getPlugins } from 'state/plugins/installed/selectors';
-import { infoNotice } from 'state/notices/actions';
 import { isEnabled } from 'config';
 import { NEWEST_FIRST } from './constants';
 
@@ -55,13 +51,6 @@ export class CommentsManagement extends Component {
 	};
 
 	setOrder = order => () => this.setState( { order } );
-
-	updateJetpackHandler = () => {
-		const { siteId, translate, jetpackPlugin } = this.props;
-
-		this.props.infoNotice( translate( 'Please wait while we update your Jetpack plugin.' ) );
-		this.props.updatePlugin( siteId, jetpackPlugin );
-	};
 
 	render() {
 		const {
@@ -137,9 +126,6 @@ const mapStateToProps = ( state, { postId, siteFragment } ) => {
 	const canModerateComments = canCurrentUser( state, siteId, 'edit_posts' );
 	const showPermissionError = false === canModerateComments;
 
-	const sitePlugins = getPlugins( state, [ siteId ] );
-	const jetpackPlugin = find( sitePlugins, { slug: 'jetpack' } );
-
 	const showCommentTree =
 		! showPermissionError && isPostView && isEnabled( 'comments/management/threaded-view' );
 
@@ -147,16 +133,10 @@ const mapStateToProps = ( state, { postId, siteFragment } ) => {
 
 	return {
 		siteId,
-		jetpackPlugin,
 		showCommentList,
 		showCommentTree,
 		showPermissionError,
 	};
 };
 
-const mapDispatchToProps = {
-	updatePlugin,
-	infoNotice,
-};
-
-export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentsManagement ) );
+export default connect( mapStateToProps )( localize( CommentsManagement ) );

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -12,7 +12,7 @@ import { saveAs } from 'browser-filesaver';
  * Internal dependencies
  */
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { Card, Button, CompactCard } from '@automattic/components';
 import InfiniteScroll from 'components/infinite-scroll';
 import QueryMembershipsEarnings from 'components/data/query-memberships-earnings';
@@ -167,6 +167,7 @@ class MembershipsSection extends Component {
 			)
 			.join( '\n' );
 
+		// eslint-disable-next-line no-undef
 		const blob = new Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
 
 		saveAs( blob, fileName );
@@ -415,23 +416,6 @@ class MembershipsSection extends Component {
 	}
 
 	render() {
-		if ( this.props.isJetpackTooOld ) {
-			return this.renderOnboarding(
-				<Notice
-					status="is-warning"
-					text={ this.props.translate(
-						'Please update the Jetpack plugin to version 7.4 or higher in order to use the Recurring Payments button block.'
-					) }
-					showDismiss={ false }
-				>
-					<NoticeAction
-						href={ `https://wordpress.com/plugins/jetpack/${ this.props.siteSlug }` }
-						icon="external"
-					/>
-				</Notice>
-			);
-		}
-
 		if ( ! this.props.paidPlan ) {
 			return this.renderOnboarding(
 				<UpgradeNudge
@@ -469,7 +453,7 @@ class MembershipsSection extends Component {
 const mapStateToProps = state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const isJetpack = isJetpackSite( state, siteId );
+
 	return {
 		site,
 		siteId,
@@ -488,8 +472,7 @@ const mapStateToProps = state => {
 		),
 		connectUrl: get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], '' ),
 		paidPlan: isSiteOnPaidPlan( state, siteId ),
-		isJetpackTooOld: isJetpack && isJetpackMinimumVersion( state, siteId, '7.4' ) === false,
-		isJetpack: isJetpack,
+		isJetpack: isJetpackSite( state, siteId ),
 		products: get( state, [ 'memberships', 'productList', 'items', siteId ], [] ),
 	};
 };

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -167,8 +167,7 @@ class MembershipsSection extends Component {
 			)
 			.join( '\n' );
 
-		// eslint-disable-next-line no-undef
-		const blob = new Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
+		const blob = new window.Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
 
 		saveAs( blob, fileName );
 	}

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
 import MultiCheckbox from 'components/forms/multi-checkbox';
 import SupportInfo from 'components/support-info';
 import { getPostTypes } from 'state/post-types/selectors';
@@ -19,7 +18,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import getSharingButtons from 'state/selectors/get-sharing-buttons';
-import { isJetpackSite, isJetpackMinimumVersion, getSiteAdminUrl } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
@@ -30,7 +29,6 @@ class SharingButtonsOptions extends Component {
 		buttons: PropTypes.array,
 		initialized: PropTypes.bool,
 		isJetpack: PropTypes.bool,
-		isTwitterButtonAllowed: PropTypes.bool,
 		onChange: PropTypes.func,
 		postTypes: PropTypes.array,
 		recordGoogleEvent: PropTypes.func,
@@ -153,8 +151,8 @@ class SharingButtonsOptions extends Component {
 	}
 
 	getTwitterViaOptionElement() {
-		const { isJetpack, initialized, isTwitterButtonAllowed, settings, translate } = this.props;
-		if ( ! this.isTwitterButtonEnabled() || ! isTwitterButtonAllowed ) {
+		const { isJetpack, initialized, settings, translate } = this.props;
+		if ( ! this.isTwitterButtonEnabled() ) {
 			return;
 		}
 
@@ -222,11 +220,7 @@ class SharingButtonsOptions extends Component {
 	}
 
 	getSharingShowOptionsElement = () => {
-		const { initialized, isSharingShowAllowed, settings, translate } = this.props;
-
-		if ( ! isSharingShowAllowed ) {
-			return;
-		}
+		const { initialized, settings, translate } = this.props;
 
 		const changeSharingPostTypes = partial( this.handleMultiCheckboxChange, 'sharing_show' );
 		return (
@@ -246,20 +240,6 @@ class SharingButtonsOptions extends Component {
 					disabled={ ! initialized }
 				/>
 			</fieldset>
-		);
-	};
-
-	getWpAdminBanner = () => {
-		const { isSharingShowAllowed, siteAdminUrl, translate } = this.props;
-		if ( isSharingShowAllowed ) {
-			return;
-		}
-		return (
-			<Banner
-				className="sharing-buttons__banner"
-				href={ `${ siteAdminUrl }options-general.php?page=sharing` }
-				title={ translate( 'Visit WP Admin for more sharing buttons options.' ) }
-			/>
 		);
 	};
 
@@ -285,7 +265,6 @@ class SharingButtonsOptions extends Component {
 						{ saving ? translate( 'Saving…' ) : translate( 'Save Changes' ) }
 					</button>
 				</div>
-				{ this.getWpAdminBanner() }
 			</Fragment>
 		);
 	}
@@ -294,10 +273,6 @@ class SharingButtonsOptions extends Component {
 const connectComponent = connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
-		const isTwitterButtonAllowed =
-			! isJetpack || isJetpackMinimumVersion( state, siteId, '3.4-dev' );
-		const isSharingShowAllowed = ! isJetpack || isJetpackMinimumVersion( state, siteId, '7.3' );
 		const path = getCurrentRouteParameterized( state, siteId );
 
 		const postTypes = filter( values( getPostTypes( state, siteId ) ), 'public' );
@@ -305,12 +280,9 @@ const connectComponent = connect(
 		return {
 			buttons: getSharingButtons( state, siteId ),
 			initialized: !! postTypes || !! getSiteSettings( state, siteId ),
-			isJetpack,
-			isSharingShowAllowed,
-			isTwitterButtonAllowed,
+			isJetpack: isJetpackSite( state, siteId ),
 			path,
 			postTypes,
-			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			siteId,
 		};
 	},

--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -15,7 +15,7 @@ import QueryMailchimpSettings from 'components/data/query-mailchimp-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { isJetpackMinimumVersion, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import getJetpackConnectionStatus from 'state/selectors/get-jetpack-connection-status';
 
@@ -27,8 +27,6 @@ const MailchimpSettings = ( {
 	mailchimpListId,
 	isJetpack,
 	isJetpackConnectionBroken,
-	isJetpackTooOld,
-	siteSlug,
 	translate,
 } ) => {
 	const chooseMailchimpList = event => {
@@ -74,25 +72,6 @@ const MailchimpSettings = ( {
 			</div>
 		</div>
 	);
-	if ( isJetpackTooOld ) {
-		return (
-			<div>
-				<Notice
-					status="is-warning"
-					text={ translate(
-						'Please update Jetpack plugin to version 7.1 in order to use the Mailchimp block'
-					) }
-					showDismiss={ false }
-				>
-					<NoticeAction
-						href={ `https://wordpress.com/plugins/jetpack/${ siteSlug }` }
-						icon="external"
-					/>
-				</Notice>
-				{ common }
-			</div>
-		);
-	}
 
 	if ( isJetpackConnectionBroken ) {
 		return (
@@ -172,11 +151,10 @@ export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
+
 		return {
-			siteId: siteId,
-			siteSlug: getSiteSlug( state, siteId ),
-			isJetpackTooOld: isJetpackMinimumVersion( state, siteId, '7.1' ) === false,
-			isJetpack: isJetpack,
+			siteId,
+			isJetpack,
 			isJetpackConnectionBroken: isJetpack && getJetpackConnectionStatus( state, siteId ) === false,
 			mailchimpLists: get( state, [ 'mailchimp', 'lists', 'items', siteId ], null ),
 			mailchimpListId: get(

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -14,7 +14,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isVipSite from 'state/selectors/is-vip-site';
 import DocumentHead from 'components/data/document-head';
-import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
 import NavItem from 'components/section-nav/item';
@@ -134,9 +134,7 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const isJetpack = isJetpackSite( state, siteId );
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-	const hasSharedaddy =
-		isJetpackModuleActive( state, siteId, 'sharedaddy' ) &&
-		isJetpackMinimumVersion( state, siteId, '3.4-dev' );
+	const hasSharedaddy = isJetpackModuleActive( state, siteId, 'sharedaddy' );
 
 	return {
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -65,7 +65,6 @@ import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import {
 	getSitePlan,
 	getSiteSlug,
-	isJetpackMinimumVersion,
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
@@ -96,7 +95,7 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	isJetpackBackupAvailable() {
-		const { displayJetpackPlans, isMultisite, jetpackSupportsBackupProducts, siteId } = this.props;
+		const { displayJetpackPlans, isMultisite } = this.props;
 
 		// Jetpack Backup does not support Multisite yet.
 		if ( isMultisite ) {
@@ -105,11 +104,6 @@ export class PlansFeaturesMain extends Component {
 
 		// Only for Jetpack, non-atomic sites
 		if ( ! displayJetpackPlans ) {
-			return false;
-		}
-
-		// Only for sites with Jetpack >= 7.9alpha
-		if ( siteId && ! jetpackSupportsBackupProducts ) {
 			return false;
 		}
 
@@ -565,7 +559,6 @@ export default connect(
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack: isJetpackSite( state, siteId ),
 			isMultisite: isJetpackSiteMultiSite( state, siteId ),
-			jetpackSupportsBackupProducts: isJetpackMinimumVersion( state, siteId, '7.9-alpha' ),
 			siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
 			sitePlanSlug: currentPlan && currentPlan.product_slug,

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -15,7 +15,6 @@ import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import { Card, ProgressBar } from '@automattic/components';
 import UploadDropZone from 'blocks/upload-drop-zone';
-import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -28,12 +27,7 @@ import getPluginUploadProgress from 'state/selectors/get-plugin-upload-progress'
 import getUploadedPluginId from 'state/selectors/get-uploaded-plugin-id';
 import isPluginUploadComplete from 'state/selectors/is-plugin-upload-complete';
 import isPluginUploadInProgress from 'state/selectors/is-plugin-upload-in-progress';
-import {
-	getSiteAdminUrl,
-	isJetpackMinimumVersion,
-	isJetpackSite,
-	isJetpackSiteMultiSite,
-} from 'state/sites/selectors';
+import { getSiteAdminUrl, isJetpackSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
@@ -138,7 +132,7 @@ class PluginUpload extends React.Component {
 	}
 
 	render() {
-		const { translate, isJetpackMultisite, upgradeJetpack, siteId, siteSlug } = this.props;
+		const { translate, isJetpackMultisite, siteId, siteSlug } = this.props;
 		const { showEligibility } = this.state;
 
 		return (
@@ -146,14 +140,6 @@ class PluginUpload extends React.Component {
 				<PageViewTracker path="/plugins/upload/:site" title="Plugins > Upload" />
 				<QueryEligibility siteId={ siteId } />
 				<HeaderCake onClick={ this.back }>{ translate( 'Install plugin' ) }</HeaderCake>
-				{ upgradeJetpack && (
-					<JetpackManageErrorPage
-						template="updateJetpack"
-						siteId={ siteId }
-						featureExample={ this.renderUploadCard() }
-						version="5.1"
-					/>
-				) }
 				{ isJetpackMultisite && this.renderNotAvailableForMultisite() }
 				{ showEligibility && (
 					<EligibilityWarnings
@@ -161,7 +147,7 @@ class PluginUpload extends React.Component {
 						onProceed={ this.onProceedClick }
 					/>
 				) }
-				{ ! upgradeJetpack && ! isJetpackMultisite && ! showEligibility && this.renderUploadCard() }
+				{ ! isJetpackMultisite && ! showEligibility && this.renderUploadCard() }
 			</Main>
 		);
 	}
@@ -192,8 +178,6 @@ const mapStateToProps = state => {
 		error,
 		progress,
 		installing: progress === 100,
-		upgradeJetpack:
-			isJetpack && ! isJetpackMultisite && ! isJetpackMinimumVersion( state, siteId, '5.1' ),
 		isJetpackMultisite,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -36,7 +36,6 @@ import {
 	getPostsLastPageForQuery,
 } from 'state/posts/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
-import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import QueryPosts from 'components/data/query-posts';
 
@@ -458,12 +457,7 @@ class PostSelectorPosts extends React.Component {
 
 export default connect( ( state, ownProps ) => {
 	const { siteId, query } = ownProps;
-
-	const apiVersion =
-		! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.0' )
-			? '1.2'
-			: undefined;
-	const queryWithVersion = { ...query, apiVersion };
+	const queryWithVersion = { ...query, apiVersion: '1.2' };
 
 	return {
 		posts: getPostsForQueryIgnoringPage( state, siteId, queryWithVersion ),

--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -17,13 +17,10 @@ import AccordionSection from 'components/accordion/section';
 import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 import TermSelector from 'post-editor/editor-term-selector';
 import TermTokenField from 'post-editor/term-token-field';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import { addSiteFragment } from 'lib/route';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
-import { getSiteOption, isJetpackMinimumVersion, getSiteSlug } from 'state/sites/selectors';
+import { getSiteOption } from 'state/sites/selectors';
 import { getTerm } from 'state/terms/selectors';
 
 /**
@@ -37,28 +34,10 @@ export class EditorCategoriesTagsAccordion extends Component {
 		postTerms: PropTypes.object,
 		postType: PropTypes.string,
 		defaultCategory: PropTypes.object,
-		isTermsSupported: PropTypes.bool,
-		siteSlug: PropTypes.string,
 	};
 
-	renderJetpackNotice() {
-		const { translate, siteSlug } = this.props;
-		return (
-			<Notice
-				status="is-warning"
-				showDismiss={ false }
-				text={ translate( 'You must update Jetpack to use this feature.' ) }
-				className="editor-categories-tags__upgrade-notice"
-			>
-				<NoticeAction href={ addSiteFragment( '/plugins/jetpack', siteSlug ) }>
-					{ translate( 'Update Now' ) }
-				</NoticeAction>
-			</Notice>
-		);
-	}
-
 	renderCategories() {
-		const { translate, postType, isTermsSupported } = this.props;
+		const { translate, postType } = this.props;
 		if ( postType === 'page' ) {
 			return;
 		}
@@ -69,17 +48,13 @@ export class EditorCategoriesTagsAccordion extends Component {
 					helpText={ translate( 'Use categories to group your posts by topic.' ) }
 					labelText={ translate( 'Categories' ) }
 				/>
-				{ isTermsSupported ? (
-					<TermSelector compact taxonomyName="category" />
-				) : (
-					this.renderJetpackNotice()
-				) }
+				<TermSelector compact taxonomyName="category" />
 			</AccordionSection>
 		);
 	}
 
 	renderTags() {
-		const { isTermsSupported, postType, translate } = this.props;
+		const { postType, translate } = this.props;
 		const helpText =
 			postType === 'page'
 				? translate( 'Use tags to associate more specific keywords with your pages.' )
@@ -88,11 +63,7 @@ export class EditorCategoriesTagsAccordion extends Component {
 		return (
 			<AccordionSection>
 				<EditorDrawerLabel helpText={ helpText } labelText={ translate( 'Tags' ) } />
-				{ isTermsSupported ? (
-					<TermTokenField taxonomyName="post_tag" />
-				) : (
-					this.renderJetpackNotice()
-				) }
+				<TermTokenField taxonomyName="post_tag" />
 			</AccordionSection>
 		);
 	}
@@ -199,15 +170,12 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
 	const defaultCategoryId = getSiteOption( state, siteId, 'default_category' );
-	const isTermsSupported = false !== isJetpackMinimumVersion( state, siteId, '4.1.0' );
 
 	return {
 		defaultCategory: getTerm( state, siteId, 'category', defaultCategoryId ),
 		postTerms: getEditedPostValue( state, siteId, postId, 'terms' ),
 		postType: getEditedPostValue( state, siteId, postId, 'type' ),
-		siteSlug: getSiteSlug( state, siteId ),
 		siteId,
 		postId,
-		isTermsSupported,
 	};
 } )( localize( EditorCategoriesTagsAccordion ) );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -24,11 +24,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import { getPlugins, isRequesting } from 'state/plugins/installed/selectors';
-import {
-	isJetpackMinimumVersion,
-	isJetpackModuleActive,
-	isJetpackSite,
-} from 'state/sites/selectors';
+import { isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
 import config from 'config';
 import areSitePermalinksEditable from 'state/selectors/are-site-permalinks-editable';
 import EditorDrawerTaxonomies from './taxonomies';
@@ -78,7 +74,6 @@ const POST_TYPE_SUPPORTS = {
 class EditorDrawer extends Component {
 	static propTypes = {
 		site: PropTypes.object,
-		canJetpackUseTaxonomies: PropTypes.bool,
 		typeObject: PropTypes.object,
 		type: PropTypes.string,
 		setPostDate: PropTypes.func,
@@ -118,10 +113,9 @@ class EditorDrawer extends Component {
 
 	// Custom Taxonomies
 	renderTaxonomies() {
-		const { canJetpackUseTaxonomies } = this.props;
 		const isCustomTypesEnabled = config.isEnabled( 'manage/custom-post-types' );
 
-		if ( isCustomTypesEnabled && false !== canJetpackUseTaxonomies ) {
+		if ( isCustomTypesEnabled ) {
 			return <EditorDrawerTaxonomies />;
 		}
 	}
@@ -170,10 +164,7 @@ class EditorDrawer extends Component {
 	renderLocation() {
 		const { translate } = this.props;
 
-		if (
-			! this.props.site ||
-			( this.props.isJetpack && ! this.props.jetpackVersionSupportsLocation )
-		) {
+		if ( ! this.props.site ) {
 			return;
 		}
 
@@ -206,7 +197,6 @@ class EditorDrawer extends Component {
 			hasConflictingSeoPlugins,
 			isSeoToolsModuleActive,
 			isJetpack,
-			jetpackVersionSupportsSeo,
 			isRequestingPlugins,
 			site,
 		} = this.props;
@@ -219,7 +209,6 @@ class EditorDrawer extends Component {
 			if (
 				isRequestingPlugins ||
 				! isSeoToolsModuleActive ||
-				! jetpackVersionSupportsSeo ||
 				// Hide SEO accordion if this setting is managed by another SEO plugin.
 				hasConflictingSeoPlugins
 			) {
@@ -327,11 +316,8 @@ const enhance = flow(
 		return {
 			hasConflictingSeoPlugins: !! getFirstConflictingPlugin( activePlugins ),
 			isPermalinkEditable: areSitePermalinksEditable( state, siteId ),
-			canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
 			isJetpack: isJetpackSite( state, siteId ),
 			isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
-			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
-			jetpackVersionSupportsLocation: isJetpackMinimumVersion( state, siteId, '6.3-beta' ),
 			isRequestingPlugins: isRequesting( state, siteId ),
 			type,
 			typeObject: getPostType( state, siteId, type ),

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -17,7 +17,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostTypeTaxonomies } from 'state/post-types/taxonomies/selectors';
-import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import Accordion from 'components/accordion';
 import TermTokenField from 'post-editor/term-token-field';
 import TermSelector from 'post-editor/editor-term-selector';
@@ -34,11 +33,7 @@ function isSkippedTaxonomy( postType, taxonomy ) {
 	return false;
 }
 
-function EditorDrawerTaxonomies( { translate, siteId, postType, isSupported, taxonomies, terms } ) {
-	if ( ! isSupported ) {
-		return null;
-	}
-
+function EditorDrawerTaxonomies( { translate, siteId, postType, taxonomies, terms } ) {
 	return (
 		<div className="editor-drawer__taxonomies">
 			{ siteId && postType && <QueryTaxonomies { ...{ siteId, postType } } /> }
@@ -87,7 +82,6 @@ EditorDrawerTaxonomies.propTypes = {
 	translate: PropTypes.func,
 	siteId: PropTypes.number,
 	postType: PropTypes.string,
-	isSupported: PropTypes.bool,
 	terms: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ),
 	taxonomies: PropTypes.array,
 };
@@ -96,12 +90,10 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
-	const isSupported = false !== isJetpackMinimumVersion( state, siteId, '4.1.0' );
 
 	return {
 		siteId,
 		postType,
-		isSupported,
 		terms: getEditedPostValue( state, siteId, postId, 'terms' ),
 		taxonomies: getPostTypeTaxonomies( state, siteId, postType ),
 	};


### PR DESCRIPTION
Currently we use `isJetpackMinimumVersion` in many locations, to display a feature or functionality only for a certain Jetpack version or newer. However, Jetpack's official support policy is to support the current - 1 version. Any older versions aren't supported. This means we can remove any checks that check for 7.9-only or older versions of Jetpack. This basically means removing all of the `isJetpackMinimumVersion` usages.

We keep the `isJetpackMinimumVersion` selector though, as it might be useful for future features.

This cleanup helps in removing some dead unnecessary code and keeping the codebase cleaner.

#### Changes proposed in this Pull Request

* Jetpack: Remove obsolete `isJetpackMinimumVersion` checks.

#### Testing instructions
Test the following screens and flows and verify they work like they did before:
* Simple payments dialog in classic editor (Jetpack and WP.com site).
* Memberships in the Simple Payments dialog in classic editor.
* Comments - navigation - newest / oldest sorting functionality.
* Comments - comment tree and comment nesting.
* Comments - comment inline editing.
* Comments - main screen.
* Tools -> Earn -> Payments - recurring payments.
* Tools -> Marketing -> Sharing Buttons -> Options card settings.
* Tools -> Marketing -> Connections -> Mailchimp connection.
* Tools -> Marketing - The "Get social, and share your blog posts where the people are" card.
* Plans - Jetpack backup purchase card for Jetpack sites.
* Plugins -> Upload (http://calypso.localhost:3000/plugins/upload/:site), test with single site and multisite (multisite should suggest going to wp-admin).
* Pages -> Edit Page (classic editor) -> Sidebar -> Page Attributes, selecting a parent page.
* Posts -> Edit Post (classic editor) -> Sidebar -> Categories & Tags, displaying categories with the current category selected and tags inputted.
* Posts -> Edit Post (classic editor) -> Sidebar - test everything on a Jetpack and WP.com site.
* Posts -> Edit Post (classic editor) -> Sidebar -> Categories & Tags, selecting a category and inputting tags.
* Not removing the selector because it will be necessary as we release new features.