### PR TITLE
Framework: Remove escape-regexp dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12626,11 +12626,6 @@
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
-		"escape-regexp": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz",
-			"integrity": "sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ="
-		},
 		"escape-regexp-component": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
 		"email-validator": "2.0.4",
 		"emoji-text": "0.2.6",
 		"emotion-theming": "10.0.19",
-		"escape-regexp": "0.0.1",
 		"escape-string-regexp": "2.0.0",
 		"events": "3.0.0",
 		"exports-loader": "0.7.0",


### PR DESCRIPTION
`escape-regexp` has been a dependency in the pre-OSS version of Calypso, but it is not used at all right now. This PR removes it.

#### Changes proposed in this Pull Request

* Remove `escape-regexp` because it's no longer used.

#### Testing instructions

* Checkout this branch.
* Run `npm install` and `npm run build`.
* Verify `escape-regexp` is used nowhere.
