### PR TITLE
Remove rememo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
 		"redux-form": "8.2.6",
 		"redux-thunk": "2.3.0",
 		"refx": "3.1.1",
-		"rememo": "3.0.0",
 		"resize-observer-polyfill": "1.5.1",
 		"rtlcss": "2.4.0",
 		"social-logos": "2.1.0",


### PR DESCRIPTION
`rememo` is currently not a specific dependency of Calypso (it still is a dependency of some `@wordpress/packages` though), so this PR removes it from the main `package.json`.

#### Changes proposed in this Pull Request

* Remove `rememo` because it's no longer used.

#### Testing instructions

* Checkout this branch.
* Run `npm install` and `npm run build`.
* Verify `rememo` is used nowhere.
