### PR TITLE
Reader: Fix feed discovery error handling

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -162,7 +162,7 @@ const exported = {
 					page.redirect( `/read/feeds/${ feedId }` );
 				} )
 				.catch( function() {
-					renderFeedError( context );
+					renderFeedError( context, next );
 				} );
 		} else {
 			next();


### PR DESCRIPTION
Currently, we have an error in how we handle feed discovery errors. To repro, just go to: https://wordpress.com/read/feeds/asddadsadas and you'll get a console error. This happens because of a missing `next()` in the controller.

#### Changes proposed in this Pull Request

* Reader: Fix feed discovery error handling

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/read/feeds/asddadsadas
* Verify you can see the expected user-friendly error message:

![](https://cldup.com/U6IpvfHNBn.png)

