### PR TITLE
Gutenboarding: Allow user-specified vertical

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -14,7 +14,6 @@ import { Dialog, DialogBackdrop } from 'reakit/Dialog';
 /**
  * Internal dependencies
  */
-import { SiteVertical } from '../../stores/onboard/types';
 import DesignCard from './design-card';
 
 import './style.scss';
@@ -26,7 +25,7 @@ const VERTICALS_TEMPLATES_STORE = VerticalsTemplates.register();
 
 const DesignSelector: FunctionComponent = () => {
 	const siteVertical = useSelect(
-		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical
+		select => select( 'automattic/onboard' ).getState().siteVertical
 	);
 
 	// @FIXME: If we don't have an ID (because we're dealing with a user-supplied vertical that

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -29,9 +29,17 @@ const DesignSelector: FunctionComponent = () => {
 		select => select( 'automattic/onboard' ).getState().siteVertical as SiteVertical
 	);
 
+	// @FIXME: If we don't have an ID (because we're dealing with a user-supplied vertical that
+	// WordPress.com doesn't know about), fall back to the 'm1' (Business) vertical. This is the
+	// vertical that the endpoint would fall back to anyway if an unknown ID is passed.
+	// This seems okay since the list of templates currently appears to be the same for all verticals
+	// anyway.
+	// We should modify the endpoint (or rather, add a `verticals/templates` route that doesn't require
+	// a vertical ID) for this case.
 	const templates =
-		useSelect( select => select( VERTICALS_TEMPLATES_STORE ).getTemplates( siteVertical.id ) ) ??
-		[];
+		useSelect( select =>
+			select( VERTICALS_TEMPLATES_STORE ).getTemplates( siteVertical?.id ?? 'm1' )
+		) ?? [];
 
 	const [ designs, otherTemplates ] = partition(
 		templates,

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -28,7 +28,7 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onL
 	useEffect( () => void ( new window.Image().src = defaultImageUrl ), [] );
 
 	useEffect( () => {
-		if ( siteVertical ) {
+		if ( siteVertical?.id ) {
 			const preloadImage = new window.Image();
 			const failureHandler = () => {
 				setImageUrl( defaultImageUrl );

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -28,12 +28,19 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onL
 	useEffect( () => void ( new window.Image().src = defaultImageUrl ), [] );
 
 	useEffect( () => {
-		if ( siteVertical?.id ) {
+		// Has the user selected a vertical yet?
+		if ( siteVertical ) {
 			const preloadImage = new window.Image();
 			const failureHandler = () => {
 				setImageUrl( defaultImageUrl );
 				onLoad();
 			};
+
+			// If this is a user-supplied vertical, use the default background.
+			if ( ! siteVertical.id ) {
+				return failureHandler;
+			}
+
 			// We get an esmodule wrapping the url here
 			const successHandler = ( { default: url }: { default: string } ) => {
 				preloadImage.onload = () => {

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -115,12 +115,15 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 				.filter( x => Object.prototype.hasOwnProperty.call( x, 'label' ) )
 		: verticals.filter( x => x.label.toLowerCase().includes( normalizedInputValue ) );
 
+	// Does the verticals list include an exact match? If it doesn't, we prepend the user-suppied
+	// vertical to the list.
 	if (
 		! suggestions.some(
 			( suggestion: SiteVertical ) => suggestion.label.toLowerCase() === normalizedInputValue
 		)
 	) {
-		suggestions.unshift( { id: undefined, label: inputValue.trim() } );
+		// User-supplied verticals don't have IDs.
+		suggestions.unshift( { label: inputValue.trim() } );
 	}
 
 	const label = NO__( 'My site is about' );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -117,6 +117,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 	// Does the verticals list include an exact match? If it doesn't, we prepend the user-suppied
 	// vertical to the list.
 	if (
+		normalizedInputValue &&
 		! suggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
 	) {
 		// User-supplied verticals don't have IDs.

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -43,7 +43,8 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 	];
 
 	const [ inputValue, setInputValue ] = useState( '' );
-	const [ dirty, setDirty ] = useState( false );
+
+	const normalizedInputValue = inputValue.trim().toLowerCase();
 
 	/**
 	 * Ref to the <Suggestions />, necessary for handling input events
@@ -69,9 +70,6 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
 
 	const handleSuggestionChangeEvent = ( e: React.ChangeEvent< HTMLInputElement > ) => {
-		if ( e.target.value !== inputValue && ! dirty ) {
-			setDirty( true );
-		}
 		setInputValue( e.target.value );
 	};
 
@@ -87,15 +85,19 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 
 	const handleSelect = ( vertical: SiteVertical ) => {
 		setSiteVertical( vertical );
-		setDirty( false );
 		onSelect();
 	};
 
 	const handleBlur = () => {
-		if ( dirty ) {
+		if ( ! normalizedInputValue ) {
 			resetSiteVertical();
+		} else {
+			const vertical = verticals.find( ( { label } ) =>
+				label.toLowerCase().includes( normalizedInputValue )
+			) ?? { label: inputValue.trim() };
+
+			setSiteVertical( vertical );
 		}
-		setDirty( false );
 		onSelect();
 	};
 
@@ -105,8 +107,6 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 			category: NO__( 'Loading, please wait…' ),
 		},
 	];
-
-	const normalizedInputValue = inputValue.trim().toLowerCase();
 
 	const suggestions: Suggestion[] = ! inputValue.length
 		? verticals

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -120,7 +120,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 			( suggestion: SiteVertical ) => suggestion.label.toLowerCase() === normalizedInputValue
 		)
 	) {
-		suggestions.unshift( { id: '', label: inputValue.trim() } );
+		suggestions.unshift( { id: undefined, label: inputValue.trim() } );
 	}
 
 	const label = NO__( 'My site is about' );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -96,6 +96,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 		suggestions = verticals
 			.filter( vertical => popular.includes( vertical.label ) )
 			.map( vertical => ( { ...vertical, category: NO__( 'Popular' ) } ) );
+		resetSiteVertical();
 	} else {
 		suggestions = verticals.filter( vertical =>
 			vertical.label.toLowerCase().includes( normalizedInputValue )
@@ -118,15 +119,11 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 	};
 
 	const handleBlur = () => {
-		if ( ! normalizedInputValue ) {
-			resetSiteVertical();
-		} else {
-			const vertical = suggestions.find( ( { label } ) =>
-				label.toLowerCase().includes( normalizedInputValue )
-			) ?? { label: inputValue.trim() };
+		const vertical = suggestions.find( ( { label } ) =>
+			label.toLowerCase().includes( normalizedInputValue )
+		) ?? { label: inputValue.trim() };
 
-			setSiteVertical( vertical );
-		}
+		setSiteVertical( vertical );
 		onSelect();
 	};
 

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -83,24 +83,6 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 		}
 	};
 
-	const handleSelect = ( vertical: SiteVertical ) => {
-		setSiteVertical( vertical );
-		onSelect();
-	};
-
-	const handleBlur = () => {
-		if ( ! normalizedInputValue ) {
-			resetSiteVertical();
-		} else {
-			const vertical = verticals.find( ( { label } ) =>
-				label.toLowerCase().includes( normalizedInputValue )
-			) ?? { label: inputValue.trim() };
-
-			setSiteVertical( vertical );
-		}
-		onSelect();
-	};
-
 	const loadingMessage = [
 		{
 			label: '',
@@ -123,6 +105,24 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 		// User-supplied verticals don't have IDs.
 		suggestions.unshift( { label: inputValue.trim() } );
 	}
+
+	const handleSelect = ( vertical: SiteVertical ) => {
+		setSiteVertical( vertical );
+		onSelect();
+	};
+
+	const handleBlur = () => {
+		if ( ! normalizedInputValue ) {
+			resetSiteVertical();
+		} else {
+			const vertical = suggestions.find( ( { label } ) =>
+				label.toLowerCase().includes( normalizedInputValue )
+			) ?? { label: inputValue.trim() };
+
+			setSiteVertical( vertical );
+		}
+		onSelect();
+	};
 
 	const label = NO__( 'My site is about' );
 	const displayValue = siteVertical?.label ?? NO__( 'enter a topic' );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -42,10 +42,6 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 		NO__( 'Real Estate Agent' ),
 	];
 
-	const [ inputValue, setInputValue ] = useState( '' );
-
-	const normalizedInputValue = inputValue.trim().toLowerCase();
-
 	/**
 	 * Ref to the <Suggestions />, necessary for handling input events
 	 *
@@ -68,6 +64,10 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 
 	const { siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
+
+	const [ inputValue, setInputValue ] = useState( siteVertical?.label ?? '' );
+
+	const normalizedInputValue = inputValue.trim().toLowerCase();
 
 	const handleSuggestionChangeEvent = ( e: React.ChangeEvent< HTMLInputElement > ) => {
 		setInputValue( e.target.value );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -111,7 +111,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 					category: NO__( 'Popular' ),
 				} ) )
 				.filter( x => Object.prototype.hasOwnProperty.call( x, 'label' ) )
-		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.toLowerCase() ) );
+		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.trim().toLowerCase() ) );
 
 	const label = NO__( 'My site is about' );
 	const displayValue = siteVertical?.label ?? NO__( 'enter a topic' );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -90,20 +90,25 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 		},
 	];
 
-	const suggestions: Suggestion[] = ! inputValue.length
-		? verticals
-				.filter( vertical => popular.includes( vertical.label ) )
-				.map( vertical => ( { ...vertical, category: NO__( 'Popular' ) } ) )
-		: verticals.filter( vertical => vertical.label.toLowerCase().includes( normalizedInputValue ) );
+	let suggestions: Suggestion[];
 
-	// Does the verticals list include an exact match? If it doesn't, we prepend the user-suppied
-	// vertical to the list.
-	if (
-		normalizedInputValue &&
-		! suggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
-	) {
-		// User-supplied verticals don't have IDs.
-		suggestions.unshift( { label: inputValue.trim() } );
+	if ( ! normalizedInputValue ) {
+		suggestions = verticals
+			.filter( vertical => popular.includes( vertical.label ) )
+			.map( vertical => ( { ...vertical, category: NO__( 'Popular' ) } ) );
+	} else {
+		suggestions = verticals.filter( vertical =>
+			vertical.label.toLowerCase().includes( normalizedInputValue )
+		);
+
+		// Does the verticals list include an exact match? If it doesn't, we prepend the user-suppied
+		// vertical to the list.
+		if (
+			! suggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
+		) {
+			// User-supplied verticals don't have IDs.
+			suggestions.unshift( { label: inputValue.trim() } );
+		}
 	}
 
 	const handleSelect = ( vertical: SiteVertical ) => {

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -22,6 +22,8 @@ import { __TodoAny__ } from '../../../../types';
  */
 import './style.scss';
 
+type Suggestion = SiteVertical & { category?: string };
+
 const VERTICALS_STORE = Verticals.register();
 
 const VerticalSelect: FunctionComponent< StepProps > = ( {
@@ -106,7 +108,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 
 	const normalizedInputValue = inputValue.trim().toLowerCase();
 
-	const suggestions = ! inputValue.length
+	const suggestions: Suggestion[] = ! inputValue.length
 		? verticals
 				.filter( vertical => popular.includes( vertical.label ) )
 				.map( vertical => ( { ...vertical, category: NO__( 'Popular' ) } ) )

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -107,20 +107,15 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 	const normalizedInputValue = inputValue.trim().toLowerCase();
 
 	const suggestions = ! inputValue.length
-		? popular
-				.map( label => ( {
-					...verticals.find( vertical => vertical.label === label ),
-					category: NO__( 'Popular' ),
-				} ) )
-				.filter( x => Object.prototype.hasOwnProperty.call( x, 'label' ) )
-		: verticals.filter( x => x.label.toLowerCase().includes( normalizedInputValue ) );
+		? verticals
+				.filter( vertical => popular.includes( vertical.label ) )
+				.map( vertical => ( { ...vertical, category: NO__( 'Popular' ) } ) )
+		: verticals.filter( vertical => vertical.label.toLowerCase().includes( normalizedInputValue ) );
 
 	// Does the verticals list include an exact match? If it doesn't, we prepend the user-suppied
 	// vertical to the list.
 	if (
-		! suggestions.some(
-			( suggestion: SiteVertical ) => suggestion.label.toLowerCase() === normalizedInputValue
-		)
+		! suggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
 	) {
 		// User-supplied verticals don't have IDs.
 		suggestions.unshift( { label: inputValue.trim() } );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -104,6 +104,8 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 		},
 	];
 
+	const normalizedInputValue = inputValue.trim().toLowerCase();
+
 	const suggestions = ! inputValue.length
 		? popular
 				.map( label => ( {
@@ -111,7 +113,15 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 					category: NO__( 'Popular' ),
 				} ) )
 				.filter( x => Object.prototype.hasOwnProperty.call( x, 'label' ) )
-		: verticals.filter( x => x.label.toLowerCase().includes( inputValue.trim().toLowerCase() ) );
+		: verticals.filter( x => x.label.toLowerCase().includes( normalizedInputValue ) );
+
+	if (
+		! suggestions.some(
+			( suggestion: SiteVertical ) => suggestion.label.toLowerCase() === normalizedInputValue
+		)
+	) {
+		suggestions.unshift( { id: '', label: inputValue.trim() } );
+	}
 
 	const label = NO__( 'My site is about' );
 	const displayValue = siteVertical?.label ?? NO__( 'enter a topic' );

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -113,6 +113,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 
 	const handleSelect = ( vertical: SiteVertical ) => {
 		setSiteVertical( vertical );
+		setInputValue( vertical.label );
 		onSelect();
 	};
 

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -9,6 +9,19 @@ enum ActionType {
 export { ActionType };
 
 export interface SiteVertical {
+	/**
+	 * Vertical Label. Either obtained from WP.com, or specified by the user.
+	 *
+	 * @example
+	 * Christmas Tree Farm
+	 */
 	label: string;
-	id: string;
+
+	/**
+	 * Vertical ID. Can be undefined for user-specified verticals that don't exist in WP.com's curated list.
+	 *
+	 * @example
+	 * p2v19
+	 */
+	id?: string;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Allow the user to specify their own (free-form) vertical, rather than restricting them to the list.
This also allows us to persist a free-form vertical when the input loses focus.

Fixes #37854.

#### Testing instructions

- Go to `http://calypso.localhost:3000/gutenboarding`
- Verify that if you enter the free-form vertical (but don't select it from the suggestions list) and then focus on a different control, the free-form vertical will still be present in the vertical field.
- Verify that you can enter a free-form vertical, and that you can select it from the list.

#### Screencast

![free-verticals](https://user-images.githubusercontent.com/96308/71518991-ab00dd00-28df-11ea-9217-09787063bb58.gif)

#### Follow-up

- We need to change the endpoint to return a list of templates if no vertical is specified.
- We might want to debounce, so the (costly) suggestions search isn't run on every keystroke.
- Theoretically, we could get rid of `inputValue` component state now, and directly propagate the input contents to the `siteVertical` store. However, we'd need to be quite careful when modifying suggestions handling accordingly.