### PR TITLE
Session dashboard: Add timezone indicator based on browser local time

### DIFF
--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -34,6 +34,12 @@ class AppointmentInfo extends Component {
 
 		const conferenceLink = meta.conference_link || '';
 
+		const endTimeFormat = translate( 'LT z', {
+			comment:
+				'moment.js formatting string. See http://momentjs.com/docs/#/displaying/format/.' +
+				'e.g. 03:45 EST.',
+		} );
+
 		return (
 			<>
 				<CompactCard className="shared__site-block">
@@ -74,7 +80,9 @@ class AppointmentInfo extends Component {
 						<FormLabel>{ translate( 'When?' ) }</FormLabel>
 						<FormSettingExplanation>
 							{ moment( beginTimestamp ).format( 'llll - ' ) }
-							{ moment( endTimestamp ).format( 'LT ' ) }
+							{ moment( endTimestamp )
+								.tz( moment.tz.guess() )
+								.format( endTimeFormat ) }
 						</FormSettingExplanation>
 					</FormFieldset>
 

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -75,7 +75,6 @@ class AppointmentInfo extends Component {
 						<FormSettingExplanation>
 							{ moment( beginTimestamp ).format( 'llll - ' ) }
 							{ moment( endTimestamp ).format( 'LT ' ) }
-							{ moment.tz.zone( meta.timezone ).abbr( 360 ) }
 						</FormSettingExplanation>
 					</FormFieldset>
 

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -34,12 +34,6 @@ class AppointmentInfo extends Component {
 
 		const conferenceLink = meta.conference_link || '';
 
-		const endTimeFormat = translate( 'LT z', {
-			comment:
-				'moment.js formatting string. See http://momentjs.com/docs/#/displaying/format/.' +
-				'e.g. 03:45 EST.',
-		} );
-
 		return (
 			<>
 				<CompactCard className="shared__site-block">
@@ -80,9 +74,7 @@ class AppointmentInfo extends Component {
 						<FormLabel>{ translate( 'When?' ) }</FormLabel>
 						<FormSettingExplanation>
 							{ moment( beginTimestamp ).format( 'llll - ' ) }
-							{ moment( endTimestamp )
-								.tz( moment.tz.guess() )
-								.format( endTimeFormat ) }
+							{ moment( endTimestamp ).format( 'LT' ) }
 						</FormSettingExplanation>
 					</FormFieldset>
 

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import 'moment-timezone';
 
 /**
  * Internal dependencies
@@ -33,6 +34,7 @@ class AppointmentInfo extends Component {
 		} = this.props;
 
 		const conferenceLink = meta.conference_link || '';
+		const guessedTimezone = moment.tz.guess();
 
 		return (
 			<>
@@ -74,7 +76,8 @@ class AppointmentInfo extends Component {
 						<FormLabel>{ translate( 'When?' ) }</FormLabel>
 						<FormSettingExplanation>
 							{ moment( beginTimestamp ).format( 'llll - ' ) }
-							{ moment( endTimestamp ).format( 'LT' ) }
+							{ moment.tz( endTimestamp, guessedTimezone ).format( 'LT z' ) }
+							{ ` (${ guessedTimezone })` }
 						</FormSettingExplanation>
 					</FormFieldset>
 

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -76,8 +76,8 @@ class AppointmentInfo extends Component {
 						<FormLabel>{ translate( 'When?' ) }</FormLabel>
 						<FormSettingExplanation>
 							{ moment( beginTimestamp ).format( 'llll - ' ) }
-							{ moment.tz( endTimestamp, guessedTimezone ).format( 'LT z' ) }
-							{ ` (${ guessedTimezone })` }
+							{ moment.tz( endTimestamp, guessedTimezone ).format( 'LT z' ) }{ ' ' }
+							{ `(${ guessedTimezone })` }
 						</FormSettingExplanation>
 					</FormFieldset>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ~Removing time zone indicator for the concierge appointment time to support localized formats that do not use timezone indicators. Since the time of the appointment is shown in the user's browser local time, a timezone indicator is not needed. ~

* The timezone indicator on the session dashboard is based on the timezone in which the appointmetn is booked.
* Change this to make the timezone based on the browser local time. So if a user booked their session for 8 AM EST, and if they are currently in GMT timezone, the session time should shown in GMT.
* Fixes 56-gh-concierge-admin

In the images below, the session appointment begins at 8 AM EDT. So, in my timezone(Indian Standard Time), it is 17:30. 

**Before:**

**Timezone incorrectly shown to be EST, though the time of the appointment is correctly converted to my local timezone.**

<img width="722" alt="Screenshot 2020-03-19 at 12 26 33 PM" src="https://user-images.githubusercontent.com/1269602/77039923-f4436300-69dc-11ea-90c5-9434d215dae8.png">

**After:**

<img width="727" alt="Screenshot 2020-03-19 at 12 26 39 PM" src="https://user-images.githubusercontent.com/1269602/77039963-058c6f80-69dd-11ea-82cd-7379ed31c61f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you are eligible for purchasing a concierge session - you either need to be on a Business plan or must have purchased a concierge product at /checkout/offer-support-session.
* Next, navigate to /me/concierge and book an appointment, preferably in a timezone that is not your current timezone.
* Visit your session dashboard by navigating again to /me/concierge and check the appointment time. 
* Verify that it displays the local time format correctly.

