### PR TITLE
Gutenboarding: Don't pass id prop to VerticalBackground

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -28,7 +28,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 
 	return (
 		<>
-			<VerticalBackground id={ siteVertical?.id } onLoad={ () => setHasBackground( true ) } />
+			<VerticalBackground onLoad={ () => setHasBackground( true ) } />
 			<Switch>
 				<Route exact path={ Step.IntentGathering }>
 					<div

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -17,7 +17,6 @@ import { STORE_KEY } from '../stores/onboard';
 import defaultImageUrl from '../../../../static/images/verticals/default.jpg';
 
 export interface VerticalBackgroundProps {
-	id?: string;
 	onLoad: () => void;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #38577, the `VerticalBackground` component was changed to fetch the user's selected site vertical from the `automattic/onboard` store, rather than using the `id` prop passed to it. However, the `id` prop was still being passed at `VerticalBackground`'s only callsite. This went undetected since `id` also wasn't removed from `VerticalBackground`'s props interface definition.

This PR fixes both oversights.

Documented here: https://github.com/Automattic/wp-calypso/pull/38577/files#r361384432

#### Testing instructions

Verify that Gutenboarding still works -- particularly the vertical background.