### PR TITLE
Layout: AsyncLoad banners

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -39,7 +39,6 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import DocumentHead from 'components/data/document-head';
-import GdprBanner from 'blocks/gdpr-banner';
 import { getPreference } from 'state/preferences/selectors';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
@@ -181,7 +180,9 @@ class Layout extends Component {
 					) }
 				<SupportArticleDialog />
 				<AsyncLoad require="blocks/app-banner" placeholder={ null } />
-				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
+				{ config.isEnabled( 'gdpr-banner' ) && (
+					<AsyncLoad require="blocks/gdpr-banner" placeholder={ null } />
+				) }
 			</div>
 		);
 	}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -39,7 +39,6 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import DocumentHead from 'components/data/document-head';
-import AppBanner from 'blocks/app-banner';
 import GdprBanner from 'blocks/gdpr-banner';
 import { getPreference } from 'state/preferences/selectors';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
@@ -181,7 +180,7 @@ class Layout extends Component {
 						<AsyncLoad require="blocks/inline-help" placeholder={ null } />
 					) }
 				<SupportArticleDialog />
-				<AppBanner />
+				<AsyncLoad require="blocks/app-banner" placeholder={ null } />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 			</div>
 		);


### PR DESCRIPTION
This PR changes a couple of PRs that are loaded on each page to be loaded asynchronously, as they are not critical for the app.

#### Changes proposed in this Pull Request

* Layout: AsyncLoad `AppBanner`
* Layout: AsyncLoad `GdprBanner`

#### Testing instructions

* Checkout this branch.
* Delete the `appBannerDismissTimes` preference if it exists for the current page.
* Go to http://calypso.localhost:3000/read on a mobile device or with a mobile device user agent
* Verify you can still see the app banner:

![](https://cldup.com/SBrYt03z1n.png)
* Delete the `sensitive_pixel_option` cookie if you have it.
* Go to  http://calypso.localhost:3000/read?flags=gdpr-banner
* If you're not in a GDPR-enabled country, you will have to enable `isCurrentUserMaybeInGdprZone` to return `true`.
* Verify you can still see the gdpr banner:

![](https://cldup.com/QV1HSZELvq.png)
