### PR TITLE
Post Editor: Fix icon prop in EditorDiscussion external links

### DIFF
--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -152,14 +152,14 @@ export class EditorDiscussion extends React.Component {
 											<ExternalLink
 												href="https://support.wordpress.com/comments/pingbacks/"
 												target="_blank"
-												icon="true"
+												icon
 											/>
 										),
 										trackbacksLink: (
 											<ExternalLink
 												href="https://support.wordpress.com/comments/trackbacks/"
 												target="_blank"
-												icon="true"
+												icon
 											/>
 										),
 									},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Post Editor: Fix icon prop in EditorDiscussion external links

#### Testing instructions

* Checkout this branch.
* Go to edit a Page or Post with the classic editor.
* In the sidebar, click on "More Options"
* Click on the "Allow Pingbacks & Trackbacks" (i) popover button.
* Verify the external links in the popover still work.
* Verify you no longer see this React warning:

![](https://cldup.com/1VNiXeEw0G.png)