### PR TITLE
Comments: Fix CommentHeader bulk checkbox to be readOnly

### DIFF
--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -29,7 +29,7 @@ export class CommentHeader extends PureComponent {
 			<div className="comment__header">
 				{ isBulkMode && (
 					<span className="comment__bulk-select">
-						<FormCheckbox checked={ isSelected } tabIndex="0" disabled={ isDisabled } />
+						<FormCheckbox checked={ isSelected } disabled={ isDisabled } readOnly tabIndex="0" />
 					</span>
 				) }
 


### PR DESCRIPTION
This PR updates the bulk edit checkbox in the `CommentHeader` component to be `readOnly` because its value is actually controlled from the wrapping `Card` and it doesn't have a `onClick` itself.

#### Changes proposed in this Pull Request

* Comments: Fix CommentHeader bulk checkbox to be readOnly

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/comments/all/:site where `:site` is one of your sites.
* Click the "Bulk Edit" button in the top right.
* Verify the bulk edit checkbox works just like it did before when (de)selecting all comments or (de)selecting comments one by one.
* Verify you no longer see this React warning:

![](https://cldup.com/6xPgjRwvzy.png)