### PR TITLE
Me: Fix showingForm to be string in ProfileLinks

### DIFF
--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -17,7 +17,7 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 class AddProfileLinksButtons extends React.Component {
 	static propTypes = {
-		showingForm: PropTypes.bool,
+		showingForm: PropTypes.string,
 		showPopoverMenu: PropTypes.bool,
 		onShowAddWordPress: PropTypes.func.isRequired,
 		onShowAddOther: PropTypes.func.isRequired,
@@ -47,7 +47,7 @@ class AddProfileLinksButtons extends React.Component {
 				<Button
 					ref={ this.popoverContext }
 					compact
-					disabled={ this.props.showingForm }
+					disabled={ !! this.props.showingForm }
 					onClick={ this.props.onShowPopoverMenu }
 				>
 					<Gridicon icon="add-outline" />

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -29,7 +29,7 @@ import './style.scss';
 
 class ProfileLinks extends React.Component {
 	state = {
-		showingForm: false,
+		showingForm: null,
 		showPopoverMenu: false,
 	};
 
@@ -61,7 +61,7 @@ class ProfileLinks extends React.Component {
 
 	hideForms = () => {
 		this.setState( {
-			showingForm: false,
+			showingForm: null,
 		} );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Me: Fix `showingForm` prop to be `string` in `ProfileLinks`

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/me
* Scroll down to the "Profile Links" section.
* Try adding both a custom link and one of your sites as a profile link.
* Verify the entire section works like it did before (try adding and removing links).
* Verify you no longer see this React warning:

![](https://cldup.com/jhTqFiJcY7.png)