### PR TITLE
Build: Don't use @wordpress/element transpilation in FSE

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,12 +10,6 @@ const codeSplit = config.isEnabled( 'code-splitting' );
 const babelConfig = {
 	presets: [ [ '@automattic/calypso-build/babel/default', { modules } ] ],
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
-	overrides: [
-		{
-			test: './apps/full-site-editing',
-			presets: [ require.resolve( '@automattic/calypso-build/babel/wordpress-element' ) ],
-		},
-	],
 	env: {
 		production: {
 			plugins: [ 'babel-plugin-transform-react-remove-prop-types' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

No longer transpile JSX in `apps/full-site-editing` using the `@wordpress/element` preset at app level.
Leftover from #38282. This was only needed while FSE code was being imported from the Gutenboarding entrypoint, which is built as part of Calypso-the-app. It's no longer required per #38584, since FSE is now only built separately (as it was before #38282), using its own build config.

#### Testing instructions

Verify that Calypso still builds, and that Gutenboarding still works.
