### PR TITLE
SPT: Handle NUX deprecation

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -369,10 +369,8 @@ export const PageTemplatesPlugin = compose(
 			postContentBlock: select( 'core/editor' )
 				.getBlocks()
 				.find( block => block.name === 'a8c/post-content' ),
-			isWelcomeGuideActive: select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ), // Gutenberg 7.2.0 and higher
-			areTipsEnabled: select( 'core/nux' ).areTipsEnabled
-				? select( 'core/nux' ).areTipsEnabled()
-				: false, // Gutenberg 7.1.0 and lower
+			isWelcomeGuideActive: select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ), // Gutenberg 7.2.0 or higher
+			areTipsEnabled: select( 'core/nux' ) ? select( 'core/nux' ).areTipsEnabled() : false, // Gutenberg 7.1.0 or lower
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -93,6 +93,11 @@ class PageTemplateModal extends Component {
 		if ( ! prevState.isOpen && this.state.isOpen ) {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
+
+		// Disable welcome guide right away as it collides with the modal window.
+		if ( this.props.isWelcomeGuideActive || this.props.areTipsEnabled ) {
+			this.props.hideWelcomeGuide();
+		}
 	}
 
 	static getDefaultSelectedTemplate = props => {
@@ -364,19 +369,13 @@ export const PageTemplatesPlugin = compose(
 			postContentBlock: select( 'core/editor' )
 				.getBlocks()
 				.find( block => block.name === 'a8c/post-content' ),
-			isWelcomeGuideActive: select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ),
+			isWelcomeGuideActive: select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ), // Gutenberg 7.2.0 and higher
+			areTipsEnabled: select( 'core/nux' ).areTipsEnabled
+				? select( 'core/nux' ).areTipsEnabled()
+				: false, // Gutenberg 7.1.0 and lower
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
-		// Disable welcome guide right away as it collides with the modal window.
-		if ( ownProps.isWelcomeGuideActive ) {
-			// Gutenberg 7.1.0 or higher.
-			dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-		} else if ( dispatch( 'core/nux' ).disableTips ) {
-			// Gutenberg 7.0.0 or lower.
-			dispatch( 'core/nux' ).disableTips();
-		}
-
 		const editorDispatcher = dispatch( 'core/editor' );
 		return {
 			saveTemplateChoice: slug => {
@@ -402,6 +401,15 @@ export const PageTemplatesPlugin = compose(
 					blocks,
 					false
 				);
+			},
+			hideWelcomeGuide: () => {
+				if ( ownProps.isWelcomeGuideActive ) {
+					// Gutenberg 7.2.0 or higher.
+					dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+				} else if ( ownProps.areTipsEnabled ) {
+					// Gutenberg 7.1.0 or lower.
+					dispatch( 'core/nux' ).disableTips();
+				}
 			},
 		};
 	} )

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -364,11 +364,18 @@ export const PageTemplatesPlugin = compose(
 			postContentBlock: select( 'core/editor' )
 				.getBlocks()
 				.find( block => block.name === 'a8c/post-content' ),
+			isWelcomeGuideActive: select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
-		// Disable tips right away as the collide with the modal window.
-		dispatch( 'core/nux' ).disableTips();
+		// Disable welcome guide right away as it collides with the modal window.
+		if ( ownProps.isWelcomeGuideActive ) {
+			// Gutenberg 7.1.0 or higher.
+			dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+		} else if ( dispatch( 'core/nux' ).disableTips ) {
+			// Gutenberg 7.0.0 or lower.
+			dispatch( 'core/nux' ).disableTips();
+		}
 
 		const editorDispatcher = dispatch( 'core/editor' );
 		return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

SPT is currently dispatching a `disableTips` action for disabling the welcome guide when the page layout selector is displayed, but `@wordpress/nux` will be deprecated and not imported by default in Gutenberg 7.2.0 (https://github.com/WordPress/gutenberg/pull/18981). That means that `disableTips` will not be available and will break the editor:

<img width="925" alt="Screenshot 2019-12-30 at 11 18 49" src="https://user-images.githubusercontent.com/1233880/71580917-1f679600-2b03-11ea-837d-ae2a123a0824.png">

This PR handles that deprecation by hiding the welcome guide using `isFeatureActive( 'welcomeGuide' )`/`toggleFeature( 'welcomeGuide' )` (available since Gutenberg 7.1.0) and defers to `disableTips` only when the action is available (Gutenberg 7.0.0 and below).

#### Testing instructions

* Generate a new build of the FSE plugin and upload it to a WP.org test site.
* Make sure you're running a custom build of the Gutenberg plugin based on master (so the NUX package is deprecated).
* Clear your browser's persisted state by running `localStorage.clear()` in DevTools.
* Go to Pages > Add New.
* Verify the page layout selector is displayed without the welcome guide.
* Deactivate the Gutenberg plugin (so WP loads the block editor bundled in core where the NUX package is not deprecated yet).
* Clear your browser's persisted state by running `localStorage.clear()` in DevTools.
* Go to Pages > Add New.
* Verify the page layout selector is displayed without the welcome guide.
