### PR TITLE
Checklist: make sure icons are in front of vertical line

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -88,6 +88,7 @@ $z-layers: (
 		'.google-my-business__close-icon': 1,
 		'.google-my-business__stats-nudge.dismissible-card__close-icon': 1,
 		'.is-section-purchases .search': 1,
+		'.checklist__task': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,
@@ -272,6 +273,10 @@ $z-layers: (
 	'.upwork-banner': (
 		'.button.upwork-banner__cta': 2,
 		'.button.upwork-banner__close': 4
+	),
+	'.checklist__task': (
+		'.checklist__task::before': 10,
+		'.checklist__task-icon': 20
 	),
 
 	// The following may be inserted into different areas.

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -57,6 +57,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		border: 2px solid var( --color-neutral-5 );
 		border-radius: 16px;
 		background: var( --color-surface );
+		z-index: 2;
 
 		@include breakpoint( '>660px' ) {
 			left: 24px;

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -27,6 +27,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 .checklist__task {
 	width: 100%;
 	order: 1;
+	z-index: z-index( 'root', '.checklist__task' );
 
 	.hide-completed &.is-completed {
 		display: none;
@@ -44,7 +45,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		bottom: 0;
 		left: 34px;
 		border-left: 1px solid var( --color-neutral-10 );
-		z-index: 1;
+		z-index: z-index( '.checklist__task', '.checklist__task::before' );
 	}
 
 	.checklist__task-icon {
@@ -57,7 +58,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		border: 2px solid var( --color-neutral-5 );
 		border-radius: 16px;
 		background: var( --color-surface );
-		z-index: 2;
+		z-index: z-index( '.checklist__task', '.checklist__task-icon' );
 
 		@include breakpoint( '>660px' ) {
 			left: 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR brings back a z-index value for the icons on the checklist. This ensures the icons are in front of the vertical line.
* This was introduced in https://github.com/Automattic/wp-calypso/pull/34130 and later removed in https://github.com/Automattic/wp-calypso/pull/37809 in what seems to be a regression? cc @sixhours

#### Before

![image](https://user-images.githubusercontent.com/390760/71590555-e5a58800-2b20-11ea-9b94-c462abc059ae.png)


#### After

![image](https://user-images.githubusercontent.com/390760/71590548-dc1c2000-2b20-11ea-8a5f-3593148e7586.png)


#### Testing instructions

* Spin up this PR.
* Create a [new JN site](https://jurassic.ninja/create/).
* Connect the site and purchase a plan.
* When dropped on the checklist, ensure all icons are in front of the vertical line.

Fixes #38643