### PR TITLE
Site migration: error view

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -63,11 +63,11 @@ class SectionMigrate extends Component {
 	resetMigration = () => {
 		const { targetSiteId, targetSiteSlug } = this.props;
 
-		this.setMigrationState( { migrationStatus: 'unknown', errorMessage: '' } );
-		this.updateFromAPI();
+		this.setMigrationState( { migrationStatus: 'inactive', errorMessage: '' } );
 
 		wpcom.resetMigration( targetSiteId ).then( () => {
 			page( `/migrate/${ targetSiteSlug }` );
+			this.updateFromAPI();
 		} );
 	};
 
@@ -152,8 +152,8 @@ class SectionMigrate extends Component {
 					} );
 				}
 			} )
-			.catch( () => {
-				// @TODO: handle status error
+			.catch( error => {
+				this.setMigrationState( { migrationStatus: 'error', errorMessage: error.message } );
 			} );
 	};
 
@@ -175,7 +175,7 @@ class SectionMigrate extends Component {
 
 		return (
 			<CompactCard className="migrate__card-footer">
-				A Business Plan is required to migrate your theme and plugins. Or you can{ ' ' }
+				You need a Business Plan to import your theme and plugins. Or you can{ ' ' }
 				<a href={ this.getImportHref() }>import just your content</a> instead.
 			</CompactCard>
 		);
@@ -201,7 +201,7 @@ class SectionMigrate extends Component {
 					align="left"
 				/>
 				<CompactCard>
-					<div className="migrate__status">Your migration has completed successfully.</div>
+					<div className="migrate__status">Your import has completed successfully.</div>
 					<Button primary href={ viewSiteURL }>
 						View site
 					</Button>
@@ -219,9 +219,9 @@ class SectionMigrate extends Component {
 
 		return (
 			<>
-				<HeaderCake backHref={ backHref }>Migrate { sourceSiteDomain }</HeaderCake>
+				<HeaderCake backHref={ backHref }>Import { sourceSiteDomain }</HeaderCake>
 				<CompactCard>
-					<CardHeading>{ `Migrate everything from ${ sourceSiteDomain } to WordPress.com.` }</CardHeading>
+					<CardHeading>{ `Import everything from ${ sourceSiteDomain } to WordPress.com.` }</CardHeading>
 					<div className="migrate__confirmation">
 						We can move everything from your current site to this WordPress.com site. It will keep
 						working as expected, but your WordPress.com dashboard will be locked during the
@@ -250,7 +250,7 @@ class SectionMigrate extends Component {
 						</ul>
 					</div>
 					<Button primary onClick={ this.startMigration }>
-						Migrate site
+						Import site
 					</Button>
 					<Button className="migrate__cancel" href={ backHref }>
 						Cancel
@@ -308,7 +308,7 @@ class SectionMigrate extends Component {
 				/>
 				<FormattedHeader
 					className="migrate__section-header"
-					headerText="Migration in progress"
+					headerText="Import in progress"
 					subHeaderText={ subHeaderText }
 					align="center"
 				/>
@@ -324,7 +324,7 @@ class SectionMigrate extends Component {
 			return <div className="migrate__start-time">&nbsp;</div>;
 		}
 
-		return <div className="migrate__start-time">Migration started { this.state.startTime }</div>;
+		return <div className="migrate__start-time">Import started { this.state.startTime }</div>;
 	}
 
 	renderProgressBar() {
@@ -419,9 +419,9 @@ class SectionMigrate extends Component {
 					align="left"
 				/>
 				<CompactCard className="migrate__card">
-					<CardHeading>Select the Jetpack enabled site you want to migrate.</CardHeading>
+					<CardHeading>Select the Jetpack enabled site you want to import.</CardHeading>
 					<div className="migrate__explain">
-						If your site is connected to your WordPress.com account through Jetpack, we can migrate
+						If your site is connected to your WordPress.com account through Jetpack, we can import
 						all your content, users, themes, plugins, and settings.
 					</div>
 					<SiteSelector

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -8,6 +8,10 @@
 	margin-bottom: 16px;
 }
 
+.migrate__status {
+	text-align: center;
+}
+
 .migrate__card {
 	.site__content, .site-selector__hidden-sites-message {
 		border-bottom: 1px solid var( --color-neutral-10 );


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Adds illustration and some formatting tweaks to error view.
* If migration endpoint returns an error, sets component error state which is only cleared when user resets the migration.

#### Testing instructions

(Note: most of these instructions are general instructions for testing migration. The bolded steps are the ones specific to this change)

* **Sandbox the public API and hack one of the endpoint files to force the migration endpoint to return an error. For example, comment out one of the conditions in the migration permission callback.**
* Check out this pull request and run Calypso locally, or use calypso.live.
* Viewing calypso.localhost:3000/migrate/, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* **Select a Simple site.** 
* When you select the site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Accept the confirmation.
* **You should see an error view.**
* **Dismiss the view by clicking the "Try again" button.**
* **This time, switch your site to a normally valid target site and start a migration.**
* **You should see the error view again when the start migration endpoint or migration status endpoints return the forced error.**

<img width="954" alt="image" src="https://user-images.githubusercontent.com/1647564/71591821-ac234b80-2b25-11ea-8f80-9875dc8a25bc.png">


Fixes #
