### PR TITLE
composite-checkout: Move onPaymentComplete call to CheckoutProvider

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -360,3 +360,5 @@ To maintain the integrity of the line item schema, adding custom fields is disco
 ## Development
 
 In the root of the monorepo, run `npm run composite-checkout-demo` which will start a local webserver that will display the component.
+
+To run the tests for this package, run `npm run test-packages composite-checkout`.

--- a/packages/composite-checkout/jest.config.js
+++ b/packages/composite-checkout/jest.config.js
@@ -1,1 +1,6 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	testEnvironment: 'jsdom',
+	globals: { window: { navigator: { userAgent: 'jest' } } },
+};

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -48,6 +48,12 @@ export const CheckoutProvider = props => {
 	);
 
 	const [ formStatus, setFormStatus ] = useFormStatusManager( isLoading );
+	useEffect( () => {
+		if ( formStatus === 'complete' ) {
+			debug( "form status is complete so I'm calling onPaymentComplete" );
+			onPaymentComplete();
+		}
+	}, [ formStatus, onPaymentComplete ] );
 
 	// Remove undefined and duplicate CheckoutWrapper properties
 	const wrappers = [
@@ -64,7 +70,6 @@ export const CheckoutProvider = props => {
 			allPaymentMethods: paymentMethods,
 			paymentMethodId,
 			setPaymentMethodId,
-			onPaymentComplete,
 			showErrorMessage,
 			showInfoMessage,
 			showSuccessMessage,
@@ -78,7 +83,6 @@ export const CheckoutProvider = props => {
 			failureRedirectUrl,
 			formStatus,
 			onEvent,
-			onPaymentComplete,
 			paymentMethodId,
 			paymentMethods,
 			setFormStatus,
@@ -178,14 +182,6 @@ function PaymentMethodWrapperProvider( { children, wrappers } ) {
 	return wrappers.reduce( ( whole, Wrapper ) => {
 		return <Wrapper>{ whole }</Wrapper>;
 	}, children );
-}
-
-export function usePaymentComplete() {
-	const { onPaymentComplete } = useContext( CheckoutContext );
-	if ( ! onPaymentComplete ) {
-		throw new Error( 'usePaymentComplete can only be used inside a CheckoutProvider' );
-	}
-	return onPaymentComplete;
 }
 
 export function useEvents() {

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -31,7 +31,7 @@ import {
 	getDefaultOrderReviewStep,
 } from './default-steps';
 import { validateSteps } from '../lib/validation';
-import { useEvents, usePaymentComplete } from './checkout-provider';
+import { useEvents } from './checkout-provider';
 import { useFormStatus } from '../lib/form-status';
 import useConstructor from '../lib/use-constructor';
 
@@ -84,7 +84,6 @@ export default function Checkout( { steps, className } ) {
 	const [ paymentData ] = usePaymentData();
 	const activePaymentMethod = usePaymentMethod();
 	const { formStatus } = useFormStatus();
-	const onPaymentComplete = usePaymentComplete();
 
 	// Re-render if any store changes; that way isComplete can rely on any data
 	useRenderOnStoreUpdate();
@@ -135,13 +134,6 @@ export default function Checkout( { steps, className } ) {
 	const isThereAnIncompleteStep = !! annotatedSteps.find( step => ! step.isComplete );
 	const isCheckoutInProgress =
 		isThereAnIncompleteStep || isThereAnotherNumberedStep || formStatus !== 'ready';
-
-	useEffect( () => {
-		if ( formStatus === 'complete' ) {
-			debug( "form status is complete so I'm calling onPaymentComplete" );
-			onPaymentComplete();
-		}
-	}, [ formStatus, onPaymentComplete ] );
 
 	if ( formStatus === 'loading' ) {
 		return (

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -19,9 +19,15 @@ import {
 const noop = () => {};
 
 const CustomForm = () => {
-	const { formStatus, setFormComplete, setFormLoading } = useFormStatus();
+	const { formStatus, setFormComplete, setFormLoading, setFormSubmitting } = useFormStatus();
 	if ( formStatus === 'loading' ) {
 		return <div>Loading</div>;
+	}
+	if ( formStatus === 'submitting' ) {
+		return <div>Submitting</div>;
+	}
+	if ( formStatus === 'complete' ) {
+		return <div>Form Complete</div>;
 	}
 	return (
 		<div>
@@ -29,8 +35,11 @@ const CustomForm = () => {
 			<button disabled={ formStatus !== 'ready' } onClick={ setFormLoading }>
 				Load
 			</button>
-			<button disabled={ formStatus !== 'ready' } onClick={ setFormComplete }>
+			<button disabled={ formStatus !== 'ready' } onClick={ setFormSubmitting }>
 				Submit
+			</button>
+			<button disabled={ formStatus !== 'ready' } onClick={ setFormComplete }>
+				Complete
 			</button>
 		</div>
 	);
@@ -76,12 +85,20 @@ describe( 'CheckoutProvider', () => {
 		expect( getByText( 'Submit' ) ).not.toBeDisabled();
 	} );
 
-	it( 'sets form status to complete when setFormComplete is called', () => {
-		const { getByText } = render( <MyCheckout /> );
+	it( 'sets form status to submitting when setFormSubmitting is called', () => {
+		const { getByText, queryByText } = render( <MyCheckout /> );
 		const button = getByText( 'Submit' );
-		expect( button ).not.toBeDisabled();
+		expect( queryByText( 'Submitting' ) ).not.toBeInTheDocument();
 		fireEvent.click( button );
-		expect( button ).toBeDisabled();
+		expect( getByText( 'Submitting' ) ).toBeInTheDocument();
+	} );
+
+	it( 'sets form status to complete when setFormComplete is called', () => {
+		const { getByText, queryByText } = render( <MyCheckout /> );
+		const button = getByText( 'Complete' );
+		expect( queryByText( 'Form Complete' ) ).not.toBeInTheDocument();
+		fireEvent.click( button );
+		expect( getByText( 'Form Complete' ) ).toBeInTheDocument();
 	} );
 
 	it( 'sets form status to loading when setFormLoading is called', () => {
@@ -102,9 +119,9 @@ describe( 'CheckoutProvider', () => {
 	it( 'calls onPaymentComplete when form status is complete', () => {
 		const onPaymentComplete = jest.fn();
 		const { getByText } = render( <MyCheckout onPaymentComplete={ onPaymentComplete } /> );
-		const button = getByText( 'Submit' );
+		const button = getByText( 'Complete' );
 		fireEvent.click( button );
-		expect( button ).toBeDisabled();
+		expect( getByText( 'Form Complete' ) ).toBeInTheDocument();
 		expect( onPaymentComplete ).toBeCalled();
 	} );
 } );

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CheckoutProvider,
+	useSelect,
+	useDispatch,
+	useRegisterStore,
+	useFormStatus,
+} from '../src/public-api';
+
+const noop = () => {};
+
+const CustomForm = () => {
+	const { formStatus, setFormComplete, setFormLoading } = useFormStatus();
+	if ( formStatus === 'loading' ) {
+		return <div>Loading</div>;
+	}
+	return (
+		<div>
+			<input type="text" />
+			<button disabled={ formStatus !== 'ready' } onClick={ setFormLoading }>
+				Load
+			</button>
+			<button disabled={ formStatus !== 'ready' } onClick={ setFormComplete }>
+				Submit
+			</button>
+		</div>
+	);
+};
+
+describe( 'CheckoutProvider', () => {
+	let MyCheckout;
+	const mockMethod = createMockMethod();
+	const { items, total } = createMockItems();
+
+	beforeEach( () => {
+		MyCheckout = ( { onPaymentComplete, isLoading } ) => (
+			<CheckoutProvider
+				locale="en-us"
+				items={ items }
+				total={ total }
+				isLoading={ isLoading || null }
+				onPaymentComplete={ onPaymentComplete || noop }
+				showErrorMessage={ noop }
+				showInfoMessage={ noop }
+				showSuccessMessage={ noop }
+				successRedirectUrl="#"
+				failureRedirectUrl="#"
+				paymentMethods={ [ mockMethod ] }
+			>
+				<CustomForm />
+			</CheckoutProvider>
+		);
+	} );
+
+	it( 'sets form status to loading when isLoading is true', () => {
+		const { getByText } = render( <MyCheckout isLoading={ true } /> );
+		expect( getByText( 'Loading' ) ).toBeInTheDocument();
+	} );
+
+	it( 'sets form status to ready when isLoading is false', () => {
+		const { getByText } = render( <MyCheckout isLoading={ false } /> );
+		expect( getByText( 'Submit' ) ).not.toBeDisabled();
+	} );
+
+	it( 'sets form status to ready when isLoading is absent', () => {
+		const { getByText } = render( <MyCheckout /> );
+		expect( getByText( 'Submit' ) ).not.toBeDisabled();
+	} );
+
+	it( 'sets form status to complete when setFormComplete is called', () => {
+		const { getByText } = render( <MyCheckout /> );
+		const button = getByText( 'Submit' );
+		expect( button ).not.toBeDisabled();
+		fireEvent.click( button );
+		expect( button ).toBeDisabled();
+	} );
+
+	it( 'sets form status to loading when setFormLoading is called', () => {
+		const { getByText, queryByText } = render( <MyCheckout /> );
+		const button = getByText( 'Load' );
+		expect( queryByText( 'Loading' ) ).not.toBeInTheDocument();
+		fireEvent.click( button );
+		expect( getByText( 'Loading' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not call onPaymentComplete when form status is not complete', () => {
+		const onPaymentComplete = jest.fn();
+		const { getByText } = render( <MyCheckout onPaymentComplete={ onPaymentComplete } /> );
+		expect( getByText( 'Submit' ) ).not.toBeDisabled();
+		expect( onPaymentComplete ).not.toBeCalled();
+	} );
+
+	it( 'calls onPaymentComplete when form status is complete', () => {
+		const onPaymentComplete = jest.fn();
+		const { getByText } = render( <MyCheckout onPaymentComplete={ onPaymentComplete } /> );
+		const button = getByText( 'Submit' );
+		fireEvent.click( button );
+		expect( button ).toBeDisabled();
+		expect( onPaymentComplete ).toBeCalled();
+	} );
+} );
+
+function createMockMethod() {
+	return {
+		id: 'mock',
+		label: <span data-testid="mock-label">Mock Label</span>,
+		activeContent: <MockPaymentForm />,
+		submitButton: <button>Pay Please</button>,
+		inactiveContent: 'Mock Method',
+		getAriaLabel: () => 'Mock Method',
+	};
+}
+
+function MockPaymentForm( { summary } ) {
+	useRegisterStore( 'mock', {
+		reducer( state = {}, action ) {
+			switch ( action.type ) {
+				case 'CARDHOLDER_NAME_SET':
+					return { ...state, cardholderName: action.payload };
+			}
+			return state;
+		},
+		actions: {
+			changeCardholderName( payload ) {
+				return { type: 'CARDHOLDER_NAME_SET', payload };
+			},
+		},
+		selectors: {
+			getCardholderName( state ) {
+				return state.cardholderName || '';
+			},
+		},
+	} );
+	const cardholderName = useSelect( select => select( 'mock' ).getCardholderName() );
+	const { changeCardholderName } = useDispatch( 'mock' );
+	return (
+		<div data-testid="mock-payment-form">
+			<label>
+				{ summary ? 'Name Summary' : 'Cardholder Name' }
+				<input name="cardholderName" value={ cardholderName } onChange={ changeCardholderName } />
+			</label>
+		</div>
+	);
+}
+
+function createMockItems() {
+	const items = [
+		{
+			label: 'Illudium Q-36 Explosive Space Modulator',
+			id: 'space-modulator',
+			type: 'widget',
+			amount: { currency: 'USD', value: 5500, displayValue: '$55' },
+		},
+		{
+			label: 'Air Jordans',
+			id: 'sneakers',
+			type: 'apparel',
+			amount: { currency: 'USD', value: 12000, displayValue: '$120' },
+		},
+	];
+	const total = {
+		label: 'Total',
+		id: 'total',
+		type: 'total',
+		amount: { currency: 'USD', value: 17500, displayValue: '$175' },
+	};
+	return { items, total };
+}

--- a/packages/composite-checkout/test/checkout-step.js
+++ b/packages/composite-checkout/test/checkout-step.js
@@ -7,7 +7,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import CheckoutStep from '../../src/components/checkout-step';
+import CheckoutStep from '../src/components/checkout-step';
 
 describe( 'CheckoutStep', function() {
 	describe( 'inactive and incomplete', function() {

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -1,6 +1,3 @@
-// This is required to fix the "regeneratorRuntime is not defined" error
-require( '@babel/polyfill' );
-
 /**
  * External dependencies
  */
@@ -25,7 +22,7 @@ import {
 	createRegistry,
 	useRegisterStore,
 	usePaymentData,
-} from '../../src/public-api';
+} from '../src/public-api';
 
 const noop = () => {};
 

--- a/packages/composite-checkout/test/join-classes.js
+++ b/packages/composite-checkout/test/join-classes.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import joinClasses from '../../src/lib/join-classes';
+import joinClasses from '../src/lib/join-classes';
 
 describe( 'joinClasses', function() {
 	it( 'returns an empty string when passed an empty array', function() {

--- a/packages/composite-checkout/test/line-items.js
+++ b/packages/composite-checkout/test/line-items.js
@@ -8,7 +8,7 @@ import '@testing-library/jest-dom/extend-expect';
 /**
  * Internal dependencies
  */
-import { LineItemsProvider, useLineItems } from '../../src/lib/line-items';
+import { LineItemsProvider, useLineItems } from '../src/lib/line-items';
 
 // React writes to console.error when a component throws before re-throwing
 // but we don't want to see that here so we mock console.error.

--- a/packages/composite-checkout/test/localize.js
+++ b/packages/composite-checkout/test/localize.js
@@ -8,7 +8,7 @@ import '@testing-library/jest-dom/extend-expect';
 /**
  * Internal dependencies
  */
-import { useLocalize, LocalizeProvider } from '../../src/lib/localize';
+import { useLocalize, LocalizeProvider } from '../src/lib/localize';
 
 // React writes to console.error when a component throws before re-throwing
 // but we don't want to see that here so we mock console.error.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to #38525

The concepts of form status and the `onPaymentComplete` callback all
exist at the level of the `CheckoutProvider`. Since the `Checkout`
component could, by design, be substituted for a different form, it
shouldn't have to hold the responsibility of calling `onPaymentComplete`
when the form status becomes complete.

This PR moves that responsibility up to the `CheckoutProvider` instead.

In addition, this means that the `onPaymentComplete` callback never has
to leave the `CheckoutProvider` and becomes tied directly to the form
status.

#### Testing instructions

This PR should not actually change any behavior, but the behavior should be tested regardless.

First test the demo.

- Run `npm run composite-checkout-demo`.
- Complete the form using the Credit card payment method (use the Stripe test card of `4242424242424242`) and press "Pay".
- Verify that there is a short pause during which the button is disabled, then the page should redirect to a "complete" page.

Then test Calypso.

- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`
- Add a plan to your cart (not a domain) and visit checkout.
- Complete the form using the Credit card payment method (use the Stripe test card of `4242424242424242`) and press "Pay".
- Verify that there is a short pause during which the button is disabled, then the page should redirect to a "complete" page.
