### PR TITLE
Components: Fix dialog backdrop card style

### DIFF
--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -1,4 +1,5 @@
-.dialog__backdrop {
+.dialog__backdrop,
+.dialog__backdrop.card {
 	background-color: rgba( var( --color-neutral-0-rgb ), 0.8 );
 	align-items: center;
 	bottom: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix dialog backdrop card style

#### Preview

Before:
![](https://cldup.com/6-GxvKyxkz.png)

After:
![](https://cldup.com/fbc2y7bQcu.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/my-plan/:site?thank-you= where `:site` is a Jetpack site slug.
* Verify you can see the background overlay on the full screen as shown on the "After" screenshot

Note: this issue is not reproducible locally. If it looks unchanged after this change locally, it should be good.

Fixes #38617