### PR TITLE
Marketing: A/B test reader sidebar upsell nudge

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -156,6 +156,5 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 		localeTargets: 'any',
-		localeExceptions: [ 'en' ],
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -149,7 +149,7 @@ export default {
 	},
 	readerFreeToPaidPlanNudge: {
 		datestamp: '20200102',
-		variatations: {
+		variations: {
 			display: 50,
 			control: 50,
 		},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -147,4 +147,15 @@ export default {
 		localeTargets: 'any',
 		localeExceptions: [ 'en' ],
 	},
+	readerFreeToPaidPlanNudge: {
+		datestamp: '20200102',
+		variatations: {
+			display: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+		localeExceptions: [ 'en' ],
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -154,7 +154,7 @@ export default {
 			control: 50,
 		},
 		defaultVariation: 'control',
-		allowExistingUsers: true,
+		allowExistingUsers: false,
 		localeTargets: 'any',
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an a/b test for the reader sidebar upsell nudge. English speaking US users are not included in the test though they can see the nudge.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You should be a user who has only one free plan dotcom site.
* Go to the Reader page.
  1. If you are an English US user, you should be able to see the nudge in the sidebar but you should not be assigned to any group of the `readerFreeToPaidPlanNudge` test.
  2. If you are a non EN user or non US user, you should be assigned to a group of the `readerFreeToPaidPlanNudge` test. If you are in `display` group, the nudge should appear in the sidebar.
  3. If you have two sites or more, the nudge should not appear.
  4. If the only site you have is on a paid plan, the nudge should not appear.

_Note_: In dev env, you can change your country as follows.
```
// in browser console
window.userCountryCode = 'US';
```