### PR TITLE
Show backup screenshot in activity log

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -159,28 +159,29 @@ class ActivityLogItem extends Component {
 				activityMedia,
 				isBreakpointActive: isDesktop,
 				activityName,
-				rewindId,
+				backupPeriod,
 			},
 			siteId,
 		} = this.props;
 
-		wpcom.req
-			.get( {
-				path: `/sites/${ siteId }/rewind/screenshots?period=${ rewindId }`,
-				apiNamespace: 'wpcom/v2',
-			} )
-			.then( resp => {
-				if ( null === resp.encodedData ) {
-					return;
-				}
-
-				// inject the received response into the img
-				const URL = 'data:' + resp.contentType + ';base64,' + resp.encodedData;
-				document.getElementById( `img_${ rewindId }` ).src = URL;
-			} )
-			.catch( err => {
-				return err;
-			} );
+		if ( backupPeriod ) {
+			wpcom.req
+				.get( {
+					path: `/sites/${ siteId }/rewind/screenshots?period=${ backupPeriod }`,
+					apiNamespace: 'wpcom/v2',
+				} )
+				.then( resp => {
+					if ( null === resp.data ) {
+						return;
+					}
+					// inject the received response into the img
+					const URL = 'data:' + resp.contentType + ';base64,' + resp.data;
+					document.getElementById( `img_${ backupPeriod }` ).src = URL;
+				} )
+				.catch( err => {
+					return err;
+				} );
+		}
 
 		return (
 			<div className="activity-log-item__card-header">
@@ -204,12 +205,12 @@ class ActivityLogItem extends Component {
 							activity={ this.props.activity }
 							rewindIsActive={ this.props.rewindIsActive }
 						/>
-						{ 'rewind__backup_complete_full' === activityName && (
+						{ backupPeriod && 'rewind__backup_complete_full' === activityName && (
 							<Image
 								src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
 								alt="Backup screenshot"
 								className="activity-log-item__screenshot-picture"
-								id={ `img_${ rewindId }` }
+								id={ `img_${ backupPeriod }` }
 							/>
 						) }
 					</div>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -43,6 +43,8 @@ import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import { getSite } from 'state/sites/selectors';
 import { withDesktopBreakpoint } from 'lib/viewport/react';
 import { withLocalizedMoment } from 'components/localized-moment';
+import Image from 'components/image';
+import wpcom from 'lib/wp';
 
 /**
  * Style dependencies
@@ -156,8 +158,30 @@ class ActivityLogItem extends Component {
 				actorType,
 				activityMedia,
 				isBreakpointActive: isDesktop,
+				activityName,
+				rewindId,
 			},
+			siteId,
 		} = this.props;
+
+		wpcom.req
+			.get( {
+				path: `/sites/${ siteId }/rewind/screenshots?period=${ rewindId }`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			.then( resp => {
+				if ( null === resp.encodedData ) {
+					return;
+				}
+
+				// inject the received response into the img
+				const URL = 'data:' + resp.contentType + ';base64,' + resp.encodedData;
+				document.getElementById( `img_${ rewindId }` ).src = URL;
+			} )
+			.catch( err => {
+				return err;
+			} );
+
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
@@ -180,6 +204,14 @@ class ActivityLogItem extends Component {
 							activity={ this.props.activity }
 							rewindIsActive={ this.props.rewindIsActive }
 						/>
+						{ 'rewind__backup_complete_full' === activityName && (
+							<Image
+								src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+								alt="Backup screenshot"
+								className="activity-log-item__screenshot-picture"
+								id={ `img_${ rewindId }` }
+							/>
+						) }
 					</div>
 					<div className="activity-log-item__description-summary">{ activityTitle }</div>
 				</div>

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -68,6 +68,7 @@ export function processItem( item ) {
 			activityMedia: get( item, 'image' ),
 			activityMeta,
 		},
+		item.object && item.object.backup_period && { backupPeriod: item.object.backup_period },
 		item.rewind_id && { rewindId: item.rewind_id },
 		item.status && { activityStatus: item.status },
 		object && object.target_ts && { activityTargetTs: object.target_ts },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Render an image component to display a screenshot of a backup in the Activity Log entry.
* The image generation was a meetup project.

#### Testing instructions

1) Apply D36774 and related diffs. Make sure you sandbox both wpcom and vaultpress.
2) Trigger a backup. Take note of the period number.
3) Run the job async_store_backup_screenshot() by hand.
4) You should see the generated screenshot in the AL. It can take some time for it to be generated and saved, so keep refreshing.

OPTIONAL:

Use the API console.