### PR TITLE
Site migration: error view

### DIFF
--- a/client/my-sites/migrate/migrate-button.jsx
+++ b/client/my-sites/migrate/migrate-button.jsx
@@ -20,7 +20,7 @@ class MigrateButton extends Component {
 	render() {
 		return (
 			<Button primary busy={ this.state.busy } onClick={ this.handleClick }>
-				Migrate site
+				Import site
 			</Button>
 		);
 	}

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -265,11 +265,6 @@ class SectionMigrate extends Component {
 	renderMigrationError() {
 		return (
 			<Card className="migrate__pane">
-				<img
-					className="migrate__illustration"
-					src={ '/calypso/images/illustrations/waitTime.svg' }
-					alt=""
-				/>
 				<FormattedHeader
 					className="migrate__section-header"
 					headerText="Import failed"
@@ -281,7 +276,7 @@ class SectionMigrate extends Component {
 					{ this.state.errorMessage }
 				</div>
 				<Button primary onClick={ this.resetMigration }>
-					Try again
+					Back to your site
 				</Button>
 			</Card>
 		);

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -42,6 +42,7 @@ class SectionMigrate extends Component {
 		migrationStatus: 'unknown',
 		percent: 0,
 		startTime: '',
+		errorMessage: '',
 	};
 
 	componentDidMount() {
@@ -75,7 +76,7 @@ class SectionMigrate extends Component {
 			 * Note this migrationStatus is local, thus the setState vs setMigrationState.
 			 * Call to updateFromAPI will update both local and non-local state.
 			 */
-			this.setState( { migrationStatus: 'inactive' }, this.updateFromAPI );
+			this.setState( { migrationStatus: 'inactive', errorMessage: '' }, this.updateFromAPI );
 		} );
 	};
 
@@ -100,7 +101,10 @@ class SectionMigrate extends Component {
 		wpcom
 			.startMigration( sourceSiteId, targetSiteId )
 			.then( () => this.updateFromAPI() )
-			.catch( () => this.setMigrationState( { migrationStatus: 'error' } ) );
+			.catch( error => {
+				const { message = '' } = error;
+				this.setMigrationState( { migrationStatus: 'error', errorMessage: message } );
+			} );
 	};
 
 	updateFromAPI = () => {
@@ -150,8 +154,9 @@ class SectionMigrate extends Component {
 					} );
 				}
 			} )
-			.catch( () => {
-				// @TODO: handle status error
+			.catch( error => {
+				const { message = '' } = error;
+				this.setMigrationState( { migrationStatus: 'error', errorMessage: message } );
 			} );
 	};
 
@@ -173,7 +178,7 @@ class SectionMigrate extends Component {
 
 		return (
 			<CompactCard className="migrate__card-footer">
-				A Business Plan is required to migrate your theme and plugins. Or you can{ ' ' }
+				You need a Business Plan to import your theme and plugins. Or you can{ ' ' }
 				<a href={ this.getImportHref() }>import just your content</a> instead.
 			</CompactCard>
 		);
@@ -199,7 +204,7 @@ class SectionMigrate extends Component {
 					align="left"
 				/>
 				<CompactCard>
-					<div className="migrate__status">Your migration has completed successfully.</div>
+					<div className="migrate__status">Your import has completed successfully.</div>
 					<Button primary href={ viewSiteURL }>
 						View site
 					</Button>
@@ -217,9 +222,9 @@ class SectionMigrate extends Component {
 
 		return (
 			<>
-				<HeaderCake backHref={ backHref }>Migrate { sourceSiteDomain }</HeaderCake>
+				<HeaderCake backHref={ backHref }>Import { sourceSiteDomain }</HeaderCake>
 				<CompactCard>
-					<CardHeading>{ `Migrate everything from ${ sourceSiteDomain } to WordPress.com.` }</CardHeading>
+					<CardHeading>{ `Import everything from ${ sourceSiteDomain } to WordPress.com.` }</CardHeading>
 					<div className="migrate__confirmation">
 						We can move everything from your current site to this WordPress.com site. It will keep
 						working as expected, but your WordPress.com dashboard will be locked during the
@@ -259,20 +264,26 @@ class SectionMigrate extends Component {
 
 	renderMigrationError() {
 		return (
-			<>
+			<Card className="migrate__pane">
+				<img
+					className="migrate__illustration"
+					src={ '/calypso/images/illustrations/waitTime.svg' }
+					alt=""
+				/>
 				<FormattedHeader
 					className="migrate__section-header"
-					headerText="Migrate"
-					subHeaderText="Migrate your WordPress site to WordPress.com"
-					align="left"
+					headerText="Import failed"
+					align="center"
 				/>
-				<CompactCard>
-					<div className="migrate__status">There was an error with your migration.</div>
-					<Button primary onClick={ this.resetMigration }>
-						Try again
-					</Button>
-				</CompactCard>
-			</>
+				<div className="migrate__status">
+					There was an error with your import.
+					<br />
+					{ this.state.errorMessage }
+				</div>
+				<Button primary onClick={ this.resetMigration }>
+					Try again
+				</Button>
+			</Card>
 		);
 	}
 
@@ -300,7 +311,7 @@ class SectionMigrate extends Component {
 					/>
 					<FormattedHeader
 						className="migrate__section-header"
-						headerText="Migration in progress"
+						headerText="Import in progress"
 						subHeaderText={ subHeaderText }
 						align="center"
 					/>
@@ -317,7 +328,7 @@ class SectionMigrate extends Component {
 			return <div className="migrate__start-time">&nbsp;</div>;
 		}
 
-		return <div className="migrate__start-time">Migration started { this.state.startTime }</div>;
+		return <div className="migrate__start-time">Import started { this.state.startTime }</div>;
 	}
 
 	renderProgressBar() {
@@ -408,13 +419,13 @@ class SectionMigrate extends Component {
 			<>
 				<FormattedHeader
 					className="migrate__section-header"
-					headerText="Migrate your WordPress site to WordPress.com"
+					headerText="Import your WordPress site to WordPress.com"
 					align="left"
 				/>
 				<CompactCard className="migrate__card">
-					<CardHeading>Select the Jetpack enabled site you want to migrate.</CardHeading>
+					<CardHeading>Select the Jetpack enabled site you want to import.</CardHeading>
 					<div className="migrate__explain">
-						If your site is connected to your WordPress.com account through Jetpack, we can migrate
+						If your site is connected to your WordPress.com account through Jetpack, we can import
 						all your content, users, themes, plugins, and settings.
 					</div>
 					<SiteSelector

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -4,8 +4,13 @@
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
-.migrate__source-site, .migrate__confirmation, .migrate__status, .migrate__explain {
+.migrate__source-site, .migrate__confirmation, .migrate__explain {
 	margin-bottom: 16px;
+}
+
+.migrate__status {
+	margin-bottom: 16px;
+	text-align: center;
 }
 
 .migrate__card {


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

This PR is based on https://github.com/Automattic/wp-calypso/pull/38523 – we should merge that one first.

#### Changes proposed in this Pull Request

* Adds illustration and some formatting tweaks to error view.
* Changes "migrate" to "import" in texts displayed to the user in line with our decision to present migration as a form of import.

<img width="919" alt="image" src="https://user-images.githubusercontent.com/1647564/71621446-2ce65400-2bc7-11ea-9a70-4da50d61cc7c.png">

#### Testing instructions


(Note: most of these instructions are general instructions for testing migration. The bolded steps are the ones specific to this change)

* Check out this pull request and run Calypso locally, or use calypso.live.
* Viewing calypso.localhost:3000/migrate/, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* **Select a Simple site.** 
* When you select the site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Accept the confirmation.
* **You should see an error view.**
* **Dismiss the view by clicking the "Try again" button.**