### PR TITLE
Add FormFieldAnnotation component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32079,9 +32079,9 @@
 					}
 				},
 				"terser": {
-					"version": "4.6.1",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.1.tgz",
-					"integrity": "sha512-w0f2OWFD7ka3zwetgVAhNMeyzEbj39ht2Tb0qKflw9PmW9Qbo5tjTh01QJLkhO9t9RDDQYvk+WXqpECI2C6i2A==",
+					"version": "4.4.3",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
+					"integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
 					"dev": true,
 					"requires": {
 						"commander": "^2.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
 				"enzyme-to-json": "3.4.3",
 				"file-loader": "4.2.0",
 				"jest-config": "24.9.0",
+				"jest-emotion": "^10.0.27",
 				"jest-enzyme": "7.1.2",
 				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
 				"node-sass": "4.13.0",
@@ -459,7 +460,6 @@
 				"debug": "4.1.1",
 				"emotion-theming": "10.0.19",
 				"i18n-calypso": "file:packages/i18n-calypso",
-				"jest-emotion": "^10.0.27",
 				"prop-types": "^15.7.2",
 				"react": "^16.8.6",
 				"react-stripe-elements": "^5.1.0"
@@ -10719,6 +10719,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
 			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"source-map": "^0.6.1",
@@ -10729,7 +10730,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -17642,6 +17644,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/jest-emotion/-/jest-emotion-10.0.27.tgz",
 			"integrity": "sha512-SNHZ98+bjVj/1Ph/4fYxFdCpqd8UNP9kabTP0bERerK7cM9IiXDCXJAzxbBvPqmiGOOjEJllMgNFWVK36+9FdQ==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@types/jest": "^23.0.2",
@@ -17652,12 +17655,14 @@
 				"@types/jest": {
 					"version": "23.3.14",
 					"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.14.tgz",
-					"integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug=="
+					"integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==",
+					"dev": true
 				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -17667,7 +17672,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,6 +459,7 @@
 				"debug": "4.1.1",
 				"emotion-theming": "10.0.19",
 				"i18n-calypso": "file:packages/i18n-calypso",
+				"jest-emotion": "^10.0.27",
 				"prop-types": "^15.7.2",
 				"react": "^16.8.6",
 				"react-stripe-elements": "^5.1.0"
@@ -6538,6 +6539,22 @@
 				"humanize-ms": "^1.2.1"
 			}
 		},
+		"aggregate-error": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+			"integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+				}
+			}
+		},
 		"airbnb-js-shims": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-2.2.1.tgz",
@@ -9607,6 +9624,11 @@
 				}
 			}
 		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+		},
 		"cli-boxes": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
@@ -10697,7 +10719,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
 			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"source-map": "^0.6.1",
@@ -10708,8 +10729,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -17618,6 +17638,39 @@
 				}
 			}
 		},
+		"jest-emotion": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/jest-emotion/-/jest-emotion-10.0.27.tgz",
+			"integrity": "sha512-SNHZ98+bjVj/1Ph/4fYxFdCpqd8UNP9kabTP0bERerK7cM9IiXDCXJAzxbBvPqmiGOOjEJllMgNFWVK36+9FdQ==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@types/jest": "^23.0.2",
+				"chalk": "^2.4.1",
+				"css": "^2.2.1"
+			},
+			"dependencies": {
+				"@types/jest": {
+					"version": "23.3.14",
+					"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.14.tgz",
+					"integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug=="
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+				}
+			}
+		},
 		"jest-environment-enzyme": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/jest-environment-enzyme/-/jest-environment-enzyme-7.1.2.tgz",
@@ -20293,6 +20346,75 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+				}
+			}
+		},
+		"minipass-collect": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
+		"minipass-flush": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
+		"minipass-pipeline": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+			"integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -31766,9 +31888,207 @@
 			"integrity": "sha512-dNxivOXmDgZqrGxOttBH6B4xaxT4zNC+Xd+2K8jwGDMK5q2CZI+KZMA1AAnSRT+BTRvuzKsDx+fpxzPAmAMVcA==",
 			"dev": true,
 			"requires": {
+				"cacache": "^13.0.1",
+				"find-cache-dir": "^3.2.0",
 				"jest-worker": "^24.9.0",
+				"schema-utils": "^2.6.1",
 				"serialize-javascript": "^2.1.2",
+				"source-map": "^0.6.1",
+				"terser": "^4.4.3",
 				"webpack-sources": "^1.4.3"
+			},
+			"dependencies": {
+				"cacache": {
+					"version": "13.0.1",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
+					"integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.2",
+						"figgy-pudding": "^3.5.1",
+						"fs-minipass": "^2.0.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.2",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^5.1.1",
+						"minipass": "^3.0.0",
+						"minipass-collect": "^1.0.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.2",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"p-map": "^3.0.0",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.7.1",
+						"ssri": "^7.0.0",
+						"unique-filename": "^1.1.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.0",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"fs-minipass": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.0.0.tgz",
+					"integrity": "sha512-40Qz+LFXmd9tzYVnnBmZvFfvAADfUA14TXPK1s7IfElJTIZ97rA8w4Kin7Wt5JBrC3ShnnFJO/5vPjPEeJIq9A==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					},
+					"dependencies": {
+						"yallist": {
+							"version": "3.1.1",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+							"dev": true
+						}
+					}
+				},
+				"make-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"minipass": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+					"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"schema-utils": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
+					"integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"ssri": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+					"integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"minipass": "^3.1.1"
+					}
+				},
+				"terser": {
+					"version": "4.6.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.1.tgz",
+					"integrity": "sha512-w0f2OWFD7ka3zwetgVAhNMeyzEbj39ht2Tb0qKflw9PmW9Qbo5tjTh01QJLkhO9t9RDDQYvk+WXqpECI2C6i2A==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
 			}
 		},
 		"test-exclude": {

--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
 		"interpolate-components": "1.1.1",
 		"jest": "24.9.0",
 		"jest-docblock": "24.9.0",
+		"jest-emotion": "10.0.27",
 		"jest-fetch-mock": "2.1.2",
 		"jest-junit": "9.0.0",
 		"md5-file": "4.0.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -60,6 +60,7 @@
 		"enzyme-to-json": "3.4.3",
 		"file-loader": "4.2.0",
 		"jest-config": "24.9.0",
+		"jest-emotion": "^10.0.27",
 		"jest-enzyme": "7.1.2",
 		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#v0.7.0-with-rtl",
 		"node-sass": "4.13.0",

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -46,8 +46,7 @@
 		"i18n-calypso": "file:../i18n-calypso",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",
-		"react-stripe-elements": "^5.1.0",
-		"jest-emotion": "^10.0.27"
+		"react-stripe-elements": "^5.1.0"
 	},
 	"private": true
 }

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -46,7 +46,8 @@
 		"i18n-calypso": "file:../i18n-calypso",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",
-		"react-stripe-elements": "^5.1.0"
+		"react-stripe-elements": "^5.1.0",
+		"jest-emotion": "^10.0.27"
 	},
 	"private": true
 }

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -4,15 +4,23 @@
 import React, { FunctionComponent } from 'react';
 import styled from '@emotion/styled';
 
+/**
+ * Annotate a form field element with a label, description, and an optional
+ * colored error border with error text.
+ *
+ * If you pass a labelText, you should also pass labelId and formFieldId
+ * for accessibility purposes. formFieldId must be the id attribute of the
+ * child component, of which there should be exactly one.
+ */
 type FormFieldAnnotationProps = {
 	// Semantic props
 	labelText: string;
-	descriptionText?: string;
-	errorMessage: string;
+	normalDescription?: string;
+	errorDescription: string;
 
 	// Functional props
-	isError: boolean;
-	isDisabled: boolean;
+	isError?: boolean; // default false
+	isDisabled?: boolean; // default false
 
 	// Technical props
 	className?: string;
@@ -21,35 +29,38 @@ type FormFieldAnnotationProps = {
 	formFieldId: string;
 };
 
-export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > = ( {
+const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > = ( {
 	formFieldId,
 	labelText,
 	labelId,
-	descriptionText,
+	normalDescription,
 	descriptionId,
-	errorMessage,
+	errorDescription,
 	isError,
 	isDisabled,
 	className,
 	children,
-} ) => (
-	<div className={ className }>
-		{ labelText && (
-			<Label htmlFor={ formFieldId } id={ labelId } isDisabled={ isDisabled }>
+} ) => {
+	const isErrorWithDefault: boolean = isError === undefined ? false : isError;
+	const isDisabledWithDefault: boolean = isDisabled === undefined ? false : isDisabled;
+
+	return (
+		<div className={ className }>
+			<Label htmlFor={ formFieldId } id={ labelId } isDisabled={ isDisabledWithDefault }>
 				{ labelText }
 			</Label>
-		) }
-		<FormFieldWrapper data-testid={ `${ className }_wrapper` } isError={ isError }>
-			{ children }
-		</FormFieldWrapper>
-		<RenderedDescription
-			descriptionText={ descriptionText }
-			descriptionId={ descriptionId }
-			isError={ isError }
-			errorMessage={ errorMessage }
-		/>
-	</div>
-);
+			<FormFieldWrapper data-testid={ `${ className }_wrapper` } isError={ isErrorWithDefault }>
+				{ children }
+			</FormFieldWrapper>
+			<RenderedDescription
+				descriptionText={ normalDescription }
+				descriptionId={ descriptionId }
+				isError={ isError }
+				errorMessage={ errorDescription }
+			/>
+		</div>
+	);
+};
 
 type LabelProps = {
 	isDisabled: boolean;
@@ -115,3 +126,5 @@ const Description = styled.p< DescriptionProps >`
 	font-style: italic;
 	font-size: 14px;
 `;
+
+export default FormFieldAnnotation;

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import React, { Component, FunctionComponent } from 'react';
+import styled from '@emotion/styled';
+
+type FormFieldAnnotationProps = {
+	formField: Component;
+
+	// Semantic props
+	labelText: string;
+	descriptionText: string;
+	errorMessage: string;
+
+	// Functional props
+	isError: boolean;
+	isDisabled: boolean;
+
+	// Technical props
+	className?: string;
+	labelId: string;
+	descriptionId: string;
+};
+
+export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > = ( {
+	formField,
+	labelText,
+	labelId,
+	descriptionText,
+	descriptionId,
+	errorMessage,
+	isError,
+	isDisabled,
+	className,
+} ) => (
+	<div className={ className }>
+		{ labelText && (
+			<Label id={ labelId } isDisabled={ isDisabled }>
+				{ labelText }
+			</Label>
+		) }
+		<FormFieldWrapper isError={ isError }>{ formField }</FormFieldWrapper>
+		<RenderedDescription
+			descriptionText={ descriptionText }
+			descriptionId={ descriptionId }
+			isError={ isError }
+			errorMessage={ errorMessage }
+		/>
+	</div>
+);
+
+type LabelProps = {
+	isDisabled: boolean;
+	theme?: any;
+};
+
+const Label = styled.label< LabelProps >`
+	display: block;
+	color: ${props => props.theme.colors.textColor};
+	font-weight: ${props => props.theme.weights.bold};
+	font-size: 14px;
+	margin-bottom: 8px;
+
+	:hover {
+		cursor: ${props => ( props.isDisabled ? 'default' : 'pointer' )};
+	}
+`;
+
+type FormFieldWrapperProps = {
+	isError: boolean;
+	theme?: any;
+};
+
+const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	font-size: 16px;
+	border: 1px solid
+		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
+
+	:focus {
+		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
+			solid 2px !important;
+	}
+
+	::-webkit-inner-spin-button,
+	::-webkit-outer-spin-button {
+		-webkit-appearance: none;
+	}
+`;
+
+function RenderedDescription( { descriptionText, descriptionId, isError, errorMessage } ) {
+	if ( descriptionText || isError ) {
+		return (
+			<Description isError={ isError } id={ descriptionId }>
+				{ isError ? errorMessage : descriptionText }
+			</Description>
+		);
+	}
+	return null;
+}
+
+type DescriptionProps = {
+	isError: boolean;
+	theme?: any;
+};
+
+const Description = styled.p< DescriptionProps >`
+	margin: 8px 0 0 0;
+	color: ${props =>
+		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight};
+	font-style: italic;
+	font-size: 14px;
+`;

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -20,10 +20,12 @@ type FormFieldAnnotationProps = {
 	className?: string;
 	labelId: string;
 	descriptionId: string;
+	formFieldId: string;
 };
 
 export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > = ( {
 	formField,
+	formFieldId,
 	labelText,
 	labelId,
 	descriptionText,
@@ -35,7 +37,7 @@ export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > 
 } ) => (
 	<div className={ className }>
 		{ labelText && (
-			<Label id={ labelId } isDisabled={ isDisabled }>
+			<Label htmlFor={ formFieldId } id={ labelId } isDisabled={ isDisabled }>
 				{ labelText }
 			</Label>
 		) }

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -1,15 +1,13 @@
 /**
  * External dependencies
  */
-import React, { Component, FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 import styled from '@emotion/styled';
 
 type FormFieldAnnotationProps = {
-	formField: Component;
-
 	// Semantic props
 	labelText: string;
-	descriptionText: string;
+	descriptionText?: string;
 	errorMessage: string;
 
 	// Functional props
@@ -24,7 +22,6 @@ type FormFieldAnnotationProps = {
 };
 
 export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > = ( {
-	formField,
 	formFieldId,
 	labelText,
 	labelId,
@@ -34,6 +31,7 @@ export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > 
 	isError,
 	isDisabled,
 	className,
+	children,
 } ) => (
 	<div className={ className }>
 		{ labelText && (
@@ -41,7 +39,7 @@ export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > 
 				{ labelText }
 			</Label>
 		) }
-		<FormFieldWrapper isError={ isError }>{ formField }</FormFieldWrapper>
+		<FormFieldWrapper isError={ isError }>{ children }</FormFieldWrapper>
 		<RenderedDescription
 			descriptionText={ descriptionText }
 			descriptionId={ descriptionId }

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -39,7 +39,9 @@ export const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > 
 				{ labelText }
 			</Label>
 		) }
-		<FormFieldWrapper isError={ isError }>{ children }</FormFieldWrapper>
+		<FormFieldWrapper data-testid={ `${ className }_wrapper` } isError={ isError }>
+			{ children }
+		</FormFieldWrapper>
 		<RenderedDescription
 			descriptionText={ descriptionText }
 			descriptionId={ descriptionId }

--- a/packages/composite-checkout-wpcom/test/form-field-annotation.js
+++ b/packages/composite-checkout-wpcom/test/form-field-annotation.js
@@ -39,17 +39,17 @@ describe( 'FormFieldAnnotation', () => {
 			MyFormFieldAnnotation = () => (
 				<ThemeProvider theme={ theme }>
 					<FormFieldAnnotation
-						formFieldId={ 'fieldId' }
-						labelText={ 'A Label' }
-						labelId={ 'labelId' }
-						normalDescription={ 'A description' }
-						descriptionId={ 'descriptionId' }
-						errorDescription={ 'An Error Message' }
+						formFieldId="fieldId"
+						labelText="A Label"
+						labelId="labelId"
+						normalDescription="A description"
+						descriptionId="descriptionId"
+						errorDescription="An Error Message"
 						isError={ false }
 						isDisabled={ false }
-						className={ 'test__annotation_class' }
+						className="test__annotation_class"
 					>
-						<span id={ 'fieldId' }>{ 'child contents' }</span>
+						<span id="fieldId">{ 'child contents' }</span>
 					</FormFieldAnnotation>
 				</ThemeProvider>
 			);
@@ -81,17 +81,17 @@ describe( 'FormFieldAnnotation', () => {
 			MyFormFieldAnnotation = () => (
 				<ThemeProvider theme={ theme }>
 					<FormFieldAnnotation
-						formFieldId={ 'fieldId' }
-						labelText={ 'A Label' }
-						labelId={ 'labelId' }
-						normalDescription={ 'A description' }
-						descriptionId={ 'descriptionId' }
-						errorDescription={ 'An Error Message' }
-						isError={ true }
-						isDisabled={ false }
-						className={ 'test__annotation_class' }
+						formFieldId="fieldId"
+						labelText="A Label"
+						labelId="labelId"
+						normalDescription="A description"
+						descriptionId="descriptionId"
+						errorDescription="An Error Message"
+						isError="true"
+						isDisabled="false"
+						className="test__annotation_class"
 					>
-						<span id={ 'fieldId' }>{ 'child contents' }</span>
+						<span id="fieldId">{ 'child contents' }</span>
 					</FormFieldAnnotation>
 				</ThemeProvider>
 			);

--- a/packages/composite-checkout-wpcom/test/form-field-annotation.js
+++ b/packages/composite-checkout-wpcom/test/form-field-annotation.js
@@ -16,7 +16,7 @@ import { ThemeProvider } from 'emotion-theming';
 /**
  * Internal dependencies
  */
-import { FormFieldAnnotation } from '../src/components/form-field-annotation';
+import FormFieldAnnotation from '../src/components/form-field-annotation';
 
 // Add the custom matchers provided by 'jest-emotion'
 expect.extend( matchers );
@@ -42,9 +42,9 @@ describe( 'FormFieldAnnotation', () => {
 						formFieldId={ 'fieldId' }
 						labelText={ 'A Label' }
 						labelId={ 'labelId' }
-						descriptionText={ 'A description' }
+						normalDescription={ 'A description' }
 						descriptionId={ 'descriptionId' }
-						errorMessage={ 'An Error Message' }
+						errorDescription={ 'An Error Message' }
 						isError={ false }
 						isDisabled={ false }
 						className={ 'test__annotation_class' }
@@ -84,9 +84,9 @@ describe( 'FormFieldAnnotation', () => {
 						formFieldId={ 'fieldId' }
 						labelText={ 'A Label' }
 						labelId={ 'labelId' }
-						descriptionText={ 'A description' }
+						normalDescription={ 'A description' }
 						descriptionId={ 'descriptionId' }
-						errorMessage={ 'An Error Message' }
+						errorDescription={ 'An Error Message' }
 						isError={ true }
 						isDisabled={ false }
 						className={ 'test__annotation_class' }

--- a/packages/composite-checkout-wpcom/test/form-field-annotation.js
+++ b/packages/composite-checkout-wpcom/test/form-field-annotation.js
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import {
+	render,
+	getAllByLabelText as getAllByLabelTextInNode,
+	getByText as getByTextInNode,
+	queryByText as queryByTextInNode,
+	fireEvent,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { matchers } from 'jest-emotion';
+import { ThemeProvider } from 'emotion-theming';
+
+/**
+ * Internal dependencies
+ */
+import { FormFieldAnnotation } from '../src/components/form-field-annotation';
+
+// Add the custom matchers provided by 'jest-emotion'
+expect.extend( matchers );
+
+const theme = {
+	colors: {
+		textColor: 'blue',
+		textColorLight: 'lightblue',
+		borderColor: 'black',
+		error: 'red',
+	},
+	weights: { bold: '15pt' },
+};
+
+describe( 'FormFieldAnnotation', () => {
+	describe( 'with no error and not disabled', () => {
+		let MyFormFieldAnnotation = null;
+
+		beforeEach( () => {
+			MyFormFieldAnnotation = () => (
+				<ThemeProvider theme={ theme }>
+					<FormFieldAnnotation
+						formFieldId={ 'fieldId' }
+						labelText={ 'A Label' }
+						labelId={ 'labelId' }
+						descriptionText={ 'A description' }
+						descriptionId={ 'descriptionId' }
+						errorMessage={ 'An Error Message' }
+						isError={ false }
+						isDisabled={ false }
+						className={ 'annotation_class' }
+					>
+						<span id={ 'fieldId' }>{ 'child contents' }</span>
+					</FormFieldAnnotation>
+				</ThemeProvider>
+			);
+		} );
+
+		it( 'renders the description string', () => {
+			const { getAllByText } = render( <MyFormFieldAnnotation /> );
+			expect( getAllByText( 'A description' )[ 0 ] ).toBeInTheDocument();
+		} );
+
+		it( 'does not render the error string', () => {
+			const { queryAllByText } = render( <MyFormFieldAnnotation /> );
+			expect( queryAllByText( 'An Error Message' )[ 0 ] ).toBeUndefined();
+		} );
+
+		it( 'does not have a highlighted border', () => {
+			const { getAllByTestId } = render( <MyFormFieldAnnotation /> );
+			expect( getAllByTestId( 'annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
+				'border',
+				'1px solid black'
+			);
+		} );
+	} );
+
+	describe( 'with error and not disabled', () => {
+		let MyFormFieldAnnotation = null;
+
+		beforeEach( () => {
+			MyFormFieldAnnotation = () => (
+				<ThemeProvider theme={ theme }>
+					<FormFieldAnnotation
+						formFieldId={ 'fieldId' }
+						labelText={ 'A Label' }
+						labelId={ 'labelId' }
+						descriptionText={ 'A description' }
+						descriptionId={ 'descriptionId' }
+						errorMessage={ 'An Error Message' }
+						isError={ true }
+						isDisabled={ false }
+						className={ 'annotation_class' }
+					>
+						<span id={ 'fieldId' }>{ 'child contents' }</span>
+					</FormFieldAnnotation>
+				</ThemeProvider>
+			);
+		} );
+
+		it( 'does not render the description string', () => {
+			const { queryAllByText } = render( <MyFormFieldAnnotation /> );
+			expect( queryAllByText( 'A description' )[ 0 ] ).toBeUndefined();
+		} );
+
+		it( 'renders the error string', () => {
+			const { getAllByText } = render( <MyFormFieldAnnotation /> );
+			expect( getAllByText( 'An Error Message' )[ 0 ] ).toBeInTheDocument();
+		} );
+
+		it( 'does not have a highlighted border', () => {
+			const { getAllByTestId } = render( <MyFormFieldAnnotation /> );
+			expect( getAllByTestId( 'annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
+				'border',
+				'1px solid red'
+			);
+		} );
+	} );
+} );

--- a/packages/composite-checkout-wpcom/test/form-field-annotation.js
+++ b/packages/composite-checkout-wpcom/test/form-field-annotation.js
@@ -2,17 +2,13 @@
  * @jest-environment jsdom
  */
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 /**
  * External dependencies
  */
 import React from 'react';
-import {
-	render,
-	getAllByLabelText as getAllByLabelTextInNode,
-	getByText as getByTextInNode,
-	queryByText as queryByTextInNode,
-	fireEvent,
-} from '@testing-library/react';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { matchers } from 'jest-emotion';
 import { ThemeProvider } from 'emotion-theming';
@@ -51,7 +47,7 @@ describe( 'FormFieldAnnotation', () => {
 						errorMessage={ 'An Error Message' }
 						isError={ false }
 						isDisabled={ false }
-						className={ 'annotation_class' }
+						className={ 'test__annotation_class' }
 					>
 						<span id={ 'fieldId' }>{ 'child contents' }</span>
 					</FormFieldAnnotation>
@@ -71,7 +67,7 @@ describe( 'FormFieldAnnotation', () => {
 
 		it( 'does not have a highlighted border', () => {
 			const { getAllByTestId } = render( <MyFormFieldAnnotation /> );
-			expect( getAllByTestId( 'annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
+			expect( getAllByTestId( 'test__annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
 				'border',
 				'1px solid black'
 			);
@@ -93,7 +89,7 @@ describe( 'FormFieldAnnotation', () => {
 						errorMessage={ 'An Error Message' }
 						isError={ true }
 						isDisabled={ false }
-						className={ 'annotation_class' }
+						className={ 'test__annotation_class' }
 					>
 						<span id={ 'fieldId' }>{ 'child contents' }</span>
 					</FormFieldAnnotation>
@@ -113,7 +109,7 @@ describe( 'FormFieldAnnotation', () => {
 
 		it( 'does not have a highlighted border', () => {
 			const { getAllByTestId } = render( <MyFormFieldAnnotation /> );
-			expect( getAllByTestId( 'annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
+			expect( getAllByTestId( 'test__annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
 				'border',
 				'1px solid red'
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a `FormFieldAnnotation` component.

Composite checkout needs a consistent way to annotate form fields with labels and error messages, including field components pulled in from calypso over which we have less control. This component extracts some functionality from the existing `Field` component to apply a border and show an error message to any component.

#### Testing instructions

`npm run test-packages composite-checkout-wpcom`