### PR TITLE
Make automattic/components Button work in isolation

### DIFF
--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -7,6 +7,7 @@ Buttons express what action will occur when the user clicks or taps it. Buttons 
 ```jsx
 import Gridicon from 'components/gridicons';
 import { Button } from '@automattic/components';
+import '@automattic/calypso-color-schemes/dist/calypso-color-schemes.css';
 
 export default function RockOnButton() {
 	return (

--- a/packages/components/src/button/index.stories.jsx
+++ b/packages/components/src/button/index.stories.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
+import '@automattic/calypso-color-schemes/dist/calypso-color-schemes.css';
+
 import Button from '.';
 
 export default { title: 'Button' };
@@ -11,29 +13,21 @@ export default { title: 'Button' };
 const helloWorld = `Hello World!`;
 const handleClick = action( 'click' );
 
-export const Default = () => <Button onClick={ handleClick }>{ helloWorld }</Button>;
-export const IsPrimary = () => (
-	<Button primary onClick={ handleClick }>
-		{ helloWorld }
-	</Button>
+const ButtonVariantions = props => (
+	<>
+		<Button onClick={ handleClick } { ...props }>
+			{ helloWorld }
+		</Button>{ ' ' }
+		<Button primary onClick={ handleClick } { ...props }>
+			{ helloWorld }
+		</Button>
+	</>
 );
-export const IsScary = () => (
-	<Button scary onClick={ handleClick }>
-		{ helloWorld }
-	</Button>
-);
-export const IsBusy = () => (
-	<Button busy onClick={ handleClick }>
-		{ helloWorld }
-	</Button>
-);
-export const IsBorderless = () => (
-	<Button borderless onClick={ handleClick }>
-		{ helloWorld }
-	</Button>
-);
-export const AsLink = () => (
-	<Button href="https://www.google.com/" target="_blank">
-		{ helloWorld }
-	</Button>
-);
+
+export const Normal = () => <ButtonVariantions />;
+export const Compact = () => <ButtonVariantions compact />;
+export const Busy = () => <ButtonVariantions busy />;
+export const Scary = () => <ButtonVariantions scary />;
+export const Borderless = () => <ButtonVariantions borderless />;
+export const Disabled = () => <ButtonVariantions disabled />;
+export const Link = () => <ButtonVariantions href="https://www.google.com/" target="_blank" />;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,8 +1,10 @@
 // ==========================================================================
 // Buttons
 // ==========================================================================
+@import '../typography.scss';
 
 .button {
+	font-family: $aui-fontFamily-sans;
 	background: transparent;
 	border-style: solid;
 	border-width: 1px 1px 2px;
@@ -21,6 +23,10 @@
 	border-radius: 4px;
 	padding: 7px 14px 9px;
 	appearance: none;
+
+	.rtl & {
+		font-family: $aui-fontFamily-sans-rtl;
+	}
 
 	&.hidden {
 		display: none;

--- a/packages/components/src/typography.scss
+++ b/packages/components/src/typography.scss
@@ -1,0 +1,5 @@
+
+$aui-fontFamily-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
+'Helvetica Neue', sans-serif;
+$aui-fontFamily-sans-rtl: Tahoma, $aui-fontFamily-sans;
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to get `Button` visually consistent with `devdocs` when used in isolation (not relying on the `calypso` styles) with minimal changes.

*Recommend that the consuming developer imports `calypso-color-schemes`*
Importing this module defines the CSS color variables used by `Button`. This is a quick win to get the colors working. The color variables are global and their naming is quite generic which could lead to potential conflicts when used in other codebases - I think we should be safe with `gutenberg` for now but its probably worth a discussion around how we'd like to avoid that going into the future - a variable prefix, CSS-in-JS etc

*Copied missing CSS from the `assets/stylesheets/*` into the component styles*
Copied some of the styles defined in the `calypso` reset into the components themselves in order to avoid conflicts with whatever base styles the consuming developers may be using.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Compare the `Button` component in the Storybook and devdocs

#### Fixes #

This PR fixes missing colors and typography styles.

Before:
<img width="116" alt="Screen Shot 2020-01-02 at 10 17 20 am" src="https://user-images.githubusercontent.com/2237996/71647351-ac9c2c00-2d49-11ea-8c3a-1deb7226d9d7.png">

After:
<img width="116" alt="Screen Shot 2020-01-02 at 10 21 08 am" src="https://user-images.githubusercontent.com/2237996/71647347-a1e19700-2d49-11ea-9a60-72e79ff126d9.png">
