### PR TITLE
Plan bump test: Launch the variant as control

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,15 +88,6 @@ export default {
 		},
 		defaultVariation: 'default',
 	},
-	showPlanUpsellConcierge: {
-		datestamp: '20191106',
-		variations: {
-			variantShowPlanBump: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	domainStepCopyUpdates: {
 		datestamp: '20191121',
 		variations: {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -599,10 +599,7 @@ export class Checkout extends React.Component {
 			return redirectPathForGSuiteUpsell;
 		}
 
-		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge(
-			pendingOrReceiptId,
-			stepResult
-		);
+		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge( pendingOrReceiptId );
 		if ( redirectPathForConciergeUpsell ) {
 			return redirectPathForConciergeUpsell;
 		}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -88,7 +88,6 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import getPreviousPath from 'state/selectors/get-previous-path.js';
 import config from 'config';
-import { abtest } from 'lib/abtest';
 import { loadTrackingTool } from 'state/analytics/actions';
 import {
 	persistSignupDestination,
@@ -474,13 +473,11 @@ export class Checkout extends React.Component {
 		return;
 	}
 
-	maybeShowPlanBumpOfferConcierge( receiptId, stepResult ) {
+	maybeShowPlanBumpOfferConcierge( receiptId ) {
 		const { cart, selectedSiteSlug } = this.props;
 
-		if ( hasPersonalPlan( cart ) && stepResult && isEmpty( stepResult.failed_purchases ) ) {
-			if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellConcierge' ) ) {
-				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
-			}
+		if ( hasPersonalPlan( cart ) ) {
+			return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
 		}
 
 		return;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -473,17 +473,7 @@ export class Checkout extends React.Component {
 		return;
 	}
 
-	maybeShowPlanBumpOfferConcierge( receiptId ) {
-		const { cart, selectedSiteSlug } = this.props;
-
-		if ( hasPersonalPlan( cart ) ) {
-			return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
-		}
-
-		return;
-	}
-
-	maybeRedirectToConciergeNudge( pendingOrReceiptId, stepResult ) {
+	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
 		const { cart, selectedSiteSlug, previousRoute } = this.props;
 
 		// For a user purchasing a qualifying plan, show either a plan upgrade upsell or concierge upsell.
@@ -497,9 +487,8 @@ export class Checkout extends React.Component {
 			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
 			! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-plan-upgrade` )
 		) {
-			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId, stepResult );
-			if ( upgradePath ) {
-				return upgradePath;
+			if ( hasPersonalPlan( cart ) ) {
+				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
 			}
 
 			// A user just purchased one of the qualifying plans


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following the success of the plan bump test introduced in https://github.com/Automattic/wp-calypso/pull/37349 and https://github.com/Automattic/wp-calypso/pull/36655 which tests an offer to upgrade to Premium against an offer to buy a concierge session for users who purchase a Personal plan, we have decided to launch the variant as control.
* For more context, check the discussion in p8Eqe3-EW-p2#comment-2984.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1** _(Test that the plan bump offer is shown for Personal plan purchase)_

* Signup for a new account from http://calypso.localhost:3000/start.
* Add a Personal plan to cart and complete the purchase
* Verify that you are shown the premium upgrade upsell.
* Clicking the `No thanks ...` button should take you to the checklist page.
* Clicking the `Yes, I'd love to try ....` button should take you to the checkout page with the Premium plan added to cart and **credits applied**. Verify that after you complete the purchase, you are **not shown the concierge upsell** but instead taken to the checklist page.

**Scenario 2**

* Signup for an account and purchase a Premium plan.
* After completing payment, verify that you are always shown the Concierge upsell offer.

**Scenario 3** _(Test that the test is not assigned when the user is eligible for GSuite upsell)_
* Go through the signup flow and checkout with a Personal plan and domain. Complete purchase.
* Verify that you are always shown the GSuite upsell offer

**Scenario 4** _(Test that the offer is shown when upgrading from a lower tier plan to Personal)_
* Login to a site having a Free or Blogger plan, go to /plans page and upgrade to Personal
* After purchase completes, verify that you are shown the premium upgrade upsell.

**Scenario 5** _(Verify that invalid payment methods do not show the offer but instead take you back to Checkout)_

* Signup for an account and add a Personal plan to cart
* In the Checkout page, enter an invalid card number like `4539747991309129`. Click the Pay Now button and verify that an error is shown. The upsell offer page should not be shown.
* Now, enter PayPal as the payment method. After you're redirected to paypal.com, click the 
`Cancel and return to WordPress.com` link(if sandboxed, this will appear with a different wording).
* Verify that you are taken back the Checkout page.
* Now pay with a redirect payment type like Giropay(requires an EU proxy). While Sandboxed, this will redirect to a Sandbox payment page - click the Cancel payment button. Verify that you are taken back the Checkout page.


 

