### PR TITLE
Hosting: Check new manage_hosting capability for access

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -9,7 +9,6 @@ import { translate } from 'i18n-calypso';
  */
 import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 import { localizeUrl } from 'lib/i18n-utils';
-import { isEnabled } from 'config';
 
 /**
  * Module variables
@@ -907,7 +906,7 @@ const contextLinksForSection = {
 		},
 	],
 	hosting: [
-		isEnabled( 'hosting/sftp-phpmyadmin' ) && {
+		{
 			link: localizeUrl( 'https://en.support.wordpress.com/sftp/' ),
 			post_id: 159771,
 			title: translate( 'SFTP on WordPress.com' ),
@@ -915,7 +914,7 @@ const contextLinksForSection = {
 				"Access and edit your website's files directly by using an SFTP client."
 			),
 		},
-		isEnabled( 'hosting/sftp-phpmyadmin' ) && {
+		{
 			link: localizeUrl( 'https://en.support.wordpress.com/phpmyadmin-and-mysql/' ),
 			post_id: 159822,
 			title: translate( 'phpMyAdmin and MySQL' ),

--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -46,7 +46,7 @@ export async function handleHostingPanelRedirect( context, next ) {
 		return;
 	}
 
-	page.redirect( `/stats/day/${ context.params.siteId || '' }` );
+	page.redirect( '/hosting-config' );
 }
 
 export function layout( context, next ) {

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -23,7 +23,6 @@ import PhpMyAdminCard from './phpmyadmin-card';
 import SupportCard from './support-card';
 import PhpVersionCard from './php-version-card';
 import SiteBackupCard from './site-backup-card';
-import { isEnabled } from 'config';
 import NoticeAction from 'components/notice/notice-action';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import Notice from 'components/notice';
@@ -74,8 +73,6 @@ class Hosting extends Component {
 		if ( ! canViewAtomicHosting ) {
 			return null;
 		}
-
-		const sftpPhpMyAdminFeaturesEnabled = isEnabled( 'hosting/sftp-phpmyadmin' );
 
 		const getUpgradeBanner = () => (
 			<Banner
@@ -159,12 +156,12 @@ class Hosting extends Component {
 				<WrapperComponent>
 					<div className="hosting__layout">
 						<div className="hosting__layout-col">
-							{ sftpPhpMyAdminFeaturesEnabled && <SFTPCard disabled={ isDisabled } /> }
-							{ sftpPhpMyAdminFeaturesEnabled && <PhpMyAdminCard disabled={ isDisabled } /> }
+							<SFTPCard disabled={ isDisabled } />
+							<PhpMyAdminCard disabled={ isDisabled } />
 							{ <PhpVersionCard disabled={ isDisabled } /> }
 						</div>
 						<div className="hosting__layout-col">
-							{ sftpPhpMyAdminFeaturesEnabled && <SiteBackupCard disabled={ isDisabled } /> }
+							<SiteBackupCard disabled={ isDisabled } />
 							<SupportCard />
 						</div>
 					</div>
@@ -179,11 +176,9 @@ class Hosting extends Component {
 				<SidebarNavigation />
 				<FormattedHeader
 					headerText={ translate( 'Hosting Configuration' ) }
-					subHeaderText={
-						sftpPhpMyAdminFeaturesEnabled
-							? translate( 'Access your website’s database and more advanced settings.' )
-							: translate( 'Access and manage more advanced settings of your website.' )
-					}
+					subHeaderText={ translate(
+						'Access your website’s database and more advanced settings.'
+					) }
 					align="left"
 				/>
 				{ isOnAtomicPlan ? getAtomicActivationNotice() : getUpgradeBanner() }

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -43,8 +43,7 @@ class Sites extends Component {
 		}
 
 		if ( /^\/hosting-config/.test( path ) ) {
-			// Hosting routes are not applicable to any VIP or WP.org Jetpack sites.
-			if ( site.is_vip || ( site.jetpack && ! site.options.is_automated_transfer ) ) {
+			if ( ! site.capabilities.view_hosting ) {
 				return false;
 			}
 

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -1,43 +1,22 @@
 /**
  * Internal Dependencies
  */
-import { isEnabled } from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
-import isVipSite from 'state/selectors/is-vip-site';
 import getRawSite from 'state/selectors/get-raw-site';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import canCurrentUser from 'state/selectors/can-current-user';
 
 /**
- * TODO: this selector should be backed by an API response instead
  * Returns true if hosting section should be viewable
  *
  * @param  {object}  state  Global state tree
  * @returns {?boolean}        Whether site can display the atomic hosting section
  */
 export default function canSiteViewAtomicHosting( state ) {
-	if ( ! isEnabled( 'hosting' ) ) {
-		return false;
-	}
-
 	const siteId = getSelectedSiteId( state );
 
 	if ( ! getRawSite( state, siteId ) ) {
 		return false;
 	}
 
-	if ( ! canCurrentUser( state, siteId, 'manage_options' ) ) {
-		return false;
-	}
-
-	if ( isVipSite( state, siteId ) ) {
-		return false;
-	}
-
-	if ( isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId ) ) {
-		return false;
-	}
-
-	return true;
+	return canCurrentUser( state, siteId, 'manage_hosting' );
 }

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -18,5 +18,5 @@ export default function canSiteViewAtomicHosting( state ) {
 		return false;
 	}
 
-	return canCurrentUser( state, siteId, 'manage_hosting' );
+	return canCurrentUser( state, siteId, 'view_hosting' );
 }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -35,8 +35,6 @@
 		"google-my-business": false,
 		"help": true,
 		"help/courses": true,
-		"hosting": true,
-		"hosting/sftp-phpmyadmin": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/development.json
+++ b/config/development.json
@@ -62,8 +62,6 @@
 		"gutenboarding": true,
 		"help": true,
 		"help/courses": true,
-		"hosting": true,
-		"hosting/sftp-phpmyadmin": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -37,8 +37,6 @@
 		"happychat": false,
 		"help": true,
 		"help/courses": true,
-		"hosting": true,
-		"hosting/sftp-phpmyadmin": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -37,8 +37,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"hosting": true,
-		"hosting/sftp-phpmyadmin": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,8 +38,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"hosting": true,
-		"hosting/sftp-phpmyadmin": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/test.json
+++ b/config/test.json
@@ -37,8 +37,6 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,
-		"hosting": true,
-		"hosting/sftp-phpmyadmin": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -47,8 +47,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"hosting": true,
-		"hosting/sftp-phpmyadmin": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes all the client logic from `canSiteViewAtomicHosting` in favor of a `view_hosting` capability check added in D37177-code that indicates if the user can access the hosting section.
* Changes the redirect performed when loading invalid sites at `/hosting-config/:invalid-site` to the site selector (`/hosting-config`).
* Cleans up all the features flags since the section is now stable and visible in all envs.

#### Testing instructions

* Apply D37177-code and sandbox the API.
* Verify the hosting section is not viewable for the following cases from both from the sidebar or visiting directly the `/hosting-config/:site` URL.:
  * VIP sites.
  * Jetpack sites.
  * Sites with a `blocked-from-atomic-transfer` blog sticker.
  * Non-admin users.
* Verify the hosting section is viewable for the rest of cases.

Fixes #38484
