### PR TITLE
Update eslint config to use browser environment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,7 @@ module.exports = {
 		// mocha is only still on because we have not finished porting all of our tests to jest's syntax
 		mocha: true,
 		node: true,
+		browser: true,
 	},
 	globals: {
 		// allow the browser globals. ESLint's `browser` env is too permissive and allows referencing


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds `browser` env to eslint config.
This way.`jsdoc/no-undefined-types` and `no-undef` rules are not broken when using browser globals such as `XMLHttpRequest` or `location`.

This gets the number of errors down to **11979** from **12207** 🎉

#### Testing instructions

* run `npm run lint:js`
