### PR TITLE
composite-checkout: Remove extraneous domain fields

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -115,21 +115,8 @@ export function createCartFromLineItems( {
 }
 
 function getDomainDetails() {
-	const isDomainContactSame = select( 'wpcom' )?.isDomainContactSame?.() ?? false;
-	const {
-		firstName,
-		lastName,
-		email,
-		phoneNumber,
-		address,
-		city,
-		state,
-		country,
-		postalCode,
-	} = isDomainContactSame
-		? select( 'wpcom' )?.getContactInfo?.() ?? {}
-		: select( 'wpcom' )?.getDomainContactInfo?.() ?? {};
-	// TODO: what is getContactInfo for other than the domainDetails?
+	const { firstName, lastName, email, phoneNumber, address, city, state, country, postalCode } =
+		select( 'wpcom' )?.getContactInfo?.() ?? {};
 	return {
 		firstName,
 		lastName,

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -40,8 +40,6 @@ export default function WPCheckout( { removeItem, changePlanLength, siteId } ) {
 	);
 
 	const contactInfo = useSelect( sel => sel( 'wpcom' ).getContactInfo() ) || {};
-	const domainContactInfo = useSelect( sel => sel( 'wpcom' ).getDomainContactInfo() ) || {};
-	const isDomainContactSame = useSelect( sel => sel( 'wpcom' ).isDomainContactSame() ) || false;
 	const { setSiteId } = useDispatch( 'wpcom' );
 
 	// Copy siteId to the store so it can be more easily accessed during payment submission
@@ -70,10 +68,8 @@ export default function WPCheckout( { removeItem, changePlanLength, siteId } ) {
 			titleContent: <ContactFormTitle />,
 			activeStepContent: <WPContactForm isComplete={ false } isActive={ true } />,
 			completeStepContent: <WPContactForm summary isComplete={ true } isActive={ false } />,
-			isCompleteCallback: () =>
-				isFormComplete( contactInfo, domainContactInfo, isDomainContactSame, itemsWithTax ),
-			isEditableCallback: () =>
-				isFormEditable( contactInfo, domainContactInfo, isDomainContactSame, itemsWithTax ),
+			isCompleteCallback: () => isFormComplete( contactInfo, itemsWithTax ),
+			isEditableCallback: () => isFormEditable( contactInfo, itemsWithTax ),
 			getEditButtonAriaLabel: () => translate( 'Edit the billing details' ),
 			getNextStepButtonAriaLabel: () => translate( 'Continue with the entered billing details' ),
 		},
@@ -98,7 +94,7 @@ function isElligibleForVat() {
 	return false;
 }
 
-function isFormComplete( contactInfo, domainContactInfo, isDomainContactSame, items ) {
+function isFormComplete( contactInfo, items ) {
 	const taxFields = [ contactInfo.country, contactInfo.postalCode ];
 	const contactFields = [
 		contactInfo.firstName,
@@ -109,21 +105,9 @@ function isFormComplete( contactInfo, domainContactInfo, isDomainContactSame, it
 		contactInfo.state,
 		...( isElligibleForVat() ? [ contactInfo.vatId ] : [] ),
 	];
-	const domainFields = [
-		domainContactInfo.firstName,
-		domainContactInfo.lastName,
-		domainContactInfo.email,
-		domainContactInfo.address,
-		domainContactInfo.city,
-		domainContactInfo.state,
-		domainContactInfo.phoneNumber,
-	];
 	let allFields = taxFields;
 	if ( areDomainsInLineItems( items ) ) {
 		allFields = allFields.concat( contactFields );
-		if ( ! isDomainContactSame ) {
-			allFields = allFields.concat( domainFields );
-		}
 	}
 
 	if ( ! allFields.every( field => field ) ) {
@@ -134,7 +118,7 @@ function isFormComplete( contactInfo, domainContactInfo, isDomainContactSame, it
 	return allFields.every( ( { isValid } ) => isValid );
 }
 
-function isFormEditable( contactInfo, domainContactInfo, isDomainContactSame, items ) {
+function isFormEditable( contactInfo, items ) {
 	const taxFields = [ contactInfo.country, contactInfo.postalCode ];
 	const contactFields = [
 		contactInfo.firstName,
@@ -145,21 +129,9 @@ function isFormEditable( contactInfo, domainContactInfo, isDomainContactSame, it
 		contactInfo.state,
 		...( isElligibleForVat() ? [ contactInfo.vatId ] : [] ),
 	];
-	const domainFields = [
-		domainContactInfo.firstName,
-		domainContactInfo.lastName,
-		domainContactInfo.email,
-		domainContactInfo.address,
-		domainContactInfo.city,
-		domainContactInfo.state,
-		domainContactInfo.phoneNumber,
-	];
 	let allFields = taxFields;
 	if ( areDomainsInLineItems( items ) ) {
 		allFields = allFields.concat( contactFields );
-		if ( ! isDomainContactSame ) {
-			allFields = allFields.concat( domainFields );
-		}
 	}
 
 	if ( ! allFields.every( field => field ) ) {

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -18,7 +18,6 @@ import { LeftColumn, RightColumn } from './ie-fallback';
 export default function WPContactForm( { summary, isComplete, isActive } ) {
 	const isDomainFieldsVisible = useHasDomainsInCart();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
-	const isDomainContactSame = useSelect( select => select( 'wpcom' ).isDomainContactSame() );
 	const setters = useDispatch( 'wpcom' );
 
 	if ( summary && isComplete ) {
@@ -28,14 +27,9 @@ export default function WPContactForm( { summary, isComplete, isActive } ) {
 		return null;
 	}
 
-	const toggleDomainFieldsVisibility = () =>
-		setters.setIsDomainContactSame( ! isDomainContactSame );
-
 	return (
 		<BillingFormFields>
-			{ isDomainFieldsVisible && (
-				<AddressFields section="contact" contactInfo={ contactInfo } setters={ setters } />
-			) }
+			{ isDomainFieldsVisible && <DomainFields /> }
 
 			<TaxFields section="contact" taxInfo={ contactInfo } setters={ setters } />
 
@@ -46,15 +40,6 @@ export default function WPContactForm( { summary, isComplete, isActive } ) {
 			/>
 
 			{ isElligibleForVat() && <VatIdField /> }
-
-			{ isDomainFieldsVisible && (
-				<DomainFieldsCheckbox
-					toggleVisibility={ toggleDomainFieldsVisibility }
-					isDomainContactVisible={ ! isDomainContactSame }
-				/>
-			) }
-
-			{ ! isDomainContactSame && isDomainFieldsVisible && <DomainFields /> }
 		</BillingFormFields>
 	);
 }
@@ -385,46 +370,24 @@ function isZipOrPostal() {
 
 function DomainFields() {
 	const translate = useTranslate();
-	const contactInfo = useSelect( select => select( 'wpcom' ).getDomainContactInfo() );
-	const { setDomainContactField } = useDispatch( 'wpcom' );
-	const setters = {
-		setContactField: setDomainContactField,
-	};
+	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
+	const setters = useDispatch( 'wpcom' );
 
 	return (
 		<DomainContactFields>
-			<DomainContactFieldsTitle>
-				{ translate( 'Enter your domain registration contact information' ) }
-			</DomainContactFieldsTitle>
 			<DomainContactFieldsDescription>
 				{ translate(
 					'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
 				) }
 			</DomainContactFieldsDescription>
 
-			<AddressFields section="domains" contactInfo={ contactInfo } setters={ setters } />
-			<TaxFields section="domains" taxInfo={ contactInfo } setters={ setters } />
-			<PhoneNumberField
-				id="domains-phone-number"
-				isRequired
-				phoneNumber={ contactInfo.phoneNumber }
-				onChange={ setDomainContactField }
-			/>
+			<AddressFields section="contact" contactInfo={ contactInfo } setters={ setters } />
 		</DomainContactFields>
 	);
 }
 
 const DomainContactFields = styled.div`
 	margin: 16px 0 24px;
-`;
-
-const DomainContactFieldsTitle = styled.h2`
-	font-size: 16px;
-	margin: 0 0 4px;
-	font-weight: 600;
-	color: ${props => props.theme.colors.borderColorDark};
-	padding-top: 24px;
-	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
 `;
 
 const DomainContactFieldsDescription = styled.p`
@@ -436,14 +399,9 @@ const DomainContactFieldsDescription = styled.p`
 function ContactFormSummary() {
 	const translate = useTranslate();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
-	const domainContactInfo = useSelect( select => select( 'wpcom' ).getDomainContactInfo() );
-	const isDomainContactSame = useSelect( select => select( 'wpcom' ).isDomainContactSame() );
 
 	//Check if paymentData is empty
-	if (
-		Object.entries( contactInfo ).length === 0 &&
-		Object.entries( domainContactInfo ).length === 0
-	) {
+	if ( Object.entries( contactInfo ).length === 0 ) {
 		return null;
 	}
 
@@ -457,22 +415,6 @@ function ContactFormSummary() {
 		', ',
 		contactInfo.postalCode.value,
 		contactInfo.country.value
-	);
-
-	const domainFullName = joinNonEmptyValues(
-		' ',
-		domainContactInfo.firstName.value,
-		domainContactInfo.lastName.value
-	);
-	const domainCityAndState = joinNonEmptyValues(
-		', ',
-		domainContactInfo.city.value,
-		domainContactInfo.state.value
-	);
-	const domainPostalAndCountry = joinNonEmptyValues(
-		', ',
-		domainContactInfo.postalCode.value,
-		domainContactInfo.country.value
 	);
 
 	return (
@@ -506,32 +448,6 @@ function ContactFormSummary() {
 					</SummaryDetails>
 				) }
 			</div>
-
-			{ ! isDomainContactSame && (
-				<div>
-					<SummaryDetails>
-						{ domainFullName && <SummaryLine>{ domainFullName }</SummaryLine> }
-
-						{ domainContactInfo.email.value.length > 0 && (
-							<SummarySpacerLine>{ domainContactInfo.email.value }</SummarySpacerLine>
-						) }
-
-						{ domainContactInfo.address.value.length > 0 && (
-							<SummaryLine>{ domainContactInfo.address.value }</SummaryLine>
-						) }
-
-						{ domainCityAndState && <SummaryLine>{ domainCityAndState }</SummaryLine> }
-
-						{ domainPostalAndCountry && <SummaryLine>{ domainPostalAndCountry }</SummaryLine> }
-					</SummaryDetails>
-
-					{ domainContactInfo.phoneNumber.value.length > 0 && (
-						<SummaryDetails>
-							<SummaryLine>{ domainContactInfo.phoneNumber.value }</SummaryLine>
-						</SummaryDetails>
-					) }
-				</div>
-			) }
 		</GridRow>
 	);
 }

--- a/packages/composite-checkout-wpcom/src/hooks/has-domains.js
+++ b/packages/composite-checkout-wpcom/src/hooks/has-domains.js
@@ -9,8 +9,12 @@ export function useHasDomainsInCart() {
 }
 
 export function areDomainsInLineItems( items ) {
-	if ( items.find( item => item.type === 'domain' ) ) {
+	if ( items.find( isLineItemADomain ) ) {
 		return true;
 	}
 	return false;
+}
+
+function isLineItemADomain( item ) {
+	return item.type.includes( 'domain' );
 }

--- a/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
+++ b/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
@@ -33,36 +33,6 @@ export function useWpcomStore( registerStore, onEvent ) {
 		}
 	}
 
-	const domainContactDefaults = {
-		firstName: { value: '', isTouched: false, isValid: false },
-		lastName: { value: '', isTouched: false, isValid: false },
-		email: { value: '', isTouched: false, isValid: false },
-		phoneNumber: { value: '', isTouched: false, isValid: false },
-		address: { value: '', isTouched: false, isValid: false },
-		city: { value: '', isTouched: false, isValid: false },
-		state: { value: '', isTouched: false, isValid: false },
-		country: { value: '', isTouched: false, isValid: false },
-		postalCode: { value: '', isTouched: false, isValid: false },
-	};
-
-	function domainContactReducer( state = domainContactDefaults, action ) {
-		switch ( action.type ) {
-			case 'CONTACT_SET_DOMAIN_FIELD':
-				return { ...state, [ action.payload.key ]: action.payload.field };
-			default:
-				return state;
-		}
-	}
-
-	function isDomainContactSameReducer( state = true, action ) {
-		switch ( action.type ) {
-			case 'CONTACT_SET_DOMAIN_SAME':
-				return action.payload;
-			default:
-				return state;
-		}
-	}
-
 	function siteIdReducer( state = null, action ) {
 		switch ( action.type ) {
 			case 'SET_SITE_ID':
@@ -75,9 +45,7 @@ export function useWpcomStore( registerStore, onEvent ) {
 	registerStore( 'wpcom', {
 		reducer( state = {}, action ) {
 			return {
-				isDomainContactSame: isDomainContactSameReducer( state.isDomainContactSame, action ),
 				contact: contactReducer( state.contact, action ),
-				domainContact: domainContactReducer( state.domainContact, action ),
 				siteId: siteIdReducer( state.siteId, action ),
 			};
 		},
@@ -85,10 +53,6 @@ export function useWpcomStore( registerStore, onEvent ) {
 		actions: {
 			setSiteId( payload ) {
 				return { type: 'SET_SITE_ID', payload };
-			},
-
-			setIsDomainContactSame( payload ) {
-				return { type: 'CONTACT_SET_DOMAIN_SAME', payload };
 			},
 
 			setContactField( key, field ) {
@@ -101,25 +65,17 @@ export function useWpcomStore( registerStore, onEvent ) {
 						},
 					} );
 				}
-
 				return { type: 'CONTACT_SET_FIELD', payload: { key, field } };
 			},
+
 			setVatId( payload ) {
 				return { type: 'CONTACT_SET_FIELD', payload: { key: 'vatId', payload } };
-			},
-
-			setDomainContactField( key, field ) {
-				return { type: 'CONTACT_SET_DOMAIN_FIELD', payload: { key, field } };
 			},
 		},
 
 		selectors: {
 			getSiteId( state ) {
 				return state.siteId;
-			},
-
-			isDomainContactSame( state ) {
-				return state.isDomainContactSame;
 			},
 
 			getContactInfo( state ) {
@@ -134,21 +90,6 @@ export function useWpcomStore( registerStore, onEvent ) {
 					postalCode: state.contact.postalCode,
 					phoneNumber: state.contact.phoneNumber,
 					vatId: state.contact.vatId,
-				};
-			},
-
-			getDomainContactInfo( state ) {
-				return {
-					firstName: state.domainContact.firstName,
-					lastName: state.domainContact.lastName,
-					email: state.domainContact.email,
-					address: state.domainContact.address,
-					city: state.domainContact.city,
-					state: state.domainContact.state,
-					country: state.domainContact.country,
-					postalCode: state.domainContact.postalCode,
-					phoneNumber: state.domainContact.phoneNumber,
-					vatId: state.contact.vatId, // There is only one vatId
 				};
 			},
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The design for the Calypso checkout form contact step when a domain was in the cart included a checkbox which allowed displaying a separate set of fields for domain details. However, the contact fields are not shown at all if there is no domain, so the contact fields _are_ the domain details.

This PR removes the checkbox and the unnecessary fields.

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan (not a domain) to your cart.
- Visit checkout.
- Verify that the contact details step (step 2) displays the country, postal code, and phone number fields.
- Verify that typing in the fields works and that the "Continue" button is only enabled when the fields are all filled.
- Go back and add a domain to your cart.
- Visit checkout.
- Verify that the contact details step (step 2) displays the original fields but also the name and address fields.
- Verify that typing in the fields works and that the "Continue" button is only enabled when the fields are all filled.
