### PR TITLE
composite-checkout: Add existing card payment method

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -293,11 +293,11 @@ function useCreatePaymentMethods() {
 					submit: submitData =>
 						submitExistingCardPayment( {
 							...submitData,
-							getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
+							siteId: select( 'wpcom' )?.getSiteId?.(),
 							storedDetailsId: storedDetails.stored_details_id,
 							paymentMethodToken: storedDetails.mp_ref,
 							paymentPartnerProcessorId: storedDetails.payment_partner,
-							getDomainDetails,
+							domainDetails: getDomainDetails(),
 						} ),
 					registerStore,
 					getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -336,6 +336,7 @@ function useStoredCards() {
 }
 
 async function submitExistingCardPayment( transactionData ) {
+	debug( 'formatting existing card transaction', transactionData );
 	const formattedTransactionData = formatDataForTransactionsEndpoint( {
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -187,11 +187,7 @@ export default function CompositeCheckoutContainer( {
 
 	// Payment methods must be created inside the component so their stores are
 	// re-created when the checkout unmounts and remounts.
-	const { stripeMethod, paypalMethod, applePayMethod } = useCreatePaymentMethods();
-	const availablePaymentMethods = useMemo(
-		() => [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ),
-		[ applePayMethod, stripeMethod, paypalMethod ]
-	);
+	const availablePaymentMethods = useCreatePaymentMethods();
 
 	const onPaymentComplete = useCallback( () => {
 		debug( 'payment completed successfully' );
@@ -273,5 +269,9 @@ function useCreatePaymentMethods() {
 				: null,
 		[]
 	);
-	return { stripeMethod, paypalMethod, applePayMethod };
+	return useMemo( () => [ stripeMethod, paypalMethod, applePayMethod ].filter( Boolean ), [
+		stripeMethod,
+		paypalMethod,
+		applePayMethod,
+	] );
 }

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -286,21 +286,24 @@ function useCreatePaymentMethods() {
 			storedCards.map( storedDetails =>
 				createExistingCardMethod( {
 					id: `existingCard-${ storedDetails.stored_details_id }`,
-					storedDetailsId: storedDetails.stored_details_id,
-					paymentMethodToken: storedDetails.mp_ref,
-					paymentPartnerProcessorId: storedDetails.payment_partner,
 					cardholderName: storedDetails.name,
 					cardExpiry: storedDetails.expiry,
 					brand: storedDetails.card_type,
 					last4: storedDetails.card,
-					submit: submitExistingCardPayment,
+					submit: submitData =>
+						submitExistingCardPayment( {
+							...submitData,
+							getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
+							storedDetailsId: storedDetails.stored_details_id,
+							paymentMethodToken: storedDetails.mp_ref,
+							paymentPartnerProcessorId: storedDetails.payment_partner,
+							getDomainDetails,
+						} ),
 					registerStore,
-					getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
 					getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,
 					getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 					getPhoneNumber: () => select( 'wpcom' )?.getContactInfo?.()?.phoneNumber?.value,
 					getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-					getDomainDetails,
 				} )
 			),
 		[ storedCards ]

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -290,7 +290,7 @@ function useCreatePaymentMethods() {
 					cardExpiry: storedDetails.expiry,
 					brand: storedDetails.card_type,
 					last4: storedDetails.card,
-					submit: submitData =>
+					submitTransaction: submitData =>
 						submitExistingCardPayment( {
 							...submitData,
 							siteId: select( 'wpcom' )?.getSiteId?.(),

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -223,7 +223,6 @@ Creates a [Payment Method](#payment-methods) object for an existing credit card.
 - `getCountry: () => string`. A function that returns the country to use for the transaction.
 - `getPostalCode: () => string`. A function that returns the postal code for the transaction.
 - `getSubdivisionCode: () => string`. A function that returns the subdivision code for the transaction.
-- `getDomainDetails: () => object`. A function that returns the domain details for the the transaction.
 - `id: string`. A unique id for this payment method (since there are likely to be several existing cards).
 - `cardholderName: string`. The cardholder's name. Used for display only.
 - `cardExpiry: string`. The card's expiry date. Used for display only.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -219,7 +219,7 @@ Creates a [data store](#data-stores) registry to be passed (optionally) to [Chec
 Creates a [Payment Method](#payment-methods) object for an existing credit card. Requires passing an object with the following properties:
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
-- `submit: async ?object => object`. An async function that sends the request to the endpoint process the payment.
+- `submitTransaction: async ?object => object`. An async function that sends the request to the endpoint process the payment.
 - `getCountry: () => string`. A function that returns the country to use for the transaction.
 - `getPostalCode: () => string`. A function that returns the postal code for the transaction.
 - `getSubdivisionCode: () => string`. A function that returns the subdivision code for the transaction.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -216,19 +216,15 @@ Creates a [data store](#data-stores) registry to be passed (optionally) to [Chec
 
 ### createExistingCardMethod
 
-Creates a [Payment Method](#payment-methods) object for an existing credit card. This is specific to WordPress.com and many of the options required should come from WordPress.com. Requires passing an object with the following properties:
+Creates a [Payment Method](#payment-methods) object for an existing credit card. Requires passing an object with the following properties:
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
 - `submit: async ?object => object`. An async function that sends the request to the endpoint process the payment.
-- `getSiteId: () => string`. A function that returns the WordPress.com site id.
 - `getCountry: () => string`. A function that returns the country to use for the transaction.
 - `getPostalCode: () => string`. A function that returns the postal code for the transaction.
 - `getSubdivisionCode: () => string`. A function that returns the subdivision code for the transaction.
 - `getDomainDetails: () => object`. A function that returns the domain details for the the transaction.
 - `id: string`. A unique id for this payment method (since there are likely to be several existing cards).
-- `storedDetailsId: string`. The stored details id to send to the transactions endpoint. Comes from WordPress.com.
-- `paymentMethodToken: string`. The token for this stored card to send to the transactions endpoint. Comes from WordPress.com.
-- `paymentPartnerProcessorId: string`. The payment partner name (eg: `stripe`). Comes from WordPress.com.
 - `cardholderName: string`. The cardholder's name. Used for display only.
 - `cardExpiry: string`. The card's expiry date. Used for display only.
 - `brand: string`. The card's brand (eg: `visa`). Used for display only.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -25,7 +25,7 @@ It's also possible to build an entirely custom form using the other components e
 
 ## How to use this package
 
-Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the functions [createStripeMethod](#createstripemethod), [createApplePayMethod](#createapplepaymethod), and [createPayPalMethod](#createpaypalmethod).
+Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the functions [createStripeMethod](#createstripemethod), [createApplePayMethod](#createapplepaymethod), [createPayPalMethod](#createpaypalmethod), and [createExistingCardMethod](#createExistingCardMethod).
 
 Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [useFormStatus](#useFormStatus), [useMessages](#useMessages), [useCheckoutRedirects](#useCheckoutRedirects), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentData](#usePaymentData), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
 
@@ -213,6 +213,26 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 ### createRegistry
 
 Creates a [data store](#data-stores) registry to be passed (optionally) to [CheckoutProvider](#checkoutprovider). See the `@wordpress/data` [docs for this function](https://developer.wordpress.org/block-editor/packages/packages-data/#createRegistry).
+
+### createExistingCardMethod
+
+Creates a [Payment Method](#payment-methods) object for an existing credit card. This is specific to WordPress.com and many of the options required should come from WordPress.com. Requires passing an object with the following properties:
+
+- `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
+- `submit: async ?object => object`. An async function that sends the request to the endpoint process the payment.
+- `getSiteId: () => string`. A function that returns the WordPress.com site id.
+- `getCountry: () => string`. A function that returns the country to use for the transaction.
+- `getPostalCode: () => string`. A function that returns the postal code for the transaction.
+- `getSubdivisionCode: () => string`. A function that returns the subdivision code for the transaction.
+- `getDomainDetails: () => object`. A function that returns the domain details for the the transaction.
+- `id: string`. A unique id for this payment method (since there are likely to be several existing cards).
+- `storedDetailsId: string`. The stored details id to send to the transactions endpoint. Comes from WordPress.com.
+- `paymentMethodToken: string`. The token for this stored card to send to the transactions endpoint. Comes from WordPress.com.
+- `paymentPartnerProcessorId: string`. The payment partner name (eg: `stripe`). Comes from WordPress.com.
+- `cardholderName: string`. The cardholder's name. Used for display only.
+- `cardExpiry: string`. The card's expiry date. Used for display only.
+- `brand: string`. The card's brand (eg: `visa`). Used for display only.
+- `last4: string`. The card's last four digits. Used for display only.
 
 ### createPayPalMethod
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -19,11 +20,17 @@ import {
 } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 
+const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
+
 export default function CheckoutPaymentMethods( { summary, isComplete, className } ) {
 	const localize = useLocalize();
 
 	const paymentMethod = usePaymentMethod();
 	const [ , setPaymentMethod ] = usePaymentMethodId();
+	const onClickPaymentMethod = newMethod => {
+		debug( 'setting payment method to', newMethod );
+		setPaymentMethod( newMethod );
+	};
 	const paymentMethods = useAllPaymentMethods();
 
 	if ( summary && isComplete && paymentMethod ) {
@@ -60,7 +67,7 @@ export default function CheckoutPaymentMethods( { summary, isComplete, className
 						<PaymentMethod
 							{ ...method }
 							checked={ paymentMethod.id === method.id }
-							onClick={ setPaymentMethod }
+							onClick={ onClickPaymentMethod }
 							ariaLabel={ method.getAriaLabel( localize ) }
 						/>
 					</CheckoutErrorBoundary>

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -1,0 +1,501 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import styled from '@emotion/styled';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../../components/button';
+import { useStripe, createStripePaymentMethod, confirmStripePaymentIntent } from '../stripe';
+import {
+	useSelect,
+	useDispatch,
+	useMessages,
+	useLineItems,
+	useCheckoutRedirects,
+	renderDisplayValueMarkdown,
+} from '../../public-api';
+import { sprintf, useLocalize } from '../localize';
+import {
+	VisaLogo,
+	AmexLogo,
+	MastercardLogo,
+	JcbLogo,
+	DinersLogo,
+	UnionpayLogo,
+	DiscoverLogo,
+} from '../../components/payment-logos';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import { useFormStatus } from '../form-status';
+
+const debug = debugFactory( 'composite-checkout:existing-card-payment-method' );
+
+export function createExistingCardMethod( {
+	getSiteId,
+	getCountry,
+	getPostalCode,
+	getPhoneNumber,
+	getSubdivisionCode,
+	getDomainDetails,
+	registerStore,
+	fetchStripeConfiguration,
+	sendStripeTransaction,
+	id,
+	labelText,
+} ) {
+	debug( 'creating a new existing credit card payment method' );
+	const actions = {
+		changeBrand( payload ) {
+			return { type: 'BRAND_SET', payload };
+		},
+		setCardDataError( type, message ) {
+			return { type: 'CARD_DATA_ERROR_SET', payload: { type, message } };
+		},
+		setCardDataComplete( type, complete ) {
+			return { type: 'CARD_DATA_COMPLETE_SET', payload: { type, complete } };
+		},
+		changeCardholderName( payload ) {
+			return { type: 'CARDHOLDER_NAME_SET', payload };
+		},
+		setStripeError( payload ) {
+			return { type: 'STRIPE_TRANSACTION_ERROR', payload };
+		},
+		*getConfiguration( payload ) {
+			let configuration;
+			try {
+				configuration = yield { type: 'STRIPE_CONFIGURATION_FETCH', payload };
+			} catch ( error ) {
+				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
+			}
+			return { type: 'STRIPE_CONFIGURATION_SET', payload: configuration };
+		},
+		*beginStripeTransaction( payload ) {
+			let stripeResponse;
+			try {
+				const paymentMethodToken = yield {
+					type: 'STRIPE_CREATE_PAYMENT_METHOD_TOKEN',
+					payload: {
+						...payload,
+						country: getCountry(),
+						postalCode: getPostalCode(),
+						phoneNumber: getPhoneNumber(),
+					},
+				};
+				debug( 'stripe payment token created' );
+				stripeResponse = yield {
+					type: 'STRIPE_TRANSACTION_BEGIN',
+					payload: {
+						...payload,
+						siteId: getSiteId(),
+						country: getCountry(),
+						postalCode: getPostalCode(),
+						subdivisionCode: getSubdivisionCode(),
+						domainDetails: getDomainDetails(),
+						paymentMethodToken,
+					},
+				};
+				debug( 'stripe transaction complete', stripeResponse );
+			} catch ( error ) {
+				debug( 'stripe transaction had an error', error );
+				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
+			}
+			if ( stripeResponse?.message?.payment_intent_client_secret ) {
+				debug( 'stripe transaction requires auth' );
+				return { type: 'STRIPE_TRANSACTION_AUTH', payload: stripeResponse };
+			}
+			if ( stripeResponse?.redirect_url ) {
+				debug( 'stripe transaction requires redirect' );
+				return { type: 'STRIPE_TRANSACTION_REDIRECT', payload: stripeResponse };
+			}
+			debug( 'stripe transaction requires is successful' );
+			return { type: 'STRIPE_TRANSACTION_END', payload: stripeResponse };
+		},
+	};
+
+	const selectors = {
+		getStripeConfiguration( state ) {
+			return state.stripeConfiguration;
+		},
+		getBrand( state ) {
+			return state.brand || '';
+		},
+		getCardholderName( state ) {
+			return state.cardholderName || '';
+		},
+		getTransactionError( state ) {
+			return state.transactionError;
+		},
+		getTransactionStatus( state ) {
+			return state.transactionStatus;
+		},
+		getTransactionAuthData( state ) {
+			return state.transactionAuthData;
+		},
+		getCardDataErrors( state ) {
+			return state.cardDataErrors;
+		},
+		areAllFieldsComplete( state ) {
+			return Object.keys( state.cardDataComplete ).every( key => state.cardDataComplete[ key ] );
+		},
+	};
+
+	function cardDataCompleteReducer(
+		state = {
+			cardNumber: false,
+			cardCvc: false,
+			cardExpiry: false,
+		},
+		action
+	) {
+		switch ( action?.type ) {
+			case 'CARD_DATA_COMPLETE_SET':
+				return { ...state, [ action.payload.type ]: action.payload.complete };
+			default:
+				return state;
+		}
+	}
+
+	function cardDataErrorsReducer( state = {}, action ) {
+		switch ( action?.type ) {
+			case 'CARD_DATA_ERROR_SET':
+				return { ...state, [ action.payload.type ]: action.payload.message };
+			default:
+				return state;
+		}
+	}
+
+	registerStore( 'existing-card', {
+		reducer(
+			state = {
+				cardDataErrors: cardDataErrorsReducer(),
+				cardDataComplete: cardDataCompleteReducer(),
+			},
+			action
+		) {
+			switch ( action.type ) {
+				case 'STRIPE_TRANSACTION_END':
+					return {
+						...state,
+						transactionStatus: 'complete',
+					};
+				case 'STRIPE_TRANSACTION_ERROR':
+					return {
+						...state,
+						transactionStatus: 'error',
+						transactionError: action.payload,
+					};
+				case 'STRIPE_TRANSACTION_AUTH':
+					return {
+						...state,
+						transactionStatus: 'auth',
+						transactionAuthData: action.payload,
+					};
+				case 'STRIPE_TRANSACTION_REDIRECT':
+					return {
+						...state,
+						transactionStatus: 'redirect',
+					};
+				case 'STRIPE_CONFIGURATION_SET':
+					return { ...state, stripeConfiguration: action.payload };
+				case 'CARDHOLDER_NAME_SET':
+					return { ...state, cardholderName: action.payload };
+				case 'BRAND_SET':
+					return { ...state, brand: action.payload };
+				case 'CARD_DATA_COMPLETE_SET':
+					return {
+						...state,
+						cardDataComplete: cardDataCompleteReducer( state.cardDataComplete, action ),
+					};
+				case 'CARD_DATA_ERROR_SET':
+					return {
+						...state,
+						cardDataErrors: cardDataErrorsReducer( state.cardDataErrors, action ),
+					};
+			}
+			return state;
+		},
+		actions,
+		selectors,
+		controls: {
+			STRIPE_CONFIGURATION_FETCH( action ) {
+				return fetchStripeConfiguration( action.payload );
+			},
+			STRIPE_CREATE_PAYMENT_METHOD_TOKEN( action ) {
+				return createStripePaymentMethodToken( action.payload );
+			},
+			STRIPE_TRANSACTION_BEGIN( action ) {
+				return sendStripeTransaction( action.payload );
+			},
+		},
+	} );
+
+	return {
+		id,
+		label: <ExistingCardLabel labelText={ labelText } />,
+		submitButton: <ExistingCardPayButton />,
+		inactiveContent: <ExistingCardSummary />,
+		getAriaLabel: () => labelText,
+	};
+}
+
+export function ExistingCardLabel( { labelText } ) {
+	return (
+		<React.Fragment>
+			<span>{ labelText }</span>
+		</React.Fragment>
+	);
+}
+
+const LockIconGraphic = styled( LockIcon )`
+	display: block;
+	position: absolute;
+	right: 10px;
+	top: 14px;
+	width: 20px;
+	height: 20px;
+`;
+
+function CardFieldIcon( { brand, isSummary } ) {
+	let cardFieldIcon = null;
+
+	switch ( brand ) {
+		case 'visa':
+			cardFieldIcon = (
+				<BrandLogo isSummary={ isSummary }>
+					<VisaLogo />
+				</BrandLogo>
+			);
+			break;
+		case 'mastercard':
+			cardFieldIcon = (
+				<SmallBrandLogo isSummary={ isSummary }>
+					<MastercardLogo />
+				</SmallBrandLogo>
+			);
+			break;
+		case 'amex':
+			cardFieldIcon = (
+				<BrandLogo isSummary={ isSummary }>
+					<AmexLogo />
+				</BrandLogo>
+			);
+			break;
+		case 'jcb':
+			cardFieldIcon = (
+				<SmallBrandLogo isSummary={ isSummary }>
+					<JcbLogo />
+				</SmallBrandLogo>
+			);
+			break;
+		case 'diners':
+			cardFieldIcon = (
+				<SmallBrandLogo isSummary={ isSummary }>
+					<DinersLogo />
+				</SmallBrandLogo>
+			);
+			break;
+		case 'unionpay':
+			cardFieldIcon = (
+				<SmallBrandLogo isSummary={ isSummary }>
+					<UnionpayLogo />
+				</SmallBrandLogo>
+			);
+			break;
+		case 'discover':
+			cardFieldIcon = (
+				<BrandLogo isSummary={ isSummary }>
+					<DiscoverLogo />
+				</BrandLogo>
+			);
+			break;
+		default:
+			cardFieldIcon = brand === 'unknown' && isSummary ? null : <LockIconGraphic />;
+	}
+
+	return cardFieldIcon;
+}
+
+const BrandLogo = styled.span`
+	display: ${props => ( props.isSummary ? 'inline-block' : 'block' )};
+	position: ${props => ( props.isSummary ? 'relative' : 'absolute' )};
+	top: ${props => ( props.isSummary ? '0' : '15px' )};
+	right: ${props => ( props.isSummary ? '0' : '10px' )};
+	transform: translateY( ${props => ( props.isSummary ? '4px' : '0' )} );
+`;
+
+const SmallBrandLogo = styled( BrandLogo )`
+	transform: translate( ${props => ( props.isSummary ? '-10px, 4px' : '10px, 0' )} );
+`;
+
+function LockIcon( { className } ) {
+	return (
+		<svg
+			className={ className }
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<g fill="none">
+				<path d="M0 0h24v24H0V0z" />
+				<path opacity=".87" d="M0 0h24v24H0V0z" />
+			</g>
+			<path
+				fill="#8E9196"
+				d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zM9 6c0-1.66 1.34-3 3-3s3 1.34 3 3v2H9V6zm9 14H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+			/>
+		</svg>
+	);
+}
+
+function ExistingCardPayButton( { disabled } ) {
+	const localize = useLocalize();
+	const [ items, total ] = useLineItems();
+	const { showErrorMessage } = useMessages();
+	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
+	const { stripe, stripeConfiguration } = useStripe();
+	const transactionStatus = useSelect( select => select( 'existing-card' ).getTransactionStatus() );
+	const transactionError = useSelect( select => select( 'existing-card' ).getTransactionError() );
+	const transactionAuthData = useSelect( select =>
+		select( 'existing-card' ).getTransactionAuthData()
+	);
+	const { beginStripeTransaction } = useDispatch( 'existing-card' );
+	const name = useSelect( select => select( 'existing-card' ).getCardholderName() );
+	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+
+	useEffect( () => {
+		if ( transactionStatus === 'error' ) {
+			// TODO: clear this after showing it
+			showErrorMessage(
+				transactionError || localize( 'An error occurred during the transaction' )
+			);
+			setFormReady();
+		}
+		if ( transactionStatus === 'complete' ) {
+			debug( 'stripe transaction is complete' );
+			setFormComplete();
+		}
+		if ( transactionStatus === 'redirect' ) {
+			// TODO: notify user that we are going to redirect
+		}
+		if ( transactionStatus === 'auth' ) {
+			showStripeModalAuth( {
+				stripeConfiguration,
+				response: transactionAuthData,
+			} ).catch( error => {
+				setFormReady();
+				showErrorMessage( error.stripeError || error.message );
+			} );
+		}
+	}, [
+		setFormReady,
+		setFormComplete,
+		showErrorMessage,
+		transactionStatus,
+		transactionError,
+		transactionAuthData,
+		stripeConfiguration,
+		localize,
+	] );
+
+	const buttonString =
+		formStatus === 'submitting'
+			? localize( 'Processing...' )
+			: sprintf( localize( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ () =>
+				submitStripePayment( {
+					name,
+					items,
+					total,
+					stripe,
+					stripeConfiguration,
+					showErrorMessage,
+					successUrl: successRedirectUrl,
+					cancelUrl: failureRedirectUrl,
+					beginStripeTransaction,
+					setFormSubmitting,
+				} )
+			}
+			buttonState={ disabled ? 'disabled' : 'primary' }
+			fullWidth
+		>
+			{ buttonString }
+		</Button>
+	);
+}
+
+function ExistingCardSummary() {
+	const cardholderName = useSelect( select => select( 'existing-card' ).getCardholderName() );
+	const brand = useSelect( select => select( 'existing-card' ).getBrand() );
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ cardholderName }</SummaryLine>
+			<SummaryLine>
+				{ brand !== 'unknown' && '****' } <CardFieldIcon brand={ brand } isSummary={ true } />
+			</SummaryLine>
+		</SummaryDetails>
+	);
+}
+
+async function submitStripePayment( {
+	name,
+	items,
+	total,
+	stripe,
+	stripeConfiguration,
+	showErrorMessage,
+	successUrl,
+	cancelUrl,
+	beginStripeTransaction,
+	setFormSubmitting,
+	setFormReady,
+} ) {
+	debug( 'submitting stripe payment' );
+	try {
+		setFormSubmitting();
+		beginStripeTransaction( {
+			stripe,
+			name,
+			items,
+			total,
+			stripeConfiguration,
+			successUrl,
+			cancelUrl,
+		} );
+	} catch ( error ) {
+		setFormReady();
+		showErrorMessage( error );
+		return;
+	}
+}
+
+function createStripePaymentMethodToken( { stripe, name, country, postalCode, phoneNumber } ) {
+	return createStripePaymentMethod( stripe, {
+		name,
+		address: {
+			country,
+			postal_code: postalCode,
+		},
+		...( phoneNumber ? { phone: phoneNumber } : {} ),
+	} );
+}
+
+async function showStripeModalAuth( { stripeConfiguration, response } ) {
+	const authenticationResponse = await confirmStripePaymentIntent(
+		stripeConfiguration,
+		response.message.payment_intent_client_secret
+	);
+
+	if ( authenticationResponse ) {
+		// TODO: what do we do here?
+	}
+}

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -96,7 +96,7 @@ export function createExistingCardMethod( {
 		},
 	};
 
-	registerStore( 'existing-card', {
+	registerStore( `existing-card-${ id }`, {
 		reducer(
 			state = {
 				transactionStatus: null,
@@ -282,12 +282,16 @@ function ExistingCardPayButton( { disabled, id } ) {
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage } = useMessages();
 	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
-	const transactionStatus = useSelect( select => select( 'existing-card' ).getTransactionStatus() );
-	const transactionError = useSelect( select => select( 'existing-card' ).getTransactionError() );
-	const transactionAuthData = useSelect( select =>
-		select( 'existing-card' ).getTransactionAuthData()
+	const transactionStatus = useSelect( select =>
+		select( `existing-card-${ id }` ).getTransactionStatus()
 	);
-	const { beginCardTransaction } = useDispatch( 'existing-card' );
+	const transactionError = useSelect( select =>
+		select( `existing-card-${ id }` ).getTransactionError()
+	);
+	const transactionAuthData = useSelect( select =>
+		select( `existing-card-${ id }` ).getTransactionAuthData()
+	);
+	const { beginCardTransaction } = useDispatch( `existing-card-${ id }` );
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 
 	useEffect( () => {

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -150,7 +150,7 @@ export function createExistingCardMethod( {
 				brand={ brand }
 			/>
 		),
-		submitButton: <ExistingCardPayButton />,
+		submitButton: <ExistingCardPayButton id={ id } />,
 		inactiveContent: (
 			<ExistingCardSummary cardholderName={ cardholderName } brand={ brand } last4={ last4 } />
 		),
@@ -277,7 +277,7 @@ function LockIcon( { className } ) {
 	);
 }
 
-function ExistingCardPayButton( { disabled } ) {
+function ExistingCardPayButton( { disabled, id } ) {
 	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage } = useMessages();
@@ -323,6 +323,7 @@ function ExistingCardPayButton( { disabled } ) {
 			disabled={ disabled }
 			onClick={ () =>
 				submitExistingCardPayment( {
+					id,
 					items,
 					total,
 					showErrorMessage,
@@ -353,6 +354,7 @@ function ExistingCardSummary( { cardholderName, brand, last4 } ) {
 }
 
 async function submitExistingCardPayment( {
+	id,
 	items,
 	total,
 	showErrorMessage,
@@ -362,7 +364,7 @@ async function submitExistingCardPayment( {
 	setFormSubmitting,
 	setFormReady,
 } ) {
-	debug( 'submitting existing card payment' );
+	debug( 'submitting existing card payment with the id', id );
 	try {
 		setFormSubmitting();
 		beginCardTransaction( {

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -54,6 +54,7 @@ export function createExistingCardMethod( {
 					type: 'EXISTING_CARD_TRANSACTION_BEGIN',
 					payload: {
 						...payload,
+						name: cardholderName,
 						country: getCountry(),
 						postalCode: getPostalCode(),
 						subdivisionCode: getSubdivisionCode(),
@@ -279,7 +280,6 @@ function ExistingCardPayButton( { disabled } ) {
 		select( 'existing-card' ).getTransactionAuthData()
 	);
 	const { beginCardTransaction } = useDispatch( 'existing-card' );
-	const name = useSelect( select => select( 'existing-card' ).getCardholderName() );
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 
 	useEffect( () => {
@@ -315,7 +315,6 @@ function ExistingCardPayButton( { disabled } ) {
 			disabled={ disabled }
 			onClick={ () =>
 				submitExistingCardPayment( {
-					name,
 					items,
 					total,
 					showErrorMessage,
@@ -345,7 +344,6 @@ function ExistingCardSummary( { cardholderName, brand } ) {
 }
 
 async function submitExistingCardPayment( {
-	name,
 	items,
 	total,
 	showErrorMessage,
@@ -359,7 +357,6 @@ async function submitExistingCardPayment( {
 	try {
 		setFormSubmitting();
 		beginCardTransaction( {
-			name,
 			items,
 			total,
 			successUrl,

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -43,7 +43,7 @@ export function createExistingCardMethod( {
 	id,
 	storedDetailsId,
 	paymentMethodToken,
-	paymentPartnerKey,
+	paymentPartnerProcessorId,
 	cardholderName,
 	cardExpiry,
 	brand,
@@ -66,7 +66,7 @@ export function createExistingCardMethod( {
 						domainDetails: getDomainDetails(),
 						storedDetailsId,
 						paymentMethodToken,
-						paymentPartnerKey,
+						paymentPartnerProcessorId,
 					},
 				};
 				debug( 'existing card transaction complete', response );

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -151,7 +151,9 @@ export function createExistingCardMethod( {
 			/>
 		),
 		submitButton: <ExistingCardPayButton />,
-		inactiveContent: <ExistingCardSummary cardholderName={ cardholderName } brand={ brand } />,
+		inactiveContent: (
+			<ExistingCardSummary cardholderName={ cardholderName } brand={ brand } last4={ last4 } />
+		),
 		getAriaLabel: () => `${ brand } ${ last4 } ${ cardholderName }`,
 	};
 }
@@ -338,12 +340,13 @@ function ExistingCardPayButton( { disabled } ) {
 	);
 }
 
-function ExistingCardSummary( { cardholderName, brand } ) {
+function ExistingCardSummary( { cardholderName, brand, last4 } ) {
 	return (
 		<SummaryDetails>
 			<SummaryLine>{ cardholderName }</SummaryLine>
 			<SummaryLine>
-				{ brand !== 'unknown' && '****' } <CardFieldIcon brand={ brand } isSummary={ true } />
+				{ brand !== 'unknown' && `****${ last4 }` }{ ' ' }
+				<CardFieldIcon brand={ brand } isSummary={ true } />
 			</SummaryLine>
 		</SummaryDetails>
 	);

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -44,7 +44,13 @@ export function createExistingCardMethod( {
 	brand,
 	last4,
 } ) {
-	debug( 'creating a new existing credit card payment method', {} );
+	debug( 'creating a new existing credit card payment method', {
+		id,
+		cardholderName,
+		cardExpiry,
+		brand,
+		last4,
+	} );
 
 	const actions = {
 		*beginCardTransaction( payload ) {

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -33,17 +33,12 @@ import { useFormStatus } from '../form-status';
 const debug = debugFactory( 'composite-checkout:existing-card-payment-method' );
 
 export function createExistingCardMethod( {
-	getSiteId,
 	getCountry,
 	getPostalCode,
 	getSubdivisionCode,
-	getDomainDetails,
 	registerStore,
 	submit,
 	id,
-	storedDetailsId,
-	paymentMethodToken,
-	paymentPartnerProcessorId,
 	cardholderName,
 	cardExpiry,
 	brand,
@@ -59,14 +54,9 @@ export function createExistingCardMethod( {
 					type: 'EXISTING_CARD_TRANSACTION_BEGIN',
 					payload: {
 						...payload,
-						siteId: getSiteId(),
 						country: getCountry(),
 						postalCode: getPostalCode(),
 						subdivisionCode: getSubdivisionCode(),
-						domainDetails: getDomainDetails(),
-						storedDetailsId,
-						paymentMethodToken,
-						paymentPartnerProcessorId,
 					},
 				};
 				debug( 'existing card transaction complete', response );

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -37,7 +37,7 @@ export function createExistingCardMethod( {
 	getPostalCode,
 	getSubdivisionCode,
 	registerStore,
-	submit,
+	submitTransaction,
 	id,
 	cardholderName,
 	cardExpiry,
@@ -135,7 +135,7 @@ export function createExistingCardMethod( {
 		selectors,
 		controls: {
 			EXISTING_CARD_TRANSACTION_BEGIN( action ) {
-				return submit( action.payload );
+				return submitTransaction( action.payload );
 			},
 		},
 	} );

--- a/packages/composite-checkout/src/lib/payment-methods/index.js
+++ b/packages/composite-checkout/src/lib/payment-methods/index.js
@@ -20,7 +20,7 @@ export function usePaymentMethod() {
 	const { paymentMethodId, setPaymentMethodId } = useContext( CheckoutContext );
 	const allPaymentMethods = useAllPaymentMethods();
 	if ( ! setPaymentMethodId ) {
-		throw new Error( 'usePaymentMethodId can only be used inside a CheckoutProvider' );
+		throw new Error( 'usePaymentMethod can only be used inside a CheckoutProvider' );
 	}
 	if ( ! paymentMethodId ) {
 		return null;

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -31,6 +31,7 @@ import { createStripeMethod } from './lib/payment-methods/stripe-credit-card-fie
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createCreditCardMethod } from './lib/payment-methods/credit-card';
+import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
 import { useActiveStep, useIsStepActive } from './lib/active-step';
 import CheckoutOrderSummary, {
 	CheckoutOrderSummaryTitle,
@@ -56,6 +57,7 @@ export {
 	OrderReviewTotal,
 	createApplePayMethod,
 	createCreditCardMethod,
+	createExistingCardMethod,
 	createPayPalMethod,
 	createRegistry,
 	createStripeMethod,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds payment methods for existing credit cards to composite checkout.

When the checkout form in Calypso is first loaded, it fetches the existing cards from the REST API and then creates a new Payment Method Object for each one using the new `createExistingCardMethod()` function that's part of composite-checkout's public API.

The payment method label and inactive content are not currently styled, but that can come in a later PR.

#### Testing instructions

- Sandbox the store.
- Using calypso master, add a saved credit card to your account. It can be a Stripe test card, eg: `4242 4242 4242 4242`.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to your cart and visit checkout.
- Verify that you see a payment method in the list for your existing card.
- Select the existing card and complete the payment form.
- Verify that the payment is successful and that the plan is added to your site successfully.