### PR TITLE
Eligibility Warnings: Fix a couple of conditional strings in the "hold list"

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -131,7 +131,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			message: hasLocalizedText(
 				"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
 			)
-				? hasLocalizedText(
+				? translate(
 						"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
 				  )
 				: translate( "Contact us to review your site's standing and resolve the dispute." ),
@@ -142,7 +142,7 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			message: hasLocalizedText(
 				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
 			)
-				? hasLocalizedText(
+				? translate(
 						'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
 				  )
 				: translate(


### PR DESCRIPTION
There were a couple of places where we were attempting to render the return value of `hasLocalizedText` instead of `translate`, so the messages were not being displayed.

|Before|After|
|---|---|
|<img width="776" alt="screen_shot_2020-01-02_at_2 28 10_pm" src="https://user-images.githubusercontent.com/1587282/71747795-9c19ad80-2e3e-11ea-8c7b-30cdc1b42413.png">|<img width="757" alt="Screen Shot 2020-01-03 at 3 22 33 PM" src="https://user-images.githubusercontent.com/1587282/71747802-a20f8e80-2e3e-11ea-9ab9-09b216531b6c.png">|

It's also worth noting that this section is in the process of a redesign, so this is not its final form.  Also, these strings should be fully localized by now, so I'll follow up with a PR to pull out the conditionals, but wanted to get this in to fix the broken notice.

### Changes proposed in this Pull Request

* Return the value of `translate` for `SITE_GRAYLISTED`
* Return the value of `translate` for `NO_SSL_CERTIFICATE`

#### Testing instructions

* Apply this patch to force the blocking hold in the client: https://gist.github.com/jblz/1b1179caf735b3cbef283460ed213372
* Browse to `/plugins/upload/` for a Business Plan site
* You should see appropriate text in the notice

Fixes #38638
