### PR TITLE
Eligibility Warnings: Remove usages of hasLocalizedText

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import hasLocalizedText from './has-localized-text';
 import { Button } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
@@ -21,31 +20,17 @@ import { localizeUrl } from 'lib/i18n-utils';
 function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: hasLocalizedText( 'Upgrade to a Business plan' )
-				? translate( 'Upgrade to a Business plan' )
-				: translate( 'Upgrade to Business' ),
+			title: translate( 'Upgrade to a Business plan' ),
 			description: ( function() {
 				if ( context === 'themes' ) {
-					return hasLocalizedText(
+					return translate(
 						"You'll also get to install custom plugins, have more storage, and access live support."
-					)
-						? translate(
-								"You'll also get to install custom plugins, have more storage, and access live support."
-						  )
-						: translate(
-								'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
-						  );
+					);
 				}
 
-				return hasLocalizedText(
+				return translate(
 					"You'll also get to install custom themes, have more storage, and access live support."
-				)
-					? translate(
-							"You'll also get to install custom themes, have more storage, and access live support."
-					  )
-					: translate(
-							'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
-					  );
+				);
 			} )(),
 			supportUrl: null,
 		},
@@ -98,15 +83,9 @@ function getHoldMessages( context: string | null, translate: LocalizeProps[ 'tra
 function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 	return {
 		BLOCKED_ATOMIC_TRANSFER: {
-			message: hasLocalizedText(
+			message: translate(
 				'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
-			)
-				? translate(
-						'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
-				  )
-				: translate(
-						'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
-				  ),
+			),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},
@@ -128,26 +107,16 @@ function getBlockingMessages( translate: LocalizeProps[ 'translate' ] ) {
 			contactUrl: null,
 		},
 		SITE_GRAYLISTED: {
-			message: hasLocalizedText(
+			message: translate(
 				"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
-			)
-				? hasLocalizedText(
-						"There's an ongoing site dispute. Contact us to review your site's standing and resolve the dispute."
-				  )
-				: translate( "Contact us to review your site's standing and resolve the dispute." ),
+			),
 			status: 'is-error',
 			contactUrl: localizeUrl( 'https://en.support.wordpress.com/suspended-blogs/' ),
 		},
 		NO_SSL_CERTIFICATE: {
-			message: hasLocalizedText(
+			message: translate(
 				'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
-			)
-				? hasLocalizedText(
-						'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
-				  )
-				: translate(
-						'Hold tight! We are setting up a digital certificate to allow secure browsing on your site, using "HTTPS". Please try again in a few minutes.\''
-				  ),
+			),
 			status: null,
 			contactUrl: null,
 		},
@@ -241,24 +210,15 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 };
 
 function getCardHeading( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
-	const defaultCopy = translate( "To continue you'll need to:" );
 	switch ( context ) {
 		case 'plugins':
-			return hasLocalizedText( "To install plugins you'll need to:" )
-				? translate( "To install plugins you'll need to:" )
-				: defaultCopy;
+			return translate( "To install plugins you'll need to:" );
 		case 'themes':
-			return hasLocalizedText( "To install themes you'll need to:" )
-				? translate( "To install themes you'll need to:" )
-				: defaultCopy;
+			return translate( "To install themes you'll need to:" );
 		case 'hosting':
-			return hasLocalizedText( "To activate hosting access you'll need to:" )
-				? translate( "To activate hosting access you'll need to:" )
-				: defaultCopy;
+			return translate( "To activate hosting access you'll need to:" );
 		default:
-			return hasLocalizedText( "To continue you'll need to:" )
-				? translate( "To continue you'll need to:" )
-				: defaultCopy;
+			return translate( "To continue you'll need to:" );
 	}
 }
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -12,7 +12,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import hasLocalizedText from './has-localized-text';
 import { FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES, FEATURE_SFTP } from 'lib/plans/constants';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -116,33 +115,23 @@ function getSiteIsEligibleMessage(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ]
 ) {
-	const defaultCopy = translate( 'This site is eligible to install plugins and upload themes.' );
 	switch ( context ) {
 		case 'plugins':
 		case 'themes':
-			return hasLocalizedText( 'This site is eligible to install plugins and upload themes.' )
-				? translate( 'This site is eligible to install plugins and upload themes.' )
-				: defaultCopy;
+			return translate( 'This site is eligible to install plugins and upload themes.' );
 		case 'hosting':
-			return hasLocalizedText( 'This site is eligible to activate hosting access.' )
-				? translate( 'This site is eligible to activate hosting access.' )
-				: defaultCopy;
+			return translate( 'This site is eligible to activate hosting access.' );
 		default:
-			return hasLocalizedText( 'This site is eligible to continue.' )
-				? translate( 'This site is eligible to continue.' )
-				: defaultCopy;
+			return translate( 'This site is eligible to continue.' );
 	}
 }
 
 function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'translate' ] ) {
-	const defaultCopy = translate( 'Proceed' );
 	if ( holds.includes( 'NO_BUSINESS_PLAN' ) ) {
-		return hasLocalizedText( 'Upgrade and continue' )
-			? translate( 'Upgrade and continue' )
-			: defaultCopy;
+		return translate( 'Upgrade and continue' );
 	}
 
-	return hasLocalizedText( 'Continue' ) ? translate( 'Continue' ) : defaultCopy;
+	return translate( 'Continue' );
 }
 
 function isProceedButtonDisabled( isEligible: boolean, holds: string[] ) {

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -9,7 +9,6 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import hasLocalizedText from './has-localized-text';
 import ExternalLink from 'components/external-link';
 import ActionPanelLink from 'components/action-panel/link';
 
@@ -50,24 +49,14 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 
 		<div className="eligibility-warnings__warning">
 			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-title">
-					{ hasLocalizedText( 'Questions?' )
-						? translate( 'Questions?' )
-						: translate( 'Any Questions?' ) }
-				</span>
+				<span className="eligibility-warnings__message-title">{ translate( 'Questions?' ) }</span>
 				:&nbsp;
 				<span className="eligibility-warnings__message-description">
-					{ hasLocalizedText( '{{a}}Contact support{{/a}} for help.' ) ? (
-						translate( '{{a}}Contact support{{/a}} for help.', {
-							components: {
-								a: <ActionPanelLink href="/help/contact" />,
-							},
-						} )
-					) : (
-						<ActionPanelLink href="/help/contact">
-							{ translate( 'Contact support' ) }
-						</ActionPanelLink>
-					) }
+					{ translate( '{{a}}Contact support{{/a}} for help.', {
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					} ) }
 				</span>
 			</div>
 		</div>
@@ -79,56 +68,36 @@ function getWarningDescription(
 	warningCount: number,
 	translate: LocalizeProps[ 'translate' ]
 ) {
-	const defaultCopy = translate(
-		"By proceeding you'll lose %d feature:",
-		"By proceeding you'll lose these %d features:",
-		{
-			count: warningCount,
-			args: warningCount,
-		}
-	);
 	switch ( context ) {
 		case 'plugins':
-			return hasLocalizedText(
-				"This feature isn't (yet) compatible with plugin uploads and will be disabled:"
-			)
-				? translate(
-						"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
-						"These features aren't (yet) compatible with plugin uploads and will be disabled:",
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  )
-				: defaultCopy;
+			return translate(
+				"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
+				"These features aren't (yet) compatible with plugin uploads and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
 
 		case 'themes':
-			return hasLocalizedText(
-				"This feature isn't (yet) compatible with theme uploads and will be disabled:"
-			)
-				? translate(
-						"This feature isn't (yet) compatible with theme uploads and will be disabled:",
-						"These features aren't (yet) compatible with theme uploads and will be disabled:",
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  )
-				: defaultCopy;
+			return translate(
+				"This feature isn't (yet) compatible with theme uploads and will be disabled:",
+				"These features aren't (yet) compatible with theme uploads and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
 
 		case 'hosting':
-			return hasLocalizedText(
-				"This feature isn't (yet) compatible with hosting access and will be disabled:"
-			)
-				? translate(
-						"This feature isn't (yet) compatible with hosting access and will be disabled:",
-						"These features aren't (yet) compatible with hosting access and will be disabled:",
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  )
-				: defaultCopy;
+			return translate(
+				"This feature isn't (yet) compatible with hosting access and will be disabled:",
+				"These features aren't (yet) compatible with hosting access and will be disabled:",
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
 
 		default:
 			return null;


### PR DESCRIPTION
As a follow-up to #38644, this removes the conditional text values for the Eligibility Warnings section provided by `hasLocalizedText`.

These strings are most-likely all translated to top locales, so hopefully we can pull out the old strings & extra complexity.

#### Changes proposed in this Pull Request

* ...

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
