### PR TITLE
composite-checkout: Remove WPCOM-specific code from stripe payment method

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -241,12 +241,10 @@ function useCreatePaymentMethods() {
 	const stripeMethod = useMemo(
 		() =>
 			createStripeMethod( {
-				getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
 				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,
 				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 				getPhoneNumber: () => select( 'wpcom' )?.getContactInfo?.()?.phoneNumber?.value,
 				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-				getDomainDetails,
 				registerStore,
 				fetchStripeConfiguration,
 				submitTransaction: submitData =>

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -249,7 +249,12 @@ function useCreatePaymentMethods() {
 				getDomainDetails,
 				registerStore,
 				fetchStripeConfiguration,
-				submitTransaction: sendStripeTransaction,
+				submitTransaction: submitData =>
+					sendStripeTransaction( {
+						...submitData,
+						siteId: select( 'wpcom' )?.getSiteId?.(),
+						domainDetails: getDomainDetails(),
+					} ),
 			} ),
 		[]
 	);

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -249,7 +249,7 @@ function useCreatePaymentMethods() {
 				getDomainDetails,
 				registerStore,
 				fetchStripeConfiguration,
-				sendStripeTransaction,
+				submitTransaction: sendStripeTransaction,
 			} ),
 		[]
 	);

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -227,7 +227,7 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
 - `fetchStripeConfiguration: async ?object => object`. An async function that fetches the stripe configuration (we use Stripe for Apple Pay).
-- `sendStripeTransaction: async ?object => object`. An async function that sends the request to the endpoint.
+- `submitTransaction: async ?object => object`. An async function that sends the request to the endpoint.
 
 ### getDefaultOrderReviewStep
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -228,6 +228,10 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
 - `fetchStripeConfiguration: async ?object => object`. An async function that fetches the stripe configuration (we use Stripe for Apple Pay).
 - `submitTransaction: async ?object => object`. An async function that sends the request to the endpoint.
+- `getCountry: () => string`. A function that returns the country to use for the transaction.
+- `getPostalCode: () => string`. A function that returns the postal code for the transaction.
+- `getSubdivisionCode: () => string`. A function that returns the subdivision code for the transaction.
+- `getPhoneNumber: () => string`. A function that returns the phone number for the transaction.
 
 ### getDefaultOrderReviewStep
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -96,7 +96,7 @@ const stripeMethod = createStripeMethod( {
 	getDomainDetails: () => ( {} ),
 	registerStore,
 	fetchStripeConfiguration,
-	sendStripeTransaction,
+	submitTransaction: sendStripeTransaction,
 } );
 
 const applePayMethod = isApplePayAvailable()

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -88,12 +88,10 @@ const registry = createRegistry();
 const { registerStore, select, subscribe } = registry;
 
 const stripeMethod = createStripeMethod( {
-	getSiteId: () => 5555,
 	getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
 	getPostalCode: () => 90210,
 	getPhoneNumber: () => 5555555555,
 	getSubdivisionCode: () => 'CA',
-	getDomainDetails: () => ( {} ),
 	registerStore,
 	fetchStripeConfiguration,
 	submitTransaction: sendStripeTransaction,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -49,12 +49,10 @@ import { useFormStatus } from '../form-status';
 const debug = debugFactory( 'composite-checkout:stripe-payment-method' );
 
 export function createStripeMethod( {
-	getSiteId,
 	getCountry,
 	getPostalCode,
 	getPhoneNumber,
 	getSubdivisionCode,
-	getDomainDetails,
 	registerStore,
 	fetchStripeConfiguration,
 	submitTransaction,
@@ -102,11 +100,9 @@ export function createStripeMethod( {
 					type: 'STRIPE_TRANSACTION_BEGIN',
 					payload: {
 						...payload,
-						siteId: getSiteId(),
 						country: getCountry(),
 						postalCode: getPostalCode(),
 						subdivisionCode: getSubdivisionCode(),
-						domainDetails: getDomainDetails(),
 						paymentMethodToken,
 					},
 				};

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -57,7 +57,7 @@ export function createStripeMethod( {
 	getDomainDetails,
 	registerStore,
 	fetchStripeConfiguration,
-	sendStripeTransaction,
+	submitTransaction,
 } ) {
 	debug( 'creating a new stripe payment method' );
 	const actions = {
@@ -240,7 +240,7 @@ export function createStripeMethod( {
 				return createStripePaymentMethodToken( action.payload );
 			},
 			STRIPE_TRANSACTION_BEGIN( action ) {
-				return sendStripeTransaction( action.payload );
+				return submitTransaction( action.payload );
 			},
 		},
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `createStripeMethod()` factory function which creates the Stripe Credit Card payment method requires certain callback functions which it uses to fill in the data needed to submit to the endpoint. However, much of that data is dependent on a WPCOM host, like site id and domain details.

Since the host page is already the one gathering that data, this PR removes those callbacks from the payment method and injects them when the host submits the data instead. This will make the payment method more flexible so it will work across hosts more easily that don't have information like site id.

We cannot easily do the same for the country, postal code, phone number, and subdivision code because they must also be submitted to Stripe directly when creating the Stripe Payment Method.

#### Testing instructions

- Run `npm run composite-checkout-demo`.
- Verify that the demo form works as expected.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to your cart and complete checkout using the credit card payment method.
- Verify that the payment is successful and the plan is added to your site.