### PR TITLE
Notifications: Update styles

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -386,6 +386,15 @@
 			background: rgba( var( --color-primary-rgb ), 0.1 ); // rgba is used to meet AA contrast standard
 		}
 
+		.wpnc__traffic_surge .wpnc__note-icon img {
+			width: 32px;
+			height: 32px;
+			background: var( --color-primary );
+			border-color: var( --color-primary );
+			border-width: 4px;
+			border-style: solid;
+		}
+
 		.wpnc__selected-note {
 			box-shadow: inset 4px 0 0 var( --color-primary );
 
@@ -405,7 +414,6 @@
 				@extend %ellipsy-box;
 				font-size: 16px;
 				letter-spacing: 0.15px;
-
 			}
 
 			.wpnc__subject .wpnc__gridicon {

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -423,6 +423,10 @@
 				font-weight: 600;
 			}
 
+			.wpnc__subject .wpnc__site {
+				font-weight: 600;
+			}
+
 			.wpnc__excerpt {
 				max-height: 3em;
 				-webkit-line-clamp: 2;

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -149,7 +149,7 @@
 	}
 
 	span.wpnc__post {
-		font-style: italic;
+		font-weight: 600;
 	}
 
 	%headertext {
@@ -265,7 +265,7 @@
 			height: $wpnc__icon-size;
 			position: relative;
 			float: left;
-			margin: 0 $wpnc__padding-medium 0 $wpnc__padding-medium;
+			margin: 0 $wpnc__padding-large 0 $wpnc__padding-large;
 		}
 
 		.wpnc__note-icon img {
@@ -278,10 +278,10 @@
 			align-items: center;
 			justify-content: center;
 			color: white;
-			height: 22px;
-			width: 22px;
+			height: 16px;
+			width: 16px;
 			border: {
-				width: 2px;
+				width: 1px;
 				style: solid;
 				radius: 50%;
 			}
@@ -395,7 +395,7 @@
 		}
 
 		.wpnc__text-summary {
-			padding: 0 $wpnc__padding-medium 0 1.6 * $wpnc__icon-size;
+			padding: 0 $wpnc__padding-large 0 2 * $wpnc__padding-large + $wpnc__icon-size;
 			word-wrap: break-word;
 			text-align: left;
 
@@ -403,6 +403,9 @@
 				max-height: 3em;
 				-webkit-line-clamp: 2;
 				@extend %ellipsy-box;
+				font-size: 16px;
+				letter-spacing: 0.15px;
+
 			}
 
 			.wpnc__subject .wpnc__gridicon {
@@ -413,7 +416,7 @@
 			}
 
 			.wpnc__subject .wpnc__comment {
-				font-style: italic;
+				font-weight: 600;
 			}
 
 			.wpnc__subject .wpnc__user__site {
@@ -425,6 +428,8 @@
 				-webkit-line-clamp: 2;
 				@extend %ellipsy-box;
 				color: var( --color-text-subtle );
+				font-size: 14px;
+				letter-spacing: 0.25px;
 			}
 		}
 
@@ -560,6 +565,7 @@
 			}
 
 			.wpnc__excerpt {
+				color: var( --color-secondary );
 				-webkit-line-clamp: 1;
 				@extend %ellipsy-box;
 				white-space: nowrap;
@@ -572,9 +578,9 @@
 		}
 
 		.wpnc__comment .wpnc__user p.wpnc__excerpt {
-			color: var( --color-primary );
-			font-style: italic;
+			color: var( --color-secondary );
 			max-height: 1.5em;
+			font-size: 14px;
 		}
 
 		.wpnc__reply {
@@ -654,7 +660,7 @@
 
 	.wpnc__summary {
 		@extend %container;
-		padding: $wpnc__padding-medium 0;
+		padding: $wpnc__padding-large 0;
 	}
 
 	.time-notification {

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -56,7 +56,7 @@
 	}
 
 	header {
-		border-bottom: 1px solid var( --color-neutral-0 );
+		border-bottom: 1px solid var( --color-neutral-5 );
 		box-sizing: border-box;
 		background-color: var( --color-surface );
 		font-size: $wpnc__capital-font-size;
@@ -167,7 +167,7 @@
 		width: 100%;
 		background-color: var( --color-surface );
 		color: var( --color-text-subtle );
-		border-bottom: 1px solid var( --color-neutral-0 );
+		border-bottom: 1px solid var( --color-neutral-5 );
 		border-left: 1px solid var( --color-border-inverted );
 		text-align: center; // Center filter in IE 9
 		height: $wpnc__filter-height;
@@ -251,7 +251,7 @@
 		font-weight: normal;
 		position: relative;
 		clear: both;
-		border-bottom: 1px solid var( --color-neutral-0 );
+		border-bottom: 1px solid var( --color-neutral-5 );
 
 		div.wpnc__body > p,
 		div.wpnc__preface p {
@@ -439,7 +439,7 @@
 			color: var( --color-neutral-40 );
 			padding: 6px 0;
 			background: rgba( 255, 255, 255, 0.95 );
-			border-bottom: 1px solid var( --color-neutral-0 );
+			border-bottom: 1px solid var( --color-neutral-5 );
 
 			.gridicons-time {
 				align-self: center;
@@ -586,7 +586,7 @@
 		.wpnc__reply {
 			color: var( --color-text-subtle );
 			padding: $wpnc__padding-medium 0;
-			border-bottom: 1px solid var( --color-neutral-0 );
+			border-bottom: 1px solid var( --color-neutral-5 );
 
 			.wpnc__gridicon {
 				padding: 0 10px;
@@ -772,7 +772,7 @@
 	.wpnc__comment .wpnc__body .wpnc__body-content,
 	.wpnc__new_post .wpnc__body .wpnc__body-content,
 	.wpnc__automattcher .wpnc__body .wpnc__body-content {
-		border-bottom: 1px solid var( --color-neutral-0 );
+		border-bottom: 1px solid var( --color-neutral-5 );
 		padding-top: $wpnc__padding-small;
 	}
 

--- a/apps/notifications/src/panel/boot/stylesheets/shared/sizes.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/sizes.scss
@@ -1,4 +1,4 @@
-$wpnc__icon-size: 48px;
+$wpnc__icon-size: 40px;
 $wpnc__icon-size-detail: 32px;
 $wpnc__font-size: 14px;
 $wpnc__line-height: 21px;

--- a/apps/notifications/src/panel/templates/summary-in-list.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-list.jsx
@@ -53,7 +53,7 @@ export class SummaryInList extends React.Component {
 						}
 					/>
 					<span className="wpnc__gridicon">
-						<Gridicon icon={ noticon2gridicon( this.props.note.noticon ) } size={ 16 } />
+						<Gridicon icon={ noticon2gridicon( this.props.note.noticon ) } size={ 12 } />
 					</span>
 				</div>
 				<div className="wpnc__text-summary">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the notifications panel styles to match upcoming updates to the app styles.

The primary changes are:

* Remove all italic text and use bold instead (for post titles, etc.)
* Make user and action type icons slightly smaller
* Header text slightly larger, excerpt text slightly smaller
* A bit more padding within the notes panel
* Use a slightly darker gray for the dividers

See pauD4L-z9-p2 for context

#### Screenshots

Before:
 
<img width="417" alt="Screen Shot 2020-01-03 at 4 39 55 PM" src="https://user-images.githubusercontent.com/52152/71757026-c0c65300-2e47-11ea-9615-94659a746966.png">

After:

<img width="410" alt="Screen Shot 2020-01-03 at 4 43 01 PM" src="https://user-images.githubusercontent.com/52152/71757097-2b778e80-2e48-11ea-9414-cc315cfceb7f.png">

#### Testing instructions

* Check the notifications panel with various sorts of notifications and make sure the styles look consistent