### PR TITLE
lib/human-date: fix tests if your current timezone is a different date than UTC

### DIFF
--- a/client/lib/human-date/test/index.js
+++ b/client/lib/human-date/test/index.js
@@ -6,6 +6,7 @@
  * Internal dependencies
  */
 import humanDate from '..';
+import moment from 'moment';
 
 describe( 'humanDate', () => {
 	it( 'should work without a provided format or locale', () => {
@@ -37,8 +38,8 @@ describe( 'humanDate', () => {
 	} );
 
 	it( 'should return a formatted date for dates older than a week', () => {
-		const thirtyDaysAgo = new Date( '2000-01-01' );
-		expect( humanDate( thirtyDaysAgo, 'll', 'en' ) ).toBe( 'Jan 1, 2000' );
-		expect( humanDate( thirtyDaysAgo, 'l', 'en' ) ).toBe( '1/1/2000' );
+		const overThirtyDaysAgo = moment.utc( new Date( '2000-01-01' ) );
+		expect( humanDate( overThirtyDaysAgo, 'll', 'en' ) ).toBe( 'Jan 1, 2000' );
+		expect( humanDate( overThirtyDaysAgo, 'l', 'en' ) ).toBe( '1/1/2000' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I was just running the test suite for an unrelated reason and noticed this test fails for me at 6pm Pacific, which is the next day in UTC. Adding `moment` and running the `Date()` through `moment.utc()` does fix this issue, but I'm not sure if this exposes an underlying problem with `human-date` (AKA, should `human-date` be loading up a passed Date with `moment.utc()` rather than simply `moment()`, which assumes local time)?

This test was added in #37337 along with some other changes to `moment`.

<img width="1042" alt="Screen Shot 2020-01-03 at 6 05 59 PM" src="https://user-images.githubusercontent.com/52152/71758694-f2471a80-2e57-11ea-8043-47110f97053a.png">

#### Testing instructions

* Be in a timezone where it's a different day in UTC than local time
* Run `npm run test-client client/lib/human-date/` and verify it all passes
* Be in a timezone where it's the same day in UTC
* Ditto