### PR TITLE
make storybook build on CI and added the /storybook route

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -155,6 +155,7 @@
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/wpcc": true,
+		"storybook": true,
 		"memberships": true,
 		"support-user": true,
 		"tools/migrate": true,

--- a/config/test.json
+++ b/config/test.json
@@ -90,6 +90,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/social": true,
+		"storybook": true,
 		"support-user": true,
 		"2fa/keys-support": true,
 		"upgrades/checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,6 +130,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
 		"signup/wpcc": true,
+		"storybook": true,
 		"support-user": true,
 		"try/preconnect": true,
 		"try/preload": true,

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
 		"autoprefixer": "postcss -u autoprefixer -r --no-map --config packages/calypso-build/postcss.config.js",
 		"postcss": "postcss -r --config packages/calypso-build/postcss.config.js",
 		"prebuild": "npm run -s install-if-deps-outdated",
-		"build": "npm run build-static && npm run build-packages && npm run build-css && run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop",
+		"build": "npm run build-static && npm run build-packages && npm run build-css && run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop && npm run components:storybook:build",
 		"build-css": "run-p -s build-css:*",
 		"build-css:directly": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js --include-path client client/assets/stylesheets/directly.scss public/directly.css --output-style compressed && npm run -s postcss -- public/directly.css",
 		"build-css:editor": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js --include-path client client/assets/stylesheets/editor.scss public/editor.css --output-style compressed && npm run -s postcss -- public/editor.css",
@@ -299,7 +299,8 @@
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",
 		"whybundled": "whybundled stats.json",
 		"composite-checkout-demo": "webpack-dev-server --config ./packages/composite-checkout/webpack.config.demo.js --mode development",
-		"components:storybook:start": "start-storybook -c packages/components/.storybook"
+		"components:storybook:start": "start-storybook -c packages/components/.storybook",
+		"components:storybook:build": "build-storybook -c packages/components/.storybook -o packages/components/storybook-static"
 	},
 	"devDependencies": {
 		"@automattic/babel-plugin-i18n-calypso": "file:./packages/babel-plugin-i18n-calypso",

--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -1,0 +1,1 @@
+storybook-static

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -16,8 +16,8 @@ const analytics = require( '../lib/analytics' ).default;
 
 /**
  * Returns the server HTTP request handler "app".
+ *
  * @returns {object} The express app
- * @api public
  */
 function setup() {
 	const app = express();
@@ -99,6 +99,10 @@ function setup() {
 
 	if ( config.isEnabled( 'devdocs' ) ) {
 		app.use( require( 'devdocs' )() );
+	}
+
+	if ( config.isEnabled( 'storybook' ) ) {
+		app.use( require( 'storybook' ) );
 	}
 
 	if ( config.isEnabled( 'desktop' ) ) {

--- a/server/storybook/index.js
+++ b/server/storybook/index.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+
+import * as path from 'path';
+import express from 'express';
+
+module.exports = express
+	.Router()
+	.use(
+		'/storybook',
+		express.static( path.join( __dirname, '../../packages/components/storybook-static' ) )
+	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Building and deploying the Storybook as part of the Calypso app so that any changes to the components can be reviewed without having to locally checkout the branch and run the app.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `npm start` and navigate to `/storybook`.

Fixes #
