### PR TITLE
Site migration: add confirm before starting migration

### DIFF
--- a/client/my-sites/migrate/migrate-button.jsx
+++ b/client/my-sites/migrate/migrate-button.jsx
@@ -4,9 +4,22 @@
 import React, { Component } from 'react';
 import { Button } from '@automattic/components';
 
+/**
+ * Internal dependencies
+ */
+import accept from 'lib/accept';
+
 class MigrateButton extends Component {
 	state = {
 		busy: false,
+	};
+
+	confirmCallback = accepted => {
+		if ( accepted ) {
+			this.setState( { busy: true }, this.props.onClick );
+		} else {
+			return;
+		}
 	};
 
 	handleClick = () => {
@@ -14,13 +27,19 @@ class MigrateButton extends Component {
 			return;
 		}
 
-		this.setState( { busy: true }, this.props.onClick );
+		const message =
+			'Overwrite ' +
+			this.props.targetSiteDomain +
+			'? All posts, pages,' +
+			' comments and media will be lost on this WordPress.com site.';
+
+		accept( message, this.confirmCallback, 'Overwrite this site' );
 	};
 
 	render() {
 		return (
 			<Button primary busy={ this.state.busy } onClick={ this.handleClick }>
-				Migrate site
+				Import site
 			</Button>
 		);
 	}

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -213,6 +213,7 @@ class SectionMigrate extends Component {
 		const { sourceSite, targetSite, targetSiteSlug } = this.props;
 
 		const sourceSiteDomain = get( sourceSite, 'domain' );
+		const targetSiteDomain = get( targetSite, 'domain' );
 		const backHref = `/migrate/${ targetSiteSlug }`;
 
 		return (
@@ -247,7 +248,7 @@ class SectionMigrate extends Component {
 							</li>
 						</ul>
 					</div>
-					<MigrateButton onClick={ this.startMigration } />
+					<MigrateButton onClick={ this.startMigration } targetSiteDomain={ targetSiteDomain } />
 					<Button className="migrate__cancel" href={ backHref }>
 						Cancel
 					</Button>


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Shows a confirm modal when the user clicks the "Start migration" button. 
    * I have made the modal's cancel button simply dismiss the modal for now: it's the same behaviour as clicking outside the modal, and simpler than redirecting to some other page.
    * The confirm component doesn't support a heading, so I've gone with a single block of text.

![image](https://user-images.githubusercontent.com/1647564/71824873-68cf5c80-3092-11ea-8b5c-e0065b13cfed.png)

#### Testing instructions

(Note: most of these instructions are general instructions for testing migration. The bolded steps are the ones specific to this change)

* Check out this pull request and run Calypso locally.
* Viewing calypso.localhost:3000/migrate/, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* **Click the "Start Migration" button.**
* **You should see a confirm modal.**
* **Click the "Cancel" button. The modal should disappear.**
* **Click the "Start Migration" button again.**
* **The migration should begin.**