### PR TITLE
Settings: Update footer credit upgrade banner

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -555,7 +555,7 @@ export class SiteSettingsFormGeneral extends Component {
 									'Remove the footer credit entirely with WordPress.com Business'
 								) }
 								description={ translate(
-									'Upgrade to remove the footer credit, add Google Analytics and more'
+									'Upgrade to remove the footer credit, use advanced SEO tools and more'
 								) }
 							/>
 						) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the footer credit upgrade banner, removing the reference to Google Analytics in the Business plan

Google Analytics was added to the Premium plan in #36367 , so should not be referenced as a feature when upgrading from Premium to Business plans.

<img width="729" alt="Screen Shot 2020-01-06 at 16 54 19" src="https://user-images.githubusercontent.com/1699996/71854921-38dd8480-30a5-11ea-9f89-be5d921cbc71.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/settings/general/{site}` on a site with Premium plan or below
* Verify new text for upsell banner under the Footer Credit setting
