### PR TITLE
composite-checkout: Change step titles when step is complete

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -7,7 +7,7 @@ import {
 	Checkout,
 	getDefaultPaymentMethodStep,
 	useIsStepActive,
-	useActiveStep,
+	useIsStepComplete,
 	useSelect,
 	useLineItems,
 	useDispatch,
@@ -24,10 +24,8 @@ import WPContactForm from './wp-contact-form';
 const ContactFormTitle = () => {
 	const translate = useTranslate();
 	const isActive = useIsStepActive();
-	const activeStep = useActiveStep();
-	// TODO: check this step's isComplete, not the active step's isComplete
-	const isComplete = isActive === false && activeStep.isComplete;
-	return isComplete
+	const isComplete = useIsStepComplete();
+	return isActive && isComplete
 		? translate( 'Contact information' )
 		: translate( 'Enter your contact information' );
 };

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -7,6 +7,7 @@ import {
 	Checkout,
 	getDefaultPaymentMethodStep,
 	useIsStepActive,
+	useActiveStep,
 	useSelect,
 	useLineItems,
 	useDispatch,
@@ -23,7 +24,11 @@ import WPContactForm from './wp-contact-form';
 const ContactFormTitle = () => {
 	const translate = useTranslate();
 	const isActive = useIsStepActive();
-	return isActive ? translate( 'Billing details' ) : translate( 'Enter your billing details' );
+	const activeStep = useActiveStep();
+	const isComplete = isActive === false && activeStep.isComplete;
+	return isComplete
+		? translate( 'Contact information' )
+		: translate( 'Enter your contact information' );
 };
 
 const OrderReviewTitle = () => {

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -25,6 +25,7 @@ const ContactFormTitle = () => {
 	const translate = useTranslate();
 	const isActive = useIsStepActive();
 	const activeStep = useActiveStep();
+	// TODO: check this step's isComplete, not the active step's isComplete
 	const isComplete = isActive === false && activeStep.isComplete;
 	return isComplete
 		? translate( 'Contact information' )

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -25,9 +25,16 @@ const ContactFormTitle = () => {
 	const translate = useTranslate();
 	const isActive = useIsStepActive();
 	const isComplete = useIsStepComplete();
+	const [ items ] = useLineItems();
+
+	if ( areDomainsInLineItems( items ) ) {
+		return ! isActive && isComplete
+			? translate( 'Contact information' )
+			: translate( 'Enter your contact information' );
+	}
 	return ! isActive && isComplete
-		? translate( 'Contact information' )
-		: translate( 'Enter your contact information' );
+		? translate( 'Billing information' )
+		: translate( 'Enter your billing information' );
 };
 
 const OrderReviewTitle = () => {

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -25,7 +25,7 @@ const ContactFormTitle = () => {
 	const translate = useTranslate();
 	const isActive = useIsStepActive();
 	const isComplete = useIsStepComplete();
-	return isActive && isComplete
+	return ! isActive && isComplete
 		? translate( 'Contact information' )
 		: translate( 'Enter your contact information' );
 };

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -282,6 +282,12 @@ Takes one argument, a displayValue string, and returns the displayValue with som
 
 A React Hook that will return the currently active [Step object](#steps). Only works within a step.
 
+The step object that is returned will include some additional properties:
+
+- `isComplete: boolean`. True if the `isCompleteCallback` function returned true (it's not recommended to call the function yourself because it expects certain arguments that you may not be able to provide).
+- `stepNumber: number | null`. The step's visible number. If the step has no number (because `hasStepNumber` is false), this will be `null`.
+- `stepIndex: number`. The index of the step in the array of steps.
+
 ### useAllPaymentMethods
 
 A React Hook that will return an array of all payment method objects. See `usePaymentMethod()`, which returns the active object only. Only works within [CheckoutProvider](#CheckoutProvider).

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -31,7 +31,7 @@ Any component which is a child of `CheckoutProvider` gets access to the custom h
 
 The [Checkout](#checkout) component creates the form itself. That component displays a series of steps which are passed in as [Step objects](#steps). While you can create these objects manually, the package provides three pre-defined steps that can be created by using the functions [getDefaultOrderSummaryStep](#getDefaultOrderSummaryStep), [getDefaultPaymentMethodStep](#getDefaultPaymentMethodStep), and [getDefaultOrderReviewStep](#getDefaultOrderReviewStep).
 
-Any component within a Step object gets access to the custom hooks above as well as [useActiveStep](#useActiveStep), and [useIsStepActive](#useIsStepActive).
+Any component within a Step object gets access to the custom hooks above as well as [useActiveStep](#useActiveStep), and [useIsStepActive](#useIsStepActive) and [useIsStepComplete](#useIsStepComplete).
 
 ## Submitting the form
 
@@ -319,6 +319,10 @@ Only works within [CheckoutProvider](#CheckoutProvider).
 ### useIsStepActive
 
 A React Hook that will return true if the current step is the currently active [Step](#steps). Only works within a step.
+
+### useIsStepComplete
+
+A React Hook that will return true if the current [Step](#steps) is complete as defined by the `isCompleteCallback` of that step. Only works within a step.
 
 ### useLineItems
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -17,6 +17,7 @@ import {
 	usePaymentMethod,
 	usePaymentMethodId,
 	useIsStepActive,
+	useIsStepComplete,
 } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 
@@ -86,7 +87,10 @@ CheckoutPaymentMethods.propTypes = {
 export function CheckoutPaymentMethodsTitle() {
 	const localize = useLocalize();
 	const isActive = useIsStepActive();
-	return isActive ? localize( 'Pick a payment method' ) : localize( 'Payment method' );
+	const isComplete = useIsStepComplete();
+	return ! isActive && isComplete
+		? localize( 'Payment method' )
+		: localize( 'Pick a payment method' );
 }
 
 function PaymentMethod( {

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -136,7 +136,7 @@ export default function Checkout( { steps, className } ) {
 				className={ joinClasses( [ className, 'checkout__content' ] ) }
 				isCheckoutInProgress={ isCheckoutInProgress }
 			>
-				<ActiveStepProvider step={ activeStep }>
+				<ActiveStepProvider step={ activeStep } steps={ annotatedSteps }>
 					{ annotatedSteps.map( step => (
 						<CheckoutStepContainer
 							{ ...step }

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -109,7 +109,7 @@ export default function Checkout( { steps, className } ) {
 		throw new Error( 'No steps found' );
 	}
 
-	const activeStep = annotatedSteps.find( step => step.stepNumber === stepNumber );
+	let activeStep = annotatedSteps.find( step => step.stepNumber === stepNumber );
 	if ( ! activeStep ) {
 		throw new Error( 'There is no active step' );
 	}
@@ -123,6 +123,12 @@ export default function Checkout( { steps, className } ) {
 				step.isCompleteCallback( { paymentData, activeStep, activePaymentMethod } ),
 		};
 	} );
+
+	// Re-assign activeStep so useActiveStep has isComplete available
+	activeStep = annotatedSteps.find( step => step.stepNumber === stepNumber );
+	if ( ! activeStep ) {
+		throw new Error( 'The active step was lost' );
+	}
 
 	// Change the step if the url changes
 	useChangeStepNumberForUrl( annotatedSteps );

--- a/packages/composite-checkout/src/lib/active-step.js
+++ b/packages/composite-checkout/src/lib/active-step.js
@@ -43,3 +43,17 @@ export const useIsStepActive = () => {
 	}
 	return stepId === activeStep.id;
 };
+
+const useThisStep = () => {
+	const stepId = useContext( RenderedStepContext );
+	if ( ! stepId ) {
+		throw new Error( 'useThisStep can only be used inside an RenderedStepProvider' );
+	}
+	const steps = useSteps();
+	return steps.find( step => step.id === stepId );
+};
+
+export const useIsStepComplete = () => {
+	const thisStep = useThisStep();
+	return !! thisStep.isComplete;
+};

--- a/packages/composite-checkout/src/lib/active-step.js
+++ b/packages/composite-checkout/src/lib/active-step.js
@@ -1,23 +1,32 @@
 /**
  * External dependencies
  */
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 
 const ActiveStepContext = createContext();
 
-export const ActiveStepProvider = ( { step, children } ) => {
+export const ActiveStepProvider = ( { step, steps, children } ) => {
 	if ( ! step ) {
 		throw new Error( 'ActiveStepProvider requires a step object' );
 	}
-	return <ActiveStepContext.Provider value={ step }>{ children }</ActiveStepContext.Provider>;
+	const value = useMemo( () => ( { step, steps } ), [ step, steps ] );
+	return <ActiveStepContext.Provider value={ value }>{ children }</ActiveStepContext.Provider>;
 };
 
 export const useActiveStep = () => {
-	const step = useContext( ActiveStepContext );
+	const { step } = useContext( ActiveStepContext );
 	if ( ! step ) {
 		throw new Error( 'useActiveStep can only be used inside an ActiveStepProvider' );
 	}
 	return step;
+};
+
+export const useSteps = () => {
+	const { steps } = useContext( ActiveStepContext );
+	if ( ! steps ) {
+		throw new Error( 'useSteps can only be used inside an ActiveStepProvider' );
+	}
+	return steps;
 };
 
 const RenderedStepContext = createContext();

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -32,7 +32,7 @@ import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createCreditCardMethod } from './lib/payment-methods/credit-card';
 import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
-import { useActiveStep, useIsStepActive } from './lib/active-step';
+import { useActiveStep, useIsStepActive, useIsStepComplete } from './lib/active-step';
 import CheckoutOrderSummary, {
 	CheckoutOrderSummaryTitle,
 } from './components/checkout-order-summary';
@@ -72,6 +72,7 @@ export {
 	useEvents,
 	useFormStatus,
 	useIsStepActive,
+	useIsStepComplete,
 	useLineItems,
 	useMessages,
 	usePaymentData,

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -22,6 +22,7 @@ import {
 	createRegistry,
 	useRegisterStore,
 	usePaymentData,
+	useActiveStep,
 } from '../src/public-api';
 
 const noop = () => {};
@@ -459,6 +460,30 @@ describe( 'Checkout', () => {
 			const { getByText } = render( <MyCheckout steps={ [ steps[ 0 ], steps[ 1 ] ] } /> );
 			expect( getByText( 'Pay Please' ) ).not.toBeDisabled();
 		} );
+
+		it( 'provides the active step through useActiveStep to components in the step', () => {
+			const { getByText } = render( <MyCheckout steps={ [ steps[ 1 ], steps[ 4 ] ] } /> );
+			expect( getByText( 'Possibly Complete id custom-contact-step' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete hasStepNumber true' ) ).toBeInTheDocument();
+		} );
+
+		it( 'provides the active step with additional fields through useActiveStep to components in the step', () => {
+			const { getByText } = render( <MyCheckout steps={ [ steps[ 1 ], steps[ 4 ] ] } /> );
+			expect( getByText( 'Possibly Complete step number 1' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete step index 0' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete isComplete true' ) ).toBeInTheDocument();
+		} );
+
+		it( 'provides the active step through useActiveStep with isComplete that changes based on isCompleteCallback', () => {
+			const { getAllByText, getByText } = render(
+				<MyCheckout steps={ [ steps[ 1 ], steps[ 4 ] ] } />
+			);
+			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
+			fireEvent.click( firstStepContinue );
+			expect( getByText( 'Possibly Complete step number 2' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete step index 1' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete isComplete false' ) ).toBeInTheDocument();
+		} );
 	} );
 } );
 
@@ -587,7 +612,7 @@ function createMockSteps() {
 			id: 'custom-possibly-complete-step',
 			className: 'custom-possibly-complete-step-class',
 			hasStepNumber: true,
-			titleContent: <span>Custom Step - Possibly Complete Title</span>,
+			titleContent: <PossiblyCompleteTitle />,
 			activeStepContent: <StepWithEditableField />,
 			incompleteStepContent: <span>Custom Step - Possibly Complete Incomplete</span>,
 			completeStepContent: <span>Custom Step - Possibly Complete Complete</span>,
@@ -614,6 +639,20 @@ function createMockSteps() {
 			getNextStepButtonAriaLabel: () => 'Custom Step - Uneditable next button label',
 		},
 	];
+}
+
+function PossiblyCompleteTitle() {
+	const activeStep = useActiveStep();
+	return (
+		<div>
+			<span>Custom Step - Possibly Complete Title</span>
+			<span>Possibly Complete id { activeStep.id }</span>
+			<span>Possibly Complete hasStepNumber { activeStep.hasStepNumber ? 'true' : 'false' }</span>
+			<span>Possibly Complete step number { activeStep.stepNumber }</span>
+			<span>Possibly Complete step index { activeStep.stepIndex }</span>
+			<span>Possibly Complete isComplete { activeStep.isComplete ? 'true' : 'false' }</span>
+		</div>
+	);
 }
 
 function StepWithEditableField() {

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -464,15 +464,15 @@ describe( 'Checkout', () => {
 
 		it( 'provides the active step through useActiveStep to components in the step', () => {
 			const { getByText } = render( <MyCheckout steps={ [ steps[ 1 ], steps[ 4 ] ] } /> );
-			expect( getByText( 'Possibly Complete id custom-contact-step' ) ).toBeInTheDocument();
-			expect( getByText( 'Possibly Complete hasStepNumber true' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active id custom-contact-step' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active hasStepNumber true' ) ).toBeInTheDocument();
 		} );
 
 		it( 'provides the active step with additional fields through useActiveStep to components in the step', () => {
 			const { getByText } = render( <MyCheckout steps={ [ steps[ 1 ], steps[ 4 ] ] } /> );
-			expect( getByText( 'Possibly Complete step number 1' ) ).toBeInTheDocument();
-			expect( getByText( 'Possibly Complete step index 0' ) ).toBeInTheDocument();
-			expect( getByText( 'Possibly Complete isComplete true' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active step number 1' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active step index 0' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active isComplete true' ) ).toBeInTheDocument();
 		} );
 
 		it( 'provides the active step through useActiveStep with isComplete that changes based on isCompleteCallback', () => {
@@ -481,9 +481,20 @@ describe( 'Checkout', () => {
 			);
 			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
 			fireEvent.click( firstStepContinue );
-			expect( getByText( 'Possibly Complete step number 2' ) ).toBeInTheDocument();
-			expect( getByText( 'Possibly Complete step index 1' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active step number 2' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active step index 1' ) ).toBeInTheDocument();
+			expect( getByText( 'Possibly Complete active isComplete false' ) ).toBeInTheDocument();
+		} );
+
+		it( 'provides the currently rendering step isComplete through useIsStepComplete', () => {
+			const { getAllByText, getByText, getByLabelText } = render(
+				<MyCheckout steps={ [ steps[ 4 ], steps[ 1 ] ] } />
+			);
 			expect( getByText( 'Possibly Complete isComplete false' ) ).toBeInTheDocument();
+			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
+			fireEvent.click( firstStepContinue );
+			fireEvent.change( getByLabelText( 'User Name' ), { target: { value: 'Lyra' } } );
+			expect( getByText( 'Possibly Complete isComplete true' ) ).toBeInTheDocument();
 		} );
 	} );
 } );
@@ -644,14 +655,18 @@ function createMockSteps() {
 
 function PossiblyCompleteTitle() {
 	const activeStep = useActiveStep();
+	const isComplete = useIsStepComplete();
 	return (
 		<div>
 			<span>Custom Step - Possibly Complete Title</span>
-			<span>Possibly Complete id { activeStep.id }</span>
-			<span>Possibly Complete hasStepNumber { activeStep.hasStepNumber ? 'true' : 'false' }</span>
-			<span>Possibly Complete step number { activeStep.stepNumber }</span>
-			<span>Possibly Complete step index { activeStep.stepIndex }</span>
-			<span>Possibly Complete isComplete { activeStep.isComplete ? 'true' : 'false' }</span>
+			<span>Possibly Complete active id { activeStep.id }</span>
+			<span>
+				Possibly Complete active hasStepNumber { activeStep.hasStepNumber ? 'true' : 'false' }
+			</span>
+			<span>Possibly Complete active step number { activeStep.stepNumber }</span>
+			<span>Possibly Complete active step index { activeStep.stepIndex }</span>
+			<span>Possibly Complete active isComplete { activeStep.isComplete ? 'true' : 'false' }</span>
+			<span>Possibly Complete isComplete { isComplete ? 'true' : 'false' }</span>
 		</div>
 	);
 }

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -23,6 +23,7 @@ import {
 	useRegisterStore,
 	usePaymentData,
 	useActiveStep,
+	useIsStepComplete,
 } from '../src/public-api';
 
 const noop = () => {};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `useActiveStep` custom React hook provides a component (within a step) with access to the currently active step object. There are also additional dynamic properties added to that object: the step's visible number and its index in the step array. This change adds a third dynamic property: the result of calling `isCompleteCallback` for that step. In addition, this change documents these dynamic properties and adds tests to prove they exist.

This PR also adds a new public API hook called `useIsStepComplete()` which will return true if the current step (not necessarily the active step) is complete as defined by that step's `isCompleteCallback` function.

Finally, this PR uses `useIsStepComplete` in the default payment method step and the Calypso contact step to change the step's title based on the completion status of the step.

#### Testing instructions

1. Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
1. Add a plan to your cart and visit checkout.
1. Verify that the initial title of the payment method step is "Pick a payment method" and that of the contact step is "Enter your contact information".
1. Pick a payment method and press "Continue" to move on to the contact step.
1. Verify that the title of the payment method step is now "Payment method", and the contact step title is unchanged.
1. Press the "edit" button on the payment method step to jump back there.
1. Verify that the title of the payment method step is "Pick a payment method" and that of the contact step is "Enter your contact information".
1. Press "Continue" to move on to the contact step.
1. Fill out the contact step and click "Continue" to move on to the final step.
1. Verify that the title of the payment method step is "Payment method" and that of the contact step is "Contact information".
1. Press the "edit" button on the contact info step to jump back there.
1. Verify that the title of the payment method step is "Payment method" and that of the contact step is "Enter your contact information".
