### PR TITLE
Move single purpose products below plans grid for now

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -164,6 +164,7 @@ export class PlansFeaturesMain extends Component {
 						isSecondary
 					/>
 				) }
+
 				<PlanFeatures
 					basePlansPath={ basePlansPath }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
@@ -445,18 +446,18 @@ export class PlansFeaturesMain extends Component {
 		return (
 			<div className="plans-features-main__group is-narrow">
 				<PlansFeaturesMainProductsHeader />
-				<AsyncLoad
-					require="blocks/product-plan-overlap-notices"
-					placeholder={ null }
-					plans={ JETPACK_PLANS }
-					products={ JETPACK_BACKUP_PRODUCTS }
-				/>
 				<ProductSelector
 					products={ JETPACK_PRODUCTS }
 					intervalType={ intervalType }
 					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }
 					redirectTo={ redirectTo }
+				/>
+				<AsyncLoad
+					require="blocks/product-plan-overlap-notices"
+					placeholder={ null }
+					plans={ JETPACK_PLANS }
+					products={ JETPACK_BACKUP_PRODUCTS }
 				/>
 			</div>
 		);
@@ -479,8 +480,9 @@ export class PlansFeaturesMain extends Component {
 				<QueryPlans />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
-				{ this.renderProductsSelector() }
 				{ this.getPlanFeatures() }
+				{ this.renderProductsSelector() }
+
 				<CartData>
 					<PaymentMethods />
 				</CartData>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -164,7 +164,6 @@ export class PlansFeaturesMain extends Component {
 						isSecondary
 					/>
 				) }
-
 				<PlanFeatures
 					basePlansPath={ basePlansPath }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
@@ -446,18 +445,18 @@ export class PlansFeaturesMain extends Component {
 		return (
 			<div className="plans-features-main__group is-narrow">
 				<PlansFeaturesMainProductsHeader />
+				<AsyncLoad
+					require="blocks/product-plan-overlap-notices"
+					placeholder={ null }
+					plans={ JETPACK_PLANS }
+					products={ JETPACK_BACKUP_PRODUCTS }
+				/>
 				<ProductSelector
 					products={ JETPACK_PRODUCTS }
 					intervalType={ intervalType }
 					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }
 					redirectTo={ redirectTo }
-				/>
-				<AsyncLoad
-					require="blocks/product-plan-overlap-notices"
-					placeholder={ null }
-					plans={ JETPACK_PLANS }
-					products={ JETPACK_BACKUP_PRODUCTS }
 				/>
 			</div>
 		);
@@ -482,7 +481,6 @@ export class PlansFeaturesMain extends Component {
 				<QuerySitePlans siteId={ siteId } />
 				{ this.getPlanFeatures() }
 				{ this.renderProductsSelector() }
-
 				<CartData>
 					<PaymentMethods />
 				</CartData>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move new Backups product prompt below plans grid

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Connection Flow

* Connect a Jetpack site that is eligible for single-purpose products
* In the signup flow, on the plans page, observe that the plans "grid" with Jetpack's bundles is above the Backups product prompt.

Before:

![calypso localhost_3000_jetpack_connect_authorize_client_id=171183437 redirect_uri=https%3A%2F%2Fpractical-snail jurassic ninja%2Fwp-admin%2Fadmin php%3Fpage%3Djetpack%26action%3Dauthorize%26_wpnonce%3Da9523427fd%26redirect%3Dhttps%253A%252F](https://user-images.githubusercontent.com/51896/71845672-ad043200-307d-11ea-948c-21050966209e.png)


After:

![calypso localhost_3000_jetpack_connect_plans_practical-snail jurassic ninja_redirect=https%3A%2F%2Fpractical-snail jurassic ninja%2Fwp-admin%2Fadmin php%3Fpage%3Djetpack(iPad Pro)](https://user-images.githubusercontent.com/51896/71845679-afff2280-307d-11ea-9bbd-c278c49f3f9d.png)


#### My plans page

* On a Jetpack site that is eligible to install Jetpack backups, go to /plans/(site-domain)
* Observe that plans grid order is above single purpose Backups product

Before:

![calypso localhost_3000_plans_practical-snail jurassic ninja(iPad Pro) (2)](https://user-images.githubusercontent.com/51896/71845365-0324a580-307d-11ea-9352-81ee244f2ec0.png)

After:

![calypso localhost_3000_plans_practical-snail jurassic ninja(iPad Pro)](https://user-images.githubusercontent.com/51896/71845373-0881f000-307d-11ea-9d0b-06978240785e.png)
