### PR TITLE
Sidebar: Remove redundant site redirect nudge

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import url from 'url';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -17,7 +16,6 @@ import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import getActiveDiscount from 'state/selectors/get-active-discount';
-import { domainManagementList } from 'my-sites/domains/paths';
 import { hasDomainCredit, isCurrentUserCurrentPlanOwner } from 'state/sites/plans/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
@@ -53,33 +51,6 @@ export class SiteNotice extends React.Component {
 	};
 
 	static defaultProps = {};
-
-	getSiteRedirectNotice( site ) {
-		if ( ! site || this.props.isDomainOnly ) {
-			return null;
-		}
-		if ( ! ( site.options && site.options.is_redirect ) ) {
-			return null;
-		}
-		const { hostname } = url.parse( site.URL );
-		const { translate } = this.props;
-
-		return (
-			<Notice
-				icon="info-outline"
-				isCompact
-				showDismiss={ false }
-				text={ translate( 'Redirects to {{a}}%(url)s{{/a}}', {
-					args: { url: hostname },
-					components: { a: <a href={ site.URL } /> },
-				} ) }
-			>
-				<NoticeAction href={ domainManagementList( site.domain ) }>
-					{ translate( 'Edit' ) }
-				</NoticeAction>
-			</Notice>
-		);
-	}
 
 	domainCreditNotice() {
 		if ( ! this.props.hasDomainCredit || ! this.props.canManageOptions ) {
@@ -279,7 +250,6 @@ export class SiteNotice extends React.Component {
 		}
 
 		const discountOrFreeToPaid = this.activeDiscountNotice();
-		const siteRedirectNotice = this.getSiteRedirectNotice( site );
 		const domainCreditNotice = this.domainCreditNotice();
 		const jetpackPluginsSetupNotice = this.jetpackPluginsSetupNotice();
 
@@ -295,7 +265,6 @@ export class SiteNotice extends React.Component {
 							template="sidebar-banner"
 						/>
 					) ) }
-				{ siteRedirectNotice }
 				<QuerySitePlans siteId={ site.ID } />
 				{ this.pendingPaymentNotice() }
 				{ ! hasJITM && domainCreditNotice }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In preparation for #38537 and unifying the sidebar upsell nudges, we'd like to remove this; it's not an upsell.
* We show this nudge in the sidebar for site redirects, in addition to a "flag" in the current site block. Both seem unnecessary, especially since they appear one after the other, so I'm suggesting we remove the nudge in this PR.
* We do lose the call to action to edit the site redirect, but I don't think a sidebar nudge is the best place for this functionality. Ideally, this area of the sidebar should have one purpose to reduce confusion -- right now, it's mostly for upsells.

**Before**

<img width="290" alt="Screen Shot 2020-01-06 at 3 54 13 PM" src="https://user-images.githubusercontent.com/2124984/71848198-da140d00-309c-11ea-815c-b199d5453d34.png">


**After**

<img width="292" alt="Screen Shot 2020-01-06 at 3 54 22 PM" src="https://user-images.githubusercontent.com/2124984/71848204-de402a80-309c-11ea-9f7b-07adfe321f8f.png">


#### Testing instructions

* Switch to this PR.
* Navigate to a site that has a site redirect set up.
* Note the lack of a nudge for the site redirect.
