### PR TITLE
tweak vertical centering of text inside badges

### DIFF
--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -3,7 +3,8 @@
 	border-radius: 1000px; // A number large enough to exceed height of any badge to make it look like a pill
 	padding: $badge-padding-y $badge-padding-x;
 	font-size: 14px;
-	line-height: 18px;
+	line-height: 17px;
+	height: 18px;
 }
 
 .badge--warning {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Address this feedback https://github.com/Automattic/wp-calypso/issues/38661
* Vertically align text in badges.

#### Testing instructions

* Inspect badges on the domain search page https://wordpress.com/start/domains-with-preview.
* Test in FF, safari, chrome, edge, and ie11
* Test on mobile sized screen
* The external height of the badge remains 18px+4px so it's unlikely to affect other pages

Fixes #38661

I used `line-height: 17px` because it best vertically centers the text in the badge (boxes are added to show spacing).

<img width="355" alt="Screen Shot 2020-01-07 at 10 27 41 AM" src="https://user-images.githubusercontent.com/22446385/71851661-ebf8bd00-313b-11ea-9987-9a55d65c0c78.png">