### PR TITLE
composite-checkout: Remove global redirects

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -36,16 +36,11 @@ async function fetchStripeConfiguration( requestArgs ) {
 }
 
 async function sendStripeTransaction( transactionData ) {
-	// TODO: figure out what these should be
-	const successRedirectUrl = window.location.href;
-	const failureRedirectUrl = window.location.href;
 	const formattedTransactionData = formatDataForTransactionsEndpoint( {
 		...transactionData,
 		paymentMethodToken: transactionData.paymentMethodToken.id,
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
 		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
-		successUrl: successRedirectUrl,
-		cancelUrl: failureRedirectUrl,
 	} );
 	debug( 'sending stripe transaction', formattedTransactionData );
 	return wpcom.transactions( formattedTransactionData );
@@ -62,8 +57,6 @@ function formatDataForTransactionsEndpoint( {
 	name,
 	items,
 	total,
-	successUrl,
-	cancelUrl,
 	paymentMethodType,
 	paymentPartnerProcessorId,
 	storedDetailsId,
@@ -77,8 +70,6 @@ function formatDataForTransactionsEndpoint( {
 		zip: postalCode, // TODO: do we need this in addition to postalCode?
 		postalCode,
 		country,
-		successUrl,
-		cancelUrl,
 	};
 	return {
 		cart: createCartFromLineItems( {
@@ -379,14 +370,9 @@ function useStoredCards() {
 
 async function submitExistingCardPayment( transactionData ) {
 	debug( 'formatting existing card transaction', transactionData );
-	// TODO: figure out what these should be
-	const successRedirectUrl = window.location.href;
-	const failureRedirectUrl = window.location.href;
 	const formattedTransactionData = formatDataForTransactionsEndpoint( {
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
-		successUrl: successRedirectUrl,
-		cancelUrl: failureRedirectUrl,
 	} );
 	debug( 'submitting existing card transaction', formattedTransactionData );
 	return wpcom.transactions( formattedTransactionData );

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -293,6 +293,8 @@ function useCreatePaymentMethods() {
 	const paypalMethod = useMemo(
 		() =>
 			createPayPalMethod( {
+				successUrl: `/checkout/thank-you/${ select( 'wpcom' )?.getSiteId?.() }/`, // TODO: get the correct redirect URL
+				cancelUrl: window.location.href,
 				registerStore: registerStore,
 				submitTransaction: submitData =>
 					makePayPalExpressRequest( {

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -36,11 +36,16 @@ async function fetchStripeConfiguration( requestArgs ) {
 }
 
 async function sendStripeTransaction( transactionData ) {
+	// TODO: figure out what these should be
+	const successRedirectUrl = window.location.href;
+	const failureRedirectUrl = window.location.href;
 	const formattedTransactionData = formatDataForTransactionsEndpoint( {
 		...transactionData,
 		paymentMethodToken: transactionData.paymentMethodToken.id,
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
 		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
+		successUrl: successRedirectUrl,
+		cancelUrl: failureRedirectUrl,
 	} );
 	debug( 'sending stripe transaction', formattedTransactionData );
 	return wpcom.transactions( formattedTransactionData );
@@ -372,9 +377,14 @@ function useStoredCards() {
 
 async function submitExistingCardPayment( transactionData ) {
 	debug( 'formatting existing card transaction', transactionData );
+	// TODO: figure out what these should be
+	const successRedirectUrl = window.location.href;
+	const failureRedirectUrl = window.location.href;
 	const formattedTransactionData = formatDataForTransactionsEndpoint( {
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
+		successUrl: successRedirectUrl,
+		cancelUrl: failureRedirectUrl,
 	} );
 	debug( 'submitting existing card transaction', formattedTransactionData );
 	return wpcom.transactions( formattedTransactionData );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -23,11 +23,6 @@ import { getPlanBySlug } from 'state/plans/selectors';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
-// These are used only for redirect payment methods
-// TODO: determine what these should be
-const successRedirectUrl = window.location.href;
-const failureRedirectUrl = window.location.href;
-
 export function CompositeCheckout( {
 	siteSlug,
 	planSlug,
@@ -73,8 +68,6 @@ export function CompositeCheckout( {
 			showInfoMessage={ showInfoMessage }
 			showSuccessMessage={ showSuccessMessage }
 			onEvent={ handleCheckoutEvent }
-			successRedirectUrl={ successRedirectUrl }
-			failureRedirectUrl={ failureRedirectUrl }
 			paymentMethods={ availablePaymentMethods }
 			registry={ registry }
 			isLoading={ isLoading }

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -110,6 +110,8 @@ test( 'When we enter checkout, the line items and total are rendered', async () 
 					createPayPalMethod( {
 						registerStore: registerStore,
 						submitTransaction: mockPayPalExpressRequest,
+						successUrl: '#',
+						cancelUrl: '#',
 					} ),
 				] }
 				registry={ registry }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -27,7 +27,7 @@ It's also possible to build an entirely custom form using the other components e
 
 Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the functions [createStripeMethod](#createstripemethod), [createApplePayMethod](#createapplepaymethod), [createPayPalMethod](#createpaypalmethod), and [createExistingCardMethod](#createExistingCardMethod).
 
-Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [useFormStatus](#useFormStatus), [useMessages](#useMessages), [useCheckoutRedirects](#useCheckoutRedirects), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentData](#usePaymentData), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
+Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [useFormStatus](#useFormStatus), [useMessages](#useMessages), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentData](#usePaymentData), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
 
 The [Checkout](#checkout) component creates the form itself. That component displays a series of steps which are passed in as [Step objects](#steps). While you can create these objects manually, the package provides three pre-defined steps that can be created by using the functions [getDefaultOrderSummaryStep](#getDefaultOrderSummaryStep), [getDefaultPaymentMethodStep](#getDefaultPaymentMethodStep), and [getDefaultOrderReviewStep](#getDefaultOrderReviewStep).
 
@@ -38,8 +38,6 @@ Any component within a Step object gets access to the custom hooks above as well
 When the payment button is pressed, the form data will be validated and submitted in a way appropriate to the payment method. If there is a problem with either validation or submission, or if the payment method's service returns an error, the `showErrorMessage` prop on `Checkout` will be called with an object describing the error.
 
 If the payment method succeeds, the `onPaymentComplete` prop will be called instead.
-
-Some payment methods may require a redirect to an external site. If that occurs, the `failureRedirectUrl` and `successRedirectUrl` props on `Checkout` will be used instead of the `showErrorMessage` and `onPaymentComplete` callbacks. All four props are required.
 
 ## Steps
 
@@ -165,8 +163,6 @@ It has the following props.
 - `showInfoMessage: (string) => null`. A function that will display a message with an "info" type.
 - `showSuccessMessage: (string) => null`. A function that will display a message with a "success" type.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
-- `successRedirectUrl: string`. The url to load if using a redirect payment method and it succeeds.
-- `failureRedirectUrl: string`. The url to load if using a redirect payment method and it fails.
 - `paymentMethods: object[]`: An array of [Payment Method objects](#payment-methods).
 - `registry?: object`. An object returned by [createRegistry](#createRegistry). If not provided, a default registry will be created.
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder.
@@ -291,10 +287,6 @@ The step object that is returned will include some additional properties:
 ### useAllPaymentMethods
 
 A React Hook that will return an array of all payment method objects. See `usePaymentMethod()`, which returns the active object only. Only works within [CheckoutProvider](#CheckoutProvider).
-
-### useCheckoutRedirects
-
-A React Hook that will return a two element array where the first element is the `successRedirectUrl` handler and the second is the `failureRedirectUrl` handler as passed to `Checkout`. Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useDispatch
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -231,6 +231,8 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
 - `submitTransaction: async object => string`. An async function that sends the request to the endpoint to get the redirect url.
+- `successUrl: string`. The URL to return to after a successful payment redirect.
+- `cancelUrl: string`. The URL to return to after a unsuccessful payment redirect.
 
 ### createStripeMethod
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -106,6 +106,8 @@ const applePayMethod = isApplePayAvailable()
 const paypalMethod = createPayPalMethod( {
 	registerStore,
 	submitTransaction: makePayPalExpressRequest,
+	successUrl: '#',
+	cancelUrl: '#',
 } );
 
 export function isApplePayAvailable() {

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -40,7 +40,6 @@ const initialItems = [
 ];
 
 const successRedirectUrl = '/complete.html';
-const failureRedirectUrl = window.location.href;
 
 const onPaymentComplete = () => {
 	window.location.href = successRedirectUrl;
@@ -315,8 +314,6 @@ function MyCheckout() {
 			showErrorMessage={ showErrorMessage }
 			showInfoMessage={ showInfoMessage }
 			showSuccessMessage={ showSuccessMessage }
-			successRedirectUrl={ successRedirectUrl }
-			failureRedirectUrl={ failureRedirectUrl }
 			registry={ registry }
 			isLoading={ isLoading }
 			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -39,9 +39,8 @@ const initialItems = [
 	},
 ];
 
-const successRedirectUrl = '/complete.html';
-
 const onPaymentComplete = () => {
+	const successRedirectUrl = '/complete.html';
 	window.location.href = successRedirectUrl;
 };
 const onEvent = event => window.console.log( 'Event', event );

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -34,8 +34,6 @@ export const CheckoutProvider = props => {
 		showErrorMessage,
 		showInfoMessage,
 		showSuccessMessage,
-		successRedirectUrl,
-		failureRedirectUrl,
 		theme,
 		paymentMethods,
 		registry,
@@ -73,14 +71,11 @@ export const CheckoutProvider = props => {
 			showErrorMessage,
 			showInfoMessage,
 			showSuccessMessage,
-			successRedirectUrl,
-			failureRedirectUrl,
 			onEvent: onEvent || ( () => {} ),
 			formStatus,
 			setFormStatus,
 		} ),
 		[
-			failureRedirectUrl,
 			formStatus,
 			onEvent,
 			paymentMethodId,
@@ -89,7 +84,6 @@ export const CheckoutProvider = props => {
 			showErrorMessage,
 			showInfoMessage,
 			showSuccessMessage,
-			successRedirectUrl,
 		]
 	);
 
@@ -199,11 +193,3 @@ export function useMessages() {
 	}
 	return { showErrorMessage, showInfoMessage, showSuccessMessage };
 }
-
-export const useCheckoutRedirects = () => {
-	const { successRedirectUrl, failureRedirectUrl } = useContext( CheckoutContext );
-	if ( ! successRedirectUrl || ! failureRedirectUrl ) {
-		throw new Error( 'useCheckoutRedirects can only be used inside a CheckoutProvider' );
-	}
-	return { successRedirectUrl, failureRedirectUrl };
-};

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -121,8 +121,6 @@ CheckoutProvider.propTypes = {
 	showErrorMessage: PropTypes.func.isRequired,
 	showInfoMessage: PropTypes.func.isRequired,
 	showSuccessMessage: PropTypes.func.isRequired,
-	successRedirectUrl: PropTypes.string.isRequired,
-	failureRedirectUrl: PropTypes.string.isRequired,
 	onEvent: PropTypes.func,
 	isLoading: PropTypes.bool,
 };
@@ -136,8 +134,6 @@ function CheckoutProviderPropValidator( { propsToValidate } ) {
 		showErrorMessage,
 		showInfoMessage,
 		showSuccessMessage,
-		successRedirectUrl,
-		failureRedirectUrl,
 		paymentMethods,
 	} = propsToValidate;
 	useEffect( () => {
@@ -154,10 +150,7 @@ function CheckoutProviderPropValidator( { propsToValidate } ) {
 		validateArg( showErrorMessage, 'CheckoutProvider missing required prop: showErrorMessage' );
 		validateArg( showInfoMessage, 'CheckoutProvider missing required prop: showInfoMessage' );
 		validateArg( showSuccessMessage, 'CheckoutProvider missing required prop: showSuccessMessage' );
-		validateArg( successRedirectUrl, 'CheckoutProvider missing required prop: successRedirectUrl' );
-		validateArg( failureRedirectUrl, 'CheckoutProvider missing required prop: failureRedirectUrl' );
 	}, [
-		failureRedirectUrl,
 		items,
 		locale,
 		onPaymentComplete,
@@ -166,7 +159,6 @@ function CheckoutProviderPropValidator( { propsToValidate } ) {
 		showErrorMessage,
 		showInfoMessage,
 		showSuccessMessage,
-		successRedirectUrl,
 		total,
 	] );
 	return null;

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -14,7 +14,6 @@ import {
 	useDispatch,
 	useMessages,
 	useLineItems,
-	useCheckoutRedirects,
 	renderDisplayValueMarkdown,
 } from '../../public-api';
 import { sprintf, useLocalize } from '../localize';
@@ -281,7 +280,6 @@ function ExistingCardPayButton( { disabled, id } ) {
 	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage } = useMessages();
-	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
 	const transactionStatus = useSelect( select =>
 		select( `existing-card-${ id }` ).getTransactionStatus()
 	);
@@ -331,8 +329,6 @@ function ExistingCardPayButton( { disabled, id } ) {
 					items,
 					total,
 					showErrorMessage,
-					successUrl: successRedirectUrl,
-					cancelUrl: failureRedirectUrl,
 					beginCardTransaction,
 					setFormSubmitting,
 				} )
@@ -362,8 +358,6 @@ async function submitExistingCardPayment( {
 	items,
 	total,
 	showErrorMessage,
-	successUrl,
-	cancelUrl,
 	beginCardTransaction,
 	setFormSubmitting,
 	setFormReady,
@@ -374,8 +368,6 @@ async function submitExistingCardPayment( {
 		beginCardTransaction( {
 			items,
 			total,
-			successUrl,
-			cancelUrl,
 		} );
 	} catch ( error ) {
 		setFormReady();

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -11,17 +11,17 @@ import debugFactory from 'debug';
 import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
 import { useDispatch, useSelect } from '../../lib/registry';
-import { useMessages, useCheckoutRedirects, useLineItems } from '../../public-api';
+import { useMessages, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 const debug = debugFactory( 'composite-checkout:paypal' );
 
-export function createPayPalMethod( { registerStore, submitTransaction } ) {
+export function createPayPalMethod( { registerStore, submitTransaction, successUrl, cancelUrl } ) {
 	registerStore( 'paypal', {
 		controls: {
 			PAYPAL_TRANSACTION_SUBMIT( action ) {
-				const { items, successUrl, cancelUrl } = action.payload;
+				const { items } = action.payload;
 				return submitTransaction( {
 					successUrl,
 					cancelUrl,
@@ -91,15 +91,12 @@ export function PaypalSubmitButton( { disabled } ) {
 	const localize = useLocalize();
 	const { submitPaypalPayment } = useDispatch( 'paypal' );
 	const [ items ] = useLineItems();
-	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
 	useTransactionStatusHandler();
 	const { formStatus } = useFormStatus();
 
 	const onClick = () =>
 		submitPaypalPayment( {
 			items,
-			successUrl: successRedirectUrl,
-			cancelUrl: failureRedirectUrl,
 		} );
 	return (
 		<Button

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -25,7 +25,6 @@ import {
 	useDispatch,
 	useMessages,
 	useLineItems,
-	useCheckoutRedirects,
 	renderDisplayValueMarkdown,
 	useEvents,
 } from '../../public-api';
@@ -623,7 +622,6 @@ function StripePayButton( { disabled } ) {
 	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage } = useMessages();
-	const { successRedirectUrl, failureRedirectUrl } = useCheckoutRedirects();
 	const { stripe, stripeConfiguration } = useStripe();
 	const transactionStatus = useSelect( select => select( 'stripe' ).getTransactionStatus() );
 	const transactionError = useSelect( select => select( 'stripe' ).getTransactionError() );
@@ -682,8 +680,6 @@ function StripePayButton( { disabled } ) {
 					stripe,
 					stripeConfiguration,
 					showErrorMessage,
-					successUrl: successRedirectUrl,
-					cancelUrl: failureRedirectUrl,
 					beginStripeTransaction,
 					setFormSubmitting,
 				} )
@@ -717,8 +713,6 @@ async function submitStripePayment( {
 	stripe,
 	stripeConfiguration,
 	showErrorMessage,
-	successUrl,
-	cancelUrl,
 	beginStripeTransaction,
 	setFormSubmitting,
 	setFormReady,
@@ -732,8 +726,6 @@ async function submitStripePayment( {
 			items,
 			total,
 			stripeConfiguration,
-			successUrl,
-			cancelUrl,
 		} );
 	} catch ( error ) {
 		setFormReady();

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -1,12 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	CheckoutProvider,
-	useEvents,
-	useMessages,
-	useCheckoutRedirects,
-} from './components/checkout-provider';
+import { CheckoutProvider, useEvents, useMessages } from './components/checkout-provider';
 import CheckoutStep from './components/checkout-step';
 import CheckoutPaymentMethods from './components/checkout-payment-methods';
 import {
@@ -67,7 +62,6 @@ export {
 	renderDisplayValueMarkdown,
 	useActiveStep,
 	useAllPaymentMethods,
-	useCheckoutRedirects,
 	useDispatch,
 	useEvents,
 	useFormStatus,

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -61,8 +61,6 @@ describe( 'CheckoutProvider', () => {
 				showErrorMessage={ noop }
 				showInfoMessage={ noop }
 				showSuccessMessage={ noop }
-				successRedirectUrl="#"
-				failureRedirectUrl="#"
 				paymentMethods={ [ mockMethod ] }
 			>
 				<CustomForm />

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -45,8 +45,6 @@ describe( 'Checkout', () => {
 						showErrorMessage={ noop }
 						showInfoMessage={ noop }
 						showSuccessMessage={ noop }
-						successRedirectUrl="#"
-						failureRedirectUrl="#"
 						paymentMethods={ [ mockMethod ] }
 					>
 						<Checkout />
@@ -112,8 +110,6 @@ describe( 'Checkout', () => {
 						showErrorMessage={ noop }
 						showInfoMessage={ noop }
 						showSuccessMessage={ noop }
-						successRedirectUrl="#"
-						failureRedirectUrl="#"
 						paymentMethods={ [ mockMethod ] }
 						registry={ registry }
 					>
@@ -179,8 +175,6 @@ describe( 'Checkout', () => {
 						showErrorMessage={ noop }
 						showInfoMessage={ noop }
 						showSuccessMessage={ noop }
-						successRedirectUrl="#"
-						failureRedirectUrl="#"
 						paymentMethods={ [ mockMethod ] }
 					>
 						<Checkout />
@@ -225,8 +219,6 @@ describe( 'Checkout', () => {
 						showErrorMessage={ noop }
 						showInfoMessage={ noop }
 						showSuccessMessage={ noop }
-						successRedirectUrl="#"
-						failureRedirectUrl="#"
 						paymentMethods={ [ mockMethod ] }
 					>
 						<Checkout />
@@ -268,8 +260,6 @@ describe( 'Checkout', () => {
 					showErrorMessage={ noop }
 					showInfoMessage={ noop }
 					showSuccessMessage={ noop }
-					successRedirectUrl="#"
-					failureRedirectUrl="#"
 					paymentMethods={ [ mockMethod ] }
 				>
 					<Checkout steps={ props.steps || steps } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the public API of `CheckoutProvider` was first designed, there was the idea that payment methods would require success/failure handlers, and because some payment methods might be redirects instead, we'd need similar success/failure redirect URLs. By providing them to the `CheckoutProvider`, they could be made available anywhere that might need them.

However, as the code has evolved, the success/failure handlers have been replaced by a single `onPaymentComplete` function and three notification functions. There's also the possibility that different redirect payment methods might want to have different, or dynamically generated, redirect URLs. Together, this makes storing redirect URLs in the `CheckoutProvider` seem to me to be the wrong abstraction.

Instead, if payment methods require URLs, those URLs should be provided as data (or functions, for dynamic URLs) when the payment method is created by its factory function, or by the submission function which also comes from the host page.

This PR removes the `successRedirectUrl` and `failureRedirectUrl` props of `CheckoutProvider` and the associated `useCheckoutRedirects` custom hook. It also removes use of the `successUrl` and `failureUrl` strings that were being sent to the `transactions/` endpoint when performing Stripe or existing card transactions, since I don't believe those strings were being used.

#### Testing instructions

- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to the cart and visit checkout.
- Choose the "Credit card" payment method and fill out the form using a Stripe test card like `4242 4242 4242 4242`.
- Click "Pay".
- Verify that the payment is successful and that the plan is added properly to your site.
- Repeat the above steps with an existing card (see #38637 )
- Repeat the above steps with PayPal (see #38435 ), which actually uses a redirect URL.