### PR TITLE
Reader: update Gutenberg gallery styles to include blocks-gallery-grid

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -177,7 +177,7 @@
 	figure figcaption,
 	figure .caption,
 	.wp-caption .wp-media-credit {
-		padding: 12px;
+		padding: 12px 12px 12px 0;
 		margin: 0;
 		font-size: 13px;
 		text-align: center;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -177,7 +177,7 @@
 	figure figcaption,
 	figure .caption,
 	.wp-caption .wp-media-credit {
-		padding: 12px 12px 12px 0;
+		padding: 12px;
 		margin: 0;
 		font-size: 13px;
 		text-align: center;
@@ -235,6 +235,10 @@
 	.wp-block-gallery {
 		margin-left: 0;
 		margin-bottom: 1em;
+	}
+
+	.blocks-gallery-caption {
+		margin: auto;
 	}
 
 	// Import Gutenberg gallery styles

--- a/client/blocks/reader-full-post/gutenberg-gallery.scss
+++ b/client/blocks/reader-full-post/gutenberg-gallery.scss
@@ -11,11 +11,15 @@ $white: #fff;
 	}
 }
 
-.wp-block-gallery {
+// From https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/gallery/style.scss
+.wp-block-gallery,
+.blocks-gallery-grid {
 	display: flex;
 	flex-wrap: wrap;
 	list-style-type: none;
 	padding: 0;
+	// Some themes give all <ul> default margin instead of padding.
+	margin: 0;
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
@@ -149,14 +153,6 @@ $white: #fff;
 	&.alignright {
 		max-width: $content-width / 2;
 		width: 100%;
-	}
-
-	// Keep the display property consistent when alignments are applied
-	// to preserve columns
-	&.alignleft,
-	&.aligncenter,
-	&.alignright {
-		display: flex;
 	}
 
 	// If the gallery is centered, center the content inside as well.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates Reader's Gutenberg gallery block styles to include the recently-added `blocks-gallery-grid` class. This fixes the tiling of smaller image galleries, which were previously displayed vertically rather than filling the available horizontal space.

#### Testing instructions

Head to http://calypso.localhost:3000/read/blogs/82798297/posts/132 and confirm that the three images appear in a row.

Compare with the existing version http://wordpress.com/read/blogs/82798297/posts/132, where the images appear above one another.

Before:

<img width="769" alt="Screen Shot 2020-01-07 at 15 07 16" src="https://user-images.githubusercontent.com/17325/71863037-7a7f3580-3160-11ea-900a-dbeb9815fc1d.png">

After:

<img width="765" alt="Screen Shot 2020-01-07 at 15 11 41" src="https://user-images.githubusercontent.com/17325/71863045-83700700-3160-11ea-8857-f1596e3f7b87.png">
