### PR TITLE
Increase default width of the domain picker

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -3,7 +3,7 @@
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 
 .domain-picker {
-	min-width: 22em;
+	min-width: 24em;
 }
 
 .domain-picker__choose-domain-header {


### PR DESCRIPTION
Addresses this issue https://github.com/Automattic/wp-calypso/issues/38018

I slightly increased the domain picker width to stop it from jumping around so much when typing in longer domains. I didn't increase it by more because this would cause it to be re positioned so that it is no longer underneath the current domain name.

#### Changes proposed in this Pull Request

* Slightly increase the popover width

#### Testing instructions
* View the domain selection page of http://calypso.localhost:3000/gutenboarding/design 
in different browsers via browserstack, try short and very long domain names.

Reasonably long domain name no longer jumps
<img width="363" alt="Screen Shot 2020-01-07 at 3 42 32 PM" src="https://user-images.githubusercontent.com/22446385/71864330-6b01eb80-3164-11ea-9ead-f42b3b62e672.png">



#### Very long domain name still gets cut off

If a very long domain name is typed, the picker(popover) will move outside of the page. I could not find a great solution to this

One possible solutions is to make the popover left aligned instead of center aligned, but this would not look good in the normal case because it would no longer be directly bellow the domain name

Another solution would be to wrap very long domain names within the popup

<img width="475" alt="Screen Shot 2020-01-07 at 3 43 48 PM" src="https://user-images.githubusercontent.com/22446385/71864397-91278b80-3164-11ea-9b6d-377611c9771f.png">

#### Mobile site is completely cut off

On mobile screens the popup is entirely too far to the left

<img width="363" alt="Screen Shot 2020-01-07 at 3 56 45 PM" src="https://user-images.githubusercontent.com/22446385/71864996-5e7e9280-3166-11ea-86d5-a1e55a9610ce.png">

