### PR TITLE
[WIP] Add user initialization to Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/common.ts
+++ b/client/landing/gutenboarding/common.ts
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { parse } from 'qs';
+import page from 'page';
+import url from 'url';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import config from '../../config';
+import analytics from '../../lib/analytics';
+import getSuperProps from '../../lib/analytics/super-props';
+import { bindState as bindWpLocaleState } from '../../lib/wp/localization';
+import { setCurrentUser } from '../../state/current-user/actions';
+import setRouteAction from '../../state/ui/actions/set-route';
+
+const debug = debugFactory( 'calypso' );
+
+export function setupContextMiddleware() {
+	page( '*', ( context, next ) => {
+		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
+		const parsed = url.parse( context.canonicalPath, true );
+		context.prevPath = parsed.path === context.path ? false : parsed.path;
+		context.query = parsed.query;
+
+		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';
+		// set `context.hash` (we have to parse manually)
+		if ( context.hashstring ) {
+			try {
+				context.hash = parse( context.hashstring );
+			} catch ( e ) {
+				debug( 'failed to query-string parse `location.hash`', e );
+				context.hash = {};
+			}
+		} else {
+			context.hash = {};
+		}
+
+		// client version of the isomorphic method for redirecting to another page
+		context.redirect = ( httpCode, newUrl = null ) => {
+			if ( isNaN( httpCode ) && ! newUrl ) {
+				newUrl = httpCode;
+			}
+
+			return page.replace( newUrl, context.state, false, false );
+		};
+
+		// Break routing and do full load for logout link in /me
+		if ( context.pathname === '/wp-login.php' ) {
+			window.location.href = context.path;
+			return;
+		}
+
+		next();
+	} );
+}
+
+function renderDevHelpers( reduxStore ) {
+	if ( config.isEnabled( 'dev/test-helper' ) ) {
+		const testHelperEl = document.querySelector( '.environment.is-tests' );
+		if ( testHelperEl ) {
+			asyncRequire( 'lib/abtest/test-helper', testHelper => {
+				testHelper( testHelperEl );
+			} );
+		}
+	}
+
+	if ( config.isEnabled( 'dev/preferences-helper' ) ) {
+		const prefHelperEl = document.querySelector( '.environment.is-prefs' );
+		if ( prefHelperEl ) {
+			asyncRequire( 'lib/preferences-helper', prefHelper => {
+				prefHelper( prefHelperEl, reduxStore );
+			} );
+		}
+	}
+}
+
+export const configureReduxStore = ( currentUser, reduxStore ) => {
+	debug( 'Executing Calypso configure Redux store.' );
+
+	bindWpLocaleState( reduxStore );
+
+	if ( currentUser.get() ) {
+		// Set current user in Redux store
+		reduxStore.dispatch( setCurrentUser( currentUser.get() ) );
+		currentUser.on( 'change', () => {
+			reduxStore.dispatch( setCurrentUser( currentUser.get() ) );
+		} );
+	}
+
+	if ( config.isEnabled( 'network-connection' ) ) {
+		asyncRequire( 'lib/network-connection', networkConnection =>
+			networkConnection.init( reduxStore )
+		);
+	}
+};
+
+const setRouteMiddleware = reduxStore => {
+	page( '*', ( context, next ) => {
+		reduxStore.dispatch( setRouteAction( context.pathname, context.query ) );
+
+		next();
+	} );
+};
+
+const setAnalyticsMiddleware = ( currentUser, reduxStore ) => {
+	analytics.initialize( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
+};
+
+export function setupMiddlewares( currentUser, reduxStore ) {
+	setupContextMiddleware( reduxStore );
+	setRouteMiddleware( reduxStore );
+	setAnalyticsMiddleware( currentUser, reduxStore );
+	renderDevHelpers( reduxStore );
+}

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -26,6 +26,7 @@ interface Props {
 	prev?: string;
 	toggleGeneralSidebar: () => void;
 	toggleSidebarShortcut: KeyboardShortcut;
+	isLoggedIn?: boolean;
 }
 
 interface KeyboardShortcut {
@@ -40,6 +41,7 @@ const Header: FunctionComponent< Props > = ( {
 	prev,
 	toggleGeneralSidebar,
 	toggleSidebarShortcut,
+	isLoggedIn,
 } ) => {
 	const { domain, siteTitle, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
@@ -94,10 +96,17 @@ const Header: FunctionComponent< Props > = ( {
 		>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Link className="gutenboarding__header-back-button" to={ prev }>
-						<Icon icon="arrow-left-alt" />
-						{ NO__( 'Back' ) }
-					</Link>
+					{ prev || ! isLoggedIn ? (
+						<Link className="gutenboarding__header-back-button" to={ prev }>
+							<Icon icon="arrow-left-alt" />
+							{ NO__( 'Back' ) }
+						</Link>
+					) : (
+						<a className="gutenboarding__header-back-button" href="/sites">
+							<Icon icon="arrow-left-alt" />
+							{ NO__( 'Back to My Sites' ) }
+						</a>
+					) }
 				</div>
 				<div className="gutenboarding__header-group">
 					{ siteTitle ? (

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -7,3 +7,5 @@
  * @see https://stackoverflow.com/a/44755058/1432801
  */
 export const selectorDebounce = 300;
+
+export const USER_STORE_KEY = 'automattic/user';

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -18,7 +18,6 @@ import {
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
-import { useSelector } from 'react-redux';
 import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useRef, useState } from 'react';
@@ -28,12 +27,12 @@ import { useRouteMatch } from 'react-router-dom';
 /**
  * Internal dependencies
  */
-import { getCurrentUserId } from '../../state/current-user/selectors';
 import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import { Slot as SidebarSlot } from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
 import { STORE_KEY } from './stores/onboard';
+import { USER_STORE_KEY } from './constants';
 import { routes, Step } from './steps';
 import './style.scss';
 
@@ -52,7 +51,7 @@ export function Gutenboard() {
 	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
 
 	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
-	const isLoggedIn = useSelector( state => getCurrentUserId( state ) );
+	const isLoggedIn = useSelect( select => select( USER_STORE_KEY ).getCurrentUserId() );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -18,6 +18,7 @@ import {
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
+import { useSelector } from 'react-redux';
 import '@wordpress/format-library';
 import classnames from 'classnames';
 import React, { useRef, useState } from 'react';
@@ -27,6 +28,7 @@ import { useRouteMatch } from 'react-router-dom';
 /**
  * Internal dependencies
  */
+import { getCurrentUserId } from '../../state/current-user/selectors';
 import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import { Slot as SidebarSlot } from './components/sidebar';
@@ -50,6 +52,7 @@ export function Gutenboard() {
 	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
 
 	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
+	const isLoggedIn = useSelector( state => getCurrentUserId( state ) );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation
@@ -96,6 +99,7 @@ export function Gutenboard() {
 							toggleSidebarShortcut={ toggleSidebarShortcut }
 							prev={ prev }
 							next={ next }
+							isLoggedIn={ isLoggedIn }
 						/>
 						<BlockEditorProvider
 							useSubRegistry={ false }

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -1,16 +1,22 @@
 /**
  * External dependencies
  */
+import debugFactory from 'debug';
+import page from 'page';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import config from '../../config';
-
+import { Provider } from 'react-redux';
 /**
  * Internal dependencies
  */
+import createStore from './store';
+import { setupMiddlewares, configureReduxStore } from './common';
+import userFactory from '../../lib/user';
 import { Gutenboard } from './gutenboard';
 import { setupWpDataDebug } from './devtools';
+import { setupLocale } from '../../boot/locale';
 
 /**
  * Style dependencies
@@ -18,16 +24,46 @@ import { setupWpDataDebug } from './devtools';
 import 'assets/stylesheets/gutenboarding.scss';
 import 'components/environment-badge/style.scss';
 
+const debug = debugFactory( 'calypso' );
+
+// Create Redux store
+const store = createStore();
+
+function boot( currentUser ) {
+	debug( "Starting Calypso. Let's do this." );
+
+	configureReduxStore( currentUser, store );
+	setupMiddlewares( currentUser, store );
+	setupLocale( currentUser.get(), store );
+
+	page( '*', ( context, next ) => {
+		context.store = store;
+		next();
+	} );
+
+	page.exit( '*', ( context, next ) => {
+		context.store = store;
+		next();
+	} );
+
+	page.start( { decodeURLComponents: false } );
+}
+
 window.AppBoot = () => {
 	if ( ! config.isEnabled( 'gutenboarding' ) ) {
 		window.location.href = '/';
 	} else {
+		const user = userFactory();
+		user.initialize().then( () => boot( user ) );
+
 		setupWpDataDebug();
 
 		ReactDom.render(
-			<BrowserRouter basename="gutenboarding">
-				<Gutenboard />
-			</BrowserRouter>,
+			<Provider store={ store }>
+				<BrowserRouter basename="gutenboarding">
+					<Gutenboard />
+				</BrowserRouter>
+			</Provider>,
 			document.getElementById( 'wpcom' )
 		);
 	}

--- a/client/landing/gutenboarding/store.ts
+++ b/client/landing/gutenboarding/store.ts
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+
+/**
+ * Internal dependencies
+ */
+import wpcomApiMiddleware from '../../state/data-layer/wpcom-api-middleware';
+import analyticsMiddleware from '../../state/analytics/middleware';
+import {
+	reducer as httpData,
+	enhancer as httpDataEnhancer,
+} from '../../state/data-layer/http-data';
+import { combineReducers } from '../../state/utils';
+import application from '../../state/application/reducer';
+import documentHead from '../../state/document-head/reducer';
+import login from '../../state/login/reducer';
+import language from '../../state/ui/language/reducer';
+import route from '../../state/ui/route/reducer';
+import masterbarVisibility from '../../state/ui/masterbar-visibility/reducer';
+import oauth2ClientsUI from '../../state/ui/oauth2-clients/reducer';
+import section from '../../state/ui/section/reducer';
+import notices from '../../state/notices/reducer';
+import i18n from '../../state/i18n/reducer';
+import users from '../../state/users/reducer';
+import currentUser from '../../state/current-user/reducer';
+import preferences from '../../state/preferences/reducer';
+import oauth2Clients from '../../state/oauth2-clients/reducer';
+
+// Create Redux store
+const reducer = combineReducers( {
+	application,
+	documentHead,
+	httpData,
+	login,
+	notices,
+	i18n,
+	users,
+	currentUser,
+	preferences,
+	oauth2Clients,
+	ui: combineReducers( {
+		language,
+		route,
+		masterbarVisibility,
+		oauth2Clients: oauth2ClientsUI,
+		section,
+	} ),
+} );
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
+export default () =>
+	createStore(
+		reducer,
+		composeEnhancers(
+			httpDataEnhancer,
+			applyMiddleware( thunkMiddleware, wpcomApiMiddleware, analyticsMiddleware )
+		)
+	);


### PR DESCRIPTION
This is a draft PR for exploring [adding the user object to Gutenboarding](https://github.com/Automattic/wp-calypso/issues/37852), copying over the code used in [client/landing/login](https://github.com/automattic/wp-calypso/blob/4b5f048bbb81d6a7b7ec1521bf558870c7ac69a9/client/landing/login/index.js#L31). This really is a hacky WIP at the moment as it adds back in a normal Redux store instead of using the API in `@wordpress/data`, and I haven't added in types.

This PR also provides a simple use-case for including the user object — working out whether or not the user is logged in, so that we can have the `Back` button say `Back to My Sites` for logged in users, and redirect the back button to `/sites`, similar to the existing behaviour in the current signup framework.

#### Changes proposed in this Pull Request

* TBC

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
