### PR TITLE
A/B test the plan bump offer against GSuite offer

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -148,4 +148,13 @@ export default {
 		allowExistingUsers: false,
 		localeTargets: 'any',
 	},
+	showPlanBumpVsGsuite: {
+		datestamp: '20200107',
+		variations: {
+			variantShowPlanBumpOffer: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -96,6 +96,7 @@ import {
 } from 'signup/utils';
 import { isExternal } from 'lib/url';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -451,6 +452,18 @@ export class Checkout extends React.Component {
 		}
 	}
 
+	maybeRedirectToPlanBumpOffer( pendingOrReceiptId ) {
+		const { cart, selectedSiteSlug } = this.props;
+
+		if ( hasPersonalPlan( cart ) ) {
+			if ( 'variantShowPlanBumpOffer' === abtest( 'showPlanBumpVsGsuite' ) ) {
+				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
+			}
+		}
+
+		return null;
+	}
+
 	maybeRedirectToGSuiteNudge( pendingOrReceiptId, stepResult ) {
 		const { isNewlyCreatedSite, selectedSiteSlug, cart } = this.props;
 
@@ -465,7 +478,10 @@ export class Checkout extends React.Component {
 			) {
 				const domainsForGSuite = this.getEligibleDomainFromCart();
 				if ( domainsForGSuite.length ) {
-					return `/checkout/${ selectedSiteSlug }/with-gsuite/${ domainsForGSuite[ 0 ].meta }/${ pendingOrReceiptId }`;
+					return (
+						this.maybeRedirectToPlanBumpOffer( pendingOrReceiptId ) ||
+						`/checkout/${ selectedSiteSlug }/with-gsuite/${ domainsForGSuite[ 0 ].meta }/${ pendingOrReceiptId }`
+					);
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new A/B test for testing the plan bump offer against the GSuite offer in signup.
* Presently, only users who purchase a domain along with a plan are shown the GSuite offer. This test will show only to those users who purchase a Personal plan and domain. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1** (Test that the A/B test assignment works)

1. Begin at /start and purchase and purchase a domain and Personal plan
2. Verify that after purchase transaction is complete:
    - you should see the GSuite upsell offer if in the _control_ group of the _showPlanBumpVsGsuite_ test
    - you should see the Premium plan bump offer if in the `variantShowPlanBumpOffer` group of the _showPlanBumpVsGsuite_ test

**Scenario 2** (_Verify that you are not assigned to the test if purchasing a Personal plan without custom domain_)

1. Begin at /start and purchase a Personal plan without custom domain
2. After purchase transaction completes, verify that you are not assigned to the test. You can check this by typing `localstorage.ABTests;` in the browser console and checking that the result does not have the _showPlanBumpVsGsuite_ in it.

**Scenario 3** (_Verify that you are not assigned to the test if purchasing a Premium plan_)

1. Begin at /start and purchase a domain with Premium plan
2. After purchase transaction completes, verify that you are shown the GSuite offer.
3. Verify that you are not assigned to the test. You can check this by typing `localstorage.ABTests;` in the browser console and checking that the result does not have the _showPlanBumpVsGsuite_ in it.

**Scenario 4** (Failed transaction should not assign to the test)
1. Begin at /start and add a custom domain and Personal plan to cart
2. In the checkout page, use an invalid credit credit card number. I used `4892128261797411 `
3. The transaction should fail and you should see an error message. At this point, verify that you have not been assigned to the test. You can check this by typing `localstorage.ABTests;` in the browser console and checking that the result does not have the _showPlanBumpVsGsuite_ in it.