### PR TITLE
Retry: Remove node's url from lib/i18n-utils

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -4,12 +4,12 @@
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
 import { map, includes } from 'lodash';
-import { parse as parseUrl, format as formatUrl } from 'url';
 
 /**
  * Internal dependencies
  */
 import { isDefaultLocale, getLanguage } from './utils';
+import { getUrlFromParts } from 'lib/url/url-parts';
 
 const debug = debugFactory( 'calypso:i18n' );
 
@@ -18,6 +18,7 @@ const getPromises = {};
 /**
  * De-duplicates repeated GET fetches of the same URL while one is taking place.
  * Once it's finished, it'll allow for the same request to be done again.
+ *
  * @param {string} url The URL to fetch
  *
  * @returns {Promise} The fetch promise.
@@ -35,7 +36,7 @@ function dedupedGet( url ) {
  * Normally it should only serve as a helper function for `getLanguageFileUrl`,
  * but we export it here still in help with the test suite.
  *
- * @return {String} The path URL to the language files.
+ * @returns {string} The path URL to the language files.
  */
 export function getLanguageFilePathUrl() {
 	const protocol = typeof window === 'undefined' ? 'https://' : '//'; // use a protocol-relative path in the browser
@@ -47,11 +48,11 @@ export function getLanguageFilePathUrl() {
  * Get the language file URL for the given locale and file type, js or json.
  * A revision cache buster will be appended automatically if `setLangRevisions` has been called beforehand.
  *
- * @param {String} localeSlug A locale slug. e.g. fr, jp, zh-tw
- * @param {String} fileType The desired file type, js or json. Default to json.
- * @param {Object} languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
+ * @param {string} localeSlug A locale slug. e.g. fr, jp, zh-tw
+ * @param {string} fileType The desired file type, js or json. Default to json.
+ * @param {object} languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
  *
- * @return {String} A language file URL.
+ * @returns {string} A language file URL.
  */
 export function getLanguageFileUrl( localeSlug, fileType = 'json', languageRevisions = {} ) {
 	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
@@ -144,11 +145,16 @@ export default function switchLocale( localeSlug ) {
 }
 
 export function loadUserUndeployedTranslations( currentLocaleSlug ) {
-	if ( ! location || ! location.search ) {
+	if ( typeof window === 'undefined' || ! window.location || ! window.location.search ) {
 		return;
 	}
 
-	const parsedURL = parseUrl( location.search, true );
+	const search = new URLSearchParams( window.location.search );
+	// TODO: replace with Object.fromEntries when available (core-js@3).
+	const params = {};
+	for ( const [ key, value ] of search.entries() ) {
+		params[ key ] = value;
+	}
 
 	const {
 		'load-user-translations': username,
@@ -156,7 +162,7 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		translationSet = 'default',
 		translationStatus = 'current',
 		locale = currentLocaleSlug,
-	} = parsedURL.query;
+	} = params;
 
 	if ( ! username ) {
 		return;
@@ -186,17 +192,18 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		format: 'json',
 	};
 
-	const requestUrl = formatUrl( {
+	const requestUrl = getUrlFromParts( {
 		protocol: 'https:',
 		host: 'translate.wordpress.com',
 		pathname,
 		query,
 	} );
 
-	return fetch( requestUrl, {
-		headers: { Accept: 'application/json' },
-		credentials: 'include',
-	} )
+	return window
+		.fetch( requestUrl.href, {
+			headers: { Accept: 'application/json' },
+			credentials: 'include',
+		} )
 		.then( res => res.json() )
 		.then( translations => i18n.addTranslations( translations ) );
 }
@@ -237,8 +244,8 @@ function switchWebpackCSS( isRTL ) {
  * Loads a CSS stylesheet into the page.
  *
  * @param {string} cssUrl URL of a CSS stylesheet to be loaded into the page
- * @param {Element} currentLink an existing <link> DOM element before which we want to insert the new one
- * @returns {Promise<String>} the new <link> DOM element after the CSS has been loaded
+ * @param {window.Element} currentLink an existing <link> DOM element before which we want to insert the new one
+ * @returns {Promise<string>} the new <link> DOM element after the CSS has been loaded
  */
 function loadCSS( cssUrl, currentLink ) {
 	return new Promise( resolve => {

--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -12,4 +12,4 @@ export { default as isHttps } from './is-https';
 export { addSchemeIfMissing, setUrlScheme } from './scheme-utils';
 export { decodeURIIfValid, decodeURIComponentIfValid } from './decode-utils';
 export { default as format } from './format';
-export { getUrlParts } from './url-parts';
+export { getUrlParts, getUrlFromParts } from './url-parts';

--- a/client/lib/url/test/url-parts.js
+++ b/client/lib/url/test/url-parts.js
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { getUrlParts } from '../url-parts';
+import { getUrlParts, getUrlFromParts } from '../url-parts';
 
 describe( 'getUrlParts', () => {
 	test( 'should empty parts for invalid URLs', () => {
@@ -170,5 +170,158 @@ describe( 'getUrlParts', () => {
 			searchParams: expect.any( URLSearchParams ),
 			username: '',
 		} );
+	} );
+} );
+
+describe( 'getUrlFromParts', () => {
+	test( 'should throw an error if no parts object is provided', () => {
+		expect( () => getUrlFromParts().toThrow() );
+		expect( () => getUrlFromParts( undefined ).toThrow() );
+		expect( () => getUrlFromParts( null ).toThrow() );
+	} );
+
+	test( 'should throw an error if an empty parts object is provided', () => {
+		expect( () => getUrlFromParts( {} ) ).toThrow();
+	} );
+
+	test( 'should throw an error if no protocol is specified', () => {
+		expect( () => getUrlFromParts( { host: 'example.com', pathname: '/path' } ) ).toThrow();
+	} );
+
+	test( 'should throw an error if no host is specified', () => {
+		expect( () => getUrlFromParts( { protocol: 'http:', pathname: '/path' } ) ).toThrow();
+	} );
+
+	test( 'should throw an error if an invalid origin is specified', () => {
+		expect( () => getUrlFromParts( { origin: '///' } ) ).toThrow();
+		expect( () => getUrlFromParts( { origin: 'example.com' } ) ).toThrow();
+		expect( () => getUrlFromParts( { origin: 'http://' } ) ).toThrow();
+		expect( () => getUrlFromParts( { origin: '' } ) ).toThrow();
+	} );
+
+	test( 'should produce valid URLs from valid parts objects', () => {
+		expect(
+			getUrlFromParts( {
+				origin: 'http://example.com',
+			} ).href
+		).toBe( 'http://example.com/' );
+
+		expect(
+			getUrlFromParts( {
+				protocol: 'http:',
+				host: 'example.com',
+			} ).href
+		).toBe( 'http://example.com/' );
+
+		expect(
+			getUrlFromParts( {
+				protocol: 'https:',
+				host: 'example.com',
+				pathname: '/path',
+			} ).href
+		).toBe( 'https://example.com/path' );
+
+		expect(
+			getUrlFromParts( {
+				protocol: 'http:',
+				host: 'example.com:8080',
+				pathname: '/path',
+			} ).href
+		).toBe( 'http://example.com:8080/path' );
+
+		expect(
+			getUrlFromParts( {
+				protocol: 'http:',
+				port: '8080',
+				hostname: 'example.com',
+				pathname: '/path',
+			} ).href
+		).toBe( 'http://example.com:8080/path' );
+
+		expect(
+			getUrlFromParts( {
+				hash: '#baz',
+				host: 'example.com:8080',
+				hostname: 'example.com',
+				password: 'pass',
+				pathname: '/path',
+				port: '8080',
+				protocol: 'http:',
+				search: '?foo=bar',
+				username: 'user',
+			} ).href
+		).toBe( 'http://user:pass@example.com:8080/path?foo=bar#baz' );
+
+		expect(
+			getUrlFromParts( {
+				hash: '#baz',
+				host: 'example.com:8080',
+				hostname: 'example.com',
+				password: 'pass',
+				pathname: '/path',
+				port: '8080',
+				protocol: 'http:',
+				searchParams: new URLSearchParams( { foo: 'bar' } ),
+				username: 'user',
+			} ).href
+		).toBe( 'http://user:pass@example.com:8080/path?foo=bar#baz' );
+	} );
+
+	test( 'should override values in origin with values from host', () => {
+		expect(
+			getUrlFromParts( {
+				origin: 'https://override-me.invalid:8000',
+				host: 'example.com:8080',
+			} ).href
+		).toBe( 'https://example.com:8080/' );
+	} );
+
+	test( 'should override values in origin with values from protocol, hostname, and port', () => {
+		expect(
+			getUrlFromParts( {
+				protocol: 'http:',
+				port: '8080',
+				origin: 'https://override-me.invalid:8000',
+				hostname: 'example.com',
+			} ).href
+		).toBe( 'http://example.com:8080/' );
+	} );
+
+	test( 'should override values in host with values from hostname and port', () => {
+		expect(
+			getUrlFromParts( {
+				protocol: 'http:',
+				port: '8080',
+				host: 'override-me.invalid:8000',
+				hostname: 'example.com',
+			} ).href
+		).toBe( 'http://example.com:8080/' );
+	} );
+
+	test( 'should override values in searchParams with values from search', () => {
+		expect(
+			getUrlFromParts( {
+				origin: 'http://example.com',
+				searchParams: new URLSearchParams( { foo: 'bar' } ),
+				search: '?bar=baz',
+			} ).href
+		).toBe( 'http://example.com/?bar=baz' );
+	} );
+
+	test( 'should ignore empty values in parts', () => {
+		expect(
+			getUrlFromParts( {
+				protocol: 'https:',
+				host: '',
+				hostname: 'example.com',
+				origin: '',
+				password: '',
+				pathname: '',
+				port: '',
+				search: '',
+				searchParams: null,
+				username: '',
+			} ).href
+		).toBe( 'https://example.com/' );
 	} );
 } );

--- a/client/lib/url/url-parts.ts
+++ b/client/lib/url/url-parts.ts
@@ -138,7 +138,9 @@ export function getUrlFromParts( parts: OptionalUrlParts ): URL {
 
 	for ( const part of URL_PART_KEYS ) {
 		if ( part !== 'host' && part !== 'origin' && part !== 'searchParams' ) {
-			result[ part ] = parts[ part ] ?? result[ part ];
+			if ( parts[ part ] && parts[ part ] !== result[ part ] ) {
+				result[ part ] = parts[ part ];
+			}
 		}
 	}
 	return result;

--- a/client/lib/url/url-parts.ts
+++ b/client/lib/url/url-parts.ts
@@ -24,6 +24,20 @@ interface UrlParts {
 	password: string;
 }
 
+interface OptionalUrlParts {
+	protocol?: string;
+	host?: string;
+	hostname?: string;
+	port?: string;
+	origin?: string;
+	pathname?: string;
+	hash?: string;
+	search?: string;
+	searchParams?: URLSearchParams;
+	username?: string;
+	password?: string;
+}
+
 type UrlPartKey = keyof UrlParts;
 
 const EMPTY_URL: Readonly< UrlParts > = Object.freeze( {
@@ -99,4 +113,33 @@ export function getUrlParts( url: URLString | URL ): UrlParts {
 	}
 
 	return pathParts;
+}
+
+/**
+ * Returns a URL object built from the provided URL parts.
+ *
+ * @param parts the provided URL parts.
+ *
+ * @returns the generated URL object.
+ */
+export function getUrlFromParts( parts: OptionalUrlParts ): URL {
+	if ( ! parts?.protocol ) {
+		throw new Error( 'getUrlFromParts: protocol missing.' );
+	}
+
+	if ( ! parts.host && ! parts.hostname ) {
+		throw new Error( 'getUrlFromParts: host missing.' );
+	}
+
+	const result = new URL( BASE_URL );
+
+	// Apply 'host' first, since it includes both hostname and port.
+	result.host = parts.host ?? result.host;
+
+	for ( const part of URL_PART_KEYS ) {
+		if ( part !== 'host' && part !== 'origin' && part !== 'searchParams' ) {
+			result[ part ] = parts[ part ] ?? result[ part ];
+		}
+	}
+	return result;
 }


### PR DESCRIPTION
Retry of #38560 with a workaround for the following Safari bug (see #38668).

```js
result = new URL( 'http://__domain__.invalid' );
result.port = '';
console.log( result.port )
```

Safari 13.0.4 returns: `"0"`, all other browsers return `""`.

This is an invalid implementation in Safari (almost 6 year old [Webkit bug 127958](https://bugs.webkit.org/show_bug.cgi?id=127958)) since [the spec says](https://url.spec.whatwg.org/#dom-url-port):
> If the given value is the empty string, then set context object's url's port to null.

The workaround it to simply only assign changed values, and not re-assign equal ones.