### PR TITLE
Site migration: lock the UI immediately the migration starts

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -98,6 +98,8 @@ class SectionMigrate extends Component {
 			return;
 		}
 
+		this.setMigrationState( { migrationStatus: 'backing-up' } );
+
 		wpcom
 			.startMigration( sourceSiteId, targetSiteId )
 			.then( () => this.updateFromAPI() )

--- a/client/state/selectors/is-site-migration-in-progress.js
+++ b/client/state/selectors/is-site-migration-in-progress.js
@@ -5,7 +5,10 @@
 import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 
 /**
- * Returns true if the site is the target of an active migration
+ * Returns true if the site is the target of an active migration.
+ * Possible migration statuses: inactive, backing-up, restoring, error, done.
+ * We regard 'error' as 'in progress' – the user needs to dismiss that
+ * state.
  *
  * @param {object} state Global state tree
  * @param {object} siteId Site ID
@@ -14,5 +17,5 @@ import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 export default function isSiteMigrationInProgress( state, siteId ) {
 	const migrationStatus = getSiteMigrationStatus( state, siteId );
 
-	return migrationStatus !== 'inactive';
+	return migrationStatus !== 'inactive' && migrationStatus !== 'done';
 }


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Sets the `migrationStatus` state to `backing-up` as soon as the user clicks the "Start Migration" button, so the UI locks before we make a request to the migration status endpoint.
* Includes `done` among the statuses indicating that a migration is not in progress, so the UI unlocks at the end of a migration without the user needing to dismiss the success message.

#### Testing instructions

(Note: most of these instructions are general instructions for testing migration. The bolded steps are the ones specific to this change)

* Check out this pull request and run Calypso locally, or run it on `calypso.live`.
* Viewing `calypso.localhost:3000/migrate/`, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* When you select a site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Click the "Start Migration" button.
* You'll see a confirm modal. Click the "Overwrite this site" button.
* **The migration should start and the UI should lock immediately.**
* **When the migration is finished, the UI should unlock.**
