### PR TITLE
Data Stores: Disable automatic type inclusion

### DIFF
--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -19,7 +19,10 @@
 		"moduleResolution": "node",
 		"esModuleInterop": true,
 
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": []
 	},
 	"files": [ "src/index" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -1,4 +1,4 @@
-require( '@babel/polyfill' );
+import '@babel/polyfill';
 
 /**
  * Internal dependencies

--- a/packages/composite-checkout-wpcom/tsconfig.json
+++ b/packages/composite-checkout-wpcom/tsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"jsx": "react",
-		"target": "es5",
+		"target": "ES5",
+		"lib": [ "DOM", "ES2015", "ScriptHost" ],
 		"module": "esnext",
 		"declaration": true,
 		"declarationDir": "types",
@@ -18,7 +19,10 @@
 		"strictNullChecks": true,
 
 		"moduleResolution": "node",
-		"esModuleInterop": true
+		"esModuleInterop": true,
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": []
 	},
 	"include": [ "src/**/*" ],
 	"exclude": [ "**/test/**/*", "**/docs/**/*" ]

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -26,6 +26,7 @@
 		"forceConsistentCasingInFileNames": true,
 
 		"typeRoots": [ "../../node_modules/@types" ],
+		"types": [],
 
 		"noEmitHelpers": true,
 		"importHelpers": true


### PR DESCRIPTION
Automatically including type definitions can be problematic. Only
include imported types.

See tsconfig types documentation:
https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types

```
> @automattic/data-stores@1.0.0-alpha.0 prepare …/packages/data-stores
> tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json

../../node_modules/@types/node/globals.d.ts(139,11): error TS2320: Interface 'NodeRequire' cannot simultaneously extend types 'Require' and 'RequireFunction'.
  Named property 'cache' of types 'Require' and 'RequireFunction' are not identical.
../../node_modules/@types/node/globals.d.ts(139,11): error TS2320: Interface 'NodeRequire' cannot simultaneously extend types 'Require' and 'RequireFunction'.
  Named property 'resolve' of types 'Require' and 'RequireFunction' are not identical.
../../node_modules/@types/node/globals.d.ts(141,11): error TS2320: Interface 'NodeModule' cannot simultaneously extend types 'Module' and 'Module'.
  Named property 'children' of types 'Module' and 'Module' are not identical.
../../node_modules/@types/node/globals.d.ts(141,11): error TS2320: Interface 'NodeModule' cannot simultaneously extend types 'Module' and 'Module'.
  Named property 'parent' of types 'Module' and 'Module' are not identical.
../../node_modules/@types/node/globals.d.ts(141,11): error TS2320: Interface 'NodeModule' cannot simultaneously extend types 'Module' and 'Module'.
  Named property 'require' of types 'Module' and 'Module' are not identical.
../../node_modules/@types/react-transition-group/node_modules/@types/react/index.d.ts(2891,14): error TS2300: Duplicate identifier 'LibraryManagedAttributes'.
../../node_modules/@types/react/index.d.ts(2852,14): error TS2300: Duplicate identifier 'LibraryManagedAttributes'.
```

Orinially reported by @jsnajdr 

#### Testing instructions

* `npm run distclean && npm run update-deps` will error on master (like above) but will correctly build on this branch.
* `npx lerna run prepare --scope='@automattic/data-stores'` is the specific command that would fail
