### PR TITLE
Settings: don't display Follow email settings on sites with no subs

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -417,10 +417,16 @@ class SiteSettingsFormDiscussion extends Component {
 		const {
 			fields,
 			handleAutosavingToggle,
+			isJetpack,
+			isSubscriptionsModuleActive,
 			isRequestingSettings,
 			isSavingSettings,
 			translate,
 		} = this.props;
+		// Subscriptions are only supported on jetpack sites with the Subscriptions module activated
+		if ( isJetpack && ! isSubscriptionsModuleActive ) {
+			return null;
+		}
 
 		return (
 			<CompactFormToggle
@@ -637,12 +643,14 @@ const connectComponent = connect( state => {
 
 	const isJetpack = isJetpackSite( state, siteId );
 	const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
+	const isSubscriptionsModuleActive = isJetpackModuleActive( state, siteId, 'subscriptions' );
 
 	return {
 		siteId,
 		siteSlug,
 		isJetpack,
 		isLikesModuleActive,
+		isSubscriptionsModuleActive,
 	};
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On Jetpack sites, the toggle offering to switch follow email notifications
is only useful if one uses the Subscriptions module. Let's hide the toggle otherwise.

#### Testing instructions

* Go to Settings > Discussion on a Jetpack site. 
* Toggle the "Let visitors subscribe to new posts and comments via email" option at the bottom of the page.
* The "Someone follows my blog" option appearing above on the page should appear / disappear accordingly.
* WordPress.com sites should not be affected.

Reported in p8oabR-sb-p2#comment-3754
