### PR TITLE
Site Settings: Unify settings save notices

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -68,7 +68,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 					this.props.isSaveRequestSuccessful &&
 					( this.props.isJetpackSaveRequestSuccessful || ! this.props.siteIsJetpack )
 				) {
-					this.props.successNotice( this.props.translate( 'Settings saved!' ), noticeSettings );
+					this.props.successNotice(
+						this.props.translate( 'Settings saved successfully!' ),
+						noticeSettings
+					);
 					// Upon failure to save Jetpack Settings, don't show an error message,
 					// since the JP settings data layer already does that for us.
 				} else if ( ! this.props.isSaveRequestSuccessful ) {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -60,13 +60,15 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			}
 
 			if ( ! this.props.isSavingSettings && prevProps.isSavingSettings ) {
+				const noticeSettings = {
+					id: 'site-settings-save',
+					duration: 10000,
+				};
 				if (
 					this.props.isSaveRequestSuccessful &&
 					( this.props.isJetpackSaveRequestSuccessful || ! this.props.siteIsJetpack )
 				) {
-					this.props.successNotice( this.props.translate( 'Settings saved!' ), {
-						id: 'site-settings-save',
-					} );
+					this.props.successNotice( this.props.translate( 'Settings saved!' ), noticeSettings );
 					// Upon failure to save Jetpack Settings, don't show an error message,
 					// since the JP settings data layer already does that for us.
 				} else if ( ! this.props.isSaveRequestSuccessful ) {
@@ -80,7 +82,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 							);
 							break;
 					}
-					this.props.errorNotice( text, { id: 'site-settings-save' } );
+					this.props.errorNotice( text, noticeSettings );
 				}
 			}
 		}

--- a/client/state/notices/jetpack-modules/index.js
+++ b/client/state/notices/jetpack-modules/index.js
@@ -21,7 +21,10 @@ export const onJetpackModuleActivationActionMessage = ( { type, moduleSlug, sile
 		return null;
 	}
 
-	const noticeSettings = { duration: 10000 };
+	const noticeSettings = {
+		duration: 10000,
+		id: 'site-settings-save',
+	};
 	let message = MODULE_NOTICES[ moduleSlug ] && MODULE_NOTICES[ moduleSlug ][ type ];
 	let messageType;
 


### PR DESCRIPTION
This PR does a few minor changes to unify the site settings saving notices:

* Use the settings save notice ID for module notices to ensure that we display only a single notice when saving settings and (de)activating modules. This also removes the possibility for the notice to be duplicated when saving multiple times within a short period of time.
* Add a duration to settings save notices, to make sure that they disappear just like other settings save notices disappear (the module (de)activation ones).
* Use the same copy for the success notice that is used most commonly everywhere.

#### Changes proposed in this Pull Request

* State: Use the settings save notice ID for module notices
* Site Settings: Add duration to settings save notices
* Site Settings: Use the universal save success copy

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/settings/security/:site where `:site` is a Jetpack site slug.
* Click a "Save Settings" button and verify you see a 'Settings saved successfully!' success message.
* Verify that notice disappears after 10 sec.
* Click at least a couple other save buttons briefly and verify you see the same notice, but just once.
* Activate and deactivate a Jetpack module toggle, verify you see the same notice, and it's not duplicated.
