### PR TITLE
ESLint: Fix triple asterisks in JSdoc blocks

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -300,7 +300,7 @@ class PostCommentList extends React.Component {
 		);
 	};
 
-	/***
+	/**
 	 * Gets comments for display
 	 * @param {Immutable.List<Number>} commentIds The top level commentIds to take from
 	 * @param {number} numberToTake How many top level comments to take

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-/***
+/**
  * Internal dependencies
  */
 import PostCommentForm from './form';

--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 
-/***
+/**
  * Internal dependencies
  */
 import TimeSince from 'components/time-since';

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { map, get, last, uniqBy, size, filter, takeRight, compact } from 'lodash';
 import { localize } from 'i18n-calypso';
 
-/***
+/**
  * Internal dependencies
  */
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { map, zipObject, fill, size, filter, get, compact, partition, min, noop } from 'lodash';
 
-/***
+/**
  * Internal dependencies
  */
 import getActiveReplyCommentId from 'state/selectors/get-active-reply-comment-id';

--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -22,14 +22,14 @@ const SPACE_CHARACTERS = {
 	' ': true,
 };
 
-/***
+/**
  * Checks whether a character is a space character
  * @param {string} character character to examine
  * @returns {bool} true if character is a space character, false otherwise
  */
 const isSpaceCharacter = character => !! SPACE_CHARACTERS[ character ];
 
-/***
+/**
  * Get index of the first character that is not within a tag
  * @param {string} text text to examine
  * @returns {number} index not within a tag
@@ -55,7 +55,7 @@ const getTaglessIndex = text => {
 	return 0;
 };
 
-/***
+/**
  * Gets text content from react element in case that's a leaf element
  * @param {React.Element} reactElement react element
  * @returns {string|null} returns a text content of the react element or null if it's not a leaf element
@@ -101,7 +101,7 @@ const getContent = reactElement => {
 	return null;
 };
 
-/***
+/**
  * Gets the main directionality in a text
  * It returns what kind of characters we had the most, RTL or LTR according to some ratio
  *
@@ -153,7 +153,7 @@ const getChildDirection = ( child, isRtl ) => {
 };
 
 const inlineComponents = [ Emojify ];
-/***
+/**
  * Sets a react component child directionality according to it's text content
  * That function intended to be used recursively with React.Children.map
  * It will set directionality only to the leaf components - because it does so according
@@ -202,7 +202,7 @@ const setChildDirection = ( child, isRtl ) => {
 	return child;
 };
 
-/***
+/**
  * Auto direction component that will set direction to child components according to their text content
  * @param {object.children} props react element props that must contain some children
  * @returns {React.Element} returns a react element with adjusted children

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -71,7 +71,7 @@ export const receiveCommentsError = ( { siteId, commentId } ) => ( {
 	commentId,
 } );
 
-/***
+/**
  * Creates an action that requests comments for a given post
  * @param {number} siteId site identifier
  * @param {number} postId post identifier
@@ -182,7 +182,7 @@ export const deleteComment = (
 	} );
 };
 
-/***
+/**
  * Creates a write comment action for a siteId and postId
  * @param {string} commentText text of the comment
  * @param {number} siteId site identifier
@@ -196,7 +196,7 @@ export const writeComment = ( commentText, siteId, postId ) => ( {
 	commentText,
 } );
 
-/***
+/**
  * Creates a reply to comment action for a siteId, postId and commentId
  * @param {string} commentText text of the comment
  * @param {number} siteId site identifier
@@ -220,7 +220,7 @@ export const replyComment = (
 	refreshCommentListQuery,
 } );
 
-/***
+/**
  * Creates a thunk that likes a comment
  * @param {number} siteId site identifier
  * @param {number} postId post identifier
@@ -234,7 +234,7 @@ export const likeComment = ( siteId, postId, commentId ) => ( {
 	commentId,
 } );
 
-/***
+/**
  * Creates an action that unlikes a comment
  * @param {number} siteId site identifier
  * @param {number} postId post identifier
@@ -334,7 +334,7 @@ export const expandComments = ( { siteId, commentIds, postId, displayType } ) =>
 	payload: { siteId, commentIds, postId, displayType },
 } );
 
-/***
+/**
  * Creates an action that sets the active reply for a given site ID and post ID
  * This is used on the front end to show a reply box under the specified comment.
  *

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -84,7 +84,7 @@ const updateComment = ( commentId, newProperties ) => comment => {
 	};
 };
 
-/***
+/**
  * Comments items reducer, stores a comments items Immutable.List per siteId, postId
  * @param {object} state redux state
  * @param {object} action redux action
@@ -169,7 +169,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-/***
+/**
  * Comments pending items reducer, stores new comments per siteId and postId
  * @param {object} state redux state
  * @param {object} action redux action
@@ -277,7 +277,7 @@ export const expansions = withoutPersistence( ( state = {}, action ) => {
 	return state;
 } );
 
-/***
+/**
  * Stores whether or not there are more comments, and in which directions, for a particular post.
  * Also includes whether or not a before/after has ever been queried
  * Example state:
@@ -323,7 +323,7 @@ export const fetchStatus = withoutPersistence( ( state = {}, action ) => {
 	return state;
 } );
 
-/***
+/**
  * Stores latest comments count for post we've seen from the server
  * @param {object} state redux state, prev totalCommentsCount
  * @param {object} action redux action
@@ -392,7 +392,7 @@ export const treesInitialized = keyedReducer(
 	keyedReducer( 'status', treesInitializedReducer )
 );
 
-/***
+/**
  * Stores the active reply comment for a given siteId and postId
  * @param {object} state redux state
  * @param {object} action redux action

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -1,4 +1,4 @@
-/***
+/**
  * External dependencies
  */
 import {
@@ -25,7 +25,7 @@ import treeSelect from '@automattic/tree-select';
 import { fetchStatusInitialState } from './reducer';
 import { getStateKey, deconstructStateKey, getErrorKey } from './utils';
 
-/***
+/**
  * Gets comment items for post
  * @param {object} state redux state
  * @param {number} siteId site identification
@@ -60,7 +60,7 @@ export const getCommentErrors = state => {
 	return state.comments.errors;
 };
 
-/***
+/**
  * Get total number of comments on the server for a given post
  * @param {object} state redux state
  * @param {number} siteId site identification
@@ -70,7 +70,7 @@ export const getCommentErrors = state => {
 export const getPostTotalCommentsCount = ( state, siteId, postId ) =>
 	get( state.comments.totalCommentsCount, `${ siteId }-${ postId }` );
 
-/***
+/**
  * Get total number of comments in state at a given date and time
  *
  * @param {object} state redux state
@@ -101,7 +101,7 @@ export const getPostCommentsCountAtDate = ( state, siteId, postId, date ) => {
 	return size( postCommentsAtDate );
 };
 
-/***
+/**
  * Get most recent comment date for a given post
  * @param {object} state redux state
  * @param {number} siteId site identification
@@ -116,7 +116,7 @@ export const getPostNewestCommentDate = treeSelect(
 	}
 );
 
-/***
+/**
  * Get oldest comment date for a given post
  * @param {object} state redux state
  * @param {number} siteId site identification
@@ -131,7 +131,7 @@ export const getPostOldestCommentDate = treeSelect(
 	}
 );
 
-/***
+/**
  * Gets comment tree for a given post
  * @param {object} state redux state
  * @param {number} siteId site identification
@@ -218,7 +218,7 @@ export const commentsFetchingStatus = ( state, siteId, postId, commentTotal = 0 
 	};
 };
 
-/***
+/**
  * Gets likes stats for the comment
  * @param {object} state redux state
  * @param {number} siteId site identification

--- a/client/state/http/actions.js
+++ b/client/state/http/actions.js
@@ -4,7 +4,7 @@
 
 import { HTTP_REQUEST } from 'state/action-types';
 
-/***
+/**
  * @typedef {object} RequestDescription
  * @property {string} url the url to request
  * @property {string} method the method we should use in the request: GET, POST etc.
@@ -17,7 +17,7 @@ import { HTTP_REQUEST } from 'state/action-types';
  * @property {object} options other options
  */
 
-/***
+/**
  * Creates a raw http action request
  *
  * @param {RequestDescription} request HTTP request description

--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -3,7 +3,7 @@
  */
 import { fromPairs, identity, toPairs } from 'lodash';
 
-/***
+/**
  * Internal dependencies
  */
 import { extendAction } from 'state/utils';
@@ -28,7 +28,7 @@ const isAllHeadersValid = headers =>
 			typeof headerPair[ 1 ] === 'string'
 	);
 
-/***
+/**
  * Handler to perform an http request based on `HTTP_REQUEST` action parameters:
  * {string} url the url to request
  * {string} method the method we should use in the request: GET, POST etc.

--- a/client/state/jetpack-connect/utils.js
+++ b/client/state/jetpack-connect/utils.js
@@ -4,7 +4,7 @@
 
 import { JETPACK_CONNECT_TTL } from './constants';
 
-/***
+/**
  * Whether a Jetpack Connect store timestamp is stale.
  * @param   {number} timestamp  Item to check.
  * @param   {number} expiration Expiration to compare with, in milliseconds. Default is JETPACK_CONNECT_TTL.

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -37,7 +37,7 @@ export const getTwoFactorNotificationSent = state => {
 	return get( state, 'login.twoFactorAuth.two_step_notification_sent', null );
 };
 
-/***
+/**
  * Retrieve a token to be used for push notification auth polling
  *
  * @param  {object}   state  Global state tree
@@ -46,7 +46,7 @@ export const getTwoFactorNotificationSent = state => {
 export const getTwoFactorPushToken = state =>
 	get( state, 'login.twoFactorAuth.push_web_token', null );
 
-/***
+/**
  * Retrieve the progress status of polling for push authentication
  *
  * @param  {object}   state  Global state tree
@@ -55,7 +55,7 @@ export const getTwoFactorPushToken = state =>
 export const getTwoFactorPushPollInProgress = state =>
 	get( state, 'login.twoFactorAuthPushPoll.inProgress', false );
 
-/***
+/**
  * Get whether user logged in successfully via push auth
  *
  * @param  {object}   state  Global state tree
@@ -150,7 +150,7 @@ export const getRequestNotice = state => {
 	return get( state, 'login.requestNotice', null );
 };
 
-/***
+/**
  * Retrieves the last redirect url provided in the query parameters of any login page. This url must be sanitized by the
  * API before being used to avoid open redirection attacks.
  *
@@ -162,7 +162,7 @@ export const getRedirectToOriginal = state => {
 	return get( state, 'login.redirectTo.original', null );
 };
 
-/***
+/**
  * Retrieves the last redirect url provided in the query parameters of any login page that was sanitized by the API
  * during the authentication process.
  *
@@ -173,7 +173,7 @@ export const getRedirectToSanitized = state => {
 	return get( state, 'login.redirectTo.sanitized', null );
 };
 
-/***
+/**
  * Retrieves whether the login form should be disabled due to actions.
  *
  * @param  {object}   state  Global state tree
@@ -193,7 +193,7 @@ export const getAuthAccountType = state => {
 	return get( state, 'login.authAccountType', null );
 };
 
-/***
+/**
  * Tells us if we're in a process of creating a social account
  *
  * @param  {object}   state  Global state tree
@@ -202,7 +202,7 @@ export const getAuthAccountType = state => {
 export const isSocialAccountCreating = state =>
 	get( state, 'login.socialAccount.isCreating', null );
 
-/***
+/**
  * Gets Username of the created social account
  *
  * @param  {object}   state  Global state tree
@@ -211,7 +211,7 @@ export const isSocialAccountCreating = state =>
 export const getCreatedSocialAccountUsername = state =>
 	get( state, 'login.socialAccount.username', null );
 
-/***
+/**
  * Gets Bearer token of the created social account
  *
  * @param  {object}   state  Global state tree
@@ -220,7 +220,7 @@ export const getCreatedSocialAccountUsername = state =>
 export const getCreatedSocialAccountBearerToken = state =>
 	get( state, 'login.socialAccount.bearerToken', null );
 
-/***
+/**
  * Gets error for the create social account request.
  *
  * @param  {object}   state  Global state tree
@@ -229,7 +229,7 @@ export const getCreatedSocialAccountBearerToken = state =>
 export const getCreateSocialAccountError = state =>
 	get( state, 'login.socialAccount.createError', null );
 
-/***
+/**
  * Gets error for the get social account request.
  *
  * @param  {object}   state  Global state tree
@@ -238,7 +238,7 @@ export const getCreateSocialAccountError = state =>
 export const getRequestSocialAccountError = state =>
 	get( state, 'login.socialAccount.requestError', null );
 
-/***
+/**
  * Gets social account linking status
  *
  * @param  {object}   state  Global state tree
@@ -247,7 +247,7 @@ export const getRequestSocialAccountError = state =>
 export const getSocialAccountIsLinking = state =>
 	get( state, 'login.socialAccountLink.isLinking', null );
 
-/***
+/**
  * Gets social account linking email
  *
  * @param  {object}   state  Global state tree
@@ -256,7 +256,7 @@ export const getSocialAccountIsLinking = state =>
 export const getSocialAccountLinkEmail = state =>
 	get( state, 'login.socialAccountLink.email', null );
 
-/***
+/**
  * Gets social account linking service
  *
  * @param  {object}   state  Global state tree
@@ -265,7 +265,7 @@ export const getSocialAccountLinkEmail = state =>
 export const getSocialAccountLinkService = state =>
 	get( state, 'login.socialAccountLink.authInfo.service', null );
 
-/***
+/**
  * Gets the auth information of the social account to be linked.
  *
  * @param  {object}   state  Global state tree

--- a/client/state/oauth2-clients/selectors.js
+++ b/client/state/oauth2-clients/selectors.js
@@ -4,7 +4,7 @@
 
 import { get } from 'lodash';
 
-/***
+/**
  * Gets the OAuth2 client data.
  *
  * @param  {object}   state  Global state tree

--- a/client/state/ui/oauth2-clients/selectors.js
+++ b/client/state/ui/oauth2-clients/selectors.js
@@ -19,7 +19,7 @@ export function getCurrentOAuth2ClientId( state ) {
 	return get( state, 'ui.oauth2Clients.currentClientId' );
 }
 
-/***
+/**
  * Gets the OAuth2 client data.
  *
  * @param  {object}   state  Global state tree
@@ -35,7 +35,7 @@ export const getCurrentOAuth2Client = state => {
 	return getOAuth2Client( state, currentClientId );
 };
 
-/***
+/**
  * Determines if the OAuth2 layout should be used.
  *
  * @param  {object}   state  Global state tree


### PR DESCRIPTION
In #38142 and #38627 we have been mass-fixing some ESLint warnings and noticed that we have several `/***` comment opening instances that make ESLint fail in parsing those as proper JSdoc blocks. 

This PR fixes all of them to be `/**`. It doesn't fix the ESLint warnings that were there before and are now properly recognized as ESLint warnings. 

#### Changes proposed in this Pull Request

* ESLint: Fix triple asterisks in JSdoc blocks

#### Testing instructions

* Testing not necessary, this changes some comment blocks only.
