### PR TITLE
composite-checkout: Allow purchasing domains

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -131,11 +131,11 @@ function getDomainDetails() {
 		firstName,
 		lastName,
 		email,
-		phoneNumber,
-		address,
+		phone: phoneNumber,
+		address_1: address,
 		city,
 		state,
-		country,
+		countryCode: country,
 		postalCode,
 	};
 }

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -128,15 +128,15 @@ function getDomainDetails() {
 	const { firstName, lastName, email, phoneNumber, address, city, state, country, postalCode } =
 		select( 'wpcom' )?.getContactInfo?.() ?? {};
 	return {
-		firstName,
-		lastName,
-		email,
-		phone: phoneNumber,
-		address_1: address,
-		city,
-		state,
-		countryCode: country,
-		postalCode,
+		firstName: firstName?.value,
+		lastName: lastName?.value,
+		email: email?.value,
+		phone: phoneNumber?.value,
+		address_1: address?.value,
+		city: city?.value,
+		state: state?.value,
+		countryCode: country?.value,
+		postalCode: postalCode?.value,
 	};
 }
 

--- a/client/my-sites/checkout/checkout/composite-checkout-container.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-container.js
@@ -110,7 +110,7 @@ export function createCartFromLineItems( {
 		extra: [],
 		products: items.map( item => ( {
 			product_id: item.wpcom_meta?.product_id,
-			meta: '', // TODO: get this for domains, etc
+			meta: item.sublabel,
 			currency: item.amount.currency,
 			volume: 1, // TODO: get this from the item
 		} ) ),

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -278,7 +278,7 @@ function PhoneNumberField( { id, isRequired, phoneNumber, onChange } ) {
 	return (
 		<FormField
 			id={ id }
-			type="Number"
+			type="text"
 			label={ isRequired ? translate( 'Phone number (Optional)' ) : translate( 'Phone number' ) }
 			value={ phoneNumber.value }
 			onChange={ value =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When attempting to purchase a domain with composite checkout, we weren't sending the domain name at all with the product ID, and the domain contact data was incorrect. This PR fixes both of those issues.

#### Testing instructions

- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan _and a domain_ to your cart. Choose a `.live` domain, since the store sandbox will simulate that purchase rather than actually purchasing it.
- Visit checkout.
- Complete the checkout process using a credit card payment (new or existing).
- The State and Country fields will need to be in two-letter format (eg: `CA` and `US` rather than `California` and `United States`).
- The phone number will need to be in this format: `+1.6032223432`.
- Press the button to Pay.
- Verify that the payment is successful.