### PR TITLE
Remove Jetpack plugin setup notice from sidebar

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -25,10 +25,6 @@ import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryActivePromotions from 'components/data/query-active-promotions';
-import {
-	isStarted as isJetpackPluginsStarted,
-	isFinished as isJetpackPluginsFinished,
-} from 'state/plugins/premium/selectors';
 import CartData from 'components/data/cart';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PendingPaymentNotice from './pending-payment-notice';
@@ -234,32 +230,6 @@ export class SiteNotice extends React.Component {
 		return moment( now ).format( format ) === moment( endsAt ).format( format );
 	}
 
-	jetpackPluginsSetupNotice() {
-		if (
-			! this.props.pausedJetpackPluginsSetup ||
-			this.props.site.plan.product_slug === 'jetpack_free'
-		) {
-			return null;
-		}
-
-		const { translate } = this.props;
-
-		return (
-			<Notice
-				icon="plugins"
-				isCompact
-				status="is-info"
-				text={ translate( 'Your %(plan)s plan needs setting up!', {
-					args: { plan: this.props.site.plan.product_name_short },
-				} ) }
-			>
-				<NoticeAction href={ `/plugins/setup/${ this.props.site.slug }` }>
-					{ translate( 'Finish' ) }
-				</NoticeAction>
-			</Notice>
-		);
-	}
-
 	pendingPaymentNotice() {
 		if ( ! config.isEnabled( 'async-payments' ) ) {
 			return null;
@@ -281,7 +251,6 @@ export class SiteNotice extends React.Component {
 		const discountOrFreeToPaid = this.activeDiscountNotice();
 		const siteRedirectNotice = this.getSiteRedirectNotice( site );
 		const domainCreditNotice = this.domainCreditNotice();
-		const jetpackPluginsSetupNotice = this.jetpackPluginsSetupNotice();
 
 		return (
 			<div className="current-site__notices">
@@ -299,13 +268,7 @@ export class SiteNotice extends React.Component {
 				<QuerySitePlans siteId={ site.ID } />
 				{ this.pendingPaymentNotice() }
 				{ ! hasJITM && domainCreditNotice }
-				{ jetpackPluginsSetupNotice }
-				{ ! (
-					hasJITM ||
-					discountOrFreeToPaid ||
-					domainCreditNotice ||
-					jetpackPluginsSetupNotice
-				) && this.domainUpsellNudge() }
+				{ ! ( hasJITM || discountOrFreeToPaid || domainCreditNotice ) && this.domainUpsellNudge() }
 			</div>
 		);
 	}
@@ -323,8 +286,6 @@ export default connect(
 			activeDiscount: getActiveDiscount( state ),
 			hasDomainCredit: hasDomainCredit( state, siteId ),
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
-			pausedJetpackPluginsSetup:
-				isJetpackPluginsStarted( state, siteId ) && ! isJetpackPluginsFinished( state, siteId ),
 			productsList: getProductsList( state ),
 			domains: getDomainsBySiteId( state, siteId ),
 			isPlanOwner: isCurrentUserCurrentPlanOwner( state, siteId ),


### PR DESCRIPTION
<img width="277" alt="screen_shot_2020-01-07_at_4 16 18_pm" src="https://user-images.githubusercontent.com/51896/71933373-d349d080-3156-11ea-9187-b308a10cfac7.png">

We no longer use the sidebar for this kind of notification.