### PR TITLE
composite-checkout: Don't save URL if step number is 1

### DIFF
--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -304,7 +304,7 @@ function saveStepNumberToUrl( stepNumber ) {
 	if ( ! window.history?.pushState ) {
 		return;
 	}
-	const newHash = `#step${ stepNumber }`;
+	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
 	if ( window.location.hash === newHash ) {
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #38493, we set up the checkout form to save the current step to the URL, pushing it on to the history so that the browser's back button allows going backwards through the steps. This works well, but it also changes the URL for the first step; the result of which is that when pressing the back button on the first step, we go back to the same form without the step in the URL, and the step is immediately added back in. To the user this may appear that you cannot go back from the first step to whatever page was before it.

In this PR, we avoid changing the URL for the first step, and if we go back to the first step, we treat it as the bare URL without a step number.

#### Testing instructions

- Run `npm run composite-checkout-demo`.
- Visit the demo site and verify that the URL does not contain a "step1" hash.
- Choose a payment method and press "Continue" to go to the second step.
- Verify that the URL contains a "step2" hash.
- Press the "Back" button in the browser and verify that the URL has no hash again.