### PR TITLE
Prevent Gutenboarding questions from jumping around

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -41,6 +41,8 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 								{ ! siteVertical &&
 									! siteTitle &&
 									NO__( "Let's set up your website – it takes only a moment." ) }
+								{ /* This empty 'non breaking space' is here so that the content below doesn't jump around once the 'siteTitle' is added */ }
+								&nbsp;
 							</h2>
 							<StepperWizard
 								stepComponents={ [ VerticalSelect, ( siteVertical || siteTitle ) && SiteTitle ] }

--- a/client/landing/gutenboarding/onboarding-block/question/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/question/style.scss
@@ -2,26 +2,12 @@
 
 .onboarding-block__question {
 	display: flex;
-	font-size: 28px;
+	font-size: 40px;
 	margin-bottom: 10px;
 	transition-property: 'font-size';
 	transition-duration: 0.25s;
 	transition-timing-function: 'linear';
 	transition-delay: 0;
-
-	&.selected {
-		font-size: 40px;
-		margin-top: 18px;
-		margin-bottom: 28px;
-
-		&:first-of-type {
-			margin-top: 0;
-		}
-
-		&:last-of-type {
-			margin-bottom: 0;
-		}
-	}
 
 	.onboarding-block__question-input {
 		border: 0;


### PR DESCRIPTION
I removed the focus styling, I think using the larger size for all text is most readable. I also added a white-space character to prevent the page jumping when the help text is removed.

#### Changes proposed in this Pull Request

* Remove css style that changes size of selected question
* Add whitespace to reserve space taken by the help text

#### Testing instructions

View the page at `/gutenboarding`, when you enter the site topic and site name, the page should no longer jump around

![Jan-08-2020 13-00-21](https://user-images.githubusercontent.com/22446385/71939291-0eabd400-3217-11ea-905f-dfbd3b1366be.gif)


Fixes #38687
