### PR TITLE
i18n-utils: Add translationExists function

### DIFF
--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -22,6 +22,7 @@ export {
 	removeLocaleFromPath,
 	getPathParts,
 	filterLanguageRevisions,
+	translationExists,
 } from './utils';
 
 export const getLocaleSlug = () => config( 'i18n_default_locale_slug' );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -17,6 +17,7 @@ import {
 	canBeTranslated,
 	getPathParts,
 	filterLanguageRevisions,
+	translationExists,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -78,6 +79,7 @@ jest.mock( 'config', () => key => {
 
 jest.mock( 'i18n-calypso', () => ( {
 	getLocaleSlug: jest.fn( () => 'en' ),
+	hasTranslation: jest.fn( () => false ),
 } ) );
 
 describe( 'utils', () => {
@@ -509,6 +511,33 @@ describe( 'utils', () => {
 			};
 
 			expect( filterLanguageRevisions( invalid ) ).toEqual( valid );
+		} );
+	} );
+
+	describe( 'translationExists()', function() {
+		it( 'should return true for a simple translation', function() {
+			expect( translationExists( 'test1' ) ).toBe( true );
+		} );
+
+		it( 'should return false for a string without translation', function() {
+			getLocaleSlug.mockImplementationOnce( () => 'fr' );
+			expect(
+				translationExists(
+					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'
+				)
+			).toBe( false );
+		} );
+
+		it( 'should return true for a simple translation when using default locale', function() {
+			expect( translationExists( 'test1' ) ).toBe( true );
+		} );
+
+		it( 'should return true for a string without translation when using default locale', function() {
+			expect(
+				translationExists(
+					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'
+				)
+			).toBe( true );
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { find, isString, map, pickBy, includes, endsWith } from 'lodash';
-import { getLocaleSlug } from 'i18n-calypso';
+import { getLocaleSlug, hasTranslation } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -72,6 +72,20 @@ export function isLocaleRtl( locale ) {
  */
 export function canBeTranslated( locale ) {
 	return [ 'en', 'sr_latin' ].indexOf( locale ) === -1;
+}
+
+/**
+ * To be used with the same parameters as i18n-calpyso's translate():
+ * Check whether the user would be exposed to text not in their language.
+ *
+ * Since the text is in English, this is always true in that case. Otherwise
+ * We check whether a translation was provided for this text.
+ *
+ * @returns {boolean} true when a user would see text they can read.
+ */
+export function translationExists() {
+	const localeSlug = typeof getLocaleSlug === 'function' ? getLocaleSlug() : 'en';
+	return isDefaultLocale( localeSlug ) || hasTranslation.apply( null, arguments );
 }
 
 /**


### PR DESCRIPTION
As an alternative implementation of #38565 and #38566, we add a utility function that developers can use to see whether (new) text can already be used for this language.

#### Changes proposed in this Pull Request

**Problem:** (see #38565)

* When user has locale set to default locale...
* ... and `hasTranslation` is called...
* ....it returns false, even though passing the input through `translate()` would return a valid result (the input itself)

New: Instead of modifying the i18n-calypso API, we try an user side implementation.
