### PR TITLE
Gutenboarding: Introduce flag to temporarily disable sidebar

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -15,7 +15,7 @@ import { DomainSuggestions } from '@automattic/data-stores';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
-import { selectorDebounce } from '../../constants';
+import { selectorDebounce, enableSidebarDisplay } from '../../constants';
 import Link from '../link';
 
 const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
@@ -121,16 +121,18 @@ const Header: FunctionComponent< Props > = ( {
 					{ NO__( 'Next' ) }
 				</Link>
 				<div className="gutenboarding__header-group">
-					<IconButton
-						aria-expanded={ isEditorSidebarOpened }
-						aria-haspopup="menu"
-						aria-pressed={ isEditorSidebarOpened }
-						icon="admin-generic"
-						isToggled={ isEditorSidebarOpened }
-						label={ NO__( 'Site block settings' ) }
-						onClick={ toggleGeneralSidebar }
-						shortcut={ toggleSidebarShortcut }
-					/>
+					{ enableSidebarDisplay && (
+						<IconButton
+							aria-expanded={ isEditorSidebarOpened }
+							aria-haspopup="menu"
+							aria-pressed={ isEditorSidebarOpened }
+							icon="admin-generic"
+							isToggled={ isEditorSidebarOpened }
+							label={ NO__( 'Site block settings' ) }
+							onClick={ toggleGeneralSidebar }
+							shortcut={ toggleSidebarShortcut }
+						/>
+					) }
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -7,3 +7,10 @@
  * @see https://stackoverflow.com/a/44755058/1432801
  */
 export const selectorDebounce = 300;
+
+/**
+ * Flag for temporarily hiding the sidebar and related toggle button.
+ *
+ * @todo Remove once we re-enact the sidebar or decide to go without (or via another route).
+ */
+export const enableSidebarDisplay = false

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -33,6 +33,7 @@ import { Slot as SidebarSlot } from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
 import { STORE_KEY } from './stores/onboard';
 import { routes, Step } from './steps';
+import { enableSidebarDisplay } from './constants';
 import './style.scss';
 
 // Copied from https://github.com/WordPress/gutenberg/blob/c7d00c64a4c74236a4aab528b3987811ab928deb/packages/edit-post/src/keyboard-shortcuts.js#L11-L15
@@ -116,10 +117,12 @@ export function Gutenboard() {
 									</WritingFlow>
 								</div>
 							</div>
-							<div>
-								<SettingsSidebar isActive={ isEditorSidebarOpened } />
-								<SidebarSlot />
-							</div>
+							{ enableSidebarDisplay && (
+								<div>
+									<SettingsSidebar isActive={ isEditorSidebarOpened } />
+									<SidebarSlot />
+								</div>
+							) }
 						</BlockEditorProvider>
 					</div>
 				</DropZoneProvider>


### PR DESCRIPTION
### Changes proposed in this Pull Request

Introduces a temporary flag for disabling the sidebar and button in header. 

~Disclaimer:~ (lol) Notes: I was not sure whether to ~reap~ rip this out entirely (sidebar components, header button, keyboard shortcut bindings) or to handle it along these lines. A temporary flag feels like the quickest option to allow us to "move fast" in case we want to re-introduce it in the near term (?).

#### Testing instructions

- Gear icon in header should not be visible.
- Sidebar should not respond to keyboard shortcut.

Fixes #38686
