### PR TITLE
Photon.js: remove dependency on node's url.

### DIFF
--- a/packages/photon/History.md
+++ b/packages/photon/History.md
@@ -1,4 +1,10 @@
-TBD
+3.0.0 / TBD
+===========
+
+  * Drop dependency on `url` npm package.
+  * Breaking change: support for URL / URLSearchParams APIs is now required.
+
+2.1.0 / 2019-06-03
 ==================
 
   * Move source into [Calypso](https://github.com/Automattic/wp-calypso).

--- a/packages/photon/README.md
+++ b/packages/photon/README.md
@@ -2,19 +2,37 @@
 
 JavaScript library for the [WordPress.com][] [Photon][] image manipulation service.
 
+## Requirements
+
+Photon.js requires support for the standard URL and URLSearchParams APIs.
+Be sure to use a polyfill if you're targetting environments without support for them. This includes old browsers, such
+as Internet Explorer 11, and old versions of Node.js (5 or older).
+
 ## How to use
 
-Install for Node.js via `npm`:
+Install via `npm`:
 
 ```bash
 npm install photon
 ```
 
-Use `require( 'photon' );` in your module to generate build Photon URLs:
+Import the `photon` method into your module.
+
+For CommonJS:
 
 ```js
 const photon = require( 'photon' );
+```
 
+For ES Modules:
+
+```js
+import photon from 'photon';
+```
+
+Then use the imported method to generate Photon URLs:
+
+```js
 const url = photon( 'https://wordpress.org/style/images/wporg-logo.svg' );
 
 console.log( url );

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "photon",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "JavaScript library for the WordPress.com Photon image manipulation service",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -33,8 +33,7 @@
 	"dependencies": {
 		"crc32": "0.2.2",
 		"debug": "^4.0.0",
-		"seed-random": "2.2.0",
-		"url": "^0.11.0"
+		"seed-random": "2.2.0"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/photon/src/index.js
+++ b/packages/photon/src/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import url from 'url';
 import crc32 from 'crc32';
 import seed from 'seed-random';
 import debugFactory from 'debug';
@@ -18,6 +17,10 @@ const mappings = {
 	removeLetterboxing: 'ulb',
 };
 
+const PARSE_BASE_HOST = '__domain__.invalid';
+const PARSE_BASE_URL = `http://${ PARSE_BASE_HOST }`;
+const PHOTON_BASE_URL = 'https://i0.wp.com';
+
 /**
  * Returns a "photon" URL from the given image URL.
  *
@@ -29,39 +32,42 @@ const mappings = {
  * @param {string} imageUrl - the URL of the image to run through Photon
  * @param {object} [opts] - optional options object with Photon options
  * @returns {string} The generated Photon URL string
- * @api public
  */
 export default function photon( imageUrl, opts ) {
-	// parse the URL, assuming //host.com/path style URLs are ok and parse the querystring
-	const parsedUrl = url.parse( imageUrl, true, true );
+	let parsedUrl;
+	try {
+		parsedUrl = new URL( imageUrl, PARSE_BASE_URL );
+	} catch {
+		// Return null for invalid URLs.
+		return null;
+	}
+
 	const wasSecure = parsedUrl.protocol === 'https:';
-
-	delete parsedUrl.protocol;
-	delete parsedUrl.auth;
-	delete parsedUrl.port;
-
-	const params = {
-		slashes: true,
-		protocol: 'https:',
-		query: {},
-	};
+	const photonUrl = new URL( PHOTON_BASE_URL );
 
 	if ( isAlreadyPhotoned( parsedUrl.host ) ) {
 		// We already have a server to use.
 		// Use it, even if it doesn't match our hash.
-		params.pathname = parsedUrl.pathname;
-		params.hostname = parsedUrl.hostname;
+		photonUrl.pathname = parsedUrl.pathname;
+		photonUrl.hostname = parsedUrl.hostname;
 	} else {
 		// Photon does not support URLs with a querystring component
 		if ( parsedUrl.search ) {
 			return null;
 		}
-		const formattedUrl = url.format( parsedUrl );
-		params.pathname =
-			0 === formattedUrl.indexOf( '//' ) ? formattedUrl.substring( 1 ) : formattedUrl;
-		params.hostname = serverFromPathname( params.pathname );
+		let formattedUrl = parsedUrl.href.replace( `${ parsedUrl.protocol }//`, '' );
+		// Handle blob: protocol URLs.
+		if ( parsedUrl.protocol === 'blob:' ) {
+			formattedUrl = parsedUrl.pathname.replace( '://', '//' );
+		}
+		// Handle path-absolute and path-relative URLs.
+		if ( parsedUrl.hostname === PARSE_BASE_HOST ) {
+			formattedUrl = parsedUrl.pathname;
+		}
+		photonUrl.pathname = formattedUrl;
+		photonUrl.hostname = serverFromPathname( formattedUrl );
 		if ( wasSecure ) {
-			params.query.ssl = 1;
+			photonUrl.searchParams.set( 'ssl', 1 );
 		}
 	}
 
@@ -69,25 +75,24 @@ export default function photon( imageUrl, opts ) {
 		for ( const i in opts ) {
 			// allow configurable "hostname"
 			if ( i === 'host' || i === 'hostname' ) {
-				params.hostname = opts[ i ];
+				photonUrl.hostname = opts[ i ];
 				continue;
 			}
 
 			// allow non-secure access
 			if ( i === 'secure' && ! opts[ i ] ) {
-				params.protocol = 'http:';
+				photonUrl.protocol = 'http:';
 				continue;
 			}
 
-			params.query[ mappings[ i ] || i ] = opts[ i ];
+			photonUrl.searchParams.set( mappings[ i ] || i, opts[ i ] );
 		}
 	}
 
 	// do this after so a passed opt can't override it
 
-	const photonUrl = url.format( params );
-	debug( 'generated Photon URL: %s', photonUrl );
-	return photonUrl;
+	debug( 'generated Photon URL: %s', photonUrl.href );
+	return photonUrl.href;
 }
 
 function isAlreadyPhotoned( host ) {
@@ -98,6 +103,7 @@ function isAlreadyPhotoned( host ) {
  * Determine which Photon server to connect to: `i0`, `i1`, or `i2`.
  *
  * Statically hash the subdomain based on the URL, to optimize browser caches.
+ *
  * @param  {string} pathname The pathname to use
  * @returns {string}          The hostname for the pathname
  */

--- a/packages/photon/src/index.js
+++ b/packages/photon/src/index.js
@@ -55,7 +55,7 @@ export default function photon( imageUrl, opts ) {
 		if ( parsedUrl.search ) {
 			return null;
 		}
-		let formattedUrl = parsedUrl.href.replace( `${ parsedUrl.protocol }//`, '' );
+		let formattedUrl = parsedUrl.href.replace( `${ parsedUrl.protocol }/`, '' );
 		// Handle blob: protocol URLs.
 		if ( parsedUrl.protocol === 'blob:' ) {
 			formattedUrl = parsedUrl.pathname.replace( '://', '//' );

--- a/packages/photon/test/index.js
+++ b/packages/photon/test/index.js
@@ -1,11 +1,6 @@
 /* eslint jest/expect-expect: [ "error", { "assertFunctionNames": [ "expect", "expectPathname", "expectQuery", "expectHostedOnPhoton", "expectHostedOnPhotonInsecurely" ] } ] */
 
 /**
- * External dependencies
- */
-import { parse as parseUrl } from 'url';
-
-/**
  * Internal dependencies
  */
 import photon from '../src';
@@ -19,13 +14,15 @@ function expectHostedOnPhotonInsecurely( url ) {
 }
 
 function expectPathname( url, expected ) {
-	const parsedUrl = parseUrl( url, true, true );
+	const parsedUrl = new URL( url );
 	expect( parsedUrl.pathname ).toBe( expected );
 }
 
 function expectQuery( url, expected ) {
-	const query = parseUrl( url, true, true ).query;
-	expect( query ).toEqual( expected );
+	const searchParams = new URL( url ).searchParams;
+	for ( const key of Object.keys( expected ) ) {
+		expect( searchParams.get( key ) ).toBe( expected[ key ] );
+	}
 }
 
 describe( 'photon()', function() {


### PR DESCRIPTION
That functionality is deprecated, and the dependency adds to the package size.
This PR replaces it with standard `URL` / `URLSearchParams`, which have been available in Node.js for a long time, and are polyfilled in Calypso client code.

It increases the major version number, as the new requirement is technically a breaking change.

#### Changes proposed in this Pull Request

* Replace usage of node's `url` with standard `URL` / `URLSearchParams`.
* Update package version.
* Update Readme.
* Minor lint fixes.

#### Testing instructions

* Ensure the unit tests continue to pass
* Ensure Photon-related functionality in Calypso continues to work correctly.
