### PR TITLE
Gutenboarding: add react-spring transitions to intent gathering 

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/question/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/question/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
+import { useSpring, animated } from 'react-spring';
 import classNames from 'classnames';
 
 /**
@@ -26,22 +27,32 @@ const Question: FunctionComponent< Props > = ( {
 	isActive,
 	label,
 	onExpand,
-} ) => (
-	<div className={ classNames( 'onboarding-block__question', className, { selected: isActive } ) }>
-		<span>{ label }</span>
-		<div>
-			{ isActive ? (
-				children
-			) : (
-				<>
-					<button className="onboarding-block__question-answered" onClick={ onExpand }>
-						{ displayValue }
-					</button>
-					<span>.</span>
-				</>
-			) }
-		</div>
-	</div>
-);
+} ) => {
+	const springProps = useSpring( {
+		opacity: 1,
+		fontSize: isActive ? 40 : 28, // transition to a bigger font when the question is active
+		from: { opacity: 0 }, // fade in when mounting
+	} );
 
+	return (
+		<animated.div
+			style={ springProps }
+			className={ classNames( 'onboarding-block__question', className ) }
+		>
+			<span>{ label }</span>
+			<div>
+				{ isActive ? (
+					children
+				) : (
+					<>
+						<button className="onboarding-block__question-answered" onClick={ onExpand }>
+							{ displayValue }
+						</button>
+						<span>.</span>
+					</>
+				) }
+			</div>
+		</animated.div>
+	);
+};
 export default Question;

--- a/client/landing/gutenboarding/onboarding-block/question/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/question/style.scss
@@ -8,19 +8,6 @@
 	transition-timing-function: 'linear';
 	transition-delay: 0;
 
-	// &.selected {
-	// 	margin-top: 18px;
-	// 	margin-bottom: 28px;
-
-	// 	&:first-of-type {
-	// 		margin-top: 0;
-	// 	}
-
-	// 	&:last-of-type {
-	// 		margin-bottom: 0;
-	// 	}
-	// }
-
 	.onboarding-block__question-input {
 		border: 0;
 		border-bottom: 3px solid $light-gray-500;

--- a/client/landing/gutenboarding/onboarding-block/question/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/question/style.scss
@@ -2,26 +2,24 @@
 
 .onboarding-block__question {
 	display: flex;
-	font-size: 28px;
 	margin-bottom: 10px;
 	transition-property: 'font-size';
 	transition-duration: 0.25s;
 	transition-timing-function: 'linear';
 	transition-delay: 0;
 
-	&.selected {
-		font-size: 40px;
-		margin-top: 18px;
-		margin-bottom: 28px;
+	// &.selected {
+	// 	margin-top: 18px;
+	// 	margin-bottom: 28px;
 
-		&:first-of-type {
-			margin-top: 0;
-		}
+	// 	&:first-of-type {
+	// 		margin-top: 0;
+	// 	}
 
-		&:last-of-type {
-			margin-bottom: 0;
-		}
-	}
+	// 	&:last-of-type {
+	// 		margin-bottom: 0;
+	// 	}
+	// }
 
 	.onboarding-block__question-input {
 		border: 0;

--- a/client/landing/gutenboarding/onboarding-block/stepper-wizard.tsx
+++ b/client/landing/gutenboarding/onboarding-block/stepper-wizard.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent, useState, ComponentType } from 'react';
+import { useSpring, animated } from 'react-spring';
 import { Falsy } from 'utility-types';
 
 export interface StepProps {
@@ -18,23 +19,30 @@ interface Props {
 
 const StepperWizard: FunctionComponent< Props > = ( { stepComponents } ) => {
 	const [ activeStep, setActiveStep ] = useState( 0 );
-
 	const handleNext = () => setActiveStep( activeStep + 1 );
 
+	const visibleStepCount = stepComponents.filter( step => !! step ).length;
+	const translatePercent =
+		( 100 / visibleStepCount ) * Math.min( activeStep, visibleStepCount - 1 ); // sometimes activeStep is invisible because of current Next handling
+	const springProps = useSpring( {
+		transform: `translate(0, -${ translatePercent }%)`,
+	} );
+
 	return (
-		<>
-			{ stepComponents.map( ( Komponent, index ) => {
-				return Komponent ? (
-					<Komponent
-						inputClass="onboarding-block__question-input"
-						isActive={ index === activeStep }
-						key={ index }
-						onExpand={ () => setActiveStep( index ) }
-						onSelect={ handleNext }
-					/>
-				) : null;
-			} ) }
-		</>
+		<animated.div style={ springProps }>
+			{ stepComponents.map(
+				( Komponent, index ) =>
+					Komponent && (
+						<Komponent
+							inputClass="onboarding-block__question-input"
+							isActive={ index === activeStep }
+							key={ index }
+							onExpand={ () => setActiveStep( index ) }
+							onSelect={ handleNext }
+						/>
+					)
+			) }
+		</animated.div>
 	);
 };
 

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
 		"react-modal": "3.11.1",
 		"react-redux": "7.1.3",
 		"react-router-dom": "5.1.2",
+		"react-spring": "8.0.27",
 		"react-stripe-elements": "4.0.2",
 		"react-transition-group": "4.3.0",
 		"react-virtualized": "9.21.2",


### PR DESCRIPTION
part of https://github.com/Automattic/wp-calypso/issues/38612

#### Changes proposed in this Pull Request

* Introduce `react-spring` to Gutenboarding
* Use it to animate questions in the Intent Gathering steps according to design prototype.

Before:
https://cloudup.com/ckQpYNOlyXA

After:
https://cloudup.com/cLUQz7mtICK

#### Testing instructions

Go to http://calypso.localhost:3000/gutenboarding/ and toggle between questions in the Intent Gathering step. 
* Font should transition smoothly from to a bigger size when the question is focused.
* Questions should translate above so the active step is always in the same position.
