### PR TITLE
Eventbrite: Properly remove the Keyring connection on disconnect.

### DIFF
--- a/client/my-sites/marketing/connections/services/eventbrite.js
+++ b/client/my-sites/marketing/connections/services/eventbrite.js
@@ -8,7 +8,7 @@ import { last, isEqual } from 'lodash';
  * Internal dependencies
  */
 import { SharingService, connectFor } from 'my-sites/marketing/connections/service';
-import { deleteKeyringConnection } from 'state/sharing/keyring/actions';
+import { deleteStoredKeyringConnection } from 'state/sharing/keyring/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
 
 export class Eventbrite extends SharingService {
@@ -18,28 +18,25 @@ export class Eventbrite extends SharingService {
 		...SharingService.propTypes,
 		saveRequests: PropTypes.object,
 		saveSiteSettings: PropTypes.func,
-		deleteKeyringConnection: PropTypes.func,
+		deleteStoredKeyringConnection: PropTypes.func,
 	};
 
 	static defaultProps = {
 		...SharingService.defaultProps,
 		saveRequests: {},
 		saveSiteSettings: () => {},
-		deleteKeyringConnection: () => {},
+		deleteStoredKeyringConnection: () => {},
 	};
 
 	createOrUpdateConnection = () => {};
 
 	/**
-	 * Deletes the passed connections.
-	 *
-	 * @param {Array} connections Optional. Connections to be deleted.
-	 *                            Default: All connections for this service.
+	 * Deletes the Keyring connection from our database and removes any stored token in site options.
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );
 		this.props.saveSiteSettings( this.props.siteId, { eventbrite_api_token: null } );
-		this.props.deleteKeyringConnection( last( this.props.keyringConnections ) );
+		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
 	};
 
 	UNSAFE_componentWillReceiveProps( { availableExternalAccounts, saveRequests } ) {
@@ -97,6 +94,6 @@ export default connectFor(
 	},
 	{
 		saveSiteSettings,
-		deleteKeyringConnection,
+		deleteStoredKeyringConnection,
 	}
 );


### PR DESCRIPTION
This PR uses `deleteStoredKeyringConnection` to properly delete Eventbrite's Keyring connection on disconnect. Up to now, it's only been removing the connection from app state.

#### Testing instructions

* Be sure to have an Eventbrite connection under `marketing/connections/:site`. Ping me for credentials if you're not able to create a new connection yourself.
* On production, disconnect, and reload the page. Notice that the connection is there again.
* On this branch, disconnect.
* Refresh the page, and verify that the disconnected account is not showing.

Fixes #38723 .
