### PR TITLE
Add storybook instructions for @automattic/components

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,0 +1,14 @@
+# @automattic/components
+
+A library of React components designed for use in Automattic products.
+
+# Using [Storybook](https://storybook.js.org/)
+
+```bash
+# devDependencies are shared across the monorepo so ensure it is setup first
+$ npm install
+
+# Run `start-storybook` from this directory
+$ cd packages/components
+$ ../../.bin/start-storybook
+```

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -2,13 +2,17 @@
 
 A library of React components designed for use in Automattic products.
 
-# Using [Storybook](https://storybook.js.org/)
+## Development Workflow
 
-```bash
-# devDependencies are shared across the monorepo so ensure it is setup first
-$ npm install
+This package is developed as part of the Calypso monorepo. Run `npm install`
+in the root of the repository to get the required `devDependencies`.
 
-# Run `start-storybook` from this directory
-$ cd packages/components
-$ ../../.bin/start-storybook
-```
+### Tests
+
+```npm run test-packages```
+
+```npm run test-packages:watch```
+
+### Using [Storybook](https://storybook.js.org/)
+
+```npm run components:storybook:start```

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,4 +1,4 @@
-# @automattic/components
+# Components
 
 A library of React components designed for use in Automattic products.
 


### PR DESCRIPTION
There's probably a lot that will need to be said in the `@automattic/components` README about design decisions and other high level things, but I didn't want that to be a hurdle to getting some docs started. Since I just had to figure out how to get Storybook going I thought get the ball rolling.

@jameslnewell wanted to make sure you're aware that I'm adding this, and also to ask if there's a nicer way that you're running Storybook at the moment?

#### Changes proposed in this Pull Request

* Add README to `@automattic/components`
* Add brief instructions for getting Storybook started
