### PR TITLE
Banner: Allow for more customization from parent instances

### DIFF
--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -39,6 +39,7 @@ render() {
 | ---- | ---- | ------- | ----------- |
 | `callToAction` | `string` | null | Shows a CTA text. |
 | `className` | `string` | null | Any additional CSS classes. |
+| `compact` | `bool` | false | Display a compact version of the banner. |
 | `description` | `string` | null | The banner description. |
 | `disableHref` | `bool` | false | When true, prevent the Banner to be linked either via the `href` props or as a side effect of the `siteSlug` connected prop. |
 | `dismissPreferenceName` | `bool` | false | The user preference name that we store a boolean against, prefixed with `dismissible-card-` to avoid namespace collisions. |
@@ -46,7 +47,7 @@ render() {
 | `event` | `string` | null | Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property. |
 | `feature` | `string` | null | Slug of the feature to highlight in the plans compare card. |
 | `href` | `string` | null | The component target URL. |
-| `icon` | `string` | null | The component icon. |
+| `icon` | `string` or `bool` | null or false | The component icon. |
 | `list` | `string` | null | A list of the upgrade features. |
 | `onClick` | `string` | null | A function associated to the click on the whole banner or just the CTA or dismiss button. |
 | `plan` | `string` | null | PlanSlug of the plan that upgrade leads to. |

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -27,6 +27,12 @@ render() {
 			plan={ PLAN_BUSINESS }
 			prices={ [ 10.99, 9.99 ] }
 			title="Upgrade to a better plan!"
+			tracksImpressionName="calypso_banner_upgrade_view"
+			tracksClickName="calypso_banner_upgrade_click"
+			tracksDismissName="calypso_banner_upgrade_dismiss"
+			tracksImpressionProperties={ { cta_name: 'calyspo_banner_upgrade' } }
+			tracksClickProperties={ { cta_name: 'calyspo_banner_upgrade' } }
+			tracksDismissProperties={ { cta_name: 'calyspo_banner_upgrade' } }
 		/>
 	);
 }
@@ -47,12 +53,19 @@ render() {
 | `event` | `string` | null | Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property. |
 | `feature` | `string` | null | Slug of the feature to highlight in the plans compare card. |
 | `href` | `string` | null | The component target URL. |
-| `icon` | `string` or `bool` | null or false | The component icon. |
+| `icon` | `string` | null | The component icon. |
 | `list` | `string` | null | A list of the upgrade features. |
+| `noIcon` | `bool` | `false` | Do not show an icon. |
 | `onClick` | `string` | null | A function associated to the click on the whole banner or just the CTA or dismiss button. |
 | `plan` | `string` | null | PlanSlug of the plan that upgrade leads to. |
 | `price` | `string` | null | One or two (original/discounted) upgrade prices. |
 | `title` | `string` | null | (required) The banner title. |
+| `tracksImpressionName` | `string` | | Unique event name to track when the nudge is viewed |
+| `tracksClickName` | `string` | | Unique event name to track when the nudge is clicked |
+| `tracksDismissName` | `string` |  | Unique event name to track when the nudge is dismissed |
+| `tracksImpressionProperties` | `object` | | Additional props to track when the nudge is viewed |
+| `tracksClickProperties` | `object` | | Additional props to track when the nudge is clicked |
+| `tracksDismissProperties` | `object` |  | Additional props to track when the nudge is dismissed |
 
 ### General guidelines
 

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -26,6 +26,7 @@ render() {
 			onClick={ someFunction }
 			plan={ PLAN_BUSINESS }
 			prices={ [ 10.99, 9.99 ] }
+			showIcon={ false }
 			title="Upgrade to a better plan!"
 			tracksImpressionName="calypso_banner_upgrade_view"
 			tracksClickName="calypso_banner_upgrade_click"
@@ -55,10 +56,10 @@ render() {
 | `href` | `string` | null | The component target URL. |
 | `icon` | `string` | null | The component icon. |
 | `list` | `string` | null | A list of the upgrade features. |
-| `noIcon` | `bool` | `false` | Do not show an icon. |
 | `onClick` | `string` | null | A function associated to the click on the whole banner or just the CTA or dismiss button. |
 | `plan` | `string` | null | PlanSlug of the plan that upgrade leads to. |
 | `price` | `string` | null | One or two (original/discounted) upgrade prices. |
+| `showIcon` | `bool` | `true` | Show the icon specified in `icon` |
 | `title` | `string` | null | (required) The banner title. |
 | `tracksImpressionName` | `string` | | Unique event name to track when the nudge is viewed |
 | `tracksClickName` | `string` | | Unique event name to track when the nudge is clicked |

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -49,7 +49,7 @@ render() {
 | `compact` | `bool` | false | Display a compact version of the banner. |
 | `description` | `string` | null | The banner description. |
 | `disableHref` | `bool` | false | When true, prevent the Banner to be linked either via the `href` props or as a side effect of the `siteSlug` connected prop. |
-| `dismissPreferenceName` | `bool` | false | The user preference name that we store a boolean against, prefixed with `dismissible-card-` to avoid namespace collisions. |
+| `dismissPreferenceName` | `string` | null | The user preference name that we store a boolean against, prefixed with `dismissible-card-` to avoid namespace collisions. |
 | `dismissTemporary` | `bool` | false | When true, clicking on the cross will dismiss the card for the current page load. |
 | `event` | `string` | null | Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property. |
 | `feature` | `string` | null | Slug of the feature to highlight in the plans compare card. |

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -29,6 +29,7 @@ const BannerExample = () => (
 			icon="star"
 			title="Banner unrelated to any plan"
 		/>
+		<Banner showIcon={ false } title="Banner with showIcon set to false" />
 		<Banner href="#" plan={ PLAN_BLOGGER } title="Upgrade to a Blogger Plan!" />
 		<Banner href="#" plan={ PLAN_PERSONAL } title="Upgrade to a Personal Plan!" />
 		<Banner href="#" plan={ PLAN_PREMIUM } title="Upgrade to a Premium Plan!" />

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -48,9 +48,10 @@ export class Banner extends Component {
 		event: PropTypes.string,
 		feature: PropTypes.string,
 		href: PropTypes.string,
-		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		icon: PropTypes.string,
 		compact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
+		noIcon: PropTypes.bool,
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
 		plan: PropTypes.string,
@@ -72,6 +73,7 @@ export class Banner extends Component {
 		disableHref: false,
 		dismissTemporary: false,
 		compact: false,
+		noIcon: false,
 		onClick: noop,
 		onDismiss: noop,
 		tracksImpressionName: 'calypso_banner_cta_impression',
@@ -143,10 +145,6 @@ export class Banner extends Component {
 					<PlanIcon plan={ plan } />
 				</div>
 			);
-		}
-
-		if ( 'no-icon' === icon ) {
-			return;
 		}
 
 		return (
@@ -245,6 +243,7 @@ export class Banner extends Component {
 			disableHref,
 			dismissPreferenceName,
 			dismissTemporary,
+			noIcon,
 			plan,
 			compact,
 		} = this.props;
@@ -272,7 +271,7 @@ export class Banner extends Component {
 					temporary={ dismissTemporary }
 					onClick={ this.handleDismiss }
 				>
-					{ this.getIcon() }
+					{ ! noIcon && this.getIcon() }
 					{ this.getContent() }
 				</DismissibleCard>
 			);

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -49,6 +49,7 @@ export class Banner extends Component {
 		feature: PropTypes.string,
 		href: PropTypes.string,
 		icon: PropTypes.string,
+		isCompact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
@@ -64,6 +65,7 @@ export class Banner extends Component {
 		forceHref: false,
 		disableHref: false,
 		dismissTemporary: false,
+		isCompact: false,
 		onClick: noop,
 		onDismiss: noop,
 	};
@@ -126,6 +128,10 @@ export class Banner extends Component {
 					<PlanIcon plan={ plan } />
 				</div>
 			);
+		}
+
+		if ( ! icon ) {
+			return;
 		}
 
 		return (
@@ -221,6 +227,7 @@ export class Banner extends Component {
 			dismissPreferenceName,
 			dismissTemporary,
 			plan,
+			isCompact,
 		} = this.props;
 
 		const classes = classNames(
@@ -234,6 +241,7 @@ export class Banner extends Component {
 			{ 'is-upgrade-ecommerce': plan && isEcommercePlan( plan ) },
 			{ 'is-jetpack-plan': plan && planMatches( plan, { group: GROUP_JETPACK } ) },
 			{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) },
+			{ 'is-compact': isCompact },
 			{ 'is-dismissible': dismissPreferenceName }
 		);
 

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -104,6 +104,10 @@ export class Banner extends Component {
 	handleClick = e => {
 		const { event, feature, compact, onClick, tracksClickName, tracksClickProperties } = this.props;
 
+		if ( ! tracksClickName ) {
+			return;
+		}
+
 		this.props.recordTracksEvent( tracksClickName, {
 			cta_name: event,
 			cta_feature: feature,
@@ -116,6 +120,10 @@ export class Banner extends Component {
 
 	handleDismiss = e => {
 		const { event, feature, onDismiss, tracksDismissName, tracksDismissProperties } = this.props;
+
+		if ( ! tracksDismissName ) {
+			return;
+		}
 
 		this.props.recordTracksEvent( tracksDismissName, {
 			cta_name: event,
@@ -173,15 +181,17 @@ export class Banner extends Component {
 
 		return (
 			<div className="banner__content">
-				<TrackComponentView
-					eventName={ tracksImpressionName }
-					eventProperties={ {
-						cta_name: event,
-						cta_feature: feature,
-						cta_size: compact ? 'compact' : 'regular',
-						...tracksImpressionProperties,
-					} }
-				/>
+				{ tracksImpressionName && (
+					<TrackComponentView
+						eventName={ tracksImpressionName }
+						eventProperties={ {
+							cta_name: event,
+							cta_feature: feature,
+							cta_size: compact ? 'compact' : 'regular',
+							...tracksImpressionProperties,
+						} }
+					/>
+				) }
 				<div className="banner__info">
 					<div className="banner__title">{ title }</div>
 					{ description && <div className="banner__description">{ description }</div> }

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -183,7 +183,7 @@ export class Banner extends Component {
 
 		return (
 			<div className="banner__content">
-				{ tracksImpressionName && (
+				{ tracksImpressionName && event && (
 					<TrackComponentView
 						eventName={ tracksImpressionName }
 						eventProperties={ {

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -145,7 +145,7 @@ export class Banner extends Component {
 			);
 		}
 
-		if ( ! icon ) {
+		if ( 'no-icon' === icon ) {
 			return;
 		}
 

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -51,11 +51,11 @@ export class Banner extends Component {
 		icon: PropTypes.string,
 		compact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
-		noIcon: PropTypes.bool,
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
 		plan: PropTypes.string,
 		price: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+		showIcon: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		target: PropTypes.string,
 		title: PropTypes.string.isRequired,
@@ -73,9 +73,9 @@ export class Banner extends Component {
 		disableHref: false,
 		dismissTemporary: false,
 		compact: false,
-		noIcon: false,
 		onClick: noop,
 		onDismiss: noop,
+		showIcon: true,
 		tracksImpressionName: 'calypso_banner_cta_impression',
 		tracksClickName: 'calypso_banner_cta_click',
 		tracksDismissName: 'calypso_banner_dismiss',
@@ -137,7 +137,7 @@ export class Banner extends Component {
 	};
 
 	getIcon() {
-		const { icon, plan } = this.props;
+		const { icon, showIcon, plan } = this.props;
 
 		if ( plan && ! icon ) {
 			return (
@@ -145,6 +145,10 @@ export class Banner extends Component {
 					<PlanIcon plan={ plan } />
 				</div>
 			);
+		}
+
+		if ( ! showIcon ) {
+			return;
 		}
 
 		return (
@@ -239,13 +243,12 @@ export class Banner extends Component {
 		const {
 			callToAction,
 			className,
-			forceHref,
+			compact,
 			disableHref,
 			dismissPreferenceName,
 			dismissTemporary,
-			noIcon,
+			forceHref,
 			plan,
-			compact,
 		} = this.props;
 
 		const classes = classNames(
@@ -271,7 +274,7 @@ export class Banner extends Component {
 					temporary={ dismissTemporary }
 					onClick={ this.handleDismiss }
 				>
-					{ ! noIcon && this.getIcon() }
+					{ this.getIcon() }
 					{ this.getContent() }
 				</DismissibleCard>
 			);

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -106,16 +106,14 @@ export class Banner extends Component {
 	handleClick = e => {
 		const { event, feature, compact, onClick, tracksClickName, tracksClickProperties } = this.props;
 
-		if ( ! tracksClickName ) {
-			return;
+		if ( event && tracksClickName ) {
+			this.props.recordTracksEvent( tracksClickName, {
+				cta_name: event,
+				cta_feature: feature,
+				cta_size: compact ? 'compact' : 'regular',
+				...tracksClickProperties,
+			} );
 		}
-
-		this.props.recordTracksEvent( tracksClickName, {
-			cta_name: event,
-			cta_feature: feature,
-			cta_size: compact ? 'compact' : 'regular',
-			...tracksClickProperties,
-		} );
 
 		onClick( e );
 	};
@@ -123,15 +121,13 @@ export class Banner extends Component {
 	handleDismiss = e => {
 		const { event, feature, onDismiss, tracksDismissName, tracksDismissProperties } = this.props;
 
-		if ( ! tracksDismissName ) {
-			return;
+		if ( event && tracksDismissName ) {
+			this.props.recordTracksEvent( tracksDismissName, {
+				cta_name: event,
+				cta_feature: feature,
+				...tracksDismissProperties,
+			} );
 		}
-
-		this.props.recordTracksEvent( tracksDismissName, {
-			cta_name: event,
-			cta_feature: feature,
-			...tracksDismissProperties,
-		} );
 
 		onDismiss( e );
 	};

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -58,6 +58,9 @@ export class Banner extends Component {
 		siteSlug: PropTypes.string,
 		target: PropTypes.string,
 		title: PropTypes.string.isRequired,
+		tracksImpressionName: PropTypes.string,
+		tracksClickName: PropTypes.string,
+		tracksDismissName: PropTypes.string,
 		customerType: PropTypes.string,
 	};
 
@@ -68,6 +71,9 @@ export class Banner extends Component {
 		compact: false,
 		onClick: noop,
 		onDismiss: noop,
+		tracksImpressionName: 'calypso_banner_cta_impression',
+		tracksClickName: 'calypso_banner_cta_click',
+		tracksDismissName: 'calypso_banner_dismiss',
 	};
 
 	getHref() {
@@ -93,10 +99,10 @@ export class Banner extends Component {
 	}
 
 	handleClick = e => {
-		const { event, feature, compact, onClick } = this.props;
+		const { event, feature, compact, onClick, tracksClickName } = this.props;
 
 		if ( event ) {
-			this.props.recordTracksEvent( 'calypso_banner_cta_click', {
+			this.props.recordTracksEvent( tracksClickName, {
 				cta_name: event,
 				cta_feature: feature,
 				cta_size: compact ? 'compact' : 'regular',
@@ -107,10 +113,10 @@ export class Banner extends Component {
 	};
 
 	handleDismiss = e => {
-		const { event, feature, onDismiss } = this.props;
+		const { event, feature, onDismiss, tracksDismissName } = this.props;
 
 		if ( event ) {
-			this.props.recordTracksEvent( 'calypso_banner_dismiss', {
+			this.props.recordTracksEvent( tracksDismissName, {
 				cta_name: event,
 				cta_feature: feature,
 			} );
@@ -158,6 +164,7 @@ export class Banner extends Component {
 			price,
 			title,
 			target,
+			tracksImpressionName,
 		} = this.props;
 
 		const prices = Array.isArray( price ) ? price : [ price ];
@@ -166,7 +173,7 @@ export class Banner extends Component {
 			<div className="banner__content">
 				{ event && (
 					<TrackComponentView
-						eventName={ 'calypso_banner_cta_impression' }
+						eventName={ tracksImpressionName }
 						eventProperties={ {
 							cta_name: event,
 							cta_feature: feature,

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -48,7 +48,7 @@ export class Banner extends Component {
 		event: PropTypes.string,
 		feature: PropTypes.string,
 		href: PropTypes.string,
-		icon: PropTypes.string,
+		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		isCompact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -93,13 +93,13 @@ export class Banner extends Component {
 	}
 
 	handleClick = e => {
-		const { event, feature, onClick } = this.props;
+		const { event, feature, isCompact, onClick } = this.props;
 
 		if ( event ) {
 			this.props.recordTracksEvent( 'calypso_banner_cta_click', {
 				cta_name: event,
 				cta_feature: feature,
-				cta_size: 'regular',
+				cta_size: isCompact ? 'compact' : 'regular',
 			} );
 		}
 
@@ -153,6 +153,7 @@ export class Banner extends Component {
 			description,
 			event,
 			feature,
+			isCompact,
 			list,
 			price,
 			title,
@@ -169,7 +170,7 @@ export class Banner extends Component {
 						eventProperties={ {
 							cta_name: event,
 							cta_feature: feature,
-							cta_size: 'regular',
+							cta_size: isCompact ? 'compact' : 'regular',
 						} }
 					/>
 				) }

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -49,7 +49,7 @@ export class Banner extends Component {
 		feature: PropTypes.string,
 		href: PropTypes.string,
 		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
-		isCompact: PropTypes.bool,
+		compact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
@@ -65,7 +65,7 @@ export class Banner extends Component {
 		forceHref: false,
 		disableHref: false,
 		dismissTemporary: false,
-		isCompact: false,
+		compact: false,
 		onClick: noop,
 		onDismiss: noop,
 	};
@@ -93,13 +93,13 @@ export class Banner extends Component {
 	}
 
 	handleClick = e => {
-		const { event, feature, isCompact, onClick } = this.props;
+		const { event, feature, compact, onClick } = this.props;
 
 		if ( event ) {
 			this.props.recordTracksEvent( 'calypso_banner_cta_click', {
 				cta_name: event,
 				cta_feature: feature,
-				cta_size: isCompact ? 'compact' : 'regular',
+				cta_size: compact ? 'compact' : 'regular',
 			} );
 		}
 
@@ -153,7 +153,7 @@ export class Banner extends Component {
 			description,
 			event,
 			feature,
-			isCompact,
+			compact,
 			list,
 			price,
 			title,
@@ -170,7 +170,7 @@ export class Banner extends Component {
 						eventProperties={ {
 							cta_name: event,
 							cta_feature: feature,
-							cta_size: isCompact ? 'compact' : 'regular',
+							cta_size: compact ? 'compact' : 'regular',
 						} }
 					/>
 				) }
@@ -228,7 +228,7 @@ export class Banner extends Component {
 			dismissPreferenceName,
 			dismissTemporary,
 			plan,
-			isCompact,
+			compact,
 		} = this.props;
 
 		const classes = classNames(
@@ -242,7 +242,7 @@ export class Banner extends Component {
 			{ 'is-upgrade-ecommerce': plan && isEcommercePlan( plan ) },
 			{ 'is-jetpack-plan': plan && planMatches( plan, { group: GROUP_JETPACK } ) },
 			{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) },
-			{ 'is-compact': isCompact },
+			{ 'is-compact': compact },
 			{ 'is-dismissible': dismissPreferenceName }
 		);
 

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -46,6 +46,7 @@ export class Banner extends Component {
 		dismissPreferenceName: PropTypes.string,
 		dismissTemporary: PropTypes.bool,
 		event: PropTypes.string,
+		eventProperties: PropTypes.object,
 		feature: PropTypes.string,
 		href: PropTypes.string,
 		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
@@ -99,13 +100,14 @@ export class Banner extends Component {
 	}
 
 	handleClick = e => {
-		const { event, feature, compact, onClick, tracksClickName } = this.props;
+		const { event, feature, compact, onClick, tracksClickName, eventProperties } = this.props;
 
 		if ( event ) {
 			this.props.recordTracksEvent( tracksClickName, {
 				cta_name: event,
 				cta_feature: feature,
 				cta_size: compact ? 'compact' : 'regular',
+				...eventProperties,
 			} );
 		}
 
@@ -113,12 +115,13 @@ export class Banner extends Component {
 	};
 
 	handleDismiss = e => {
-		const { event, feature, onDismiss, tracksDismissName } = this.props;
+		const { event, feature, onDismiss, tracksDismissName, eventProperties } = this.props;
 
 		if ( event ) {
 			this.props.recordTracksEvent( tracksDismissName, {
 				cta_name: event,
 				cta_feature: feature,
+				...eventProperties,
 			} );
 		}
 
@@ -158,6 +161,7 @@ export class Banner extends Component {
 			forceHref,
 			description,
 			event,
+			eventProperties,
 			feature,
 			compact,
 			list,
@@ -178,6 +182,7 @@ export class Banner extends Component {
 							cta_name: event,
 							cta_feature: feature,
 							cta_size: compact ? 'compact' : 'regular',
+							...eventProperties,
 						} }
 					/>
 				) }

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -46,7 +46,6 @@ export class Banner extends Component {
 		dismissPreferenceName: PropTypes.string,
 		dismissTemporary: PropTypes.bool,
 		event: PropTypes.string,
-		eventProperties: PropTypes.object,
 		feature: PropTypes.string,
 		href: PropTypes.string,
 		icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
@@ -62,6 +61,9 @@ export class Banner extends Component {
 		tracksImpressionName: PropTypes.string,
 		tracksClickName: PropTypes.string,
 		tracksDismissName: PropTypes.string,
+		tracksImpressionProperties: PropTypes.object,
+		tracksClickProperties: PropTypes.object,
+		tracksDismissProperties: PropTypes.object,
 		customerType: PropTypes.string,
 	};
 
@@ -100,30 +102,26 @@ export class Banner extends Component {
 	}
 
 	handleClick = e => {
-		const { event, feature, compact, onClick, tracksClickName, eventProperties } = this.props;
+		const { event, feature, compact, onClick, tracksClickName, tracksClickProperties } = this.props;
 
-		if ( event ) {
-			this.props.recordTracksEvent( tracksClickName, {
-				cta_name: event,
-				cta_feature: feature,
-				cta_size: compact ? 'compact' : 'regular',
-				...eventProperties,
-			} );
-		}
+		this.props.recordTracksEvent( tracksClickName, {
+			cta_name: event,
+			cta_feature: feature,
+			cta_size: compact ? 'compact' : 'regular',
+			...tracksClickProperties,
+		} );
 
 		onClick( e );
 	};
 
 	handleDismiss = e => {
-		const { event, feature, onDismiss, tracksDismissName, eventProperties } = this.props;
+		const { event, feature, onDismiss, tracksDismissName, tracksDismissProperties } = this.props;
 
-		if ( event ) {
-			this.props.recordTracksEvent( tracksDismissName, {
-				cta_name: event,
-				cta_feature: feature,
-				...eventProperties,
-			} );
-		}
+		this.props.recordTracksEvent( tracksDismissName, {
+			cta_name: event,
+			cta_feature: feature,
+			...tracksDismissProperties,
+		} );
 
 		onDismiss( e );
 	};
@@ -161,7 +159,6 @@ export class Banner extends Component {
 			forceHref,
 			description,
 			event,
-			eventProperties,
 			feature,
 			compact,
 			list,
@@ -169,23 +166,22 @@ export class Banner extends Component {
 			title,
 			target,
 			tracksImpressionName,
+			tracksImpressionProperties,
 		} = this.props;
 
 		const prices = Array.isArray( price ) ? price : [ price ];
 
 		return (
 			<div className="banner__content">
-				{ event && (
-					<TrackComponentView
-						eventName={ tracksImpressionName }
-						eventProperties={ {
-							cta_name: event,
-							cta_feature: feature,
-							cta_size: compact ? 'compact' : 'regular',
-							...eventProperties,
-						} }
-					/>
-				) }
+				<TrackComponentView
+					eventName={ tracksImpressionName }
+					eventProperties={ {
+						cta_name: event,
+						cta_feature: feature,
+						cta_size: compact ? 'compact' : 'regular',
+						...tracksImpressionProperties,
+					} }
+				/>
 				<div className="banner__info">
 					<div className="banner__title">{ title }</div>
 					{ description && <div className="banner__description">{ description }</div> }

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -9,6 +9,13 @@
 		padding-right: 48px;
 	}
 
+	&.is-compact {
+		border-left-width: 4px;
+		font-size: 12px;
+		margin-bottom: 8px;
+		padding: 8px 12px 8px 8px;
+	}
+
 	&[href] {
 		cursor: pointer;
 	}
@@ -57,6 +64,10 @@
 		display: flex;
 	}
 
+	&.is-compact .card__link-indicator {
+		right: 8px;
+	}
+
 	&:hover {
 		transition: all 100ms ease-in-out;
 
@@ -73,6 +84,10 @@
 
 		&.is-dismissible {
 			padding-right: 16px;
+		}
+
+		&.is-compact.is-dismissible {
+			padding-right: 8px;
 		}
 	}
 
@@ -145,6 +160,10 @@
 	}
 }
 
+.is-compact .banner__content {
+	padding: 5px;
+}
+
 .banner__info {
 	flex-grow: 1;
 	line-height: 1.4;
@@ -190,6 +209,10 @@
 	}
 }
 
+.is-compact .banner__title {
+	font-size: 12px;
+}
+
 .banner__action {
 	align-self: center;
 	font-size: 12px;
@@ -224,9 +247,25 @@
 			margin-top: 40px;
 		}
 
+		.is-compact & {
+			margin-right: 0;
+		}
+
+		.is-dismissible.is-compact & {
+			margin-top: 0;
+			margin-right: 32px;
+		}
+
 		.banner__prices {
 			justify-content: flex-end;
 			text-align: right;
 		}
 	}
+}
+
+.is-compact .dismissible-card__close-icon {
+	width: 16px;
+	height: 16px;
+	top: 50%;
+	margin-top: -8px;
 }

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -54,8 +54,9 @@ import PlanPrice from 'my-sites/plan-price/';
 import { Banner } from '../index';
 
 const props = {
-	callToAction: false,
+	callToAction: null,
 	plan: PLAN_FREE,
+	title: 'banner title',
 };
 
 describe( 'Banner basic tests', () => {
@@ -64,25 +65,25 @@ describe( 'Banner basic tests', () => {
 		assert.lengthOf( comp.find( '.banner' ), 1 );
 	} );
 
-	test( 'should render Card if dismissPreferenceName is false', () => {
-		const comp = shallow( <Banner { ...props } dismissPreferenceName={ false } /> );
+	test( 'should render Card if dismissPreferenceName is null', () => {
+		const comp = shallow( <Banner { ...props } dismissPreferenceName={ null } /> );
 		assert.lengthOf( comp.find( 'Card' ), 1 );
 		assert.lengthOf( comp.find( 'DismissibleCard' ), 0 );
 	} );
 
-	test( 'should render DismissibleCard if dismissPreferenceName is true', () => {
-		const comp = shallow( <Banner { ...props } dismissPreferenceName={ true } /> );
+	test( 'should render DismissibleCard if dismissPreferenceName is defined', () => {
+		const comp = shallow( <Banner { ...props } dismissPreferenceName={ 'banner-test' } /> );
 		assert.lengthOf( comp.find( 'Card' ), 0 );
 		assert.lengthOf( comp.find( 'DismissibleCard' ), 1 );
 	} );
 
-	test( 'should have .has-call-to-action class if callToAction is true', () => {
-		const comp = shallow( <Banner { ...props } callToAction={ true } /> );
+	test( 'should have .has-call-to-action class if callToAction is defined', () => {
+		const comp = shallow( <Banner { ...props } callToAction={ 'Upgrade Now!' } /> );
 		assert.lengthOf( comp.find( '.has-call-to-action' ), 1 );
 	} );
 
-	test( 'should not have .has-call-to-action class if callToAction is false', () => {
-		const comp = shallow( <Banner { ...props } callToAction={ false } /> );
+	test( 'should not have .has-call-to-action class if callToAction is null', () => {
+		const comp = shallow( <Banner { ...props } callToAction={ null } /> );
 		assert.lengthOf( comp.find( '.has-call-to-action' ), 0 );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're planning to use the `Banner` component as a base for the new `UpsellNudge` block. See #38537 for more information.

This PR makes a few minor changes to make that possible:

* Adds an `isCompact` prop and class name so we can use a smaller version of the banner in the sidebar (or other tight spaces)
* Adds some default styles for compact Banners
* Adds three props for impression, click, and dismiss Tracks events, so we can override these as necessary, with defaults so existing uses of `Banner` won't be affected.
* Adds Tracks event properties for impression, click, and dismiss events from the parent.
* Don't display an icon by default; if no icon is set, none is shown

**Regular**

<img width="504" alt="Screen Shot 2020-01-10 at 1 01 20 PM" src="https://user-images.githubusercontent.com/2124984/72175112-582c2880-33a9-11ea-8b40-cbaf1c7fed43.png">

**Compact**

<img width="503" alt="Screen Shot 2020-01-10 at 1 00 53 PM" src="https://user-images.githubusercontent.com/2124984/72175124-5d897300-33a9-11ea-8568-49dbe2bcc162.png">

#### Testing instructions

* TBD