### PR TITLE
Eventbrite: Don't allow any more new connections.

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -84,6 +84,16 @@ const SharingServiceAction = ( {
 		);
 	}
 
+	// No new connections allowed due to Eventbrite shutting down an endpoint needed
+	// for our integration. See: https://groups.google.com/forum/#!topic/eventbrite-api/FT2MsDswdrA
+	if ( 'eventbrite' === service.ID && status === 'not-connected' ) {
+		return (
+			<Button compact disabled={ true }>
+				{ label }
+			</Button>
+		);
+	}
+
 	if ( 'mailchimp' === service.ID && status === 'not-connected' ) {
 		return (
 			<div>


### PR DESCRIPTION
Eventbrite has shut down an endpoint relied upon by our integration. Existing connections will continue to work until Feb 20, 2020, but no new accounts have been able to use the endpoint since December 2019. Let's just block users from creating any new connections at this point by disabling the Connect button.

<img width="819" alt="Screen Shot 2020-01-08 at 4 42 55 PM" src="https://user-images.githubusercontent.com/349751/72028197-7de4f080-3236-11ea-95c0-9bff1fb96146.png">

#### Testing instructions

* Go to `/marketing/connections/:site` on a site with no existing Eventbrite connection.
* Verify the Connect button is disabled, and does nothing when clicked.
* Check a site with an existing connection; verify an active Disconnect button is displayed. If you do not have a site with an existing connection, DM me for credentials and create a connection in production.
