### PR TITLE
Popular badge test: Remove test dependency on the nonEnglishDomainStepCopyUpdates test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -128,7 +128,7 @@ export default {
 		defaultVariation: 'variation2_front',
 	},
 	showBusinessPlanPopular: {
-		datestamp: '20191220',
+		datestamp: '20200109',
 		variations: {
 			variantShowBizPopular: 50,
 			control: 50,

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -464,7 +464,6 @@ export const getPopularPlanSpec = ( {
 			isInSignup &&
 			! isLaunchPage &&
 			isUserOutsideUS &&
-			'control' === abtest( 'nonEnglishDomainStepCopyUpdates' ) &&
 			'variantShowBizPopular' === abtest( 'showBusinessPlanPopular' )
 		) {
 			return spec;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We launched a test for showing "Popular" badge on the Business plan in https://github.com/Automattic/wp-calypso/pull/38334. This test [has a dependency](https://github.com/Automattic/wp-calypso/blob/master/client/lib/plans/index.js#L467) on `nonEnglishDomainStepCopyUpdates` - only users in the control group of nonEnglishDomainStepCopyUpdates test are eligible for the popular badge test.
* This dependency was needed to reduce interference since both `nonEnglishDomainStepCopyUpdates` and `showBusinessPlanPopular` are running in parallel. Now that we have declared a winner for nonEnglishDomainStepCopyUpdates test and wrapping it up, we can use the new control group and remove dependency. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The test plan in https://github.com/Automattic/wp-calypso/pull/38334 should pass

