### PR TITLE
Randomize the auto-renewal cancellation survey options.

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { shuffle } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -63,7 +64,7 @@ class CancelAutoRenewalForm extends Component {
 		const { translate } = props;
 		const productType = this.getProductTypeString();
 
-		this.radioButtons = [
+		this.radioButtons = shuffle( [
 			[
 				'let-it-expire',
 				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
@@ -79,7 +80,7 @@ class CancelAutoRenewalForm extends Component {
 				} ),
 			],
 			[ 'not-sure', translate( "I'm not sure." ) ],
-		];
+		] );
 	}
 
 	onSubmit = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the randomization of the auto-renewal cancellation survey to mitigate the selection tendency caused by the fixed order.

#### Testing instructions

1. Go to the purchase management page of a subscription.
1. Turn off the auto-renewal toggle.
1. Click "Confirm cancellation"
1. The survey should show up.
1. Turn the auto-renewal back on and refresh the page. Refreshing is necessary here since the survey won't show up twice without navigating away.
1. Perform the same steps to reach the survey and note the order again. The order 
might or might not be the same as the previous run due to the nature of randomization. If it is still the same, please just redo the same steps.

