### PR TITLE
[WIP] Add simple user store to `data-stores` and use it to check if user is logged in for Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -26,6 +26,7 @@ interface Props {
 	prev?: string;
 	toggleGeneralSidebar: () => void;
 	toggleSidebarShortcut: KeyboardShortcut;
+	isLoggedIn?: boolean;
 }
 
 interface KeyboardShortcut {
@@ -40,6 +41,7 @@ const Header: FunctionComponent< Props > = ( {
 	prev,
 	toggleGeneralSidebar,
 	toggleSidebarShortcut,
+	isLoggedIn,
 } ) => {
 	const { domain, siteTitle, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
@@ -94,10 +96,17 @@ const Header: FunctionComponent< Props > = ( {
 		>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Link className="gutenboarding__header-back-button" to={ prev }>
-						<Icon icon="arrow-left-alt" />
-						{ NO__( 'Back' ) }
-					</Link>
+					{ ! isLoggedIn ? (
+						<Link className="gutenboarding__header-back-button" to={ prev }>
+							<Icon icon="arrow-left-alt" />
+							{ NO__( 'Back' ) }
+						</Link>
+					) : (
+						<a className="gutenboarding__header-back-button" href="/sites">
+							<Icon icon="arrow-left-alt" />
+							{ NO__( 'Back to My Sites' ) }
+						</a>
+					) }
 				</div>
 				<div className="gutenboarding__header-group">
 					{ siteTitle ? (

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -53,7 +53,7 @@ export function Gutenboard() {
 	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
 
 	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
-	const { isLoggedIn } = useSelect( select => select( USER_STORE ).getUser() );
+	const isLoggedIn = useSelect( select => select( USER_STORE ).getUser()?.ID );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -32,6 +32,7 @@ import { name, settings } from './onboarding-block';
 import { Slot as SidebarSlot } from './components/sidebar';
 import SettingsSidebar from './components/settings-sidebar';
 import { STORE_KEY } from './stores/onboard';
+import { User } from '@automattic/data-stores';
 import { routes, Step } from './steps';
 import './style.scss';
 
@@ -45,11 +46,14 @@ const toggleSidebarShortcut = {
 
 registerBlockType( name, settings );
 
+const USER_STORE = User.register();
+
 export function Gutenboard() {
 	const [ isEditorSidebarOpened, updateIsEditorSidebarOpened ] = useState( false );
 	const toggleGeneralSidebar = () => updateIsEditorSidebarOpened( isOpen => ! isOpen );
 
 	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
+	const { isLoggedIn } = useSelect( select => select( USER_STORE ).getUser() );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation
@@ -96,6 +100,7 @@ export function Gutenboard() {
 							toggleSidebarShortcut={ toggleSidebarShortcut }
 							prev={ prev }
 							next={ next }
+							isLoggedIn={ isLoggedIn }
 						/>
 						<BlockEditorProvider
 							useSubRegistry={ false }

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -2,10 +2,11 @@
  * Internal dependencies
  */
 import * as DomainSuggestions from './domain-suggestions';
+import * as User from './user';
 import * as Verticals from './verticals';
 import * as VerticalsTemplates from './verticals-templates';
 
-export { DomainSuggestions, Verticals, VerticalsTemplates };
+export { DomainSuggestions, User, Verticals, VerticalsTemplates };
 
 /**
  * Helper types

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { ActionType, User } from './types';
+
+export const receiveUser = ( user: User ) => ( {
+	type: ActionType.RECEIVE_USER as const,
+	user,
+} );

--- a/packages/data-stores/src/user/constants.ts
+++ b/packages/data-stores/src/user/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/user';

--- a/packages/data-stores/src/user/index.ts
+++ b/packages/data-stores/src/user/index.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { controls } from '@wordpress/data-controls';
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as actions from './actions';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
+export * from './types';
+export { State };
+
+let isRegistered = false;
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			actions,
+			controls,
+			reducer,
+			resolvers,
+			selectors,
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { Reducer } from 'redux';
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ActionType, User } from './types';
+import * as Actions from './actions';
+
+const user: Reducer< User, ReturnType< typeof Actions[ 'receiveUser' ] > > = (
+	state = {},
+	action
+) => {
+	if ( action.type === ActionType.RECEIVE_USER ) {
+		return action.user;
+	}
+	return state;
+};
+
+const reducer = combineReducers( { user } );
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/packages/data-stores/src/user/resolvers.ts
+++ b/packages/data-stores/src/user/resolvers.ts
@@ -1,16 +1,14 @@
 /**
  * External dependencies
  */
-import { apiFetch } from '@wordpress/data-controls';
+import wpcom from 'lib/wp';
 
 /**
  * Internal dependencies
  */
 import { receiveUser } from './actions';
 
-export function* getUser() {
-	const url = 'https://public-api.wordpress.com/rest/v1.1/me';
-	const user = yield apiFetch( { url } );
-
+export async function getUser() {
+	const user = await wpcom.me().get();
 	return receiveUser( user );
 }

--- a/packages/data-stores/src/user/resolvers.ts
+++ b/packages/data-stores/src/user/resolvers.ts
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
+import { receiveUser } from './actions';
+
+export function* getUser() {
+	const url = 'https://public-api.wordpress.com/rest/v1.1/me';
+	const user = yield apiFetch( { url } );
+
+	return receiveUser( user );
+}

--- a/packages/data-stores/src/user/selectors.ts
+++ b/packages/data-stores/src/user/selectors.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { State } from './reducer';
+
+export const getState = ( state: State ) => state;
+export const getUser = ( state: State ) => state.user;

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -1,0 +1,9 @@
+export const enum ActionType {
+	RECEIVE_USER = 'RECEIVE_USER',
+}
+
+export interface User {
+	ID: number;
+	display_name: string;
+	username: string;
+}


### PR DESCRIPTION
This is a hacky WIP exploring checking whether or not a user is already logged in for Gutenboarding. This approaches it from the other end of the spectrum as my other messy WIP https://github.com/Automattic/wp-calypso/pull/38679 where I attempted to merge in the existing user object. This attempts to break it down to the smallest possible state and API calls needed for the tasks at home (checking whether a user is logged in).

Note: this is currently broken as the API call needs to be fixed.

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
