### PR TITLE
Site migration: go to cart when target site doesn't have a supported plan

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -513,8 +513,6 @@ class SectionMigrate extends Component {
 
 		let migrationElement;
 
-		this.state.migrationStatus = 'backing-up';
-
 		switch ( this.state.migrationStatus ) {
 			case 'inactive':
 				migrationElement = sourceSiteId

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -98,16 +98,17 @@ class SectionMigrate extends Component {
 	};
 
 	setMigrationState = state => {
-		// Avoids a response from the migration-status endpoint
-		// accidentally resetting the state after the migrate/from endpoint
-		// has returned an error
+		// A response from the status endpoint may come in after the
+		// migrate/from endpoint has returned an error. This avoids that
+		// response accidentally clearing the error state.
 		if ( 'error' === this.state.migrationStatus ) {
 			return;
 		}
 
-		// Avoids a response from the migration-status endpoint
-		// accidentally resetting the state after a redirect from the cart
-		// has set local state and sent request to start backup
+		// When we redirect from the cart, we set migrationState to 'backing-up'
+		// and start migration straight away. This condition prevents a response
+		// from the status endpoint accidentally changing the local state
+		// before the server's properly registered that we're backing up.
 		if (
 			this._startedMigrationFromCart &&
 			'backing-up' === this.state.migrationStatus &&
@@ -511,6 +512,8 @@ class SectionMigrate extends Component {
 		const { sourceSiteId } = this.props;
 
 		let migrationElement;
+
+		this.state.migrationStatus = 'backing-up';
 
 		switch ( this.state.migrationStatus ) {
 			case 'inactive':

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -98,12 +98,24 @@ class SectionMigrate extends Component {
 	};
 
 	setMigrationState = state => {
-		// This is necessary to avoid a response from the migration-status endpoint
+		// Avoids a response from the migration-status endpoint
 		// accidentally resetting the state after the migrate/from endpoint
 		// has returned an error
 		if ( 'error' === this.state.migrationStatus ) {
 			return;
 		}
+
+		// Avoids a response from the migration-status endpoint
+		// accidentally resetting the state after a redirect from the cart
+		// has set local state and sent request to start backup
+		if (
+			this._startedMigrationFromCart &&
+			'backing-up' === this.state.migrationStatus &&
+			state.migrationStatus === 'inactive'
+		) {
+			return;
+		}
+
 		if ( state.migrationStatus ) {
 			this.props.updateSiteMigrationStatus( this.props.targetSiteId, state.migrationStatus );
 		}
@@ -507,6 +519,7 @@ class SectionMigrate extends Component {
 					: this.renderSourceSiteSelector();
 				break;
 
+			case 'new':
 			case 'backing-up':
 			case 'restoring':
 				migrationElement = this.renderMigrationProgress();

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -98,6 +98,9 @@ class SectionMigrate extends Component {
 	};
 
 	setMigrationState = state => {
+		// This is necessary to avoid a response from the migration-status endpoint
+		// accidentally resetting the state after the migrate/from endpoint
+		// has returned an error
 		if ( 'error' === this.state.migrationStatus ) {
 			return;
 		}

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -89,6 +89,7 @@
 	display: block;
 	margin: auto;
 	width: 260px;
+	height: 202px;
 }
 
 .migrate__section-header {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -89,7 +89,7 @@
 	display: block;
 	margin: auto;
 	width: 260px;
-	height: 202px;
+	height: 200px;
 }
 
 .migrate__section-header {


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* When the target site doesn't have a plan that allows the uploading of themes and plugins, redirect the user to a cart containing a Business Plan. On purchase of the plan, redirect them back to the migration view and start the migration.
* Adds a height to the illustration on the migration progress page, to avoid jumps in the page when the illustration loads.

#### Testing instructions

(Note: most of these instructions are general instructions for testing migration. The bolded steps are the ones specific to this change)

* Check out this pull request and run Calypso locally, or run it on `calypso.live`.
* Viewing `calypso.localhost:3000/migrate/`, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* **Choose a site with a Free Plan.**
* After you select the site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Click the "Start Migration" button.
* You'll see a confirm modal. Click the "Overwrite this site" button.
* **You'll be taken to a shopping cart with a Business Plan in it.**
* **Buy the Business Plan.**
* **You'll be taken back to the migration page, and the migration will start.**
* **The migration will stop with an error if the target site is not Atomic.**
