### PR TITLE
i18n-utils: Address hasTranslation warning

### DIFF
--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { find, isString, map, pickBy, includes, endsWith } from 'lodash';
-import { getLocaleSlug, hasTranslation } from 'i18n-calypso';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -85,7 +85,7 @@ export function canBeTranslated( locale ) {
  */
 export function translationExists() {
 	const localeSlug = typeof getLocaleSlug === 'function' ? getLocaleSlug() : 'en';
-	return isDefaultLocale( localeSlug ) || hasTranslation.apply( null, arguments );
+	return isDefaultLocale( localeSlug ) || i18n.hasTranslation.apply( null, arguments );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #38711 I introduced a warning at `npm start`, this removes it

```
WARNING in ./client/lib/i18n-utils/utils.js 89:40-54
"export 'hasTranslation' was not found in 'i18n-calypso'
```

#### Testing instructions

* Run `npm start`, the warning should no longer appear.
