### PR TITLE
non-EN domain test: Launch the variant as winner

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,7 +94,7 @@ export default {
 			variantShowUpdates: 90,
 			control: 10,
 		},
-		defaultVariation: 'control',
+		defaultVariation: 'variantShowUpdates',
 		allowExistingUsers: true,
 	},
 	domainStepMoveParagraph: {
@@ -105,17 +105,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-	},
-	nonEnglishDomainStepCopyUpdates: {
-		datestamp: '20191219',
-		variations: {
-			variantShowUpdates: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-		localeExceptions: [ 'en' ],
 	},
 	domainSuggestionsWithHints: {
 		datestamp: '20191220',

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -123,13 +123,12 @@ class DomainsStep extends React.Component {
 		this.showTestCopy = false;
 
 		// Do not assign user to the test if either in the launch flow or in /start/{PLAN_SLUG} flow
-		if ( false !== this.props.shouldShowDomainTestCopy && ! props.isPlanStepFulfilled ) {
-			if (
-				'variantShowUpdates' === abtest( 'domainStepCopyUpdates' ) ||
-				'variantShowUpdates' === abtest( 'nonEnglishDomainStepCopyUpdates' )
-			) {
-				this.showTestCopy = true;
-			}
+		if (
+			false !== this.props.shouldShowDomainTestCopy &&
+			! props.isPlanStepFulfilled &&
+			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
+		) {
+			this.showTestCopy = true;
 		}
 
 		this.showTestParagraph = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The non-EN domain step test launched in https://github.com/Automattic/wp-calypso/pull/38233 has found the variant to be a winner. For more context, check p8Eqe3-10k-p2.
* This PR launches the variant for all non-EN users. `en` locale users will continue to get assigned to the `domainStepCopyUpdates` test, while non-EN users will see the variant without getting assigned to the test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow in any non-EN locale - for example, use the link /start/fr. In the domain step, you should see the new domain step version(i.e the variant version of `domainStepCopyUpdates` ). 
<img width="1216" alt="Screenshot 2020-01-09 at 6 41 01 PM" src="https://user-images.githubusercontent.com/1269602/72070449-9e34ae00-330f-11ea-98bd-8e9b128dbe32.png">
* Now verify that you are not assigned to the `domainStepCopyUpdates` test. In your browser console, type `localstorage.ABTests();` - the object displayed should not contain domainStepCopyUpdates. 

_Test for en locale_

* Go through signup flow from /start in `en` locale. When in the domain step, verify that you do get assigned to the `domainStepCopyUpdates` test. (check in your browser console by typing `localstorage.ABTests();`


