### PR TITLE
Stop the `domainSuggestionsWithHints` abtest

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,15 +106,16 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	domainSuggestionsWithHints: {
-		datestamp: '20191220',
+	nonEnglishDomainStepCopyUpdates: {
+		datestamp: '20191219',
 		variations: {
-			variation2_front: 0,
-			variation3_front: 50,
-			variation4_front: 25,
-			variation5_front: 25,
+			variantShowUpdates: 50,
+			control: 50,
 		},
-		defaultVariation: 'variation2_front',
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+		localeExceptions: [ 'en' ],
 	},
 	showBusinessPlanPopular: {
 		datestamp: '20200109',

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,11 +1,7 @@
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 
-export const getSuggestionsVendor = ( isSignup = false ) => {
-	if ( isSignup ) {
-		return abtest( 'domainSuggestionsWithHints' );
-	}
+export const getSuggestionsVendor = () => {
 	return 'variation2_front';
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -474,7 +474,7 @@ class DomainsStep extends React.Component {
 				showTestParagraph={ this.showTestParagraph }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( true ) }
+				vendor={ getSuggestionsVendor() }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }


### PR DESCRIPTION
We'll stop the abtest till we decide if/how to restart those

#### Changes proposed in this Pull Request

* remove the `domainSuggestionsWithHints` abtest

#### Testing instructions

* go through NUX and verify that variation2_front is used for domain suggestions
