### PR TITLE
Gutenboarding: Add Template Title in Page Selector

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Card from '../../components/card';
-import CardBody from '../../components/card/body';
+import CardFooter from '../../components/card/footer';
 import CardMedia from '../../components/card/media';
 import { removeQueryArgs } from '@wordpress/url';
 import { Icon } from '@wordpress/components';
@@ -49,10 +49,12 @@ const PageLayoutSelector: FunctionComponent< Props > = ( {
 						<span className="page-layout-selector__selected-indicator">
 							<Icon icon="yes" size={ 24 } />
 						</span>
-						<CardMedia as="span">
+						<CardMedia className="page-layout-selector__card-media" as="span">
 							<img alt={ template.description } src={ removeQueryArgs( template.preview, 'w' ) } />
 						</CardMedia>
-						<CardBody>{ template.title }</CardBody>
+						<CardFooter className="page-layout-selector__card-footer" as="span">
+							{ template.title }
+						</CardFooter>
 					</Card>
 				) ) }
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Card from '../../components/card';
+import CardBody from '../../components/card/body';
 import CardMedia from '../../components/card/media';
 import { removeQueryArgs } from '@wordpress/url';
 import { Icon } from '@wordpress/components';
@@ -51,6 +52,7 @@ const PageLayoutSelector: FunctionComponent< Props > = ( {
 						<CardMedia as="span">
 							<img alt={ template.description } src={ removeQueryArgs( template.preview, 'w' ) } />
 						</CardMedia>
+						<CardBody>{ template.title }</CardBody>
 					</Card>
 				) ) }
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -138,8 +138,6 @@ $deisgn-selector-selection-space: 175px;
 	padding: 2px;
 
 	&.is-selected {
-		border: 3px solid $blue-medium-focus;
-		padding: 0;
 		.page-layout-selector__selected-indicator {
 			top: -2px;
 			right: -2px;
@@ -147,10 +145,16 @@ $deisgn-selector-selection-space: 175px;
 		}
 	}
 
+	&.is-selected,
 	&:hover,
 	&:focus {
-		border: 3px solid var( --color-neutral-dark );
 		padding: 0;
+		border: 3px solid $blue-medium-focus;
+	}
+
+	&:hover,
+	&:focus {
+		border-color: var( --color-neutral-dark );
 		.page-layout-selector__selected-indicator {
 			background: linear-gradient(
 				to bottom left,
@@ -215,4 +219,12 @@ $deisgn-selector-selection-space: 175px;
 			opacity: 1;
 		}
 	}
+}
+
+// Adjust to display full with accounting for padding/borders
+.page-layout-selector__card-footer,
+.page-layout-selector__card-media {
+	display: block;
+	margin-left: -2px;
+	margin-right: -2px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add the template title

#### Screenshot

Current state of this PR:

![image](https://user-images.githubusercontent.com/96308/72074165-abdb3b00-32f1-11ea-9c0d-ee09e53ea9a8.png)

#### Testing instructions

- `http://calypso.localhost:3000/gutenboarding`
- Follow onboarding steps
- Verify that page templates have captions.

Fixes #38742
