### PR TITLE
Remove url and qs from lib/analytics.

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -419,9 +419,10 @@ const analytics = {
 
 			const referrer = window.location.href;
 			const parsedUrl = urlParseAmpCompatible( referrer );
-			const affiliateId = parsedUrl.query.aff || parsedUrl.query.affiliate;
-			const campaignId = parsedUrl.query.cid;
-			const subId = parsedUrl.query.sid;
+			const affiliateId =
+				parsedUrl?.searchParams.get( 'aff' ) || parsedUrl?.searchParams.get( 'affiliate' );
+			const campaignId = parsedUrl?.searchParams.get( 'cid' );
+			const subId = parsedUrl?.searchParams.get( 'sid' );
 
 			if ( affiliateId && ! isNaN( affiliateId ) ) {
 				analytics.tracks.recordEvent( 'calypso_refer_visit', {

--- a/client/lib/analytics/refer.js
+++ b/client/lib/analytics/refer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { stringify } from 'qs';
 import { pick } from 'lodash';
 import debug from 'debug';
 
@@ -33,12 +32,12 @@ export async function trackAffiliateReferral( { affiliateId, campaignId, subId, 
 		Accept: 'application/json',
 	};
 
-	const body = stringify( {
+	const body = new URLSearchParams( {
 		affiliate_id: affiliateId,
 		campaign_id: campaignId || '',
 		sub_id: subId || '',
 		referrer: referrer || '',
-	} );
+	} ).toString();
 
 	referDebug( 'Fetching Refer platform response.' );
 

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -91,20 +91,23 @@ export function updateQueryParamsTracking() {
 		return;
 	}
 
-	const query = urlParseAmpCompatible( document.location.href ).query;
+	const searchParams = urlParseAmpCompatible( document.location.href )?.searchParams;
 
 	// Sanitize query params
 	const sanitized_query = {};
-	Object.keys( query ).forEach( key => {
-		const value = query[ key ];
-		if ( isValidWhitelistedUrlParamValue( key, value ) ) {
-			sanitized_query[ key ] = value;
-		}
-	} );
 
-	// Cross domain tracking for AMP.
-	if ( query.amp_client_id ) {
-		window._tkq.push( [ 'identifyAnonUser', query.amp_client_id ] );
+	if ( searchParams ) {
+		for ( const key of searchParams.keys() ) {
+			const value = searchParams.get( key );
+			if ( isValidWhitelistedUrlParamValue( key, value ) ) {
+				sanitized_query[ key ] = value;
+			}
+		}
+
+		// Cross domain tracking for AMP.
+		if ( searchParams.get( 'amp_client_id' ) ) {
+			window._tkq.push( [ 'identifyAnonUser', searchParams.get( 'amp_client_id' ) ] );
+		}
 	}
 
 	// Drop SEM cookie update if either of these is missing

--- a/client/lib/analytics/utils/save-coupon-query-argument.js
+++ b/client/lib/analytics/utils/save-coupon-query-argument.js
@@ -10,14 +10,14 @@ import urlParseAmpCompatible from './url-parse-amp-compatible';
  */
 export default function saveCouponQueryArgument() {
 	// Read coupon query argument, return early if there is none.
-	const parsedUrl = urlParseAmpCompatible( location.href );
-	const couponCode = parsedUrl.query.coupon;
+	const parsedUrl = urlParseAmpCompatible( window.location.href );
+	const couponCode = parsedUrl?.searchParams.get( 'coupon' );
 	if ( ! couponCode ) {
 		return;
 	}
 
 	// Read coupon list from localStorage, create new if it's not there yet, refresh existing.
-	const couponsJson = localStorage.getItem( MARKETING_COUPONS_KEY );
+	const couponsJson = window.localStorage.getItem( MARKETING_COUPONS_KEY );
 	const coupons = JSON.parse( couponsJson ) || {};
 	const THIRTY_DAYS_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 	const now = Date.now();
@@ -34,5 +34,5 @@ export default function saveCouponQueryArgument() {
 
 	// Write remembered coupons back to localStorage.
 	debug( 'Storing coupons in localStorage: ', coupons );
-	localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
+	window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
 }

--- a/client/lib/analytics/utils/url-parse-amp-compatible.js
+++ b/client/lib/analytics/utils/url-parse-amp-compatible.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-import { assign } from 'lodash';
-import { parse as parseUrl } from 'url';
-
-/**
  * Internal dependencies
  */
 import debug from './debug';
@@ -22,7 +16,7 @@ function urlSafeBase64DecodeString( str ) {
 		'.': '=',
 	};
 
-	return atob( str.replace( /[-_.]/g, ch => decodeMap[ ch ] ) );
+	return window.atob( str.replace( /[-_.]/g, ch => decodeMap[ ch ] ) );
 }
 
 /**
@@ -50,26 +44,33 @@ function parseAmpEncodedParams( value ) {
 }
 
 /**
- * Returns an object equivalent to what url.parse( url, true ) would return plus the data extracted from `tk_amp`.
+ * Returns a URL instance with the original data plus the data extracted from `tk_amp`. Null if not a valid absolute URL.
  * URL parameters explicitly present in the URL take precedence over the ones extracted from `tk_amp`.
  * This function is used to support AMP-compatible tracking.
  *
  * @param {string} url URL to be parsed like `document.location.href`.
- * @returns {object} An object equivalent to what url.parse( url, true ) would return plus the data extracted from in `tk_amp`
+ * @returns {object} A URL instance with the original data plus the data extracted from `tk_amp`. Null if not a valid absolute URL.
  */
 export default function urlParseAmpCompatible( url ) {
-	const parsedUrl = parseUrl( url, true );
-	const query = parsedUrl.query;
+	try {
+		const parsedUrl = new URL( url );
 
-	debug( 'urlParseAmpCompatible: original query:', query );
+		debug( 'urlParseAmpCompatible: original query:', parsedUrl.search );
 
-	if ( 'tk_amp' in query ) {
-		const tk_amp = parseAmpEncodedParams( query.tk_amp );
-		debug( 'urlParseAmpCompatible: tk_amp:', tk_amp );
-		parsedUrl.query = assign( {}, tk_amp, query );
+		if ( parsedUrl.searchParams.has( 'tk_amp' ) ) {
+			const tk_amp = parseAmpEncodedParams( parsedUrl.searchParams.tk_amp );
+			debug( 'urlParseAmpCompatible: tk_amp:', tk_amp );
+			for ( const key of Object.keys( tk_amp ) ) {
+				if ( ! parsedUrl.searchParams.has( key ) ) {
+					parsedUrl.searchParams.set( key, tk_amp[ key ] );
+				}
+			}
+		}
+
+		debug( 'urlParseAmpCompatible: merged query:', parsedUrl.search );
+
+		return parsedUrl;
+	} catch {
+		return null;
 	}
-
-	debug( 'urlParseAmpCompatible: merged query:', parsedUrl.query );
-
-	return parsedUrl;
 }


### PR DESCRIPTION
Node's `url` is deprecated, and `qs` is a largeish 3rd party library.

All of the functionality replaced here is easily achievable with the standard `URL` and `URLSearchParams` APIs, which are available in both node and the browser (polyfilled, if needed).

This is one of many PRs working towards dropping 3rd-party libraries for URL and URL parameter handling and replacing them with native functionality.

#### Changes proposed in this Pull Request

* Replace `url` and `qs` usage with standard `URL` and `URLSearchParams` APIs.
* Fix minor lint issues

#### Testing instructions

There don't seem to be many unit tests covering this, and I'm not very familiar with this functionality. I'm hoping that some of the folks I asked for a review will be able to test this appropriately.
