### PR TITLE
WP Migration: Redirect WordPress importer to the migration screen if migration is enabled

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -43,6 +43,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 			}
 		),
+		overrideDestination: '/migrate/%SITE_SLUG%',
 		weight: 1,
 	};
 

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -20,6 +20,7 @@ import ImportingPane from './importing-pane';
 import UploadingPane from './uploading-pane';
 import { startImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+
 /**
  * Style dependencies
  */

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -7,11 +7,11 @@ import React from 'react';
 import classNames from 'classnames';
 import { includes } from 'lodash';
 import { connect } from 'react-redux';
-import page from 'page';
+
 /**
  * Internal dependencies
  */
-import { isConfigEnabled } from 'config';
+import { isEnabled as isConfigEnabled } from 'config';
 import { appStates } from 'state/imports/constants';
 import { Card } from '@automattic/components';
 import ErrorPane from './error-pane';
@@ -69,7 +69,7 @@ class FileImporter extends React.PureComponent {
 	handleClick = () => {
 		const {
 			importerStatus: { type },
-			site: { ID: siteId, slug: siteSlug },
+			site: { ID: siteId },
 			importerData: { overrideDestination },
 		} = this.props;
 
@@ -79,7 +79,7 @@ class FileImporter extends React.PureComponent {
 		 * This is used for the new Migration logic for the moment.
 		 */
 		if ( isConfigEnabled( 'tools/migrate' ) && overrideDestination ) {
-			return page.redirect( overrideDestination.replace( '%SITE_SLUG%', siteSlug ) );
+			return false;
 		}
 
 		startImport( siteId, type );
@@ -91,7 +91,13 @@ class FileImporter extends React.PureComponent {
 	};
 
 	render() {
-		const { title, icon, description, uploadDescription } = this.props.importerData;
+		const {
+			title,
+			icon,
+			description,
+			overrideDestination,
+			uploadDescription,
+		} = this.props.importerData;
 		const { importerStatus, site } = this.props;
 		const { errorData, importerState } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
@@ -105,6 +111,10 @@ class FileImporter extends React.PureComponent {
 			onClick: this.handleClick,
 			tagName: 'button',
 		};
+
+		if ( isConfigEnabled( 'tools/migrate' ) && overrideDestination ) {
+			cardProps.href = overrideDestination.replace( '%SITE_SLUG%', site.slug );
+		}
 
 		return (
 			<Card className={ cardClasses } { ...( showStart ? cardProps : undefined ) }>

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -7,10 +7,11 @@ import React from 'react';
 import classNames from 'classnames';
 import { includes } from 'lodash';
 import { connect } from 'react-redux';
-
+import page from 'page';
 /**
  * Internal dependencies
  */
+import { isConfigEnabled } from 'config';
 import { appStates } from 'state/imports/constants';
 import { Card } from '@automattic/components';
 import ErrorPane from './error-pane';
@@ -19,7 +20,6 @@ import ImportingPane from './importing-pane';
 import UploadingPane from './uploading-pane';
 import { startImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-
 /**
  * Style dependencies
  */
@@ -69,8 +69,18 @@ class FileImporter extends React.PureComponent {
 	handleClick = () => {
 		const {
 			importerStatus: { type },
-			site: { ID: siteId },
+			site: { ID: siteId, slug: siteSlug },
+			importerData: { overrideDestination },
 		} = this.props;
+
+		/**
+		 * Override where the clicks sends a user.
+		 *
+		 * This is used for the new Migration logic for the moment.
+		 */
+		if ( isConfigEnabled( 'tools/migrate' ) && overrideDestination ) {
+			return page.redirect( overrideDestination.replace( '%SITE_SLUG%', siteSlug ) );
+		}
 
 		startImport( siteId, type );
 

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -70,17 +70,7 @@ class FileImporter extends React.PureComponent {
 		const {
 			importerStatus: { type },
 			site: { ID: siteId },
-			importerData: { overrideDestination },
 		} = this.props;
-
-		/**
-		 * Override where the clicks sends a user.
-		 *
-		 * This is used for the new Migration logic for the moment.
-		 */
-		if ( isConfigEnabled( 'tools/migrate' ) && overrideDestination ) {
-			return false;
-		}
 
 		startImport( siteId, type );
 
@@ -113,7 +103,13 @@ class FileImporter extends React.PureComponent {
 		};
 
 		if ( isConfigEnabled( 'tools/migrate' ) && overrideDestination ) {
+			/**
+			 * Override where the user lands when they click the importer.
+			 *
+			 * This is used for the new Migration logic for the moment.
+			 */
 			cardProps.href = overrideDestination.replace( '%SITE_SLUG%', site.slug );
+			cardProps.onClick = null;
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the Migration option is enabled, when a user clicks on the WordPress importer in the imports screen, they will be sent to the migration screen instead. 

#### Testing instructions

* Apply diff
* Enable the `tools/migration` option, either via query parameter or via cookies
* Go to a WordPress.com site that doesn't have a Business plan (at the moment)
* Go to Import
* Click WordPress 
* You should be sent to the migration screen
* Clicking on any other importer should still show their respective UIs and they should work.

#### Known issues:

* This PR essentially disables the WordPress importer, but as it's only working when a flag is enabled, it should be fine, as we'll handle the updated flow in subsequent PRs. 