### PR TITLE
People: Improve Invite Button Alignment

### DIFF
--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -163,7 +163,9 @@ class PeopleInvites extends React.PureComponent {
 						</Card>
 					</div>
 				) : (
-					<div className="people-invites__pending">{ this.renderInviteUsersAction( false ) }</div>
+					<div className="people-invites__pending has-invite-button">
+						{ this.renderInviteUsersAction( false ) }
+					</div>
 				) }
 
 				{ hasAcceptedInvites && (

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -1,3 +1,8 @@
+.people-invites__pending.has-invite-button {
+	margin: 17px;
+	text-align: center;
+}
+
 .people-invites__invites-list {
 	padding: 0;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This horizontally and vertically aligns the Invite button.

#### Testing instructions

Visit `/people/invites/` on a site that has had an invitation accepted and has no pending invites (invites waiting to be accepted).

**Before:**
<img width="872" alt="Screenshot 2020-01-09 at 16 57 21" src="https://user-images.githubusercontent.com/43215253/72088850-e8636280-3302-11ea-803f-9e65f08da1b8.png">

**After:**
<img width="967" alt="Screenshot 2020-01-09 at 17 06 59" src="https://user-images.githubusercontent.com/43215253/72088856-ed281680-3302-11ea-8b38-5a32a663ab6f.png">

cc @arunsathiya, @scruffian 

Fixes #35504
