### PR TITLE
Add vertical space around design grid

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -61,9 +61,8 @@ const DesignSelector: FunctionComponent = () => {
 	useLayoutEffect( () => {
 		if ( headingContainer.current ) {
 			// We'll use this height to move the heading up out of the viewport.
-			// Gutenberg editor adds 50px
 			const rect = headingContainer.current.getBoundingClientRect();
-			selectionTransitionShift.current = rect.height + rect.y - 50;
+			selectionTransitionShift.current = rect.height;
 		}
 	}, [ selectedDesign ] );
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import React, { useState, FunctionComponent, MouseEvent } from 'react';
+import React, { useLayoutEffect, useRef, useState, FunctionComponent, MouseEvent } from 'react';
 import classnames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 import PageLayoutSelector from './page-layout-selector';
@@ -56,6 +56,17 @@ const DesignSelector: FunctionComponent = () => {
 	const [ isDialogVisible, setIsDialogVisible ] = useState( hasSelectedDesign );
 	const [ cp, setCp ] = useState< number >();
 
+	const headingContainer = useRef< HTMLDivElement >( null );
+	const selectionTransitionShift = useRef< number >( 0 );
+	useLayoutEffect( () => {
+		if ( headingContainer.current ) {
+			// We'll use this height to move the heading up out of the viewport.
+			// Gutenberg editor adds 50px
+			const rect = headingContainer.current.getBoundingClientRect();
+			selectionTransitionShift.current = rect.height + rect.y - 50;
+		}
+	}, [ selectedDesign ] );
+
 	const dialogId = 'page-selector-modal';
 
 	const descriptionOnRight: boolean =
@@ -63,10 +74,18 @@ const DesignSelector: FunctionComponent = () => {
 		designs.findIndex( ( { slug } ) => slug === selectedDesign.slug ) % 2 === 0;
 
 	return (
-		<div className={ classnames( 'design-selector', { 'has-selected-design': selectedDesign } ) }>
+		<div
+			className="design-selector"
+			style={
+				selectedDesign && {
+					transform: `translate3d( 0,  -${ selectionTransitionShift.current }px, 0 )`,
+				}
+			}
+		>
 			<div
 				className="design-selector__header-container"
 				aria-hidden={ hasSelectedDesign ? 'true' : undefined }
+				ref={ headingContainer }
 			>
 				<h1 className="design-selector__title">
 					{ NO__( 'Choose a starting design for your site' ) }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -40,7 +40,7 @@ $design-selector-selection-space: 285px;
 .design-selector__grid-container {
 	position: absolute;
 	padding-bottom: 50px;
-	padding-top: 50px;
+	padding-top: 19px;
 
 	&.exit,
 	&.exit-done {
@@ -104,6 +104,7 @@ $design-selector-selection-space: 285px;
 }
 
 .design-selector__header-container {
+	padding-bottom: 31px;
 }
 
 .page-layout-selector__title {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -47,7 +47,8 @@ $deisgn-selector-selection-space: 175px;
 
 .design-selector__grid-container {
 	position: absolute;
-	margin-top: 1em;
+	padding-bottom: 50px;
+	padding-top: 50px;
 
 	&.exit,
 	&.exit-done {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -5,11 +5,7 @@ $design-selector-transition-timing: 250ms;
 $design-selector-grid-gap: 4.5em;
 
 $design-selector-max-width: 1100px;
-$design-selector-header-height: 60px;
-// We'll use this height to move the heading up out of the viewport.
-// Gutenberg editor adds 50px
-$design-selector-header-vertical-shift: $design-selector-header-height + 50px;
-$deisgn-selector-selection-space: 175px;
+$design-selector-selection-space: 285px;
 
 @mixin design-selector-show {
 	transform: translate3d( 0, 0, 0 );
@@ -25,9 +21,6 @@ $deisgn-selector-selection-space: 175px;
 .design-selector {
 	@include design-selector-transition();
 	transform: translate3d( 0, 0, 0 );
-	&.has-selected-design {
-		transform: translate3d( 0, -( $design-selector-header-vertical-shift ), 0 );
-	}
 }
 
 .design-selector__title {
@@ -41,7 +34,6 @@ $deisgn-selector-selection-space: 175px;
 .design-selector__subtitle {
 	color: $dark-gray-800;
 	font-size: 1.3em;
-	margin-bottom: 3em;
 	text-align: center;
 }
 
@@ -83,7 +75,7 @@ $deisgn-selector-selection-space: 175px;
 
 .design-selector__page-layout-container {
 	position: absolute;
-	top: $design-selector-header-vertical-shift + $deisgn-selector-selection-space;
+	top: $design-selector-selection-space;
 	width: 100%;
 	background: $white;
 	box-shadow: $dark-gray-300 0 0 12px;
@@ -112,7 +104,6 @@ $deisgn-selector-selection-space: 175px;
 }
 
 .design-selector__header-container {
-	height: $design-selector-header-height;
 }
 
 .page-layout-selector__title {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -39,7 +39,7 @@ $design-selector-selection-space: 285px;
 
 .design-selector__grid-container {
 	position: absolute;
-	padding-bottom: 50px;
+	padding-bottom: 48px;
 	padding-top: 19px;
 
 	&.exit,
@@ -104,7 +104,8 @@ $design-selector-selection-space: 285px;
 }
 
 .design-selector__header-container {
-	padding-bottom: 31px;
+	padding-top: 48px;
+	padding-bottom: 29px;
 }
 
 .page-layout-selector__title {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added vertical space around the design selector heading.

The space around the heading is intended to be 48px (see https://github.com/Automattic/wp-calypso/issues/38741#issuecomment-572707554) however the Gutenberg editor adds 50px above the heading, so I've used that below as well.

The vertical space wasn't maintained when the heading text wrapped (mobile view or after text is translated). I couldn't think of a CSS only solution to this, so I'm using JavaScript to measure the height of the heading once. The transition is still performed by CSS.

* Add padding below around design selector heading
* Removed fixed heading height so space is maintained between heading and grid when text wraps
* Use JavaScript to measure how far design selector should move during transition
* Add gap at bottom of the design selector grid so the page doesn't end abruptly

Using a margin at the bottom of the design selector grid collapses, which is why I switched to padding.

**Transition with two line header**
![desktop](https://user-images.githubusercontent.com/1500769/72224391-0cfb5b00-35df-11ea-90c4-65b2b7867b93.gif)

**Transition with a four line header**
![phone](https://user-images.githubusercontent.com/1500769/72224393-0ff64b80-35df-11ea-9905-32aaba7a0247.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/gutenboarding/design` and observe padding
* Try mobile layout
* The heading slides out of view when a design is selected.

Known issue: choose a design in desktop layout and then change to mobile layout; some of the heading appears at the top of the page. This is probably the least of our mobile worries ATM.

Fixes #38741
Fixes #38804 
