### PR TITLE
Allow for non-absolute URLs in gravatar component.

### DIFF
--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -47,11 +47,12 @@ export class Gravatar extends Component {
 
 	getResizedImageURL( imageURL ) {
 		const { imgSize } = this.props;
-		imageURL = imageURL || 'https://www.gravatar.com/avatar/0';
+		const defaultUrl = 'https://www.gravatar.com/avatar/0';
+		imageURL = imageURL || defaultUrl;
 		const urlType = determineUrlType( imageURL );
 
 		if ( urlType === URL_TYPE.INVALID || urlType === URL_TYPE.PATH_RELATIVE ) {
-			return imageURL;
+			return defaultUrl;
 		}
 
 		const { search, origin, host, ...parsedURL } = getUrlParts( imageURL );


### PR DESCRIPTION
It appears that scheme-relative URLs may be getting used in some situations, unlike what I expected. This change will allow for that, as well as path-absolute, path-relative, and even invalid URLs.

#### Changes proposed in this Pull Request

* Allow for non-absolute URLs in gravatar component

#### Testing instructions

I was unable to reproduce the issue described in 2619939-zen , and I couldn't find any way of setting a gravatar to a non-absolute URL, so I'm afraid I can't offer any testing instructions for the original issue.

Testing that the usual absolute URL scenario doesn't get broken by this fix is easy, however: simply load any logged-in page. The gravatar component will be used in the masterbar and should display your gravatar.
