### PR TITLE
People: Only show the invite button when there are no pending invites

### DIFF
--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -155,21 +155,20 @@ class PeopleInvites extends React.PureComponent {
 
 		return (
 			<React.Fragment>
-				{ hasPendingInvites ? (
+				{ hasPendingInvites && (
 					<div className="people-invites__pending">
 						<PeopleListSectionHeader label={ pendingLabel } site={ site } />
 						<Card className="people-invites__invites-list">
 							{ pendingInvites.map( this.renderInvite ) }
 						</Card>
 					</div>
-				) : (
-					<div className="people-invites__pending">{ this.renderInviteUsersAction( false ) }</div>
 				) }
 
 				{ hasAcceptedInvites && (
 					<div className="people-invites__accepted">
 						<PeopleListSectionHeader
 							label={ acceptedLabel }
+							site={ hasPendingInvites ? null : site }
 							// Excluding `site=` hides the "Invite user" link.
 						>
 							{ this.renderClearAll() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an alternative take on https://github.com/Automattic/wp-calypso/pull/38753. 

#### Testing instructions

There are two cases to consider here - site with pending invites, and sites without pending invites. When a site has pending invites we show the invite button above the pending invites like this:
<img width="925" alt="Screenshot 2020-01-10 at 11 18 13" src="https://user-images.githubusercontent.com/275961/72149741-b8b46900-339b-11ea-9fdf-60db88424148.png">

And then the accepted invites section doesn't have an invite button, like this:
<img width="828" alt="Screenshot 2020-01-10 at 11 18 20" src="https://user-images.githubusercontent.com/275961/72149767-c833b200-339b-11ea-9ffb-d7c327e5d008.png">

But if the site has no pending invites and only accepted invites, you see this:
<img width="866" alt="Screenshot 2020-01-10 at 11 19 00" src="https://user-images.githubusercontent.com/275961/72149792-d5e93780-339b-11ea-869f-2600c240bfab.png">
 

Fixes #35504