### PR TITLE
eslint-plugin-wpcalypso: make jsx-classname-namespace work well with Storybook

### DIFF
--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Unreleased
 - Breaking: Removed rule [`import-no-redux-combine-reducers`](docs/rules/import-no-redux-combine-reducers.md)
+- Enhancement: `jsx-classname-namespace` understands Storybook `index.stories.js` files and treats them as root files
 
 #### v4.1.0 (2019-05-07)
 

--- a/packages/eslint-plugin-wpcalypso/lib/rules/jsx-classname-namespace.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/jsx-classname-namespace.js
@@ -101,7 +101,15 @@ const rule = ( module.exports = function( context ) {
 } );
 
 rule.ERROR_MESSAGE = 'className should follow CSS namespace guidelines (expected {{expected}})';
-rule.DEFAULT_ROOT_FILES = [ 'index.js', 'index.jsx', 'index.ts', 'index.tsx' ];
+rule.DEFAULT_ROOT_FILES = [
+	'index.js',
+	'index.jsx',
+	'index.ts',
+	'index.tsx',
+	// Storybook files
+	'index.stories.js',
+	'index.stories.jsx',
+];
 
 rule.schema = [
 	{


### PR DESCRIPTION
Treat `index.stories.js` as a root file and don't suggest `index.stories` as a CSS class name. It's not a good suggestion 🙂 Useful for Storybook.

Inspired by: https://github.com/Automattic/wp-calypso/pull/38675#discussion_r364104798

**How to test:**
In a file named `product-icon/index.stories.js`, the only class name allowed by the `jsx-classname-namespace` rule should be `product-icon`. Never `index.stories`.