### PR TITLE
E2E: Check revisions modal on Gutenberg

### DIFF
--- a/test/e2e/lib/components/revisions-modal-component.js
+++ b/test/e2e/lib/components/revisions-modal-component.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../driver-helper';
+import AsyncBaseContainer from '../async-base-container';
+
+export default class RevisionsModalComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.editor-revisions' ) );
+	}
+
+	async _preInit() {
+		return await this.driver.switchTo().defaultContent();
+	}
+
+	async loadFirstRevision() {
+		const firstRevision = await this.driver.findElement(
+			By.css( '.editor-revisions-list__revision:last-child .editor-revisions-list__button' )
+		);
+		const loadButton = await this.driver.findElement( By.css( '[data-e2e-button="load"]' ) );
+
+		// Using a JS clicks here since Webdriver clicks weren't working.
+		await this.driver.executeScript( 'arguments[0].click()', firstRevision );
+		await this.driver.executeScript( 'arguments[0].click()', loadButton );
+
+		return driverHelper.waitTillNotPresent( this.driver, this.expectedElementSelector );
+	}
+}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -94,12 +94,28 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( titleFieldSelector ).sendKeys( title );
 	}
 
+	async getTitle() {
+		return await this.driver
+			.findElement( By.css( '.editor-post-title__input' ) )
+			.getAttribute( 'value' );
+	}
+
 	async enterText( text ) {
 		const appenderSelector = By.css( '.editor-default-block-appender' );
 		const textSelector = By.css( '.wp-block-paragraph' );
 		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, textSelector );
 		return await this.driver.findElement( textSelector ).sendKeys( text );
+	}
+
+	async getContent() {
+		return await this.driver.findElement( By.css( '.block-editor-block-list__layout' ) ).getText();
+	}
+
+	async replaceTextOnLastParagraph( text ) {
+		const paragraph = By.css( '.wp-block-paragraph' );
+		await driverHelper.clearTextArea( this.driver, paragraph );
+		return await this.driver.findElement( paragraph ).sendKeys( text );
 	}
 
 	async insertShortcode( shortcode ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -293,4 +293,11 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			fileDetails.imageName
 		);
 	}
+
+	async openRevisionsDialog() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.edit-post-last-revision__panel' )
+		);
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a new test checking the block editor integration with the Calypso revisions modal.
