### PR TITLE
Gutenboarding: Add description to design-selector

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -72,6 +72,10 @@ const DesignSelector: FunctionComponent = () => {
 
 	const dialogId = 'page-selector-modal';
 
+	const descriptionOnRight: boolean =
+		!! selectedDesign &&
+		designs.findIndex( ( { slug } ) => slug === selectedDesign.slug ) % 2 === 0;
+
 	return (
 		<div className={ classnames( 'design-selector', { 'has-selected-design': selectedDesign } ) }>
 			<div
@@ -113,6 +117,24 @@ const DesignSelector: FunctionComponent = () => {
 								} }
 							/>
 						) ) }
+					</div>
+				</div>
+			</CSSTransition>
+
+			<CSSTransition in={ hasSelectedDesign } timeout={ transitionTiming }>
+				<div
+					className={ classnames( 'design-selector__description-container', {
+						'on-right-side': descriptionOnRight,
+					} ) }
+				>
+					<div className="design-selector__description-title">Title!</div>
+					<div className="design-selector__description-description">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+						incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+						exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+						dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+						Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+						mollit anim id est laborum.
 					</div>
 				</div>
 			</CSSTransition>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -127,14 +127,12 @@ const DesignSelector: FunctionComponent = () => {
 						'on-right-side': descriptionOnRight,
 					} ) }
 				>
-					<div className="design-selector__description-title">Title!</div>
+					<div className="design-selector__description-title">{ selectedDesign?.title }</div>
 					<div className="design-selector__description-description">
+						{ /* @TODO: Real description? */ }
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 						incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-						exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-						dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-						Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-						mollit anim id est laborum.
+						exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 					</div>
 				</div>
 			</CSSTransition>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -2,6 +2,8 @@
 
 $design-selector-transition-timing: 250ms;
 
+$design-selector-grid-gap: 4.5em;
+
 $design-selector-max-width: 1100px;
 $design-selector-header-height: 60px;
 // We'll use this height to move the heading up out of the viewport.
@@ -64,10 +66,11 @@ $deisgn-selector-selection-space: 175px;
 		}
 	}
 }
+
 .design-selector__grid {
 	@include design-selector-transition();
 	display: grid;
-	grid-gap: 4.5em;
+	grid-gap: $design-selector-grid-gap;
 
 	@include breakpoint( '>660px' ) {
 		grid-template-columns: 1fr 1fr;
@@ -227,4 +230,40 @@ $deisgn-selector-selection-space: 175px;
 	display: block;
 	margin-left: -2px;
 	margin-right: -2px;
+}
+
+.design-selector__description-container {
+	@include design-selector-transition();
+	position: fixed;
+	@include design-selector-hide;
+
+	position: fixed;
+	// top: 100px;
+	display: flex;
+	flex-direction: column;
+	width: calc( 50% - #{$design-selector-grid-gap} );
+	padding-top: 23px;
+
+	@include breakpoint( '>660px' ) {
+		&.on-right-side {
+			right: 0;
+		}
+	}
+
+	&.enter-active,
+	&.enter-done {
+		@include design-selector-show;
+	}
+}
+
+.design-selector__description-title {
+	color: $dark-gray-800;
+	font-size: 2em;
+	font-weight: bold;
+	margin-bottom: 0.8em;
+}
+.design-selector__description-description {
+	color: $dark-gray-800;
+	font-size: 1.3em;
+	line-height: 1.3;
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -238,7 +238,6 @@ $deisgn-selector-selection-space: 175px;
 	@include design-selector-hide;
 
 	position: fixed;
-	// top: 100px;
 	display: flex;
 	flex-direction: column;
 	width: calc( 50% - #{$design-selector-grid-gap} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add design title and description to the page selector.

Note that this doesn't look good in dark mode, which will be removed for now (#38587).

Closes #38748

![description](https://user-images.githubusercontent.com/841763/72168793-25485b80-33ce-11ea-8e2d-662ebc02ee25.gif)


#### Testing instructions

* Visit `/gutenboarding` and try the design selector.
* The design name and a "lorm ipsum" text should slide up next to the selected design when it's selected.