### PR TITLE
Remove url and qs from login.

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -10,7 +10,6 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -458,12 +457,12 @@ export class LoginForm extends Component {
 
 		if ( isOauthLogin && config.isEnabled( 'signup/wpcc' ) ) {
 			const oauth2Flow = isCrowdsignalOAuth2Client( oauth2Client ) ? 'crowdsignal' : 'wpcc';
-			const oauth2Params = {
+			const oauth2Params = new globalThis.URLSearchParams( {
 				oauth2_client_id: oauth2Client.id,
 				oauth2_redirect: redirectTo,
-			};
+			} );
 
-			signupUrl = `/start/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
+			signupUrl = `/start/${ oauth2Flow }?${ oauth2Params.toString() }`;
 		}
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -2,10 +2,8 @@
  * External dependencies
  */
 import page from 'page';
-import { parse } from 'qs';
 import React from 'react';
 import { includes } from 'lodash';
-import { parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -16,6 +14,7 @@ import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
+import { getUrlParts } from 'lib/url';
 
 const enhanceContextWithLogin = context => {
 	const {
@@ -64,10 +63,9 @@ export async function login( context, next ) {
 			return next( error );
 		}
 
-		const parsedRedirectUrl = parseUrl( redirect_to );
-		const redirectQueryString = parse( parsedRedirectUrl.query );
+		const { searchParams: redirectParams } = getUrlParts( redirect_to );
 
-		if ( client_id !== redirectQueryString.client_id ) {
+		if ( client_id !== redirectParams.get( 'client_id' ) ) {
 			const error = new Error(
 				'The `redirect_to` query parameter is invalid with the given `client_id`.'
 			);

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -7,8 +7,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { parse as parseUrl } from 'url';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -18,7 +16,7 @@ import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
-import { addQueryArgs } from 'lib/url';
+import { addQueryArgs, getUrlParts } from 'lib/url';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'state/selectors/get-current-route';
@@ -84,9 +82,9 @@ export class LoginLinks extends React.Component {
 	};
 
 	renderBackLink() {
-		const redirectTo = get( this.props, [ 'query', 'redirect_to' ] );
+		const redirectTo = this.props.query?.redirect_to;
 		if ( redirectTo ) {
-			const { pathname, query: redirectToQuery } = parseUrl( redirectTo, true );
+			const { pathname, searchParams: redirectToQuery } = getUrlParts( redirectTo );
 
 			// If we are in a Domain Connect authorization flow, don't show the back link
 			// since this page was loaded by a redirect from a third party service provider.
@@ -96,13 +94,13 @@ export class LoginLinks extends React.Component {
 
 			// If we seem to be in a Jetpack connection flow, provide some special handling
 			// so users can go back to their site rather than WordPress.com
-			if ( pathname === '/jetpack/connect/authorize' && redirectToQuery.client_id ) {
+			if ( pathname === '/jetpack/connect/authorize' && redirectToQuery.get( 'client_id' ) ) {
 				const returnToSiteUrl = addQueryArgs(
-					{ client_id: redirectToQuery.client_id },
+					{ client_id: redirectToQuery.get( 'client_id' ) },
 					'https://jetpack.wordpress.com/jetpack.returntosite/1/'
 				);
 
-				const { hostname } = parseUrl( redirectToQuery.site_url );
+				const { hostname } = getUrlParts( redirectToQuery.get( 'site_url' ) );
 				const linkText = hostname
 					? this.props.translate( 'Back to %(hostname)s', { args: { hostname } } )
 					: this.props.translate( 'Back' );
@@ -255,12 +253,12 @@ export class LoginLinks extends React.Component {
 		if ( config.isEnabled( 'signup/wpcc' ) && isCrowdsignalOAuth2Client( oauth2Client ) ) {
 			const oauth2Flow = 'crowdsignal';
 			const redirectTo = get( currentQuery, 'redirect_to', '' );
-			const oauth2Params = {
+			const oauth2Params = new URLSearchParams( {
 				oauth2_client_id: oauth2Client.id,
 				oauth2_redirect: redirectTo,
-			};
+			} );
 
-			signupUrl = `${ signupUrl }/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
+			signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
 		}
 
 		if (
@@ -270,13 +268,13 @@ export class LoginLinks extends React.Component {
 			wccomFrom
 		) {
 			const redirectTo = get( currentQuery, 'redirect_to', '' );
-			const oauth2Params = {
+			const oauth2Params = new URLSearchParams( {
 				oauth2_client_id: oauth2Client.id,
 				'wccom-from': wccomFrom,
 				oauth2_redirect: redirectTo,
-			};
+			} );
 
-			signupUrl = `${ signupUrl }/wpcc?${ stringify( oauth2Params ) }`;
+			signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
 		}
 
 		return (

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { stringify } from 'qs';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
@@ -52,11 +47,11 @@ export const hideMagicLoginRequestNotice = () => {
 };
 
 async function postMagicLoginRequest( url, bodyObj ) {
-	const response = await fetch( url, {
+	const response = await globalThis.fetch( url, {
 		method: 'POST',
 		credentials: 'include',
 		headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-		body: stringify( bodyObj ),
+		body: new globalThis.URLSearchParams( bodyObj ).toString(),
 	} );
 
 	if ( response.ok ) {

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { get, omit } from 'lodash';
-import { stringify } from 'qs';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -170,7 +169,7 @@ export async function postLoginRequest( action, bodyObj ) {
 			method: 'POST',
 			credentials: 'include',
 			headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: stringify( bodyObj ),
+			body: new globalThis.URLSearchParams( bodyObj ).toString(),
 		}
 	);
 


### PR DESCRIPTION
Node's `url` is deprecated, and `qs` is a largeish 3rd party library.

All of the functionality replaced here is available in `lib/url`, which is built on top of standard APIs that are available in both node and the browser (polyfilled, if needed).

This is one of many PRs working towards dropping 3rd-party libraries for URL and URL parameter handling and replacing them with native functionality.

#### Changes proposed in this Pull Request

* Replace `url` and `qs` usage with `lib/url`.

#### Testing instructions

I'm not very familiar with this part of the login flow (going back to the original site in a Jetpack connection flow), so I'm hoping that the E2E tests and the reviewers will be able to help out with in-depth testing.
