### PR TITLE
Jetpack Cloud: PoC v2

### DIFF
--- a/apps/jetpack-cloud/package.json
+++ b/apps/jetpack-cloud/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@automattic/jetpack-cloud",
+	"version": "1.0.0-alpha.0",
+	"description": "Jetpack Cloud",
+	"sideEffects": true,
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/Automattic/wp-calypso.git",
+		"directory": "apps/jetpack-cloud"
+	},
+	"private": true,
+	"author": "Automattic Inc.",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"scripts": {
+		"bundle": "calypso-build",
+		"build:dev": "npm run bundle --",
+		"build:prod": "NODE_ENV=production npm run bundle --",
+		"build": "npm-run-all --parallel \"build:* -- {@}\" --",
+		"clean": "npx rimraf dist",
+		"prebuild": "npm run clean"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@automattic/calypso-build": "file:../../packages/calypso-build"
+	}
+}

--- a/apps/jetpack-cloud/src/index.js
+++ b/apps/jetpack-cloud/src/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import 'landing/jetpack-cloud';

--- a/apps/jetpack-cloud/webpack.config.js
+++ b/apps/jetpack-cloud/webpack.config.js
@@ -1,0 +1,156 @@
+/**
+ **** WARNING: No ES6 modules here. Not transpiled! ****
+ */
+/* eslint-disable import/no-nodejs-modules */
+
+/**
+ * External dependencies
+ */
+const _ = require( 'lodash' );
+const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
+const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const path = require( 'path' );
+const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
+const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
+
+/**
+ * Internal variables
+ */
+const cacheIdentifier = require( '../../server/bundler/babel/babel-loader-cache-identifier' );
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+const nodeModulesToTranspile = [
+	// general form is <package-name>/.
+	// The trailing slash makes sure we're not matching these as prefixes
+	// In some cases we do want prefix style matching (lodash. for lodash.assign)
+	'@github/webauthn-json/',
+	'acorn-jsx/',
+	'chalk/',
+	'd3-array/',
+	'd3-scale/',
+	'debug/',
+	'escape-string-regexp/',
+	'filesize/',
+	'prismjs/',
+	'react-spring/',
+	'regenerate-unicode-properties/',
+	'regexpu-core/',
+	'striptags/',
+	'unicode-match-property-ecmascript/',
+	'unicode-match-property-value-ecmascript/',
+];
+
+/**
+ * Check to see if we should transpile certain files in node_modules
+ *
+ * @param {string} filepath the path of the file to check
+ * @returns {boolean} True if we should transpile it, false if not
+ *
+ * We had a thought to try to find the package.json and use the engines property
+ * to determine what we should transpile, but not all libraries set engines properly
+ * (see d3-array@2.0.0). Instead, we transpile libraries we know to have dropped Node 4 support
+ * are likely to remain so going forward.
+ */
+function shouldTranspileDependency( filepath ) {
+	// find the last index of node_modules and check from there
+	// we want <working>/node_modules/a-package/node_modules/foo/index.js to only match foo, not a-package
+	const marker = '/node_modules/';
+	const lastIndex = filepath.lastIndexOf( marker );
+	if ( lastIndex === -1 ) {
+		// we're not in node_modules
+		return false;
+	}
+
+	const checkFrom = lastIndex + marker.length;
+
+	return _.some(
+		nodeModulesToTranspile,
+		modulePart => filepath.substring( checkFrom, checkFrom + modulePart.length ) === modulePart
+	);
+}
+
+/**
+ * Return a webpack config object
+ *
+ * Arguments to this function replicate webpack's so this config can be used on the command line,
+ * with individual options overridden by command line args.
+ *
+ * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
+ * @see {@link https://webpack.js.org/api/cli/}
+ *
+ * @param   {object}  env                           environment options
+ * @param   {object}  argv                          options map
+ * @param   {object}  argv.entry                    Entry point(s)
+ * @param   {string}  argv.'output-path'            Output path
+ * @param   {string}  argv.'output-filename'        Output filename pattern
+ * @param   {string}  argv.'output-library-target'  Output library target
+ * @returns {object}                                webpack config
+ */
+function getWebpackConfig(
+	env = {},
+	{
+		entry = {
+			default: path.join( __dirname, 'src', 'index' ),
+		},
+		'output-path': outputPath = path.join( __dirname, 'dist' ),
+		'output-filename': outputFilename = isDevelopment ? '[name].js' : '[name].min.js',
+	}
+) {
+	const webpackConfig = getBaseWebpackConfig( env, {
+		entry,
+		'output-filename': outputFilename,
+		'output-path': outputPath,
+	} );
+	const rootDir = path.dirname( path.dirname( __dirname ) );
+
+	return {
+		...webpackConfig,
+		watch: isDevelopment,
+		devtool: isDevelopment ? 'inline-cheap-source-map' : false,
+		resolve: {
+			...webpackConfig.resolve,
+			modules: [ ...webpackConfig.resolve.modules, path.join( rootDir, 'client' ) ],
+		},
+		module: {
+			rules: [
+				TranspileConfig.loader( {
+					workerCount: 1,
+					configFile: path.join( rootDir, 'babel.config.js' ),
+					cacheDirectory: path.join( rootDir, 'build', '.babel-client-cache', 'defaults' ),
+					cacheIdentifier,
+					exclude: /node_modules\//,
+				} ),
+				TranspileConfig.loader( {
+					workerCount: 1,
+					configFile: path.resolve( rootDir, 'babel.dependencies.config.js' ),
+					cacheDirectory: path.join( rootDir, 'build', '.babel-client-cache', 'defaults' ),
+					cacheIdentifier,
+					include: shouldTranspileDependency,
+				} ),
+				FileConfig.loader(),
+				SassConfig.loader( {
+					includePaths: [ path.join( rootDir, 'client' ) ],
+					prelude: `@import '${ path.join(
+						rootDir,
+						'client/assets/stylesheets/shared/_utils.scss'
+					) }';`,
+					postCssConfig: { path: __dirname },
+				} ),
+				{
+					include: path.join( __dirname, 'client/sections.js' ),
+					loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
+					options: {
+						include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
+					},
+				},
+			],
+		},
+		externals: [ 'electron' ],
+		node: {
+			fs: 'empty',
+		},
+		stats: 'minimal',
+	};
+}
+
+module.exports = getWebpackConfig;

--- a/apps/jetpack-cloud/webpack.config.js
+++ b/apps/jetpack-cloud/webpack.config.js
@@ -136,13 +136,6 @@ function getWebpackConfig(
 					) }';`,
 					postCssConfig: { path: __dirname },
 				} ),
-				{
-					include: path.join( __dirname, 'client/sections.js' ),
-					loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
-					options: {
-						include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
-					},
-				},
 			],
 		},
 		externals: [ 'electron' ],

--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -1,0 +1,33 @@
+// Color Schemes
+// Currently used only by Calypso dev badge shown in development mode
+@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+
+// Shared
+@import 'shared/reset'; // css reset before the rest of the styles are defined
+@import './shared/loading';
+@import './gutenberg-base-styles';
+@import './shared/mixins/placeholder'; // Contains the placeholder mixin
+@import './shared/animation'; // Needed for the placeholder
+
+// Gutenberg resets
+// Not an actual "CSS reset", but an opiniated base style for HTML elements in Gutenberg views.
+:root {
+	@include reset;
+}
+
+// Change loading logo's color while Calypso boots
+.wpcom-site__logo {
+	fill: $light-gray-500;
+}
+
+// Hide Calypso header while Calypso boots
+.masterbar {
+	display: none;
+}
+
+// Gutenberg default typography
+html,
+body {
+	font-family: $default-font;
+	font-size: $default-font-size;
+}

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -225,9 +225,7 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 	}
 };
 
-export const setupMiddlewares = ( currentUser, reduxStore ) => {
-	debug( 'Executing Calypso setup middlewares.' );
-
+export const setupBasicMiddlewares = ( currentUser, reduxStore ) => {
 	installPerfmonPageHandlers();
 	setupContextMiddleware( reduxStore );
 	oauthTokenMiddleware();
@@ -240,6 +238,12 @@ export const setupMiddlewares = ( currentUser, reduxStore ) => {
 
 	// The analytics module requires user (when logged in) and superProps objects. Inject these here.
 	analytics.initialize( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
+};
+
+export const setupMiddlewares = ( currentUser, reduxStore ) => {
+	debug( 'Executing Calypso setup middlewares.' );
+
+	setupBasicMiddlewares( currentUser, reduxStore );
 
 	// Render Layout only for non-isomorphic sections.
 	// Isomorphic sections will take care of rendering their Layout last themselves.

--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+import { Provider as ReduxProvider } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import JetpackCloudLayout from './layout';
+import JetpackCloudSidebar from './sidebar';
+
+export const makeLayout = ( context, next ) => {
+	const { store, primary, secondary } = context;
+
+	context.layout = (
+		<ReduxProvider store={ store }>
+			<JetpackCloudLayout primary={ primary } secondary={ secondary } />
+		</ReduxProvider>
+	);
+
+	next();
+};
+
+export const clientRender = context => {
+	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+};
+
+export function setupSidebar( context, next ) {
+	context.secondary = <JetpackCloudSidebar />;
+	next();
+}
+
+export function jetpackCloud( context, next ) {
+	context.primary = <div>Hi, this is the Jetpack.com Cloud!</div>;
+	next();
+}
+
+export function jetpackBackups( context, next ) {
+	context.primary = <div>This is the Jetpack Backup landing page!</div>;
+	next();
+}
+
+export function jetpackScan( context, next ) {
+	context.primary = <div>This is the Jetpack Scan landing page!</div>;
+	next();
+}

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -8,10 +8,10 @@ import page from 'page';
  * Internal dependencies
  */
 import detectHistoryNavigation from 'lib/detect-history-navigation';
-import initialReducer from 'state/reducer';
+import initialReducer from './reducer';
 import initJetpackCloudRoutes from './routes';
 import userFactory from 'lib/user';
-import { configureReduxStore, setupMiddlewares, utils } from 'boot/common';
+import { configureReduxStore, setupBasicMiddlewares, utils } from 'boot/common';
 import { createReduxStore } from 'state';
 import { getInitialState, persistOnChange } from 'state/initial-state';
 import { setupLocale } from 'boot/locale';
@@ -28,7 +28,7 @@ const boot = currentUser => {
 		persistOnChange( reduxStore );
 		setupLocale( currentUser.get(), reduxStore );
 		configureReduxStore( currentUser, reduxStore );
-		setupMiddlewares( currentUser, reduxStore );
+		setupBasicMiddlewares( currentUser, reduxStore );
 		detectHistoryNavigation.start();
 		initJetpackCloudRoutes( '/jetpack-cloud' );
 		page.start( { decodeURLComponents: false } );

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import config from '../../config';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import detectHistoryNavigation from 'lib/detect-history-navigation';
+import initialReducer from 'state/reducer';
+import initJetpackCloudRoutes from './routes';
+import userFactory from 'lib/user';
+import { configureReduxStore, setupMiddlewares, utils } from 'boot/common';
+import { createReduxStore } from 'state';
+import { getInitialState, persistOnChange } from 'state/initial-state';
+import { setupLocale } from 'boot/locale';
+
+/**
+ * Style dependencies
+ */
+import 'assets/stylesheets/jetpack-cloud.scss';
+
+const boot = currentUser => {
+	utils();
+	getInitialState( initialReducer ).then( initialState => {
+		const reduxStore = createReduxStore( initialState, initialReducer );
+		persistOnChange( reduxStore );
+		setupLocale( currentUser.get(), reduxStore );
+		configureReduxStore( currentUser, reduxStore );
+		setupMiddlewares( currentUser, reduxStore );
+		detectHistoryNavigation.start();
+		initJetpackCloudRoutes( '/jetpack-cloud' );
+		page.start( { decodeURLComponents: false } );
+	} );
+};
+
+window.AppBoot = () => {
+	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
+		window.location.href = '/';
+	} else {
+		const user = userFactory();
+		user.initialize().then( () => boot( user ) );
+	}
+};

--- a/client/landing/jetpack-cloud/layout.js
+++ b/client/landing/jetpack-cloud/layout.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import MasterbarLoggedIn from './masterbar';
+import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
+import DocumentHead from 'components/data/document-head';
+
+class JetpackCloudLayout extends Component {
+	static propTypes = {
+		primary: PropTypes.element,
+		secondary: PropTypes.element,
+		// connected props
+		sectionName: PropTypes.string,
+	};
+
+	render() {
+		const sectionClass = classnames( 'layout', `is-section-${ this.props.sectionName }` );
+
+		return (
+			<div className={ sectionClass }>
+				<DocumentHead />
+
+				<MasterbarLoggedIn />
+
+				<div id="content" className="layout__content">
+					<div id="secondary" className="layout__secondary" role="navigation">
+						{ this.props.secondary }
+					</div>
+					<div id="primary" className="layout__primary">
+						{ this.props.primary }
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const sectionName = getSectionName( state );
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		sectionName,
+		siteId,
+	};
+} )( JetpackCloudLayout );

--- a/client/landing/jetpack-cloud/masterbar.jsx
+++ b/client/landing/jetpack-cloud/masterbar.jsx
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function() {
+	return <div>Jetpack</div>;
+}

--- a/client/landing/jetpack-cloud/reducer.js
+++ b/client/landing/jetpack-cloud/reducer.js
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import { combineReducers } from 'state/utils';
+import { reducer as httpData } from 'state/data-layer/http-data';
+
+/**
+ * Reducers
+ */
+import application from 'state/application/reducer';
+import currentUser from 'state/current-user/reducer';
+import documentHead from 'state/document-head/reducer';
+import i18n from 'state/i18n/reducer';
+import notices from 'state/notices/reducer';
+import plans from 'state/plans/reducer';
+import preferences from 'state/preferences/reducer';
+import productsList from 'state/products-list/reducer';
+import purchases from 'state/purchases/reducer';
+import sites from 'state/sites/reducer';
+import ui from 'state/ui/reducer';
+import users from 'state/users/reducer';
+import { reducer as dataRequests } from 'state/data-layer/wpcom-http/utils';
+
+const reducers = {
+	application,
+	currentUser,
+	dataRequests,
+	documentHead,
+	httpData,
+	i18n,
+	notices,
+	plans,
+	preferences,
+	productsList,
+	purchases,
+	sites,
+	ui,
+	users,
+};
+
+export default combineReducers( reducers );

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import {
+	clientRender,
+	jetpackCloud,
+	jetpackBackups,
+	jetpackScan,
+	makeLayout,
+	setupSidebar,
+} from './controller';
+
+const router = ( baseRoute = '' ) => {
+	page( baseRoute + '/', setupSidebar, jetpackCloud, makeLayout, clientRender );
+
+	page( baseRoute + '/backups', setupSidebar, jetpackBackups, makeLayout, clientRender );
+
+	page( baseRoute + '/scan', setupSidebar, jetpackScan, makeLayout, clientRender );
+};
+
+export default router;

--- a/client/landing/jetpack-cloud/section.js
+++ b/client/landing/jetpack-cloud/section.js
@@ -1,0 +1,8 @@
+export const JETPACK_CLOUD_SECTION_DEFINITION = {
+	name: 'jetpack-cloud',
+	paths: [ '/jetpack-cloud' ],
+	module: 'jetpack-cloud',
+	secondary: false,
+	group: 'jetpack-cloud',
+	enableLoggedOut: true,
+};

--- a/client/landing/jetpack-cloud/sidebar.jsx
+++ b/client/landing/jetpack-cloud/sidebar.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function() {
+	return (
+		<div>
+			<ul>
+				<li>
+					<a href="/jetpack-cloud">Dashboard</a>
+				</li>
+				<li>
+					<a href="/jetpack-cloud/backups">Backups</a>
+				</li>
+				<li>
+					<a href="/jetpack-cloud/scan">Scan</a>
+				</li>
+			</ul>
+		</div>
+	);
+}

--- a/config/development.json
+++ b/config/development.json
@@ -69,6 +69,7 @@
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,
+		"jetpack-cloud": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -47,6 +47,7 @@ import analytics from '../lib/analytics';
 import { getLanguage, filterLanguageRevisions } from 'lib/i18n-utils';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { GUTENBOARDING_SECTION_DEFINITION } from '../../client/landing/gutenboarding/section';
+import { JETPACK_CLOUD_SECTION_DEFINITION } from '../../client/landing/jetpack-cloud/section';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -803,6 +804,8 @@ module.exports = function() {
 	loginRouter( serverRouter( app, setUpRoute, null ) );
 
 	handleSectionPath( GUTENBOARDING_SECTION_DEFINITION, '/gutenboarding', 'entry-gutenboarding' );
+
+	handleSectionPath( JETPACK_CLOUD_SECTION_DEFINITION, '/jetpack-cloud', 'entry-jetpack-cloud' );
 
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers
 	app.post(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,6 +147,7 @@ const webpackConfig = {
 	entry: {
 		'entry-main': [ path.join( __dirname, 'client', 'boot', 'app' ) ],
 		'entry-domains-landing': [ path.join( __dirname, 'client', 'landing', 'domains' ) ],
+		'entry-jetpack-cloud': [ path.join( __dirname, 'client', 'landing', 'jetpack-cloud' ) ],
 		'entry-login': [ path.join( __dirname, 'client', 'landing', 'login' ) ],
 		'entry-gutenboarding': [ path.join( __dirname, 'client', 'landing', 'gutenboarding' ) ],
 	},


### PR DESCRIPTION
This PR creates a foundation for the Jetpack Cloud. The idea is to be able to build it in Calypso but to then build it to be standalone and embeddable wherever we want.

This PR is an alternative to #36574 and differs a lot from it - here we create a new entry point and a new app that consumes it.

This initial PR provides us with all the fundamentals we are used to having when we develop in Calypso (state handling, current user, REST API and data layer, i18n and locale management, dev and debugging tools, etc.), but uses a lot of existing Calypso functionality. 

Next steps: The idea is that we should clean up any of it that is not used, but this can be done in subsequent PRs. As I've mentioned in my self-review, there is a lot that can be improved, but our goal is to land this PR as it is and then iterate on all the points in separate PRs. That will allow for more people to be focused on that work and to work on separate tasks simultaneously.

#### Changes proposed in this Pull Request

* Jetpack Cloud: Add fundamentals
  * Entry point
  * Boot (mostly borrowed from Calypso's)
  * Section definition
  * Layout
  * Masterbar
  * Sidebar
  * Example routes
  * Controller
  * Custom reducer
  * Basic stylesheet
* Jetpack Cloud: Create as an app
  * Create package.json
  * Create webpack.config
  * Import the entry point.

#### Testing instructions

* Checkout this branch.
* Build Calypso.
* Go to http://calypso.localhost:3000/jetpack-cloud
* Verify you can navigate through the example routes in the sidebar.
* Run `npx lerna run build --scope="@automattic/jetpack-cloud"` and verify it produces build files in the `apps/jetpack-cloud/dist` dir. 

Note: app build is currently slow as it bundles too many things, but it will naturally get faster as we remove things.