### PR TITLE
Gutenboarding: Remove dark theme

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -43,13 +43,6 @@ $deisgn-selector-selection-space: 175px;
 	text-align: center;
 }
 
-@media ( prefers-color-scheme: dark ) {
-	.design-selector__subtitle,
-	.design-selector__title {
-		color: $white;
-	}
-}
-
 .design-selector__grid-container {
 	position: absolute;
 	margin-top: 1em;

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -4,8 +4,7 @@
 import { __ as NO__ } from '@wordpress/i18n';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import React, { FunctionComponent, useState } from 'react';
-import classNames from 'classnames';
+import React, { FunctionComponent } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
 /**
@@ -24,18 +23,13 @@ import Link from '../components/link';
 
 const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => {
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
-	const [ hasBackground, setHasBackground ] = useState( false );
 
 	return (
 		<>
-			<VerticalBackground onLoad={ () => setHasBackground( true ) } />
+			<VerticalBackground />
 			<Switch>
 				<Route exact path={ Step.IntentGathering }>
-					<div
-						className={ classNames( 'onboarding-block__acquire-intent', {
-							'has-background': hasBackground && siteVertical,
-						} ) }
-					>
+					<div className="onboarding-block__acquire-intent">
 						<div className="onboarding-block__questions">
 							<h2 className="onboarding-block__questions-heading">
 								{ ! siteVertical &&

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -13,17 +13,6 @@ $onboarding-block-css-transition-duration: 750ms;
 	top: 20%;
 	left: 0%;
 	width: 100%;
-
-	.onboarding-block__question-answered,
-	.onboarding-block__question-input,
-	.onboarding-block__question-input::placeholder,
-	.onboarding-block__question,
-	.onboarding-block__questions-heading,
-	.onboarding-block__question-skip {
-		// @TODO: replace with opacity transition as described in https://github.com/Automattic/wp-calypso/pull/38412/files#r358123862
-		transition: $onboarding-block-css-transition-duration color linear
-			$onboarding-block-css-transition-duration;
-	}
 }
 
 .onboarding-block__questions {
@@ -73,13 +62,7 @@ $onboarding-block-css-transition-duration: 750ms;
 	bottom: 0;
 	left: 0;
 	opacity: 0.7;
-	transition: opacity $onboarding-block-css-transition-duration linear,
-		// @TODO: replace with opacity transition
-			background-color $onboarding-block-css-transition-duration linear
-			$onboarding-block-css-transition-duration;
-	@media ( prefers-color-scheme: dark ) {
-		background-color: $dark-gray-900;
-	}
+	transition: opacity $onboarding-block-css-transition-duration linear;
 }
 
 .onboarding-block__background-fade-enter {
@@ -97,31 +80,4 @@ $onboarding-block-css-transition-duration: 750ms;
 .onboarding-block__background-fade-exit,
 .onboarding-block__background-fade-enter-done {
 	transition: opacity $onboarding-block-css-transition-duration linear;
-}
-
-@media ( prefers-color-scheme: dark ) {
-	.onboarding-block__acquire-intent.has-background {
-		.onboarding-block__questions-heading {
-			color: $light-gray-300;
-		}
-		.onboarding-block__question {
-			color: $light-gray-300;
-
-			.onboarding-block__question-input {
-				&::placeholder {
-					color: $light-gray-900;
-				}
-				&:focus,
-				&:active {
-					color: $light-gray-300;
-				}
-			}
-			.onboarding-block__question-answered {
-				color: $blue-medium-highlight;
-			}
-		}
-		.components-button.is-link.onboarding-block__question-skip {
-			color: $light-gray-500;
-		}
-	}
 }

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -17,10 +17,12 @@ import { STORE_KEY } from '../stores/onboard';
 import defaultImageUrl from '../../../../static/images/verticals/default.jpg';
 
 export interface VerticalBackgroundProps {
-	onLoad: () => void;
+	onLoad?: () => void;
 }
 
-const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( { onLoad } ) => {
+const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( {
+	onLoad = () => undefined,
+} ) => {
 	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 	const [ imageUrl, setImageUrl ] = useState< string | undefined >();
 

--- a/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-background.tsx
@@ -16,13 +16,7 @@ import { STORE_KEY } from '../stores/onboard';
  */
 import defaultImageUrl from '../../../../static/images/verticals/default.jpg';
 
-export interface VerticalBackgroundProps {
-	onLoad?: () => void;
-}
-
-const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( {
-	onLoad = () => undefined,
-} ) => {
+const VerticalBackground: FunctionComponent = () => {
 	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 	const [ imageUrl, setImageUrl ] = useState< string | undefined >();
 
@@ -35,7 +29,6 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( {
 			const preloadImage = new window.Image();
 			const failureHandler = () => {
 				setImageUrl( defaultImageUrl );
-				onLoad();
 			};
 
 			// If this is a user-supplied vertical, use the default background.
@@ -47,7 +40,6 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( {
 			const successHandler = ( { default: url }: { default: string } ) => {
 				preloadImage.onload = () => {
 					setImageUrl( url );
-					onLoad();
 				};
 				preloadImage.onerror = failureHandler;
 				preloadImage.src = url;
@@ -66,7 +58,7 @@ const VerticalBackground: FunctionComponent< VerticalBackgroundProps > = ( {
 			};
 		}
 		setImageUrl( undefined );
-	}, [ siteVertical, onLoad ] );
+	}, [ siteVertical ] );
 
 	return (
 		<SwitchTransition mode="in-out">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the dark theme. It's only partially designed and implemented and is slowing us down.

Part of #38587

Before (prefer dark):
![Screen Shot 2020-01-10 at 17 44 07](https://user-images.githubusercontent.com/841763/72170293-e7990200-33d0-11ea-943d-d2608bcad5ee.png)

After (prefer dark):
![Screen Shot 2020-01-10 at 17 43 58](https://user-images.githubusercontent.com/841763/72170281-e36ce480-33d0-11ea-8f34-b4c2b62f0b40.png)


#### Testing instructions

- Vist `/gutenboarding`
- Pick a vertical
- Toggle between dark/light mode. We should always have light theme. _Settings_ -> _General_ on macOS:

![Screen Shot 2020-01-10 at 17 41 18](https://user-images.githubusercontent.com/841763/72170056-8bce7900-33d0-11ea-8476-96cfbef7bde8.png)

