### PR TITLE
Gutenboarding: Improve skip button styles

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -48,6 +48,19 @@ $onboarding-block-css-transition-duration: 750ms;
 	margin: 10px 0;
 	text-decoration: none;
 	position: relative;
+
+	&:hover,
+	&:focus {
+		background: none;
+		border: none;
+		color: $blue-medium-focus;
+		outline: none;
+		box-shadow: none;
+	}
+
+	&:focus {
+		border-bottom: 2px solid $blue-medium-focus;
+	}
 }
 
 .onboarding-block__question input {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Improves the skip button styling

##### Before

###### Hover
![Screen Shot 2020-01-10 at 18 03 05](https://user-images.githubusercontent.com/841763/72171623-a5bd8b00-33d3-11ea-93b4-d9f68b931f28.png)

###### Focus
![Screen Shot 2020-01-10 at 18 02 54](https://user-images.githubusercontent.com/841763/72171619-a3f3c780-33d3-11ea-9abf-457ed25fe131.png)

##### After

###### Hover
![Screen Shot 2020-01-10 at 18 02 16](https://user-images.githubusercontent.com/841763/72171614-a0f8d700-33d3-11ea-8dd6-ec1cb8e1aa8c.png)

###### Focus
![Screen Shot 2020-01-10 at 18 02 37](https://user-images.githubusercontent.com/841763/72171610-9dfde680-33d3-11ea-8378-f4081cc0d2f2.png)

#### Testing instructions

* Visit `/gutenboarding` and hover/focus the continue button
