### PR TITLE
Remove HotJar during the Jetpack connect flow

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -34,7 +34,6 @@ import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
 import versionCompare from 'lib/version-compare';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
@@ -754,8 +753,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackAuthorize );
+export default flowRight( connectComponent, localize )( JetpackAuthorize );

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -17,7 +17,6 @@ import JetpackInstallStep from './install-step';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addCalypsoEnvQueryArg } from './utils';
 import { confirmJetpackInstallStatus } from 'state/jetpack-connect/actions';
 import { externalRedirect } from 'lib/route';
@@ -139,8 +138,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( InstallInstructions );
+export default flowRight( connectComponent, localize )( InstallInstructions );

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -16,7 +16,6 @@ import DocumentHead from 'components/data/document-head';
 import JetpackLogo from 'components/jetpack-logo';
 import BackButton from 'components/back-button';
 import SiteUrlInput from '../site-url-input';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WordPressLogo from 'components/wordpress-logo';
 import { cleanUrl } from '../utils';
 import { persistSession } from '../persistence-utils';
@@ -162,8 +161,4 @@ const connectComponent = connect( null, {
 	recordTracksEvent,
 } );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackNewSite );
+export default flowRight( connectComponent, localize )( JetpackNewSite );

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -23,7 +23,6 @@ import MainWrapper from './main-wrapper';
 import page from 'page';
 import SiteUrlInput from './site-url-input';
 import versionCompare from 'lib/version-compare';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addCalypsoEnvQueryArg, cleanUrl } from './utils';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
@@ -416,8 +415,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackConnectMain );
+export default flowRight( connectComponent, localize )( JetpackConnectMain );

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -19,7 +19,6 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import Placeholder from './plans-placeholder';
 import PlansGrid from './plans-grid';
 import QueryPlans from 'components/data/query-plans';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
@@ -133,8 +132,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( PlansLanding );
+export default flowRight( connectComponent, localize )( PlansLanding );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -35,7 +35,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { persistSignupDestination } from 'signup/utils';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
@@ -262,4 +261,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight( connectComponent, localize, withTrackingTool( 'HotJar' ) )( Plans );
+export default flowRight( connectComponent, localize )( Plans );

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -26,7 +26,6 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import MainWrapper from './main-wrapper';
 import Spinner from 'components/spinner';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addCalypsoEnvQueryArg } from './utils';
 import { addQueryArgs } from 'lib/route';
 import {
@@ -303,7 +302,6 @@ export class OrgCredentialsForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				{ ( this.isInvalidCreds() || ! installError ) && (
-					// eslint-disable-next-line react/no-jsx-bind
 					<LoggedOutFormLinkItem href={ manualInstallUrl } onClick={ manualInstallClick }>
 						{ translate( 'Install Jetpack manually' ) }
 					</LoggedOutFormLinkItem>
@@ -383,8 +381,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( OrgCredentialsForm );
+export default flowRight( connectComponent, localize )( OrgCredentialsForm );

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -26,7 +26,6 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
 import SignupForm from 'blocks/signup-form';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { addQueryArgs } from 'lib/route';
 import { authQueryPropTypes } from './utils';
@@ -250,8 +249,4 @@ const connectComponent = connect( null, {
 	warningNotice: warningNoticeAction,
 } );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackSignup );
+export default flowRight( connectComponent, localize )( JetpackSignup );

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -16,7 +16,6 @@ import SkipButton from './skip-button';
 import SiteTopicForm from 'signup/steps/site-topic/form';
 import WpcomColophon from 'components/wpcom-colophon';
 import jetpackOnly from './jetpack-only';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import versionCompare from 'lib/version-compare';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption } from 'state/sites/selectors';
@@ -86,9 +85,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	jetpackOnly,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackSiteTopic );
+export default flowRight( connectComponent, jetpackOnly, localize )( JetpackSiteTopic );

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -15,7 +15,6 @@ import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
 import SkipButton from './skip-button';
 import SiteTypeForm from 'signup/steps/site-type/form';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteType } from 'state/jetpack-connect/actions';
@@ -77,9 +76,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	jetpackOnly,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackSiteType );
+export default flowRight( connectComponent, jetpackOnly, localize )( JetpackSiteType );

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -30,7 +30,6 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSSO } from 'state/jetpack-connect/selectors';
@@ -489,8 +488,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackSsoForm );
+export default flowRight( connectComponent, localize )( JetpackSsoForm );

--- a/client/jetpack-connect/user-type/index.js
+++ b/client/jetpack-connect/user-type/index.js
@@ -15,7 +15,6 @@ import jetpackOnly from '../jetpack-only';
 import MainWrapper from '../main-wrapper';
 import SkipButton from '../skip-button';
 import UserTypeForm from './form';
-import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteUserType } from 'state/jetpack-connect/actions';
@@ -66,9 +65,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	jetpackOnly,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackUserType );
+export default flowRight( connectComponent, jetpackOnly, localize )( JetpackUserType );


### PR DESCRIPTION
We made a decision not to use HotJar during Jetpack connect.

See: p1HpG7-8ga-p2

#### Changes proposed in this Pull Request

* Remove hotjar from the Jetpack connect flow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect Jetpack with the Chrome debugger open
* You should not see any requests to *.hotjar.com in the network inspector
