### PR TITLE
composite-checkout: Use allowed payment methods from cart

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
@@ -64,7 +64,7 @@ export function createPaymentMethods( {
 			  } )
 			: null;
 
-	const stripeMethod = isMethodEnabled( 'stripe', allowedPaymentMethods )
+	const stripeMethod = isMethodEnabled( 'card', allowedPaymentMethods )
 		? createStripeMethod( {
 				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,
 				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
@@ -114,7 +114,7 @@ export function createPaymentMethods( {
 			  } )
 			: null;
 
-	const existingCardMethods = isMethodEnabled( 'existing-cards', allowedPaymentMethods )
+	const existingCardMethods = isMethodEnabled( 'card', allowedPaymentMethods )
 		? storedCards.map( storedDetails =>
 				createExistingCardMethod( {
 					id: `existingCard-${ storedDetails.stored_details_id }`,

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -95,6 +95,7 @@ export default function CompositeCheckout( {
 		changePlanLength,
 		errors,
 		isLoading,
+		allowedPaymentMethods: serverAllowedPaymentMethods,
 	} = useShoppingCart( siteSlug, setCart || wpcomSetCart, getCart || wpcomGetCart );
 
 	const { registerStore } = registry;
@@ -117,7 +118,7 @@ export default function CompositeCheckout( {
 			createPaymentMethods( {
 				isLoading: isLoading || isLoadingStoredCards,
 				storedCards,
-				allowedPaymentMethods,
+				allowedPaymentMethods: allowedPaymentMethods || serverAllowedPaymentMethods,
 				select,
 				registerStore,
 				wpcom,
@@ -127,6 +128,7 @@ export default function CompositeCheckout( {
 			} ),
 		[
 			allowedPaymentMethods,
+			serverAllowedPaymentMethods,
 			isLoading,
 			isLoadingStoredCards,
 			storedCards,

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -27,6 +27,8 @@ const debug = debugFactory( 'composite-checkout-wpcom:shopping-cart-manager' );
  * communicating with the backend are handled inside the hook. The interface
  * exposed by the hook consists of the following:
  *
+ *     * isLoading: true if we are loading the cart
+ *     * allowedPaymentMethods: the allowed payment method keys
  *     * items: the array of items currently in the cart
  *     * tax: the tax line item
  *     * total: the total price line item
@@ -36,6 +38,7 @@ const debug = debugFactory( 'composite-checkout-wpcom:shopping-cart-manager' );
  */
 export interface ShoppingCartManager {
 	isLoading: boolean;
+	allowedPaymentMethods: string[];
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem;
 	total: CheckoutCartTotal;
@@ -206,6 +209,7 @@ export function useShoppingCart(
 		total: cart.total,
 		credits: cart.credits,
 		errors: responseCart.messages?.errors ?? [],
+		allowedPaymentMethods: cart.allowedPaymentMethods,
 		addItem,
 		removeItem,
 		changePlanLength,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The shopping cart endpoint makes some decisions about what payment methods can be safely displayed to the user (the server sends an `allowed_payment_methods` array of strings). Currently that data is transformed by `useShoppingCart` into an `allowedPaymentMethods` array on the `WPCOMCart` object but is then not added to the response value of the hook and is ignored in the UI. The `CompositeCheckout` component does have its own `allowedPaymentMethods` prop, but it is used only for testing.

This PR adds the array to the response value of `useShoppingCart` and changes the behavior of the `CompositeCheckout` component in Calypso to use the shopping cart's `allowedPaymentMethods` array if the prop by that name is undefined (which preserves its use for testing). It also renames the string keys used to enable the stripe and existing card payment methods so they are both activated by the key `card` (because the server does not distinguish between the two and also isn't aware that the card is handled by stripe).

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to your cart and visit checkout.
- Verify that in the payment method selection step you see existing card options, the new card option, and the paypal option. If you have enough credits for the full purchase you may also see the credits option.