### PR TITLE
Prevent safari from prompting for storage

### DIFF
--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { kebabCase } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { once } from 'lib/memoize-last';
@@ -11,7 +16,7 @@ import {
 } from './bypass';
 import { StoredItems } from './types';
 import { mc } from 'lib/analytics';
-import { kebabCase } from 'lodash';
+import config from 'config';
 
 let shouldBypass = false;
 
@@ -23,6 +28,7 @@ const SANITY_TEST_KEY = 'browser-storage-sanity-test';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isAffectedSafari =
+	config.isEnabled( 'safari-idb-mitigation' ) &&
 	typeof window !== 'undefined' &&
 	!! window.IDBKeyRange?.lowerBound( 0 ).includes &&
 	!! ( window as any ).webkitAudioContext &&

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -21,9 +21,11 @@ const STORE_NAME = 'calypso_store';
 
 const SANITY_TEST_KEY = 'browser-storage-sanity-test';
 
-function isAffectedSafari() {
-	return true;
-}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isAffectedSafari =
+	!! window.IDBKeyRange?.lowerBound( 0 ).includes &&
+	!! ( window as any ).webkitAudioContext &&
+	!! window.PointerEvent;
 
 const getDB = once( () => {
 	const request = window.indexedDB.open( DB_NAME, DB_VERSION );
@@ -141,7 +143,7 @@ function idbSet< T >( key: string, value: T ): Promise< void > {
 				}
 				// if we're on safari 13, we need to clear out the object store every
 				// so many writes to make sure we don't chew up the transaction log
-				if ( isAffectedSafari() && ++idbWriteCount % 20 === 0 ) {
+				if ( isAffectedSafari && ++idbWriteCount % 20 === 0 ) {
 					await idbSafariReset();
 				}
 

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -21,6 +21,10 @@ const STORE_NAME = 'calypso_store';
 
 const SANITY_TEST_KEY = 'browser-storage-sanity-test';
 
+function isAffectedSafari() {
+	return true;
+}
+
 const getDB = once( () => {
 	const request = window.indexedDB.open( DB_NAME, DB_VERSION );
 	return new Promise< IDBDatabase >( ( resolve, reject ) => {
@@ -125,10 +129,22 @@ function idbGetAll( pattern?: RegExp ): Promise< StoredItems > {
 	);
 }
 
+let idbWriteCount = 0;
+let idbWriteBlock: Promise< void > | null = null;
 function idbSet< T >( key: string, value: T ): Promise< void > {
 	return new Promise( ( resolve, reject ) => {
 		getDB()
-			.then( db => {
+			.then( async db => {
+				// if there's a write lock, wait on it
+				if ( idbWriteBlock ) {
+					await idbWriteBlock;
+				}
+				// if we're on safari 13, we need to clear out the object store every
+				// so many writes to make sure we don't chew up the transaction log
+				if ( isAffectedSafari() && ++idbWriteCount % 20 === 0 ) {
+					await idbSafariReset();
+				}
+
 				const transaction = db.transaction( STORE_NAME, 'readwrite' );
 				transaction.objectStore( STORE_NAME ).put( value, key );
 
@@ -158,6 +174,41 @@ function idbClear(): Promise< void > {
 				transaction.onerror = error;
 			} )
 			.catch( err => reject( err ) );
+	} );
+}
+
+async function idbSafariReset() {
+	if ( idbWriteBlock ) {
+		return idbWriteBlock;
+	}
+	idbWriteBlock = _idbSafariReset();
+	idbWriteBlock.finally( () => {
+		idbWriteBlock = null;
+	} );
+	return idbWriteBlock;
+}
+
+async function _idbSafariReset(): Promise< void > {
+	const items = await idbGetAll();
+	await idbClear();
+
+	return new Promise( ( resolve, reject ) => {
+		getDB().then(
+			db => {
+				const transaction = db.transaction( STORE_NAME, 'readwrite' );
+				// eslint-disable-next-line prefer-const
+				for ( let [ key, value ] of Object.entries( items ) ) {
+					transaction.objectStore( STORE_NAME ).put( value, key );
+				}
+				const success = () => resolve();
+				const error = () => reject( transaction.error );
+
+				transaction.oncomplete = success;
+				transaction.onabort = error;
+				transaction.onerror = error;
+			},
+			err => reject( err )
+		);
 	} );
 }
 

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -23,6 +23,7 @@ const SANITY_TEST_KEY = 'browser-storage-sanity-test';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isAffectedSafari =
+	typeof window !== 'undefined' &&
 	!! window.IDBKeyRange?.lowerBound( 0 ).includes &&
 	!! ( window as any ).webkitAudioContext &&
 	!! window.PointerEvent;

--- a/config/development.json
+++ b/config/development.json
@@ -139,6 +139,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,6 +91,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,

--- a/config/production.json
+++ b/config/production.json
@@ -100,6 +100,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"safari-idb-mitigation": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -101,6 +101,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,6 +113,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,


### PR DESCRIPTION
Safari has a bug where the write-ahead log that indexed db uses grows continually until the page reloads, and this size counts towards our storage quota. If you use Calypso long enough, eventually you'll be prompted to give us more storage room, even though we're not using much.

To work around this, clear out storage before saving off the redux tree. This also clears the write-ahead log and keeps us under the cap.


Fixes #36858 