### PR TITLE
Gutenboarding: Fix design selector description always visible

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -227,8 +227,8 @@ $deisgn-selector-selection-space: 175px;
 
 .design-selector__description-container {
 	@include design-selector-transition();
-	position: fixed;
 	@include design-selector-hide;
+	visibility: hidden;
 
 	position: fixed;
 	display: flex;
@@ -245,6 +245,7 @@ $deisgn-selector-selection-space: 175px;
 	&.enter-active,
 	&.enter-done {
 		@include design-selector-show;
+		visibility: visible;
 	}
 }
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**

Design selector description should be hidden when no design is selected.

**Fixes**

<img width="1249" alt="Screenshot 2020-01-10 at 22 59 43" src="https://user-images.githubusercontent.com/14192054/72186374-cb5f8a00-33fd-11ea-952c-bbbb4b8a5932.png">

