### PR TITLE
Components: Suggestions escape regexp

### DIFF
--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { escapeRegExp, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -144,7 +144,7 @@ class SuggestionSearch extends Component {
 				/>
 				<Suggestions
 					ref={ this.setSuggestionsRef }
-					query={ escapeRegExp( this.state.query ) }
+					query={ this.state.query }
 					suggestions={ this.getSuggestions() }
 					suggest={ this.handleSuggestionMouseDown }
 					railcar={ this.props.railcar }

--- a/package-lock.json
+++ b/package-lock.json
@@ -416,7 +416,7 @@
 			"version": "file:packages/components",
 			"requires": {
 				"classnames": "^2.2.6",
-				"enzyme": "^3.10.0",
+				"escape-string-regexp": "^2.0.0",
 				"gridicons": "^3.3.1",
 				"lodash": "^4.17.15",
 				"prop-types": "^15.7.2",
@@ -6835,7 +6835,8 @@
 		"array-filter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-			"integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+			"integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+			"dev": true
 		},
 		"array-find": {
 			"version": "1.0.0",
@@ -8864,6 +8865,7 @@
 			"version": "1.0.0-rc.3",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
 			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+			"dev": true,
 			"requires": {
 				"css-select": "~1.2.0",
 				"dom-serializer": "~0.1.1",
@@ -11897,7 +11899,8 @@
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+			"dev": true
 		},
 		"dns-equal": {
 			"version": "1.0.0",
@@ -12442,6 +12445,7 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
 			"integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
+			"dev": true,
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
 				"cheerio": "^1.0.0-rc.2",
@@ -15711,6 +15715,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.2.0.tgz",
 			"integrity": "sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==",
+			"dev": true,
 			"requires": {
 				"array-filter": "^1.0.0"
 			}
@@ -16763,7 +16768,8 @@
 		"is-boolean-object": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M="
+			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -17058,7 +17064,8 @@
 		"is-number-object": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k="
+			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+			"dev": true
 		},
 		"is-obj": {
 			"version": "1.0.1",
@@ -17164,12 +17171,14 @@
 		"is-string": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
+			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+			"dev": true
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+			"dev": true
 		},
 		"is-supported-regexp-flag": {
 			"version": "1.0.1",
@@ -19462,7 +19471,8 @@
 		"lodash.escape": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
+			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+			"dev": true
 		},
 		"lodash.filter": {
 			"version": "4.6.0",
@@ -19479,7 +19489,8 @@
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
 		},
 		"lodash.foreach": {
 			"version": "4.5.0",
@@ -19512,7 +19523,8 @@
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -20724,7 +20736,8 @@
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+			"dev": true
 		},
 		"morgan": {
 			"version": "1.9.1",
@@ -20877,6 +20890,7 @@
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.0.tgz",
 			"integrity": "sha512-2v52FTw7RPqieZr3Gth1luAXZR7Je6q3KaDHY5bjl/paDUdMu35fZ8ICNgiYJRr3tf3NMvIQQR1r27AvEr9CRA==",
+			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
 				"moo": "^0.4.3",
@@ -22828,6 +22842,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -26756,6 +26771,7 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
 			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
 			}
@@ -26763,7 +26779,8 @@
 		"railroad-diagrams": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+			"dev": true
 		},
 		"ramda": {
 			"version": "0.26.1",
@@ -26774,6 +26791,7 @@
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
 			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
 				"ret": "~0.1.10"
@@ -29011,6 +29029,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+			"dev": true,
 			"requires": {
 				"lodash.flattendeep": "^4.4.0",
 				"nearley": "^2.7.10"
@@ -30961,6 +30980,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
 			"integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.13.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
 	"types": "types",
 	"dependencies": {
 		"classnames": "^2.2.6",
-		"enzyme": "^3.10.0",
+		"escape-string-regexp": "^2.0.0",
 		"gridicons": "^3.3.1",
 		"lodash": "^4.17.15",
 		"prop-types": "^15.7.2",

--- a/packages/components/src/suggestions/item.jsx
+++ b/packages/components/src/suggestions/item.jsx
@@ -27,9 +27,11 @@ class Item extends PureComponent {
 
 	/**
 	 * Highlights the part of the text that matches the query.
+	 *
 	 * @param  {string} text  Text.
 	 * @param  {string} query The text to be matched.
-	 * @returns {element}      A React element including the highlighted text.
+	 *
+	 * @returns {React.ReactElement<JSX.IntrinsicElements['span']>} An element including the highlighted text.
 	 */
 	createTextWithHighlight( text, query ) {
 		const re = new RegExp( '(' + escapeRegexp( query ) + ')', 'gi' );

--- a/packages/components/src/suggestions/item.jsx
+++ b/packages/components/src/suggestions/item.jsx
@@ -4,6 +4,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import escapeRegexp from 'escape-string-regexp';
 
 class Item extends PureComponent {
 	static propTypes = {
@@ -31,7 +32,7 @@ class Item extends PureComponent {
 	 * @returns {element}      A React element including the highlighted text.
 	 */
 	createTextWithHighlight( text, query ) {
-		const re = new RegExp( '(' + query + ')', 'gi' );
+		const re = new RegExp( '(' + escapeRegexp( query ) + ')', 'gi' );
 		const parts = text.split( re );
 
 		return parts.map( ( part, i ) => {

--- a/packages/components/src/suggestions/item.jsx
+++ b/packages/components/src/suggestions/item.jsx
@@ -31,7 +31,7 @@ class Item extends PureComponent {
 	 * @param  {string} text  Text.
 	 * @param  {string} query The text to be matched.
 	 *
-	 * @returns {React.ReactElement<JSX.IntrinsicElements['span']>} An element including the highlighted text.
+	 * @returns {Array< ReactElement< JSX.IntrinsicElements[ 'span' ] > >} An element including the highlighted text.
 	 */
 	createTextWithHighlight( text, query ) {
 		const re = new RegExp( '(' + escapeRegexp( query ) + ')', 'gi' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Escape a user input Regexp in the `Item` component used internally by `Suggestions`.

Fixes an error when an invalid Regexp may be formed.

#### Testing instructions

* At [current `/gutenboarding`](https://wpcalypso.wordpress.com/gutenboarding), enter `[` in the vertical search. An error occurs and the block will put the editor into block error state.
* On [this branch `/gutenboarding`](https://calypso.live/gutenboarding?branch=fix/suggestions-regexp-error), enter `[` in the vertical search. No error.

The same issue is likely present in current signup.