### PR TITLE
Gutenboarding: prevent unneccessary cursor change over gutenbo…

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -3,12 +3,7 @@
  */
 import '@wordpress/editor'; // This shouldn't be necessary
 import { __ as NO__ } from '@wordpress/i18n';
-import {
-	BlockEditorProvider,
-	BlockList,
-	WritingFlow,
-	ObserveTyping,
-} from '@wordpress/block-editor';
+import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { Popover, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
@@ -67,11 +62,7 @@ export function Gutenboard() {
 								aria-label={ NO__( 'Onboarding screen content' ) }
 								tabIndex={ -1 }
 							>
-								<WritingFlow>
-									<ObserveTyping>
-										<BlockList className="gutenboarding-block-list" />
-									</ObserveTyping>
-								</WritingFlow>
+								<BlockList className="gutenboarding-block-list" />
 							</div>
 						</div>
 					</BlockEditorProvider>


### PR DESCRIPTION
The WritingFlow and ObserveTyping componenets seem to be used for communicating between blocks, since gutenboarding is currently implemented as a single block, we do not need these components yet. Removing those blocks fixes the cursor issue identified here #38682. We can add these components in again once we need communication between multiple blocks in gutenboarding.

#### Changes proposed in this Pull Request

* Remove unneccessary WritingFlow and ObserveTyping elements to prevent cursor from changing  

#### Testing instructions

Navigate to /gutenboarding
Move the cursor over the middle of the page
Cursor should remain the pointer type

![Jan-13-2020 11-15-22](https://user-images.githubusercontent.com/22446385/72226433-0d532080-35f6-11ea-9296-e0cfde006746.gif)

Fixes #38682
