### PR TITLE
Gutenboarding: fix height of card media/img

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -52,6 +52,7 @@ const PageLayoutSelector: FunctionComponent< Props > = ( { templates } ) => {
 								<img
 									alt={ template.description }
 									src={ removeQueryArgs( template.preview, 'w' ) }
+									className="page-layout-selector__card-media-img"
 								/>
 							</CardMedia>
 							<CardFooter className="page-layout-selector__card-footer" as="span">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -49,7 +49,6 @@ const PageLayoutSelector: FunctionComponent< Props > = ( { templates } ) => {
 								<img
 									alt={ template.description }
 									src={ removeQueryArgs( template.preview, 'w' ) }
-									className="page-layout-selector__card-media-img"
 								/>
 							</CardMedia>
 							<CardFooter className="page-layout-selector__card-footer" as="span">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -44,11 +44,17 @@ const PageLayoutSelector: FunctionComponent< Props > = ( { templates } ) => {
 							} ) }
 							onClick={ () => togglePageLayout( template ) }
 							key={ template.slug }
-							style={ { backgroundImage: `url( "${ removeQueryArgs( template.preview, 'w' ) }" )` } }
 						>
 							<span className="page-layout-selector__selected-indicator">
 								<Icon icon="yes" size={ 24 } />
 							</span>
+							<CardMedia className="page-layout-selector__card-media" as="span">
+								<img
+									alt={ template.description }
+									src={ removeQueryArgs( template.preview, 'w' ) }
+									className="page-layout-selector__card-media-img"
+								/>
+							</CardMedia>
 							<CardFooter className="page-layout-selector__card-footer" as="span">
 								{ template.title }
 							</CardFooter>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -45,9 +45,6 @@ const PageLayoutSelector: FunctionComponent< Props > = ( { templates } ) => {
 							onClick={ () => togglePageLayout( template ) }
 							key={ template.slug }
 						>
-							<span className="page-layout-selector__selected-indicator">
-								<Icon icon="yes" size={ 24 } />
-							</span>
 							<CardMedia className="page-layout-selector__card-media" as="span">
 								<img
 									alt={ template.description }
@@ -58,6 +55,9 @@ const PageLayoutSelector: FunctionComponent< Props > = ( { templates } ) => {
 							<CardFooter className="page-layout-selector__card-footer" as="span">
 								{ template.title }
 							</CardFooter>
+							<span className="page-layout-selector__selected-indicator">
+								<Icon icon="yes" size={ 24 } />
+							</span>
 						</Card>
 					) ) }
 				</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -44,17 +44,11 @@ const PageLayoutSelector: FunctionComponent< Props > = ( { templates } ) => {
 							} ) }
 							onClick={ () => togglePageLayout( template ) }
 							key={ template.slug }
+							style={ { backgroundImage: `url( "${ removeQueryArgs( template.preview, 'w' ) }" )` } }
 						>
 							<span className="page-layout-selector__selected-indicator">
 								<Icon icon="yes" size={ 24 } />
 							</span>
-							<CardMedia className="page-layout-selector__card-media" as="span">
-								<img
-									alt={ template.description }
-									src={ removeQueryArgs( template.preview, 'w' ) }
-									className="page-layout-selector__card-media-img"
-								/>
-							</CardMedia>
 							<CardFooter className="page-layout-selector__card-footer" as="span">
 								{ template.title }
 							</CardFooter>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -123,8 +123,19 @@ $deisgn-selector-selection-space: 175px;
 .page-layout-selector__grid {
 	display: grid;
 	grid-gap: 1.25em;
+	grid-template-columns: repeat( auto-fill, minmax( 280px, 1fr ) );
+
 	@include breakpoint( '>660px' ) {
 		grid-template-columns: 1fr 1fr 1fr;
+	}
+}
+
+.page-layout-selector__grid {
+	.page-layout-selector__item {
+		background: none;
+		background-position: center top;
+		background-repeat: no-repeat;
+		background-size: cover;
 	}
 }
 
@@ -132,6 +143,15 @@ $deisgn-selector-selection-space: 175px;
 	position: relative;
 	overflow: hidden;
 	padding: 2px;
+	width: 100%;
+
+	&:before {
+		content: "";
+		display: inline-block;
+		width: 1px;
+		height: 0;
+		padding-bottom: 87.5%;
+	}
 
 	&.is-selected {
 		.page-layout-selector__selected-indicator {
@@ -223,14 +243,7 @@ $deisgn-selector-selection-space: 175px;
 	display: block;
 	margin-left: -2px;
 	margin-right: -2px;
-}
-
-.page-layout-selector__card-media {
-	.page-layout-selector__card-media-img {
-		height: 280px;
-		object-fit: cover;
-		object-position: top;
-	}
+	background: $white;
 }
 
 .design-selector__description-container {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -131,7 +131,7 @@ $deisgn-selector-selection-space: 175px;
 	overflow: hidden;
 	padding: 2px;
 
-	&:before {
+	&::before {
 		content: "";
 		display: inline-block;
 		width: 1px;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -129,6 +129,7 @@ $deisgn-selector-selection-space: 175px;
 .page-layout-selector__item {
 	position: relative;
 	overflow: hidden;
+	padding: 2px;
 
 	&:before {
 		content: "";
@@ -225,6 +226,8 @@ $deisgn-selector-selection-space: 175px;
 .page-layout-selector__card-footer,
 .page-layout-selector__card-media {
 	display: block;
+	margin-left: -2px;
+	margin-right: -2px;
 }
 
 // Necessary for grid layout

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -225,6 +225,14 @@ $deisgn-selector-selection-space: 175px;
 	margin-right: -2px;
 }
 
+.page-layout-selector__card-media {
+	.page-layout-selector__card-media-img {
+		height: 280px;
+		object-fit: cover;
+		object-position: top;
+	}
+}
+
 .design-selector__description-container {
 	@include design-selector-transition();
 	position: fixed;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -124,26 +124,14 @@ $deisgn-selector-selection-space: 175px;
 	display: grid;
 	grid-gap: 1.25em;
 	grid-template-columns: repeat( auto-fill, minmax( 280px, 1fr ) );
-
 	@include breakpoint( '>660px' ) {
 		grid-template-columns: 1fr 1fr 1fr;
-	}
-}
-
-.page-layout-selector__grid {
-	.page-layout-selector__item {
-		background: none;
-		background-position: center top;
-		background-repeat: no-repeat;
-		background-size: cover;
 	}
 }
 
 .page-layout-selector__item {
 	position: relative;
 	overflow: hidden;
-	padding: 2px;
-	width: 100%;
 
 	&:before {
 		content: "";
@@ -185,7 +173,6 @@ $deisgn-selector-selection-space: 175px;
 .page-layout-selector__selected-indicator {
 	$size: 24px; // should match icon size
 	$full-size: floor( $size * 1.66 );
-
 	position: absolute;
 	top: 0;
 	right: 0;
@@ -241,9 +228,23 @@ $deisgn-selector-selection-space: 175px;
 .page-layout-selector__card-footer,
 .page-layout-selector__card-media {
 	display: block;
-	margin-left: -2px;
-	margin-right: -2px;
+}
+
+// Necessary for grid layout
+.page-layout-selector__card-footer {
 	background: $white;
+	bottom: 0;
+	position: absolute;
+	width: 100%;
+}
+
+// Necessary for grid layout
+.page-layout-selector__card-media {
+	.page-layout-selector__card-media-img {
+		position: absolute;
+		top: 0;
+		width: 100%;
+	}
 }
 
 .design-selector__description-container {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -132,11 +132,13 @@ $deisgn-selector-selection-space: 175px;
 	padding: 2px;
 
 	&::before {
-		content: "";
+		content: '';
 		display: inline-block;
 		width: 1px;
 		height: 0;
-		padding-bottom: 87.5%;
+		padding-bottom: calc(
+			100% * 7 / 8
+		); // This gives us a 7:8 aspect ratio for individual grid items.
 	}
 
 	&.is-selected {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -240,11 +240,9 @@ $deisgn-selector-selection-space: 175px;
 
 // Necessary for grid layout
 .page-layout-selector__card-media {
-	.page-layout-selector__card-media-img {
-		position: absolute;
-		top: 0;
-		width: 100%;
-	}
+	position: absolute;
+	top: 0;
+	width: 100%;
 }
 
 .design-selector__description-container {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -124,9 +124,6 @@ $deisgn-selector-selection-space: 175px;
 	display: grid;
 	grid-gap: 1.25em;
 	grid-template-columns: repeat( auto-fill, minmax( 280px, 1fr ) );
-	@include breakpoint( '>660px' ) {
-		grid-template-columns: 1fr 1fr 1fr;
-	}
 }
 
 .page-layout-selector__item {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses #38762 (partially?)

Sets a fixed height of 280px to the imgs passed to the card media.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In page selector section:

![Kapture 2020-01-13 at 14 55 33](https://user-images.githubusercontent.com/1705499/72257641-ca547580-3614-11ea-845a-a587a0422001.gif)

CC @dwolfe 