### PR TITLE
Make `blog_public=0` a checkbox instead of a separate option in the Privacy picker

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -296,25 +296,22 @@ export class SiteSettingsFormGeneral extends Component {
 		return (
 			<FormFieldset>
 				{ ! siteIsJetpack && (
-					<>
-						<FormLabel className="site-settings__visibility-label">
-							<FormRadio
-								name="blog_public"
-								value="1"
-								checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
-								onChange={ handleRadio }
-								disabled={ isRequestingSettings }
-								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-							/>
-							<span>{ translate( 'Public' ) }</span>
-						</FormLabel>
-						<FormSettingExplanation isIndented>
-							{ translate(
-								'Your site is visible to everyone.'
-							) }
-						</FormSettingExplanation>
-					</>
+					<FormLabel className="site-settings__visibility-label">
+						<FormRadio
+							name="blog_public"
+							value="1"
+							checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
+							onChange={ handleRadio }
+							disabled={ isRequestingSettings }
+							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+						/>
+						<span>{ translate( 'Public' ) }</span>
+					</FormLabel>
 				) }
+
+				<FormSettingExplanation isIndented>
+					{ translate( 'Your site is visible to everyone.' ) }
+				</FormSettingExplanation>
 
 				<FormLabel className="site-settings__visibility-label is-checkbox">
 					<FormInputCheckbox

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -283,19 +283,23 @@ export class SiteSettingsFormGeneral extends Component {
 		const {
 			fields,
 			handleRadio,
+			updateFields,
 			isRequestingSettings,
 			eventTracker,
 			siteIsJetpack,
+			trackEvent,
 			translate,
 		} = this.props;
 
+		const currentValue = parseInt( fields.blog_public, 10 );
+
 		return (
 			<FormFieldset>
-				<FormLabel>
+				<FormLabel className="site-settings__visibility-label">
 					<FormRadio
 						name="blog_public"
 						value="1"
-						checked={ 1 === parseInt( fields.blog_public, 10 ) }
+						checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
 						onChange={ handleRadio }
 						disabled={ isRequestingSettings }
 						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
@@ -308,30 +312,29 @@ export class SiteSettingsFormGeneral extends Component {
 					) }
 				</FormSettingExplanation>
 
-				<FormLabel>
-					<FormRadio
+				<FormLabel className="site-settings__visibility-label is-checkbox">
+					<FormInputCheckbox
 						name="blog_public"
 						value="0"
-						checked={ 0 === parseInt( fields.blog_public, 10 ) }
-						onChange={ handleRadio }
+						checked={ 0 === currentValue }
+						onChange={ () => {
+							const newValue = currentValue === 0 ? 1 : 0;
+							trackEvent( `Set blog_public to ${ newValue }` );
+							updateFields( { blog_public: newValue } );
+						} }
 						disabled={ isRequestingSettings }
 						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
 					/>
-					<span>{ translate( 'Hidden' ) }</span>
+					<span>{ translate( 'Do not allow search engines to index my site' ) }</span>
 				</FormLabel>
-				<FormSettingExplanation isIndented>
-					{ translate(
-						'Your site is visible to everyone, but we ask search engines to not index your site.'
-					) }
-				</FormSettingExplanation>
 
 				{ ! siteIsJetpack && (
-					<div>
-						<FormLabel>
+					<>
+						<FormLabel className="site-settings__visibility-label">
 							<FormRadio
 								name="blog_public"
 								value="-1"
-								checked={ -1 === parseInt( fields.blog_public, 10 ) }
+								checked={ -1 === currentValue }
 								onChange={ handleRadio }
 								disabled={ isRequestingSettings }
 								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
@@ -341,7 +344,7 @@ export class SiteSettingsFormGeneral extends Component {
 						<FormSettingExplanation isIndented>
 							{ translate( 'Your site is only visible to you and users you approve.' ) }
 						</FormSettingExplanation>
-					</div>
+					</>
 				) }
 			</FormFieldset>
 		);

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -310,7 +310,7 @@ export class SiteSettingsFormGeneral extends Component {
 						</FormLabel>
 						<FormSettingExplanation isIndented>
 							{ translate(
-								'Your site is visible to everyone, and it may be indexed by search engines.'
+								'Your site is visible to everyone.'
 							) }
 						</FormSettingExplanation>
 					</>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { flowRight, get, has } from 'lodash';
 import moment from 'moment-timezone';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -309,9 +310,12 @@ export class SiteSettingsFormGeneral extends Component {
 					</FormLabel>
 				) }
 
-				<FormSettingExplanation isIndented>
-					{ translate( 'Your site is visible to everyone.' ) }
-				</FormSettingExplanation>
+				{ i18n.state.localeSlug === i18n.defaultLocaleSlug ||
+					( i18n.hasTranslation( 'Your site is visible to everyone.' ) && (
+						<FormSettingExplanation isIndented>
+							{ translate( 'Your site is visible to everyone.' ) }
+						</FormSettingExplanation>
+					) ) }
 
 				<FormLabel className="site-settings__visibility-label is-checkbox">
 					<FormInputCheckbox

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -296,17 +296,19 @@ export class SiteSettingsFormGeneral extends Component {
 		return (
 			<FormFieldset>
 				<FormLabel className="site-settings__visibility-label">
-					<FormRadio
-						name="blog_public"
-						value="1"
-						checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
-						onChange={ handleRadio }
-						disabled={ isRequestingSettings }
-						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-					/>
+					{ ! siteIsJetpack && (
+						<FormRadio
+							name="blog_public"
+							value="1"
+							checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
+							onChange={ handleRadio }
+							disabled={ isRequestingSettings }
+							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+						/>
+					) }
 					<span>{ translate( 'Public' ) }</span>
 				</FormLabel>
-				<FormSettingExplanation isIndented>
+				<FormSettingExplanation isIndented={ ! siteIsJetpack }>
 					{ translate(
 						'Your site is visible to everyone, and it may be indexed by search engines.'
 					) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -295,24 +295,26 @@ export class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<FormFieldset>
-				<FormLabel className="site-settings__visibility-label">
-					{ ! siteIsJetpack && (
-						<FormRadio
-							name="blog_public"
-							value="1"
-							checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
-							onChange={ handleRadio }
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-						/>
-					) }
-					<span>{ translate( 'Public' ) }</span>
-				</FormLabel>
-				<FormSettingExplanation isIndented={ ! siteIsJetpack }>
-					{ translate(
-						'Your site is visible to everyone, and it may be indexed by search engines.'
-					) }
-				</FormSettingExplanation>
+				{ ! siteIsJetpack && (
+					<>
+						<FormLabel className="site-settings__visibility-label">
+							<FormRadio
+								name="blog_public"
+								value="1"
+								checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
+								onChange={ handleRadio }
+								disabled={ isRequestingSettings }
+								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+							/>
+							<span>{ translate( 'Public' ) }</span>
+						</FormLabel>
+						<FormSettingExplanation isIndented>
+							{ translate(
+								'Your site is visible to everyone, and it may be indexed by search engines.'
+							) }
+						</FormSettingExplanation>
+					</>
+				) }
 
 				<FormLabel className="site-settings__visibility-label is-checkbox">
 					<FormInputCheckbox


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates site visibility picker. Instead of 3 radio buttons for each value of `blog_public` site option, it exposes a checkbox under `Public` for "site = hidden" (`blog_public = 0`). This makes more sense - this choice only has SEO implications and doesn't really "Hide" a site other than changing what's inside robots.txt.

More context available here: paObgF-MY-p2

*Before:*
<img width="751" alt="Zrzut ekranu 2020-01-13 o 14 52 54" src="https://user-images.githubusercontent.com/205419/72261218-b1e45b00-3614-11ea-9b0d-1b0ee252d852.png">

*After:*
<img width="734" alt="Zrzut ekranu 2020-01-13 o 14 59 26" src="https://user-images.githubusercontent.com/205419/72261544-54044300-3615-11ea-9c6a-8cadcd8403dc.png">

#### Testing instructions

1. Try selecting different options in the picker and confirm they're properly stored AND reflected in the form after saving.
2. Repeat for Atomic site
