### PR TITLE
E2E: Add Gutenberg basic publish post to IE11 canary test suite

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -50,10 +50,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async initEditor( { dismissPageTemplateSelector = false } = {} ) {
 		if ( dismissPageTemplateSelector ) {
-			this.dismissPageTemplateSelector();
+			await this.dismissPageTemplateSelector();
 		}
-		this.dismissEditorWelcomeModal();
-		this.closeSidebar();
+		await this.dismissEditorWelcomeModal();
+		return await this.closeSidebar();
 	}
 
 	async publish( { visit = false } = {} ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -243,7 +243,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Basic Public Post @canary @parallel', function() {
+	describe( 'Basic Public Post @canary @ie11canary @parallel', function() {
 		describe( 'Publish a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/38767 we added the Gutenberg basic publish posts to the IE11 canary test suite in order to prevent more IE11 regressions from happening.

However, we had to remove it in https://github.com/Automattic/wp-calypso/pull/38507 after activating Gutenberg 7.2.0 since the test was failing for some reason.

This PR adds that test back and properly fixes the test by adding some missing `await`s (props @Stojdza)
