### PR TITLE
Remove url and qs from login and boot entry.

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -51,28 +51,20 @@ import { getUrlParts } from 'lib/url/url-parts';
 
 const debug = debugFactory( 'calypso' );
 
-function convertParamsToObject( searchParams ) {
-	const result = {};
-	for ( const key of searchParams.keys() ) {
-		result[ key ] = searchParams.get( key );
-	}
-	return result;
-}
-
 const setupContextMiddleware = reduxStore => {
 	page( '*', ( context, next ) => {
 		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = getUrlParts( context.canonicalPath );
 		const path = parsed.pathname + parsed.search || null;
 		context.prevPath = path === context.path ? false : path;
-		context.query = convertParamsToObject( parsed.searchParams );
+		context.query = Object.fromEntries( parsed.searchParams.entries() );
 
 		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';
 		// set `context.hash` (we have to parse manually)
 		if ( context.hashstring ) {
 			try {
-				context.hash = convertParamsToObject(
-					new globalThis.URLSearchParams( context.hashstring )
+				context.hash = Object.fromEntries(
+					new globalThis.URLSearchParams( context.hashstring ).entries()
 				);
 			} catch ( e ) {
 				debug( 'failed to query-string parse `location.hash`', e );

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -1,11 +1,8 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import page from 'page';
-import { parse } from 'qs';
-import url from 'url';
 import { startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
@@ -50,21 +47,33 @@ import initialReducer from 'state/reducer';
 import { getInitialState, persistOnChange, loadAllState } from 'state/initial-state';
 import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
+import { getUrlParts } from 'lib/url/url-parts';
 
 const debug = debugFactory( 'calypso' );
+
+function convertParamsToObject( searchParams ) {
+	const result = {};
+	for ( const key of searchParams.keys() ) {
+		result[ key ] = searchParams.get( key );
+	}
+	return result;
+}
 
 const setupContextMiddleware = reduxStore => {
 	page( '*', ( context, next ) => {
 		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
-		const parsed = url.parse( context.canonicalPath, true );
-		context.prevPath = parsed.path === context.path ? false : parsed.path;
-		context.query = parsed.query;
+		const parsed = getUrlParts( context.canonicalPath );
+		const path = parsed.pathname + parsed.search || null;
+		context.prevPath = path === context.path ? false : path;
+		context.query = convertParamsToObject( parsed.searchParams );
 
 		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';
 		// set `context.hash` (we have to parse manually)
 		if ( context.hashstring ) {
 			try {
-				context.hash = parse( context.hashstring );
+				context.hash = convertParamsToObject(
+					new globalThis.URLSearchParams( context.hashstring )
+				);
 			} catch ( e ) {
 				debug( 'failed to query-string parse `location.hash`', e );
 				context.hash = {};

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -17,28 +17,20 @@ import setRouteAction from 'state/ui/actions/set-route';
 
 const debug = debugFactory( 'calypso' );
 
-function convertParamsToObject( searchParams ) {
-	const result = {};
-	for ( const key of searchParams.keys() ) {
-		result[ key ] = searchParams.get( key );
-	}
-	return result;
-}
-
 export function setupContextMiddleware() {
 	page( '*', ( context, next ) => {
 		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = getUrlParts( context.canonicalPath );
 		const path = parsed.pathname + parsed.search || null;
 		context.prevPath = path === context.path ? false : path;
-		context.query = convertParamsToObject( parsed.searchParams );
+		context.query = Object.fromEntries( parsed.searchParams.entries() );
 
 		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';
 		// set `context.hash` (we have to parse manually)
 		if ( context.hashstring ) {
 			try {
-				context.hash = convertParamsToObject(
-					new globalThis.URLSearchParams( context.hashstring )
+				context.hash = Object.fromEntries(
+					new globalThis.URLSearchParams( context.hashstring ).entries()
 				);
 			} catch ( e ) {
 				debug( 'failed to query-string parse `location.hash`', e );


### PR DESCRIPTION
This change removes `url` (a deprecated node module) and `qs` (a largeish 3rd party library) from the login and boot entry common files. It replaces them with `lib/url`, built on top of native functionality.

I decided to keep the code duplicated between both entry points, as is currently the case.

This is one of many PRs working towards dropping 3rd-party libraries for URL and URL parameter handling and replacing them with native functionality.

#### Changes proposed in this Pull Request

* Replace `url` and `qs` usage with standard `URL` and `URLSearchParams` APIs.

#### Testing instructions

Ensure that navigation in Calypso continues to work correctly, particularly in any sections where query string parameters (`?foo=bar`) or hashes (`#baz`) are used. I haven't found any examples of the latter, but for the former you can check the Stats page and switch between tabs on the chart.
