### PR TITLE
Upsell Nudges: Add a feature flag for the new component

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -169,6 +169,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-component": true,
 		"webpack/hot-loader": false,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,

--- a/config/production.json
+++ b/config/production.json
@@ -124,6 +124,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-component": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -126,6 +126,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-component": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,6 +142,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
+		"upsell/nudge-component": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds feature flags for allowing us to use`UpsellNudge`, a new component in development in #38537

#### Testing instructions

* Switch to this PR
* Confirm that `upsell/nudge-component` is present as a feature in the config files (we don't currently have an active implementation running yet)
* `https://calypso.localhost:3000/?flags=upsell/nudge-component` should show the `upsell/nudge-component` as true in development and wpcalypso, false in production and stage.
