### PR TITLE
composite-checkout: Hide expired cards

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
@@ -115,7 +115,7 @@ export function createPaymentMethods( {
 			: null;
 
 	const existingCardMethods = isMethodEnabled( 'card', allowedPaymentMethods )
-		? storedCards.map( storedDetails =>
+		? storedCards.filter( isCardAvailable ).map( storedDetails =>
 				createExistingCardMethod( {
 					id: `existingCard-${ storedDetails.stored_details_id }`,
 					cardholderName: storedDetails.name,
@@ -363,6 +363,16 @@ function isMethodEnabled( method, allowedPaymentMethods ) {
 		return true;
 	}
 	return allowedPaymentMethods.includes( method );
+}
+
+function isCardAvailable( storedDetails ) {
+	const expiryDate = new Date( storedDetails.expiry );
+	const now = new Date();
+	now.setHours( 0, 0, 0, 0 );
+	if ( expiryDate < now ) {
+		return false;
+	}
+	return true;
 }
 
 function WordPressCreditsLabel( { credits } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, if the stored cards endpoint returns an expired credit card, it will still be shown in the list of payment methods.

This PR filters out expired cards before the list is created.

#### Testing instructions

This is hard to test because the `/stored-cards` endpoint already filters out expired cards.