### PR TITLE
Composite checkout: add loading animation

### DIFF
--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -2,8 +2,112 @@
  * External dependencies
  */
 import React from 'react';
+import styled from '@emotion/styled';
+import { keyframes } from '@emotion/core';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalize } from '../lib/localize';
 
 export default function LoadingContent() {
-	// TODO: fill this in and style it
-	return <div>Loading...</div>;
+	const localize = useLocalize();
+
+	return (
+		<div>
+			<LoadingCard>
+				<LoadingTitle>{ localize( 'Loading checkout' ) }</LoadingTitle>
+				<LoadingCopy />
+				<LoadingCopy />
+			</LoadingCard>
+			<LoadingCard>
+				<LoadingTitle />
+				<LoadingCopy />
+				<LoadingCopy />
+			</LoadingCard>
+			<LoadingCard>
+				<LoadingTitle />
+			</LoadingCard>
+			<LoadingCard>
+				<LoadingTitle />
+			</LoadingCard>
+			<LoadingFooter />
+		</div>
+	);
 }
+
+const LoadingCard = styled.div`
+	padding: 24px;
+	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
+
+	:first-of-type {
+		border-top: 0;
+	}
+`;
+
+const pulse = keyframes`
+  0% {
+    opacity: 1;
+  }
+
+  70% {
+  	opacity: 0.5;
+  }
+
+  100% {
+    opacity: 1;
+  }
+`;
+
+const LoadingTitle = styled.h1`
+	font-size: 14px;
+	content: '';
+	font-weight: ${props => props.theme.weights.normal};
+	background: ${props => props.theme.colors.borderColorLight};
+	color: ${props => props.theme.colors.borderColorLight};
+	width: 40%;
+	margin: 3px 0 0 35px;
+	padding: 0;
+	position: relative;
+	animation: ${pulse} 2s ease-in-out infinite;
+	height: 20px;
+
+	:before {
+		content: '';
+		display: block;
+		position: absolute;
+		left: -35px;
+		top: -3px;
+		width: 27px;
+		height: 27px;
+		background: ${props => props.theme.colors.borderColorLight};
+		border-radius: 100%;
+	}
+`;
+const LoadingCopy = styled.p`
+	font-size: 14px;
+	height: 16px;
+	content: '';
+	background: ${props => props.theme.colors.borderColorLight};
+	color: ${props => props.theme.colors.borderColorLight};
+	margin: 8px 0 0 35px;
+	padding: 0;
+	animation: ${pulse} 2s ease-in-out infinite;
+`;
+
+const LoadingFooter = styled.div`
+	background: ${props => props.theme.colors.background};
+	content: '';
+	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
+	padding: 24px;
+
+	:before {
+		content: '';
+		display: block;
+		border: 1px solid ${props => props.theme.colors.borderColorLight};
+		border-radius: 3px;
+		font-size: 14px;
+		width: 100%;
+		height: 40px;
+	}
+`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a loading placeholder animation while checkout is in its loading state. 

![image](https://user-images.githubusercontent.com/6981253/72284687-9c206700-360f-11ea-8441-8b617c2b660a.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get calypso running locally
* Add a product to your cart and go to checkout
* Add the following query string to the URL: `flags=composite-checkout-wpcom`
* Reload the page to see the loader.
