### PR TITLE
Compress FSE build to tar.gz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
           name: Build the Full Site Editing plugin and theme
           command: |
             npx lerna run build --scope='@automattic/full-site-editing'
-            cp -R apps/full-site-editing/full-site-editing-plugin $CIRCLE_ARTIFACTS/full-site-editing/
+            tar -czvf $CIRCLE_ARTIFACTS/full-site-editing/build-archive.tar.gz apps/full-site-editing/full-site-editing-plugin            
       - store-artifacts-and-test-results
   test-full-site-editing:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
           name: Build the Full Site Editing plugin and theme
           command: |
             npx lerna run build --scope='@automattic/full-site-editing'
-            tar -czvf $CIRCLE_ARTIFACTS/full-site-editing/build-archive.tar.gz apps/full-site-editing/full-site-editing-plugin -C apps/full-site-editing/full-site-editing-plugin
+            tar -czvf $CIRCLE_ARTIFACTS/full-site-editing/build-archive.tar.gz -C apps/full-site-editing/full-site-editing-plugin .
       - store-artifacts-and-test-results
   test-full-site-editing:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
           name: Build the Full Site Editing plugin and theme
           command: |
             npx lerna run build --scope='@automattic/full-site-editing'
-            tar -czvf $CIRCLE_ARTIFACTS/full-site-editing/build-archive.tar.gz apps/full-site-editing/full-site-editing-plugin            
+            tar -czvf $CIRCLE_ARTIFACTS/full-site-editing/build-archive.tar.gz apps/full-site-editing/full-site-editing-plugin -C apps/full-site-editing/full-site-editing-plugin
       - store-artifacts-and-test-results
   test-full-site-editing:
     <<: *defaults


### PR DESCRIPTION
Instead of copying every single file to the archive directory, create a single compressed archive file.

#### Testing instructions
Check the output of the FSE build step on this PR to make sure it outputs an archive.