### PR TITLE
composite-checkout: Fill in site name or domain name in summary

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -157,6 +157,7 @@ export default function CompositeCheckout( {
 				removeItem={ removeItem }
 				changePlanLength={ changePlanLength }
 				siteId={ siteId }
+				siteUrl={ siteSlug }
 			/>
 		</CheckoutProvider>
 	);

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -35,7 +35,7 @@ export default function WPCheckoutOrderSummary( { siteUrl } ) {
 
 			<SummaryContent>
 				<ProductList>
-					{ items.map( product => {
+					{ items.filter( shouldItemBeInSummary ).map( product => {
 						return <ProductListItem key={ product.id }>{ product.label }</ProductListItem>;
 					} ) }
 				</ProductList>
@@ -133,4 +133,9 @@ function handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent ) {
 	onEvent( {
 		type: 'a8c_checkout_add_coupon_button_clicked',
 	} );
+}
+
+function shouldItemBeInSummary( item ) {
+	const itemTypesToIgnore = [ 'tax', 'credits', 'wordpress-com-credits' ];
+	return ! itemTypesToIgnore.includes( item.type );
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -18,7 +18,7 @@ import Button from './button';
 import Coupon from './coupon';
 import { isLineItemADomain } from '../hooks/has-domains';
 
-export default function WPCheckoutOrderSummary() {
+export default function WPCheckoutOrderSummary( { siteUrl } ) {
 	const translate = useTranslate();
 	const [ items ] = useLineItems();
 	const onEvent = useEvents();
@@ -27,11 +27,11 @@ export default function WPCheckoutOrderSummary() {
 	const [ hasCouponBeenApplied, setHasCouponBeenApplied ] = useState( false );
 
 	const firstDomainItem = items.find( isLineItemADomain );
+	const domainUrl = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
 
-	//TODO: show domain of site or .wordpress subdomain if no custom domain available or in the cart
 	return (
 		<React.Fragment>
-			{ firstDomainItem && <DomainURL>{ firstDomainItem.sublabel }</DomainURL> }
+			{ domainUrl && <DomainURL>{ domainUrl }</DomainURL> }
 
 			<SummaryContent>
 				<ProductList>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -16,6 +16,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Button from './button';
 import Coupon from './coupon';
+import { isLineItemADomain } from '../hooks/has-domains';
 
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();
@@ -25,10 +26,12 @@ export default function WPCheckoutOrderSummary() {
 	const [ isCouponFieldVisible, setIsCouponFieldVisible ] = useState( false );
 	const [ hasCouponBeenApplied, setHasCouponBeenApplied ] = useState( false );
 
-	//TODO: Replace yourdomain.tld with actual domian: show .wordpress subdomain if no custom domain available or in the cart
+	const firstDomainItem = items.find( isLineItemADomain );
+
+	//TODO: show domain of site or .wordpress subdomain if no custom domain available or in the cart
 	return (
 		<React.Fragment>
-			<DomainURL>yourdomain.tld</DomainURL>
+			{ firstDomainItem && <DomainURL>{ firstDomainItem.sublabel }</DomainURL> }
 
 			<SummaryContent>
 				<ProductList>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -42,7 +42,7 @@ const OrderReviewTitle = () => {
 	return translate( 'Review your order' );
 };
 
-export default function WPCheckout( { removeItem, changePlanLength, siteId } ) {
+export default function WPCheckout( { removeItem, changePlanLength, siteId, siteUrl } ) {
 	const translate = useTranslate();
 	const [ itemsWithTax ] = useLineItems();
 
@@ -64,7 +64,7 @@ export default function WPCheckout( { removeItem, changePlanLength, siteId } ) {
 			className: 'checkout__order-summary-step',
 			hasStepNumber: false,
 			titleContent: <WPCheckoutOrderSummaryTitle />,
-			completeStepContent: <WPCheckoutOrderSummary />,
+			completeStepContent: <WPCheckoutOrderSummary siteUrl={ siteUrl } />,
 			isCompleteCallback: () => true,
 		},
 		{

--- a/packages/composite-checkout-wpcom/src/hooks/has-domains.js
+++ b/packages/composite-checkout-wpcom/src/hooks/has-domains.js
@@ -15,6 +15,6 @@ export function areDomainsInLineItems( items ) {
 	return false;
 }
 
-function isLineItemADomain( item ) {
+export function isLineItemADomain( item ) {
 	return item.type.includes( 'domain' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fills in the `DomainURL` component in the summary step (which previously contained a placeholder) so that it contains either the first domain name in the cart, if one is present, or the current site's slug otherwise.

It also hides taxes and credits from the summary step.

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to your cart, but not a domain.
- Visit checkout and verify that you see the site's current domain name in the summary step (just below the words "You are all set to check out").
- Go back and add a domain to your cart.
- Visit checkout and verify that you see the new domain name in the summary step (just below the words "You are all set to check out").

#### Screenshots

Before:

![Screen Shot 2020-01-13 at 6 53 39 PM](https://user-images.githubusercontent.com/2036909/72304968-43b58d80-3640-11ea-950b-34aade018f1c.png)

After:

![Screen Shot 2020-01-13 at 8 05 00 PM](https://user-images.githubusercontent.com/2036909/72304925-208ade00-3640-11ea-8905-0f4e20412ba5.png)
