### PR TITLE
composite-checkout: Disable form controls when form status is not ready

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -65,6 +65,7 @@ export default function Coupon( { id, couponAdded, className, isCouponFieldVisib
 Coupon.propTypes = {
 	id: PropTypes.string.isRequired,
 	couponAdded: PropTypes.func,
+	isCouponFieldVisible: PropTypes.bool,
 };
 
 const animateIn = keyframes`

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useLineItems } from '@automattic/composite-checkout';
+import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -20,6 +20,7 @@ import {
 
 export default function WPCheckoutOrderReview( { className, removeItem } ) {
 	const [ items, total ] = useLineItems();
+	const { formStatus } = useFormStatus();
 
 	//TODO: tie the coupon field visibility based on whether there is a coupon in the cart
 	return (
@@ -28,7 +29,7 @@ export default function WPCheckoutOrderReview( { className, removeItem } ) {
 				<WPOrderReviewLineItems items={ items } removeItem={ removeItem } />
 			</WPOrderReviewSection>
 
-			<CouponField id="order-review-coupon" isCouponFieldVisible={ true } />
+			<CouponField id="order-review-coupon" isCouponFieldVisible={ formStatus === 'ready' } />
 
 			<WPOrderReviewSection>
 				<WPOrderReviewTotal total={ total } />

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -8,6 +8,7 @@ import {
 	useTotal,
 	renderDisplayValueMarkdown,
 	useEvents,
+	useFormStatus,
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
@@ -19,6 +20,7 @@ import Coupon from './coupon';
 
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();
+	const { formStatus } = useFormStatus();
 	const [ items ] = useLineItems();
 	const onEvent = useEvents();
 	//TODO: tie the default coupon field visibility based on whether there is a coupon in the cart
@@ -37,7 +39,7 @@ export default function WPCheckoutOrderSummary() {
 					} ) }
 				</ProductList>
 
-				{ ! hasCouponBeenApplied && ! isCouponFieldVisible && (
+				{ ! hasCouponBeenApplied && ! isCouponFieldVisible && formStatus === 'ready' && (
 					<AddCouponButton
 						buttonState="text-button"
 						onClick={ () => {
@@ -52,6 +54,7 @@ export default function WPCheckoutOrderSummary() {
 			<CouponField
 				id="order-summary-coupon"
 				isCouponFieldVisible={ isCouponFieldVisible }
+				disabled={ formStatus !== 'ready' }
 				couponAdded={ () => {
 					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
 				} }

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -53,8 +53,7 @@ export default function WPCheckoutOrderSummary() {
 
 			<CouponField
 				id="order-summary-coupon"
-				isCouponFieldVisible={ isCouponFieldVisible }
-				disabled={ formStatus !== 'ready' }
+				isCouponFieldVisible={ isCouponFieldVisible && formStatus === 'ready' }
 				couponAdded={ () => {
 					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
 				} }

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -4,7 +4,11 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { renderDisplayValueMarkdown, CheckoutModal } from '@automattic/composite-checkout';
+import {
+	renderDisplayValueMarkdown,
+	CheckoutModal,
+	useFormStatus,
+} from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -34,6 +38,7 @@ const OrderReviewSectionArea = styled.div`
 function WPLineItem( { item, className, hasDeleteButton, removeItem } ) {
 	const translate = useTranslate();
 	const hasDomainsInCart = useHasDomainsInCart();
+	const { formStatus } = useFormStatus();
 	const itemSpanId = `checkout-line-item-${ item.id }`;
 	const deleteButtonId = `checkout-delete-button-${ item.id }`;
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
@@ -45,7 +50,7 @@ function WPLineItem( { item, className, hasDeleteButton, removeItem } ) {
 			<span aria-labelledby={ itemSpanId }>
 				{ renderDisplayValueMarkdown( item.amount.displayValue ) }
 			</span>
-			{ hasDeleteButton && (
+			{ hasDeleteButton && formStatus === 'ready' && (
 				<React.Fragment>
 					<DeleteButton
 						buttonState="borderless"

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -147,6 +147,7 @@ export default function Checkout( { steps, className } ) {
 							}
 							goToNextStep={ () => changeStep( nextStep.stepNumber ) }
 							onEdit={
+								formStatus === 'ready' &&
 								step.id !== activeStep.id &&
 								step.hasStepNumber &&
 								step.isEditableCallback &&

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -19,6 +19,7 @@ import {
 	CheckoutProvider,
 	useSelect,
 	useDispatch,
+	useFormStatus,
 	createRegistry,
 	useRegisterStore,
 	usePaymentData,
@@ -423,6 +424,18 @@ describe( 'Checkout', () => {
 			expect( getByTextInNode( step, 'Edit' ) ).toBeInTheDocument();
 		} );
 
+		it( 'does not render the edit button if the form status is submitting', () => {
+			const { queryByText, getAllByText } = render(
+				<MyCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 2 ] ] } />
+			);
+			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
+			fireEvent.click( firstStepContinue );
+			expect( queryByText( 'Edit' ) ).toBeInTheDocument();
+			const submitButton = getAllByText( 'Pay Please' )[ 0 ];
+			fireEvent.click( submitButton );
+			expect( queryByText( 'Edit' ) ).not.toBeInTheDocument();
+		} );
+
 		it( 'renders the payment method submitButton', () => {
 			const { getByText } = render( <MyCheckout /> );
 			expect( getByText( 'Pay Please' ) ).toBeTruthy();
@@ -494,10 +507,22 @@ function createMockMethod() {
 		id: 'mock',
 		label: <span data-testid="mock-label">Mock Label</span>,
 		activeContent: <MockPaymentForm />,
-		submitButton: <button>Pay Please</button>,
+		submitButton: <MockSubmitButton />,
 		inactiveContent: 'Mock Method',
 		getAriaLabel: () => 'Mock Method',
 	};
+}
+
+function MockSubmitButton( { disabled } ) {
+	const { setFormSubmitting } = useFormStatus();
+	const onClick = () => {
+		setFormSubmitting();
+	};
+	return (
+		<button disabled={ disabled } onClick={ onClick }>
+			Pay Please
+		</button>
+	);
 }
 
 function MockPaymentForm( { summary } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the form so that the "Edit" buttons on any editable steps are not shown if the form is currently not in a "ready" status (meaning it is either loading, submitting, or complete).

This will not disable other additions to the form, so any custom buttons or fields added by the host page must be explicitly disabled as well. Therefore this PR also modifies the coupon fields, the add coupon button, and the delete item buttons so that they are also disabled when the form is not ready.

#### Testing instructions

First apply the following patch to break form submission:

```js
--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -22,11 +22,7 @@ export function createPayPalMethod( { registerStore, submitTransaction, successU
                controls: {
                        PAYPAL_TRANSACTION_SUBMIT( action ) {
                                const { items } = action.payload;
-                               return submitTransaction( {
-                                       successUrl,
-                                       cancelUrl,
-                                       items,
-                               } );
+                               return new Promise(() => {});
                        },
                },
                actions: {
```

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to the cart and visit checkout.
- Choose the PayPal payment method.
- Complete checkout and click "Pay".
- Verify that while the form is submitting, the edit buttons on previous steps do not appear, nor does the delete button on the plan, nor does the "Add a coupon" button, and the "Enter your coupon code" field is disabled.