### PR TITLE
Photon: Consolidate secure traffic onto i0.wp.com

### DIFF
--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -14,6 +14,7 @@ describe( 'Gravatar', () => {
 	/**
 	 * Gravatar URLs use email hashes
 	 * Here we're hashing MyEmailAddress@example.com
+	 *
 	 * @see https://en.gravatar.com/site/implement/hash/
 	 */
 	const gravatarHash = 'f9879d71855b5ff21e4963273a886bfc';
@@ -130,7 +131,7 @@ describe( 'Gravatar', () => {
 
 			expect( img.length ).to.equal( 1 );
 			expect( img.prop( 'src' ) ).to.equal(
-				'https://i2.wp.com/www.example.com/avatar?resize=96%2C96'
+				'https://i0.wp.com/www.example.com/avatar?resize=96%2C96'
 			);
 			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
 			expect( img.prop( 'width' ) ).to.equal( 32 );

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -89,7 +89,7 @@ describe( 'MediaUtils', () => {
 			} );
 
 			expect( url ).to.equal(
-				'https://i2.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6?ssl=1'
+				'https://i0.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6?ssl=1'
 			);
 		} );
 
@@ -100,7 +100,7 @@ describe( 'MediaUtils', () => {
 			} );
 
 			expect( url ).to.equal(
-				'https://i2.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6?ssl=1&w=450'
+				'https://i0.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6?ssl=1&w=450'
 			);
 		} );
 

--- a/client/lib/post-normalizer/test/utils.js
+++ b/client/lib/post-normalizer/test/utils.js
@@ -52,7 +52,7 @@ describe( 'isFeaturedImageInContent', () => {
 	test( 'should understand photon urls embed the hostname when comparing', () => {
 		const post = {
 			post_thumbnail: {
-				URL: 'http://i2.wp.com/example2.com/image.jpg',
+				URL: 'http://i0.wp.com/example2.com/image.jpg',
 			},
 			images: [ { src: 'http://example.com/image.jpg' }, { src: 'http://example.com/image.jpg' } ],
 		};

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -129,7 +129,7 @@ describe( 'resizeImageUrl()', () => {
 				const original = 'https://blacktacho.com/wp-content/uploads/2018/10/Divo07.jpg';
 				const resized = resizeImageUrl( original, 450 );
 				expect( resized ).to.equal(
-					'https://i2.wp.com/blacktacho.com/wp-content/uploads/2018/10/Divo07.jpg?ssl=1&w=450'
+					'https://i0.wp.com/blacktacho.com/wp-content/uploads/2018/10/Divo07.jpg?ssl=1&w=450'
 				);
 			} );
 		} );

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -22,13 +22,13 @@ describe( 'safeImageUrl()', () => {
 
 		test( 'should make a non-wpcom http url safe', () => {
 			expect( safeImageUrl( 'http://example.com/foo' ) ).toEqual(
-				'https://i1.wp.com/example.com/foo'
+				'https://i0.wp.com/example.com/foo'
 			);
 		} );
 
 		test( 'should make a non-wpcom https url safe', () => {
 			expect( safeImageUrl( 'https://example.com/foo' ) ).toEqual(
-				'https://i1.wp.com/example.com/foo?ssl=1'
+				'https://i0.wp.com/example.com/foo?ssl=1'
 			);
 		} );
 
@@ -53,18 +53,20 @@ describe( 'safeImageUrl()', () => {
 		} );
 
 		test( 'should make a non-wpcom protocol relative url safe', () => {
-			expect( safeImageUrl( '//example.com/foo' ) ).toEqual( 'https://i1.wp.com/example.com/foo' );
+			expect( safeImageUrl( '//example.com/foo' ) ).toBe(
+				'https://i0.wp.com/example.com/foo?ssl=1'
+			);
 		} );
 
 		test( 'should make a non-wpcom http protocol url with params safe', () => {
-			expect( safeImageUrl( 'http://example.com/foo?w=100' ) ).toEqual(
-				'https://i1.wp.com/example.com/foo'
+			expect( safeImageUrl( 'http://example.com/foo?w=100' ) ).toBe(
+				'https://i0.wp.com/example.com/foo'
 			);
 		} );
 
 		test( 'should make a non-wpcom protocol relative url with params safe', () => {
-			expect( safeImageUrl( '//example.com/foo?w=100' ) ).toEqual(
-				'https://i1.wp.com/example.com/foo?ssl=1'
+			expect( safeImageUrl( '//example.com/foo?w=100' ) ).toBe(
+				'https://i0.wp.com/example.com/foo?ssl=1'
 			);
 		} );
 
@@ -155,7 +157,7 @@ describe( 'safeImageUrl()', () => {
 		test( 'should make a blob url for other origin safe', () => {
 			const originalUrl = 'blob:http://example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
 			const expectedUrl =
-				'https://i1.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+				'https://i0.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
 			expect( safeImageUrl( originalUrl ) ).toEqual( expectedUrl );
 		} );
 
@@ -170,7 +172,7 @@ describe( 'safeImageUrl()', () => {
 		test( 'should make a blob url safe', () => {
 			const originalUrl = 'blob:http://example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
 			const expectedUrl =
-				'https://i1.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+				'https://i0.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
 			expect( safeImageUrl( originalUrl ) ).toEqual( expectedUrl );
 		} );
 

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -45,7 +45,7 @@ describe( 'logged-out', () => {
 				author_uri: 'http://www.organicthemes.com',
 				demo_uri: 'https://naturaldemo.wordpress.com/',
 				screenshot:
-					'https://i2.wp.com/theme.wordpress.com/wp-content/themes/premium/natural/screenshot.png',
+					'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/natural/screenshot.png',
 				price: '$69',
 			},
 			{
@@ -67,7 +67,7 @@ describe( 'logged-out', () => {
 				author_uri: 'http://theme.wordpress.com/themes/by/anariel-design/',
 				demo_uri: 'https://penademo.wordpress.com/',
 				screenshot:
-					'https://i2.wp.com/theme.wordpress.com/wp-content/themes/premium/pena/screenshot.png',
+					'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/pena/screenshot.png',
 				price: '$89',
 			},
 			{

--- a/packages/photon/History.md
+++ b/packages/photon/History.md
@@ -4,6 +4,7 @@
 
 - Drop dependency on `url` npm package.
 - Breaking change: support for URL / URLSearchParams APIs is now required.
+- Consolidate onto `i0.wp.com` for HTTPS URLs
 
 ## 3.0.0 / 2019-01-08
 

--- a/packages/photon/src/index.js
+++ b/packages/photon/src/index.js
@@ -18,7 +18,7 @@ const mappings = {
 };
 
 const PARSE_BASE_HOST = '__domain__.invalid';
-const PARSE_BASE_URL = `http://${ PARSE_BASE_HOST }`;
+const PARSE_BASE_URL = `https://${ PARSE_BASE_HOST }`;
 const PHOTON_BASE_URL = 'https://i0.wp.com';
 
 /**
@@ -49,7 +49,7 @@ export default function photon( imageUrl, opts ) {
 		// We already have a server to use.
 		// Use it, even if it doesn't match our hash.
 		photonUrl.pathname = parsedUrl.pathname;
-		photonUrl.hostname = parsedUrl.hostname;
+		photonUrl.hostname = wasSecure ? 'i0.wp.com' : parsedUrl.hostname;
 	} else {
 		// Photon does not support URLs with a querystring component
 		if ( parsedUrl.search ) {
@@ -65,7 +65,7 @@ export default function photon( imageUrl, opts ) {
 			formattedUrl = parsedUrl.pathname;
 		}
 		photonUrl.pathname = formattedUrl;
-		photonUrl.hostname = serverFromPathname( formattedUrl );
+		photonUrl.hostname = serverFromUrlParts( formattedUrl, photonUrl.protocol === 'https:' );
 		if ( wasSecure ) {
 			photonUrl.searchParams.set( 'ssl', 1 );
 		}
@@ -103,11 +103,17 @@ function isAlreadyPhotoned( host ) {
  * Determine which Photon server to connect to: `i0`, `i1`, or `i2`.
  *
  * Statically hash the subdomain based on the URL, to optimize browser caches.
+ * Only use i0 when using photon over https, based on the assumption that https
+ * maps to http/2 (or later)
  *
  * @param  {string} pathname The pathname to use
+ * @param  {boolean} isSecure Whether we're constructing a HTTPS URL or a HTTP one
  * @returns {string}          The hostname for the pathname
  */
-function serverFromPathname( pathname ) {
+function serverFromUrlParts( pathname, isSecure ) {
+	if ( isSecure ) {
+		return 'i0.wp.com';
+	}
 	const hash = crc32( pathname );
 	const rng = seed( hash );
 	const server = 'i' + Math.floor( rng() * 3 );

--- a/packages/photon/test/index.js
+++ b/packages/photon/test/index.js
@@ -6,11 +6,11 @@
 import photon from '../src';
 
 function expectHostedOnPhoton( url ) {
-	expect( url ).toEqual( expect.stringMatching( /^https:\/\/i[0-2].wp.com/ ) );
+	expect( url ).toEqual( expect.stringMatching( /^https:\/\/i0\.wp\.com/ ) );
 }
 
 function expectHostedOnPhotonInsecurely( url ) {
-	expect( url ).toEqual( expect.stringMatching( /^http:\/\/i[0-2].wp.com/ ) );
+	expect( url ).toEqual( expect.stringMatching( /^http:\/\/i[0-2]\.wp\.com/ ) );
 }
 
 function expectPathname( url, expected ) {
@@ -45,14 +45,26 @@ describe( 'photon()', function () {
 		);
 	} );
 
-	test( 'should not Photon-ify an existing Photon URL, even if the host is wrong', function () {
+	test( 'should not Photon-ify an existing insecure Photon URL, even if the host is wrong', function () {
 		const photonedUrl = photon( 'http://www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc' );
 		const alternateUrl =
-			'https://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
+			'http://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
 
 		expectHostedOnPhoton( photonedUrl );
 		expect( photonedUrl ).not.toBe( alternateUrl );
-		expect( photon( alternateUrl ) ).toBe( alternateUrl );
+		expect( photon( alternateUrl, { secure: false } ) ).toBe( alternateUrl );
+	} );
+
+	test( 'should move an existing Photon URL to i0 if it was on another host', function () {
+		const photonedUrl = photon( 'http://www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc' );
+		const alternateUrl =
+			'https://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
+		const alternateUrloni0 =
+			'https://i0.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
+
+		expectHostedOnPhoton( photonedUrl );
+		expect( photonedUrl ).not.toBe( alternateUrl );
+		expect( photon( alternateUrl ) ).toBe( alternateUrloni0 );
 	} );
 
 	test( 'should handle photoning a photoned url', function () {


### PR DESCRIPTION
Modern browsers perform better on HTTP/2 to one host rather than spreading traffic over several hosts. Update photon to consolidate all url rewrites onto i0.wp.com when we're building a secure link to photon. HTTP traffic remains spread over 0-2.


#### Testing instructions

* Images in the reader and on the post listing screen should load as before


