### PR TITLE
Revert "Fix: Sites created through the ecommerce flow should be private"

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -165,6 +165,10 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
 			purchaseRequired: true,
+			/**
+			 * eCommerce sites are created public since they go Atomic at purchase.
+			 * p1578348423018900-slack-CCS1W9QVA
+			 */
 			forcePublicSite: true,
 			domainsStepSubheader: i18n.translate(
 				"Enter your site's name or some keywords that describe it to get started."

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -165,11 +165,6 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
 			purchaseRequired: true,
-			/**
-			 * eCommerce sites are created public since they go Atomic at purchase.
-			 * p1578348423018900-slack-CCS1W9QVA
-			 */
-			forcePublicSite: true,
 			domainsStepSubheader: i18n.translate(
 				"Enter your site's name or some keywords that describe it to get started."
 			),

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -165,6 +165,7 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
 			purchaseRequired: true,
+			forcePublicSite: true,
 			domainsStepSubheader: i18n.translate(
 				"Enter your site's name or some keywords that describe it to get started."
 			),

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -35,6 +35,7 @@ import { getSignupDependencyStore } from 'state/signup/dependency-store/selector
 import { requestSites } from 'state/sites/actions';
 import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
+import getNewSitePublicSetting from 'state/selectors/get-new-site-public-setting';
 
 // Current directory dependencies
 import { isValidLandingPageVertical } from './verticals';
@@ -171,7 +172,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			},
 			site_creation_flow: flowToCheck,
 		},
-		public: -1,
+		public: getNewSitePublicSetting( state ),
 		validate: false,
 	};
 
@@ -498,11 +499,12 @@ export function createAccount(
 export function createSite( callback, dependencies, stepData, reduxStore ) {
 	const { themeSlugWithRepo } = dependencies;
 	const { site } = stepData;
+	const state = reduxStore.getState();
 
 	const data = {
 		blog_name: site,
 		blog_title: '',
-		public: -1,
+		public: getNewSitePublicSetting( state ),
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};

--- a/client/state/selectors/get-new-site-public-setting.ts
+++ b/client/state/selectors/get-new-site-public-setting.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import shouldNewSiteBePrivateByDefault from './should-new-site-be-private-by-default';
+
+/**
+ * Get the numeric value that should be provided to the "new site" endpoint
+ * @param state The current client state
+ * @returns `-1` for private by default & `1` for public
+ */
+export default function getNewSitePublicSetting( state: object ): number {
+	return shouldNewSiteBePrivateByDefault( state ) ? -1 : 1;
+}

--- a/client/state/selectors/get-new-site-public-setting.ts
+++ b/client/state/selectors/get-new-site-public-setting.ts
@@ -5,6 +5,7 @@ import shouldNewSiteBePrivateByDefault from './should-new-site-be-private-by-def
 
 /**
  * Get the numeric value that should be provided to the "new site" endpoint
+ *
  * @param state The current client state
  * @returns `-1` for private by default & `1` for public
  */

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getCurrentFlowName } from 'state/signup/flow/selectors';
+
+/**
+ * Should the site be private by default
+ * @param state The current client state
+ * @returns `true` for private by default & `false` for not
+ */
+export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
+	if ( getCurrentFlowName( state ) === 'test-fse' ) {
+		return true;
+	}
+	if ( getSiteTypePropertyValue( 'slug', getSiteType( state ).trim(), 'forcePublicSite' ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -3,17 +3,14 @@
  */
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { getCurrentFlowName } from 'state/signup/flow/selectors';
 
 /**
  * Should the site be private by default
+ *
  * @param state The current client state
  * @returns `true` for private by default & `false` for not
  */
 export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
-	if ( getCurrentFlowName( state ) === 'test-fse' ) {
-		return true;
-	}
 	if ( getSiteTypePropertyValue( 'slug', getSiteType( state ).trim(), 'forcePublicSite' ) ) {
 		return false;
 	}

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -1,8 +1,13 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
+import { isEcommercePlan } from 'lib/plans';
 
 /**
  * Should the site be private by default
@@ -11,7 +16,12 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
  * @returns `true` for private by default & `false` for not
  */
 export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
-	if ( getSiteTypePropertyValue( 'slug', getSiteType( state ).trim(), 'forcePublicSite' ) ) {
+	/**
+	 * eCommerce sites are created public since they go Atomic at purchase.
+	 * p1578348423018900-slack-CCS1W9QVA
+	 */
+	const plan = get( getSignupDependencyStore( state ), 'cartItem.product_slug', false );
+	if ( plan && isEcommercePlan( plan ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/test/get-new-site-public-setting.js
+++ b/client/state/selectors/test/get-new-site-public-setting.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import getNewSitePublicSetting from '../get-new-site-public-setting';
+
+jest.mock( 'lib/abtest', () => ( {
+	abtest: testName => ( testName === 'privateByDefault' ? 'selected' : '' ),
+} ) );
+
+describe( 'getNewSitePublicSetting()', () => {
+	test( 'should return `-1` by default', () => {
+		expect( getNewSitePublicSetting() ).toBe( -1 );
+	} );
+
+	test( 'should return `-1` if on test-fse flow', () => {
+		const mockState = {
+			signup: { flow: { currentFlowName: 'test-fse' }, steps: { siteType: 'online-store' } },
+		};
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
+	} );
+
+	test( 'should return `-1` for invalid siteType', () => {
+		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
+	} );
+
+	test( 'should return `-1` for business segment', () => {
+		const mockState = { signup: { steps: { siteType: 'business' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
+	} );
+
+	test( 'should return `-1` for blog segment', () => {
+		const mockState = { signup: { steps: { siteType: 'blog' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
+	} );
+
+	test( 'should return `1` for online-store segment', () => {
+		const mockState = { signup: { steps: { siteType: 'online-store' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( 1 );
+	} );
+
+	test( 'should return `-1` for professional segment', () => {
+		const mockState = { signup: { steps: { siteType: 'professional' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
+	} );
+} );

--- a/client/state/selectors/test/get-new-site-public-setting.js
+++ b/client/state/selectors/test/get-new-site-public-setting.js
@@ -3,37 +3,36 @@
  */
 import getNewSitePublicSetting from '../get-new-site-public-setting';
 
-jest.mock( 'lib/abtest', () => ( {
-	abtest: testName => ( testName === 'privateByDefault' ? 'selected' : '' ),
-} ) );
-
 describe( 'getNewSitePublicSetting()', () => {
 	test( 'should return `-1` by default', () => {
 		expect( getNewSitePublicSetting() ).toBe( -1 );
 	} );
 
-	test( 'should return `-1` for invalid siteType', () => {
-		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
+	test( 'should return `-1` for invalid plan', () => {
+		const mockState = { signup: { dependencyStore: { cartItem: 'notARealPlan' } } };
 		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
-	test( 'should return `-1` for business segment', () => {
-		const mockState = { signup: { steps: { siteType: 'business' } } };
+	test( 'should return `-1` for free site', () => {
+		const mockState = { signup: { dependencyStore: { cartItem: null } } };
 		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
-	test( 'should return `-1` for blog segment', () => {
-		const mockState = { signup: { steps: { siteType: 'blog' } } };
+	test( 'should return `-1` for business plan', () => {
+		const mockState = {
+			signup: {
+				dependencyStore: { cartItem: { product_slug: 'business-bundle', free_trial: false } },
+			},
+		};
 		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
-	test( 'should return `1` for online-store segment', () => {
-		const mockState = { signup: { steps: { siteType: 'online-store' } } };
+	test( 'should return `1` for ecommerce plan', () => {
+		const mockState = {
+			signup: {
+				dependencyStore: { cartItem: { product_slug: 'ecommerce-bundle', free_trial: false } },
+			},
+		};
 		expect( getNewSitePublicSetting( mockState ) ).toBe( 1 );
-	} );
-
-	test( 'should return `-1` for professional segment', () => {
-		const mockState = { signup: { steps: { siteType: 'professional' } } };
-		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 } );

--- a/client/state/selectors/test/get-new-site-public-setting.js
+++ b/client/state/selectors/test/get-new-site-public-setting.js
@@ -12,13 +12,6 @@ describe( 'getNewSitePublicSetting()', () => {
 		expect( getNewSitePublicSetting() ).toBe( -1 );
 	} );
 
-	test( 'should return `-1` if on test-fse flow', () => {
-		const mockState = {
-			signup: { flow: { currentFlowName: 'test-fse' }, steps: { siteType: 'online-store' } },
-		};
-		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
-	} );
-
 	test( 'should return `-1` for invalid siteType', () => {
 		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
 		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );

--- a/client/state/selectors/test/should-new-site-be-private-by-default.js
+++ b/client/state/selectors/test/should-new-site-be-private-by-default.js
@@ -8,28 +8,31 @@ describe( 'shouldNewSiteBePrivateByDefault()', () => {
 		expect( shouldNewSiteBePrivateByDefault() ).toBe( true );
 	} );
 
-	test( 'should return `true` for invalid siteType', () => {
-		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
+	test( 'should return `true` for invalid plan', () => {
+		const mockState = { signup: { dependencyStore: { cartItem: 'notARealPlan' } } };
 		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
-	test( 'should return `true` for business segment', () => {
-		const mockState = { signup: { steps: { siteType: 'business' } } };
+	test( 'should return `true` for free site', () => {
+		const mockState = { signup: { dependencyStore: { cartItem: null } } };
 		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
-	test( 'should return `true` for blog segment', () => {
-		const mockState = { signup: { steps: { siteType: 'blog' } } };
+	test( 'should return `true` for business plan', () => {
+		const mockState = {
+			signup: {
+				dependencyStore: { cartItem: { product_slug: 'business-bundle', free_trial: false } },
+			},
+		};
 		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
-	test( 'should return `false` for online-store segment', () => {
-		const mockState = { signup: { steps: { siteType: 'online-store' } } };
+	test( 'should return `false` for ecommerce plan', () => {
+		const mockState = {
+			signup: {
+				dependencyStore: { cartItem: { product_slug: 'ecommerce-bundle', free_trial: false } },
+			},
+		};
 		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( false );
-	} );
-
-	test( 'should return `true` for professional segment', () => {
-		const mockState = { signup: { steps: { siteType: 'professional' } } };
-		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/should-new-site-be-private-by-default.js
+++ b/client/state/selectors/test/should-new-site-be-private-by-default.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import shouldNewSiteBePrivateByDefault from '../should-new-site-be-private-by-default';
+
+describe( 'shouldNewSiteBePrivateByDefault()', () => {
+	test( 'should be true with no input', () => {
+		expect( shouldNewSiteBePrivateByDefault() ).toBe( true );
+	} );
+
+	test( 'should return `true` if on test-fse flow', () => {
+		const mockState = {
+			signup: { flow: { currentFlowName: 'test-fse' }, steps: { siteType: 'online-store' } },
+		};
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
+	} );
+
+	test( 'should return `true` for invalid siteType', () => {
+		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
+	} );
+
+	test( 'should return `true` for business segment', () => {
+		const mockState = { signup: { steps: { siteType: 'business' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
+	} );
+
+	test( 'should return `true` for blog segment', () => {
+		const mockState = { signup: { steps: { siteType: 'blog' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
+	} );
+
+	test( 'should return `false` for online-store segment', () => {
+		const mockState = { signup: { steps: { siteType: 'online-store' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( false );
+	} );
+
+	test( 'should return `true` for professional segment', () => {
+		const mockState = { signup: { steps: { siteType: 'professional' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
+	} );
+} );

--- a/client/state/selectors/test/should-new-site-be-private-by-default.js
+++ b/client/state/selectors/test/should-new-site-be-private-by-default.js
@@ -8,13 +8,6 @@ describe( 'shouldNewSiteBePrivateByDefault()', () => {
 		expect( shouldNewSiteBePrivateByDefault() ).toBe( true );
 	} );
 
-	test( 'should return `true` if on test-fse flow', () => {
-		const mockState = {
-			signup: { flow: { currentFlowName: 'test-fse' }, steps: { siteType: 'online-store' } },
-		};
-		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
-	} );
-
 	test( 'should return `true` for invalid siteType', () => {
 		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
 		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#38372

Reinstates the variable new site `blog_public` setting as per #35320 (& #34193 prior).

See discussion: p1579016110098700-slack-CCS1W9QVA

If eCommerce sites are created private, there's a chance that they'll be blocked from going Atomic when the upgrade succeeds. 

For now, let's just continue creating sites that select the eCommerce plan during signup as public.

## Test Plan

### Automated tests

`npm run test-client client/state/selectors/test/should-new-site-be-private-by-default.js client/state/selectors/test/get-new-site-public-setting.js`

### Manual tests

* Run this branch
* Create a new site from `/start` with the eCommerce plan selected (don't complete the purchase yet)
  * It should be created as public
* Complete the purchase
  * It should be taken Atomic

* Create a new site from `/start` with any other plan selected
  * It should be created as private

Fixes #38824