### PR TITLE
composite-checkout: Keep submit button fixed when submitting form

### DIFF
--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -114,15 +114,13 @@ export default function Checkout( { steps, className } ) {
 	} );
 	const isThereAnotherNumberedStep = !! nextStep && nextStep.hasStepNumber;
 	const isThereAnIncompleteStep = !! annotatedSteps.find( step => ! step.isComplete );
-	const isCheckoutInProgress =
-		isThereAnIncompleteStep || isThereAnotherNumberedStep || formStatus !== 'ready';
 
 	if ( formStatus === 'loading' ) {
 		return (
 			<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
 				<MainContent
 					className={ joinClasses( [ className, 'checkout__content' ] ) }
-					isCheckoutInProgress={ isCheckoutInProgress }
+					isLastStepActive={ isThereAnotherNumberedStep }
 				>
 					<LoadingContent />
 				</MainContent>
@@ -134,7 +132,7 @@ export default function Checkout( { steps, className } ) {
 		<Container className={ joinClasses( [ className, 'composite-checkout' ] ) }>
 			<MainContent
 				className={ joinClasses( [ className, 'checkout__content' ] ) }
-				isCheckoutInProgress={ isCheckoutInProgress }
+				isLastStepActive={ isThereAnotherNumberedStep }
 			>
 				<ActiveStepProvider step={ activeStep } steps={ annotatedSteps }>
 					{ annotatedSteps.map( step => (
@@ -163,7 +161,11 @@ export default function Checkout( { steps, className } ) {
 					<CheckoutErrorBoundary
 						errorMessage={ localize( 'There was a problem with the submit button.' ) }
 					>
-						<CheckoutSubmitButton disabled={ isCheckoutInProgress } />
+						<CheckoutSubmitButton
+							disabled={
+								isThereAnotherNumberedStep || isThereAnIncompleteStep || formStatus !== 'ready'
+							}
+						/>
 					</CheckoutErrorBoundary>
 				</SubmitButtonWrapper>
 			</MainContent>
@@ -240,7 +242,7 @@ const MainContent = styled.div`
 	background: ${props => props.theme.colors.surface};
 	width: 100%;
 	box-sizing: border-box;
-	margin-bottom: ${props => ( props.isCheckoutInProgress ? 0 : '89px' )};
+	margin-bottom: ${props => ( props.isLastStepActive ? '89px' : 0 )};
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -159,13 +159,13 @@ export default function Checkout( { steps, className } ) {
 					) ) }
 				</ActiveStepProvider>
 
-				<CheckoutWrapper isCheckoutInProgress={ isCheckoutInProgress }>
+				<SubmitButtonWrapper isLastStepActive={ ! isThereAnotherNumberedStep }>
 					<CheckoutErrorBoundary
 						errorMessage={ localize( 'There was a problem with the submit button.' ) }
 					>
 						<CheckoutSubmitButton disabled={ isCheckoutInProgress } />
 					</CheckoutErrorBoundary>
-				</CheckoutWrapper>
+				</SubmitButtonWrapper>
 			</MainContent>
 		</Container>
 	);
@@ -250,16 +250,16 @@ const MainContent = styled.div`
 	}
 `;
 
-const CheckoutWrapper = styled.div`
+const SubmitButtonWrapper = styled.div`
 	background: ${props => props.theme.colors.background};
 	padding: 24px;
-	position: ${props => ( props.isCheckoutInProgress ? 'relative' : 'fixed' )};
+	position: ${props => ( props.isLastStepActive ? 'fixed' : 'relative' )};
 	bottom: 0;
 	left: 0;
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;
-	border-top-width: ${props => ( props.isCheckoutInProgress ? '0' : '1px' )};
+	border-top-width: ${props => ( props.isLastStepActive ? '1px' : '0' )};
 	border-top-style: solid;
 	border-top-color: ${props => props.theme.colors.borderColorLight};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The submit button, at small screen widths, has a fixed position at the bottom of the window. However, once you click the button to submit the form, the button becomes relatively positioned instead and (if the window is not scrolled to the bottom) jumps out of view. This is not intentional behavior and appears jarring as well as making it unclear what the status of the form is since the "submitting" text is on the button itself.

This PR removes the `isCheckoutInProgress` condition which is a little ambiguous and instead makes each place it was used more explicit about what conditions should matter. Notably, the submit button should be disabled when the form is submitting, but it should still be in a fixed position.

#### Testing instructions

First apply the following patch to break form submission:

```js
--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -22,11 +22,7 @@ export function createPayPalMethod( { registerStore, submitTransaction, successU
                controls: {
                        PAYPAL_TRANSACTION_SUBMIT( action ) {
                                const { items } = action.payload;
-                               return submitTransaction( {
-                                       successUrl,
-                                       cancelUrl,
-                                       items,
-                               } );
+                               return new Promise(() => {});
                        },
                },
                actions: {
```

- Run `npm run composite-checkout-demo`.
- Visit the demo form with a window width of less than 700 px.
- Verify that the submit button is relatively positioned; it scrolls off the bottom of the screen like normal content.
- Choose the "PayPal" payment method. Complete the form and arrive at the final review step.
- Verify that the submit button is now fixed positioned; it remains stuck at the bottom of the screen no matter how you scroll.
- Press the submit button, and verify that the button remains fixed positioned.