### PR TITLE
composite-checkout: Enable 3DS for Stripe payment method

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -15,7 +15,7 @@ import joinClasses from './join-classes';
 import Field from './field';
 import Button from './button';
 
-export default function Coupon( { id, couponAdded, className, isCouponFieldVisible } ) {
+export default function Coupon( { id, couponAdded, className, disabled } ) {
 	const translate = useTranslate();
 	const onEvent = useEvents();
 	const [ isApplyButtonActive, setIsApplyButtonActive ] = useState( false );
@@ -23,7 +23,8 @@ export default function Coupon( { id, couponAdded, className, isCouponFieldVisib
 	const [ hasCouponError, setHasCouponError ] = useState( false );
 	const [ isCouponApplied, setIsCouponApplied ] = useState( false );
 
-	if ( ! isCouponFieldVisible || isCouponApplied ) {
+	//TODO: tie the coupon field visibility based on whether there is a coupon in the cart
+	if ( isCouponApplied ) {
 		return null;
 	}
 
@@ -43,6 +44,7 @@ export default function Coupon( { id, couponAdded, className, isCouponFieldVisib
 		>
 			<Field
 				id={ id }
+				disabled={ disabled }
 				placeholder={ translate( 'Enter your coupon code' ) }
 				isError={ hasCouponError }
 				errorMessage={
@@ -65,7 +67,7 @@ export default function Coupon( { id, couponAdded, className, isCouponFieldVisib
 Coupon.propTypes = {
 	id: PropTypes.string.isRequired,
 	couponAdded: PropTypes.func,
-	isCouponFieldVisible: PropTypes.bool,
+	disabled: PropTypes.bool,
 };
 
 const animateIn = keyframes`

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -22,14 +22,13 @@ export default function WPCheckoutOrderReview( { className, removeItem } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 
-	//TODO: tie the coupon field visibility based on whether there is a coupon in the cart
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems items={ items } removeItem={ removeItem } />
 			</WPOrderReviewSection>
 
-			<CouponField id="order-review-coupon" isCouponFieldVisible={ formStatus === 'ready' } />
+			<CouponField id="order-review-coupon" disabled={ formStatus !== 'ready' } />
 
 			<WPOrderReviewSection>
 				<WPOrderReviewTotal total={ total } />

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -54,13 +54,15 @@ export default function WPCheckoutOrderSummary( { siteUrl } ) {
 				) }
 			</SummaryContent>
 
-			<CouponField
-				id="order-summary-coupon"
-				isCouponFieldVisible={ isCouponFieldVisible && formStatus === 'ready' }
-				couponAdded={ () => {
-					handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
-				} }
-			/>
+			{ isCouponFieldVisible && (
+				<CouponField
+					id="order-summary-coupon"
+					disabled={ formStatus !== 'ready' }
+					couponAdded={ () => {
+						handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
+					} }
+				/>
+			) }
 		</React.Fragment>
 	);
 }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -102,7 +102,7 @@ Each payment method is an object with the following properties:
 - `activeContent: React.ReactNode`. A component that displays that payment method (this can return null or something like a credit card form).
 - `submitButton: React.ReactNode`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. When disabled, it will be provided with the `disabled` prop and must disable the button.
 - `inactiveContent: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
-- `CheckoutWrapper?: React.Component`. A component that wraps the whole of the checkout form. This can be used for custom data providers (eg: `StripeProvider`).
+- `checkoutWrapper?: (children: React.ReactNode) => React.ReactNode`. A [render prop](https://reactjs.org/docs/render-props.html) that returns a component to wrap the whole of the checkout form. Must render the provided `children` argument. This can be used for custom data providers (eg: `StripeProvider` to support [Stripe Elements](https://github.com/stripe/react-stripe-elements)).
 - `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.
 - `isCompleteCallback?: ({paymentData: object, activeStep: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning true.
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -57,11 +57,11 @@ export const CheckoutProvider = props => {
 		}
 	}, [ formStatus, onPaymentComplete ] );
 
-	// Remove undefined and duplicate CheckoutWrapper properties
+	// Remove undefined and duplicate checkoutWrapper properties
 	const wrappers = [
-		...new Set( paymentMethods.map( method => method.CheckoutWrapper ).filter( Boolean ) ),
+		...new Set( paymentMethods.map( method => method.checkoutWrapper ).filter( Boolean ) ),
 	];
-	debug( `applying ${ wrappers.length } CheckoutWrapper wrappers` );
+	debug( `applying ${ wrappers.length } checkoutWrapper wrappers` );
 
 	// Create the registry automatically if it's not a prop
 	const registryRef = useRef( registry );
@@ -169,8 +169,8 @@ function CheckoutProviderPropValidator( { propsToValidate } ) {
 }
 
 function PaymentMethodWrapperProvider( { children, wrappers } ) {
-	return wrappers.reduce( ( whole, Wrapper ) => {
-		return <Wrapper>{ whole }</Wrapper>;
+	return wrappers.reduce( ( whole, wrapper ) => {
+		return wrapper( { children: whole } );
 	}, children );
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -170,7 +170,7 @@ function CheckoutProviderPropValidator( { propsToValidate } ) {
 
 function PaymentMethodWrapperProvider( { children, wrappers } ) {
 	return wrappers.reduce( ( whole, wrapper ) => {
-		return wrapper( { children: whole } );
+		return wrapper( whole );
 	}, children );
 }
 

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -18,15 +18,6 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 		setStripeError( payload ) {
 			return { type: 'STRIPE_TRANSACTION_ERROR', payload };
 		},
-		*getConfiguration( payload ) {
-			let configuration;
-			try {
-				configuration = yield { type: 'STRIPE_CONFIGURATION_FETCH', payload };
-			} catch ( error ) {
-				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
-			}
-			return { type: 'STRIPE_CONFIGURATION_SET', payload: configuration };
-		},
 	};
 
 	registerStore( 'apple-pay', {
@@ -38,26 +29,16 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 						transactionStatus: 'error',
 						transactionError: action.payload,
 					};
-				case 'STRIPE_CONFIGURATION_SET':
-					return { ...state, stripeConfiguration: action.payload };
 			}
 			return state;
 		},
 		actions,
 		selectors: {
-			getStripeConfiguration( state ) {
-				return state.stripeConfiguration;
-			},
 			getTransactionError( state ) {
 				return state.transactionError;
 			},
 			getTransactionStatus( state ) {
 				return state.transactionStatus;
-			},
-		},
-		controls: {
-			STRIPE_CONFIGURATION_FETCH( action ) {
-				return fetchStripeConfiguration( action.payload );
 			},
 		},
 	} );
@@ -66,7 +47,11 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 		label: <ApplePayLabel />,
 		submitButton: <ApplePaySubmitButton />,
 		inactiveContent: <ApplePaySummary />,
-		checkoutWrapper: children => <StripeHookProvider>{ children }</StripeHookProvider>,
+		checkoutWrapper: children => (
+			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+				{ children }
+			</StripeHookProvider>
+		),
 		getAriaLabel: localize => localize( 'Apple Pay' ),
 	};
 }

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -66,7 +66,7 @@ export function createApplePayMethod( { registerStore, fetchStripeConfiguration 
 		label: <ApplePayLabel />,
 		submitButton: <ApplePaySubmitButton />,
 		inactiveContent: <ApplePaySummary />,
-		CheckoutWrapper: StripeHookProvider,
+		checkoutWrapper: children => <StripeHookProvider>{ children }</StripeHookProvider>,
 		getAriaLabel: localize => localize( 'Apple Pay' ),
 	};
 }

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -256,7 +256,6 @@ function ExistingCardPayButton( { disabled, id } ) {
 
 		if ( transactionStatus === 'auth' ) {
 			debug( 'showing auth' );
-			showInfoMessage( localize( 'Authorizing...' ) );
 			showStripeModalAuth( {
 				stripeConfiguration,
 				response: transactionAuthData,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -62,9 +62,6 @@ export function createStripeMethod( {
 		changeCardholderName( payload ) {
 			return { type: 'CARDHOLDER_NAME_SET', payload };
 		},
-		setStripeError( payload ) {
-			return { type: 'STRIPE_TRANSACTION_ERROR', payload };
-		},
 		setStripeComplete( payload ) {
 			debug( 'stripe transaction is successful' );
 			return { type: 'STRIPE_TRANSACTION_END', payload };

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -559,7 +559,6 @@ function StripePayButton( { disabled } ) {
 
 		if ( transactionStatus === 'auth' ) {
 			debug( 'showing auth' );
-			showInfoMessage( localize( 'Authorizing...' ) );
 			showStripeModalAuth( {
 				stripeConfiguration,
 				response: transactionAuthData,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -18,7 +18,7 @@ import PaymentLogo from './payment-logo';
 import {
 	useStripe,
 	createStripePaymentMethod,
-	confirmStripePaymentIntent,
+	showStripeModalAuth,
 	StripeHookProvider,
 } from '../stripe';
 import {
@@ -670,16 +670,4 @@ function createStripePaymentMethodToken( { stripe, name, country, postalCode, ph
 		},
 		...( phoneNumber ? { phone: phoneNumber } : {} ),
 	} );
-}
-
-async function showStripeModalAuth( { stripeConfiguration, response } ) {
-	const authenticationResponse = await confirmStripePaymentIntent(
-		stripeConfiguration,
-		response.message.payment_intent_client_secret
-	);
-
-	if ( authenticationResponse?.status ) {
-		return authenticationResponse;
-	}
-	return null;
 }

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -542,10 +542,15 @@ function StripePayButton( { disabled } ) {
 			showStripeModalAuth( {
 				stripeConfiguration,
 				response: transactionAuthData,
-			} ).catch( error => {
-				setFormReady();
-				showErrorMessage( error.stripeError || error.message );
-			} );
+			} )
+				.then( () => {
+					debug( 'stripe auth is complete' );
+					setFormComplete();
+				} )
+				.catch( error => {
+					setFormReady();
+					showErrorMessage( error.stripeError || error.message );
+				} );
 		}
 	}, [
 		redirectUrl,
@@ -646,7 +651,8 @@ async function showStripeModalAuth( { stripeConfiguration, response } ) {
 		response.message.payment_intent_client_secret
 	);
 
-	if ( authenticationResponse ) {
-		// TODO: what do we do here?
+	if ( authenticationResponse?.status ) {
+		return true;
 	}
+	return false;
 }

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -69,15 +69,6 @@ export function createStripeMethod( {
 			debug( 'stripe transaction is successful' );
 			return { type: 'STRIPE_TRANSACTION_END', payload };
 		},
-		*getConfiguration( payload ) {
-			let configuration;
-			try {
-				configuration = yield { type: 'STRIPE_CONFIGURATION_FETCH', payload };
-			} catch ( error ) {
-				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
-			}
-			return { type: 'STRIPE_CONFIGURATION_SET', payload: configuration };
-		},
 		*beginStripeTransaction( payload ) {
 			let stripeResponse;
 			try {
@@ -120,9 +111,6 @@ export function createStripeMethod( {
 	};
 
 	const selectors = {
-		getStripeConfiguration( state ) {
-			return state.stripeConfiguration;
-		},
 		getBrand( state ) {
 			return state.brand || '';
 		},
@@ -206,8 +194,6 @@ export function createStripeMethod( {
 						transactionStatus: 'redirect',
 						redirectUrl: action.payload.redirect_url,
 					};
-				case 'STRIPE_CONFIGURATION_SET':
-					return { ...state, stripeConfiguration: action.payload };
 				case 'CARDHOLDER_NAME_SET':
 					return { ...state, cardholderName: action.payload };
 				case 'BRAND_SET':
@@ -228,9 +214,6 @@ export function createStripeMethod( {
 		actions,
 		selectors,
 		controls: {
-			STRIPE_CONFIGURATION_FETCH( action ) {
-				return fetchStripeConfiguration( action.payload );
-			},
 			STRIPE_CREATE_PAYMENT_METHOD_TOKEN( action ) {
 				return createStripePaymentMethodToken( action.payload );
 			},
@@ -245,7 +228,11 @@ export function createStripeMethod( {
 		label: <CreditCardLabel />,
 		activeContent: <StripeCreditCardFields />,
 		submitButton: <StripePayButton />,
-		checkoutWrapper: children => <StripeHookProvider>{ children }</StripeHookProvider>,
+		checkoutWrapper: children => (
+			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+				{ children }
+			</StripeHookProvider>
+		),
 		inactiveContent: <StripeSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),
 		isCompleteCallback: () => {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -245,7 +245,7 @@ export function createStripeMethod( {
 		label: <CreditCardLabel />,
 		activeContent: <StripeCreditCardFields />,
 		submitButton: <StripePayButton />,
-		CheckoutWrapper: StripeHookProvider,
+		checkoutWrapper: children => <StripeHookProvider>{ children }</StripeHookProvider>,
 		inactiveContent: <StripeSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),
 		isCompleteCallback: () => {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -281,6 +281,7 @@ function StripeCreditCardFields() {
 
 	useEffect( () => {
 		if ( stripeLoadingError ) {
+			debug( 'showing error for loading', stripeLoadingError );
 			showErrorMessage( stripeLoadingError );
 		}
 	}, [ showErrorMessage, stripeLoadingError ] );
@@ -529,7 +530,7 @@ function StripePayButton( { disabled } ) {
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
-			debug( 'showing error' );
+			debug( 'showing error', transactionError );
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
@@ -570,7 +571,10 @@ function StripePayButton( { disabled } ) {
 					isSubscribed && setStripeComplete( authenticationResponse );
 				} )
 				.catch( error => {
-					showErrorMessage( error.stripeError || error.message );
+					debug( 'showing error for auth', error );
+					showErrorMessage(
+						localize( 'Authorization failed for that card. Please try a different payment method.' )
+					);
 					isSubscribed && setFormReady();
 				} );
 		}
@@ -651,6 +655,7 @@ async function submitStripePayment( {
 		} );
 	} catch ( error ) {
 		setFormReady();
+		debug( 'showing error for submit', error );
 		showErrorMessage( error );
 		return;
 	}

--- a/packages/composite-checkout/src/lib/stripe.js
+++ b/packages/composite-checkout/src/lib/stripe.js
@@ -332,3 +332,15 @@ export function useStripe() {
 	}
 	return stripeData;
 }
+
+export async function showStripeModalAuth( { stripeConfiguration, response } ) {
+	const authenticationResponse = await confirmStripePaymentIntent(
+		stripeConfiguration,
+		response.message.payment_intent_client_secret
+	);
+
+	if ( authenticationResponse?.status ) {
+		return authenticationResponse;
+	}
+	return null;
+}

--- a/packages/composite-checkout/src/lib/stripe.js
+++ b/packages/composite-checkout/src/lib/stripe.js
@@ -1,21 +1,9 @@
 /**
  * External dependencies
  */
-import React, {
-	useEffect,
-	useReducer,
-	useState,
-	useCallback,
-	useContext,
-	createContext,
-} from 'react';
+import React, { useEffect, useReducer, useState, useContext, createContext } from 'react';
 import { injectStripe, StripeProvider, Elements } from 'react-stripe-elements';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import { useSelect, useDispatch } from '../public-api';
 
 const debug = debugFactory( 'composite-checkout:lib-stripe' );
 const StripeContext = createContext();
@@ -240,32 +228,31 @@ function loadScriptAsync( url ) {
  *
  * This is internal. You probably actually want the useStripe hook.
  *
- * Returns an object with two properties: `stripeConfiguration`, and
- * `forceReload`.
+ * Returns `stripeConfiguration`, an object as returned by the stripe
+ * configuration endpoint.
  *
- * `stripeConfiguration` is an object as returned by the stripe configuration
- * endpoint, possibly including a Setup Intent if one was requested (via
- * `needs_intent`).
- *
- * If there is a stripe error, it may be necessary to reload the configuration
- * since (for example) a Setup Intent may need to be recreated. You can force
- * the configuration to reload by calling `forceReload()`.
- *
- * @param {object} requestArgs (optional) Can include `country` or `needs_intent`
+ * @param {Function} fetchStripeConfiguration Function that actually fetches the configuration
  * @returns {object} See above
  */
-function useStripeConfiguration( requestArgs ) {
-	const [ currentAttempt, setAttempt ] = useState( 1 );
-	const stripeConfiguration = useSelect( select => select( 'stripe' ).getStripeConfiguration() );
-	const { getConfiguration } = useDispatch( 'stripe' );
-	const getConfigurationMemo = useCallback( getConfiguration, [ currentAttempt, requestArgs ] );
+function useStripeConfiguration( fetchStripeConfiguration ) {
+	const [ stripeConfiguration, setStripeConfiguration ] = useState();
 	useEffect( () => {
-		debug( 'loading stripe configuration', requestArgs );
-		getConfigurationMemo( requestArgs );
-	}, [ requestArgs, currentAttempt, getConfigurationMemo ] );
-	const forceReload = () => setAttempt( currentAttempt + 1 );
-	debug( 'useStripeConfiguration returning', stripeConfiguration, forceReload );
-	return { stripeConfiguration, forceReload };
+		let isSubscribed = true;
+		if ( ! stripeConfiguration ) {
+			debug( 'loading stripe configuration' );
+			fetchStripeConfiguration()
+				.then( configuration => {
+					debug( 'stripe configuration retrieved', configuration );
+					isSubscribed && setStripeConfiguration( configuration );
+				} )
+				.catch( error => {
+					debug( 'stripe configuration fetch error', error );
+				} );
+		}
+		return () => ( isSubscribed = false );
+	}, [ stripeConfiguration, fetchStripeConfiguration ] );
+	debug( 'useStripeConfiguration returning', stripeConfiguration );
+	return stripeConfiguration;
 }
 
 function StripeHookProviderInnerWrapper( { stripe, stripeData, children } ) {
@@ -286,8 +273,8 @@ const StripeInjectedWrapper = injectStripe( StripeHookProviderInnerWrapper );
  *
  * @returns {object} React element
  */
-export function StripeHookProvider( { children, configurationArgs } ) {
-	const { stripeConfiguration, forceReload } = useStripeConfiguration( configurationArgs );
+export function StripeHookProvider( { children, fetchStripeConfiguration } ) {
+	const stripeConfiguration = useStripeConfiguration( fetchStripeConfiguration );
 	const { stripeJs, isStripeLoading, stripeLoadingError } = useStripeJs( stripeConfiguration );
 
 	const stripeData = {
@@ -295,7 +282,6 @@ export function StripeHookProvider( { children, configurationArgs } ) {
 		stripeConfiguration,
 		isStripeLoading,
 		stripeLoadingError,
-		forceReload,
 	};
 	debug( 'StripeHookProvider', stripeData );
 

--- a/packages/composite-checkout/src/lib/stripe.js
+++ b/packages/composite-checkout/src/lib/stripe.js
@@ -105,7 +105,7 @@ export async function createStripePaymentMethod( stripe, paymentDetails ) {
  * @param {string} paymentIntentClientSecret The client secret of the PaymentIntent
  * @returns {Promise} Promise that will be resolved or rejected
  */
-export async function confirmStripePaymentIntent( stripeConfiguration, paymentIntentClientSecret ) {
+async function confirmStripePaymentIntent( stripeConfiguration, paymentIntentClientSecret ) {
 	// Setup a stripe instance that is disconnected from our Elements
 	// Otherwise, we'll create another paymentMethod, which we don't want
 	const standAloneStripe = window.Stripe( stripeConfiguration.public_key );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When paying with a credit card that requires 3DS authentication, Stripe's library will display a modal to perform the authentication and then tell the page if the auth completed or failed.

This PR hooks up the response from the modal to the rest of the form, so that `onPaymentComplete` will be called when the authentication completes for both new and existing cards.

Additionally, this fixes a regression introduced in #38759 which caused the stripe form to never finish loading. This happened because the payment methods were being recreated twice; the first time the stripe payment method went and fetched the stripe configuration, but then the second time the configuration was no longer present and the hook did not try fetching it again. The cause of this double-rendering was that the `useStoredCards` hook was calling setState twice; once to set `isLoading` to false and again to save the stored cards. This PR combines these two states into a reducer so that they operate together and only cause a single render.

#### Testing instructions

- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to your cart and visit checkout.
- Enter a 3DS stripe test card, like `4000000000003220`.
- Complete checkout and press Pay.
- When the auth dialog appears, confirm it, and verify that the payment is successful and that the product is added to your site.
- Repeat the above process but refuse the auth dialog and verify that the payment fails and the product is not added.
- Repeat the above process with an existing card that requires 3DS (eg: the one you just added by completing the above transaction).