### PR TITLE
Make onSubmit prop optional in contact details form fields component

### DIFF
--- a/client/components/domains/contact-details-form-fields/README.md
+++ b/client/components/domains/contact-details-form-fields/README.md
@@ -131,9 +131,9 @@ Usage:
 	};
 ```
 
-### onSubmit {Func} (required)
+### onSubmit {Func} (optional)
 
-Triggered onSubmit and when all fields are valid
+Triggered onSubmit and when all fields are valid. If this prop is not present, do not render the Submit button.
 
 #### Arguments
 

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -493,13 +493,15 @@ export class ContactDetailsFormFields extends Component {
 				<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
 
 				<FormFooter>
-					<FormButton
-						className="contact-details-form-fields__submit-button"
-						disabled={ ! countryCode || disableSubmitButton }
-						onClick={ this.handleSubmitButtonClick }
-					>
-						{ labelTexts.submitButton || translate( 'Submit' ) }
-					</FormButton>
+					{ this.props.onSubmit && (
+						<FormButton
+							className="contact-details-form-fields__submit-button"
+							disabled={ ! countryCode || disableSubmitButton }
+							onClick={ this.handleSubmitButtonClick }
+						>
+							{ labelTexts.submitButton || translate( 'Submit' ) }
+						</FormButton>
+					) }
 					{ onCancel && (
 						<FormButton
 							className="contact-details-form-fields__cancel-button"

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -80,7 +80,7 @@ export class ContactDetailsFormFields extends Component {
 		needsFax: PropTypes.bool,
 		getIsFieldDisabled: PropTypes.func,
 		onContactDetailsChange: PropTypes.func,
-		onSubmit: PropTypes.func.isRequired,
+		onSubmit: PropTypes.func,
 		onValidate: PropTypes.func,
 		onSanitize: PropTypes.func,
 		labelTexts: PropTypes.object,
@@ -198,14 +198,8 @@ export class ContactDetailsFormFields extends Component {
 		};
 	}
 
-	getErrorMessages = () => {
-		return formState.getErrorMessages( this.state );
-	};
-
 	setFormState = form =>
-		this.setState( { form }, () =>
-			this.props.onContactDetailsChange( this.getMainFieldValues(), this.getErrorMessages() )
-		);
+		this.setState( { form }, () => this.props.onContactDetailsChange( this.getMainFieldValues() ) );
 
 	handleFormControllerError = error => {
 		throw error;

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -198,8 +198,14 @@ export class ContactDetailsFormFields extends Component {
 		};
 	}
 
+	getErrorMessages = () => {
+		return formState.getErrorMessages( this.state );
+	};
+
 	setFormState = form =>
-		this.setState( { form }, () => this.props.onContactDetailsChange( this.getMainFieldValues() ) );
+		this.setState( { form }, () =>
+			this.props.onContactDetailsChange( this.getMainFieldValues(), this.getErrorMessages() )
+		);
 
 	handleFormControllerError = error => {
 		throw error;

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -9,12 +9,12 @@ import React from 'react';
 import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import { noop, omit } from 'lodash';
-// import { Provider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { ContactDetailsFormFields } from '../';
+import FormButton from '../../../../components/forms/form-button';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
@@ -71,19 +71,13 @@ describe( 'ContactDetailsFormFields', () => {
 		} );
 	} );
 
-	/*	describe( 'No onSubmit prop', () => {
-	    test( 'should not render Submit button', () => {
-	        const newProps = { ...defaultProps, onSubmit: undefined };
-	        const wrapper = mount(
-	            <Provider
-                    state={ 'FOOOO' }
-                >
-    	            <ContactDetailsFormFields { ...newProps } />
-                </Provider>
-            );
-            expect( wrapper.find('button') ).toHaveLength(0);
-        } );
-    } ); */
+	describe( 'onSubmit prop is undefined', () => {
+		test( 'should not render Submit button', () => {
+			const newProps = { ...defaultProps, onSubmit: undefined };
+			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
+			expect( wrapper.find( FormButton ) ).toHaveLength( 0 );
+		} );
+	} );
 
 	describe( 'Google Apps Form UI state', () => {
 		test( 'should not render GAppsFieldset in place of the default contact fields by default', () => {

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -9,6 +9,7 @@ import React from 'react';
 import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import { noop, omit } from 'lodash';
+// import { Provider } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -69,6 +70,20 @@ describe( 'ContactDetailsFormFields', () => {
 			expect( wrapper.find( '[name="phone"]' ) ).toHaveLength( 1 );
 		} );
 	} );
+
+	/*	describe( 'No onSubmit prop', () => {
+	    test( 'should not render Submit button', () => {
+	        const newProps = { ...defaultProps, onSubmit: undefined };
+	        const wrapper = mount(
+	            <Provider
+                    state={ 'FOOOO' }
+                >
+    	            <ContactDetailsFormFields { ...newProps } />
+                </Provider>
+            );
+            expect( wrapper.find('button') ).toHaveLength(0);
+        } );
+    } ); */
 
 	describe( 'Google Apps Form UI state', () => {
 		test( 'should not render GAppsFieldset in place of the default contact fields by default', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `ContactDetailsFormFields` component has a required callback prop `onSubmit`. Composite checkout needs to use this component for consistency, but manages its own state and submission. This PR makes `onSubmit` optional and prevents rendering the submit button if the prop is not present.

#### Testing instructions

* `npm run test-client client/components/domains/contact-details-form-fields`
