### PR TITLE
Composite checkout: fix delete button position

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -106,10 +106,6 @@ const LineItemUI = styled( WPLineItem )`
 		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
 	position: relative;
 	margin-right: 30px;
-
-	:first-of-type button {
-		top: -3px;
-	}
 `;
 
 const ProductTitle = styled.span`
@@ -239,6 +235,10 @@ const WPOrderReviewListItems = styled.li`
 
 	:first-of-type .checkout-line-item {
 		padding-top: 10px;
+	}
+
+	:first-of-type button {
+		top: -3px;
 	}
 `;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue with the position of the delete buttons in the review step of checkout.

**Before**
![image](https://user-images.githubusercontent.com/6981253/72375407-06054300-36da-11ea-97be-76335db6e235.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/72375305-d5bda480-36d9-11ea-9138-1ecf67401ac8.png)


#### Testing instructions
* Get calypso up and running
* Add a plan and domain to your cart.
* Visit checkout and add this flag to the url: `?flags=composite-checkout-wpcom`
