### PR TITLE
Adds Themes and Plugins to valid JITM locations

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -203,7 +203,7 @@ export default connect( state => {
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
-	const isEligibleForJITM = [ 'stats', 'plans' ].indexOf( sectionName ) >= 0;
+	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
 
 	return {
 		masterbarIsHidden:

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -203,8 +203,7 @@ export default connect( state => {
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
-	const isEligibleForJITM =
-		[ 'stats', 'plans', 'themes', 'theme', 'plugins' ].indexOf( sectionName ) >= 0;
+	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
 
 	return {
 		masterbarIsHidden:

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -203,7 +203,8 @@ export default connect( state => {
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
-	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
+	const isEligibleForJITM =
+		[ 'stats', 'plans', 'themes', 'theme', 'plugins' ].indexOf( sectionName ) >= 0;
 
 	return {
 		masterbarIsHidden:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This builds on the work done in #37332 to add Plugins and Themes sections to have JITMs enabled. This is part of the work being done with 1153012803416853-as-1154888165688514.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create JITM in API that uses `calypso:plugins:admin_notices`.
* Checks if JITM shows.