### PR TITLE
composite-checkout: Redirect if the cart becomes empty

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -109,7 +109,7 @@ export default function CompositeCheckout( {
 	const itemsForCheckout = items.length ? [ ...items, tax ] : [];
 	debug( 'items for checkout', itemsForCheckout );
 
-	useRedirectIfCartEmpty( itemsForCheckout );
+	useRedirectIfCartEmpty( items, `/plans/${ siteSlug }` );
 
 	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards
@@ -236,16 +236,17 @@ function handleCheckoutEvent( action ) {
 	// TODO: record stats
 }
 
-function useRedirectIfCartEmpty( items ) {
+function useRedirectIfCartEmpty( items, redirectUrl ) {
 	const [ prevItemsLength, setPrevItemsLength ] = useState( 0 );
+
 	useEffect( () => {
 		setPrevItemsLength( items.length );
 	}, [ items ] );
 
 	useEffect( () => {
 		if ( prevItemsLength > 0 && items.length === 0 ) {
-			debug( 'cart is empty; redirecting...' );
-			window.location = '/'; // TODO: where should we redirect to?
+			debug( 'cart has become empty; redirecting...' );
+			window.location = redirectUrl;
 		}
 	}, [ items, prevItemsLength ] );
 }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import wp from 'lib/wp';
-import React, { useMemo, useEffect, useCallback } from 'react';
+import React, { useMemo, useEffect, useState, useCallback } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import debugFactory from 'debug';
@@ -108,6 +108,8 @@ export default function CompositeCheckout( {
 
 	const itemsForCheckout = items.length ? [ ...items, tax ] : [];
 	debug( 'items for checkout', itemsForCheckout );
+
+	useRedirectIfCartEmpty( itemsForCheckout );
 
 	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards
@@ -232,4 +234,18 @@ function createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } ) {
 function handleCheckoutEvent( action ) {
 	debug( 'checkout event', action );
 	// TODO: record stats
+}
+
+function useRedirectIfCartEmpty( items ) {
+	const [ prevItemsLength, setPrevItemsLength ] = useState( 0 );
+	useEffect( () => {
+		setPrevItemsLength( items.length );
+	}, [ items ] );
+
+	useEffect( () => {
+		if ( prevItemsLength > 0 && items.length === 0 ) {
+			debug( 'cart is empty; redirecting...' );
+			window.location = '/'; // TODO: where should we redirect to?
+		}
+	}, [ items, prevItemsLength ] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a hook to `CompositeCheckout` such that when the cart has items and then becomes empty, it redirects away from checkout to the plans page, which appears to be where the current checkout sends you in that situation.

We did it this way rather than just if the cart is empty because during a normal checkout the cart may be empty temporarily (for several render cycles) when a new product is about to be added to the cart (see `useAddProductToCart()`).

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to your cart and visit checkout.
- Complete checkout and get to the final step.
- Click the trash icon to remove the plan from the cart.
- Verify that you are redirected to the plans page for your site.