### PR TITLE
Migration: allow for free-form entry of site url

### DIFF
--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -23,11 +23,21 @@ export function migrateSite( context, next ) {
 		const sourceSiteId =
 			context.params.sourceSiteId &&
 			getSiteId( context.store.getState(), context.params.sourceSiteId );
-		context.primary = <SectionMigrate sourceSiteId={ sourceSiteId } />;
+		context.primary = (
+			<SectionMigrate
+				sourceSiteId={ sourceSiteId }
+				showImportSelector={ context.showImportSelector }
+			/>
+		);
 		return next();
 	}
 
 	page.redirect( '/' );
+}
+
+export function setImportSelector( context, next ) {
+	context.showImportSelector = true;
+	next();
 }
 
 export function setSiteSelectionHeader( context, next ) {

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -9,6 +9,7 @@ import page from 'page';
 import {
 	ensureFeatureFlag,
 	migrateSite,
+	setImportSelector,
 	setSiteSelectionHeader,
 } from 'my-sites/migrate/controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -40,6 +41,18 @@ export default function() {
 	page(
 		'/migrate/from/:sourceSiteId/to/:site_id',
 		ensureFeatureFlag,
+		siteSelection,
+		navigation,
+		redirectWithoutSite( '/migrate' ),
+		migrateSite,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/migrate/choose/:site_id',
+		ensureFeatureFlag,
+		setImportSelector,
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/migrate' ),

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -25,6 +25,49 @@
 	}
 }
 
+.migrate__faux-site-selector {
+	box-sizing: border-box;
+	display: flex;
+	flex: 1 0 auto;
+	justify-content: space-between;
+	padding: 0;
+	position: relative;
+}
+
+.migrate__faux-site-selector-content {
+	display: flex;
+	justify-content: space-between;
+	overflow: hidden;
+	padding: 0 16px;
+	position: relative;
+	width: 100%;
+}
+
+.migrate__faux-site-selector-icon {
+	height: 32px;
+	width: 32px;
+	line-height: 32px;
+	border: 1px dashed var( --color-text-subtle );
+	position: relative;
+	overflow: hidden;
+	align-self: flex-start;
+    margin-right: 8px;
+    flex: 0 0 auto;
+}
+
+.migrate__faux-site-selector-info {
+	width: 0;
+	flex: 1 0 auto;
+}
+
+.migrate__faux-site-selector-label {
+	color: var( --color-text );
+	display: block;
+	font-size: 13px;
+	font-weight: 400;
+	line-height: 1.3;
+}
+
 .migrate__card-footer {
 	color: var( --color-text-subtle );
 	font-size: 13px;
@@ -37,9 +80,6 @@
 
 .migrate__sites {
 	display: flex;
-	border-top: 1px solid var( --color-neutral-10 );
-	border-bottom: 1px solid var( --color-neutral-10 );
-	margin-bottom: 16px;
 
 	.site__content {
 		padding-left: 0;

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -21,6 +21,7 @@ import './section-migrate.scss';
 
 class StepImportOrMigrate extends Component {
 	static propTypes = {
+		onJetpackSelect: PropTypes.func.isRequired,
 		targetSite: PropTypes.object.isRequired,
 		targetSiteSlug: PropTypes.string.isRequired,
 	};
@@ -38,7 +39,7 @@ class StepImportOrMigrate extends Component {
 				</CompactCard>
 				<CompactCard>
 					<CardHeading>What do you want to import?</CardHeading>
-					<Button>Continue</Button>
+					<Button onClick={ this.props.onJetpackSelect }>Continue</Button>
 				</CompactCard>
 			</>
 		);

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { Button, CompactCard } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'components/card-heading';
+import Gridicon from 'components/gridicon';
+import HeaderCake from 'components/header-cake';
+import Site from 'blocks/site';
+
+/**
+ * Style dependencies
+ */
+import './section-migrate.scss';
+
+class StepImportOrMigrate extends Component {
+	static propTypes = {
+		targetSite: PropTypes.object.isRequired,
+		targetSiteSlug: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { targetSite, targetSiteSlug } = this.props;
+		const backHref = `/migrate/${ targetSiteSlug }`;
+
+		return (
+			<>
+				<HeaderCake backHref={ backHref }>Import from WordPress</HeaderCake>
+				<CompactCard className="migrate__sites">
+					<Gridicon className="migrate__sites-arrow" icon="arrow-right" />
+					<Site site={ targetSite } indicator={ false } />
+				</CompactCard>
+				<CompactCard>
+					<CardHeading>What do you want to import?</CardHeading>
+					<Button>Continue</Button>
+				</CompactCard>
+			</>
+		);
+	}
+}
+
+export default localize( StepImportOrMigrate );

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { Button, CompactCard } from '@automattic/components';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'components/card-heading';
+import FormTextInput from 'components/forms/form-text-input';
+import Gridicon from 'components/gridicon';
+import HeaderCake from 'components/header-cake';
+import Site from 'blocks/site';
+import wpLib from 'lib/wp';
+
+/**
+ * Style dependencies
+ */
+import './section-migrate.scss';
+
+const wpcom = wpLib.undocumented();
+
+class StepSourceSelect extends Component {
+	static propTypes = {
+		onSiteInfoReceived: PropTypes.func.isRequired,
+		onUrlChange: PropTypes.func.isRequired,
+		targetSite: PropTypes.object.isRequired,
+		targetSiteSlug: PropTypes.string.isRequired,
+	};
+
+	state = {
+		error: null,
+		isLoading: false,
+	};
+
+	handleContinue = () => {
+		if ( this.state.isLoading ) {
+			return;
+		}
+
+		this.setState( { error: null, isLoading: true }, () => {
+			wpcom
+				.isSiteImportable( this.props.url )
+				.then( result => {
+					const importUrl = `/import/${ this.props.targetSiteSlug }?not-wp=1&engine=${ result.site_engine }&from-site=${ result.site_url }`;
+
+					switch ( result.site_engine ) {
+						case 'wordpress':
+							return this.props.onSiteInfoReceived( result, () => {
+								page( `/migrate/choose/${ this.props.targetSiteSlug }` );
+							} );
+						default:
+							if ( window && window.history && window.history.pushState ) {
+								/**
+								 * Because query parameters aren't processed by `page.show`, we're forced to use `page.redirect`.
+								 * Unfortunately, `page.redirect` breaks the back button behavior.
+								 * This is a Work-around to push importUrl to history to fix the back button.
+								 * See https://github.com/visionmedia/page.js#readme
+								 */
+								window.history.pushState( null, null, importUrl );
+							}
+							return page.redirect( importUrl );
+					}
+				} )
+				.catch( error => {
+					switch ( error.code ) {
+						case 'rest_invalid_param':
+							return this.setState( {
+								error: "We couldn't reach that site. Please check the URL and try again.",
+								loading: false,
+							} );
+						default:
+							return this.setState( {
+								error: 'Something went wrong. Please check the URL and try again.',
+								loading: false,
+							} );
+					}
+				} );
+		} );
+	};
+
+	renderFauxSiteSelector() {
+		const { onUrlChange, url } = this.props;
+		const { error } = this.state;
+		const isError = !! error;
+
+		return (
+			<div className="migrate__faux-site-selector">
+				<div className="migrate__faux-site-selector-content">
+					<div className="migrate__faux-site-selector-icon"></div>
+					<div className="migrate__faux-site-selector-info">
+						<div className="migrate__faux-site-selector-label">Import from...</div>
+						<div className="migrate__faux-site-selector-url">
+							<FormTextInput isError={ isError } onChange={ onUrlChange } value={ url } />
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const { targetSite, targetSiteSlug } = this.props;
+		const backHref = `/import/${ targetSiteSlug }`;
+		const uploadHref = `/import/${ targetSiteSlug }?engine=wordpress`;
+
+		return (
+			<>
+				<HeaderCake backHref={ backHref }>Import from WordPress</HeaderCake>
+				<CompactCard>
+					<CardHeading>What WordPress site do you want to import?</CardHeading>
+					<div className="migrate__explain">
+						Enter a URL and we'll help you move your site to WordPress.com. If you already have a
+						backup file, you can <a href={ uploadHref }>upload it to import content</a>.
+					</div>
+				</CompactCard>
+				<CompactCard className="migrate__sites">
+					{ this.renderFauxSiteSelector() }
+					<Gridicon className="migrate__sites-arrow" icon="arrow-right" />
+					<Site site={ targetSite } indicator={ false } />
+				</CompactCard>
+				<CompactCard>
+					<Button busy={ this.state.isLoading } onClick={ this.handleContinue } primary={ true }>
+						Continue
+					</Button>
+				</CompactCard>
+			</>
+		);
+	}
+}
+
+export default localize( StepSourceSelect );


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* Remove site-selector from initial migration page
* Add free-form url field
* Call existing `is-site-importable` endpoint to verify url is importable
* Adds a new route for "import or migrate" step

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/migrate` with the `tools/import` feature-flag enabled.
* Select the site that you want to import into.
* You should see a URL-field and a continue button. The styling of these new elements is incomplete and will be completed in a future PR.
* Enter a Jetpack-connected URL into the input field. The non-happy-path is incomplete and will be completed in a future PR.
* Click "Continue".
* You should see the stub of a page with "What do you want to import?". This page is where in a future PR you'll be given the everything (migration) or content (import) option. For now, migration is the default option, so select "Continue".
* You should be taken into the normal migration flow and be able continue the migration as it was prior to these changes.


