### PR TITLE
composite-checkout: Add GSuite meta to cart during submit

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
@@ -345,7 +345,8 @@ function createCartFromLineItems( {
 			product_id: item.wpcom_meta?.product_id,
 			meta: item.sublabel,
 			currency: item.amount.currency,
-			volume: 1, // TODO: get this from the item
+			volume: item.wpcom_meta?.volume ?? 1,
+			extra: item.wpcom_meta?.extra,
 		} ) ),
 		tax: {
 			location: {

--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
@@ -343,7 +343,7 @@ function createCartFromLineItems( {
 		extra: [],
 		products: items.map( item => ( {
 			product_id: item.wpcom_meta?.product_id,
-			meta: item.sublabel,
+			meta: item.wpcom_meta?.meta,
 			currency: item.amount.currency,
 			volume: item.wpcom_meta?.volume ?? 1,
 			extra: item.wpcom_meta?.extra,

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -112,6 +112,7 @@ function translateWpcomCartItemToCheckoutCartItem(
 		},
 		wpcom_meta: {
 			uuid: String( index ),
+			meta: typeof meta === 'string' ? meta : undefined,
 			product_id,
 			extra,
 			volume,

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -93,6 +93,8 @@ function translateWpcomCartItemToCheckoutCartItem(
 		item_subtotal_display,
 		is_domain_registration,
 		meta,
+		extra,
+		volume,
 	} = serverCartItem;
 
 	// Sublabel is the domain name for registrations
@@ -111,6 +113,8 @@ function translateWpcomCartItemToCheckoutCartItem(
 		wpcom_meta: {
 			uuid: String( index ),
 			product_id,
+			extra,
+			volume,
 		},
 	};
 }

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -25,7 +25,7 @@ export async function mockSetCartEndpoint( {
 	}, taxInteger );
 
 	return {
-		products: products,
+		products,
 		locale: requestLocale,
 		currency: requestCurrency,
 		credits_integer: 0,
@@ -60,6 +60,8 @@ function convertRequestProductToResponseProduct( currency ) {
 					item_subtotal_display: 'R$144',
 					item_tax: 0,
 					meta: '',
+					volume: 1,
+					extra: {},
 				};
 		}
 

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -89,6 +89,8 @@ export interface ResponseCartProduct {
 	item_subtotal_display: string;
 	is_domain_registration: boolean;
 	meta: string;
+	volume: number;
+	extra: object;
 }
 
 export const prepareRequestCartProduct: ( ResponseCartProduct ) => RequestCartProduct = ( {

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -36,6 +36,7 @@ export interface CheckoutCartTotal {
 export type WPCOMCartItem = CheckoutCartItem & {
 	wpcom_meta: {
 		uuid: string;
+		meta?: string;
 		plan_length?: string;
 		product_id: number;
 		extra: object;

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -34,7 +34,13 @@ export interface CheckoutCartTotal {
  * Cart item with WPCOM specific info added.
  */
 export type WPCOMCartItem = CheckoutCartItem & {
-	wpcom_meta: { uuid: string; plan_length?: string; product_id: number };
+	wpcom_meta: {
+		uuid: string;
+		plan_length?: string;
+		product_id: number;
+		extra: object;
+		volume?: number;
+	};
 };
 
 export interface WPCOMCart {

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -278,6 +278,9 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			it( 'has the expected sublabel (the domain name)', function() {
 				expect( clientCart.items[ 1 ].sublabel ).toBe( 'foo.cash' );
 			} );
+			it( 'has the expected meta (the domain name)', function() {
+				expect( clientCart.items[ 1 ].wpcom_meta?.meta ).toBe( 'foo.cash' );
+			} );
 			it( 'has the expected type', function() {
 				expect( clientCart.items[ 1 ].type ).toBe( 'dotcash_domain' );
 			} );
@@ -509,6 +512,9 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			} );
 			it( 'has the expected display value', function() {
 				expect( clientCart.items[ 2 ].amount.displayValue ).toBe( '$72' );
+			} );
+			it( 'has the expected meta (the domain name)', function() {
+				expect( clientCart.items[ 2 ].wpcom_meta?.meta ).toBe( 'foo.cash' );
 			} );
 		} );
 

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -290,6 +290,9 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			it( 'has the expected display value', function() {
 				expect( clientCart.items[ 1 ].amount.displayValue ).toBe( 'R$0' );
 			} );
+			it( 'has the expected volume', function() {
+				expect( clientCart.items[ 1 ].wpcom_meta?.volume ).toBe( 1 );
+			} );
 		} );
 
 		describe( 'taxes', function() {
@@ -310,6 +313,223 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			} );
 			it( 'has the expected display value', function() {
 				expect( clientCart.tax.amount.displayValue ).toBe( 'R$5' );
+			} );
+		} );
+
+		describe( 'allowed payment methods', function() {
+			it( 'contains the expected slugs', function() {
+				expect( clientCart.allowedPaymentMethods ).toStrictEqual( [
+					'card',
+					'ebanx',
+					'apple-pay',
+				] );
+			} );
+		} );
+	} );
+
+	describe( 'Cart with plan, domain, and GSuite', function() {
+		const serverResponse = {
+			blog_id: 123,
+			products: [
+				{
+					product_id: 1009,
+					product_name: 'WordPress.com Personal',
+					product_name_en: 'WordPress.com Personal',
+					product_slug: 'personal-bundle',
+					product_cost: 144,
+					meta: '',
+					cost: 144,
+					currency: 'USD',
+					volume: 1,
+					free_trial: false,
+					orig_cost: null,
+					cost_before_coupon: 144,
+					extra: {
+						context: 'signup',
+						domain_to_bundle: 'foo.cash',
+					},
+					bill_period: 365,
+					is_domain_registration: false,
+					time_added_to_cart: 1572551402,
+					is_bundled: false,
+					item_subtotal: 144,
+					item_subtotal_integer: 14400,
+					item_subtotal_display: '$144',
+					item_tax: 0,
+					item_total: 144,
+					subscription_id: 0,
+				},
+				{
+					product_id: 106,
+					product_name: '.cash Domain Registration',
+					product_name_en: '.cash Domain Registration',
+					product_slug: 'dotcash_domain',
+					product_cost: 88,
+					meta: 'foo.cash',
+					cost: 0,
+					currency: 'USD',
+					volume: 1,
+					free_trial: false,
+					orig_cost: 0,
+					cost_before_coupon: 88,
+					extra: {
+						privacy: true,
+						context: 'signup',
+						registrar: 'KS_RAM',
+						domain_registration_agreement_url:
+							'https://wordpress.com/automattic-domain-name-registration-agreement/',
+						privacy_available: true,
+					},
+					bill_period: 365,
+					is_domain_registration: true,
+					time_added_to_cart: 1572551402,
+					is_bundled: true,
+					item_subtotal: 0,
+					item_subtotal_integer: 0,
+					item_subtotal_display: '$0',
+					item_tax: 0,
+					item_total: 0,
+					subscription_id: 0,
+				},
+				{
+					product_id: 69,
+					product_name: 'G Suite',
+					product_name_en: 'G Suite',
+					product_slug: 'gapps',
+					product_cost: 72,
+					meta: 'foo.cash',
+					cost: 72,
+					currency: 'USD',
+					volume: 2,
+					free_trial: false,
+					orig_cost: null,
+					cost_before_coupon: null,
+					extra: {
+						context: 'signup',
+						google_apps_users: [
+							{
+								email: 'foo@foo.cash',
+								firstname: 'First',
+								lastname: 'User',
+							},
+							{
+								email: 'bar@foo.cash',
+								firstname: 'Second',
+								lastname: 'User',
+							},
+						],
+					},
+					bill_period: '365',
+					is_domain_registration: false,
+					time_added_to_cart: 1572551402,
+					is_bundled: false,
+					item_subtotal: 72,
+					item_subtotal_integer: 7200,
+					item_subtotal_display: '$72',
+					item_tax: 0,
+					item_total: 72,
+					subscription_id: 0,
+				},
+			],
+			tax: [],
+			sub_total: '216',
+			sub_total_display: '$216',
+			sub_total_integer: 21600,
+			total_tax: '5',
+			total_tax_display: '$5',
+			total_tax_integer: 500,
+			total_cost: 221,
+			total_cost_display: '$221',
+			total_cost_integer: 22100,
+			currency: 'USD',
+			allowed_payment_methods: [
+				'WPCOM_Billing_Stripe_Payment_Method',
+				'WPCOM_Billing_Ebanx',
+				'WPCOM_Billing_Web_Payment',
+			],
+		};
+
+		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+
+		it( 'has a total property', function() {
+			expect( clientCart.total.amount ).toBeDefined();
+		} );
+		it( 'has the expected total value', function() {
+			expect( clientCart.total.amount.value ).toBe( 22100 );
+		} );
+		it( 'has the expected currency', function() {
+			expect( clientCart.total.amount.currency ).toBe( 'USD' );
+		} );
+		it( 'has the expected total display value', function() {
+			expect( clientCart.total.amount.displayValue ).toBe( '$221' );
+		} );
+		it( 'has a list of items', function() {
+			expect( clientCart.items ).toBeDefined();
+		} );
+		it( 'has the expected number of line items', function() {
+			expect( clientCart.items.length ).toBe( 3 );
+		} );
+		it( 'has an array of allowed payment methods', function() {
+			expect( clientCart.allowedPaymentMethods ).toBeDefined();
+		} );
+
+		describe( 'third cart item (GSuite)', function() {
+			it( 'has an id', function() {
+				expect( clientCart.items[ 2 ].id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.items[ 2 ].label ).toBe( 'G Suite' );
+			} );
+			it( 'has the expected product_id', function() {
+				expect( clientCart.items[ 2 ].wpcom_meta?.product_id ).toBe( 69 );
+			} );
+			it( 'has the expected google_apps_users', function() {
+				expect( clientCart.items[ 2 ].wpcom_meta?.extra?.google_apps_users?.[ 0 ] ).toEqual( {
+					email: 'foo@foo.cash',
+					firstname: 'First',
+					lastname: 'User',
+				} );
+				expect( clientCart.items[ 2 ].wpcom_meta?.extra?.google_apps_users?.[ 1 ] ).toEqual( {
+					email: 'bar@foo.cash',
+					firstname: 'Second',
+					lastname: 'User',
+				} );
+			} );
+			it( 'has the expected volume', function() {
+				expect( clientCart.items[ 2 ].wpcom_meta?.volume ).toBe( 2 );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.items[ 2 ].type ).toBe( 'gapps' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.items[ 2 ].amount.currency ).toBe( 'USD' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.items[ 2 ].amount.value ).toBe( 7200 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.items[ 2 ].amount.displayValue ).toBe( '$72' );
+			} );
+		} );
+
+		describe( 'taxes', function() {
+			it( 'has an id', function() {
+				expect( clientCart.tax.id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.tax.label ).toBe( 'Tax' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.tax.type ).toBe( 'tax' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.tax.amount.currency ).toBe( 'USD' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.tax.amount.value ).toBe( 500 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.tax.amount.displayValue ).toBe( '$5' );
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When submitting products to the various transaction endpoints for most payment methods, we may need to include extra meta-data. Notably, the GSuite product may include a `volume` greater than 1, and may need a list of users. All this data has already been added to the cart by the time we get to checkout but it is ignored by the cart data in `useShoppingCart` and is therefore not sent to the server again.

It's unclear to me if we _must_ resubmit this data to the server, but it seems like a good idea. This PR adds `volume` and the `extra` object to the product data created handled by `translateWpcomCartItemToCheckoutCartItem()` and included in the transaction submissions through `createCartFromLineItems()`.

#### Testing instructions

- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan and a .live domain to your cart. This must be a .live domain to avoid an actual domain purchase!
- When heading to checkout, add a GSuite user to your cart.
- Visit checkout and complete checkout with a Stripe test card like `4242 4242 4242 4242`.
- Verify that the purchase completed successfully and that the plan, domain, and GSuite product were successfully added to your site. 
