### PR TITLE
Add Deliverable Mode to Community Translator

### DIFF
--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -229,6 +229,11 @@ class TranslatorLauncher extends React.Component {
 			() => {
 				const hasSelectedDeliverableTarget = !! this.state.selectedDeliverableTarget;
 
+				document.body.classList.toggle(
+					'has-deliverable-highlighted',
+					hasSelectedDeliverableTarget
+				);
+
 				if ( hasSelectedDeliverableTarget ) {
 					window.addEventListener( 'scroll', this.handleWindowScroll );
 

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -85,7 +85,7 @@ class TranslatorLauncher extends React.Component {
 				const [ , originalId ] =
 					( node.className && node.className.match( /translator-original-(\d+)/ ) ) || [];
 
-				if ( originalId ) {
+				if ( originalId && ids.indexOf( originalId ) === -1 ) {
 					ids.push( originalId );
 				}
 

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -53,6 +53,7 @@ class TranslatorLauncher extends React.Component {
 		isEnabled: translator.isEnabled(),
 		isDeliverablesHighlightEnabled: false,
 		deliverablesTarget: null,
+		scrollTop: 0,
 	};
 
 	componentDidMount() {
@@ -90,6 +91,10 @@ class TranslatorLauncher extends React.Component {
 		if ( isActive && event.getModifierState( 'Control' ) && event.key.toLowerCase() === 'd' ) {
 			this.toggleDeliverablesHighlight();
 		}
+	};
+
+	handleWindowScroll = event => {
+		this.setState( { scrollTop: window.scrollY } );
 	};
 
 	handleMouseMove = event => {
@@ -142,9 +147,11 @@ class TranslatorLauncher extends React.Component {
 		const isDeliverablesHighlightEnabled = ! this.state.isDeliverablesHighlightEnabled;
 
 		if ( isDeliverablesHighlightEnabled ) {
+			window.addEventListener( 'scroll', this.handleWindowScroll );
 			window.addEventListener( 'mousemove', this.handleMouseMove );
 			window.addEventListener( 'mousedown', this.handleMouseDown );
 		} else {
+			window.removeEventListener( 'scroll', this.handleWindowScroll );
 			window.removeEventListener( 'mousemove', this.handleMouseMove );
 			window.removeEventListener( 'mousedown', this.handleMouseDown );
 		}
@@ -153,7 +160,7 @@ class TranslatorLauncher extends React.Component {
 	};
 
 	renderDeliverablesHighlight() {
-		const { isDeliverablesHighlightEnabled, deliverablesTarget } = this.state;
+		const { isDeliverablesHighlightEnabled, deliverablesTarget, scrollTop } = this.state;
 
 		if ( ! isDeliverablesHighlightEnabled || ! deliverablesTarget ) {
 			return null;
@@ -162,7 +169,7 @@ class TranslatorLauncher extends React.Component {
 		const { left, top, width, height } = deliverablesTarget.getBoundingClientRect();
 		const style = {
 			left: `${ left }px`,
-			top: `${ top }px`,
+			top: `${ top + scrollTop }px`,
 			width: `${ width }px`,
 			height: `${ height }px`,
 		};

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -56,6 +56,8 @@ class TranslatorLauncher extends React.Component {
 		scrollTop: 0,
 	};
 
+	highlightRef = React.createRef();
+
 	componentDidMount() {
 		i18n.on( 'change', this.onI18nChange );
 		window.addEventListener( 'keydown', this.handleKeyDown );
@@ -93,11 +95,11 @@ class TranslatorLauncher extends React.Component {
 		}
 	};
 
-	handleWindowScroll = event => {
+	handleWindowScroll = () => {
 		this.setState( { scrollTop: window.scrollY } );
 	};
 
-	handleMouseMove = event => {
+	handleHighlightMouseMove = event => {
 		const { deliverablesTarget } = this.state;
 
 		if ( deliverablesTarget !== event.target ) {
@@ -105,18 +107,26 @@ class TranslatorLauncher extends React.Component {
 		}
 	};
 
-	handleMouseDown = event => {
+	handleHighlightMouseDown = event => {
+		event.preventDefault();
+		event.stopPropagation();
+
+		if ( this.highlightRef.current ) {
+			this.highlightRef.current.style.pointerEvents = 'all';
+		}
+	};
+
+	handleHighlightClick = event => {
 		event.preventDefault();
 		event.stopPropagation();
 
 		const { deliverablesTarget } = this.state;
-
 		const deliverablesIds = [ deliverablesTarget ]
 			.concat(
 				Array.from( deliverablesTarget.querySelectorAll( '[class*=translator-original-]' ) )
 			)
 			.reduce( ( ids, node ) => {
-				const match = node.className.match( /translator-original-(\d+)/ );
+				const match = node.className && node.className.match( /translator-original-(\d+)/ );
 
 				if ( match ) {
 					ids.push( match[ 1 ] );
@@ -124,6 +134,10 @@ class TranslatorLauncher extends React.Component {
 
 				return ids;
 			}, [] );
+
+		if ( this.highlightRef.current ) {
+			this.highlightRef.current.style.pointerEvents = 'all';
+		}
 
 		this.toggleDeliverablesHighlight();
 	};
@@ -148,12 +162,14 @@ class TranslatorLauncher extends React.Component {
 
 		if ( isDeliverablesHighlightEnabled ) {
 			window.addEventListener( 'scroll', this.handleWindowScroll );
-			window.addEventListener( 'mousemove', this.handleMouseMove );
-			window.addEventListener( 'mousedown', this.handleMouseDown );
+			window.addEventListener( 'mousemove', this.handleHighlightMouseMove );
+			window.addEventListener( 'mousedown', this.handleHighlightMouseDown );
+			window.addEventListener( 'click', this.handleHighlightClick );
 		} else {
 			window.removeEventListener( 'scroll', this.handleWindowScroll );
-			window.removeEventListener( 'mousemove', this.handleMouseMove );
-			window.removeEventListener( 'mousedown', this.handleMouseDown );
+			window.removeEventListener( 'mousemove', this.handleHighlightMouseMove );
+			window.removeEventListener( 'mousedown', this.handleHighlightMouseDown );
+			window.removeEventListener( 'click', this.handleHighlightClick );
 		}
 
 		this.setState( { isDeliverablesHighlightEnabled, deliverablesTarget: null } );
@@ -175,7 +191,7 @@ class TranslatorLauncher extends React.Component {
 		};
 
 		return ReactDOM.createPortal(
-			<div className="community-translator__highlight" style={ style } />,
+			<div ref={ this.highlightRef } className="community-translator__highlight" style={ style } />,
 			document.body
 		);
 	}

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -9,6 +9,7 @@ import ReactDOM from 'react-dom';
 import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -121,7 +122,9 @@ class TranslatorLauncher extends React.Component {
 		event.stopPropagation();
 
 		const { deliverablesTarget } = this.state;
-		const deliverablesIds = [ deliverablesTarget ]
+
+		const title = window.prompt( this.props.translate( 'Deliverables title:' ) );
+		const originalIds = [ deliverablesTarget ]
 			.concat(
 				Array.from( deliverablesTarget.querySelectorAll( '[class*=translator-original-]' ) )
 			)
@@ -136,10 +139,18 @@ class TranslatorLauncher extends React.Component {
 			}, [] );
 
 		if ( this.highlightRef.current ) {
-			this.highlightRef.current.style.pointerEvents = 'all';
+			this.highlightRef.current.style.pointerEvents = '';
 		}
 
 		this.toggleDeliverablesHighlight();
+
+		const DELIVERABLES_ENDPOINT = 'https://translate.wordpress.com/deliverables/create';
+		const deliverablesUrl = addQueryArgs( DELIVERABLES_ENDPOINT, {
+			original_ids: originalIds.join( ',' ),
+			title,
+		} );
+
+		window.open( deliverablesUrl, '_blank' ).focus();
 	};
 
 	toggleInfoCheckbox = event => {

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -86,7 +86,7 @@ class TranslatorLauncher extends React.Component {
 					( node.className && node.className.match( /translator-original-(\d+)/ ) ) || [];
 
 				if ( originalId ) {
-					ids.push( originalId[ 1 ] );
+					ids.push( originalId );
 				}
 
 				return ids;

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -161,35 +161,12 @@ class TranslatorLauncher extends React.Component {
 		event.preventDefault();
 		event.stopPropagation();
 
-		// const title = window.prompt( this.props.translate( 'Deliverables title:' ) );
-		// const originalIds = [ deliverableTarget ]
-		// 	.concat(
-		// 		Array.from( deliverableTarget.querySelectorAll( '[class*=translator-original-]' ) )
-		// 	)
-		// 	.reduce( ( ids, node ) => {
-		// 		const match = node.className && node.className.match( /translator-original-(\d+)/ );
-
-		// 		if ( match ) {
-		// 			ids.push( match[ 1 ] );
-		// 		}
-
-		// 		return ids;
-		// 	}, [] );
-
 		if ( this.highlightRef.current ) {
 			this.highlightRef.current.style.pointerEvents = '';
 		}
 
 		this.toggleSelectedDeliverableTarget();
 		this.toggleDeliverableHighlight();
-
-		// const DELIVERABLES_ENDPOINT = 'https://translate.wordpress.com/deliverables/create';
-		// const deliverablesUrl = addQueryArgs( DELIVERABLES_ENDPOINT, {
-		// 	original_ids: originalIds.join( ',' ),
-		// 	title,
-		// } );
-
-		// window.open( deliverablesUrl, '_blank' ).focus();
 	};
 
 	handleDeliverableTitleChange = event => {
@@ -201,6 +178,13 @@ class TranslatorLauncher extends React.Component {
 	};
 
 	handleDeliverableCancelClick = () => {
+		this.toggleSelectedDeliverableTarget();
+	};
+
+	handleDeliverableSubmit = event => {
+		event.preventDefault();
+
+		window.open( this.getCreateDeliverableUrl(), '_blank' );
 		this.toggleSelectedDeliverableTarget();
 	};
 
@@ -240,6 +224,7 @@ class TranslatorLauncher extends React.Component {
 		this.setState(
 			( { deliverableTarget, selectedDeliverableTarget } ) => ( {
 				selectedDeliverableTarget: selectedDeliverableTarget ? null : deliverableTarget,
+				deliverableTitle: '',
 			} ),
 			() => {
 				const hasSelectedDeliverableTarget = !! this.state.selectedDeliverableTarget;
@@ -272,7 +257,7 @@ class TranslatorLauncher extends React.Component {
 
 		return (
 			<div className="masterbar community-translator__bar">
-				<form className="community-translator__bar-form">
+				<form className="community-translator__bar-form" onSubmit={ this.handleDeliverableSubmit }>
 					<div className="community-translator__bar-label">
 						{ translate( '%d string found.', '%d strings found.', {
 							count: stringIdsCount,
@@ -289,6 +274,7 @@ class TranslatorLauncher extends React.Component {
 
 					<Button
 						href={ this.getCreateDeliverableUrl() }
+						target="_blank"
 						onClick={ this.handleDeliverableLinkClick }
 						primary
 					>

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -138,7 +138,17 @@ body {
 	}
 }
 
-// Disable translatable strings highlight when deliverable is highlighted
-.has-deliverable-highlighted .translator-translatable {
-	text-shadow: none !important;
+.has-deliverable-highlighted {
+	// Disable translatable strings highlight when deliverable is highlighted
+	.translator-translatable {
+		text-shadow: none !important;
+	}
+
+	/* stylelint-disable selector-max-id */
+	#notices,
+	.environment-badge,
+	.community-translator,
+	.inline-help {
+		display: none !important;
+	}
 }

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -98,7 +98,40 @@ body {
 
 .community-translator__highlight {
 	position: absolute;
+	left: 0;
+	top: 0;
 	z-index: 1000;
-	background: rgba( 32, 80, 129, 0.5 );
+	outline: 1000vw solid rgba( 0, 0, 0, 0.5 );
+	box-shadow: 0 5px 10px 5px rgba( 0, 0, 0, 0.25 );
 	pointer-events: none;
+	transition: all 0.2s;
+}
+
+.community-translator__bar {
+	z-index: 1000;
+	background: var( --studio-orange );
+	border-color: var( --studio-orange-80 );
+
+	&-form {
+		flex: 1 1 auto;
+		display: flex;
+		flex-flow: row nowrap;
+		align-items: center;
+		justify-content: center;
+		padding: 4px 8px;
+
+		.button {
+			flex: 0 0 auto;
+			margin-left: 8px;
+		}
+
+		.form-text-input {
+			max-width: 500px;
+		}
+	}
+
+	&-label {
+		flex: 0 0 auto;
+		margin-right: 8px;
+	}
 }

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -101,6 +101,8 @@ body {
 	left: 0;
 	top: 0;
 	z-index: 1000;
+	margin: -10px;
+	padding: 10px;
 	outline: 1000vw solid rgba( 0, 0, 0, 0.5 );
 	box-shadow: 0 5px 10px 5px rgba( 0, 0, 0, 0.25 );
 	pointer-events: none;

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -95,3 +95,10 @@ body {
 .community-translator__modal {
 	max-width: 400px;
 }
+
+.community-translator__highlight {
+	position: absolute;
+	z-index: 1000;
+	background: rgba( 32, 80, 129, 0.5 );
+	pointer-events: none;
+}

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -135,3 +135,8 @@ body {
 		margin-right: 8px;
 	}
 }
+
+// Disable translatable strings highlight when deliverable is highlighted
+.has-deliverable-highlighted .translator-translatable {
+	text-shadow: none !important;
+}

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -33,7 +33,7 @@ const user = new User(),
 		contentChangedCallback() {},
 		glotPress: {
 			url: 'https://translate.wordpress.com',
-			project: 'test',
+			project: 'wpcom',
 			translation_set_slug: 'default',
 		},
 	};
@@ -200,11 +200,7 @@ const communityTranslatorJumpstart = {
 		}
 
 		this.setInjectionURL( 'community-translator.min.js' );
-		if ( process.env.NODE_ENV === 'production' ) {
-			translationDataFromPage.glotPress.project = 'wpcom';
-		} else {
-			translationDataFromPage.glotPress.project = 'test';
-		}
+
 		translationDataFromPage.glotPress.translation_set_slug =
 			translateSetSlugs[ localeVariant ] || 'default';
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds Deliverable Mode to Community Translator. It allows you to select a DOM element within Calypso and get its and all its children's translation IDs and proceed with creating a deliverable.

#### Screenshots
--

#### Testing instructions

-   Check if tests pass
-   Open http://calypso.localhost:3000/
-   Enable Community Translator
-   Press `Control + D` to toggle on and off Deliverable Mode
-   Highlight and select DOM element

#### TODO
- [x] Fix highlight box positioning when page is scrolled
- [x] Prevent mouse click when Deliverable Mode is active
- [x] Submit IDs to translate.wordpress.com
- [x] Redirect to https://translate.wordpress.com/wp-admin/post.php?action=edit&post={deliverableId}

Requires D37773-code