### PR TITLE
Use proper `this` when calling i18n.hasTranslation

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -77,10 +76,16 @@ jest.mock( 'config', () => key => {
 	}
 } );
 
-jest.mock( 'i18n-calypso', () => ( {
-	getLocaleSlug: jest.fn( () => 'en' ),
-	hasTranslation: jest.fn( () => false ),
-} ) );
+// Mock only the getLocaleSlug function from i18n-calypso, and use
+// original references for all the other functions
+function mockFunctions() {
+	const original = jest.requireActual( 'i18n-calypso' ).default;
+	return Object.assign( Object.create( Object.getPrototypeOf( original ) ), original, {
+		getLocaleSlug: jest.fn( () => 'en' ),
+	} );
+}
+jest.mock( 'i18n-calypso', () => mockFunctions() );
+const { getLocaleSlug } = jest.requireMock( 'i18n-calypso' );
 
 describe( 'utils', () => {
 	describe( '#isDefaultLocale', () => {

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -85,7 +85,7 @@ export function canBeTranslated( locale ) {
  */
 export function translationExists() {
 	const localeSlug = typeof getLocaleSlug === 'function' ? getLocaleSlug() : 'en';
-	return isDefaultLocale( localeSlug ) || i18n.hasTranslation.apply( null, arguments );
+	return isDefaultLocale( localeSlug ) || i18n.hasTranslation( ...arguments );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A follow up to #38711. Calling `translationExists` worked in jest because `hasTranslation` was mocked, but in the actual browser it resulted in an error:

```
i18n.js:138 Uncaught TypeError: Cannot read property 'state' of null
    at getTranslation (i18n.js:138)
    at I18N.hasTranslation (i18n.js:365)
    at translationExists (utils.js:108)
```

That error was caused by `null` being used as `this` in call to `hasTranslation.apply()`. This PR ensures proper `this` is used, and improves the way we mock things in tests so that the original `hasTranslation` is used.

#### Testing instructions

1. Try `translationExists` in the browser
2. Confirm the tests are working

