### PR TITLE
Gutenboarding: design picker animations with react-spring

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
@@ -4,7 +4,6 @@
 import { __ as NO__ } from '@wordpress/i18n';
 import React, { FunctionComponent, MouseEventHandler, CSSProperties } from 'react';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -17,22 +16,15 @@ const srcSet = ( src: string, widths: number[] ) =>
 	widths.map( width => addQueryArgs( src, { w: width } ) + ` ${ width }w` ).join( ', ' );
 
 interface Props {
-	isSelected?: boolean;
 	design: import('@automattic/data-stores').VerticalsTemplates.Template;
 	onClick: MouseEventHandler< HTMLDivElement >;
 	style?: CSSProperties;
 	dialogId: string;
 }
-const DesignCard: FunctionComponent< Props > = ( {
-	design,
-	dialogId,
-	isSelected,
-	onClick,
-	style,
-} ) => (
+const DesignCard: FunctionComponent< Props > = ( { design, dialogId, onClick, style } ) => (
 	<Card
 		as="button"
-		className={ classnames( 'design-selector__design-option', { 'is-selected': isSelected } ) }
+		className="design-selector__design-option"
 		isElevated
 		onClick={ onClick }
 		style={ style }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -78,6 +78,11 @@ const DesignSelector: FunctionComponent = () => {
 		}px, 0)`,
 	} );
 
+	const descriptionContainerSpring = useSpring( {
+		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0)`,
+		visibility: hasSelectedDesign ? 'visible' : 'hidden',
+	} );
+
 	return (
 		<animated.div style={ designSelectorSpring }>
 			<div
@@ -122,21 +127,20 @@ const DesignSelector: FunctionComponent = () => {
 				</div>
 			</div>
 
-			<CSSTransition in={ hasSelectedDesign } timeout={ transitionTiming }>
-				<div
-					className={ classnames( 'design-selector__description-container', {
-						'on-right-side': descriptionOnRight,
-					} ) }
-				>
-					<div className="design-selector__description-title">{ selectedDesign?.title }</div>
-					<div className="design-selector__description-description">
-						{ /* @TODO: Real description? */ }
-						Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-						incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-						exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-					</div>
+			<animated.div
+				className={ classnames( 'design-selector__description-container', {
+					'on-right-side': descriptionOnRight,
+				} ) }
+				style={ descriptionContainerSpring }
+			>
+				<div className="design-selector__description-title">{ selectedDesign?.title }</div>
+				<div className="design-selector__description-description">
+					{ /* @TODO: Real description? */ }
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+					ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+					ullamco laboris nisi ut aliquip ex ea commodo consequat.
 				</div>
-			</CSSTransition>
+			</animated.div>
 
 			<Portal>
 				<DialogBackdrop

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -77,7 +77,7 @@ const DesignSelector: FunctionComponent = () => {
 	} );
 
 	const descriptionContainerSpring = useSpring( {
-		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0)`,
+		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0 )`,
 		visibility: hasSelectedDesign ? 'visible' : 'hidden',
 	} );
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -3,9 +3,8 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import React, { useLayoutEffect, useRef, useState, FunctionComponent } from 'react';
+import React, { useLayoutEffect, useRef, FunctionComponent } from 'react';
 import classnames from 'classnames';
-import { CSSTransition } from 'react-transition-group';
 import PageLayoutSelector from './page-layout-selector';
 import { partition } from 'lodash';
 import { Portal } from 'reakit/Portal';
@@ -52,9 +51,7 @@ const DesignSelector: FunctionComponent = () => {
 		setSelectedDesign( undefined );
 	};
 
-	const transitionTiming = 250;
 	const hasSelectedDesign = !! selectedDesign;
-	const [ isDialogVisible, setIsDialogVisible ] = useState( hasSelectedDesign );
 
 	const headingContainer = useRef< HTMLDivElement >( null );
 	const selectionTransitionShift = useRef< number >( 0 );
@@ -81,6 +78,11 @@ const DesignSelector: FunctionComponent = () => {
 	const descriptionContainerSpring = useSpring( {
 		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0)`,
 		visibility: hasSelectedDesign ? 'visible' : 'hidden',
+	} );
+
+	const pageSelectorSpring = useSpring( {
+		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0)`,
+		from: { transform: 'translate3d(0, -100vh, 0)' },
 	} );
 
 	return (
@@ -150,23 +152,19 @@ const DesignSelector: FunctionComponent = () => {
 			</Portal>
 
 			<Dialog
-				visible={ isDialogVisible }
+				visible={ hasSelectedDesign }
 				baseId={ dialogId }
 				hide={ resetState }
 				aria-labelledby="page-layout-selector__title"
 				hideOnClickOutside
 				hideOnEsc
 			>
-				<CSSTransition
-					in={ hasSelectedDesign }
-					onEnter={ () => setIsDialogVisible( true ) }
-					onExited={ () => setIsDialogVisible( false ) }
-					timeout={ transitionTiming }
+				<animated.div
+					className="design-selector__page-layout-container"
+					style={ pageSelectorSpring }
 				>
-					<div className="design-selector__page-layout-container">
-						<PageLayoutSelector templates={ otherTemplates } />
-					</div>
-				</CSSTransition>
+					<PageLayoutSelector templates={ otherTemplates } />
+				</animated.div>
 			</Dialog>
 		</animated.div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -82,7 +82,7 @@ const DesignSelector: FunctionComponent = () => {
 	} );
 
 	const pageSelectorSpring = useSpring( {
-		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0)`,
+		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0 )`,
 		onStart: () => {
 			hasSelectedDesign && dialog.show();
 		},

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -73,7 +73,7 @@ const DesignSelector: FunctionComponent = () => {
 	const designSelectorSpring = useSpring( {
 		transform: `translate3d( 0, ${
 			hasSelectedDesign ? -selectionTransitionShift.current : 0
-		}px, 0)`,
+		}px, 0 )`,
 	} );
 
 	const descriptionContainerSpring = useSpring( {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import PageLayoutSelector from './page-layout-selector';
 import { partition } from 'lodash';
 import { Portal } from 'reakit/Portal';
-import { Dialog, DialogBackdrop } from 'reakit/Dialog';
+import { useDialogState, Dialog, DialogBackdrop } from 'reakit/Dialog';
 import { useSpring, animated } from 'react-spring';
 
 /**
@@ -64,6 +64,7 @@ const DesignSelector: FunctionComponent = () => {
 	}, [ selectedDesign ] );
 
 	const dialogId = 'page-selector-modal';
+	const dialog = useDialogState( { visible: false, baseId: dialogId } );
 
 	const descriptionOnRight: boolean =
 		!! selectedDesign &&
@@ -82,7 +83,12 @@ const DesignSelector: FunctionComponent = () => {
 
 	const pageSelectorSpring = useSpring( {
 		transform: `translate3d( 0, ${ hasSelectedDesign ? '0' : '100vh' }, 0)`,
-		from: { transform: 'translate3d(0, -100vh, 0)' },
+		onStart: () => {
+			hasSelectedDesign && dialog.show();
+		},
+		onRest: () => {
+			! hasSelectedDesign && dialog.hide();
+		},
 	} );
 
 	return (
@@ -152,8 +158,7 @@ const DesignSelector: FunctionComponent = () => {
 			</Portal>
 
 			<Dialog
-				visible={ hasSelectedDesign }
-				baseId={ dialogId }
+				{ ...dialog }
 				hide={ resetState }
 				aria-labelledby="page-layout-selector__title"
 				hideOnClickOutside

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -1,22 +1,9 @@
 @import '~@wordpress/base-styles/colors';
 
-$design-selector-transition-timing: 250ms;
-
 $design-selector-grid-gap: 4.5em;
 
 $design-selector-max-width: 1100px;
 $design-selector-selection-space: 285px;
-
-@mixin design-selector-show {
-	transform: translate3d( 0, 0, 0 );
-}
-@mixin design-selector-hide {
-	transform: translate3d( 0, 100vh, 0 );
-}
-
-@mixin design-selector-transition {
-	transition: $design-selector-transition-timing transform ease-out;
-}
 
 .design-selector__title {
 	color: $dark-gray-800;
@@ -67,22 +54,6 @@ $design-selector-selection-space: 285px;
 	background: $white;
 	box-shadow: $dark-gray-300 0 0 12px;
 	padding: 2em 4em;
-
-	@include design-selector-transition();
-	transition-timing-function: ease-out;
-
-	&,
-	&.enter,
-	&.exit-active.exit-active , // duplicate selector to override `.exit` below
-	&.exit-done {
-		@include design-selector-hide();
-	}
-
-	&.exit,
-	&.enter-active,
-	&.enter-done {
-		@include design-selector-show();
-	}
 }
 
 .page-layout-selector {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -206,10 +206,6 @@ $design-selector-selection-space: 285px;
 }
 
 .design-selector__description-container {
-	@include design-selector-transition();
-	@include design-selector-hide;
-	visibility: hidden;
-
 	position: fixed;
 	display: flex;
 	flex-direction: column;
@@ -220,12 +216,6 @@ $design-selector-selection-space: 285px;
 		&.on-right-side {
 			right: 0;
 		}
-	}
-
-	&.enter-active,
-	&.enter-done {
-		@include design-selector-show;
-		visibility: visible;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -18,11 +18,6 @@ $design-selector-selection-space: 285px;
 	transition: $design-selector-transition-timing transform ease-out;
 }
 
-.design-selector {
-	@include design-selector-transition();
-	transform: translate3d( 0, 0, 0 );
-}
-
 .design-selector__title {
 	color: $dark-gray-800;
 	font-size: 2em;
@@ -42,27 +37,19 @@ $design-selector-selection-space: 285px;
 	padding-bottom: 48px;
 	padding-top: 19px;
 
-	&.exit,
-	&.exit-done {
+	&.has-selected-design {
 		overflow-y: hidden;
 		height: 100vh;
-
-		.design-selector__grid {
-			@include design-selector-hide();
-		}
 	}
 }
 
 .design-selector__grid {
-	@include design-selector-transition();
 	display: grid;
 	grid-gap: $design-selector-grid-gap;
 
 	@include breakpoint( '>660px' ) {
 		grid-template-columns: 1fr 1fr;
 	}
-
-	@include design-selector-show();
 }
 
 .design-selector__page-layout-backdrop {
@@ -180,8 +167,7 @@ $design-selector-selection-space: 285px;
 }
 
 .design-selector__design-option {
-	transform: translate3d( 0, 0, 0 );
-	@include design-selector-transition();
+	position: relative;
 
 	.design-selector__option-overlay {
 		background-color: rgba( var( --color-primary-rgb ), 0.8 );

--- a/client/package.json
+++ b/client/package.json
@@ -134,6 +134,7 @@
 		"react-modal": "3.11.1",
 		"react-redux": "7.1.3",
 		"react-router-dom": "5.1.2",
+		"react-spring": "^8.0.27",
 		"react-stripe-elements": "4.0.2",
 		"react-transition-group": "4.3.0",
 		"react-virtualized": "9.21.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `react-transition-group` and CSS transitions with `react-spring`

#### Testing instructions
* Go to /gutenboarding/design
* When selecting a design the animations should follow the existing pattern but feel more natural

Fixes https://github.com/Automattic/wp-calypso/issues/38612
