### PR TITLE
Site migration: show helpful error message when target site isn't empty

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -48,6 +48,7 @@ class SectionMigrate extends Component {
 		percent: 0,
 		startTime: '',
 		errorMessage: '',
+		errorCode: '',
 	};
 
 	componentDidMount() {
@@ -91,6 +92,7 @@ class SectionMigrate extends Component {
 				{
 					migrationStatus: 'inactive',
 					errorMessage: '',
+					errorCode: '',
 				},
 				this.updateFromAPI
 			);
@@ -160,6 +162,7 @@ class SectionMigrate extends Component {
 				this.setMigrationState( {
 					migrationStatus: 'error',
 					errorMessage: message,
+					errorCode: code,
 				} );
 			} );
 	};
@@ -221,10 +224,11 @@ class SectionMigrate extends Component {
 				}
 			} )
 			.catch( error => {
-				const { message = '' } = error;
+				const { code = '', message = '' } = error;
 				this.setMigrationState( {
 					migrationStatus: 'error',
 					errorMessage: message,
+					errorCode: code,
 				} );
 			} );
 	};
@@ -333,6 +337,22 @@ class SectionMigrate extends Component {
 	}
 
 	renderMigrationError() {
+		const { targetSiteSlug } = this.props;
+		let message = this.state.errorMessage;
+
+		if ( 'target_site_not_empty' === this.state.errorCode ) {
+			message = (
+				<>
+					You can
+					<a href={ 'https://wordpress.com/settings/start-over/' + targetSiteSlug }>
+						empty this site
+					</a>{ ' ' }
+					or
+					<a href={ 'https://wordpress.com/start/site-type' }>create a new site</a> to import into.
+				</>
+			);
+		}
+
 		return (
 			<Card className="migrate__pane">
 				<FormattedHeader
@@ -343,7 +363,7 @@ class SectionMigrate extends Component {
 				<div className="migrate__status">
 					There was an error with your import.
 					<br />
-					{ this.state.errorMessage }
+					{ message }
 				</div>
 				<Button primary onClick={ this.resetMigration }>
 					Back to your site


### PR DESCRIPTION
Note: This change is behind a feature flag and is part of an in-progress larger project. For context, see pbkcP4-8-p2.

#### Changes proposed in this Pull Request

* When the user tries to migrate into a target site that's not empty, the API returns an error. This PR shows a more helpful error message with links for actions that can fix the situation.

#### Testing instructions

(Note: most of these instructions are general instructions for testing migration. The bolded steps are the ones specific to this change)

* **Make sure you have a site (ideally one with a Business plan) you've added a post to.**
* Check out this pull request and run Calypso locally, or run it on `calypso.live`.
* Viewing `calypso.localhost:3000/migrate/`, you should see a SiteSelector component allowing you to choose a site to migrate a Jetpack site into.
* **Choose the target site with the added post.**
* After you select the site, you should see another SiteSelector component, listing all the Jetpack sites your account has access to.
* Selecting one of those sites should take you to a confirmation screen.
* Click the "Start Migration" button.
* You'll see a confirm modal. Click the "Overwrite this site" button.
* **You'll see an error message with links to empty your site or create a new site.**


