### PR TITLE
G Suite: Update copy on stats nudge to remove 'click here' language

### DIFF
--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -101,21 +101,23 @@ class GSuiteStatsNudge extends Component {
 
 					<div className="gsuite-stats-nudge__info">
 						<h1 className="gsuite-stats-nudge__title">
-							{ translate( 'Customers can’t reach you at contact@%s. Add a mailbox.', {
-								args: domainSlug,
+							{ translate( 'Get custom email addresses with %(domain)s', {
+								args: { domain: domainSlug }
 							} ) }
 						</h1>
+
 						{
 							<p>
 								{ translate(
-									"Let customers reach you at {{strong}}contact@%s{{/strong}}. We've partnered with Google to offer you email, storage, docs, calendars, and more integrated with your site.",
+									"An email address like {{strong}}contact@%(domain)s{{/strong}} looks pro and helps customers trust you. We've partnered with Google to offer you email, storage, docs, calendars, and more integrated with your site.",
 									{
-										args: domainSlug,
+										args: { domain: domainSlug },
 										components: { strong: <strong /> },
 									}
 								) }
 							</p>
 						}
+
 						<div className="gsuite-stats-nudge__button-row">
 							<Button
 								href={ url }

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -101,10 +101,9 @@ class GSuiteStatsNudge extends Component {
 
 					<div className="gsuite-stats-nudge__info">
 						<h1 className="gsuite-stats-nudge__title">
-							{ translate(
-								'Customers can’t reach you at contact@%s – click here to add a mailbox',
-								{ args: domainSlug }
-							) }
+							{ translate( 'Customers can’t reach you at contact@%s. Add a mailbox.', {
+								args: domainSlug,
+							} ) }
 						</h1>
 						{
 							<p>

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
@@ -85,7 +85,7 @@ const GSuiteUpsellCard = ( {
 			<CompactCard>
 				<header className="gsuite-upsell-card__header">
 					<h2 className="gsuite-upsell-card__title">
-						{ translate( 'Add Professional email from G Suite by Google Cloud to %(domain)s', {
+						{ translate( 'Add professional email from G Suite by Google Cloud to %(domain)s', {
 							args: {
 								domain,
 							},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the copy on the G Suite stats nudge to remove "click here" in the heading. Changes `Customers can’t reach you at contact@%s - click here to add a mailbox` -> `Customers can’t reach you at contact@%s. Add a mailbox.`

It looks like there was an A/B test in #31328 that settled on this copy. However, using "click here" for this heading is not great language.

* This text is not actually clickable, so "click here" doesn't apply. Even if it was a link, [using "click here" in links is poor usability anyway](https://medium.com/@heyoka/dont-use-click-here-f32f445d1021)).
* "Click here" removes some of the human element and personality we should strive for in our copy. It reads more like a marketing click campaign.

This copy is only a suggestion. Pinging @Automattic/editorial and @Automattic/catalyst for input.

Before | After
------------ | -------------
<img width="1063" alt="Screen Shot 2020-01-15 at 9 04 22 AM" src="https://user-images.githubusercontent.com/448298/72441414-a5791300-3778-11ea-962f-f59781deb5dd.png"> | <img width="1063" alt="Screen Shot 2020-01-15 at 9 03 23 AM" src="https://user-images.githubusercontent.com/448298/72441404-a0b45f00-3778-11ea-93fc-4b25bcf6247c.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or use the calypso.live link.
* Visit the Stats page with a site that has a domain and does not have G Suite.
* Make sure the copy is updated to match the `After` screenshot above.
