### PR TITLE
UpsellNudge: Add UpsellNudge block examples to devdocs

### DIFF
--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -2,31 +2,29 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import UpsellNudge from 'blocks/upsell-nudge';
 
-const UpsellNudgeExample = ( { translate } ) => (
+const UpsellNudgeExample = () => (
 	<>
 		<UpsellNudge
 			href="#"
-			callToAction={ translate( 'Upgrade' ) }
-			title={ translate( 'Free domain with a plan! This is a regular nudge with an icon.' ) }
+			callToAction="Upgrade"
+			title="Free domain with a plan! This is a regular nudge with an icon."
 			showIcon={ true }
 		/>
 		<UpsellNudge
 			href="#"
 			compact
-			callToAction={ translate( 'Upgrade' ) }
-			title={ translate( 'Free domain with a plan! This is a compact nudge with no icon.' ) }
+			callToAction="Upgrade"
+			title="Free domain with a plan! This is a compact nudge with no icon."
 		/>
 	</>
 );
 
-const LocalizedUpsellNudgeExample = localize( UpsellNudgeExample );
-LocalizedUpsellNudgeExample.displayName = 'UpsellNudge';
+UpsellNudgeExample.displayName = 'UpsellNudge';
 
-export default LocalizedUpsellNudgeExample;
+export default UpsellNudgeExample;

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -14,14 +14,14 @@ const UpsellNudgeExample = ( { translate } ) => (
 		<UpsellNudge
 			href="#"
 			callToAction={ translate( 'Upgrade' ) }
-			title={ translate( 'Free domain with a plan! This is a regular nudge.' ) }
-			description={ translate( 'And it has a description.' ) }
+			title={ translate( 'Free domain with a plan! This is a regular nudge with an icon.' ) }
+			showIcon={ true }
 		/>
 		<UpsellNudge
 			href="#"
 			compact
 			callToAction={ translate( 'Upgrade' ) }
-			title={ translate( 'Free domain with a plan! This is a compact nudge.' ) }
+			title={ translate( 'Free domain with a plan! This is a compact nudge with no icon.' ) }
 		/>
 	</>
 );

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import UpsellNudge from 'blocks/upsell-nudge';
+
+const UpsellNudgeExample = ( { translate } ) => (
+	<>
+		<UpsellNudge
+			href="#"
+			callToAction={ translate( 'Upgrade' ) }
+			title={ translate( 'Free domain with a plan! This is a regular nudge.' ) }
+			description={ translate( 'And it has a description.' ) }
+		/>
+		<UpsellNudge
+			href="#"
+			compact
+			callToAction={ translate( 'Upgrade' ) }
+			title={ translate( 'Free domain with a plan! This is a compact nudge.' ) }
+		/>
+	</>
+);
+
+const LocalizedUpsellNudgeExample = localize( UpsellNudgeExample );
+LocalizedUpsellNudgeExample.displayName = 'UpsellNudge';
+
+export default LocalizedUpsellNudgeExample;

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -86,6 +86,7 @@ import ConversationFollowButton from 'blocks/conversation-follow-button/docs/exa
 import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
 import UserMentions from 'blocks/user-mentions/docs/example';
 import SupportArticleDialog from 'blocks/support-article-dialog/docs/example';
+import UpsellNudge from 'blocks/upsell-nudge/docs/example';
 
 export default class AppComponents extends React.Component {
 	static displayName = 'AppComponents';
@@ -203,6 +204,7 @@ export default class AppComponents extends React.Component {
 					) }
 					<SupportArticleDialog />
 					<ImageSelector readmeFilePath="image-selector" />
+					<UpsellNudge />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* DO NOT MERGE until #38537 is deployed.
* Adds `UpsellNudge` examples to `/devdocs` for design reference.
* See #38537 for the nudge implementation.

<img width="891" alt="Screen Shot 2020-01-15 at 2 50 49 PM" src="https://user-images.githubusercontent.com/2124984/72466237-7a0d1d00-37a6-11ea-995a-e6d9f094fbea.png">

#### Testing instructions

* Wait for #38537 to be merged. :)
* Switch to this PR.
* Navigate to `/devdocs/blocks/upsell-nudge` and make sure the page exists, and that the designs look right.