### PR TITLE
ECommerce plan selection: Localize the support link about privacy settings

### DIFF
--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -76,7 +76,7 @@ class InlineSupportLink extends Component {
 			<LinkComponent
 				className="inline-support-link"
 				href={ url }
-				onClick={ ( shouldOpenDialog && openDialog ) || null }
+				onClick={ ( shouldOpenDialog && openDialog ) || undefined }
 				target="_blank"
 				rel="noopener noreferrer"
 				{ ...externalLinkProps }

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 
 /**

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -98,7 +98,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 	} = ownProps;
 	return {
 		openDialog: ( event ) => {
-			if ( ! supportPostId ) {
+			if ( ! supportPostId || 'en' !== getLocaleSlug() ) {
 				return;
 			}
 			event.preventDefault();

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -76,7 +76,7 @@ class InlineSupportLink extends Component {
 			<LinkComponent
 				className="inline-support-link"
 				href={ url }
-				onClick={ shouldOpenDialog && openDialog }
+				onClick={ ( shouldOpenDialog && openDialog ) || null }
 				target="_blank"
 				rel="noopener noreferrer"
 				{ ...externalLinkProps }

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -66,6 +66,7 @@ class InlineSupportLink extends Component {
 
 		const LinkComponent = supportPostId ? 'a' : ExternalLink;
 		const url = supportPostId ? localizeUrl( supportLink ) : supportLink;
+		const shouldOpenDialog = 'en' === getLocaleSlug();
 		const externalLinkProps = ! supportPostId && {
 			icon: showIcon,
 			iconSize,
@@ -75,7 +76,7 @@ class InlineSupportLink extends Component {
 			<LinkComponent
 				className="inline-support-link"
 				href={ url }
-				onClick={ openDialog }
+				onClick={ shouldOpenDialog && openDialog }
 				target="_blank"
 				rel="noopener noreferrer"
 				{ ...externalLinkProps }
@@ -98,7 +99,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 	} = ownProps;
 	return {
 		openDialog: ( event ) => {
-			if ( ! supportPostId || 'en' !== getLocaleSlug() ) {
+			if ( ! supportPostId ) {
 				return;
 			}
 			event.preventDefault();

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -70,6 +70,7 @@ import {
 } from 'lib/plans/constants';
 import { getPlanFeaturesObject } from 'lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
+import { localizeUrl } from 'lib/i18n-utils';
 
 /**
  * Style dependencies
@@ -270,7 +271,7 @@ export class PlanFeatures extends Component {
 				<p>{ translate( 'Upgrading to this plan makes your site visible to the public.' ) }</p>
 				<InlineSupportLink
 					showIcon={ false }
-					supportLink="https://wordpress.com/support/settings/privacy-settings/"
+					supportLink={ localizeUrl( 'https://wordpress.com/support/settings/privacy-settings/' }
 					supportPostId={ 1507 }
 				/>
 			</Dialog>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -271,7 +271,7 @@ export class PlanFeatures extends Component {
 				<p>{ translate( 'Upgrading to this plan makes your site visible to the public.' ) }</p>
 				<InlineSupportLink
 					showIcon={ false }
-					supportLink={ localizeUrl( 'https://wordpress.com/support/settings/privacy-settings/' }
+					supportLink={ localizeUrl( 'https://wordpress.com/support/settings/privacy-settings/' ) }
 					supportPostId={ 1507 }
 				/>
 			</Dialog>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Localize the URL for the Site Privacy settings support page during plan selection.

![70477347-eacd6500-1a95-11ea-8218-0ec053549bce](https://user-images.githubusercontent.com/203408/72471040-27e9ed00-37e2-11ea-83b1-2746ee0f4f32.png)

#### Testing instructions

* Use WordPress.com in a Mag16 language other than English.
* Attempt to upgrade a "not yet public" site to an e-commerce plan.
* Click the "More Information" link. A localized support page should be loaded.
