### PR TITLE
G Suite: Put the Stats & Email Management page behind a capability check

### DIFF
--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -64,25 +64,26 @@ class EmailManagement extends React.Component {
 	};
 
 	render() {
-		const { selectedSiteId, canManageSite } = this.props;
+		const { selectedSiteId, selectedDomainName, canManageSite } = this.props;
+
+		if ( ! canManageSite ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ this.props.translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					/>
+				</Main>
+			);
+		}
 
 		return (
 			<Main className="email-management" wideLayout>
-				{ selectedSiteId && canManageSite && <QueryGSuiteUsers siteId={ selectedSiteId } /> }
+				{ selectedSiteId && <QueryGSuiteUsers siteId={ selectedSiteId } /> }
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				<DocumentHead title={ this.props.translate( 'Email' ) } />
 				<SidebarNavigation />
-				{ canManageSite && this.headerLayout() }
-				{ this.content() }
-			</Main>
-		);
-	}
-
-	headerLayout() {
-		const { selectedDomainName } = this.props;
-
-		return (
-			<Fragment>
 				{ ! selectedDomainName && (
 					<FormattedHeader
 						className="email-management__page-heading"
@@ -92,7 +93,8 @@ class EmailManagement extends React.Component {
 				) }
 
 				{ this.headerOrPlansNavigation() }
-			</Fragment>
+				{ this.content() }
+			</Main>
 		);
 	}
 
@@ -116,16 +118,7 @@ class EmailManagement extends React.Component {
 	}
 
 	content() {
-		const {
-			domains,
-			hasGSuiteUsersLoaded,
-			hasSiteDomainsLoaded,
-			selectedDomainName,
-			canManageSite,
-		} = this.props;
-		if ( ! canManageSite ) {
-			return this.emptyContent();
-		}
+		const { domains, hasGSuiteUsersLoaded, hasSiteDomainsLoaded, selectedDomainName } = this.props;
 
 		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded ) {
 			return <Placeholder />;
@@ -165,7 +158,7 @@ class EmailManagement extends React.Component {
 	}
 
 	getEmptyContentProps() {
-		const { selectedDomainName, selectedSiteSlug, translate, canManageSite } = this.props;
+		const { selectedDomainName, selectedSiteSlug, translate } = this.props;
 
 		const selectedDomain = getSelectedDomain( this.props );
 
@@ -207,14 +200,6 @@ class EmailManagement extends React.Component {
 				title: translate( 'G Suite is not supported on this domain' ),
 				line: translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
 				...emailForwardingAction,
-			};
-		}
-
-		if ( ! canManageSite ) {
-			return {
-				illustration: '/calypso/images/illustrations/illustration-404.svg',
-				title: translate( 'You are not authorized to view this page' ),
-				action: null,
 			};
 		}
 

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -53,18 +53,18 @@ import customDomainImage from 'assets/images/illustrations/custom-domain.svg';
 
 class EmailManagement extends React.Component {
 	static propTypes = {
+		canManageSite: PropTypes.bool.isRequired,
 		domains: PropTypes.array.isRequired,
 		gsuiteUsers: PropTypes.array,
 		hasGSuiteUsersLoaded: PropTypes.bool.isRequired,
 		hasSiteDomainsLoaded: PropTypes.bool.isRequired,
-		canManageSite: PropTypes.bool.isRequired,
+		selectedDomainName: PropTypes.string,
 		selectedSiteId: PropTypes.number.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
-		selectedDomainName: PropTypes.string,
 	};
 
 	render() {
-		const { selectedSiteId, selectedDomainName, canManageSite } = this.props;
+		const { canManageSite, selectedDomainName, selectedSiteId } = this.props;
 
 		if ( ! canManageSite ) {
 			return (
@@ -265,11 +265,11 @@ class EmailManagement extends React.Component {
 export default connect( state => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
+		canManageSite: canCurrentUser( state, selectedSiteId, 'manage_options' ),
 		domains: getDomainsBySiteId( state, selectedSiteId ),
 		gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
 		hasGSuiteUsersLoaded: hasLoadedGSuiteUsers( state, selectedSiteId ),
 		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, selectedSiteId ),
-		canManageSite: canCurrentUser( state, selectedSiteId, 'manage_options' ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	};

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -27,12 +27,14 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import UpworkStatsNudge from 'blocks/upwork-stats-nudge';
 import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import QueryEmailForwards from 'components/data/query-email-forwards';
+import canCurrentUser from 'state/selectors/can-current-user';
 
 class StatsBanners extends Component {
 	static propTypes = {
 		domains: PropTypes.array.isRequired,
 		gsuiteDomainName: PropTypes.string,
 		isCustomerHomeEnabled: PropTypes.bool.isRequired,
+		isAllowedToManageSite: PropTypes.bool.isRequired,
 		isGoogleMyBusinessStatsNudgeVisible: PropTypes.bool.isRequired,
 		isGSuiteStatsNudgeVisible: PropTypes.bool.isRequired,
 		isUpworkStatsNudgeVisible: PropTypes.bool.isRequired,
@@ -112,7 +114,14 @@ class StatsBanners extends Component {
 	}
 
 	render() {
-		const { gsuiteDomainName, isCustomerHomeEnabled, planSlug, siteId, domains } = this.props;
+		const {
+			gsuiteDomainName,
+			isCustomerHomeEnabled,
+			isAllowedToManageSite,
+			planSlug,
+			siteId,
+			domains,
+		} = this.props;
 
 		if ( isEmpty( domains ) ) {
 			return null;
@@ -120,7 +129,9 @@ class StatsBanners extends Component {
 
 		return (
 			<Fragment>
-				{ gsuiteDomainName && <QueryEmailForwards domainName={ gsuiteDomainName } /> }
+				{ gsuiteDomainName && isAllowedToManageSite && (
+					<QueryEmailForwards domainName={ gsuiteDomainName } />
+				) }
 
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 
@@ -143,6 +154,7 @@ export default connect( ( state, ownProps ) => {
 		domains,
 		gsuiteDomainName: getEligibleGSuiteDomain( null, domains ),
 		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
+		isAllowedToManageSite: canCurrentUser( state, ownProps.siteId, 'manage_options' ),
 		isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
 			state,
 			ownProps.siteId


### PR DESCRIPTION
#### Summary

This fixes a scenario where error notifications are displayed with either `Failed to retrieve G Suite Users`  and `Failed to retrieve email forwarding records for <domain>. Please try again or contact support.` when capabilities are not enough for managing a site with a custom domain. 

Fetching forwarding data | Fetching G Suite data 
---|---
<img width="1147" alt="Screenshot 2020-01-16 at 2 23 03 PM" src="https://user-images.githubusercontent.com/277661/72528930-7e9c0900-386c-11ea-8087-a96ec24c6f10.png"> |<img width="637" alt="Screenshot 2020-01-16 at 2 23 11 PM" src="https://user-images.githubusercontent.com/277661/72528955-89ef3480-386c-11ea-9387-8cc27f692183.png">

This essentially happens when Calypso attempts to fetch G Suite and/or forwarding data for a site for which you are less than an administrator.

### Replication

**Setup** 

- You need two test WPcom users 
   - User **UserA** who owns a site **SiteA** 
   - User **UserB** ( does not need own site for this test )
- Two browsers, or a browser with private/incognito mode
- A development instance of Calypso accessible at http://calypso.localhost:3000/

**Steps**

Users **UserA** and **UserB** must exist before attempts at this stage.

- Login to **UserA** at http://calypso.localhost:3000/
- Ensure **SiteA** exists for **UserA**. You can call it whatever. We'll refer to it as **SiteA**
- Add a custom domain to **SiteA** that is eligible for G Suite ( Do not purchase G Suite! )
- Let's imagine for the purposes of testing that this domain you bought is called  i.e. **sitea.dev** 
- Invite **UserB** to **SiteA** as an administrator by navigating to: http://calypso.localhost:3000/people/team
- Login to **UserB** in a separate browser or new incognito browser
- **UserB** accepts the invitation by using the URL sent to their mail
- **UserB** would be able to see **SiteA** in their list of sites, especially when they click on `My Site` at the top left in Calypso
- Because **UserB** is an administrator of **SiteA** they should be able to access all parts of **SiteA** without any issues. Still assuming that **sitea.dev** is the domain associated with **SiteA**, attempt to navigate to these URLs directly. Substitute your actual domain.
    - http://calypso.localhost:3000/stats/day/<sitea.dev>
    - http://calypso.localhost:3000/email/<sitea.dev>
- You should have no issues accessing these URLs from **UserB**'s profile/dashboard.
- Switch to **UserA**'s dashboard and reduce the access privileges of **UserB** to **Editor**.
- Back to **UserB** and attempt to refresh the URLs.
- Confirm that you see the error prompts/alerts that appear because privileges have been reduced.

### Fixes

We check whether the user has the appropriate capabilities before launching a request to fetch data in these scenarios by using `canCurrentUser`.

### Testing

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Repeat the replication steps above
- Remember that: 
     - **UserA** needs to initially to set **UserB** as an **Administrator** and reload the Stats page
     - then downgrade **UserB** to an Editor, and reload the Stats page as well 
- At the last stage: 
     - confirm that those error prompts/alerts do not appear anymore on the Stats page
     - an empty screen as below is shown on the email mgmt page when user has no management capabilities

<img width="781" alt="Screenshot 2020-01-16 at 4 28 52 PM" src="https://user-images.githubusercontent.com/277661/72537948-4f41c800-387d-11ea-9367-b034cc5c53df.png">


