### PR TITLE
composite-checkout: Add phone and state custom fields to contact form

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -272,7 +272,7 @@ function useRedirectIfCartEmpty( items, redirectUrl ) {
 			debug( 'cart has become empty; redirecting...' );
 			window.location = redirectUrl;
 		}
-	}, [ items, prevItemsLength ] );
+	}, [ redirectUrl, items, prevItemsLength ] );
 }
 
 function CountrySelectMenu( {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -8,7 +8,12 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import debugFactory from 'debug';
 import { useSelector, useDispatch } from 'react-redux';
-import { WPCheckout, useWpcomStore, useShoppingCart, FormFieldAnnotation } from '@automattic/composite-checkout-wpcom';
+import {
+	WPCheckout,
+	useWpcomStore,
+	useShoppingCart,
+	FormFieldAnnotation,
+} from '@automattic/composite-checkout-wpcom';
 import { CheckoutProvider, createRegistry } from '@automattic/composite-checkout';
 
 /**
@@ -31,7 +36,6 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import { FormCountrySelect } from 'components/forms/form-country-select';
 import getCountries from 'state/selectors/get-countries';
 import { fetchPaymentCountries } from 'state/countries/actions';
-
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
@@ -60,10 +64,6 @@ function CountrySelectMenu( {
 	debug( 'Rendering CountrySelectMenu with list', countriesList );
 
 	useEffect( () => {
-		debug(
-			'Deciding whether to dispatch a request for the countries list in the global state.',
-			countriesList
-		);
 		if ( countriesList?.length <= 0 ) {
 			debug( 'Countries list is empty; dispatching request for data' );
 			dispatch( fetchPaymentCountries() );
@@ -86,7 +86,11 @@ function CountrySelectMenu( {
 		>
 			<FormCountrySelect
 				id={ countrySelectorId }
-				countriesList={ [ { code: null, name: translate( 'Select Country' ) }, ...countriesList ] }
+				countriesList={ [
+					{ code: '', name: translate( 'Select Country' ) },
+					{ code: null, name: '' },
+					...countriesList,
+				] }
 				translate={ translate }
 				onChange={ onChange }
 				disabled={ isDisabled }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -82,7 +82,7 @@ function CountrySelectMenu( {
 			formFieldId={ countrySelectorId }
 			labelId={ countrySelectorLabelId }
 			descriptionId={ countrySelectorDescriptionId }
-			errorMessage={ errorMessage }
+			errorDescription={ errorMessage }
 		>
 			<FormCountrySelect
 				id={ countrySelectorId }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -57,7 +57,7 @@ function CountrySelectMenu( {
 	const dispatch = useDispatch();
 	const countriesList = useSelector( state => getCountries( state, 'payments' ) );
 
-	debug( 'Rendering CountrySelectMenu' );
+	debug( 'Rendering CountrySelectMenu with list', countriesList );
 
 	useEffect( () => {
 		debug(
@@ -86,7 +86,7 @@ function CountrySelectMenu( {
 		>
 			<FormCountrySelect
 				id={ countrySelectorId }
-				countriesList={ countriesList }
+				countriesList={ [ { code: null, name: translate( 'Select Country' ) }, ...countriesList ] }
 				translate={ translate }
 				onChange={ onChange }
 				disabled={ isDisabled }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -50,58 +50,6 @@ const wpcomGetCart = ( ...args ) => wpcom.getCart( ...args );
 const wpcomSetCart = ( ...args ) => wpcom.setCart( ...args );
 const wpcomGetStoredCards = ( ...args ) => wpcom.getStoredCards( ...args );
 
-function CountrySelectMenu( {
-	translate,
-	onChange,
-	isDisabled,
-	isError,
-	errorMessage,
-	currentValue,
-} ) {
-	const dispatch = useDispatch();
-	const countriesList = useSelector( state => getCountries( state, 'payments' ) );
-
-	debug( 'Rendering CountrySelectMenu with list', countriesList );
-
-	useEffect( () => {
-		if ( countriesList?.length <= 0 ) {
-			debug( 'Countries list is empty; dispatching request for data' );
-			dispatch( fetchPaymentCountries() );
-		}
-	}, [ countriesList, dispatch ] );
-
-	const countrySelectorId = 'country-selector';
-	const countrySelectorLabelId = 'country-selector-label';
-	const countrySelectorDescriptionId = 'country-selector-description';
-
-	return (
-		<FormFieldAnnotation
-			labelText={ translate( 'Country' ) }
-			isError={ isError }
-			isDisabled={ isDisabled }
-			formFieldId={ countrySelectorId }
-			labelId={ countrySelectorLabelId }
-			descriptionId={ countrySelectorDescriptionId }
-			errorDescription={ errorMessage }
-		>
-			<FormCountrySelect
-				id={ countrySelectorId }
-				countriesList={ [
-					{ code: '', name: translate( 'Select Country' ) },
-					{ code: null, name: '' },
-					...countriesList,
-				] }
-				translate={ translate }
-				onChange={ onChange }
-				disabled={ isDisabled }
-				value={ currentValue }
-				aria-labelledby={ countrySelectorLabelId }
-				aria-describedby={ countrySelectorDescriptionId }
-			/>
-		</FormFieldAnnotation>
-	);
-}
-
 export default function CompositeCheckout( {
 	siteSlug,
 	siteId,
@@ -310,4 +258,56 @@ function useRedirectIfCartEmpty( items, redirectUrl ) {
 			window.location = redirectUrl;
 		}
 	}, [ items, prevItemsLength ] );
+}
+
+function CountrySelectMenu( {
+	translate,
+	onChange,
+	isDisabled,
+	isError,
+	errorMessage,
+	currentValue,
+} ) {
+	const dispatch = useDispatch();
+	const countriesList = useSelector( state => getCountries( state, 'payments' ) );
+
+	debug( 'Rendering CountrySelectMenu with list', countriesList );
+
+	useEffect( () => {
+		if ( countriesList?.length <= 0 ) {
+			debug( 'Countries list is empty; dispatching request for data' );
+			dispatch( fetchPaymentCountries() );
+		}
+	}, [ countriesList, dispatch ] );
+
+	const countrySelectorId = 'country-selector';
+	const countrySelectorLabelId = 'country-selector-label';
+	const countrySelectorDescriptionId = 'country-selector-description';
+
+	return (
+		<FormFieldAnnotation
+			labelText={ translate( 'Country' ) }
+			isError={ isError }
+			isDisabled={ isDisabled }
+			formFieldId={ countrySelectorId }
+			labelId={ countrySelectorLabelId }
+			descriptionId={ countrySelectorDescriptionId }
+			errorDescription={ errorMessage }
+		>
+			<FormCountrySelect
+				id={ countrySelectorId }
+				countriesList={ [
+					{ code: '', name: translate( 'Select Country' ) },
+					{ code: null, name: '' },
+					...countriesList,
+				] }
+				translate={ translate }
+				onChange={ onChange }
+				disabled={ isDisabled }
+				value={ currentValue }
+				aria-labelledby={ countrySelectorLabelId }
+				aria-describedby={ countrySelectorDescriptionId }
+			/>
+		</FormFieldAnnotation>
+	);
 }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -36,6 +36,7 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import { FormCountrySelect } from 'components/forms/form-country-select';
 import getCountries from 'state/selectors/get-countries';
 import { fetchPaymentCountries } from 'state/countries/actions';
+import PhoneInput from 'components/phone-input/index.jsx';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
@@ -92,6 +93,16 @@ export default function CompositeCheckout( {
 		debug( 'success', message );
 		notices.success( message );
 	}, [] );
+
+	const dispatch = useDispatch();
+	const countriesList = useSelector( state => getCountries( state, 'payments' ) );
+
+	useEffect( () => {
+		if ( countriesList?.length <= 0 ) {
+			debug( 'countries list is empty; dispatching request for data' );
+			dispatch( fetchPaymentCountries() );
+		}
+	}, [ countriesList, dispatch ] );
 
 	const {
 		items,
@@ -169,6 +180,8 @@ export default function CompositeCheckout( {
 				siteId={ siteId }
 				siteUrl={ siteSlug }
 				CountrySelectMenu={ CountrySelectMenu }
+				countriesList={ countriesList }
+				PhoneInput={ PhoneInput }
 			/>
 		</CheckoutProvider>
 	);
@@ -267,19 +280,8 @@ function CountrySelectMenu( {
 	isError,
 	errorMessage,
 	currentValue,
+	countriesList,
 } ) {
-	const dispatch = useDispatch();
-	const countriesList = useSelector( state => getCountries( state, 'payments' ) );
-
-	debug( 'Rendering CountrySelectMenu with list', countriesList );
-
-	useEffect( () => {
-		if ( countriesList?.length <= 0 ) {
-			debug( 'Countries list is empty; dispatching request for data' );
-			dispatch( fetchPaymentCountries() );
-		}
-	}, [ countriesList, dispatch ] );
-
 	const countrySelectorId = 'country-selector';
 	const countrySelectorLabelId = 'country-selector-label';
 	const countrySelectorDescriptionId = 'country-selector-description';

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -37,6 +37,7 @@ import { FormCountrySelect } from 'components/forms/form-country-select';
 import getCountries from 'state/selectors/get-countries';
 import { fetchPaymentCountries } from 'state/countries/actions';
 import PhoneInput from 'components/phone-input/index.jsx';
+import { StateSelect } from 'my-sites/domains/components/form';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
@@ -182,6 +183,7 @@ export default function CompositeCheckout( {
 				CountrySelectMenu={ CountrySelectMenu }
 				countriesList={ countriesList }
 				PhoneInput={ PhoneInput }
+				StateSelect={ StateSelect }
 			/>
 		</CheckoutProvider>
 	);

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -64,7 +64,7 @@ const FormFieldAnnotation: FunctionComponent< FormFieldAnnotationProps > = ( {
 
 type LabelProps = {
 	isDisabled: boolean;
-	theme?: any;
+	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
 const Label = styled.label< LabelProps >`
@@ -81,7 +81,7 @@ const Label = styled.label< LabelProps >`
 
 type FormFieldWrapperProps = {
 	isError: boolean;
-	theme?: any;
+	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
 const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
@@ -103,7 +103,7 @@ function RenderedDescription( { descriptionText, descriptionId, isError, errorMe
 
 type DescriptionProps = {
 	isError: boolean;
-	theme?: any;
+	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
 const Description = styled.p< DescriptionProps >`

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -85,21 +85,8 @@ type FormFieldWrapperProps = {
 };
 
 const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
-	display: block;
-	width: 100%;
-	box-sizing: border-box;
-	font-size: 16px;
-	border: 1px solid
-		${props => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor )};
-
-	:focus {
-		outline: ${props => ( props.isError ? props.theme.colors.error : props.theme.colors.outline )}
-			solid 2px !important;
-	}
-
-	::-webkit-inner-spin-button,
-	::-webkit-outer-spin-button {
-		-webkit-appearance: none;
+	select {
+		width: 100%;
 	}
 `;
 

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -50,6 +50,7 @@ export default function WPCheckout( {
 	CountrySelectMenu,
 	countriesList,
 	PhoneInput,
+	StateSelect,
 } ) {
 	const translate = useTranslate();
 	const [ itemsWithTax ] = useLineItems();
@@ -92,6 +93,7 @@ export default function WPCheckout( {
 					CountrySelectMenu={ CountrySelectMenu }
 					countriesList={ countriesList }
 					PhoneInput={ PhoneInput }
+					StateSelect={ StateSelect }
 				/>
 			),
 			completeStepContent: <WPContactForm summary isComplete={ true } isActive={ false } />,

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -42,7 +42,7 @@ const OrderReviewTitle = () => {
 	return translate( 'Review your order' );
 };
 
-export default function WPCheckout( { removeItem, changePlanLength, siteId, siteUrl } ) {
+export default function WPCheckout( { removeItem, changePlanLength, siteId, siteUrl, CountrySelectMenu } ) {
 	const translate = useTranslate();
 	const [ itemsWithTax ] = useLineItems();
 
@@ -77,7 +77,13 @@ export default function WPCheckout( { removeItem, changePlanLength, siteId, site
 			className: 'checkout__billing-details-step',
 			hasStepNumber: true,
 			titleContent: <ContactFormTitle />,
-			activeStepContent: <WPContactForm isComplete={ false } isActive={ true } />,
+			activeStepContent: (
+				<WPContactForm
+					isComplete={ false }
+					isActive={ true }
+					CountrySelectMenu={ CountrySelectMenu }
+				/>
+			),
 			completeStepContent: <WPContactForm summary isComplete={ true } isActive={ false } />,
 			isCompleteCallback: () => isFormComplete( contactInfo, itemsWithTax ),
 			isEditableCallback: () => isFormEditable( contactInfo, itemsWithTax ),

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -42,7 +42,15 @@ const OrderReviewTitle = () => {
 	return translate( 'Review your order' );
 };
 
-export default function WPCheckout( { removeItem, changePlanLength, siteId, siteUrl, CountrySelectMenu } ) {
+export default function WPCheckout( {
+	removeItem,
+	changePlanLength,
+	siteId,
+	siteUrl,
+	CountrySelectMenu,
+	countriesList,
+	PhoneInput,
+} ) {
 	const translate = useTranslate();
 	const [ itemsWithTax ] = useLineItems();
 
@@ -82,6 +90,8 @@ export default function WPCheckout( { removeItem, changePlanLength, siteId, site
 					isComplete={ false }
 					isActive={ true }
 					CountrySelectMenu={ CountrySelectMenu }
+					countriesList={ countriesList }
+					PhoneInput={ PhoneInput }
 				/>
 			),
 			completeStepContent: <WPContactForm summary isComplete={ true } isActive={ false } />,

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -322,10 +322,17 @@ function PhoneNumberField( {
 				countryCode={ contactInfo.phoneNumberCountry.value ?? 'US' }
 				countriesList={ countriesList }
 			/>
-			{ isError && <span>{ translate( 'This field is required.' ) }</span> }
+			{ isError && <ErrorMessage>{ translate( 'This field is required.' ) }</ErrorMessage> }
 		</PhoneNumberFieldUI>
 	);
 }
+
+const ErrorMessage = styled.p`
+	margin: 8px 0 0 0;
+	color: ${props => props.theme.colors.error};
+	font-style: italic;
+	font-size: 14px;
+`;
 
 const PhoneNumberFieldUI = styled.div`
 	margin-top: 16px;

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -46,18 +46,12 @@ export default function WPContactForm( {
 				countriesList={ countriesList }
 			/>
 
-			<PhoneInput
-				onChange={ ( { value, countryCode } ) => {
-					setters.setContactField( 'phoneNumber', { value, isTouched: true, isValid: !! value } );
-					setters.setContactField( 'phoneNumberCountry', {
-						countryCode,
-						isTouched: true,
-						isValid: !! value,
-					} );
-				} }
-				value={ contactInfo.phoneNumber.value }
-				countryCode={ contactInfo.phoneNumberCountry.value ?? 'US' }
+			<PhoneNumberField
+				id="contact-phone-number"
+				setContactField={ setters.setContactField }
 				countriesList={ countriesList }
+				contactInfo={ contactInfo }
+				PhoneInput={ PhoneInput }
 			/>
 
 			{ isElligibleForVat() && <VatIdField /> }
@@ -293,30 +287,58 @@ function isStateorProvince() {
 	return 'province';
 }
 
-function PhoneNumberField( { id, isRequired, phoneNumber, onChange } ) {
+function PhoneNumberField( {
+	id,
+	isRequired,
+	setContactField,
+	contactInfo,
+	countriesList,
+	PhoneInput,
+} ) {
 	const translate = useTranslate();
 
+	// TODO: style wrapper div
+	// TODO: add id for label to target
+	// TODO: add errorMessage and isError
+	// isError={ phoneNumber.isTouched && ! phoneNumber.isValid }
+	// errorMessage={ translate( 'This field is required.' ) }
 	return (
-		<FormField
-			id={ id }
-			type="text"
-			label={ isRequired ? translate( 'Phone number (Optional)' ) : translate( 'Phone number' ) }
-			value={ phoneNumber.value }
-			onChange={ value =>
-				onChange( 'phoneNumber', { value, isTouched: true, isValid: isRequired ? !! value : true } )
-			}
-			autoComplete="tel"
-			isError={ phoneNumber.isTouched && ! phoneNumber.isValid }
-			errorMessage={ translate( 'This field is required.' ) }
-		/>
+		<div>
+			<label htmlFor={ id }>
+				{ isRequired ? translate( 'Phone number (Optional)' ) : translate( 'Phone number' ) }
+			</label>
+			<PhoneInput
+				id={ id }
+				onChange={ ( { value, countryCode } ) => {
+					setContactField( 'phoneNumber', {
+						value,
+						isTouched: true,
+						isValid: isRequired ? !! value : true,
+					} );
+					setContactField( 'phoneNumberCountry', {
+						countryCode,
+						isTouched: true,
+						isValid: !! value,
+					} );
+				} }
+				value={ contactInfo.phoneNumber.value }
+				countryCode={ contactInfo.phoneNumberCountry.value ?? 'US' }
+				countriesList={ countriesList }
+			/>
+		</div>
 	);
 }
 
 PhoneNumberField.propTypes = {
 	isRequired: PropTypes.bool,
 	id: PropTypes.string.isRequired,
-	phoneNumber: PropTypes.object.isRequired,
-	onChange: PropTypes.func.isRequired,
+	setContactField: PropTypes.func.isRequired,
+	contactInfo: PropTypes.shape( {
+		phoneNumber: PropTypes.shape( { value: PropTypes.string } ),
+		phoneNumberCountry: PropTypes.shape( { value: PropTypes.string } ),
+	} ).isRequired,
+	countriesList: PropTypes.array.isRequired,
+	PhoneInput: PropTypes.elementType.isRequired,
 };
 
 function VatIdField() {

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -21,6 +21,7 @@ export default function WPContactForm( {
 	isActive,
 	CountrySelectMenu,
 	PhoneInput,
+	StateSelect,
 	countriesList,
 } ) {
 	const isDomainFieldsVisible = useHasDomainsInCart();
@@ -36,7 +37,7 @@ export default function WPContactForm( {
 
 	return (
 		<BillingFormFields>
-			{ isDomainFieldsVisible && <DomainFields /> }
+			{ isDomainFieldsVisible && <DomainFields StateSelect={ StateSelect } /> }
 
 			<TaxFields
 				section="contact"
@@ -173,9 +174,9 @@ const DomainRegistrationCheckbox = styled.input`
 	}
 `;
 
-function AddressFields( { section, contactInfo, setters } ) {
+function AddressFields( { section, contactInfo, setters, StateSelect } ) {
 	const translate = useTranslate();
-	const { firstName, lastName, email, address, city, state } = contactInfo;
+	const { firstName, lastName, email, address, city, state, country } = contactInfo;
 	const { setContactField } = setters;
 
 	return (
@@ -256,19 +257,20 @@ function AddressFields( { section, contactInfo, setters } ) {
 				</LeftColumn>
 
 				<RightColumn>
-					<Field
-						id={ section + '-state' }
-						type="text"
+					<StateSelect
+						countryCode={ country.value ?? 'US' }
 						label={
 							isStateorProvince() === 'state' ? translate( 'State' ) : translate( 'Province' )
 						}
-						value={ state.value }
-						onChange={ value =>
-							setContactField( 'state', { value, isTouched: true, isValid: !! value } )
+						name={ section + '-state' }
+						onChange={ event =>
+							setContactField( 'state', {
+								value: event.target.value,
+								isTouched: true,
+								isValid: !! event.target.value,
+							} )
 						}
-						autoComplete={ section + ' address-level1' }
-						isError={ state.isTouched && ! state.isValid }
-						errorMessage={ translate( 'This field is required.' ) }
+						value={ state.value }
 					/>
 				</RightColumn>
 			</FieldRow>
@@ -280,6 +282,7 @@ AddressFields.propTypes = {
 	section: PropTypes.string.isRequired,
 	contactInfo: PropTypes.object.isRequired,
 	setters: PropTypes.object.isRequired,
+	StateSelect: PropTypes.elementType.isRequired,
 };
 
 function isStateorProvince() {
@@ -432,7 +435,7 @@ function isZipOrPostal() {
 	return 'postal';
 }
 
-function DomainFields() {
+function DomainFields( { StateSelect } ) {
 	const translate = useTranslate();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
 	const setters = useDispatch( 'wpcom' );
@@ -445,7 +448,12 @@ function DomainFields() {
 				) }
 			</DomainContactFieldsDescription>
 
-			<AddressFields section="contact" contactInfo={ contactInfo } setters={ setters } />
+			<AddressFields
+				section="contact"
+				contactInfo={ contactInfo }
+				setters={ setters }
+				StateSelect={ StateSelect }
+			/>
 		</DomainContactFields>
 	);
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -258,7 +258,7 @@ function AddressFields( { section, contactInfo, setters, StateSelect } ) {
 
 				<RightColumn>
 					<StateSelect
-						countryCode={ country.value ?? 'US' }
+						countryCode={ country.value || 'US' }
 						label={
 							isStateorProvince() === 'state' ? translate( 'State' ) : translate( 'Province' )
 						}
@@ -322,7 +322,7 @@ function PhoneNumberField( {
 					} );
 				} }
 				value={ contactInfo.phoneNumber.value }
-				countryCode={ contactInfo.phoneNumberCountry.value ?? 'US' }
+				countryCode={ contactInfo.phoneNumberCountry.value || 'US' }
 				countriesList={ countriesList }
 			/>
 			{ isError && <ErrorMessage>{ translate( 'This field is required.' ) }</ErrorMessage> }

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -311,6 +311,7 @@ function PhoneNumberField( {
 			<PhoneInput
 				name={ id }
 				isError={ isError }
+				enableStickyCountry={ false }
 				onChange={ ( { value, countryCode } ) => {
 					setContactField( 'phoneNumber', {
 						value,
@@ -318,13 +319,13 @@ function PhoneNumberField( {
 						isValid: isRequired ? !! value : true,
 					} );
 					setContactField( 'phoneNumberCountry', {
-						countryCode,
+						value: countryCode,
 						isTouched: true,
 						isValid: !! value,
 					} );
 				} }
 				value={ contactInfo.phoneNumber.value }
-				countryCode={ contactInfo.phoneNumberCountry.value || 'US' }
+				countryCode={ contactInfo.phoneNumberCountry.value || contactInfo.country.value || 'US' }
 				countriesList={ countriesList }
 			/>
 			{ isError && <ErrorMessage>{ translate( 'This field is required.' ) }</ErrorMessage> }

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -15,7 +15,7 @@ import Field from './field';
 import { SummaryLine, SummaryDetails, SummarySpacerLine } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
 
-export default function WPContactForm( { summary, isComplete, isActive } ) {
+export default function WPContactForm( { summary, isComplete, isActive, CountrySelectMenu } ) {
 	const isDomainFieldsVisible = useHasDomainsInCart();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
 	const setters = useDispatch( 'wpcom' );
@@ -31,7 +31,12 @@ export default function WPContactForm( { summary, isComplete, isActive } ) {
 		<BillingFormFields>
 			{ isDomainFieldsVisible && <DomainFields /> }
 
-			<TaxFields section="contact" taxInfo={ contactInfo } setters={ setters } />
+			<TaxFields
+				section="contact"
+				taxInfo={ contactInfo }
+				setters={ setters }
+				CountrySelectMenu={ CountrySelectMenu }
+			/>
 
 			<PhoneNumberField
 				id="contact-phone-number"
@@ -316,7 +321,7 @@ function VatIdField() {
 	);
 }
 
-function TaxFields( { section, taxInfo, setters } ) {
+function TaxFields( { section, taxInfo, setters, CountrySelectMenu } ) {
 	const translate = useTranslate();
 	const { postalCode, country } = taxInfo;
 	const { setContactField } = setters;
@@ -340,17 +345,16 @@ function TaxFields( { section, taxInfo, setters } ) {
 			</LeftColumn>
 
 			<RightColumn>
-				<Field
-					id={ section + '-country' }
-					type="text"
-					label={ translate( 'Country' ) }
-					value={ country.value }
-					onChange={ value =>
-						setContactField( 'country', { value, isTouched: true, isValid: !! value } )
-					}
-					autoComplete={ section + ' country' }
+				<CountrySelectMenu
+					translate={ translate }
+					onChange={ event => {
+						const value = event.target.value;
+						setContactField( 'country', { value, isTouched: true, isValid: !! value } );
+					} }
 					isError={ country.isTouched && ! country.isValid }
+					isDisabled={ false } // TODO
 					errorMessage={ translate( 'This field is required.' ) }
+					currentValue={ country.value }
 				/>
 			</RightColumn>
 		</FieldRow>

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -257,21 +257,23 @@ function AddressFields( { section, contactInfo, setters, StateSelect } ) {
 				</LeftColumn>
 
 				<RightColumn>
-					<StateSelect
-						countryCode={ country.value || 'US' }
-						label={
-							isStateorProvince() === 'state' ? translate( 'State' ) : translate( 'Province' )
-						}
-						name={ section + '-state' }
-						onChange={ event =>
-							setContactField( 'state', {
-								value: event.target.value,
-								isTouched: true,
-								isValid: !! event.target.value,
-							} )
-						}
-						value={ state.value }
-					/>
+					<StateSelectWrapper>
+						<StateSelect
+							countryCode={ country.value || 'US' }
+							label={
+								isStateorProvince() === 'state' ? translate( 'State' ) : translate( 'Province' )
+							}
+							name={ section + '-state' }
+							onChange={ event =>
+								setContactField( 'state', {
+									value: event.target.value,
+									isTouched: true,
+									isValid: !! event.target.value,
+								} )
+							}
+							value={ state.value }
+						/>
+					</StateSelectWrapper>
 				</RightColumn>
 			</FieldRow>
 		</React.Fragment>
@@ -527,3 +529,9 @@ function ContactFormSummary() {
 function joinNonEmptyValues( joinString, ...values ) {
 	return values.filter( value => value.length > 0 ).join( joinString );
 }
+
+const StateSelectWrapper = styled.div`
+	& select {
+		width: 100%;
+	}
+`;

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -284,7 +284,7 @@ AddressFields.propTypes = {
 
 function isStateorProvince() {
 	//TODO: Add location detection to return "state" or "province"
-	return 'province';
+	return 'state';
 }
 
 function PhoneNumberField( {

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -297,18 +297,15 @@ function PhoneNumberField( {
 } ) {
 	const translate = useTranslate();
 
-	// TODO: style wrapper div
-	// TODO: add id for label to target
-	// TODO: add errorMessage and isError
-	// isError={ phoneNumber.isTouched && ! phoneNumber.isValid }
-	// errorMessage={ translate( 'This field is required.' ) }
+	const isError = contactInfo.phoneNumber.isTouched && ! contactInfo.phoneNumber.isValid;
 	return (
-		<div>
-			<label htmlFor={ id }>
+		<PhoneNumberFieldUI>
+			<Label htmlFor={ id }>
 				{ isRequired ? translate( 'Phone number (Optional)' ) : translate( 'Phone number' ) }
-			</label>
+			</Label>
 			<PhoneInput
-				id={ id }
+				name={ id }
+				isError={ isError }
 				onChange={ ( { value, countryCode } ) => {
 					setContactField( 'phoneNumber', {
 						value,
@@ -325,9 +322,26 @@ function PhoneNumberField( {
 				countryCode={ contactInfo.phoneNumberCountry.value ?? 'US' }
 				countriesList={ countriesList }
 			/>
-		</div>
+			{ isError && <span>{ translate( 'This field is required.' ) }</span> }
+		</PhoneNumberFieldUI>
 	);
 }
+
+const PhoneNumberFieldUI = styled.div`
+	margin-top: 16px;
+`;
+
+const Label = styled.label`
+	display: block;
+	color: ${props => props.theme.colors.textColor};
+	font-weight: ${props => props.theme.weights.bold};
+	font-size: 14px;
+	margin-bottom: 8px;
+
+	:hover {
+		cursor: ${props => ( props.isDisabled ? 'default' : 'pointer' )};
+	}
+`;
 
 PhoneNumberField.propTypes = {
 	isRequired: PropTypes.bool,

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -15,7 +15,14 @@ import Field from './field';
 import { SummaryLine, SummaryDetails, SummarySpacerLine } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
 
-export default function WPContactForm( { summary, isComplete, isActive, CountrySelectMenu } ) {
+export default function WPContactForm( {
+	summary,
+	isComplete,
+	isActive,
+	CountrySelectMenu,
+	PhoneInput,
+	countriesList,
+} ) {
 	const isDomainFieldsVisible = useHasDomainsInCart();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
 	const setters = useDispatch( 'wpcom' );
@@ -36,12 +43,21 @@ export default function WPContactForm( { summary, isComplete, isActive, CountryS
 				taxInfo={ contactInfo }
 				setters={ setters }
 				CountrySelectMenu={ CountrySelectMenu }
+				countriesList={ countriesList }
 			/>
 
-			<PhoneNumberField
-				id="contact-phone-number"
-				phoneNumber={ contactInfo.phoneNumber }
-				onChange={ setters.setContactField }
+			<PhoneInput
+				onChange={ ( { value, countryCode } ) => {
+					setters.setContactField( 'phoneNumber', { value, isTouched: true, isValid: !! value } );
+					setters.setContactField( 'phoneNumberCountry', {
+						countryCode,
+						isTouched: true,
+						isValid: !! value,
+					} );
+				} }
+				value={ contactInfo.phoneNumber.value }
+				countryCode={ contactInfo.phoneNumberCountry.value ?? 'US' }
+				countriesList={ countriesList }
 			/>
 
 			{ isElligibleForVat() && <VatIdField /> }
@@ -321,7 +337,7 @@ function VatIdField() {
 	);
 }
 
-function TaxFields( { section, taxInfo, setters, CountrySelectMenu } ) {
+function TaxFields( { section, taxInfo, setters, CountrySelectMenu, countriesList } ) {
 	const translate = useTranslate();
 	const { postalCode, country } = taxInfo;
 	const { setContactField } = setters;
@@ -355,6 +371,7 @@ function TaxFields( { section, taxInfo, setters, CountrySelectMenu } ) {
 					isDisabled={ false } // TODO
 					errorMessage={ translate( 'This field is required.' ) }
 					currentValue={ country.value }
+					countriesList={ countriesList }
 				/>
 			</RightColumn>
 		</FieldRow>

--- a/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
+++ b/packages/composite-checkout-wpcom/src/hooks/wpcom-store.js
@@ -16,6 +16,7 @@ export function useWpcomStore( registerStore, onEvent ) {
 		lastName: { value: '', isTouched: false, isValid: false },
 		email: { value: '', isTouched: false, isValid: false },
 		phoneNumber: { value: '', isTouched: false, isValid: true },
+		phoneNumberCountry: { value: '', isTouched: false, isValid: true },
 		address: { value: '', isTouched: false, isValid: false },
 		city: { value: '', isTouched: false, isValid: false },
 		state: { value: '', isTouched: false, isValid: false },
@@ -89,6 +90,7 @@ export function useWpcomStore( registerStore, onEvent ) {
 					country: state.contact.country,
 					postalCode: state.contact.postalCode,
 					phoneNumber: state.contact.phoneNumber,
+					phoneNumberCountry: state.contact.phoneNumberCountry,
 					vatId: state.contact.vatId,
 				};
 			},

--- a/packages/composite-checkout-wpcom/src/index.js
+++ b/packages/composite-checkout-wpcom/src/index.js
@@ -5,6 +5,7 @@ import WPCheckout from './components/wp-checkout';
 import { useShoppingCart } from './hooks/use-shopping-cart';
 import { useWpcomStore } from './hooks/wpcom-store';
 import { mockSetCartEndpoint, mockGetCartEndpointWith } from './mock/cart-endpoint';
+import { FormFieldAnnotation } from './components/form-field-annotation';
 
 // Re-export the public API
-export { WPCheckout, useShoppingCart, useWpcomStore, mockSetCartEndpoint, mockGetCartEndpointWith };
+export { WPCheckout, useShoppingCart, useWpcomStore, mockSetCartEndpoint, mockGetCartEndpointWith, FormFieldAnnotation };

--- a/packages/composite-checkout-wpcom/src/index.js
+++ b/packages/composite-checkout-wpcom/src/index.js
@@ -5,7 +5,7 @@ import WPCheckout from './components/wp-checkout';
 import { useShoppingCart } from './hooks/use-shopping-cart';
 import { useWpcomStore } from './hooks/wpcom-store';
 import { mockSetCartEndpoint, mockGetCartEndpointWith } from './mock/cart-endpoint';
-import { FormFieldAnnotation } from './components/form-field-annotation';
+import FormFieldAnnotation from './components/form-field-annotation';
 
 // Re-export the public API
 export { WPCheckout, useShoppingCart, useWpcomStore, mockSetCartEndpoint, mockGetCartEndpointWith, FormFieldAnnotation };

--- a/packages/composite-checkout-wpcom/test/form-field-annotation.js
+++ b/packages/composite-checkout-wpcom/test/form-field-annotation.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
+/* eslint-disable wpcalypso/jsx-classname-namespace,import/no-extraneous-dependencies */
 
 /**
  * External dependencies

--- a/packages/composite-checkout-wpcom/test/form-field-annotation.js
+++ b/packages/composite-checkout-wpcom/test/form-field-annotation.js
@@ -64,14 +64,6 @@ describe( 'FormFieldAnnotation', () => {
 			const { queryAllByText } = render( <MyFormFieldAnnotation /> );
 			expect( queryAllByText( 'An Error Message' )[ 0 ] ).toBeUndefined();
 		} );
-
-		it( 'does not have a highlighted border', () => {
-			const { getAllByTestId } = render( <MyFormFieldAnnotation /> );
-			expect( getAllByTestId( 'test__annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
-				'border',
-				'1px solid black'
-			);
-		} );
 	} );
 
 	describe( 'with error and not disabled', () => {
@@ -105,14 +97,6 @@ describe( 'FormFieldAnnotation', () => {
 		it( 'renders the error string', () => {
 			const { getAllByText } = render( <MyFormFieldAnnotation /> );
 			expect( getAllByText( 'An Error Message' )[ 0 ] ).toBeInTheDocument();
-		} );
-
-		it( 'does not have a highlighted border', () => {
-			const { getAllByTestId } = render( <MyFormFieldAnnotation /> );
-			expect( getAllByTestId( 'test__annotation_class_wrapper' )[ 0 ] ).toHaveStyleRule(
-				'border',
-				'1px solid red'
-			);
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up to #38481 (this one currently also contains that one).

Here we add a drop-down field for state and a controlled field input for phone number.

![Screen Shot 2020-01-15 at 7 56 29 PM](https://user-images.githubusercontent.com/2036909/72484089-23690880-37d1-11ea-899e-0760c605758b.png)


#### Testing instructions

* Sandbox the store.
* Start local calypso with composite checkout enabled: `ENABLE_FEATURES=composite-checkout-wpcom npm start`
* Complete the form.
* Test the behavior of the state field and phone number input.
* Complete the purchase and verify that the receipt is correct.
* Repeat the above test with a .live domain.