### PR TITLE
calypso-build: release 6.0.0

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,4 +1,4 @@
-# next
+# 6.0.0
 
 - Breaking Change: Replace `copy-styles` with a generic `copy-assets` script to handle both styles and images.
 - Upgrade to [sass-loader@8](https://github.com/webpack-contrib/sass-loader/releases/tag/v8.0.0)

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "5.1.0",
+	"version": "6.0.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",


### PR DESCRIPTION
`@automattic/calypso-build@6.0.0` was just published to NPM. Let's merge the `package.json` and Changelog changes.