### PR TITLE
data-stores: Compile target es5 

### DIFF
--- a/packages/data-stores/global.d.ts
+++ b/packages/data-stores/global.d.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 declare module 'wpcom-proxy-request' {
-	import { WpcomRequestParams } from 'src/utils/wpcom-wrapper';
+	type WpcomRequestParams = import('./src/utils/wpcom-wrapper').WpcomRequestParams;
 	export function reloadProxy(): void;
 	export default function wpcomProxyRequest(
 		params: WpcomRequestParams,

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -1,14 +1,8 @@
 {
 	"compilerOptions": {
-		// FIXME: Should target "ES5" according to our package convention.
-		// There is a compatibility issue between the TypeScript generator
-		// es5 helper and `@wordpress/redux-routine` that breaks when
-		// targetting es5.
-		// see issue: https://github.com/microsoft/TypeScript/issues/35833
-		"target": "es2015",
-
-		"baseUrl": ".",
-		"module": "esnext",
+		"target": "ES5",
+		"lib": [ "DOM", "ES2015", "ScriptHost" ],
+		"module": "ESNEXT",
 		"allowJs": false,
 		"jsx": "react",
 		"declaration": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the workaround target `ES2015` that introduced in https://github.com/Automattic/wp-calypso/pull/38503. There was a compatibility issue that was fixed in https://github.com/WordPress/gutenberg/pull/19666.

Blocked on:
- [x] `@wordpress/redux-routine` and related packages release.

#### Testing instructions

There was an issue that would result in a console error message and failure to send API requests from the data-stores package:
https://github.com/Automattic/wp-calypso/pull/38503#issuecomment-568381810

That problem should not be present.