### PR TITLE
Notifications: Fix to make work with current calypso-build version

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -22,6 +22,7 @@
 		"build": "calypso-build --config='./webpack.config.js'"
 	},
 	"dependencies": {
+		"@automattic/calypso-color-schemes": "file:../../packages/calypso-color-schemes",
 		"@automattic/calypso-polyfills": "file:../../packages/calypso-polyfills"
 	}
 }

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -20,5 +20,8 @@
 		"clean": "npx rimraf dist",
 		"prebuild": "npm run clean",
 		"build": "calypso-build --config='./webpack.config.js'"
+	},
+	"dependencies": {
+		"@automattic/calypso-polyfills": "file:../../packages/calypso-polyfills"
 	}
 }

--- a/apps/notifications/postcss.config.js
+++ b/apps/notifications/postcss.config.js
@@ -2,6 +2,9 @@ module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
 			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+			// @TODO: Drop `preserve: false` workaround if possible
+			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
+			preserve: false,
 		},
 		autoprefixer: {},
 	},

--- a/apps/notifications/postcss.config.js
+++ b/apps/notifications/postcss.config.js
@@ -1,0 +1,8 @@
+module.exports = () => ( {
+	plugins: {
+		'postcss-custom-properties': {
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+		},
+		autoprefixer: {},
+	},
+} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -24757,8 +24757,7 @@
 			"requires": {
 				"crc32": "0.2.2",
 				"debug": "^4.0.0",
-				"seed-random": "2.2.0",
-				"url": "^0.11.0"
+				"seed-random": "2.2.0"
 			}
 		},
 		"picomatch": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Notifications were broken by recent calypso-build updates. @codebykat discovered that styling looked off in the standalone build (e.g. missing background colors). Furthermore, notifications were missing a dependency on `@automattic/calypso-polyfills`.

This PR should fix those issues.

Unfortunately, for apps within the Calypso monorepo, we cannot pin `calypso-build` versions to avoid breaking changes :confused: 

However, it's curious that the [`build-notifications`](https://github.com/Automattic/wp-calypso/blob/326fc9f65095c68c74e8268c8d23b60a3f810317/.circleci/config.yml#L291-L300) job in CircleCI didn't turn red :thinking: 

#### Testing instructions

Follow these instructions: PCYsg-elI-p2
Then, sandbox a Simple Site, and `widgets.wp.com`. Visit the Simple Site (frontend) and verify that notifications are properly styled. In particular, verify that backgrounds aren't all transparent.

For comparison, run through those instructions for any other recent PR. Notifications styling will appear broken.

_Thanks @codebykat and @dmsnell for collaborating on this fix!_