### PR TITLE
Gutenboarding: Add passwordless signup form to `/gutenboarding…

### DIFF
--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -13,13 +13,6 @@ export const setupWpDataDebug = () => {
 			}
 			if ( ! window.wp.data ) {
 				window.wp.data = require( '@wordpress/data' );
-
-				const { User } = require( '@automattic/data-stores' );
-				const config = require( 'config' ).default;
-				User.register( {
-					client_id: config( 'wpcom_signup_id' ),
-					client_secret: config( 'wpcom_signup_key' ),
-				} );
 			}
 		}
 	}

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -14,6 +14,7 @@ import { STORE_KEY } from '../stores/onboard';
 import DesignSelector from './design-selector';
 import StepperWizard from './stepper-wizard';
 import VerticalSelect from './vertical-select';
+import SignupForm from './signup-form';
 import SiteTitle from './site-title';
 import { Attributes } from './types';
 import { Step } from '../steps';
@@ -56,6 +57,9 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 				</Route>
 				<Route exact path={ Step.DesignSelection }>
 					{ ! siteVertical ? <Redirect to={ Step.IntentGathering } /> : <DesignSelector /> }
+				</Route>
+				<Route exact path={ Step.Signup }>
+					<SignupForm />
 				</Route>
 			</Switch>
 		</>

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -10,6 +10,7 @@ import {
 	usePasswordlessSignUp,
 	UsePasswordlessSignUpStatus,
 	Provider,
+	Client,
 } from '@automattic/authentication';
 import { Button, TextControl, Modal } from '@wordpress/components';
 
@@ -33,7 +34,7 @@ const SignupForm = () => {
 	};
 
 	return (
-		<Modal title="Sign up to save your changes" onRequestClose={ () => {} }>
+		<Modal className="signup-form" title="Sign up to save your changes" onRequestClose={ () => {} }>
 			<form onSubmit={ handleSignUp }>
 				<label htmlFor="email">Your Email Address</label>
 				<TextControl
@@ -42,14 +43,20 @@ const SignupForm = () => {
 					onChange={ setEmailVal }
 					placeholder="yourname@email.com"
 				/>
-				<p>By creating an account you agree to our { renderTosLink() }.</p>
-				<Button
-					type="submit"
-					disabled={ status === UsePasswordlessSignUpStatus.Authenticating }
-					isPrimary
-				>
-					Sign up
-				</Button>
+				<div className="signup-form__footer">
+					<p className="signup-form__terms-of-service-link">
+						By creating an account you agree to our { renderTosLink() }.
+					</p>
+
+					<Button
+						type="submit"
+						className="signup-form__submit"
+						disabled={ status === UsePasswordlessSignUpStatus.Authenticating }
+						isPrimary
+					>
+						Sign up
+					</Button>
+				</div>
 			</form>
 			{ status && <p>Status: { JSON.stringify( status, null, 2 ) }</p> }
 			{ error && <p>Error: { JSON.stringify( String( error ), null, 2 ) }</p> }
@@ -58,8 +65,12 @@ const SignupForm = () => {
 };
 
 const WrappedSignupForm = () => {
+	const client = new Client( {
+		clientID: '39911',
+		clientSecret: 'cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8',
+	} );
 	return (
-		<Provider clientID="1673757240" clientSecret="123">
+		<Provider client={ client }>
 			<SignupForm />
 		</Provider>
 	);

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -59,6 +59,7 @@ const SignupForm = () => {
 						type="submit"
 						className="signup-form__submit"
 						disabled={ isFetchingNewUser }
+						isBusy={ isFetchingNewUser }
 						isPrimary
 					>
 						{ NO__( 'Create your account' ) }

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -45,6 +45,7 @@ const SignupForm = () => {
 					label={ NO__( 'Your Email Address' ) }
 					value={ emailVal }
 					disabled={ isFetchingNewUser }
+					type="email"
 					onChange={ setEmailVal }
 					placeholder={ NO_x(
 						'E.g., yourname@email.com',

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -13,6 +13,7 @@ import {
 	Client,
 } from '@automattic/authentication';
 import { Button, TextControl, Modal } from '@wordpress/components';
+import FormLabel from 'components/forms/form-label';
 
 import './style.scss';
 
@@ -36,7 +37,7 @@ const SignupForm = () => {
 	return (
 		<Modal className="signup-form" title="Sign up to save your changes" onRequestClose={ () => {} }>
 			<form onSubmit={ handleSignUp }>
-				<label htmlFor="email">Your Email Address</label>
+				<FormLabel htmlFor="email">Your Email Address</FormLabel>
 				<TextControl
 					id="email"
 					value={ emailVal }

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -3,8 +3,9 @@
  */
 import { noop } from 'lodash';
 import React, { useState } from 'react';
-import { Button, TextControl, Modal } from '@wordpress/components';
+import { Button, ExternalLink, TextControl, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { __ as NO__, _x as NO_x } from '@wordpress/i18n';
 
 /**
@@ -23,14 +24,6 @@ const SignupForm = () => {
 		event.preventDefault();
 
 		createAccount( { email: emailVal, is_passwordless: true, signup_flow_name: 'gutenboarding' } );
-	};
-
-	const renderTosLink = () => {
-		return (
-			<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer">
-				{ NO__( 'Terms of Service.' ) }
-			</a>
-		);
 	};
 
 	return (
@@ -53,9 +46,7 @@ const SignupForm = () => {
 					) }
 				/>
 				<div className="signup-form__footer">
-					<p className="signup-form__terms-of-service-link">
-						{ NO__( 'By creating an account you agree to our' ) } { renderTosLink() }
-					</p>
+					<p className="signup-form__terms-of-service-link">{ renderTos() }</p>
 
 					<Button
 						type="submit"
@@ -72,5 +63,14 @@ const SignupForm = () => {
 		</Modal>
 	);
 };
+
+function renderTos() {
+	return __experimentalCreateInterpolateElement(
+		NO__( 'By creating an account you agree to our <link_to_tos>Terms of Service</link_to_tos>.' ),
+		{
+			link_to_tos: <ExternalLink href="https://wordpress.com/tos/" />,
+		}
+	);
+}
 
 export default SignupForm;

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -55,7 +55,7 @@ const SignupForm = () => {
 						disabled={ status === UsePasswordlessSignUpStatus.Authenticating }
 						isPrimary
 					>
-						Sign up
+						Create your account
 					</Button>
 				</div>
 			</form>

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+
+// /**
+//  * Internal dependencies
+//  */
+import {
+	usePasswordlessSignUp,
+	UsePasswordlessSignUpStatus,
+	Provider,
+} from '@automattic/authentication';
+import { Button, TextControl, Modal } from '@wordpress/components';
+
+import './style.scss';
+
+const SignupForm = () => {
+	const [ emailVal, setEmailVal ] = useState( '' );
+	const { signUp, status, error } = usePasswordlessSignUp();
+
+	const handleSignUp = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		signUp( emailVal );
+	};
+
+	const renderTosLink = () => {
+		return (
+			<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer">
+				Terms of Service
+			</a>
+		);
+	};
+
+	return (
+		<Modal title="Sign up to save your changes" onRequestClose={ () => {} }>
+			<form onSubmit={ handleSignUp }>
+				<label htmlFor="email">Your Email Address</label>
+				<TextControl
+					id="email"
+					value={ emailVal }
+					onChange={ setEmailVal }
+					placeholder="yourname@email.com"
+				/>
+				<p>By creating an account you agree to our { renderTosLink() }.</p>
+				<Button
+					type="submit"
+					disabled={ status === UsePasswordlessSignUpStatus.Authenticating }
+					isPrimary
+				>
+					Sign up
+				</Button>
+			</form>
+			{ status && <p>Status: { JSON.stringify( status, null, 2 ) }</p> }
+			{ error && <p>Error: { JSON.stringify( String( error ), null, 2 ) }</p> }
+		</Modal>
+	);
+};
+
+const WrappedSignupForm = () => {
+	return (
+		<Provider clientID="1673757240" clientSecret="123">
+			<SignupForm />
+		</Provider>
+	);
+};
+
+export default WrappedSignupForm;

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, ComponentType } from 'react';
 import { Button, ExternalLink, TextControl, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
@@ -12,6 +12,18 @@ import { __ as NO__, _x as NO_x } from '@wordpress/i18n';
  */
 import { USER_STORE } from '../../stores/user';
 import './style.scss';
+
+// TODO: deploy this change to @types/wordpress__element
+declare module '@wordpress/element' {
+	// eslint-disable-next-line no-shadow
+	export function __experimentalCreateInterpolateElement(
+		interpolatedString: string,
+		conversionMap: Record< string, ReactElement >
+	): ReactNode;
+}
+
+// TODO: remove this when the types land upstream https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41800
+const DismissibleModal = Modal as ComponentType< Modal.Props & { isDismissible: boolean } >;
 
 const SignupForm = () => {
 	const [ emailVal, setEmailVal ] = useState( '' );
@@ -27,7 +39,7 @@ const SignupForm = () => {
 	};
 
 	return (
-		<Modal
+		<DismissibleModal
 			className="signup-form"
 			isDismissible={ false }
 			title={ NO__( 'Sign up to save your changes' ) }
@@ -61,7 +73,7 @@ const SignupForm = () => {
 			</form>
 			{ newUserError && <pre>Error: { JSON.stringify( newUserError, null, 2 ) }</pre> }
 			{ newUser && <pre>New user: { JSON.stringify( newUser, null, 2 ) }</pre> }
-		</Modal>
+		</DismissibleModal>
 	);
 };
 

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { noop } from 'lodash';
 import React, { useState } from 'react';
 import { Button, TextControl, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -36,8 +37,9 @@ const SignupForm = () => {
 	return (
 		<Modal
 			className="signup-form"
+			isDismissible={ false }
 			title={ NO__( 'Sign up to save your changes' ) }
-			onRequestClose={ () => {} }
+			onRequestClose={ noop }
 		>
 			<form onSubmit={ handleSignUp }>
 				<FormLabel htmlFor="email">{ NO__( 'Your Email Address' ) }</FormLabel>

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -5,7 +5,7 @@ import { noop } from 'lodash';
 import React, { useState } from 'react';
 import { Button, TextControl, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __ as NO__ } from '@wordpress/i18n';
+import { __ as NO__, _x as NO_x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -46,7 +46,10 @@ const SignupForm = () => {
 					value={ emailVal }
 					disabled={ isFetchingNewUser }
 					onChange={ setEmailVal }
-					placeholder={ NO__( 'yourname@email.com' ) }
+					placeholder={ NO_x(
+						'E.g., yourname@email.com',
+						"An example of a person's email, use something appropriate for the locale"
+					) }
 				/>
 				<div className="signup-form__footer">
 					<p className="signup-form__terms-of-service-link">

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React, { useState } from 'react';
 import { Button, ExternalLink, TextControl, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -32,7 +31,7 @@ const SignupForm = () => {
 			className="signup-form"
 			isDismissible={ false }
 			title={ NO__( 'Sign up to save your changes' ) }
-			onRequestClose={ noop }
+			onRequestClose={ () => undefined }
 		>
 			<form onSubmit={ handleSignUp }>
 				<TextControl

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -14,7 +14,8 @@ import {
 } from '@automattic/authentication';
 import { Button, TextControl, Modal } from '@wordpress/components';
 import FormLabel from 'components/forms/form-label';
-
+import { __ as NO__ } from '@wordpress/i18n';
+import config from '../../../../config';
 import './style.scss';
 
 const SignupForm = () => {
@@ -29,24 +30,28 @@ const SignupForm = () => {
 	const renderTosLink = () => {
 		return (
 			<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer">
-				Terms of Service
+				{ NO__( 'Terms of Service.' ) }
 			</a>
 		);
 	};
 
 	return (
-		<Modal className="signup-form" title="Sign up to save your changes" onRequestClose={ () => {} }>
+		<Modal
+			className="signup-form"
+			title={ NO__( 'Sign up to save your changes' ) }
+			onRequestClose={ () => {} }
+		>
 			<form onSubmit={ handleSignUp }>
-				<FormLabel htmlFor="email">Your Email Address</FormLabel>
+				<FormLabel htmlFor="email">{ NO__( 'Your Email Address' ) }</FormLabel>
 				<TextControl
 					id="email"
 					value={ emailVal }
 					onChange={ setEmailVal }
-					placeholder="yourname@email.com"
+					placeholder={ NO__( 'yourname@email.com' ) }
 				/>
 				<div className="signup-form__footer">
 					<p className="signup-form__terms-of-service-link">
-						By creating an account you agree to our { renderTosLink() }.
+						{ NO__( 'By creating an account you agree to our' ) } { renderTosLink() }
 					</p>
 
 					<Button
@@ -55,7 +60,7 @@ const SignupForm = () => {
 						disabled={ status === UsePasswordlessSignUpStatus.Authenticating }
 						isPrimary
 					>
-						Create your account
+						{ NO__( 'Create your account' ) }
 					</Button>
 				</div>
 			</form>
@@ -67,8 +72,8 @@ const SignupForm = () => {
 
 const WrappedSignupForm = () => {
 	const client = new Client( {
-		clientID: '39911',
-		clientSecret: 'cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8',
+		clientID: config( 'wpcom_signup_id' ),
+		clientSecret: config( 'wpcom_signup_key' ),
 	} );
 	return (
 		<Provider client={ client }>

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -46,6 +46,7 @@ const SignupForm = () => {
 				<TextControl
 					id="email"
 					value={ emailVal }
+					disabled={ status === UsePasswordlessSignUpStatus.Authenticating }
 					onChange={ setEmailVal }
 					placeholder={ NO__( 'yourname@email.com' ) }
 				/>

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -18,6 +18,7 @@ const SignupForm = () => {
 	const [ emailVal, setEmailVal ] = useState( '' );
 	const { createAccount } = useDispatch( USER_STORE );
 	const isFetchingNewUser = useSelect( select => select( USER_STORE ).isFetchingNewUser() );
+	const newUser = useSelect( select => select( USER_STORE ).getNewUser() );
 	const newUserError = useSelect( select => select( USER_STORE ).getNewUserError() );
 
 	const handleSignUp = ( event: React.FormEvent< HTMLFormElement > ) => {
@@ -60,6 +61,7 @@ const SignupForm = () => {
 				</div>
 			</form>
 			{ newUserError && <pre>Error: { JSON.stringify( newUserError, null, 2 ) }</pre> }
+			{ newUser && <pre>New user: { JSON.stringify( newUser, null, 2 ) }</pre> }
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -11,7 +11,6 @@ import { __ as NO__ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { USER_STORE } from '../../stores/user';
-import FormLabel from 'components/forms/form-label';
 import './style.scss';
 
 const SignupForm = () => {
@@ -42,9 +41,8 @@ const SignupForm = () => {
 			onRequestClose={ noop }
 		>
 			<form onSubmit={ handleSignUp }>
-				<FormLabel htmlFor="email">{ NO__( 'Your Email Address' ) }</FormLabel>
 				<TextControl
-					id="email"
+					label={ NO__( 'Your Email Address' ) }
 					value={ emailVal }
 					disabled={ isFetchingNewUser }
 					onChange={ setEmailVal }

--- a/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
@@ -1,0 +1,48 @@
+@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+
+.signup-form
+	.components-icon-button:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+	background: var( --color-masterbar-item-hover-background );
+	box-shadow: none;
+}
+
+.signup-form.components-modal__frame {
+	border: none;
+	border-radius: 3px;
+
+	.components-modal__header {
+		color: var( --color-text-inverted );
+		background: var( --color-masterbar-background );
+
+		.components-modal__header-heading {
+			font-size: 20px;
+			font-weight: normal;
+		}
+
+		.components-icon-button {
+			.dashicon {
+				color: var( --color-text-inverted );
+			}
+		}
+	}
+
+	label {
+		display: block;
+		color: var( --color-text );
+		margin-bottom: 5px;
+	}
+
+	.signup-form__terms-of-service-link {
+		text-align: center;
+		color: var( --color-text );
+		margin: 20px 0 40px;
+	}
+
+	.components-button.signup-form__submit {
+		display: block;
+		width: 100%;
+		text-align: center;
+		font-size: 16px;
+		height: 34px;
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
@@ -1,35 +1,15 @@
 @import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
 
-.signup-form
-	.components-icon-button:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-	background: var( --color-masterbar-item-hover-background );
-	box-shadow: none;
-}
-
 .signup-form.components-modal__frame {
 	border: none;
 	border-radius: 3px;
 
 	.components-modal__header {
-		color: var( --color-text-inverted );
-		background: var( --color-masterbar-background );
 
 		.components-modal__header-heading {
 			font-size: 20px;
 			font-weight: normal;
 		}
-
-		.components-icon-button {
-			.dashicon {
-				color: var( --color-text-inverted );
-			}
-		}
-	}
-
-	label {
-		display: block;
-		color: var( --color-text );
-		margin-bottom: 5px;
 	}
 
 	.signup-form__terms-of-service-link {

--- a/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
@@ -5,16 +5,20 @@
 	border-radius: 3px;
 
 	.components-modal__header {
-
 		.components-modal__header-heading {
 			font-size: 20px;
 			font-weight: normal;
 		}
 	}
+	.components-text-control__input {
+		padding: 7px 14px;
+		font-size: 16px;
+		line-height: 1.5;
+	}
 
 	.signup-form__terms-of-service-link {
 		text-align: center;
-		color: var( --color-text );
+		color: var( --color-text-subtle );
 		margin: 20px 0 40px;
 	}
 
@@ -23,6 +27,6 @@
 		width: 100%;
 		text-align: center;
 		font-size: 16px;
-		height: 34px;
+		height: 40px;
 	}
 }

--- a/client/landing/gutenboarding/steps.ts
+++ b/client/landing/gutenboarding/steps.ts
@@ -7,6 +7,7 @@ export enum Step {
 	IntentGathering = '/',
 	DesignSelection = '/design',
 	CreateSite = '/create-site',
+	Signup = '/signup',
 }
 
 export const routes = `(${ map( Step, ( route: string ) => route ).join( '|' ) })`;

--- a/client/landing/gutenboarding/stores/user/index.ts
+++ b/client/landing/gutenboarding/stores/user/index.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { User } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import config from '../../../../config';
+
+export const USER_STORE = User.register( {
+	client_id: config( 'wpcom_signup_id' ),
+	client_secret: config( 'wpcom_signup_key' ),
+} );


### PR DESCRIPTION
WIP, not ready for review yet, see issue https://github.com/Automattic/wp-calypso/issues/38792

#### Changes proposed in this Pull Request

* Building on top of work that @jameslnewell is doing to pull out a shared authentication package
* Will have to discuss how to do translation/ i18n
* Need to wait for the authentication package to be merged

<img width="451" alt="image" src="https://user-images.githubusercontent.com/1500769/72944469-d3e09900-3ddd-11ea-91d2-c984aec66c08.png">

#### Testing instructions

* Use an incognito window, otherwise you're going to get logged out of your other tabs
* `/gutenboarding/signup`
* Enter an email that will succeed
* New user info should be shown on screen, verify it looks correct
* Enter an email that will fail
* API response will be shown on screen, verify it looks correct

Fixes #38792 
