### PR TITLE
Client README: Remove reference to notifications dir

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,5 +1,4 @@
-Client
-======
+# Client
 
 This is the heart of Calypso, the client side application. It's pieced together with webpack from different components — both external and internal. ([List of technologies used.](../docs/guide/tech-behind-calypso.md)) It only requires an HTML shell with a body to work with.
 
@@ -7,10 +6,10 @@ This is the heart of Calypso, the client side application. It's pieced together 
 
 These are some of the key modules of the application, kept in `client`'s root for clarity:
 
-* `boot` - the booting file that sets up the application and requires the main sections.
-* `config` - generated configuration settings.
-* `layout` - handles the main React layout, including the masterbar. Notably, it sets #primary and #secondary used to render the different sections.
-* `sections.js` - defines section groups, paths, and main modules. (Used by webpack to generate separate chunks.)
+- `boot` - the booting file that sets up the application and requires the main sections.
+- `config` - generated configuration settings.
+- `layout` - handles the main React layout, including the masterbar. Notably, it sets #primary and #secondary used to render the different sections.
+- `sections.js` - defines section groups, paths, and main modules. (Used by webpack to generate separate chunks.)
 
 ### Components
 
@@ -28,9 +27,8 @@ The `/lib` folder holds internal modules and utilities that power Calypso.
 
 These represent the top section in the masterbar as well as other significant areas of the app. Within these all the controllers for the entire app are expressed. Most React app-components live within their specific section and not in `client/components`.
 
-* `my-sites`: the site related admin functionality. Akin to wp-admin.
-* `reader`: the home of all Reader sections.
-* `notifications`: the notifications panel.
-* `me`: the sections under the `/me` route.
-* `post-editor`: the editor.
-* `signup`: the signup flows.
+- `my-sites`: the site related admin functionality. Akin to wp-admin.
+- `reader`: the home of all Reader sections.
+- `me`: the sections under the `/me` route.
+- `post-editor`: the editor.
+- `signup`: the signup flows.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Minor doc fix -- we moved the `notifications/` dir from `client/` to `apps/` a while ago.

#### Testing instructions

N/A
