### PR TITLE
Domains: Update the domain suggestion vendor in NUX to use selected vertical as hint

### DIFF
--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -2,6 +2,9 @@
  * Internal dependencies
  */
 
-export const getSuggestionsVendor = () => {
+export const getSuggestionsVendor = ( isSignup = false ) => {
+	if ( isSignup ) {
+		return 'variation4_front';
+	}
 	return 'variation2_front';
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -474,7 +474,7 @@ class DomainsStep extends React.Component {
 				showTestParagraph={ this.showTestParagraph }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor() }
+				vendor={ getSuggestionsVendor( true ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }


### PR DESCRIPTION
We've decided to go with `variation4_front` that uses the selected vertical for surfacing different TLDs up the suggestions results.

#### Changes proposed in this Pull Request

* use `variation4_front` as suggestion vendor in NUX

#### Testing instructions

* go to `/start` and select some vertical (for example photography) - then verify that we're using `variation4_front` as suggestion vendor and that relevant TLDs are surfaced in the suggestion results.
