### PR TITLE
Site Creation: Send "guessed" browser timezone string for new sites

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -56,6 +56,7 @@ import { fetchSitesAndUser } from 'lib/signup/step-actions/fetch-sites-and-user'
  */
 const user = userFactory();
 const debug = debugFactory( 'calypso:signup:step-actions' );
+const gmt_offset = -new Date().getTimezoneOffset() / 60;
 
 export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 	const { siteId, siteSlug } = data;
@@ -185,6 +186,10 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	if ( config.isEnabled( 'coming-soon' ) ) {
 		newSiteParams.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
+	}
+
+	if ( gmt_offset ) {
+		newSiteParams.options.gmt_offset = gmt_offset;
 	}
 
 	const shouldSkipDomainStep = ! siteUrl && isDomainStepSkippable( flowToCheck );
@@ -511,6 +516,10 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 
 	if ( config.isEnabled( 'coming-soon' ) ) {
 		data.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
+	}
+
+	if ( gmt_offset ) {
+		data.options.gmt_offset = gmt_offset;
 	}
 
 	wpcom.undocumented().sitesNew( data, function( errors, response ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -4,7 +4,6 @@
 import debugFactory from 'debug';
 import { assign, defer, difference, get, isEmpty, isNull, omitBy, pick, startsWith } from 'lodash';
 import { parse as parseURL } from 'url';
-import moment from 'moment-timezone';
 
 /**
  * Internal dependencies
@@ -13,6 +12,8 @@ import moment from 'moment-timezone';
 // Libraries
 import config from 'config';
 import wpcom from 'lib/wp';
+import guessTimezone from 'lib/i18n-utils/guess-timezone';
+
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
 import { getSavedVariations } from 'lib/abtest';
@@ -179,7 +180,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				title: siteTitle,
 			},
 			site_creation_flow: flowToCheck,
-			timezone_string: moment.tz.guess(),
+			timezone_string: guessTimezone(),
 		},
 		public: getNewSitePublicSetting( state ),
 		validate: false,
@@ -507,7 +508,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		blog_name: site,
 		blog_title: '',
 		public: getNewSitePublicSetting( state ),
-		options: { theme: themeSlugWithRepo, timezone_string: moment.tz.guess() },
+		options: { theme: themeSlugWithRepo, timezone_string: guessTimezone() },
 		validate: false,
 	};
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -4,6 +4,7 @@
 import debugFactory from 'debug';
 import { assign, defer, difference, get, isEmpty, isNull, omitBy, pick, startsWith } from 'lodash';
 import { parse as parseURL } from 'url';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies
@@ -56,7 +57,6 @@ import { fetchSitesAndUser } from 'lib/signup/step-actions/fetch-sites-and-user'
  */
 const user = userFactory();
 const debug = debugFactory( 'calypso:signup:step-actions' );
-const gmt_offset = -new Date().getTimezoneOffset() / 60;
 
 export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 	const { siteId, siteSlug } = data;
@@ -179,6 +179,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				title: siteTitle,
 			},
 			site_creation_flow: flowToCheck,
+			timezone_string: moment.tz.guess(),
 		},
 		public: getNewSitePublicSetting( state ),
 		validate: false,
@@ -186,10 +187,6 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	if ( config.isEnabled( 'coming-soon' ) ) {
 		newSiteParams.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
-	}
-
-	if ( gmt_offset ) {
-		newSiteParams.options.gmt_offset = gmt_offset;
 	}
 
 	const shouldSkipDomainStep = ! siteUrl && isDomainStepSkippable( flowToCheck );
@@ -510,16 +507,12 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		blog_name: site,
 		blog_title: '',
 		public: getNewSitePublicSetting( state ),
-		options: { theme: themeSlugWithRepo },
+		options: { theme: themeSlugWithRepo, timezone_string: moment.tz.guess() },
 		validate: false,
 	};
 
 	if ( config.isEnabled( 'coming-soon' ) ) {
 		data.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
-	}
-
-	if ( gmt_offset ) {
-		data.options.gmt_offset = gmt_offset;
 	}
 
 	wpcom.undocumented().sitesNew( data, function( errors, response ) {


### PR DESCRIPTION
Currently, when we create sites, they get a time zone of "UTC+0." instead of their current locale.  The settings page then shows a guess using the mechanism used in this PR:

<img width="608" alt="Screen Shot 2020-01-20 at 1 55 40 PM" src="https://user-images.githubusercontent.com/1587282/72751211-fa5bc580-3b8c-11ea-8334-1e0fad1b2a33.png">

This change seeks to guess the time zone under the supposition that it will be what our customers expect more often than the current behavior.

Discussion: p1579203203144700-slackCCS1W9QVA

#### Changes proposed in this Pull Request

* Send the result of `moment.tz.guess()` to the site creation endpoint via `options.timezone_string` during signup

#### Testing instructions

* Apply D37828-code (Update: I (@ramonjd) couldn't get it to work without adding the option update to Headstart. Please try D40358-code, which updates the option via Headstart if you're experiencing similar issues. )
* Sandbox `public-api.wordpress.com`
* Run this branch
* Create a new site via `/start`
  * The site's time zone should be that of the computer used to create the site (visible at `/settings/general/`)