### PR TITLE
Cleanup linting of package imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
 			files: [ 'test/e2e/**/*' ],
 			rules: {
 				'import/no-nodejs-modules': 'off',
-				'import/no-extraneous-dependencies': 'off',
 				'no-console': 'off',
 				'jest/valid-describe': 'off',
 				'jest/no-test-prefixes': 'off',
@@ -171,9 +170,5 @@ module.exports = {
 		// - events because we use it for some event emitters
 		// - path because we use it quite a bit
 		'import/no-nodejs-modules': [ 'error', { allow: [ 'url', 'events', 'path', 'config' ] } ],
-
-		// Disallow importing or requiring packages that are not listed in package.json
-		// This prevents us from depending on transitive dependencies, which could break in unexpected ways.
-		'import/no-extraneous-dependencies': 'error',
 	},
 };

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rules: {
+		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
+	},
+};

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- **** WARNING: No ES6 modules here. Not transpiled! ****
+ * **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 
 /* eslint import/no-extraneous-dependencies: [ "error", { packageDir: __dirname/.. } ] */

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -2,7 +2,7 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint import/no-extraneous-dependencies: [ "error", { packageDir: __dirname/.. } ] */
 /* eslint-disable import/no-nodejs-modules */
 
 /**

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,19 +1,19 @@
 /**
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
+
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable import/no-nodejs-modules */
 
 /**
  * External dependencies
  */
 const path = require( 'path' );
-// eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require( 'webpack' );
 const AssetsWriter = require( './server/bundler/assets-writer' );
 const ConfigFlagPlugin = require( '@automattic/webpack-config-flag-plugin' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
-// eslint-disable-next-line import/no-extraneous-dependencies
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
 const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
 const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -3,12 +3,12 @@
  */
 
 /* eslint-disable import/no-nodejs-modules */
+/* eslint-disable import/no-extraneous-dependencies */
 
 /**
  * External dependencies
  */
 const path = require( 'path' );
-// eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require( 'webpack' );
 
 /**

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -2,8 +2,8 @@
  * **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 
+/* eslint import/no-extraneous-dependencies: [ "error", { packageDir: __dirname/.. } ] */
 /* eslint-disable import/no-nodejs-modules */
-/* eslint-disable import/no-extraneous-dependencies */
 
 /**
  * External dependencies

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
 		"circular-dependency-plugin": "5.2.0",
 		"concurrently": "5.0.1",
 		"cross-env": "6.0.3",
+		"duplicate-package-checker-webpack-plugin": "3.0.0",
 		"enzyme": "3.11.0",
 		"enzyme-adapter-react-16": "1.15.1",
 		"enzyme-to-json": "3.4.3",

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '*.stories.jsx' ],
+			files: [ '*.stories.jsx', '**/test/**' ],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
 			},

--- a/packages/components/src/progress-bar/test/index.jsx
+++ b/packages/components/src/progress-bar/test/index.jsx
@@ -5,7 +5,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme'; // eslint-disable-line import/no-extraneous-dependencies
+import { shallow } from 'enzyme';
 import React from 'react';
 
 /**

--- a/packages/webpack-config-flag-plugin/.eslintrc.js
+++ b/packages/webpack-config-flag-plugin/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	rules: {
-		'import/no-extraneous-dependencies': 0,
+		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'import/no-nodejs-modules': 0,
 	},
 };

--- a/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
+++ b/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
+		'import/no-nodejs-modules': 0,
 	},
 };

--- a/packages/webpack-extensive-lodash-replacement-plugin/index.js
+++ b/packages/webpack-extensive-lodash-replacement-plugin/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-nodejs-modules */
 const path = require( 'path' );
 const semver = require( 'semver' );
 

--- a/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
+++ b/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
@@ -1,9 +1,6 @@
 module.exports = {
-	parserOptions: {
-		sourceType: 'module',
-	},
 	rules: {
+		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'import/no-nodejs-modules': 0,
-		'import/no-extraneous-dependencies': 0,
 	},
 };


### PR DESCRIPTION
Improves config of the `import/no-extraneous-dependencies` and `import/no-nodejs-modules` rules, inspired by troubles @ramonjd encountered in #36295.

Removes `import/no-extraneous-dependencies` from the root `.eslintrc.js` where it had the default config (look up the closest `package.json`. Now, every monorepo subpackage needs to declare the rule explicitly and configure it with `{ packageDir: __dirname }`.

Disables `import/no-extraneous-dependencies` in `client/webpack.config.*`. Ideally, we need a mechanism to declare that a file is a build script that can import Node.js modules and the globally declared `devDependencies`.

Disables `import/no-extraneous-dependencies` for tests in `packages/components`, because tests can import `enzyme` from global `devDependencies`. Ideally, we need a mechanism to declare that a file is a test file that can import Node.js modules, global `devDependencies` and the local `dependencies`, too.

Last, there are several webpack plugins in `packages/`. Unify their linting configs to allow Node.js modules and to require all package imports to be declared in local `package.json` (as deps or peer deps).

**How to test:**
Most importantly, test that files in `client/signup/*` no longer report extraneous dependencies all over the place.

Then test that the linter doesn't report any unexpected errors about imports.

This PR should be a lint-only change, not affecting runtime behavior or build output.