### PR TITLE
[Coming Soon] Update copy in podcasting settings

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -42,6 +42,7 @@ import UpgradeNudge from 'blocks/upgrade-nudge';
 import QueryTerms from 'components/data/query-terms';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isPrivateSite from 'state/selectors/is-private-site';
+import isSiteComingSoon from 'state/selectors/is-site-coming-soon';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -377,10 +378,10 @@ class PodcastingDetails extends Component {
 	renderSettingsError() {
 		// If there is a reason that we can't display the podcasting settings
 		// screen, it will be rendered here.
-		const { isPrivate, isUnsupportedSite, userCanManagePodcasting } = this.props;
+		const { isPrivate, isComingSoon, isUnsupportedSite, userCanManagePodcasting } = this.props;
 
 		if ( isPrivate ) {
-			return <PodcastingPrivateSiteMessage />;
+			return <PodcastingPrivateSiteMessage isComingSoon={ isComingSoon } />;
 		}
 
 		if ( ! userCanManagePodcasting ) {
@@ -493,6 +494,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		siteId,
 		siteSlug,
 		isPrivate: isPrivateSite( state, siteId ),
+		isComingSoon: isSiteComingSoon( state, siteId ),
 		isPodcastingEnabled,
 		podcastingCategoryId,
 		isCategoryChanging,

--- a/client/my-sites/site-settings/podcasting-details/private-site.tsx
+++ b/client/my-sites/site-settings/podcasting-details/private-site.tsx
@@ -3,22 +3,36 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import {localize, LocalizeProps} from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-function PodcastingPrivateSiteMessage( { siteSlug, translate } ) {
+interface Props extends LocalizeProps {
+  siteSlug: string,
+	isComingSoon: boolean,
+}
+
+const PodcastingPrivateSiteMessage: React.FC<Props> = function PodcastingPrivateSiteMessage ( { siteSlug, translate, isComingSoon }: Props ) {
 	return (
 		<div className="podcasting-details__private-site">
 			<p>
-				{ translate( "This site's visibility is currently set to {{strong}}Private{{/strong}}.", {
-					components: { strong: <strong /> },
-					comment:
-						'The translation for "Private" should match the string on the Settings > General page.',
-				} ) }
+				{ isComingSoon ? (
+					translate( "This site's visibility is currently set to {{strong}}Coming Soon{{/strong}}.",
+						{
+							components: { strong: <strong/> },
+							comment:
+								'The translation for "Coming Soon" should match the string on the Settings > General page.',
+						} )
+				) : (
+					translate( "This site's visibility is currently set to {{strong}}Private{{/strong}}.", {
+						components: { strong: <strong/> },
+						comment:
+							'The translation for "Private" should match the string on the Settings > General page.',
+					} )
+				) }
 			</p>
 			<p>
 				{ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates copy on SEO settings page to reflect Coming Soon mode whenever it's set.

#### Testing instructions

1. Go to calypso.localhost:3000 (don't test on calypso.live as the feature flag is not enabled there)
1. Go to podcasting settings on Private site, confirm the copy makes sense and says "Private"
1. Go to podcasting settings on Coming Soon site, confirm the copy makes sense and says "Coming Soon"