### PR TITLE
Build: Remove chromium install from common flows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,8 @@ references:
       - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
+    environment:
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
     name: Install npm dependencies
     command: npm ci
 

--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -55,7 +55,7 @@ function install() {
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
-		env: Object.assign( { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true' }, process.env ),
+		env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true', ...process.env },
 	} );
 	if ( installResult.status ) {
 		console.error( 'failed to install: exited with code %d', installResult.status );

--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -55,6 +55,7 @@ function install() {
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
+		env: Object.assign( { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true' }, process.env ),
 	} );
 	if ( installResult.status ) {
 		console.error( 'failed to install: exited with code %d', installResult.status );

--- a/bin/install-if-no-packages.js
+++ b/bin/install-if-no-packages.js
@@ -2,10 +2,11 @@ const spawnSync = require( 'child_process' ).spawnSync;
 const fs = require( 'fs' );
 
 if ( ! fs.existsSync( 'node_modules' ) ) {
-	console.log( 'No "node_modules" present, installing dependencies...' );
+	console.log( 'No "node_modules" present, installing dependencies…' );
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
+		env: Object.assign( { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true' }, process.env ),
 	} ).status;
 	if ( installResult.status ) {
 		console.error( 'Failed install: %o', installResult );

--- a/bin/install-if-no-packages.js
+++ b/bin/install-if-no-packages.js
@@ -1,4 +1,4 @@
-const spawnSync = require( 'child_process' ).spawnSync;
+const { spawnSync } = require( 'child_process' );
 const fs = require( 'fs' );
 
 if ( ! fs.existsSync( 'node_modules' ) ) {
@@ -6,10 +6,10 @@ if ( ! fs.existsSync( 'node_modules' ) ) {
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
-		env: Object.assign( { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true' }, process.env ),
-	} ).status;
+		env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true', ...process.env },
+	} );
 	if ( installResult.status ) {
-		console.error( 'Failed install: %o', installResult );
+		console.error( 'failed to install: exited with code %d', installResult.status );
 		process.exit( installResult.status );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`@wordpress/scripts` has a dependency that installs `chromium`. That's a big dependency that takes a long time to download and in never used in our most common workflows. Skip the `chromium` install on:

- `npm start` flows
- CircleCI 

The FSE tests that depend on `@wordpress/scripts` will need to run `npm ci` or similar before running e2e tests depending on `chromium`.

#### Testing instructions

* `touch package-lock.json; npm start` - `chromium` should not be downloaded.
* No regressions in CircleCI or e2e tests.