### PR TITLE
Use now available Object.fromEntries in i18n-utils

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -150,11 +150,7 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 	}
 
 	const search = new URLSearchParams( window.location.search );
-	// TODO: replace with Object.fromEntries when available (core-js@3).
-	const params = {};
-	for ( const [ key, value ] of search.entries() ) {
-		params[ key ] = value;
-	}
+	const params = Object.fromEntries( search.entries() );
 
 	const {
 		'load-user-translations': username,


### PR DESCRIPTION
This is a tiny change to make code more readable, now that we can make use of `Object.fromEntries`.

#### Changes proposed in this Pull Request

* Replace loop with `object.fromEntries` in `i18n-utils`.

#### Testing instructions

Ensure that the unit tests continue to pass.
