### PR TITLE
Build: Speed up `tsc` builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ references:
         "$CIRCLE_TEST_REPORTS/server"           \
         "$CIRCLE_TEST_REPORTS/e2ereports"       \
         "$HOME/jest-cache"                      \
+        "$HOME/.tsc-cache"                      \
         "$HOME/terser-cache"
 
   # Jest cache caching
@@ -58,6 +59,22 @@ references:
     key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/jest-cache
+
+  #
+  # TypeScript compiler (tsc) cache caching
+  #
+  restore-tsc-cache: &restore-tsc-cache
+    name: Restore TypeScript cache
+    keys:
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-tsc-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-tsc-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-tsc-master
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-tsc
+  save-tsc-cache: &save-tsc-cache
+    name: Save TypeScript cache
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-tsc-{{ .Branch }}-{{ .Revision }}
+    paths:
+      - ~/.tsc-cache
 
   #
   # Terser cache caching
@@ -197,10 +214,12 @@ jobs:
       - run: *update-git-master
       - save_cache: *save-git-cache
       # npm dependencies
+      - restore_cache: *restore-tsc-cache
       - restore_cache: *restore-npm-cache
       - run: *npm-install
       - run: *npm-e2e-install
       - save_cache: *save-npm-cache
+      - save_cache: *save-tsc-cache
       - run: npm run build-packages
       - persist_to_workspace:
           root: '~'

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 Dockerfile
+/.tsc-cache
 .dockerignore
 .git
 .npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.code-workspace
 *.iml
 *.iws
+/.tsc-cache/
 /tags
 node_modules
 /npm-debug.log*

--- a/client/landing/gutenboarding/tsconfig.json
+++ b/client/landing/gutenboarding/tsconfig.json
@@ -8,6 +8,10 @@
 		"baseUrl": ".",
 		"paths": {
 			"*": [ "*", "../../*" ]
-		}
+		},
+
+		"noEmit": true,
+		"incremental": true,
+		"tsBuildInfoFile": "../../../.tsc-cache/gutenboarding"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"clean:build": "npx rimraf build client/server/bundler/*.json client/server/devdocs/search-index.js",
 		"clean:packages": "npx lerna run clean --stream",
 		"clean:public": "npx rimraf public",
-		"distclean": "npm run clean && npx rimraf node_modules client/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules",
+		"distclean": "npm run clean && npx rimraf node_modules client/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .tsc-cache",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"docker-jetpack-cloud": "docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"eslint-branch": "node bin/eslint-branch.js",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -22,7 +22,10 @@
 		"forceConsistentCasingInFileNames": true,
 
 		"typeRoots": [ "../../node_modules/@types" ],
-		"types": []
+		"types": [],
+
+		"incremental": true,
+		"tsBuildInfoFile": "../../.tsc-cache/components"
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/packages/composite-checkout-wpcom/tsconfig-cjs.json
+++ b/packages/composite-checkout-wpcom/tsconfig-cjs.json
@@ -4,6 +4,8 @@
 		"module": "commonjs",
 		"declaration": false,
 		"declarationDir": null,
-		"outDir": "./dist/cjs"
+		"outDir": "./dist/cjs",
+
+		"tsBuildInfoFile": "../../.tsc-cache/composite-checkout-wpcom-cjs"
 	}
 }

--- a/packages/composite-checkout-wpcom/tsconfig.json
+++ b/packages/composite-checkout-wpcom/tsconfig.json
@@ -22,7 +22,10 @@
 		"esModuleInterop": true,
 
 		"typeRoots": [ "../../node_modules/@types" ],
-		"types": []
+		"types": [],
+
+		"incremental": true,
+		"tsBuildInfoFile": "../../.tsc-cache/composite-checkout-wpcom"
 	},
 	"include": [ "src/**/*" ],
 	"exclude": [ "**/test/**/*", "**/docs/**/*" ]

--- a/packages/data-stores/tsconfig-cjs.json
+++ b/packages/data-stores/tsconfig-cjs.json
@@ -4,6 +4,8 @@
 		"module": "commonjs",
 		"declaration": false,
 		"declarationDir": null,
-		"outDir": "dist/cjs"
+		"outDir": "dist/cjs",
+
+		"tsBuildInfoFile": "../../.tsc-cache/data-stores-cjs"
 	}
 }

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -30,7 +30,10 @@
 		"types": [],
 
 		"noEmitHelpers": true,
-		"importHelpers": true
+		"importHelpers": true,
+
+		"incremental": true,
+		"tsBuildInfoFile": "../../.tsc-cache/data-stores"
 	},
 	"files": [ "./src/index.ts", "./global.d.ts" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,24 +6,26 @@
 		"isolatedModules": true,
 
 		"paths": {
-			"*": [ "*", "client/*", "server/*" ]
+			"*": [ "*", "client/*", "client/server/*" ]
 		},
-		"baseUrl": "."
+		"baseUrl": ".",
+		"incremental": true,
+		"tsBuildInfoFile": ".tsc-cache/client"
 	},
-	"include": [ "client", "server" ],
+	"include": [ "client" ],
 	"exclude": [
-		"**/build-module/*",
-		"**/build-style/*",
-		"**/build/*",
-		"**/dist/*",
-		"**/node_modules/*",
+		"**/build",
+		"**/build-module",
+		"**/build-style",
+		"**/dist",
+		"**/node_modules",
 		"apps",
 		"build",
 		"cached-results.json",
+		"client/server/bundler/assets*.json",
+		"client/server/devdocs/search-index.js",
 		"packages",
 		"public",
-		"server/bundler/assets*.json",
-		"server/devdocs/search-index.js",
 		"stats.json"
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 		"isolatedModules": true,
 
 		"paths": {
-			"*": [ "*", "client/*", "client/server/*" ]
+			"*": [ "*", "client/*" ]
 		},
 		"baseUrl": ".",
 		"incremental": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Speed up `tsc` builds by enabling `incremental` builds (caching).
- Build info (cache) files are output to `.tsc-cache` in the repo root. 
- Clean up cache directory on `distclean`.
- git ignore the directory
- cache on CircleCI.

More `tsc` performance advice here:

https://github.com/microsoft/TypeScript/wiki/Performance#using-project-references

#### Testing instructions

Running this a few times should work fine (no regressions in `tsc` builds):

```
npx lerna run prepare
```

Test the caching:

```
rm -fr .tsc-cache
npx lerna run prepare --profile --scope="*/composite-checkout-wpcom" --stream
```

Subsequent builds should show a decent speed increase (don't `rm` between builds).