### PR TITLE
Customer Home: Move "Go Mobile" to top on mobile viewports

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -42,6 +42,8 @@ import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { getGSuiteSupportedDomains } from 'lib/gsuite';
 import { localizeUrl } from 'lib/i18n-utils';
+import userAgent from 'lib/user-agent';
+import { isDesktop, isMobile } from 'lib/viewport';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
@@ -324,6 +326,42 @@ class Home extends Component {
 		);
 	}
 
+	renderGoMobile = () => {
+		const { translate } = this.props;
+		const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
+		const isIos = isiPad || isiPod || isiPhone;
+		const showIosBadge = isDesktop() || isIos || ! isAndroid;
+		const showAndroidBadge = isDesktop() || isAndroid || ! isIos;
+		return (
+			<Card className="customer-home__go-mobile">
+				<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
+				<h6 className="customer-home__card-subheader">{ translate( 'Make updates on the go' ) }</h6>
+				<div className="customer-home__card-button-pair customer-home__card-mobile">
+					{ showIosBadge && (
+						<AppsBadge
+							storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
+							storeName={ 'ios' }
+							titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
+							altText={ translate( 'Apple App Store download badge' ) }
+						>
+							<img src={ appleStoreLogo } alt="" />
+						</AppsBadge>
+					) }
+					{ showAndroidBadge && (
+						<AppsBadge
+							storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
+							storeName={ 'android' }
+							titleText={ translate( 'Download the WordPress Android mobile app.' ) }
+							altText={ translate( 'Google Play Store download badge' ) }
+						>
+							<img src={ googlePlayLogo } alt="" />
+						</AppsBadge>
+					) }
+				</div>
+			</Card>
+		);
+	};
+
 	renderCustomerHome = () => {
 		const {
 			displayChecklist,
@@ -357,6 +395,9 @@ class Home extends Component {
 		return (
 			<div className="customer-home__layout">
 				<div className="customer-home__layout-col customer-home__layout-col-left">
+					{ // "Go Mobile" has the highest priority placement when viewed in smaller viewports, so folks
+					// can see it on their phone without needing to scroll.
+					isMobile() && this.renderGoMobile() }
 					{ displayChecklist ? (
 						<>
 							<Card className="customer-home__card-checklist-heading">
@@ -561,30 +602,8 @@ class Home extends Component {
 							</VerticalNav>
 						</div>
 					</Card>
-					<Card className="customer-home__go-mobile">
-						<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
-						<h6 className="customer-home__card-subheader">
-							{ translate( 'Make updates on the go' ) }
-						</h6>
-						<div className="customer-home__card-button-pair customer-home__card-mobile">
-							<AppsBadge
-								storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
-								storeName={ 'ios' }
-								titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
-								altText={ translate( 'Apple App Store download badge' ) }
-							>
-								<img src={ appleStoreLogo } alt="" />
-							</AppsBadge>
-							<AppsBadge
-								storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
-								storeName={ 'android' }
-								titleText={ translate( 'Download the WordPress Android mobile app.' ) }
-								altText={ translate( 'Google Play Store download badge' ) }
-							>
-								<img src={ googlePlayLogo } alt="" />
-							</AppsBadge>
-						</div>
-					</Card>
+					{ // "Go Mobile" has the lowest priority placement when viewed in bigger viewports.
+					isDesktop() && this.renderGoMobile() }
 				</div>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of #38861

* Moves to the top the "Go Mobile" card in the customer home when viewed in mobile viewports.
* Displays the store button according to the user's OS rather than display both buttons.

iPhone | Android | Other OS
--- | --- | ---
<img width="337" alt="Screenshot 2020-01-17 at 14 57 44" src="https://user-images.githubusercontent.com/1233880/72617672-d0f72b80-3939-11ea-8610-6cc06bb31afd.png"> | <img width="343" alt="Screenshot 2020-01-17 at 14 58 50" src="https://user-images.githubusercontent.com/1233880/72617707-e409fb80-3939-11ea-9380-a96e3225da5c.png"> | <img width="344" alt="Screenshot 2020-01-17 at 14 59 47" src="https://user-images.githubusercontent.com/1233880/72617800-10257c80-393a-11ea-8d00-e085a5cf6e3d.png">



#### Testing instructions

* Go to `/home/:site`.
* Verify the "Go Mobile" card is still at the end of the right column when viewed in a desktop viewport.
* In the Chrome DevTools toggle the device toolbar. 
<img width="264" alt="Screenshot 2020-01-17 at 15 03 56" src="https://user-images.githubusercontent.com/1233880/72618077-a194ee80-393a-11ea-9df5-773afb557ceb.png">

* Select any iPhone from the top toolbar.
<img width="171" alt="Screenshot 2020-01-17 at 15 05 03" src="https://user-images.githubusercontent.com/1233880/72618137-c25d4400-393a-11ea-8120-150d00751525.png">

* Reload the page.
* Make sure the "Go Mobile" card is displayed now at the top of the screen, the link to App Store is visible and there is no link to Google Play.

* Select now an Android device such as Galaxy or Pixel.
<img width="173" alt="Screenshot 2020-01-17 at 15 11 41" src="https://user-images.githubusercontent.com/1233880/72618574-af973f00-393b-11ea-9baf-18cf3791a934.png">

* Reload the page.
* Make sure the "Go Mobile" card is displayed now at the top of the screen, the link to Google Play is visible and there is no link to App Store.

* Edit the devices and add a non-iOS-or-Android mobile device such as any Nokia device:
<img width="187" alt="Screenshot 2020-01-17 at 15 13 35" src="https://user-images.githubusercontent.com/1233880/72618777-27656980-393c-11ea-88e8-431079ba0649.png">
<img width="379" alt="Screenshot 2020-01-17 at 15 14 04" src="https://user-images.githubusercontent.com/1233880/72618778-27656980-393c-11ea-930e-16f7cd2cbfa4.png">

*  Select the device you just added.
<img width="184" alt="Screenshot 2020-01-17 at 15 15 29" src="https://user-images.githubusercontent.com/1233880/72618805-3b10d000-393c-11ea-8b6c-57ea98a95de5.png">

* Reload the page.
* Make sure the "Go Mobile" card is displayed now at the top of the screen, and the link to both stores are visible.


