### PR TITLE
Jitm: Add theme jitm section

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import i18n, { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import config from 'config';
 import titlecase from 'to-title-case';
 import Gridicon from 'components/gridicon';
 import { head, split } from 'lodash';
@@ -15,6 +16,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'components/async-load';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
@@ -331,6 +333,9 @@ class ThemeSheet extends React.Component {
 
 		return (
 			<div className="theme__sheet-content">
+				{ config.isEnabled( 'jitms' ) && this.props.siteSlug && (
+					<AsyncLoad require="blocks/jitm" messagePath={ 'calypso:theme:admin_notices' } />
+				) }
 				{ this.renderSectionNav( section ) }
 				{ activeSection }
 				<div className="theme__sheet-footer-line">

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -205,6 +205,9 @@
 	div {
 		width: auto !important; // override inline style in content markup
 	}
+	.banner__icon-circle {
+		width: 24px !important;
+	}
 
 	p:last-child {
 		margin-bottom: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add Jitms in the expected section of the page. 

<img width="988" alt="Screen Shot 2020-01-17 at 3 38 41 PM" src="https://user-images.githubusercontent.com/115071/72621054-cbe9aa80-3940-11ea-83f7-bdfe8f0e305c.png">


#### Testing instructions
1. Add the following path on your .com sandbox. D37843-code
2. Sandbox public-api.wordpress.com and add JETPACK__SANDBOX_DOMAIN on the jetpack site that is being used to test this. 
3. Visit http://calypso.localhost:3000/theme/barnsbury/example.com
4. Notice the JITM shows up and it works as expect.
