### PR TITLE
JITMs: Add support for Jetpack JITM banners

### DIFF
--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -15,11 +15,14 @@ export default function DefaultTemplate( {
 	message,
 	description,
 	featureClass,
+	icon,
 	tracks,
 	trackImpression,
 	onClick,
 	onDismiss,
 } ) {
+	const isJetpack = icon && icon.indexOf( 'jetpack' ) !== -1;
+
 	return (
 		<>
 			{ trackImpression && trackImpression() }
@@ -34,6 +37,8 @@ export default function DefaultTemplate( {
 				onClick={ onClick }
 				event={ get( tracks, [ 'click', 'name' ] ) || `jitm_nudge_click_${ id }` }
 				href={ CTA.link }
+				jetpack={ isJetpack }
+				horizontal={ isJetpack }
 				target={ '_blank' }
 			/>
 		</>

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -53,7 +53,9 @@ render() {
 | `dismissTemporary` | `bool` | false | When true, clicking on the cross will dismiss the card for the current page load. |
 | `event` | `string` | null | Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property. |
 | `feature` | `string` | null | Slug of the feature to highlight in the plans compare card. |
+| `horizontal` | `bool` | false | When true, the banner content will be laid out in a single row (similar to `compact` but normal size). |
 | `href` | `string` | null | The component target URL. |
+| `jetpack` | `bool` | false | When true, a Jetpack logo will be rendered and the border color will be set to Jetpack green. |
 | `icon` | `string` | null | The component icon. |
 | `list` | `string` | null | A list of the upgrade features. |
 | `onClick` | `string` | null | A function associated to the click on the whole banner or just the CTA or dismiss button. |

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -61,10 +61,10 @@ const BannerExample = () => (
 			callToAction="Get Backups"
 			description="New plugins can lead to unexpected changes. Ensure you can restore your site if something goes wrong."
 			dismissPreferenceName="devdocs-banner-backups-example"
-			dismissTemporary={ true }
-			horizontal={ true }
+			dismissTemporary
+			horizontal
 			href="#"
-			jetpack={ true }
+			jetpack
 			title="Make sure your site is backed up before installing a new plugin."
 		/>
 	</div>

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -57,6 +57,16 @@ const BannerExample = () => (
 		<Banner href="#" plan={ PLAN_JETPACK_PERSONAL } title="Upgrade to a Jetpack Personal Plan!" />
 		<Banner href="#" plan={ PLAN_JETPACK_PREMIUM } title="Upgrade to a Jetpack Premium Plan!" />
 		<Banner href="#" plan={ PLAN_JETPACK_BUSINESS } title="Upgrade to a Jetpack Business Plan!" />
+		<Banner
+			callToAction="Get Backups"
+			description="New plugins can lead to unexpected changes. Ensure you can restore your site if something goes wrong."
+			dismissPreferenceName="devdocs-banner-backups-example"
+			dismissTemporary={ true }
+			horizontal={ true }
+			href="#"
+			jetpack={ true }
+			title="Make sure your site is backed up before installing a new plugin."
+		/>
 	</div>
 );
 

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { noop, size } from 'lodash';
 import Gridicon from 'components/gridicon';
+import JetpackLogo from 'components/jetpack-logo';
 
 /**
  * Internal dependencies
@@ -47,8 +48,10 @@ export class Banner extends Component {
 		dismissTemporary: PropTypes.bool,
 		event: PropTypes.string,
 		feature: PropTypes.string,
+		horizontal: PropTypes.bool,
 		href: PropTypes.string,
 		icon: PropTypes.string,
+		jetpack: PropTypes.bool,
 		compact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,
@@ -73,6 +76,8 @@ export class Banner extends Component {
 		disableHref: false,
 		dismissTemporary: false,
 		compact: false,
+		horizontal: false,
+		jetpack: false,
 		onClick: noop,
 		onDismiss: noop,
 		showIcon: true,
@@ -133,7 +138,7 @@ export class Banner extends Component {
 	};
 
 	getIcon() {
-		const { icon, showIcon, plan } = this.props;
+		const { icon, jetpack, showIcon, plan } = this.props;
 
 		if ( plan && ! icon ) {
 			return (
@@ -145,6 +150,14 @@ export class Banner extends Component {
 
 		if ( ! showIcon ) {
 			return;
+		}
+
+		if ( jetpack ) {
+			return (
+				<div className="banner__icon-plan">
+					<JetpackLogo size={ 32 } />
+				</div>
+			);
 		}
 
 		return (
@@ -244,6 +257,8 @@ export class Banner extends Component {
 			dismissPreferenceName,
 			dismissTemporary,
 			forceHref,
+			horizontal,
+			jetpack,
 			plan,
 		} = this.props;
 
@@ -259,7 +274,9 @@ export class Banner extends Component {
 			{ 'is-jetpack-plan': plan && planMatches( plan, { group: GROUP_JETPACK } ) },
 			{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) },
 			{ 'is-compact': compact },
-			{ 'is-dismissible': dismissPreferenceName }
+			{ 'is-dismissible': dismissPreferenceName },
+			{ 'is-horizontal': horizontal },
+			{ 'is-jetpack': jetpack }
 		);
 
 		if ( dismissPreferenceName ) {

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -58,6 +58,10 @@
 		}
 	}
 
+	&.is-jetpack {
+		@include banner-color( var( --color-jetpack ) );
+	}
+
 	.card__link-indicator {
 		align-items: center;
 		color: var( --color-neutral );
@@ -251,9 +255,19 @@
 			margin-right: 0;
 		}
 
+		.is-horizontal & {
+			flex-shrink: 0;
+			margin-right: 0;
+		}
+
 		.is-dismissible.is-compact & {
 			margin-top: 0;
 			margin-right: 32px;
+		}
+
+		.is-dismissible.is-horizontal & {
+			margin-top: 0;
+			margin-right: 40px;
 		}
 
 		.banner__prices {
@@ -268,4 +282,9 @@
 	height: 16px;
 	top: 50%;
 	margin-top: -8px;
+}
+
+.is-horizontal .dismissible-card__close-icon {
+	top: 50%;
+	margin-top: -12px;
 }

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -96,6 +96,18 @@ describe( 'Banner basic tests', () => {
 		expect( comp.find( 'Button' ) ).toHaveLength( 0 );
 	} );
 
+	test( 'should have .is-jetpack class and JetpackLogo if jetpack prop is defined', () => {
+		const { plan, ...propsWithoutPlan } = props;
+		const comp = shallow( <Banner { ...propsWithoutPlan } jetpack /> );
+		expect( comp.find( '.is-jetpack' ) ).toHaveLength( 1 );
+		expect( comp.find( 'JetpackLogo' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should render have .is-horizontal class if horizontal prop is defined', () => {
+		const comp = shallow( <Banner { ...props } horizontal /> );
+		expect( comp.find( '.is-horizontal' ) ).toHaveLength( 1 );
+	} );
+
 	test( 'should render a <PlanPrice /> when price is specified', () => {
 		const comp = shallow( <Banner { ...props } price={ 100 } /> );
 		expect( comp.find( PlanPrice ) ).toHaveLength( 1 );

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -28,9 +28,13 @@ jest.mock( 'i18n-calypso', () => ( {
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
 import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { Banner } from '../index';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
@@ -48,11 +52,6 @@ import {
 } from 'lib/plans/constants';
 import PlanPrice from 'my-sites/plan-price/';
 
-/**
- * Internal dependencies
- */
-import { Banner } from '../index';
-
 const props = {
 	callToAction: null,
 	plan: PLAN_FREE,
@@ -62,144 +61,142 @@ const props = {
 describe( 'Banner basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const comp = shallow( <Banner { ...props } /> );
-		assert.lengthOf( comp.find( '.banner' ), 1 );
+		expect( comp.find( '.banner' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render Card if dismissPreferenceName is null', () => {
 		const comp = shallow( <Banner { ...props } dismissPreferenceName={ null } /> );
-		assert.lengthOf( comp.find( 'Card' ), 1 );
-		assert.lengthOf( comp.find( 'DismissibleCard' ), 0 );
+		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
+		expect( comp.find( 'DismissibleCard' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render DismissibleCard if dismissPreferenceName is defined', () => {
 		const comp = shallow( <Banner { ...props } dismissPreferenceName={ 'banner-test' } /> );
-		assert.lengthOf( comp.find( 'Card' ), 0 );
-		assert.lengthOf( comp.find( 'DismissibleCard' ), 1 );
+		expect( comp.find( 'Card' ) ).toHaveLength( 0 );
+		expect( comp.find( 'DismissibleCard' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should have .has-call-to-action class if callToAction is defined', () => {
 		const comp = shallow( <Banner { ...props } callToAction={ 'Upgrade Now!' } /> );
-		assert.lengthOf( comp.find( '.has-call-to-action' ), 1 );
+		expect( comp.find( '.has-call-to-action' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not have .has-call-to-action class if callToAction is null', () => {
 		const comp = shallow( <Banner { ...props } callToAction={ null } /> );
-		assert.lengthOf( comp.find( '.has-call-to-action' ), 0 );
+		expect( comp.find( '.has-call-to-action' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render a <Button /> when callToAction is specified', () => {
 		const comp = shallow( <Banner { ...props } callToAction={ 'Buy something!' } /> );
-		assert.lengthOf( comp.find( 'Button' ), 1 );
+		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render a <Button /> when callToAction is not specified', () => {
 		const comp = shallow( <Banner { ...props } /> );
-		assert.lengthOf( comp.find( 'Button' ), 0 );
+		expect( comp.find( 'Button' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render a <PlanPrice /> when price is specified', () => {
 		const comp = shallow( <Banner { ...props } price={ 100 } /> );
-		assert.lengthOf( comp.find( PlanPrice ), 1 );
+		expect( comp.find( PlanPrice ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render two <PlanPrice /> components when there are two prices', () => {
 		const comp = shallow( <Banner { ...props } price={ [ 100, 80 ] } /> );
-		assert.lengthOf( comp.find( PlanPrice ), 2 );
+		expect( comp.find( PlanPrice ) ).toHaveLength( 2 );
 	} );
 
 	test( 'should render no <PlanPrice /> components when there are no prices', () => {
 		const comp = shallow( <Banner { ...props } /> );
-		assert.lengthOf( comp.find( PlanPrice ), 0 );
+		expect( comp.find( PlanPrice ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render a .banner__description when description is specified', () => {
 		const comp = shallow( <Banner { ...props } description="test" /> );
-		assert.lengthOf( comp.find( '.banner__description' ), 1 );
+		expect( comp.find( '.banner__description' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render a .banner__description when description is not specified', () => {
 		const comp = shallow( <Banner { ...props } /> );
-		assert.lengthOf( comp.find( '.banner__description' ), 0 );
+		expect( comp.find( '.banner__description' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render a .banner__list when list is specified', () => {
 		const comp = shallow( <Banner { ...props } list={ [ 'test1', 'test2' ] } /> );
-		assert.lengthOf( comp.find( '.banner__list' ), 1 );
-		assert.lengthOf( comp.find( '.banner__list li' ), 2 );
-		assert.include(
+		expect( comp.find( '.banner__list' ) ).toHaveLength( 1 );
+		expect( comp.find( '.banner__list li' ) ).toHaveLength( 2 );
+		expect(
 			comp
 				.find( '.banner__list li' )
 				.at( 0 )
-				.text(),
-			'test1'
-		);
-		assert.include(
+				.text()
+		).toContain( 'test1' );
+		expect(
 			comp
 				.find( '.banner__list li' )
 				.at( 1 )
-				.text(),
-			'test2'
-		);
+				.text()
+		).toContain( 'test2' );
 	} );
 
 	test( 'should not render a .banner__list when description is not specified', () => {
 		const comp = shallow( <Banner { ...props } /> );
-		assert.lengthOf( comp.find( '.banner__list' ), 0 );
+		expect( comp.find( '.banner__list' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should record Tracks event when event is specified', () => {
 		const comp = shallow( <Banner { ...props } event="test" /> );
-		assert.lengthOf( comp.find( 'TrackComponentView' ), 1 );
+		expect( comp.find( 'TrackComponentView' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not record Tracks event when event is not specified', () => {
 		const comp = shallow( <Banner { ...props } /> );
-		assert.lengthOf( comp.find( 'TrackComponentView' ), 0 );
+		expect( comp.find( 'TrackComponentView' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render Card with href if href prop is passed', () => {
 		const comp = shallow( <Banner { ...props } href={ '/' } /> );
-		assert.lengthOf( comp.find( 'Card' ), 1 );
-		assert.equal( '/', comp.find( 'Card' ).props().href );
+		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Card' ).props().href ).toBe( '/' );
 	} );
 
 	test( 'should render Card with no href if href prop is passed but disableHref is true', () => {
 		const comp = shallow( <Banner { ...props } href={ '/' } disableHref={ true } /> );
-		assert.lengthOf( comp.find( 'Card' ), 1 );
-		assert.equal( undefined, comp.find( 'Card' ).props().href );
+		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Card' ).props().href ).toBeNull();
 	} );
 
 	test( 'should render Card with href if href prop is passed but disableHref is true and forceHref is true', () => {
 		const comp = shallow(
 			<Banner { ...props } href={ '/' } disableHref={ true } forceHref={ true } />
 		);
-		assert.lengthOf( comp.find( 'Card' ), 1 );
-		assert.equal( '/', comp.find( 'Card' ).props().href );
+		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Card' ).props().href ).toBe( '/' );
 	} );
 
 	test( 'should render Card with no href and CTA button with href if href prop is passed and callToAction is also passed', () => {
 		const comp = shallow( <Banner { ...props } href={ '/' } callToAction="Go WordPress!" /> );
-		assert.lengthOf( comp.find( 'Card' ), 1 );
-		assert.equal( undefined, comp.find( 'Card' ).props().href );
-		assert.equal( null, comp.find( 'Card' ).props().onClick );
+		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Card' ).props().href ).toBeNull();
+		expect( comp.find( 'Card' ).props().onClick ).toBeNull();
 
-		assert.lengthOf( comp.find( 'Button' ), 1 );
-		assert.equal( '/', comp.find( 'Button' ).props().href );
-		assert.equal( 'Go WordPress!', comp.find( 'Button' ).props().children );
-		assert.equal( comp.instance().handleClick, comp.find( 'Button' ).props().onClick );
+		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Button' ).props().href ).toBe( '/' );
+		expect( comp.find( 'Button' ).props().children ).toBe( 'Go WordPress!' );
+		expect( comp.find( 'Button' ).props().onClick ).toBe( comp.instance().handleClick );
 	} );
 
 	test( 'should render Card with href and CTA button with no href if href prop is passed and callToAction is also passed and forceHref is true', () => {
 		const comp = shallow(
 			<Banner { ...props } href={ '/' } callToAction="Go WordPress!" forceHref={ true } />
 		);
-		assert.lengthOf( comp.find( 'Card' ), 1 );
-		assert.equal( '/', comp.find( 'Card' ).props().href );
-		assert.equal( comp.instance().handleClick, comp.find( 'Card' ).props().onClick );
+		expect( comp.find( 'Card' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Card' ).props().href ).toBe( '/' );
+		expect( comp.find( 'Card' ).props().onClick ).toBe( comp.instance().handleClick );
 
-		assert.lengthOf( comp.find( 'Button' ), 1 );
-		assert.equal( undefined, comp.find( 'Button' ).props().href );
-		assert.equal( 'Go WordPress!', comp.find( 'Button' ).props().children );
+		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Button' ).props().href ).toBeUndefined();
+		expect( comp.find( 'Button' ).props().children ).toBe( 'Go WordPress!' );
 	} );
 } );
 
@@ -212,7 +209,7 @@ describe( 'Banner should have a class name corresponding to appropriate plan', (
 	].forEach( plan => {
 		test( 'Personal', () => {
 			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			assert.lengthOf( comp.find( '.is-upgrade-personal' ), 1 );
+			expect( comp.find( '.is-upgrade-personal' ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -224,7 +221,7 @@ describe( 'Banner should have a class name corresponding to appropriate plan', (
 	].forEach( plan => {
 		test( 'Premium', () => {
 			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			assert.lengthOf( comp.find( '.is-upgrade-premium' ), 1 );
+			expect( comp.find( '.is-upgrade-premium' ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -236,7 +233,7 @@ describe( 'Banner should have a class name corresponding to appropriate plan', (
 	].forEach( plan => {
 		test( 'Business', () => {
 			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			assert.lengthOf( comp.find( '.is-upgrade-business' ), 1 );
+			expect( comp.find( '.is-upgrade-business' ) ).toHaveLength( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
JITMs in Calypso had no support for Jetpack messages. This PR adds a support for this kind of messages. For the icon a `JetpackLogo` is used and the border color is set to Jetpack green. Also, the layout of the `Banner` is set to `horizontal`, so that it matches the design.

<img width="929" alt="Screenshot 2020-01-17 at 16 18 30" src="https://user-images.githubusercontent.com/478735/72624846-e7a47f00-3947-11ea-95a7-2abeeb28beaf.png">

<img width="697" alt="Screenshot 2020-01-17 at 16 42 24" src="https://user-images.githubusercontent.com/478735/72625082-5eda1300-3948-11ea-8886-71693832d400.png">

#### Changes proposed in this Pull Request

* Add a `jetpack` prop to the `Banner` component
* Add a `horizontal` prop to the `Banner` component
* Add a support for Jetpack banners in JITM

#### Testing instructions

* Go to http://calypso.localhost:3000/devdocs/design/banner
* Confirm that a horizontal Jetpack banner is rendered as a last example
* Once #38859 is merged, you should also see Jetpack Backup JITMs (if you're on a free plan) in Calypso when installing a new theme or plugin.

Fixes n/a
