### PR TITLE
composite-checkout: Add TestingBanner to CompositeCheckout to warn about testing

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -15,6 +15,7 @@ import {
 	FormFieldAnnotation,
 } from '@automattic/composite-checkout-wpcom';
 import { CheckoutProvider, createRegistry } from '@automattic/composite-checkout';
+import { Card } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -162,30 +163,33 @@ export default function CompositeCheckout( {
 	);
 
 	return (
-		<CheckoutProvider
-			locale={ 'en-us' }
-			items={ itemsForCheckout }
-			total={ total }
-			onPaymentComplete={ onPaymentComplete }
-			showErrorMessage={ showErrorMessage }
-			showInfoMessage={ showInfoMessage }
-			showSuccessMessage={ showSuccessMessage }
-			onEvent={ handleCheckoutEvent }
-			paymentMethods={ paymentMethods }
-			registry={ registry }
-			isLoading={ isLoading || isLoadingStoredCards }
-		>
-			<WPCheckout
-				removeItem={ removeItem }
-				changePlanLength={ changePlanLength }
-				siteId={ siteId }
-				siteUrl={ siteSlug }
-				CountrySelectMenu={ CountrySelectMenu }
-				countriesList={ countriesList }
-				PhoneInput={ PhoneInput }
-				StateSelect={ StateSelect }
-			/>
-		</CheckoutProvider>
+		<React.Fragment>
+			<TestingBanner />
+			<CheckoutProvider
+				locale={ 'en-us' }
+				items={ itemsForCheckout }
+				total={ total }
+				onPaymentComplete={ onPaymentComplete }
+				showErrorMessage={ showErrorMessage }
+				showInfoMessage={ showInfoMessage }
+				showSuccessMessage={ showSuccessMessage }
+				onEvent={ handleCheckoutEvent }
+				paymentMethods={ paymentMethods }
+				registry={ registry }
+				isLoading={ isLoading || isLoadingStoredCards }
+			>
+				<WPCheckout
+					removeItem={ removeItem }
+					changePlanLength={ changePlanLength }
+					siteId={ siteId }
+					siteUrl={ siteSlug }
+					CountrySelectMenu={ CountrySelectMenu }
+					countriesList={ countriesList }
+					PhoneInput={ PhoneInput }
+					StateSelect={ StateSelect }
+				/>
+			</CheckoutProvider>
+		</React.Fragment>
 	);
 }
 
@@ -313,5 +317,14 @@ function CountrySelectMenu( {
 				aria-describedby={ countrySelectorDescriptionId }
 			/>
 		</FormFieldAnnotation>
+	);
+}
+
+function TestingBanner() {
+	return (
+		<Card highlight="warning" href="https://github.com/Automattic/wp-calypso/issues/new">
+			Warning! This checkout form is a new feature, still in testing. If you encounter issues,
+			please click here to report them and select "Checkout Redesign" in the project sidebar.
+		</Card>
 	);
 }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -325,10 +325,10 @@ function TestingBanner() {
 		<Card
 			className="composite-checkout__testing-banner"
 			highlight="warning"
-			href="https://github.com/Automattic/wp-calypso/issues/new"
+			href="https://github.com/Automattic/wp-calypso/issues/new?title=New%20checkout&body=%3C!--%20Thanks%20for%20filling%20your%20bug%20report%20for%20our%20New%20checkout!%20Pick%20a%20clear%20title%20(%22New%20checkout%3A%20Continue%20button%20not%20working%22)%20and%20proceed.%20--%3E%0A%0A%23%23%23%23%20Steps%20to%20reproduce%0A1.%20Starting%20at%20URL%3A%0A2.%0A3.%0A4.%0A%0A%23%23%23%23%20What%20I%20expected%0A%0A%0A%23%23%23%23%20What%20happened%20instead%0A%0A%0A%23%23%23%23%20Browser%20%2F%20OS%20version%0A%0A%0A%23%23%23%23%20Screenshot%20%2F%20Video%20(Optional)%0A%0A%40sirbrillig%2C%20%40nbloomf%2C%20%40fditrapani%20%0A"
 		>
-			Warning! This checkout form is a new feature, still in testing. If you encounter issues,
-			please click here to report them and select "Checkout Redesign" in the project sidebar.
+			Warning! This checkout is a new feature still in testing. If you encounter issues, please
+			click here to report them and select "Checkout Redesign" in the project sidebar.
 		</Card>
 	);
 }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -322,7 +322,11 @@ function CountrySelectMenu( {
 
 function TestingBanner() {
 	return (
-		<Card highlight="warning" href="https://github.com/Automattic/wp-calypso/issues/new">
+		<Card
+			className="composite-checkout__testing-banner"
+			highlight="warning"
+			href="https://github.com/Automattic/wp-calypso/issues/new"
+		>
 			Warning! This checkout form is a new feature, still in testing. If you encounter issues,
 			please click here to report them and select "Checkout Redesign" in the project sidebar.
 		</Card>

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1187,3 +1187,10 @@
 		height: 40px;
 	}
 }
+
+.composite-checkout__testing-banner {
+  @media( min-width: 700px ) {
+    margin: auto;
+    max-width: 556px;
+  }
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a warning card to the top of the checkout form so that anyone using it is explicitly aware that this is a new and still in-testing feature.

<img width="567" alt="Screen Shot 2020-01-17 at 3 05 56 PM" src="https://user-images.githubusercontent.com/2036909/72642652-e28d0300-393a-11ea-8a27-d17c6a90d35e.png">

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a plan to your cart and visit checkout.
- Verify the banner is visible and looks good at different window widths; particularly above 700px and below 700px.