### PR TITLE
FSE: Changed div to span on template select button inner HTML

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -64,7 +64,7 @@ const TemplateSelectorItem = props => {
 			onClick={ handleLabelClick }
 			aria-labelledby={ `${ id } ${ labelId }` }
 		>
-			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
+			<span className="template-selector-item__preview-wrap">{ innerPreview }</span>
 		</button>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-control.test.js.snap
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-control.test.js.snap
@@ -27,14 +27,14 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
             type="button"
             value="blank"
           >
-            <div
+            <span
               class="template-selector-item__preview-wrap"
             >
               <img
                 alt=""
                 class="template-selector-item__media"
               />
-            </div>
+            </span>
           </button>
         </li>
         <li
@@ -46,7 +46,7 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
             type="button"
             value="template-1"
           >
-            <div
+            <span
               class="template-selector-item__preview-wrap"
             >
               <img
@@ -54,7 +54,7 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
                 class="template-selector-item__media"
                 src="https://via.placeholder.com/350x150"
               />
-            </div>
+            </span>
           </button>
         </li>
         <li
@@ -66,7 +66,7 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
             type="button"
             value="template-2"
           >
-            <div
+            <span
               class="template-selector-item__preview-wrap"
             >
               <img
@@ -74,7 +74,7 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
                 class="template-selector-item__media"
                 src="https://via.placeholder.com/300x250"
               />
-            </div>
+            </span>
           </button>
         </li>
         <li
@@ -86,7 +86,7 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
             type="button"
             value="template-3"
           >
-            <div
+            <span
               class="template-selector-item__preview-wrap"
             >
               <img
@@ -94,7 +94,7 @@ exports[`TemplateSelectorControl Basic rendering renders with required props 1`]
                 class="template-selector-item__media"
                 src="https://via.placeholder.com/500x200"
               />
-            </div>
+            </span>
           </button>
         </li>
       </ul>


### PR DESCRIPTION
Addresses some a11y feedback in https://github.com/Automattic/wp-calypso/issues/33405.

#### Changes proposed in this Pull Request

* Changes `<div>` inside a `<button>` to a `<span>` to make it valid HTML

#### Testing instructions
Using the FSE Plugin:
- Add a new page to show the Starter Templates
- View the HTML on a starter template button (such as Blank or About)
- See that there are only `<span>`s and no `<div>`s inside of the button

Fixes a small part of #33405
