### PR TITLE
composite-checkout: Enable apple pay

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
@@ -115,7 +115,7 @@ export function createPaymentMethods( {
 					registerStore,
 					fetchStripeConfiguration: args => fetchStripeConfiguration( args, wpcom ),
 					submitTransaction: submitData =>
-						sendStripeTransaction(
+						submitApplePayPayment(
 							{
 								...submitData,
 								siteId: select( 'wpcom' )?.getSiteId?.(),
@@ -203,6 +203,17 @@ async function submitExistingCardPayment( transactionData, wpcom ) {
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
 	} );
 	debug( 'submitting existing card transaction', formattedTransactionData );
+	return wpcom.transactions( formattedTransactionData );
+}
+
+async function submitApplePayPayment( transactionData, wpcom ) {
+	debug( 'formatting existing card transaction', transactionData );
+	const formattedTransactionData = formatDataForTransactionsEndpoint( {
+		...transactionData,
+		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
+		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
+	} );
+	debug( 'submitting apple-pay transaction', formattedTransactionData );
 	return wpcom.transactions( formattedTransactionData );
 }
 

--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
@@ -207,7 +207,7 @@ async function submitExistingCardPayment( transactionData, wpcom ) {
 }
 
 async function submitApplePayPayment( transactionData, wpcom ) {
-	debug( 'formatting existing card transaction', transactionData );
+	debug( 'formatting apple-pay transaction', transactionData );
 	const formattedTransactionData = formatDataForTransactionsEndpoint( {
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',

--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.js
@@ -109,8 +109,20 @@ export function createPaymentMethods( {
 	const applePayMethod =
 		isMethodEnabled( 'apple-pay', allowedPaymentMethods ) && isApplePayAvailable()
 			? createApplePayMethod( {
+					getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.country?.value,
+					getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+					getPhoneNumber: () => select( 'wpcom' )?.getContactInfo?.()?.phoneNumber?.value,
 					registerStore,
 					fetchStripeConfiguration: args => fetchStripeConfiguration( args, wpcom ),
+					submitTransaction: submitData =>
+						sendStripeTransaction(
+							{
+								...submitData,
+								siteId: select( 'wpcom' )?.getSiteId?.(),
+								domainDetails: getDomainDetails( select ),
+							},
+							wpcom
+						),
 			  } )
 			: null;
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -205,6 +205,10 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 
 - `registerStore: object => object`. The `registerStore` function from the return value of [createRegistry](#createRegistry).
 - `fetchStripeConfiguration: async ?object => object`. An async function that fetches the stripe configuration (we use Stripe for Apple Pay).
+- `submitTransaction: async object => object`. An async function that sends the request to the endpoint.
+- `getCountry: () => string`. A function that returns the country to use for the transaction.
+- `getPostalCode: () => string`. A function that returns the postal code for the transaction.
+- `getPhoneNumber: () => string`. A function that returns the phone number for the transaction.
 
 ### createRegistry
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -97,8 +97,12 @@ const stripeMethod = createStripeMethod( {
 
 const applePayMethod = isApplePayAvailable()
 	? createApplePayMethod( {
+			getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
+			getPostalCode: () => 90210,
+			getPhoneNumber: () => 5555555555,
 			registerStore,
 			fetchStripeConfiguration,
+			submitTransaction: sendStripeTransaction,
 	  } )
 	: null;
 

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -41,7 +41,7 @@ export default function PaymentRequestButton( {
 			</Button>
 		);
 	}
-	if ( disabled ) {
+	if ( disabled && disabledReason ) {
 		return (
 			<Button disabled fullWidth>
 				{ disabledReason }
@@ -50,11 +50,11 @@ export default function PaymentRequestButton( {
 	}
 
 	if ( paymentType === 'apple-pay' ) {
-		return <ApplePayButton onClick={ onClick } />;
+		return <ApplePayButton disabled={ disabled } onClick={ onClick } />;
 	}
 	return (
-		<Button onClick={ onClick } fullWidth>
-			{ localize( 'Select a payment card', { context: 'Loading state on /checkout' } ) }
+		<Button disabled={ disabled } onClick={ onClick } fullWidth>
+			{ localize( 'Select a payment card' ) }
 		</Button>
 	);
 }
@@ -71,4 +71,16 @@ const ApplePayButton = styled.button`
 	-apple-pay-button-style: black;
 	-apple-pay-button-type: plain;
 	width: 100%;
+	position: relative;
+
+	&::after {
+		content: '';
+		position: ${ props => ( props.disabled ? 'absolute' : 'relative' ) }
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background-color: #ccc;
+		opacity: 0.7;
+	}
 `;

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -75,7 +75,7 @@ const ApplePayButton = styled.button`
 
 	&::after {
 		content: '';
-		position: ${ props => ( props.disabled ? 'absolute' : 'relative' ) }
+		position: ${props => ( props.disabled ? 'absolute' : 'relative' )};
 		top: 0;
 		left: 0;
 		width: 100%;

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -199,7 +199,7 @@ export function ApplePaySubmitButton( { disabled } ) {
 	return (
 		<PaymentRequestButton
 			disabled={ disabled }
-			disabledReason={ disabled && localize( 'The form is not complete' ) }
+			disabledReason={ localize( 'Pay' ) }
 			paymentRequest={ paymentRequest }
 			paymentType="apple-pay"
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Apple Pay has been prepared for a while, but this PR hooks it up to the transactions endpoint so that it can complete purchases.

#### Testing instructions

- Using Mac OS Safari, visit WordPress.com and log in. This is required because once we proxy, you will not be able to log in.
- Sandbox the store.
- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Enable Charles proxy to spoof WordPress.com. This is required because Apple Pay will only work on SSL and on a production domain. The details of how to do this are beyond the scope of this PR. Contact me if you have any issues.
- Using Mac OS Safari, reload WordPress.com and be sure you see the "dev" badge in the lower-right.
- Add a plan to your cart and visit checkout.
- Select "Apple Pay" from the available payment methods.
- Complete the form and press "Pay".
- You must use a real Apple Pay card. But as long as the store is sandboxed, you won't actually be charged.
- Complete the Apple Pay sheet that appears.
- Verify that the payment was successful and that the plan was added to your site.