### PR TITLE
Fix missing flag icons on stats

### DIFF
--- a/client/lib/flags/index.js
+++ b/client/lib/flags/index.js
@@ -6,7 +6,11 @@
  */
 export function flagUrl( countryCode ) {
 	try {
-		return require( `flag-icon-css/flags/4x3/${ countryCode }.svg` ).default;
+		const x = require( `flag-icon-css/flags/4x3/${ countryCode }.svg` );
+		if ( x.default ) {
+			return x.default;
+		}
+		return x;
 	} catch ( e ) {
 		// As a fallback, return a 'globe' SVG.
 		// Unfortunately, we're not shipping SVGs with the `gridicons` npm --

--- a/client/lib/flags/index.js
+++ b/client/lib/flags/index.js
@@ -6,7 +6,7 @@
  */
 export function flagUrl( countryCode ) {
 	try {
-		return require( `flag-icon-css/flags/4x3/${ countryCode }.svg` );
+		return require( `flag-icon-css/flags/4x3/${ countryCode }.svg` ).default;
 	} catch ( e ) {
 		// As a fallback, return a 'globe' SVG.
 		// Unfortunately, we're not shipping SVGs with the `gridicons` npm --

--- a/packages/calypso-build/jest/transform/README.md
+++ b/packages/calypso-build/jest/transform/README.md
@@ -7,7 +7,7 @@ i.e. they're not plain JavaScript:
 
 ```jsx
 const MyFlag = ( { countryCode } ) => (
-	<img alt="" src={ require( `flags/${ countryCode }.svg` ) } />
+	<img alt="" src={ import( `flags/${ countryCode }.svg` ) } />
 );
 ```
 

--- a/packages/calypso-build/jest/transform/README.md
+++ b/packages/calypso-build/jest/transform/README.md
@@ -7,7 +7,7 @@ i.e. they're not plain JavaScript:
 
 ```jsx
 const MyFlag = ( { countryCode } ) => (
-	<img alt="" src={ import( `flags/${ countryCode }.svg` ) } />
+	<img alt="" src={ require( `flags/${ countryCode }.svg` ).default } />
 );
 ```
 


### PR DESCRIPTION
When we switched to the latest file-loader in #38429, we also turned on esModule output (the new default). esModule output apparently also changes the return from a require to be the entire module instead of just the path. Instead getting a string, you receive the module object with a default property that is the path.

Update the lib/flags code to use this default property and update the only other usage of require with the file loader in the monorepo, which is just in a readme.

#### Testing instructions

* Visit stats on this branch. Flags for the various countries should appear under the map of visitor locations.

Fixes #38927
