### PR TITLE
Gutenboarding: Use pointer cursor for design selector and page layout selector.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -159,6 +159,7 @@ $design-selector-selection-space: 285px;
 		justify-content: center;
 		opacity: 0;
 		transition: 400ms;
+		cursor: pointer;
 
 		.design-selector__option-overlay-text {
 			font-size: 24px;
@@ -196,6 +197,7 @@ $design-selector-selection-space: 285px;
 	position: absolute;
 	top: 0;
 	width: 100%;
+	cursor: pointer;
 }
 
 .design-selector__description-container {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -82,6 +82,7 @@ $design-selector-selection-space: 285px;
 	position: relative;
 	overflow: hidden;
 	padding: 2px;
+	cursor: pointer;
 
 	&::before {
 		content: '';
@@ -197,7 +198,6 @@ $design-selector-selection-space: 285px;
 	position: absolute;
 	top: 0;
 	width: 100%;
-	cursor: pointer;
 }
 
 .design-selector__description-container {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -147,6 +147,7 @@ $design-selector-selection-space: 285px;
 
 .design-selector__design-option {
 	position: relative;
+	cursor: pointer;
 
 	.design-selector__option-overlay {
 		background-color: rgba( var( --color-primary-rgb ), 0.8 );
@@ -160,7 +161,6 @@ $design-selector-selection-space: 285px;
 		justify-content: center;
 		opacity: 0;
 		transition: 400ms;
-		cursor: pointer;
 
 		.design-selector__option-overlay-text {
 			font-size: 24px;


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Design selector now uses pointer cursor.
* Page layout selector now uses pointer cursor.

#### Testing instructions

1. Go to https://calypso.live/gutenboarding?branch=fix/gutenboarding-pointer-for-template-grids
2. When hovering over a design, the cursor should be a pointer.
2. When hovering over a page layout, the cursor should be pointer.

Design Selector
![image](https://user-images.githubusercontent.com/1287077/72715645-279a7a80-3b71-11ea-991b-ca05d508c809.png)

Page Layout Selector
![image](https://user-images.githubusercontent.com/1287077/72715744-531d6500-3b71-11ea-8b42-04962c338b54.png)

* Fixes #38846