### PR TITLE
Mobile Apps: Crop Google Play badge image

### DIFF
--- a/client/blocks/get-apps/apps-badge.scss
+++ b/client/blocks/get-apps/apps-badge.scss
@@ -1,14 +1,19 @@
 .get-apps__app-badge {
 	display: inline-block;
+	height: 35px;
+	overflow: hidden;
+	margin-left: 0.5rem;
+
+	&:first-child {
+		margin-left: 0;
+	}
 
 	img {
-		max-height: 41px;
-		margin: 9px 0;
-		width: auto;
+		height: 100%;
 	}
 
 	&.android-app-badge img {
-		max-height: 60px;
-		margin-left: 0;
+		transform: scale( 1.5 ) translateX( -5px );
+		transform-origin: left;
 	}
 }

--- a/client/blocks/get-apps/apps-badge.scss
+++ b/client/blocks/get-apps/apps-badge.scss
@@ -1,6 +1,7 @@
 .get-apps__app-badge {
-	display: inline-block;
-	height: 35px;
+	display: flex;
+	max-width: 135px;
+	max-height: 40px;
 	overflow: hidden;
 	margin-left: 0.5rem;
 
@@ -8,12 +9,10 @@
 		margin-left: 0;
 	}
 
-	img {
-		height: 100%;
-	}
-
+	// Crops the Android badge in order to remove the transparent space around it and generate a size-equivalent image
+	// to the iOS badge.
 	&.android-app-badge img {
-		transform: scale( 1.5 ) translateX( -5px );
+		transform: scale( 1.13 ) translate( -7px, -5.1px );
 		transform-origin: left;
 	}
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import { flowRight } from 'lodash';
 import moment from 'moment';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -332,10 +333,19 @@ class Home extends Component {
 		const isIos = isiPad || isiPod || isiPhone;
 		const showIosBadge = isDesktop() || isIos || ! isAndroid;
 		const showAndroidBadge = isDesktop() || isAndroid || ! isIos;
+		const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
 		return (
-			<Card className="customer-home__go-mobile">
-				<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
-				<h6 className="customer-home__card-subheader">{ translate( 'Make updates on the go' ) }</h6>
+			<Card
+				className={ classnames( 'customer-home__go-mobile', {
+					'is-single-store': showOnlyOneBadge,
+				} ) }
+			>
+				<div>
+					<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
+					<h6 className="customer-home__card-subheader">
+						{ translate( 'Make updates on the go' ) }
+					</h6>
+				</div>
 				<div className="customer-home__card-button-pair customer-home__card-mobile">
 					{ showIosBadge && (
 						<AppsBadge

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -194,6 +194,10 @@
 		display: flex;
 		flex-direction: row;
 		align-items: center;
+
+		.get-apps__app-badge {
+			width: 50%;
+		}
 	}
 	&__card-subheader {
 		color: var( --color-text-subtle );
@@ -210,6 +214,10 @@
 		.customer-home__card-subheader,
 		.get-apps__app-badge img {
 			margin: 0;
+		}
+
+		.get-apps__app-badge {
+			width: auto;
 		}
 
 		.customer-home__card-mobile {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -200,9 +200,24 @@
 		font-size: 0.85rem;
 		margin: -0.5rem 0 1rem;
 	}
-	&__go-mobile,
 	&__grow-earn {
 		padding-bottom: 12px;
+	}
+	&__go-mobile.is-single-store {
+		display: flex;
+		padding-bottom: 1rem;
+
+		.customer-home__card-subheader,
+		.get-apps__app-badge img {
+			margin: 0;
+		}
+
+		.customer-home__card-mobile {
+			margin-left: auto;
+			align-self: center;
+			flex-shrink: 0;
+			padding-left: 1rem;
+		}
 	}
 	&__layout {
 		@include grid-row( 3, 1 );


### PR DESCRIPTION
Part of #38907 
Follows up #38905

#### Changes proposed in this Pull Request

The Google Play badge image has some transparent space around it which causes some [alignment issues](https://github.com/Automattic/wp-calypso/pull/38905#issuecomment-575667863) when using it along with the App Store bade image (since this one doesn't have any transparent space).

Google Play | App Store
--- | ---
<img width="332" alt="Screenshot 2020-01-20 at 13 18 58" src="https://user-images.githubusercontent.com/1233880/72725978-879c1b80-3b87-11ea-936f-4eda6718fcb5.png"> | <img width="331" alt="Screenshot 2020-01-20 at 13 19 06" src="https://user-images.githubusercontent.com/1233880/72726011-97b3fb00-3b87-11ea-9a4b-33279d364c0f.png">
[Link to image](http://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png) | [Link to image](https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/appstore-lrg.svg)

This PR includes a CSS hack that crops the Google Play image in order to have a size-equivalent image to the App Store one in order to prevent those alignment issues.

That allowed to align the banner to the right when we display one single store button in the Customer Home's Go Mobile card suggested by @sixhours in https://github.com/Automattic/wp-calypso/pull/38905#issuecomment-575652889.

#### Screenshots

**`/home/:site`**

Device | Before | After
--- | --- | ---
Desktop | <img width="326" alt="Screenshot 2020-01-20 at 13 08 59" src="https://user-images.githubusercontent.com/1233880/72726520-d302f980-3b88-11ea-9bb5-1cda8bacdf30.png"> | <img width="321" alt="Screenshot 2020-01-20 at 13 10 07" src="https://user-images.githubusercontent.com/1233880/72726527-da2a0780-3b88-11ea-9f84-48927643f705.png">
iPhone | <img width="409" alt="Screenshot 2020-01-20 at 13 11 44" src="https://user-images.githubusercontent.com/1233880/72726546-e746f680-3b88-11ea-820d-1ef24a57dd62.png"> | <img width="386" alt="Screenshot 2020-01-20 at 13 13 03" src="https://user-images.githubusercontent.com/1233880/72726559-ed3cd780-3b88-11ea-8fcd-67ec61f93e8b.png">
Android | <img width="388" alt="Screenshot 2020-01-20 at 13 13 20" src="https://user-images.githubusercontent.com/1233880/72726600-004fa780-3b89-11ea-87aa-bbdd5d37bde4.png"> | <img width="391" alt="Screenshot 2020-01-20 at 13 13 40" src="https://user-images.githubusercontent.com/1233880/72726611-06de1f00-3b89-11ea-97c5-91d2950c5062.png">
Other mobile device | <img width="493" alt="Screenshot 2020-01-20 at 13 11 10" src="https://user-images.githubusercontent.com/1233880/72726631-1198b400-3b89-11ea-8043-ad180ec7121e.png"> | <img width="464" alt="Screenshot 2020-01-20 at 13 11 28" src="https://user-images.githubusercontent.com/1233880/72726639-18272b80-3b89-11ea-8d03-4caa999cae60.png">

**`/me/get-apps` and `/checklist/:site`**

Device | Before | After
--- | --- | ---
Desktop | <img width="750" alt="Screenshot 2020-01-20 at 13 07 42" src="https://user-images.githubusercontent.com/1233880/72726380-799aca80-3b88-11ea-9c94-d1017b4938e0.png"> | <img width="769" alt="Screenshot 2020-01-20 at 13 07 54" src="https://user-images.githubusercontent.com/1233880/72726387-80294200-3b88-11ea-96ac-0b5ea3bfd63c.png">
Mobile | <img width="350" alt="Screenshot 2020-01-20 at 13 08 05" src="https://user-images.githubusercontent.com/1233880/72726404-8c150400-3b88-11ea-8634-d22923a3a460.png"> | <img width="345" alt="Screenshot 2020-01-20 at 13 08 13" src="https://user-images.githubusercontent.com/1233880/72726426-9a632000-3b88-11ea-87aa-affa82bc0a6f.png">


#### Testing instructions

Access the path listed above and verify the mobile stores badges are displayed correctly according to the screenshots.

