### PR TITLE
Domains: Remove prompt to contact support

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -15,8 +15,8 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormCheckbox from 'components/forms/form-checkbox';
-import { CALYPSO_CONTACT, MOVE_DOMAIN } from 'lib/url/support';
-import { getName, isRefundable, maybeWithinRefundPeriod } from 'lib/purchases';
+import { MOVE_DOMAIN } from 'lib/url/support';
+import { getName } from 'lib/purchases';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {
@@ -53,7 +53,7 @@ class RemoveDomainDialog extends Component {
 	}
 
 	renderFirstStep( productName ) {
-		const { translate, purchase } = this.props;
+		const { translate } = this.props;
 
 		return (
 			<Fragment>
@@ -77,27 +77,6 @@ class RemoveDomainDialog extends Component {
 						}
 					) }
 				</p>
-
-				{ ! isRefundable( purchase ) && maybeWithinRefundPeriod( purchase ) && (
-					<p>
-						<strong>
-							{ translate(
-								"We're not able to refund this purchase automatically. " +
-									"If you're canceling within %(refundPeriodInDays)s days of " +
-									'purchase, {{contactLink}}contact us{{/contactLink}} to ' +
-									'request a refund.',
-								{
-									args: {
-										refundPeriodInDays: purchase.refundPeriodInDays,
-									},
-									components: {
-										contactLink: <a href={ CALYPSO_CONTACT } />,
-									},
-								}
-							) }
-						</strong>
-					</p>
-				) }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Remove prompt to contact support for domains that are not refundable in the refund window

#### Testing instructions

Using Store Sandbox:

- Purchase a test domain with credits
- Go to /me/purchases
- Find the domain you registered, and click it
- Click the remove domain button
- You should not see the prompt to contact support
- Existing functionality of the remove dialog should not break
