### PR TITLE
ESLint: fix import lint errors in tests

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -2,4 +2,16 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '**/test/**/*' ],
+			rules: {
+				'import/no-extraneous-dependencies': [
+					'error',
+					{ packageDir: [ __dirname, __dirname + '/..' ] },
+				],
+				'import/no-nodejs-modules': 'off',
+			},
+		},
+	],
 };

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -5,7 +5,7 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
+import assert from 'assert';
 import { mount, shallow } from 'enzyme';
 import { noop, uniq } from 'lodash';
 import React from 'react';

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { equal, ok } from 'assert'; // eslint-disable-line import/no-nodejs-modules
+import { equal, ok } from 'assert';
 import { groupBy, pickBy, forIn } from 'lodash';
 
 /**

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
+import assert from 'assert';
 import { flow } from 'lodash';
 
 /**

--- a/client/lib/cart/store/test/cart-synchronizer.js
+++ b/client/lib/cart/store/test/cart-synchronizer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
+import assert from 'assert';
 
 /**
  * Internal dependencies

--- a/client/lib/form-state/test/index.js
+++ b/client/lib/form-state/test/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { assign, constant, mapValues, zipObject } from 'lodash';
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
+import assert from 'assert';
 
 /**
  * Internal dependencies

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
+import assert from 'assert';
 
 /**
  * Internal dependencies

--- a/client/state/happiness-engineers/test/selectors.js
+++ b/client/state/happiness-engineers/test/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
+import assert from 'assert';
 
 /**
  * Internal dependencies

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -4,9 +4,19 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '*.stories.jsx', '**/test/**' ],
+			files: [ '*.stories.jsx' ],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+		{
+			files: [ '**/test/**/*' ],
+			rules: {
+				'import/no-extraneous-dependencies': [
+					'error',
+					{ packageDir: [ __dirname, __dirname + '/../..' ] },
+				],
+				'import/no-nodejs-modules': 'off',
 			},
 		},
 	],


### PR DESCRIPTION
Configures ESlint in `client/` and in `packages/components/` to allow importing `devDependencies` from root and Node modules in tests. For example, importing `enzyme`, `nock` or `fs` is OK in Jest tests.

Also removes several disables of the `import/no-nodejs-modules` in test files. These should be no longer necessary.

I wish we could find a way to avoid repetitive `.eslintrc.js` files like this, but I don't know how.