### PR TITLE
Customer Home: Add link to text or email a download app link

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -368,6 +368,11 @@ class Home extends Component {
 						</AppsBadge>
 					) }
 				</div>
+				{ isDesktop() && (
+					<a href="/me/get-apps" className="customer-home__mobile-download-sms-email">
+						{ translate( 'Text or email me a link' ) }
+					</a>
+				) }
 			</Card>
 		);
 	};

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -207,24 +207,33 @@
 	&__grow-earn {
 		padding-bottom: 12px;
 	}
-	&__go-mobile.is-single-store {
-		display: flex;
-		padding-bottom: 1rem;
+	&__go-mobile {
+		&.is-single-store {
+			display: flex;
+			padding-bottom: 1rem;
 
-		.customer-home__card-subheader,
-		.get-apps__app-badge img {
-			margin: 0;
+			.customer-home__card-subheader,
+			.get-apps__app-badge img {
+				margin: 0;
+			}
+
+			.get-apps__app-badge {
+				width: auto;
+			}
+
+			.customer-home__card-mobile {
+				margin-left: auto;
+				align-self: center;
+				flex-shrink: 0;
+				padding-left: 1rem;
+			}
 		}
 
-		.get-apps__app-badge {
-			width: auto;
-		}
-
-		.customer-home__card-mobile {
-			margin-left: auto;
-			align-self: center;
-			flex-shrink: 0;
-			padding-left: 1rem;
+		.customer-home__mobile-download-sms-email {
+			display: block;
+			border-top: 1px solid var( --color-neutral-5 );
+			padding-top: 12px;
+			margin-top: 1rem;
 		}
 	}
 	&__layout {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of #38861.

Adds a link to the Customer Home's "Go Mobile" card that redirects to `/me/get-apps` when viewed on desktop so users can send themselves a link to download the app via SMS or email.

<img width="323" alt="Screenshot 2020-01-20 at 17 25 44" src="https://user-images.githubusercontent.com/1233880/72742670-816b6680-3baa-11ea-9c3b-de1753eba66a.png">

Styles are based on @danhauk's mockup in pbAPfg-10-p2#comment-34. I'm open to also implement an approach that doesn't redirect users to `/me/get-apps` so they're kept in the customer home, but I'd need some design feedback or mockup.

#### Testing instructions

* Go to `/home:/site`.
* On desktop, make sure there is a `Text or email me a link` link that redirects to `/me/get-apps`.
* On mobile, make sure there is no link.
