### PR TITLE
Add @testing-library/react and @testing-library/jest-dom as dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15681,7 +15681,20 @@
 			"integrity": "sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.2.3"
+				"loader-utils": "^1.2.3",
+				"schema-utils": "^2.5.0"
+			},
+			"dependencies": {
+				"schema-utils": {
+					"version": "2.6.4",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+					"integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				}
 			}
 		},
 		"file-system-cache": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `@testing-library/react` and `@testing-library/jest-dom` as dependencies.

I am not sure why these need to be dependencies (rather than just dev dependencies), but I'm getting lint errors on `client/my-sites/checkout/checkout/test/composite-checkout` of the form

```
'@testing-library/react' should be listed in the project's dependencies. Run 'npm i -S @testing-library/react' to add it
```

#### Testing instructions

This only touches package-lock.json