### PR TITLE
Gutenboarding: Fix page selector card hover

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -106,6 +106,17 @@ $design-selector-selection-space: 285px;
 	&:focus {
 		padding: 0;
 		border: 3px solid $blue-medium-focus;
+
+		// Offset absolute-positioned card content when border state occurs
+		.page-layout-selector__card-media {
+			width: calc( 100% + 4px ); /* This number is the border width * 2, minus the width of the thin static state border */
+			top: -2px; /* This is half of the above number. */
+		}
+
+		.page-layout-selector__card-footer {
+			bottom: -2px;
+			width: calc( 100% + 4px );
+		}
 	}
 
 	&:hover,


### PR DESCRIPTION
### Summary

This PR fixes a size fluttering issue on the page selector cards during hover states, due to the discrepancies between the width of the borders and new absolute positioning of the card content.

Now, content is re-positioned behind the hover/focus/selected state border by half of the difference in width between the neutral state border, and stretched by the full difference.

<hr>

### Testing

* Spin up calypso local dev environment and hit `/gutenboarding`.
* Get to the step requiring you to select a page. Make sure that the content size doesn't fluctuate based  on hover/focus/selected states.
* Ensure there are no regressions.

<hr>

Fixes #38895 