### PR TITLE
Sidebar: Fix Site Indicator Disconnect Link Colour on Hover

### DIFF
--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -105,6 +105,7 @@
 
 	// Links within the action message
 	a:link,
+	a:hover,
 	a:visited,
 	.button.is-borderless.is-scary,
 	.site-indicator__action-button {

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -105,7 +105,7 @@
 
 	// Links within the action message
 	a:link,
-	a:hover,
+	a.is-borderless.button:hover,
 	a:visited,
 	.button.is-borderless.is-scary,
 	.site-indicator__action-button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the red on dark red hover colour in the Site Indicator in the Sidebar.

#### Testing instructions

1. Start at your Calypso dashboard on a Jetpack site which cannot be accessed (eg. a Jurassic Ninja site which has passed its lifetime) 
2. Hover over the link in the error
3. Verify it is no longer a dark red which doesn't blend well with the background.

**Before:**

<img width="274" alt="Screenshot_2019-12-19_at_22 08 31" src="https://user-images.githubusercontent.com/43215253/71644491-23014580-2cda-11ea-9043-d2a4a015e4ce.png">

**After:**

<img width="257" alt="Screenshot 2020-01-20 at 20 39 24" src="https://user-images.githubusercontent.com/43215253/72756389-f9df2100-3bc4-11ea-8f42-798e25d3f13c.png">

This is the only colour in Colour Studio which passes colour contrast requirements for the red background, but the hover status is indicated by the cursor.

Fixes #38628
