### PR TITLE
Stats: Improve Clarity of Marking Spam Text

### DIFF
--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -44,22 +44,22 @@ class StatsActionSpam extends React.Component {
 
 	render() {
 		let label = this.state.spammed
-				? this.props.translate( 'Not Spam' )
-				: this.props.translate( 'Spam', {
+				? this.props.translate( 'Mark as Not Spam' )
+				: this.props.translate( 'Mark as Spam', {
 						context: 'Stats: Action to mark an item as spam',
-						comment: 'Default label (changes into "Not Spam").',
+						comment: 'Default label (changes into "Mark as Not Spam").',
 				  } ),
 			title = this.state.spammed
-				? this.props.translate( 'Not Spam', {
+				? this.props.translate( 'Mark as Not Spam', {
 						textOnly: true,
 						context: 'Stats: Action to undo marking an item as spam',
 						comment:
 							'Secondary label (default label is "Spam"). Recommended to use a very short label.',
 				  } )
-				: this.props.translate( 'Spam', {
+				: this.props.translate( 'Mark as Spam', {
 						textOnly: true,
 						context: 'Stats: Action to mark an item as spam',
-						comment: 'Default label (changes into "Not Spam").',
+						comment: 'Default label (changes into "Mark as Not Spam").',
 				  } ),
 			wrapperClass = classNames( 'module-content-list-item-action-wrapper', {
 				spam: ! this.state.spammed,

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -53,13 +53,10 @@ class StatsActionSpam extends React.Component {
 			? this.props.translate( 'Mark as Not Spam', {
 					textOnly: true,
 					context: 'Stats: Action to undo marking an item as spam',
-					comment:
-						'Secondary label (default label is "Spam"). Recommended to use a very short label.',
 			  } )
 			: this.props.translate( 'Mark as Spam', {
 					textOnly: true,
 					context: 'Stats: Action to mark an item as spam',
-					comment: 'Default label (changes into "Mark as Not Spam").',
 			  } );
 
 		const wrapperClass = classNames( 'module-content-list-item-action-wrapper', 'is-link', {

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -13,6 +13,7 @@ const debug = debugFactory( 'calypso:stats:action-spam' );
  */
 import wpcom from 'lib/wp';
 import analytics from 'lib/analytics';
+import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 
 class StatsActionSpam extends React.Component {
@@ -23,9 +24,8 @@ class StatsActionSpam extends React.Component {
 	};
 
 	clickHandler = event => {
-		let spamType = this.state.spammed ? 'statsReferrersSpamDelete' : 'statsReferrersSpamNew',
-			gaEvent = this.state.spammed ? 'Undid Referrer Spam' : 'Marked Referrer as Spam',
-			wpcomSite;
+		const spamType = this.state.spammed ? 'statsReferrersSpamDelete' : 'statsReferrersSpamNew';
+		const gaEvent = this.state.spammed ? 'Undid Referrer Spam' : 'Marked Referrer as Spam';
 		event.stopPropagation();
 		event.preventDefault();
 		debug( this.state );
@@ -37,38 +37,39 @@ class StatsActionSpam extends React.Component {
 			this.props.afterChange( ! this.state.spammed );
 		}
 
-		wpcomSite = wpcom.site( this.props.data.siteID );
+		const wpcomSite = wpcom.site( this.props.data.siteID );
 		wpcomSite[ spamType ].call( wpcomSite, this.props.data.domain, function() {} );
 		analytics.ga.recordEvent( 'Stats', gaEvent + ' in ' + this.props.moduleName + ' List' );
 	};
 
 	render() {
-		let label = this.state.spammed
-				? this.props.translate( 'Mark as Not Spam' )
-				: this.props.translate( 'Mark as Spam', {
-						context: 'Stats: Action to mark an item as spam',
-						comment: 'Default label (changes into "Mark as Not Spam").',
-				  } ),
-			title = this.state.spammed
-				? this.props.translate( 'Mark as Not Spam', {
-						textOnly: true,
-						context: 'Stats: Action to undo marking an item as spam',
-						comment:
-							'Secondary label (default label is "Spam"). Recommended to use a very short label.',
-				  } )
-				: this.props.translate( 'Mark as Spam', {
-						textOnly: true,
-						context: 'Stats: Action to mark an item as spam',
-						comment: 'Default label (changes into "Mark as Not Spam").',
-				  } ),
-			wrapperClass = classNames( 'module-content-list-item-action-wrapper', {
-				spam: ! this.state.spammed,
-				unspam: this.state.spammed,
-			} );
+		const label = this.state.spammed
+			? this.props.translate( 'Mark as Not Spam' )
+			: this.props.translate( 'Mark as Spam', {
+					context: 'Stats: Action to mark an item as spam',
+					comment: 'Default label (changes into "Mark as Not Spam").',
+			  } );
+		const title = this.state.spammed
+			? this.props.translate( 'Mark as Not Spam', {
+					textOnly: true,
+					context: 'Stats: Action to undo marking an item as spam',
+					comment:
+						'Secondary label (default label is "Spam"). Recommended to use a very short label.',
+			  } )
+			: this.props.translate( 'Mark as Spam', {
+					textOnly: true,
+					context: 'Stats: Action to mark an item as spam',
+					comment: 'Default label (changes into "Mark as Not Spam").',
+			  } );
+
+		const wrapperClass = classNames( 'module-content-list-item-action-wrapper', 'is-link', {
+			spam: ! this.state.spammed,
+			unspam: this.state.spammed,
+		} );
 
 		return (
-			<li className="module-content-list-item-action">
-				<a
+			<li className="stats-list__spam-action module-content-list-item-action">
+				<Button
 					href="#"
 					onClick={ this.clickHandler }
 					className={ wrapperClass }
@@ -76,8 +77,10 @@ class StatsActionSpam extends React.Component {
 					aria-label={ title }
 				>
 					<Gridicon icon="spam" size={ 18 } />
-					<span className="module-content-list-item-action-label">{ label }</span>
-				</a>
+					<span className="stats-list__spam-label module-content-list-item-action-label">
+						{ label }
+					</span>
+				</Button>
 			</li>
 		);
 	}

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -366,6 +366,7 @@ ul.module-content-list-item-actions {
 		.module-content-list-item-action-wrapper,
 		ul.module-content-list-item-action-submenu {
 			display: block;
+			opacity: 1;
 			text-align: left;
 		}
 
@@ -547,21 +548,20 @@ ul.module-content-list-item-action-submenu {
 		}
 	}
 
-	// Icon settings
-	// 1: Optically align a bit better
-	// 2: When a button instead of a link is used
+	// Optically align a bit better
 	.gridicon {
 		vertical-align: middle;
 		margin-right: 4px;
-		margin-top: -2px; // 1
+		margin-top: -2px;
 
 		&.gridicons-cross {
 			margin-right: 0;
 		}
 	}
 	
+	// When a button instead of a link is used
 	.button.module-content-list-item-action-wrapper .gridicon {
-		vertical-align: unset; // 2
+		vertical-align: unset;
 	}
 
 	// Color spam action red

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -549,6 +549,7 @@ ul.module-content-list-item-action-submenu {
 
 	// Icon settings
 	// 1: Optically align a bit better
+	// 2: When a button instead of a link is used
 	.gridicon {
 		vertical-align: middle;
 		margin-right: 4px;
@@ -557,6 +558,10 @@ ul.module-content-list-item-action-submenu {
 		&.gridicons-cross {
 			margin-right: 0;
 		}
+	}
+	
+	.button.module-content-list-item-action-wrapper .gridicon {
+		vertical-align: unset; // 2
 	}
 
 	// Color spam action red


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prefixes the "Spam" text with "Mark as" for clarity in stats

#### Testing instructions

Visit the Stats page and look at the Referrers column. On a referral with an ellipses Gridicon next to it, click it and compare the text.

**Before:**
<img width="217" alt="Screenshot 2020-01-20 at 20 49 18" src="https://user-images.githubusercontent.com/43215253/72756970-acfc4a00-3bc6-11ea-9b1c-4fa48b912905.png">

**After:**
<img width="226" alt="Screenshot 2020-01-20 at 20 49 00" src="https://user-images.githubusercontent.com/43215253/72756983-b71e4880-3bc6-11ea-829d-6f1ce39e64d2.png">

Then mark the item as spam, and hover over it again to see the other label change.

<img width="320" alt="Screenshot 2020-01-20 at 20 49 43" src="https://user-images.githubusercontent.com/43215253/72756998-c1404700-3bc6-11ea-9c48-794e67c82aa8.png">

Fixes #38875
