### PR TITLE
Customer Home: Add Email Me A Login Link Button to Go Mobile Card 

### DIFF
--- a/client/my-sites/customer-home/go-mobile-card/index.jsx
+++ b/client/my-sites/customer-home/go-mobile-card/index.jsx
@@ -26,10 +26,11 @@ import { getCurrentUserEmail } from 'state/current-user/selectors';
 import './style.scss';
 
 export const GoMobileCard = ( { translate, email, sendMobileLoginEmail } ) => {
+	const isDesktopView = isDesktop();
 	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
 	const isIos = isiPad || isiPod || isiPhone;
-	const showIosBadge = isDesktop() || isIos || ! isAndroid;
-	const showAndroidBadge = isDesktop() || isAndroid || ! isIos;
+	const showIosBadge = isDesktopView || isIos || ! isAndroid;
+	const showAndroidBadge = isDesktopView || isAndroid || ! isIos;
 	const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
 
 	const emailLogin = () => {
@@ -66,9 +67,11 @@ export const GoMobileCard = ( { translate, email, sendMobileLoginEmail } ) => {
 					) }
 				</div>
 			</div>
-			<Button className="go-mobile-card__email-link-button" onClick={ emailLogin }>
-				{ translate( 'Email me a log in link' ) }
-			</Button>
+			{ isDesktopView && (
+				<Button className="go-mobile-card__email-link-button" onClick={ emailLogin }>
+					{ translate( 'Email download link' ) }
+				</Button>
+			) }
 		</Card>
 	);
 };

--- a/client/my-sites/customer-home/go-mobile-card/index.jsx
+++ b/client/my-sites/customer-home/go-mobile-card/index.jsx
@@ -30,38 +30,41 @@ export const GoMobileCard = ( { translate, email, sendMobileLoginEmail } ) => {
 	const isIos = isiPad || isiPod || isiPhone;
 	const showIosBadge = isDesktop() || isIos || ! isAndroid;
 	const showAndroidBadge = isDesktop() || isAndroid || ! isIos;
+	const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
 
 	const emailLogin = () => {
 		sendMobileLoginEmail( email );
 	};
 
 	return (
-		<Card className={ classnames( 'go-mobile-card' ) }>
-			<div>
-				<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
-				<h6 className="go-mobile-card__subheader">{ translate( 'Make updates on the go' ) }</h6>
-			</div>
-			<div className="go-mobile-card__app-badges">
-				{ showIosBadge && (
-					<AppsBadge
-						storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
-						storeName={ 'ios' }
-						titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
-						altText={ translate( 'Apple App Store download badge' ) }
-					>
-						<img src={ appleStoreLogo } alt="" />
-					</AppsBadge>
-				) }
-				{ showAndroidBadge && (
-					<AppsBadge
-						storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
-						storeName={ 'android' }
-						titleText={ translate( 'Download the WordPress Android mobile app.' ) }
-						altText={ translate( 'Google Play Store download badge' ) }
-					>
-						<img src={ googlePlayLogo } alt="" />
-					</AppsBadge>
-				) }
+		<Card className="go-mobile-card">
+			<div className={ classnames( 'go-mobile-card__row', { 'has-2-cols': showOnlyOneBadge } ) }>
+				<div className="go-mobile-card__title">
+					<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
+					<h6 className="go-mobile-card__subheader">{ translate( 'Make updates on the go' ) }</h6>
+				</div>
+				<div className="go-mobile-card__app-badges">
+					{ showIosBadge && (
+						<AppsBadge
+							storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
+							storeName={ 'ios' }
+							titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
+							altText={ translate( 'Apple App Store download badge' ) }
+						>
+							<img src={ appleStoreLogo } alt="" />
+						</AppsBadge>
+					) }
+					{ showAndroidBadge && (
+						<AppsBadge
+							storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
+							storeName={ 'android' }
+							titleText={ translate( 'Download the WordPress Android mobile app.' ) }
+							altText={ translate( 'Google Play Store download badge' ) }
+						>
+							<img src={ googlePlayLogo } alt="" />
+						</AppsBadge>
+					) }
+				</div>
 			</div>
 			<Button className="go-mobile-card__email-link-button" onClick={ emailLogin }>
 				{ translate( 'Email me a log in link' ) }

--- a/client/my-sites/customer-home/go-mobile-card/index.jsx
+++ b/client/my-sites/customer-home/go-mobile-card/index.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import AppsBadge from 'blocks/get-apps/apps-badge';
+import userAgent from 'lib/user-agent';
+import { isDesktop } from 'lib/viewport';
+import CardHeading from 'components/card-heading';
+import appleStoreLogo from 'assets/images/customer-home/apple-store.png';
+import googlePlayLogo from 'assets/images/customer-home/google-play.png';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const GoMobileCard = ( { translate } ) => {
+	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
+	const isIos = isiPad || isiPod || isiPhone;
+	const showIosBadge = isDesktop() || isIos || ! isAndroid;
+	const showAndroidBadge = isDesktop() || isAndroid || ! isIos;
+	const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
+
+	return (
+		<Card
+			className={ classnames( 'go-mobile-card', {
+				'is-single-store': showOnlyOneBadge,
+			} ) }
+		>
+			<div>
+				<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
+				<h6 className="go-mobile-card__subheader">{ translate( 'Make updates on the go' ) }</h6>
+			</div>
+			<div className="go-mobile-card__app-badges">
+				{ showIosBadge && (
+					<AppsBadge
+						storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
+						storeName={ 'ios' }
+						titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
+						altText={ translate( 'Apple App Store download badge' ) }
+					>
+						<img src={ appleStoreLogo } alt="" />
+					</AppsBadge>
+				) }
+				{ showAndroidBadge && (
+					<AppsBadge
+						storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
+						storeName={ 'android' }
+						titleText={ translate( 'Download the WordPress Android mobile app.' ) }
+						altText={ translate( 'Google Play Store download badge' ) }
+					>
+						<img src={ googlePlayLogo } alt="" />
+					</AppsBadge>
+				) }
+			</div>
+		</Card>
+	);
+};
+
+export default localize( GoMobileCard );

--- a/client/my-sites/customer-home/go-mobile-card/style.scss
+++ b/client/my-sites/customer-home/go-mobile-card/style.scss
@@ -11,17 +11,11 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	margin-bottom: 1.5em;
 }
 
 .go-mobile-card__app-badges .get-apps__app-badge {
 	width: 50%;
-}
-
-.go-mobile-card.is-single-store .go-mobile-card__app-badges {
-	margin-left: auto;
-	align-self: center;
-	flex-shrink: 0;
-	padding-left: 1rem;
 }
 
 .go-mobile-card__subheader {
@@ -30,7 +24,10 @@
 	margin: -0.5rem 0 1rem;
 }
 
-.go-mobile-card__subheader,
 .go-mobile-card .get-apps__app-badge img {
 	margin: 0;
+}
+
+.go-mobile-card__email-link-button {
+	width: 100%;
 }

--- a/client/my-sites/customer-home/go-mobile-card/style.scss
+++ b/client/my-sites/customer-home/go-mobile-card/style.scss
@@ -1,0 +1,36 @@
+.go-mobile-card.is-single-store {
+	display: flex;
+	padding-bottom: 1rem;
+}
+
+.go-mobile-card.is-single-store .get-apps__app-badge {
+	width: auto;
+}
+
+.go-mobile-card__app-badges {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+.go-mobile-card__app-badges .get-apps__app-badge {
+	width: 50%;
+}
+
+.go-mobile-card.is-single-store .go-mobile-card__app-badges {
+	margin-left: auto;
+	align-self: center;
+	flex-shrink: 0;
+	padding-left: 1rem;
+}
+
+.go-mobile-card__subheader {
+	color: var( --color-text-subtle );
+	font-size: 0.85rem;
+	margin: -0.5rem 0 1rem;
+}
+
+.go-mobile-card__subheader,
+.go-mobile-card .get-apps__app-badge img {
+	margin: 0;
+}

--- a/client/my-sites/customer-home/go-mobile-card/style.scss
+++ b/client/my-sites/customer-home/go-mobile-card/style.scss
@@ -1,21 +1,5 @@
-.go-mobile-card.is-single-store {
-	display: flex;
-	padding-bottom: 1rem;
-}
-
-.go-mobile-card.is-single-store .get-apps__app-badge {
-	width: auto;
-}
-
-.go-mobile-card__app-badges {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	margin-bottom: 1.5em;
-}
-
-.go-mobile-card__app-badges .get-apps__app-badge {
-	width: 50%;
+.go-mobile-card__row {
+	margin-bottom: 1rem;
 }
 
 .go-mobile-card__subheader {
@@ -24,10 +8,31 @@
 	margin: -0.5rem 0 1rem;
 }
 
-.go-mobile-card .get-apps__app-badge img {
-	margin: 0;
+.go-mobile-card__app-badges {
+	display: flex;
+}
+
+.go-mobile-card__app-badges .get-apps__app-badge {
+	width: 50%;
 }
 
 .go-mobile-card__email-link-button {
 	width: 100%;
+}
+
+.go-mobile-card__row.has-2-cols {
+	display: flex;
+}
+
+.go-mobile-card__row.has-2-cols .get-apps__app-badge {
+	width: auto;
+}
+
+.go-mobile-card__row.has-2-cols .go-mobile-card__subheader {
+	margin: 0;
+}
+
+.go-mobile-card__row.has-2-cols .go-mobile-card__app-badges {
+	margin-left: auto;
+	padding-left: 1rem;
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -8,12 +8,10 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import { flowRight } from 'lodash';
 import moment from 'moment';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import AppsBadge from 'blocks/get-apps/apps-badge';
 import Banner from 'components/banner';
 import { Button, Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
@@ -43,7 +41,6 @@ import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { getGSuiteSupportedDomains } from 'lib/gsuite';
 import { localizeUrl } from 'lib/i18n-utils';
-import userAgent from 'lib/user-agent';
 import { isDesktop, isMobile } from 'lib/viewport';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
@@ -57,6 +54,7 @@ import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
+import GoMobileCard from 'my-sites/customer-home/go-mobile-card';
 
 /**
  * Style dependencies
@@ -66,11 +64,9 @@ import './style.scss';
 /**
  * Image dependencies
  */
-import appleStoreLogo from 'assets/images/customer-home/apple-store.png';
 import commentIcon from 'assets/images/customer-home/comment.svg';
 import customDomainIcon from 'assets/images/customer-home/custom-domain.svg';
 import customizeIcon from 'assets/images/customer-home/customize.svg';
-import googlePlayLogo from 'assets/images/customer-home/google-play.png';
 import gSuiteIcon from 'assets/images/customer-home/gsuite.svg';
 import happinessIllustration from 'assets/images/customer-home/happiness.png';
 import imagesIcon from 'assets/images/customer-home/images.svg';
@@ -327,51 +323,6 @@ class Home extends Component {
 		);
 	}
 
-	renderGoMobile = () => {
-		const { translate } = this.props;
-		const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
-		const isIos = isiPad || isiPod || isiPhone;
-		const showIosBadge = isDesktop() || isIos || ! isAndroid;
-		const showAndroidBadge = isDesktop() || isAndroid || ! isIos;
-		const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
-		return (
-			<Card
-				className={ classnames( 'customer-home__go-mobile', {
-					'is-single-store': showOnlyOneBadge,
-				} ) }
-			>
-				<div>
-					<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
-					<h6 className="customer-home__card-subheader">
-						{ translate( 'Make updates on the go' ) }
-					</h6>
-				</div>
-				<div className="customer-home__card-button-pair customer-home__card-mobile">
-					{ showIosBadge && (
-						<AppsBadge
-							storeLink="https://apps.apple.com/app/apple-store/id335703880?pt=299112&ct=calypso-customer-home&mt=8"
-							storeName={ 'ios' }
-							titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
-							altText={ translate( 'Apple App Store download badge' ) }
-						>
-							<img src={ appleStoreLogo } alt="" />
-						</AppsBadge>
-					) }
-					{ showAndroidBadge && (
-						<AppsBadge
-							storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android&referrer=utm_source%3Dcalypso-customer-home%26utm_medium%3Dweb%26utm_campaign%3Dmobile-download-promo-pages"
-							storeName={ 'android' }
-							titleText={ translate( 'Download the WordPress Android mobile app.' ) }
-							altText={ translate( 'Google Play Store download badge' ) }
-						>
-							<img src={ googlePlayLogo } alt="" />
-						</AppsBadge>
-					) }
-				</div>
-			</Card>
-		);
-	};
-
 	renderCustomerHome = () => {
 		const {
 			displayChecklist,
@@ -407,7 +358,7 @@ class Home extends Component {
 				<div className="customer-home__layout-col customer-home__layout-col-left">
 					{ // "Go Mobile" has the highest priority placement when viewed in smaller viewports, so folks
 					// can see it on their phone without needing to scroll.
-					isMobile() && this.renderGoMobile() }
+					isMobile() && <GoMobileCard /> }
 					{ displayChecklist ? (
 						<>
 							<Card className="customer-home__card-checklist-heading">
@@ -613,7 +564,7 @@ class Home extends Component {
 						</div>
 					</Card>
 					{ // "Go Mobile" has the lowest priority placement when viewed in bigger viewports.
-					isDesktop() && this.renderGoMobile() }
+					isDesktop() && <GoMobileCard /> }
 				</div>
 			</div>
 		);

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -41,7 +41,7 @@ import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { getGSuiteSupportedDomains } from 'lib/gsuite';
 import { localizeUrl } from 'lib/i18n-utils';
-import { isDesktop, isMobile } from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
@@ -564,7 +564,7 @@ class Home extends Component {
 						</div>
 					</Card>
 					{ // "Go Mobile" has the lowest priority placement when viewed in bigger viewports.
-					isDesktop() && <GoMobileCard /> }
+					! isMobile() && <GoMobileCard /> }
 				</div>
 			</div>
 		);

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -190,15 +190,7 @@
 			}
 		}
 	}
-	&__card-mobile {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
 
-		.get-apps__app-badge {
-			width: 50%;
-		}
-	}
 	&__card-subheader {
 		color: var( --color-text-subtle );
 		font-size: 0.85rem;
@@ -207,26 +199,7 @@
 	&__grow-earn {
 		padding-bottom: 12px;
 	}
-	&__go-mobile.is-single-store {
-		display: flex;
-		padding-bottom: 1rem;
 
-		.customer-home__card-subheader,
-		.get-apps__app-badge img {
-			margin: 0;
-		}
-
-		.get-apps__app-badge {
-			width: auto;
-		}
-
-		.customer-home__card-mobile {
-			margin-left: auto;
-			align-self: center;
-			flex-shrink: 0;
-			padding-left: 1rem;
-		}
-	}
 	&__layout {
 		@include grid-row( 3, 1 );
 		@include breakpoint( '>1040px' ) {


### PR DESCRIPTION
Alternative to https://github.com/Automattic/wp-calypso/pull/38949 and fixes https://github.com/Automattic/wp-calypso/issues/38861. Note that I'm avoiding SMS for now until p3btAN-1c0-p2 is resolved.

Folks are welcome to modify styles directly in this branch if folks had any suggestions/tweaks for the various viewports.

This moves the GoMobile card into it's own component, and also adds a button that will email an app download link and magic login link.

| Desktop |
| -------------|
|  ![Jan-22-2020 09-34-21](https://user-images.githubusercontent.com/1270189/72918481-9820d300-3cfa-11ea-90f9-2434a691f4d0.gif) |

| Large Desktop Viewport  | Small Desktop Viewport | IPhone | Android |
| ------------- | ------------- |------------- | ------------- |
| <img width="324" alt="Screen Shot 2020-01-22 at 9 36 45 AM" src="https://user-images.githubusercontent.com/1270189/72919358-2d709700-3cfc-11ea-8635-9d2eb80620ee.png"> | <img width="626" alt="Screen Shot 2020-01-22 at 9 44 54 AM" src="https://user-images.githubusercontent.com/1270189/72919464-614bbc80-3cfc-11ea-9b68-8d45790721f6.png"> | <img width="411" alt="Screen Shot 2020-01-22 at 9 45 36 AM" src="https://user-images.githubusercontent.com/1270189/72919485-690b6100-3cfc-11ea-967f-425042b53383.png"> | <img width="411" alt="Screen Shot 2020-01-22 at 9 45 36 AM" src="https://user-images.githubusercontent.com/1270189/72919501-71639c00-3cfc-11ea-9012-a2dfbc74fd47.png"> |

| Sent Email |
| -------------|
| <img width="638" alt="72646837-ac508300-393c-11ea-9dea-c3d8be09bc71" src="https://user-images.githubusercontent.com/1270189/72764566-9e4d6d00-3b9d-11ea-866b-30aa0cd3c467.png"> |

### Testing Instructions

- Create a new site (or visit a site created after Aug 2019)
- Visit http://calypso.localhost:3000/home/yoursite
- In Desktop, GoMobile Card is last. Clicking on the Email me a login link appears like the gif.
- We see the following analytics event
<img width="899" alt="Screen Shot 2020-01-20 at 3 47 48 PM" src="https://user-images.githubusercontent.com/1270189/72764617-db196400-3b9d-11ea-8568-dd24b74b4220.png">

- Using Chrome devtools or a native device
<img width="312" alt="Screen Shot 2020-01-20 at 4 00 13 PM" src="https://user-images.githubusercontent.com/1270189/72764655-fedcaa00-3b9d-11ea-9ec5-bb27ca095eef.png">

- Repeat steps above simulating an Android and iOS device
- Verify that only one app badge renders at a time
- The email button should work
- Verify that the login link sent from the email works.
 