### PR TITLE
Fix/devdocs component name

### DIFF
--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -10,14 +10,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import AccordionComponent from 'components/accordion';
-import GridiconComponent from 'components/gridicon';
-
-// Wrapper with `displayName` for proper display in devdocs
-const Accordion = props => <AccordionComponent { ...props } />;
-Accordion.displayName = 'Accordion';
-const Gridicon = props => <GridiconComponent { ...props } />;
-Gridicon.displayName = 'Gridicon';
+import Accordion from 'components/accordion';
+import Gridicon from 'components/gridicon';
 
 export default function AccordionExample( props ) {
 	return props.exampleCode;

--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -10,15 +10,19 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Accordion from 'components/accordion';
-import Gridicon from 'components/gridicon';
+import AccordionComponent from 'components/accordion';
+import GridiconComponent from 'components/gridicon';
 
+// Wrapper with `displayName` for proper display in devdocs
+const Accordion = props => <AccordionComponent { ...props } />;
 Accordion.displayName = 'Accordion';
+const Gridicon = props => <GridiconComponent { ...props } />;
 Gridicon.displayName = 'Gridicon';
 
-function AccordionExample( props ) {
+export default function AccordionExample( props ) {
 	return props.exampleCode;
 }
+AccordionExample.displayName = 'AccordionExample';
 
 AccordionExample.defaultProps = {
 	exampleCode: (
@@ -92,5 +96,3 @@ AccordionExample.defaultProps = {
 		</div>
 	),
 };
-
-export default AccordionExample;

--- a/client/components/feature-example/docs/example.jsx
+++ b/client/components/feature-example/docs/example.jsx
@@ -7,10 +7,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FeatureExample from '../index';
+import FeatureComponent from '../index';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 
-export default class extends React.Component {
+const Feature = props => <FeatureComponent { ...props } />;
+Feature.displayName = 'Feature';
+
+export default class FeatureExample extends React.Component {
 	static displayName = 'FeatureExample';
 
 	getContent = () => {
@@ -55,6 +58,6 @@ export default class extends React.Component {
 	};
 
 	render() {
-		return <FeatureExample>{ this.getContent() }</FeatureExample>;
+		return <Feature>{ this.getContent() }</Feature>;
 	}
 }

--- a/client/components/feature-example/docs/example.jsx
+++ b/client/components/feature-example/docs/example.jsx
@@ -7,14 +7,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FeatureComponent from '../index';
+import FeatureExample from '..';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 
-const Feature = props => <FeatureComponent { ...props } />;
-Feature.displayName = 'Feature';
-
-export default class FeatureExample extends React.Component {
-	static displayName = 'FeatureExample';
+export default class FeatureExampleExample extends React.Component {
+	static displayName = 'FeatureExampleExample';
 
 	getContent = () => {
 		const plugins = [
@@ -58,6 +55,6 @@ export default class FeatureExample extends React.Component {
 	};
 
 	render() {
-		return <Feature>{ this.getContent() }</Feature>;
+		return <FeatureExample>{ this.getContent() }</FeatureExample>;
 	}
 }

--- a/client/components/feature-example/index.jsx
+++ b/client/components/feature-example/index.jsx
@@ -9,15 +9,11 @@ import React from 'react';
  */
 import './style.scss';
 
-export default class extends React.Component {
-	static displayName = 'FeatureExample';
-
-	render() {
-		return (
-			<div className="feature-example">
-				<div className="feature-example__content">{ this.props.children }</div>
-				<div className="feature-example__gradient" />
-			</div>
-		);
-	}
+export default function FeatureExample( { children } ) {
+	return (
+		<div className="feature-example">
+			<div className="feature-example__content">{ children }</div>
+			<div className="feature-example__gradient" />
+		</div>
+	);
 }

--- a/client/components/gravatar-caterpillar/docs/example.jsx
+++ b/client/components/gravatar-caterpillar/docs/example.jsx
@@ -12,5 +12,6 @@ import { users } from './fixtures';
 function GravatarCaterpillarExample() {
 	return <GravatarCaterpillar users={ users } />;
 }
+GravatarCaterpillarExample.displayName = 'GravatarCaterpillarExample';
 
 export default GravatarCaterpillarExample;

--- a/client/components/gsuite/docs/example.tsx
+++ b/client/components/gsuite/docs/example.tsx
@@ -11,5 +11,6 @@ import GSuiteNewUserListExample from './new-user-list';
 const GSuiteExample = () => {
 	return <GSuiteNewUserListExample />;
 };
+GSuiteExample.displayName = 'GSuiteExample';
 
 export default GSuiteExample;

--- a/client/components/gsuite/docs/example.tsx
+++ b/client/components/gsuite/docs/example.tsx
@@ -8,8 +8,8 @@ import React from 'react';
  */
 import GSuiteNewUserListExample from './new-user-list';
 
-const GSuiteExamples = () => {
+const GSuiteExample = () => {
 	return <GSuiteNewUserListExample />;
 };
 
-export default GSuiteExamples;
+export default GSuiteExample;

--- a/client/components/gsuite/docs/new-user-list.tsx
+++ b/client/components/gsuite/docs/new-user-list.tsx
@@ -92,6 +92,4 @@ const GSuiteNewUserListExample = () => {
 	);
 };
 
-GSuiteNewUserListExample.displayName = 'GSuiteNewUserListExample';
-
 export default GSuiteNewUserListExample;

--- a/client/components/gsuite/docs/new-user-list.tsx
+++ b/client/components/gsuite/docs/new-user-list.tsx
@@ -92,4 +92,6 @@ const GSuiteNewUserListExample = () => {
 	);
 };
 
+GSuiteNewUserListExample.displayName = 'GSuiteNewUserListExample';
+
 export default GSuiteNewUserListExample;

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -20,7 +20,7 @@ import SearchCard from 'components/search-card';
 /**
  * Docs examples
  */
-import Accordions from 'components/accordion/docs/example';
+import Accordion from 'components/accordion/docs/example';
 import ActionCard from 'components/action-card/docs/example';
 import ActionPanel from 'components/action-panel/docs/example';
 import Animate from 'components/animate/docs/example';
@@ -177,9 +177,9 @@ export default class DesignAssets extends React.Component {
 					{ config.isEnabled( 'devdocs/color-scheme-picker' ) && (
 						<ColorSchemePicker readmeFilePath="color-scheme-picker" />
 					) }
+					<Accordion readmeFilePath="accordion" />
 					<ActionCard readmeFilePath="action-card" />
 					<ActionPanel readmeFilePath="action-panel" />
-					<Accordions readmeFilePath="accordion" />
 					<Animate readmeFilePath="animate" />
 					<BackButton readmeFilePath="back-button" />
 					<Badge readmeFilePath="badge" />
@@ -187,9 +187,8 @@ export default class DesignAssets extends React.Component {
 					<BulkSelect readmeFilePath="bulk-select" />
 					<ButtonGroups readmeFilePath="button-group" />
 					<Buttons readmeFilePath="/packages/components/src/button" />
-					<SplitButton readmeFilePath="split-button" />
-					<Cards readmeFilePath="/packages/components/src/card" />
 					<CardHeading readmeFilePath="card-heading" />
+					<Cards readmeFilePath="/packages/components/src/card" />
 					<Chart readmeFilePath="chart" />
 					<Checklist readmeFilePath="checklist" />
 					<ClipboardButtonInput readmeFilePath="clipboard-button-input" />
@@ -241,10 +240,12 @@ export default class DesignAssets extends React.Component {
 					<PlansSkipButton readmeFilePath="plans/plans-skip-button" />
 					<PodcastIndicator readmeFilePath="podcast-indicator" />
 					<Popovers readmeFilePath="popover" />
+					<ProductCard readmeFilePath="product-card" />
 					<ProductExpiration readmeFilePath="product-expiration" />
+					<ProductIcon readmeFilePath="/packages/components/src/product-icon" />
 					<ProgressBar readmeFilePath="/packages/components/src/progress-bar" />
-					<PromoSection readmeFilePath="promo-section" />
 					<PromoCard readmeFilePath="promo-section/promo-card" />
+					<PromoSection readmeFilePath="promo-section" />
 					<Ranges readmeFilePath="forms/range" />
 					<Rating readmeFilePath="rating" />
 					<Ribbon readmeFilePath="/packages/components/src/ribbon" />
@@ -255,13 +256,12 @@ export default class DesignAssets extends React.Component {
 					<SegmentedControl readmeFilePath="segmented-control" />
 					<SelectDropdown searchKeywords="menu" readmeFilePath="select-dropdown" />
 					<ShareButton readmeFilePath="share-button" />
-					<ProductCard readmeFilePath="product-card" />
-					<ProductIcon readmeFilePath="/packages/components/src/product-icon" />
 					<SiteTitleControl readmeFilePath="site-title" />
 					<SocialLogos />
 					<Spinner searchKeywords="loading" readmeFilePath="spinner" />
 					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />
 					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
+					<SplitButton readmeFilePath="split-button" />
 					<Suggestions readmeFilePath="/packages/components/src/suggestions" />
 					<SuggestionSearchExample />
 					<SupportInfoExample />
@@ -274,9 +274,9 @@ export default class DesignAssets extends React.Component {
 					<TokenFields readmeFilePath="token-field" />
 					<Tooltip readmeFilePath="tooltip" />
 					<UserItem readmeFilePath="user" />
+					<Version readmeFilePath="version" />
 					<VerticalMenu readmeFilePath="vertical-menu" />
 					<VerticalNav readmeFilePath="vertical-nav" />
-					<Version readmeFilePath="version" />
 					<Wizard readmeFilePath="wizard" />
 					<WizardProgressBar readmeFilePath="wizard-progress-bar" />
 					<WpcomColophon readmeFilePath="wpcom-colophon" />

--- a/client/devdocs/design/playground-utils.js
+++ b/client/devdocs/design/playground-utils.js
@@ -1,7 +1,34 @@
 /**
  * External dependencies
  */
+import { findKey } from 'lodash';
 import format from 'react-element-to-jsx-string';
+
+/**
+ * Internal dependencies
+ */
+import * as scope from './playground-scope';
+
+// Figure out a React element's display name, with the help of the `playground-scope` map.
+function displayName( element ) {
+	// if `type` is a string, then it's a DOM element like `div`
+	if ( typeof element.type === 'string' ) {
+		return element.type;
+	}
+
+	// find the component (by value) in the `playground-scope` map
+	const scopeName = findKey( scope, type => element.type === type );
+	if ( scopeName ) {
+		return scopeName;
+	}
+
+	// fall back to classic (potentially minified) constructor function name
+	if ( typeof element.type === 'function' ) {
+		return element.type.displayName || element.type.name;
+	}
+
+	return 'No Display Name';
+}
 
 export const getExampleCodeFromComponent = ExampleComponent => {
 	if ( ! ExampleComponent.props.exampleCode ) {
@@ -14,5 +41,6 @@ export const getExampleCodeFromComponent = ExampleComponent => {
 
 	return format( ExampleComponent.props.exampleCode, {
 		showDefaultProps: false,
+		displayName,
 	} ).replace( /Localized\((\w+)\)/g, '$1' );
 };

--- a/packages/components/src/button/docs/example.jsx
+++ b/packages/components/src/button/docs/example.jsx
@@ -2,19 +2,23 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import GridiconComponent from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import Button from '..';
+import ButtonComponent from '..';
 import Card from '../../card';
 import DocsExample from 'devdocs/docs-example';
 
+// Wrapper with `displayName` for proper display in devdocs
+const Button = props => <ButtonComponent { ...props } />;
 Button.displayName = 'Button';
+const Gridicon = props => <GridiconComponent { ...props } />;
+Gridicon.displayName = 'Gridicon';
 
-class Buttons extends React.PureComponent {
-	static displayName = 'Button';
+export default class ButtonExample extends React.PureComponent {
+	static displayName = 'ButtonExample';
 
 	static defaultProps = {
 		exampleCode: (
@@ -176,5 +180,3 @@ class Buttons extends React.PureComponent {
 		return <DocsExample>{ this.props.exampleCode }</DocsExample>;
 	}
 }
-
-export default Buttons;

--- a/packages/components/src/button/docs/example.jsx
+++ b/packages/components/src/button/docs/example.jsx
@@ -2,20 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import GridiconComponent from 'components/gridicon';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import ButtonComponent from '..';
+import Button from '..';
 import Card from '../../card';
 import DocsExample from 'devdocs/docs-example';
-
-// Wrapper with `displayName` for proper display in devdocs
-const Button = props => <ButtonComponent { ...props } />;
-Button.displayName = 'Button';
-const Gridicon = props => <GridiconComponent { ...props } />;
-Gridicon.displayName = 'Gridicon';
 
 export default class ButtonExample extends React.PureComponent {
 	static displayName = 'ButtonExample';

--- a/packages/components/src/suggestions/docs/example.jsx
+++ b/packages/components/src/suggestions/docs/example.jsx
@@ -59,3 +59,4 @@ export default function SuggestionsExample() {
 		</div>
 	);
 }
+SuggestionsExample.displayName = 'SuggestionsExample';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #38839 I noticed many devdocs components don't display a proper component name (when production optimizations are enabled).

- Ensure human readable names are used in `/devdocs/design`. This greatly improves search.
- Fixes some issues with some components causing issues in our devdocs setup. Gridicons had this issue, I added wrapper components as needed.
- Sorts the components alphabetically.

##### Not helpful 😕 

![before](https://user-images.githubusercontent.com/841763/72802169-7caabf00-3c4b-11ea-876d-c17c225401e3.png)

##### Much better 😁✨ 


#### Testing instructions

* Visit [`/devdocs/design`](https://calypso.live/devdocs/design?branch=fix/devdocs-component-name) and compare with [wpcalypso](https://wpcalypso.wordpress.com/devdocs/design). You should see several fixed component names.