### PR TITLE
Plugin item: Fix CSS load order issues

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -305,7 +305,6 @@ class PluginItem extends Component {
 
 	renderPlaceholder() {
 		return (
-			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<CompactCard className="plugin-item is-placeholder">
 				<div className="plugin-item__link">
 					<PluginIcon isPlaceholder />

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -1,4 +1,4 @@
-.plugin-item.card {
+.plugin-item.card.is-compact {
 	padding: 0;
 	margin: 0;
 	box-shadow: none;
@@ -19,12 +19,12 @@
 		padding: 0;
 	}
 
-	.plugins-list &.is-compact:last-child {
+	.plugins-list &:last-child {
 		margin-bottom: 0;
 	}
 }
 
-.plugin-item {
+.plugin-item.card {
 	position: relative;
 	display: flex;
 	overflow: hidden; // lazy clearfix


### PR DESCRIPTION
#### Changes proposed in this Pull Request

PluginItem styling was dependent on CSS load order, as noted in https://github.com/Automattic/wp-calypso/pull/38970#issuecomment-576650242

Use specificity to fix CSS load order issues conflicting with Card styles.

#### Testing instructions

* [`/devdocs/design/feature`](https://calypso.live/devdocs/design/feature?branch=fix/plugin-item-styling) looks good 👍  Check style overrides, the most relevant ones should be improved.
* I'm not entirely sure where this is used.
