### PR TITLE
Fix/suggestion search devdocs

### DIFF
--- a/client/components/suggestion-search/docs/example.jsx
+++ b/client/components/suggestion-search/docs/example.jsx
@@ -1,32 +1,35 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { useState } from 'react';
 
 /**
  * Internal dependencies
  */
 import SuggestionSearch from '../';
 
-class SuggestionSearchExample extends PureComponent {
-	state = { selected: null };
+const SuggestionSearchExample = () => {
+	const [ state, setState ] = useState();
 
-	onSiteTopicChange = value => this.setState( { selected: value } );
-
-	sortDisplayResults = ( suggestionsArray, queryString ) =>
+	const sortDisplayResults = ( suggestionsArray, queryString ) =>
 		suggestionsArray.sort().map( item => ( item === queryString ? `→ ${ item }` : item ) );
 
-	render() {
-		return (
-			<SuggestionSearch
-				id="siteTopic"
-				placeholder={ 'Try sushi' }
-				onChange={ this.onSiteTopicChange }
-				sortResults={ this.sortDisplayResults }
-				suggestions={ [ 'sushi', 'onigiri sushi', 'sea urchin sushi', 'saury sushi' ] }
-			/>
-		);
-	}
-}
+	return (
+		<SuggestionSearch
+			id="siteTopic"
+			placeholder="Try sushi"
+			onChange={ setState }
+			sortResults={ sortDisplayResults }
+			suggestions={ [
+				{ label: 'sushi' },
+				{ label: 'onigiri sushi' },
+				{ label: 'sea urchin sushi' },
+				{ label: 'saury sushi' },
+			] }
+			value={ state }
+		/>
+	);
+};
+SuggestionSearchExample.displayName = 'SuggestionSearchExample';
 
 export default SuggestionSearchExample;

--- a/client/components/suggestion-search/docs/example.jsx
+++ b/client/components/suggestion-search/docs/example.jsx
@@ -9,7 +9,9 @@ import React, { PureComponent } from 'react';
 import SuggestionSearch from '../';
 
 class SuggestionSearchExample extends PureComponent {
-	onSiteTopicChange = value => this.state( { selected: value } );
+	state = { selected: null };
+
+	onSiteTopicChange = value => this.setState( { selected: value } );
 
 	sortDisplayResults = ( suggestionsArray, queryString ) =>
 		suggestionsArray.sort().map( item => ( item === queryString ? `→ ${ item }` : item ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fix the `SuggestionsSearch` devdocs example (state + suggestions data format)
- Use a function component

In https://github.com/Automattic/wp-calypso/pull/38839 I was hoping to use `SuggestionsSearch` devdocs page for testing, but found it to be broken.

#### Testing instructions

[`/devdocs/design/suggestion-search`](https://calypso.live/devdocs/design/suggestion-search?branch=fix/suggestion-search-devdocs) works [(broken on master - try to enter a search term)](https://wpcalypso.wordpress.com/devdocs/design/qt).
