### PR TITLE
Customer Home: Add stats card

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -55,6 +55,7 @@ import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/s
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 import GoMobileCard from 'my-sites/customer-home/go-mobile-card';
+import StatsCard from './stats-card';
 
 /**
  * Style dependencies
@@ -474,6 +475,7 @@ class Home extends Component {
 							</Button>
 						</Card>
 					) }
+					{ ! siteIsUnlaunched && <StatsCard /> }
 					{ ! siteIsUnlaunched && (
 						<Card>
 							<CardHeading>{ translate( 'My Site' ) }</CardHeading>

--- a/client/my-sites/customer-home/stats-card/index.jsx
+++ b/client/my-sites/customer-home/stats-card/index.jsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { Card } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'components/card-heading';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getCountRecords } from 'state/stats/chart-tabs/selectors';
+import { requestChartCounts } from 'state/stats/chart-tabs/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const StatsCard = ( { siteId, siteSlug, weekViews, weekVisitors, fetchWeekVisits } ) => {
+	const translate = useTranslate();
+
+	useEffect( () => {
+		fetchWeekVisits( siteId );
+	}, [ siteId ] );
+
+	return (
+		<Card className="stats-card">
+			<CardHeading>{ translate( 'Stats at a glance' ) }</CardHeading>
+			<h6 className="stats-card__subheader">{ translate( 'Your site in the last week.' ) }</h6>
+			<div className="stats-card__visits">
+				<div className="stats-card__count">
+					<div className="stats-card__count-value">{ weekViews ?? '-' }</div>
+					<div className="stats-card__count-label">{ translate( 'Views' ) }</div>
+				</div>
+				<div className="stats-card__count">
+					<div className="stats-card__count-value">{ weekVisitors ?? '-' }</div>
+					<div className="stats-card__count-label">{ translate( 'Visitors' ) }</div>
+				</div>
+			</div>
+			<a href={ `/stats/day/${ siteSlug }` }>{ translate( 'See all stats' ) }</a>
+		</Card>
+	);
+};
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+	const weekVisits = getCountRecords( state, siteId, 'week' );
+	const weekViews = weekVisits.length ? weekVisits[ 0 ].views : null;
+	const weekVisitors = weekVisits.length ? weekVisits[ 0 ].visitors : null;
+	return {
+		siteId,
+		siteSlug,
+		weekViews,
+		weekVisitors,
+	};
+};
+
+const mapDispatchToProps = {
+	fetchWeekVisits: siteId =>
+		requestChartCounts( {
+			siteId,
+			period: 'week',
+			quantity: 1,
+			statFields: [ 'views', 'visitors' ],
+		} ),
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( StatsCard );

--- a/client/my-sites/customer-home/stats-card/index.jsx
+++ b/client/my-sites/customer-home/stats-card/index.jsx
@@ -22,11 +22,15 @@ import './style.scss';
 
 export const StatsCard = ( {
 	areStatsEnabled,
+	insightsData,
+	insightsStatsQuery,
+	insightsStatsType,
+	showInsights,
 	siteId,
 	siteSlug,
 	trafficData,
-	trafficStatsQuery,
 	trafficStatsType,
+	trafficStatsQuery,
 } ) => {
 	const translate = useTranslate();
 
@@ -37,23 +41,48 @@ export const StatsCard = ( {
 	return (
 		<Card className="stats-card">
 			{ siteId && (
-				<QuerySiteStats
-					siteId={ siteId }
-					statType={ trafficStatsType }
-					query={ trafficStatsQuery }
-				/>
+				<>
+					<QuerySiteStats
+						siteId={ siteId }
+						statType={ trafficStatsType }
+						query={ trafficStatsQuery }
+					/>
+					{ showInsights && (
+						<QuerySiteStats
+							siteId={ siteId }
+							statType={ insightsStatsType }
+							query={ insightsStatsQuery }
+						/>
+					) }
+				</>
 			) }
 			<CardHeading>{ translate( 'Stats at a glance' ) }</CardHeading>
 			<h6 className="stats-card__subheader">{ translate( 'Your site in the last week.' ) }</h6>
-			<div className="stats-card__visits">
-				<div className="stats-card__count">
-					<div className="stats-card__count-value">{ trafficData?.views ?? '-' }</div>
-					<div className="stats-card__count-label">{ translate( 'Views' ) }</div>
-				</div>
-				<div className="stats-card__count">
-					<div className="stats-card__count-value">{ trafficData?.visitors ?? '-' }</div>
-					<div className="stats-card__count-label">{ translate( 'Visitors' ) }</div>
-				</div>
+			<div className="stats-card__data">
+				{ ! showInsights && (
+					<div className="stats-card__data-item">
+						<div className="stats-card__data-value">{ trafficData?.views ?? '-' }</div>
+						<div className="stats-card__data-label">{ translate( 'Views' ) }</div>
+					</div>
+				) }
+				{ ! showInsights && (
+					<div className="stats-card__data-item">
+						<div className="stats-card__data-value">{ trafficData?.visitors ?? '-' }</div>
+						<div className="stats-card__data-label">{ translate( 'Visitors' ) }</div>
+					</div>
+				) }
+				{ showInsights && (
+					<div className="stats-card__data-item">
+						<div className="stats-card__data-label">{ translate( 'Most popular day' ) }</div>
+						<div className="stats-card__data-value">{ insightsData?.day ?? '-' }</div>
+					</div>
+				) }
+				{ showInsights && (
+					<div className="stats-card__data-item">
+						<div className="stats-card__data-label">{ translate( 'Most popular hour' ) }</div>
+						<div className="stats-card__data-value">{ insightsData?.hour ?? '-' }</div>
+					</div>
+				) }
 			</div>
 			<a href={ `/stats/day/${ siteSlug }` }>{ translate( 'See all stats' ) }</a>
 		</Card>
@@ -67,12 +96,12 @@ const mapStateToProps = state => {
 	const isStatsModuleActive = isJetpackModuleActive( state, siteId, 'stats' );
 	const areStatsEnabled = ! isJetpack || isStatsModuleActive;
 
+	const trafficStatsType = 'statsVisits';
 	const trafficStatsQuery = {
 		unit: 'week',
 		quantity: 1,
 		stat_fields: 'views,visitors',
 	};
-	const trafficStatsType = 'statsVisits';
 	const trafficStats = getSiteStatsNormalizedData(
 		state,
 		siteId,
@@ -81,8 +110,23 @@ const mapStateToProps = state => {
 	);
 	const trafficData = trafficStats && trafficStats.length ? trafficStats[ 0 ] : null;
 
+	const showInsights = trafficData && trafficData.views < 10;
+
+	const insightsStatsType = 'statsInsights';
+	const insightsStatsQuery = {};
+	const insightsData = getSiteStatsNormalizedData(
+		state,
+		siteId,
+		insightsStatsType,
+		insightsStatsQuery
+	);
+
 	return {
 		areStatsEnabled,
+		insightsData,
+		insightsStatsQuery,
+		insightsStatsType,
+		showInsights,
 		siteId,
 		siteSlug,
 		trafficData,

--- a/client/my-sites/customer-home/stats-card/index.jsx
+++ b/client/my-sites/customer-home/stats-card/index.jsx
@@ -21,7 +21,7 @@ import QuerySiteStats from 'components/data/query-site-stats';
 import './style.scss';
 
 export const StatsCard = ( {
-	areStatsEnabled,
+	hideStats,
 	insightsData,
 	insightsStatsQuery,
 	insightsStatsType,
@@ -34,7 +34,7 @@ export const StatsCard = ( {
 } ) => {
 	const translate = useTranslate();
 
-	if ( ! areStatsEnabled ) {
+	if ( hideStats ) {
 		return null;
 	}
 
@@ -98,7 +98,6 @@ const mapStateToProps = state => {
 	const siteSlug = getSelectedSiteSlug( state );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isStatsModuleActive = isJetpackModuleActive( state, siteId, 'stats' );
-	const areStatsEnabled = ! isJetpack || isStatsModuleActive;
 
 	const trafficStatsType = 'statsVisits';
 	const trafficStatsQuery = {
@@ -125,8 +124,11 @@ const mapStateToProps = state => {
 		insightsStatsQuery
 	);
 
+	const hideStats =
+		( isJetpack && ! isStatsModuleActive ) || ( showInsights && ! insightsData?.percent );
+
 	return {
-		areStatsEnabled,
+		hideStats,
 		insightsData,
 		insightsStatsQuery,
 		insightsStatsType,

--- a/client/my-sites/customer-home/stats-card/index.jsx
+++ b/client/my-sites/customer-home/stats-card/index.jsx
@@ -60,32 +60,32 @@ export const StatsCard = ( {
 			<h6 className="stats-card__subheader">{ translate( 'Your site in the last week.' ) }</h6>
 			<div className="stats-card__data">
 				{ ! showInsights && (
-					<div className="stats-card__data-item">
-						<div className="stats-card__data-value">
-							{ trafficData?.views ? numberFormat( trafficData.views ) : '-' }
+					<>
+						<div className="stats-card__data-item">
+							<div className="stats-card__data-value">
+								{ trafficData?.views ? numberFormat( trafficData.views ) : '-' }
+							</div>
+							<div className="stats-card__data-label">{ translate( 'Views' ) }</div>
 						</div>
-						<div className="stats-card__data-label">{ translate( 'Views' ) }</div>
-					</div>
-				) }
-				{ ! showInsights && (
-					<div className="stats-card__data-item">
-						<div className="stats-card__data-value">
-							{ trafficData?.visitors ? numberFormat( trafficData.visitors ) : '-' }
+						<div className="stats-card__data-item">
+							<div className="stats-card__data-value">
+								{ trafficData?.visitors ? numberFormat( trafficData.visitors ) : '-' }
+							</div>
+							<div className="stats-card__data-label">{ translate( 'Visitors' ) }</div>
 						</div>
-						<div className="stats-card__data-label">{ translate( 'Visitors' ) }</div>
-					</div>
+					</>
 				) }
 				{ showInsights && (
-					<div className="stats-card__data-item">
-						<div className="stats-card__data-label">{ translate( 'Most popular day' ) }</div>
-						<div className="stats-card__data-value">{ insightsData?.day ?? '-' }</div>
-					</div>
-				) }
-				{ showInsights && (
-					<div className="stats-card__data-item">
-						<div className="stats-card__data-label">{ translate( 'Most popular hour' ) }</div>
-						<div className="stats-card__data-value">{ insightsData?.hour ?? '-' }</div>
-					</div>
+					<>
+						<div className="stats-card__data-item">
+							<div className="stats-card__data-value">{ insightsData?.day ?? '-' }</div>
+							<div className="stats-card__data-label">{ translate( 'Most popular day' ) }</div>
+						</div>
+						<div className="stats-card__data-item">
+							<div className="stats-card__data-value">{ insightsData?.hour ?? '-' }</div>
+							<div className="stats-card__data-label">{ translate( 'Most popular hour' ) }</div>
+						</div>
+					</>
 				) }
 			</div>
 			<a href={ `/stats/day/${ siteSlug }` }>{ translate( 'See all stats' ) }</a>

--- a/client/my-sites/customer-home/stats-card/index.jsx
+++ b/client/my-sites/customer-home/stats-card/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 
 /**
@@ -61,13 +61,17 @@ export const StatsCard = ( {
 			<div className="stats-card__data">
 				{ ! showInsights && (
 					<div className="stats-card__data-item">
-						<div className="stats-card__data-value">{ trafficData?.views ?? '-' }</div>
+						<div className="stats-card__data-value">
+							{ trafficData?.views ? numberFormat( trafficData.views ) : '-' }
+						</div>
 						<div className="stats-card__data-label">{ translate( 'Views' ) }</div>
 					</div>
 				) }
 				{ ! showInsights && (
 					<div className="stats-card__data-item">
-						<div className="stats-card__data-value">{ trafficData?.visitors ?? '-' }</div>
+						<div className="stats-card__data-value">
+							{ trafficData?.visitors ? numberFormat( trafficData.visitors ) : '-' }
+						</div>
 						<div className="stats-card__data-label">{ translate( 'Visitors' ) }</div>
 					</div>
 				) }

--- a/client/my-sites/customer-home/stats-card/index.jsx
+++ b/client/my-sites/customer-home/stats-card/index.jsx
@@ -13,18 +13,30 @@ import CardHeading from 'components/card-heading';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCountRecords } from 'state/stats/chart-tabs/selectors';
 import { requestChartCounts } from 'state/stats/chart-tabs/actions';
+import { isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export const StatsCard = ( { siteId, siteSlug, weekViews, weekVisitors, fetchWeekVisits } ) => {
+export const StatsCard = ( {
+	areStatsEnabled,
+	siteId,
+	siteSlug,
+	weekViews,
+	weekVisitors,
+	fetchWeekVisits,
+} ) => {
 	const translate = useTranslate();
 
 	useEffect( () => {
 		fetchWeekVisits( siteId );
 	}, [ siteId ] );
+
+	if ( ! areStatsEnabled ) {
+		return null;
+	}
 
 	return (
 		<Card className="stats-card">
@@ -48,10 +60,15 @@ export const StatsCard = ( { siteId, siteSlug, weekViews, weekVisitors, fetchWee
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
+	const isJetpack = isJetpackSite( state, siteId );
+	const isStatsModuleActive = isJetpackModuleActive( state, siteId, 'stats' );
+	const areStatsEnabled = ! isJetpack || isStatsModuleActive;
+
 	const weekVisits = getCountRecords( state, siteId, 'week' );
 	const weekViews = weekVisits.length ? weekVisits[ 0 ].views : null;
 	const weekVisitors = weekVisits.length ? weekVisits[ 0 ].visitors : null;
 	return {
+		areStatsEnabled,
 		siteId,
 		siteSlug,
 		weekViews,

--- a/client/my-sites/customer-home/stats-card/style.scss
+++ b/client/my-sites/customer-home/stats-card/style.scss
@@ -8,6 +8,11 @@
 	display: flex;
 	justify-content: center;
 	margin-bottom: 1rem;
+
+	@include breakpoint( '1040px-1280px' ) {
+		flex-direction: column;
+		align-items: center;
+	}
 }
 
 .stats-card__data-item {
@@ -23,6 +28,24 @@
 
 	&:last-child {
 		padding-right: 0;
+	}
+
+	@include breakpoint( '1040px-1280px' ) {
+		width: auto;
+		border-left: none;
+		border-top: 1px solid var( --color-neutral-5 );
+		padding: 1rem;
+
+		&:first-child {
+			border-top: none;
+			padding-top: 0;
+			padding-left: 1rem;
+		}
+
+		&:last-child {
+			padding-bottom: 0;
+			padding-right: 1rem;
+		}
 	}
 }
 

--- a/client/my-sites/customer-home/stats-card/style.scss
+++ b/client/my-sites/customer-home/stats-card/style.scss
@@ -1,0 +1,26 @@
+.stats-card__subheader {
+	color: var( --color-text-subtle );
+	font-size: 0.85rem;
+	margin: -0.5rem 0 1rem;
+}
+
+.stats-card__visits {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 1rem;
+}
+
+.stats-card__count {
+	border-left: 1px solid var( --color-neutral-5 );
+	width: 50%;
+	text-align: center;
+	padding: 1rem;
+
+	&:first-child {
+		border-left: none;
+	}
+}
+
+.stats-card__count-value {
+	font-size: 40px;
+}

--- a/client/my-sites/customer-home/stats-card/style.scss
+++ b/client/my-sites/customer-home/stats-card/style.scss
@@ -4,23 +4,33 @@
 	margin: -0.5rem 0 1rem;
 }
 
-.stats-card__visits {
+.stats-card__data {
 	display: flex;
 	justify-content: center;
 	margin-bottom: 1rem;
 }
 
-.stats-card__count {
+.stats-card__data-item {
 	border-left: 1px solid var( --color-neutral-5 );
 	width: 50%;
 	text-align: center;
-	padding: 1rem;
+	padding: 0.5rem 1rem;
 
 	&:first-child {
 		border-left: none;
+		padding-left: 0;
+	}
+
+	&:last-child {
+		padding-right: 0;
 	}
 }
 
-.stats-card__count-value {
-	font-size: 40px;
+.stats-card__data-value,
+.stats-card__data-label {
+	padding: 0.25rem 0;
+}
+
+.stats-card__data-value {
+	font-size: 24px;
 }

--- a/client/my-sites/customer-home/stats-card/style.scss
+++ b/client/my-sites/customer-home/stats-card/style.scss
@@ -26,11 +26,6 @@
 	}
 }
 
-.stats-card__data-value,
-.stats-card__data-label {
-	padding: 0.25rem 0;
-}
-
 .stats-card__data-value {
 	font-size: 24px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a simple stats card to the Customer Home that displays the current week views and visitors of the site.

<img width="327" alt="Screenshot 2020-01-22 at 14 08 15" src="https://user-images.githubusercontent.com/1233880/72896714-a7b31280-3d20-11ea-9dcb-8a226bb02615.png">

For sites that don't reach 10 visits, we show insights indicating the most popular day and hour:

<img width="322" alt="Screenshot 2020-01-23 at 15 16 50" src="https://user-images.githubusercontent.com/1233880/72992454-0c8b6d00-3df4-11ea-910a-d3d33727d807.png">

The card is not displayed in the below scenarios:
- When the site is unlaunched.
- When the site is a Jetpack or Atomic site with the Stats module disabled.
- When the site has not received any visit yet (i.e. new created sites), since there is no popular day and time recorded.

#### Testing instructions

- Go to `/home/:site`.
- Verify there is a new "Stats at a glance" in the top of the right column.
- If your site has 10 visits or more for the current week, you should see the number of views and visitors. Make sure numbers match stats displayed in `/stats/week/:site`.
- If your site has less than 10 visits for the current week, you should see the most popular day and hour. Make sure data matches `/stats/insights/:site`.
- Make sure the card is not displayed for unlaunched sites.
- Make sure the card is not displayed for Jetpack or Atomic sites with the Stats module disabled (this can be done in Marketing > Traffic).
- Make sure the card is not displayed for sites without traffic yet (i.e. new created sites).

Fixes https://github.com/Automattic/wp-calypso/issues/38997