### PR TITLE
feat(browser-storage): Report errors to MC

### DIFF
--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -36,6 +36,9 @@ const getDB = once( () => {
 				};
 				request.onsuccess = () => {
 					const db = request.result;
+					// Add a general error handler for any future requests made against this db handle.
+					// See https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#Handling_Errors for
+					// more information on how error events bubble with IndexedDB
 					db.onerror = function( errorEvent: any ) {
 						if ( errorEvent.target?.error?.name ) {
 							mc.bumpStat( 'calypso-browser-storage', kebabCase( errorEvent.target.error.name ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Report errors from IndexedDB to MC

#### Testing instructions

* **_ONLY RUN THESE IN SAFARI 13_**
* Turn on debug logging with `localStorage.setItem('debug', 'calypso:analytics:mc')`
* Run the following script in the console
``` 
(function swampIdb() {
    let db;
	let r = window.indexedDB.open( 'calypso', 2 );
    r.onsuccess = function() {
    	db = r.result;
		swamp();
    }

    function swamp() {
		console.log( 'swamping' );
		let r = db.transaction( 'calypso_store', 'readwrite' )
		  .objectStore( 'calypso_store')
		  .put( 'swamp', new Array( 1024 * 1024 * 25 ).fill('a').join('') )
        r.onsuccess = swamp;
		r.onerror = function( err ) { 
			console.error( 'swamp aborted', err.target.error ); 
		}
    }
})()
```
* **_When the permission prompt appears, refuse it_**
* Wait for the script to end with an error. 
* Click between My Sites and Reader. You should now see mc logging `Bumping stat calypso-browser-storage:quota-exceeded-error`

Part of #36858
