### PR TITLE
Jetpack Cloud: Adding more to the jetpack cloud boot

### DIFF
--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -3,11 +3,19 @@
  */
 import config from '../../config';
 import page from 'page';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
+import { configureReduxStore, setupMiddlewares, utils } from 'boot/common';
 import initJetpackCloudRoutes from './routes';
+import userFactory from 'lib/user';
+import { createReduxStore } from 'state';
+import initialReducer from 'state/reducer';
+import { setupLocale } from 'boot/locale';
+import detectHistoryNavigation from 'lib/detect-history-navigation';
+import { getInitialState, persistOnChange } from 'state/initial-state';
 
 /**
  * Style dependencies
@@ -16,11 +24,31 @@ import 'components/environment-badge/style.scss';
 import 'layout/style.scss';
 import 'assets/stylesheets/jetpack-cloud.scss';
 
+const debug = debugFactory( 'jetpack-cloud' );
+
+const boot = currentUser => {
+	debug( "Starting Jetpack Cloud. Let's do this." );
+	utils();
+	getInitialState( initialReducer ).then( initialState => {
+		const reduxStore = createReduxStore( initialState, initialReducer );
+		initJetpackCloudRoutes( '/jetpack-cloud' );
+		persistOnChange( reduxStore );
+		setupLocale( currentUser.get(), reduxStore );
+		configureReduxStore( currentUser, reduxStore );
+		setupMiddlewares( currentUser, reduxStore );
+		detectHistoryNavigation.start();
+
+		page.start( { decodeURLComponents: false } );
+	} );
+};
+
 window.AppBoot = () => {
 	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
 		window.location.href = '/';
 	} else {
-		initJetpackCloudRoutes( '/jetpack-cloud' );
-		page.start( { decodeURLComponents: false } );
+		debug( 'before userFactory' );
+		const user = userFactory();
+		debug( 'after userFactory' );
+		user.initialize().then( () => boot( user ) );
 	}
 };


### PR DESCRIPTION
This PR adds the same redux and middle ware as there are in the boot/app.js

#### Changes proposed in this Pull Request

* Adds the same redux and middle ware as they are currenlty present in calypso. 

#### Testing instructions
* Does the app boot as you expect?

I am not really sure how to test this. 