### PR TITLE
domains/contact-details-form-fields: Do not render form footer if no action buttons are rendered

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -473,6 +473,8 @@ export class ContactDetailsFormFields extends Component {
 		const { translate, onCancel, disableSubmitButton, labelTexts } = this.props;
 		const countryCode = this.getCountryCode();
 
+		const isFooterVisible = !! ( this.props.onSubmit || onCancel );
+
 		return (
 			<FormFieldset className="contact-details-form-fields">
 				<div className="contact-details-form-fields__row">
@@ -492,27 +494,29 @@ export class ContactDetailsFormFields extends Component {
 
 				<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
 
-				<FormFooter>
-					{ this.props.onSubmit && (
-						<FormButton
-							className="contact-details-form-fields__submit-button"
-							disabled={ ! countryCode || disableSubmitButton }
-							onClick={ this.handleSubmitButtonClick }
-						>
-							{ labelTexts.submitButton || translate( 'Submit' ) }
-						</FormButton>
-					) }
-					{ onCancel && (
-						<FormButton
-							className="contact-details-form-fields__cancel-button"
-							type="button"
-							isPrimary={ false }
-							onClick={ onCancel }
-						>
-							{ translate( 'Cancel' ) }
-						</FormButton>
-					) }
-				</FormFooter>
+				{ isFooterVisible && (
+					<FormFooter>
+						{ this.props.onSubmit && (
+							<FormButton
+								className="contact-details-form-fields__submit-button"
+								disabled={ ! countryCode || disableSubmitButton }
+								onClick={ this.handleSubmitButtonClick }
+							>
+								{ labelTexts.submitButton || translate( 'Submit' ) }
+							</FormButton>
+						) }
+						{ onCancel && (
+							<FormButton
+								className="contact-details-form-fields__cancel-button"
+								type="button"
+								isPrimary={ false }
+								onClick={ onCancel }
+							>
+								{ translate( 'Cancel' ) }
+							</FormButton>
+						) }
+					</FormFooter>
+				) }
 				<QueryDomainCountries />
 			</FormFieldset>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* #38835 made the `onSubmit` prop of this component optional, and if not provided does not render the submit button. That leaves behind an empty form footer, which renders with an unnecessary border. This PR detects when neither the Submit button nor the Cancel button is rendered and does not render the form footer in this case.

#### Testing instructions

`npm run test-client client/components/domains/contact-details-form-fields`