### PR TITLE
Fix FSE template part styles.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -87,7 +87,7 @@ const TemplateEdit = compose(
 	} ) => {
 		if ( ! template ) {
 			return (
-				<Placeholder>
+				<Placeholder className="template-block__placeholder">
 					<Spinner />
 				</Placeholder>
 			);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -139,7 +139,7 @@
 	}
 }
 
-
+// Center initial loading spinner in placeholder block.
 .template-block__placeholder {
 	.components-spinner {
 		margin: 0 auto;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -50,36 +50,6 @@
 	.block-editor-block-list__block-edit::before {
 		display: none;
 	}
-}
-
-.template-block__overlay {
-	background: rgba( #ffffff, 0.8 );
-	border: 0 solid rgba( #7b86a2, 0.3 ); // Gutenberg $dark-opacity-light-600
-	bottom: 0;
-	left: 0;
-	margin: 0;
-	opacity: 0;
-	padding: 0;
-	position: absolute;
-	right: 0;
-	transition: opacity 0.2s linear 0s;
-	top: 0;
-	z-index: 2;
-
-	.is-selected & {
-		border-color: rgba( #425863, 0.4 ); // Gutenberg $dark-opacity-light-800
-	}
-
-	.block-editor-block-list__block:first-child & {
-		border-bottom-width: 1px;
-	}
-	.block-editor-block-list__block:last-child & {
-		border-top-width: 1px;
-	}
-
-	@media only screen and ( min-width: 768px ) {
-		border-width: 1px;
-	}
 
 	.template-block__overlay {
 		background: rgba( #ffffff, 0.8 );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -69,10 +69,11 @@
 			border-color: rgba( #425863, 0.4 ); // Gutenberg $dark-opacity-light-800
 		}
 	
-		.editor-block-list__block:first-child & {
+		.block-editor-block-list__block:first-child & {
 			border-bottom-width: 1px;
 		}
-		.editor-block-list__block:last-child & {
+		
+		.block-editor-block-list__block:last-child & {
 			border-top-width: 1px;
 		}
 	
@@ -96,8 +97,6 @@
 		}
 	}
 }
-
-
 
 // Hide the site logo description and buttons when not editing the Template
 .block-editor-page:not( .post-type-wp_template_part ) {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -118,12 +118,12 @@
 				display: none;
 			}
 		}
-	}
 
-	.template-block__loading {
-		display: flex;
-		align-items: center;
-		color: #191e23;
+		.template-block__loading {
+			display: flex;
+			align-items: center;
+			color: #191e23;
+		}
 	}
 }
 
@@ -136,5 +136,12 @@
 		.components-placeholder__instructions {
 			display: none;
 		}
+	}
+}
+
+
+.template-block__placeholder {
+	.components-spinner {
+		margin: 0 auto;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -3,6 +3,7 @@
 	// Prevent blur bleeding
 	overflow: hidden;
 	position: relative;
+	margin-top: 20px;
 }
 
 // Override some very specific theme styles.
@@ -11,11 +12,15 @@
 }
 
 .template__block-container {
-	&.is-hovered {
+	&:hover {
 		cursor: pointer;
 	}
 
-	&.is-hovered,
+	.block-editor-block-list__block-edit [data-block] {
+		margin: 0;
+	}
+
+	&:hover,
 	&.is-selected,
 	.is-navigating-to-template {
 		.components-disabled {
@@ -76,20 +81,53 @@
 		border-width: 1px;
 	}
 
-	.components-button {
+	.template-block__overlay {
+		background: rgba( #ffffff, 0.8 );
+		border: 0 solid rgba( #7b86a2, 0.3 ); // Gutenberg $dark-opacity-light-600
+		bottom: 0;
+		left: 0;
+		margin: 0;
 		opacity: 0;
+		padding: 0;
+		position: absolute;
+		right: 0;
 		transition: opacity 0.2s linear 0s;
-		&.hidden {
-			display: none;
+		top: 0;
+		z-index: 2;
+	
+		.is-selected & {
+			border-color: rgba( #425863, 0.4 ); // Gutenberg $dark-opacity-light-800
 		}
+	
+		.editor-block-list__block:first-child & {
+			border-bottom-width: 1px;
+		}
+		.editor-block-list__block:last-child & {
+			border-top-width: 1px;
+		}
+	
+		@media only screen and ( min-width: 768px ) {
+			border-width: 1px;
+		}
+	
+		.components-button {
+			opacity: 0;
+			transition: opacity 0.2s linear 0s;
+			margin: 0 auto;
+			&.hidden {
+				display: none;
+			}
+		}
+	}
+
+	.template-block__loading {
+		display: flex;
+		align-items: center;
+		color: #191e23;
 	}
 }
 
-.template-block__loading {
-	display: flex;
-	align-items: center;
-	color: #191e23;
-}
+
 
 // Hide the site logo description and buttons when not editing the Template
 .block-editor-page:not( .post-type-wp_template_part ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Updates styles for FSE template part in editor.

**Before**
![fse-header-before](https://user-images.githubusercontent.com/28742426/72830602-0f992880-3c4f-11ea-95f2-fd01549cbffd.gif)

**After**
![fse-header-after](https://user-images.githubusercontent.com/28742426/72830613-1627a000-3c4f-11ea-900a-eb7cfc2ddfab.gif)

Note - In the time between click and release to load the template part editor, the block toolbar shows up in the top left of the template part as seen below:
![Screen Shot 2020-01-21 at 1 04 04 PM](https://user-images.githubusercontent.com/28742426/72830659-2a6b9d00-3c4f-11ea-8f16-23a429255732.png)
It seems that this used to be hidden by nesting the toolbar's `display: none;` inside the  `.template__block-container` ruleset.  With recent changes it seems that this toolbar is no longer a child of the block that triggers it, making it difficult to hide this toolbar without also hiding the toolbars for other blocks in the FSE editor.  Given that this is only visible for a very brief time in practice and that this editor is being phased-out, it is probably best to allow this brief period of visibility.

#### Testing instructions
1. Checkout this PR.
2. Sync the changes to your sandbox. (note: ensure your sandbox is up to date with the recent FSE development changes and run the new script as outlined in the FSE fieldguide).
3.  Load a FSE site's editor and ensure the styles in the page editor behave as expected.  
(note: the template part editor's styles will be addressed via a separate issue and PR)
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes #38961 
