### PR TITLE
composite-checkout: Remove mention of sidebar in banner

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -347,7 +347,7 @@ function TestingBanner() {
 			href="https://github.com/Automattic/wp-calypso/issues/new?title=New%20checkout&body=%3C!--%20Thanks%20for%20filling%20your%20bug%20report%20for%20our%20New%20checkout!%20Pick%20a%20clear%20title%20(%22New%20checkout%3A%20Continue%20button%20not%20working%22)%20and%20proceed.%20--%3E%0A%0A%23%23%23%23%20Steps%20to%20reproduce%0A1.%20Starting%20at%20URL%3A%0A2.%0A3.%0A4.%0A%0A%23%23%23%23%20What%20I%20expected%0A%0A%0A%23%23%23%23%20What%20happened%20instead%0A%0A%0A%23%23%23%23%20Browser%20%2F%20OS%20version%0A%0A%0A%23%23%23%23%20Screenshot%20%2F%20Video%20(Optional)%0A%0A%40sirbrillig%2C%20%40nbloomf%2C%20%40fditrapani%20%0A"
 		>
 			Warning! This checkout is a new feature still in testing. If you encounter issues, please
-			click here to report them and select "Checkout Redesign" in the project sidebar.
+			click here to report them.
 		</Card>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the text `and select "Checkout Redesign" in the project sidebar` from the testing banner in the composite checkout form. This was supposed to be part of #38910 but I forgot to include it.

#### Testing instructions

Visit checkout and be sure the banner displays correctly.

Before:

<img width="594" alt="Screen Shot 2020-01-21 at 4 06 34 PM" src="https://user-images.githubusercontent.com/2036909/72843202-09637600-3c68-11ea-9970-42016c0f1b68.png">

After:

<img width="574" alt="Screen Shot 2020-01-21 at 4 07 49 PM" src="https://user-images.githubusercontent.com/2036909/72843273-3152d980-3c68-11ea-84ec-84185071ce3d.png">

