### PR TITLE
composite-checkout: Allow loading checkout without selectedSite

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -75,7 +75,7 @@ export default function CompositeCheckout( {
 	const onPaymentComplete = useCallback( () => {
 		debug( 'payment completed successfully' );
 		// TODO: determine which thank-you page to visit
-		page.redirect( `/checkout/thank-you/${ siteId }/` );
+		page.redirect( `/checkout/thank-you/${ siteId || '' }/` );
 	}, [ siteId ] );
 
 	const showErrorMessage = useCallback(
@@ -123,7 +123,7 @@ export default function CompositeCheckout( {
 	const itemsForCheckout = items.length ? [ ...items, tax ] : [];
 	debug( 'items for checkout', itemsForCheckout );
 
-	useRedirectIfCartEmpty( items, `/plans/${ siteSlug }` );
+	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }` );
 
 	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards

--- a/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
@@ -28,6 +28,8 @@ export type WPCOMTransactionEndpointPaymentDetails = {
 
 export type WPCOMTransactionEndpointCart = {
 	blog_id: string;
+	cart_key: string;
+	create_new_blog: boolean;
 	coupon: string;
 	currency: string;
 	temporary: false;
@@ -94,7 +96,9 @@ export function createTransactionEndpointCartFromLineItems( {
 	};
 
 	return {
-		blog_id: siteId,
+		blog_id: siteId || '0',
+		cart_key: siteId || 'no-site',
+		create_new_blog: siteId ? false : true,
 		coupon: couponId || '',
 		currency: currency || '',
 		temporary: false,

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -56,8 +56,8 @@ export function checkout( context, next ) {
 	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
 		context.primary = (
 			<CompositeCheckout
-				siteSlug={ selectedSite.slug }
-				siteId={ selectedSite.ID }
+				siteSlug={ selectedSite?.slug }
+				siteId={ selectedSite?.ID }
 				product={ product }
 				purchaseId={ purchaseId }
 				couponCode={ couponCode }

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -81,7 +81,7 @@ type CacheStatus = 'fresh' | 'valid' | 'invalid' | 'pending' | 'error';
  *       not changed.
  *
  * @param cartKey
- *     The cart key
+ *     The cart key. Will use 'no-site' if no key is set.
  * @param setCart
  *     An asynchronous wrapper around the wpcom shopping cart POST
  *     endpoint. We pass this in to make testing easier.
@@ -93,10 +93,11 @@ type CacheStatus = 'fresh' | 'valid' | 'invalid' | 'pending' | 'error';
  * @returns ShoppingCartManager
  */
 export function useShoppingCart(
-	cartKey: string,
+	cartKey: string | null,
 	setCart: ( string, RequestCart ) => Promise< ResponseCart >,
 	getCart: ( string ) => Promise< ResponseCart >
 ): ShoppingCartManager {
+	cartKey = cartKey || 'no-site';
 	const setServerCart = useCallback( cartParam => setCart( cartKey, cartParam ), [
 		cartKey,
 		setCart,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously we assumed that there was always a selected site when making a purchase. This PR changes the code to avoid that assumption.

Fixes #38983

#### Testing instructions

- Visit http://calypso.localhost:3000/domains
- Pick a domain
- Select "Just a domain"
- Verify that checkout loads and that the cart includes the domain you chose
- Complete the form and purchase the domain
- Verify that the domain was successfully purchased