### PR TITLE
Fix "Continue" button not working due to scaling transitions.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/question/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/question/index.tsx
@@ -30,10 +30,8 @@ const Question: FunctionComponent< Props > = ( {
 	// Persist activation of question so animation only happens on mount.
 	const [ hasActivated, setHasActivated ] = useState< boolean >( false );
 	useEffect( () => {
-		if ( ! hasActivated ) {
-			setHasActivated( true );
-		}
-	}, [ hasActivated ] );
+		setHasActivated( true );
+	}, [] );
 
 	return (
 		<div

--- a/client/landing/gutenboarding/onboarding-block/question/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/question/index.tsx
@@ -27,7 +27,7 @@ const Question: FunctionComponent< Props > = ( {
 	label,
 	onExpand,
 } ) => {
-	// Persist activation of question so animation only happens on initial selection.
+	// Persist activation of question so animation only happens on mount.
 	const [ hasActivated, setHasActivated ] = useState< boolean >( false );
 	useEffect( () => {
 		if ( ! hasActivated ) {

--- a/client/landing/gutenboarding/onboarding-block/question/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/question/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState, useEffect } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -26,22 +26,36 @@ const Question: FunctionComponent< Props > = ( {
 	isActive,
 	label,
 	onExpand,
-} ) => (
-	<div className={ classNames( 'onboarding-block__question', className, { selected: isActive } ) }>
-		<span>{ label }</span>
-		<div>
-			{ isActive ? (
-				children
-			) : (
-				<>
-					<button className="onboarding-block__question-answered" onClick={ onExpand }>
-						{ displayValue }
-					</button>
-					<span>.</span>
-				</>
-			) }
+} ) => {
+	// Persist activation of question so animation only happens on initial selection.
+	const [ hasActivated, setHasActivated ] = useState< boolean >( false );
+	useEffect( () => {
+		if ( ! hasActivated && isActive ) {
+			setHasActivated( true );
+		}
+	}, [ isActive, hasActivated ] );
+
+	return (
+		<div
+			className={ classNames( 'onboarding-block__question', className, {
+				selected: hasActivated,
+			} ) }
+		>
+			<span>{ label }</span>
+			<div>
+				{ isActive ? (
+					children
+				) : (
+					<>
+						<button className="onboarding-block__question-answered" onClick={ onExpand }>
+							{ displayValue }
+						</button>
+						<span>.</span>
+					</>
+				) }
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 export default Question;

--- a/client/landing/gutenboarding/onboarding-block/question/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/question/index.tsx
@@ -30,10 +30,10 @@ const Question: FunctionComponent< Props > = ( {
 	// Persist activation of question so animation only happens on initial selection.
 	const [ hasActivated, setHasActivated ] = useState< boolean >( false );
 	useEffect( () => {
-		if ( ! hasActivated && isActive ) {
+		if ( ! hasActivated ) {
 			setHasActivated( true );
 		}
-	}, [ isActive, hasActivated ] );
+	}, [ hasActivated ] );
 
 	return (
 		<div


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes scaling transitions of questions after initial activation.  It was proposed that we could completely remove the scaling effects from the onboarding questions on #38681.  Before completely removing the transition and animations that have been put into place, this PR suggests that we continue to use the initial scale-up when a question is activated but to not scale-down once the question is deactivated.  This will allow us to retain the nice feel of load-in animation for questions without causing further issues with selecting the 'Continue' button.

![activation-persistance](https://user-images.githubusercontent.com/28742426/72844849-5f85e880-3c6b-11ea-9295-82cc1df1e1c0.gif)

To do this I have added `useState` and `useEffect` to set and keep track of a `hasActivated` variable within the Question component.  `hasActivated` starts as `false` and is then set to `true` once `isActive` becomes `true`.  `hasActivated` will then remain `true` even after subsequent changes to `isActive`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Test the onboarding vertical and site name questions on Gutenboarding.
* Verify animations are present in initial loading of question, but do not persist afterwards when deselected.
* Verify the "Continue" button is always easily clickable.

Fixes #38681
