### PR TITLE
composite-checkout: Fix TOS links and placeholder domain

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -10,6 +10,7 @@ import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
  * Internal dependencies
  */
 import joinClasses from './join-classes';
+import { isLineItemADomain } from '../hooks/has-domains';
 import Coupon from './coupon';
 import WPTermsAndConditions from './wp-terms-and-conditions';
 import {
@@ -18,9 +19,11 @@ import {
 	WPOrderReviewSection,
 } from './wp-order-review-line-items';
 
-export default function WPCheckoutOrderReview( { className, removeItem } ) {
+export default function WPCheckoutOrderReview( { className, removeItem, siteUrl } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
+	const firstDomainItem = items.find( isLineItemADomain );
+	const domainName = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
@@ -34,7 +37,7 @@ export default function WPCheckoutOrderReview( { className, removeItem } ) {
 				<WPOrderReviewTotal total={ total } />
 			</WPOrderReviewSection>
 
-			<WPTermsAndConditions />
+			<WPTermsAndConditions domainName={ domainName } />
 		</div>
 	);
 }
@@ -43,6 +46,7 @@ WPCheckoutOrderReview.propTypes = {
 	summary: PropTypes.bool,
 	className: PropTypes.string,
 	removeItem: PropTypes.func.isRequired,
+	siteUrl: PropTypes.string,
 };
 
 const CouponField = styled( Coupon )`

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -56,7 +56,11 @@ export default function WPCheckout( {
 	const [ itemsWithTax ] = useLineItems();
 
 	const ReviewContent = () => (
-		<WPCheckoutOrderReview removeItem={ removeItem } onChangePlanLength={ changePlanLength } />
+		<WPCheckoutOrderReview
+			removeItem={ removeItem }
+			onChangePlanLength={ changePlanLength }
+			siteUrl={ siteUrl }
+		/>
 	);
 
 	const contactInfo = useSelect( sel => sel( 'wpcom' ).getContactInfo() ) || {};

--- a/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
@@ -100,10 +100,6 @@ const TermsParagraph = styled.p`
 	font-size: 14px;
 	color: ${props => props.theme.colors.textColor};
 
-	a {
-		color: ${props => props.theme.colors.textColor};
-	}
-
 	a:hover {
 		text-decoration: none;
 	}

--- a/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
@@ -100,6 +100,10 @@ const TermsParagraph = styled.p`
 	font-size: 14px;
 	color: ${props => props.theme.colors.textColor};
 
+	a {
+		text-decoration: underline;
+	}
+
 	a:hover {
 		text-decoration: none;
 	}

--- a/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
@@ -11,11 +11,10 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { useHasDomainsInCart } from '../hooks/has-domains';
 
-export default function WPTermsAndConditions() {
+export default function WPTermsAndConditions( { domainName } ) {
 	const isDomainsTermsVisible = useHasDomainsInCart();
 	const translate = useTranslate();
 
-	//TODO: replace domainname.com next to domainRegistrationAgreement with the domain being purchased.
 	return (
 		<TermsAndConditionsWrapper>
 			<TermsParagraph>
@@ -50,7 +49,12 @@ export default function WPTermsAndConditions() {
 					<TermsParagraph>
 						{ interpolateComponents( {
 							mixedString: translate(
-								'You agree to the {{domainRegistrationAgreement}}Domain Registration Agreement{{/domainRegistrationAgreement}} for domainname.com.'
+								'You agree to the {{domainRegistrationAgreement}}Domain Registration Agreement{{/domainRegistrationAgreement}} for %(domainName)s.',
+								{
+									args: {
+										domainName,
+									},
+								}
 							),
 							components: {
 								domainRegistrationAgreement: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The links in the TOS were colored to look like the text and the domain name wasn't actually there. This fixes both issues.

Fixes #38994 and #38993

#### Screenshots

Before:

<img width="459" alt="Screen Shot 2020-01-21 at 5 00 40 PM" src="https://user-images.githubusercontent.com/2036909/72846947-94943a00-3c6f-11ea-98d5-f012e7bc3188.png">

After:

![Screen Shot 2020-01-21 at 4 53 22 PM](https://user-images.githubusercontent.com/2036909/72846649-0324c800-3c6f-11ea-8728-f69709fdf75e.png)


#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Add a domain and plan to the cart and visit checkout. 
- Complete all the steps. 
- Verify that the TOS at the bottom has colored links and that the domain in the cart is listed there.