### PR TITLE
FSE: Integrate wp-env environment

### DIFF
--- a/apps/full-site-editing/.wp-env.json
+++ b/apps/full-site-editing/.wp-env.json
@@ -1,0 +1,4 @@
+{
+	"plugins": [ "./full-site-editing-plugin", "../../gutenberg" ],
+	"themes": [ "../../themes/varia", "../../themes/maywood" ]
+}

--- a/apps/full-site-editing/.wp-env.json
+++ b/apps/full-site-editing/.wp-env.json
@@ -1,5 +1,4 @@
 {
-	"name": "FSE Plugin",
 	"plugins": [ "./full-site-editing-plugin", "../../../gutenberg" ],
 	"themes": [ "../../../themes/varia", "../../../themes/maywood" ]
 }

--- a/apps/full-site-editing/.wp-env.json
+++ b/apps/full-site-editing/.wp-env.json
@@ -1,4 +1,5 @@
 {
-	"plugins": [ "./full-site-editing-plugin", "../../gutenberg" ],
-	"themes": [ "../../themes/varia", "../../themes/maywood" ]
+	"name": "FSE Plugin",
+	"plugins": [ "./full-site-editing-plugin", "../../../gutenberg" ],
+	"themes": [ "../../../themes/varia", "../../../themes/maywood" ]
 }

--- a/apps/full-site-editing/.wp-env.json
+++ b/apps/full-site-editing/.wp-env.json
@@ -1,4 +1,6 @@
 {
 	"plugins": [ "./full-site-editing-plugin", "../../../gutenberg" ],
-	"themes": [ "../../../themes/varia", "../../../themes/maywood" ]
+	"themes": [ "../../../themes/varia", "../../../themes/maywood" ],
+	"portNumber": 4013,
+	"testsPortNumber": 4005
 }

--- a/apps/full-site-editing/.wp-env.json
+++ b/apps/full-site-editing/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"plugins": [ "./full-site-editing-plugin", "../../../gutenberg" ],
 	"themes": [ "../../../themes/varia", "../../../themes/maywood" ],
-	"portNumber": 4013,
-	"testsPortNumber": 4005
+	"port": 4013,
+	"testsPort": 4005
 }

--- a/apps/full-site-editing/bin/setup-env.sh
+++ b/apps/full-site-editing/bin/setup-env.sh
@@ -19,7 +19,7 @@ cd ../
 # can find them. This way they can be connected to wp-env.
 parent_dr=$(pwd)
 if [ ! -d "./themes" ] ; then
-	echo -e "\nIt does not seem as if the Automattic themes repo is a sibling of wp-calypso in your file system."
+	echo -e "\nThe Automattic themes repo is not a sibling of wp-calypso in your file system."
 	echo "If you clone it, we can automatically link it to the WordPress environment."
 	read -p "Would you like to clone Automattic/themes as a sibling of wp-calypso? (y for yes)"
 	if [[ $REPLY = 'y' ]] ; then
@@ -30,7 +30,7 @@ if [ ! -d "./themes" ] ; then
 fi
 
 if [ ! -d "./gutenberg" ] ; then
-	echo -e "\nIt does not seem as if the Gutenberg repo is a sibling of wp-calypso in your file system."
+	echo -e "\nThe Gutenberg repo is not a sibling of wp-calypso in your file system."
 	echo "If you clone it, we can automatically link it to the WordPress environment."
 	read -p "Would you like to clone and builg WordPress/gutenberg as a sibling of wp-calypso? (y for yes)"
 	if [[ $REPLY = 'y' ]] ; then
@@ -52,8 +52,15 @@ npm ci
 # Run an initial FSE build so that the plugin can load correctly.
 npx lerna run build --scope='@automattic/full-site-editing' --stream --no-prefix
 
-npm i -g @wordpress/env
+# Where the wp-env.json file lives:
+cd apps/full-site-editing
 
-# Install the environment at the plugin level.
-cd "apps/full-site-editing/full-site-editing-plugin"
-WP_ENV_PORT=4013 WP_ENV_TESTS_PORT=4008 npx wp-env start
+echo -e "\nWould you like to use the development version of wp-env? You can checkout the correct Gutenberg branch and build it before continuing."
+read -p "Type y to use the development version of wp-env. Otherwise, it will use the published version. "
+if [[ $REPLY = 'y' ]] ; then
+	WP_ENV_PORT=4013 WP_ENV_TESTS_PORT=4008 ../../../gutenberg/packages/env/bin/wp-env start
+else
+	# Use the published version of wp-env
+	npm i -g @wordpress/env
+	WP_ENV_PORT=4013 WP_ENV_TESTS_PORT=4008 npx wp-env start
+fi

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -16,7 +16,6 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
-		"init": "./bin/setup-env.sh",
 		"full-site-editing": "calypso-build --source='full-site-editing'",
 		"dev:full-site-editing": "npm run full-site-editing",
 		"build:full-site-editing": "NODE_ENV=production npm run full-site-editing",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -16,7 +16,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
-		"full-site-editing": "calypso-build --source='full-site-editing'",
+		"full-site-editing": "calypso-build --source='dotcom-fse'",
 		"dev:full-site-editing": "npm run full-site-editing",
 		"build:full-site-editing": "NODE_ENV=production npm run full-site-editing",
 		"posts-list-block": "calypso-build --source='posts-list-block'",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -16,7 +16,8 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
-		"full-site-editing": "calypso-build --source='dotcom-fse'",
+		"init": "./bin/setup-env.sh",
+		"full-site-editing": "calypso-build --source='full-site-editing'",
 		"dev:full-site-editing": "npm run full-site-editing",
 		"build:full-site-editing": "NODE_ENV=production npm run full-site-editing",
 		"posts-list-block": "calypso-build --source='posts-list-block'",


### PR DESCRIPTION
Originally, I covered several more things in this PR which I have split out into the following:
- [Fix JS unit tests (ready to go)
](https://github.com/Automattic/wp-calypso/pull/39326)
- [Add phpunit tests (WIP)
](https://github.com/Automattic/wp-calypso/pull/39328)
- [Add e2e tests (WIP)
](https://github.com/Automattic/wp-calypso/pull/39327)

This PR sets up [@wordpress/env](https://github.com/WordPress/gutenberg/tree/master/packages/env) as a Docker environment for running the plugin locally (and hopefully, in the future, in CI).

As part of this effort, I have created an opinionated "setup-env" script which sets up the repositories a developer needs for working with the FSE plugin locally.
- It clones gutenberg and themes as siblings of wp-calypso in your filesystem if they are not there yet. (So if you have gutenberg, themes, and wp-calypso cloned in the same directory, nothing will change.)
- It builds FSE plugin
- It starts wp-env on `localhost:4013`

### Changes proposed in this Pull Request
- This PR integrates @wordress/env directly into the FSE plugin so that we have a WordPress environment in which to run our tests.
- Adds an environment init script to help set up the local env (includes cloning Gutenberg and themes.)
- Adds a `.wp-env.json` file to specify dependencies of the project.

### Test Install Step
1. In your gutenberg checkout (which should be a sibling of wp-calypso), make sure you have the latest changes on the `master` branch, and build everything: `nvm use && npm ci && npm run build`.
2. From wp-calypso root, run `./apps/full-site-editing/bin/setup-env.sh`. Once it does everything, it will ask you if you want to run the development version of wp-env. **Choose yes since the changes we require have not been published to npm yet.**
3. If all goes well, you should be able to access a Docker instance at `localhost:4013`. (Note: I have experienced issues with my browser caching a redirect between different ports, so you may need to try different browsers and/or clear the cache for `localhost`).

### To do:
- [ ] Check what would be needed to make the setup-env script work in CircleCI
- [x] Ability to run env commands with the correct port numbers ([see my Gutenberg PR](https://github.com/WordPress/gutenberg/pull/20158))