### PR TITLE
Stats: display prompt to enable stats when stats module is disabled

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -274,7 +274,7 @@ class StatsSite extends Component {
 		return (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"
-				title={ translate( 'Looking for Stats?' ) }
+				title={ translate( 'Looking for stats?' ) }
 				line={ translate(
 					'Enable Site Stats below or visit {{a}}Traffic > Site Stats{{/a}} for more options',
 					{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -291,7 +291,6 @@ class StatsSite extends Component {
 
 	render() {
 		const { isJetpack, siteId, showEnableStatsModule } = this.props;
-
 		const { period } = this.props.period;
 
 		return (

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -327,8 +327,8 @@ export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const isStatsModuleActive = isJetpackModuleActive( state, siteId, 'stats' );
-		const showEnableStatsModule = siteId && isJetpack && isStatsModuleActive === false;
+		const showEnableStatsModule =
+			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
 			isJetpack,
 			siteId,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -269,8 +269,13 @@ class StatsSite extends Component {
 		);
 	}
 
+	enableStatsModule = () => {
+		const { siteId, path } = this.props;
+		this.props.enableJetpackStatsModule( siteId, path );
+	};
+
 	renderEnableStatsModule() {
-		const { slug, siteId, path } = this.props;
+		const { slug } = this.props;
 		return (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"
@@ -284,7 +289,7 @@ class StatsSite extends Component {
 					}
 				) }
 				action={ translate( 'Enable Site Stats' ) }
-				actionCallback={ () => this.props.enableJetpackStatsModule( siteId, path ) }
+				actionCallback={ this.enableStatsModule }
 			/>
 		);
 	}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -296,7 +296,7 @@ class StatsSite extends Component {
 		return (
 			<Main wideLayout={ true }>
 				<QueryKeyringConnections />
-				{ isJetpack && siteId && <QueryJetpackModules siteId={ siteId } /> }
+				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Stats and Insights' ) } />
 				<PageViewTracker

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -275,18 +275,12 @@ class StatsSite extends Component {
 	};
 
 	renderEnableStatsModule() {
-		const { slug } = this.props;
 		return (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"
 				title={ translate( 'Looking for stats?' ) }
 				line={ translate(
-					'Enable Site Stats below or visit {{a}}Traffic > Site Stats{{/a}} for more options',
-					{
-						components: {
-							a: <a href={ `/marketing/traffic/${ slug }` } />,
-						},
-					}
+					'Enable site stats to see detailed information about your traffic, likes, comments, and subscribers.'
 				) }
 				action={ translate( 'Enable Site Stats' ) }
 				actionCallback={ this.enableStatsModule }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/14253 where we'd see infinite loaders for a Jetpack site that has the stats module disabled. Changes here will display a prompt to enable stats.

Folks are welcome to commit directly to this branch if work here is of any interest.

![Jan-24-2020 12-41-49](https://user-images.githubusercontent.com/1270189/73102571-fb4f6880-3ea6-11ea-8214-da3767d886bb.gif)

### Testing Instructions
- With a Jetpack or Atomic Site disable stats in Marketing > Traffic
- Visit /stats
- Instead of infinite loaders we should see a prompt to enable the stats module
- Switching a site to a simple site or site with enabled modules should not display this prompt (Please also try on a fresh indexedDB cache )
- Clicking on Enable Stats will update the module setting, and display stats.

We also fire a related tracks event:
<img width="1053" alt="Screen Shot 2020-01-23 at 1 20 56 PM" src="https://user-images.githubusercontent.com/1270189/73025367-52d8d000-3de4-11ea-9e8f-599aa4fd90aa.png">

