### PR TITLE
Migration: Add upgrade confirmation step

### DIFF
--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -24,10 +24,7 @@ export function migrateSite( context, next ) {
 			context.params.sourceSiteId &&
 			getSiteId( context.store.getState(), context.params.sourceSiteId );
 		context.primary = (
-			<SectionMigrate
-				sourceSiteId={ sourceSiteId }
-				showImportSelector={ context.showImportSelector }
-			/>
+			<SectionMigrate sourceSiteId={ sourceSiteId } step={ context.migrationStep } />
 		);
 		return next();
 	}
@@ -35,9 +32,11 @@ export function migrateSite( context, next ) {
 	page.redirect( '/' );
 }
 
-export function setImportSelector( context, next ) {
-	context.showImportSelector = true;
-	next();
+export function setStep( migrationStep ) {
+	return ( context, next ) => {
+		context.migrationStep = migrationStep;
+		next();
+	};
 }
 
 export function setSiteSelectionHeader( context, next ) {

--- a/client/my-sites/migrate/index.js
+++ b/client/my-sites/migrate/index.js
@@ -9,8 +9,8 @@ import page from 'page';
 import {
 	ensureFeatureFlag,
 	migrateSite,
-	setImportSelector,
 	setSiteSelectionHeader,
+	setStep,
 } from 'my-sites/migrate/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'my-sites/controller';
@@ -30,6 +30,7 @@ export default function() {
 	page(
 		'/migrate/:site_id',
 		ensureFeatureFlag,
+		setStep( 'input' ),
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/migrate' ),
@@ -41,6 +42,7 @@ export default function() {
 	page(
 		'/migrate/from/:sourceSiteId/to/:site_id',
 		ensureFeatureFlag,
+		setStep( 'confirm' ),
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/migrate' ),
@@ -52,7 +54,19 @@ export default function() {
 	page(
 		'/migrate/choose/:site_id',
 		ensureFeatureFlag,
-		setImportSelector,
+		setStep( 'migrateOrImport' ),
+		siteSelection,
+		navigation,
+		redirectWithoutSite( '/migrate' ),
+		migrateSite,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/migrate/upgrade/from/:sourceSiteId/to/:site_id',
+		ensureFeatureFlag,
+		setStep( 'upgrade' ),
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/migrate' ),

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import page from 'page';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import { Button, CompactCard } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import HeaderCake from 'components/header-cake';
+import Site from 'blocks/site';
+import { FEATURE_UPLOAD_THEMES_PLUGINS } from 'lib/plans/constants';
+import { planHasFeature } from 'lib/plans';
+
+/**
+ * Style dependencies
+ */
+import './section-migrate.scss';
+
+class StepConfirmMigration extends Component {
+	static propTypes = {
+		sourceSite: PropTypes.object.isRequired,
+		startMigration: PropTypes.func.isRequired,
+		targetSite: PropTypes.object.isRequired,
+		targetSiteSlug: PropTypes.string.isRequired,
+	};
+
+	handleClick = () => {
+		const { sourceSite, targetSite, targetSiteSlug } = this.props;
+		const sourceSiteId = get( sourceSite, 'ID' );
+		const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
+		const planSlug = get( targetSite, 'plan.product_slug' );
+		if ( planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS ) ) {
+			return this.startMigration();
+		}
+
+		page( `/migrate/upgrade/from/${ sourceSiteSlug }/to/${ targetSiteSlug }` );
+	};
+
+	render() {
+		const { sourceSite, targetSite, targetSiteSlug } = this.props;
+
+		const sourceSiteDomain = get( sourceSite, 'domain' );
+		const backHref = `/migrate/${ targetSiteSlug }`;
+
+		return (
+			<>
+				<HeaderCake backHref={ backHref }>Import { sourceSiteDomain }</HeaderCake>
+				<div className="migrate__sites">
+					<div className="migrate__sites-item">
+						<Site site={ sourceSite } indicator={ false } />
+					</div>
+					<div className="migrate__sites-arrow-wrapper">
+						<Gridicon className="migrate__sites-arrow" icon="arrow-right" />
+					</div>
+					<div className="migrate__sites-item">
+						<Site site={ targetSite } indicator={ false } />
+						<div className="migrate__sites-labels-container">
+							<span className="migrate__token-label">This site</span>
+						</div>
+					</div>
+				</div>
+				<CompactCard>
+					<Button primary onClick={ this.handleClick }>
+						Import everything
+					</Button>
+				</CompactCard>
+			</>
+		);
+	}
+}
+
+export default localize( StepConfirmMigration );

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { Button, CompactCard } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+
+/**
+ * Style dependencies
+ */
+import './section-migrate.scss';
+
+class StepUpgrade extends Component {
+	static propTypes = {
+		startMigration: PropTypes.func.isRequired,
+	};
+
+	render() {
+		return (
+			<>
+				<HeaderCake>Import Everything</HeaderCake>
+
+				<CompactCard>
+					<Button onClick={ this.props.startMigration } primary>
+						Upgrade and import
+					</Button>
+				</CompactCard>
+			</>
+		);
+	}
+}
+
+export default localize( StepUpgrade );


### PR DESCRIPTION
This is a partial change behind a feature-flag

#### Changes proposed in this Pull Request

* Adds the stub of the plan confirmation step
* Moves migration confirmation into its own step
* Adds new route for the plan confirmation step
* Refactors how step is determined from context/route

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you're able to complete a migration flow by starting from `/import`. Many of the screens are stubbed right now.

