### PR TITLE
Gutenboarding: add custom pre-launch signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -15,6 +15,7 @@ export function generateFlows( {
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
 	getLaunchDestination = noop,
+	getEditorDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
 } = {} ) {
@@ -356,9 +357,10 @@ export function generateFlows( {
 	if ( isEnabled( 'gutenboarding' ) ) {
 		flows.frankenflow = {
 			steps: [ 'user', 'domains', 'plans' ],
+			destination: getEditorDestination,
 			description: 'Frankenflow testing flow for Gutenboarding',
-			pageTitle: translate( 'Launch your site' ),
 			lastModified: '2020-01-22',
+			pageTitle: translate( 'Launch your site' ),
 		};
 	}
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -353,6 +353,15 @@ export function generateFlows( {
 		};
 	}
 
+	if ( isEnabled( 'gutenboarding' ) ) {
+		flows.frankenflow = {
+			steps: [ 'user', 'domains', 'plans' ],
+			description: 'Frankenflow testing flow for Gutenboarding',
+			pageTitle: translate( 'Launch your site' ),
+			lastModified: '2020-01-22',
+		};
+	}
+
 	return flows;
 }
 


### PR DESCRIPTION
part of https://github.com/Automattic/wp-calypso/issues/38934

#### Changes proposed in this Pull Request
* use `domains` and `plans` steps + `user` for new users
* use custom `pageTitle`

#### Testing instructions
* Go to http://calypso.localhost:3000/start/frankenflow
* Page title should be 'Launch your site' instead of 'Create your site'
* If logged in, first step rendered should be `/domains` and the next one `/plans`

#### Follow up
* Customize steps content and header according to design 
* `destination` (the redirect after completing the flow) should be Calypso home instead of block-editor