### PR TITLE
Build: Silence a tsc error on update-deps

### DIFF
--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -24,7 +24,7 @@ export function register(): typeof STORE_KEY {
 		registerStore< State >( STORE_KEY, {
 			actions,
 			controls,
-			reducer,
+			reducer: reducer as any,
 			resolvers,
 			selectors,
 		} );

--- a/packages/data-stores/src/user/index.ts
+++ b/packages/data-stores/src/user/index.ts
@@ -26,7 +26,7 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
 		registerStore< State >( STORE_KEY, {
 			actions,
 			controls,
-			reducer,
+			reducer: reducer as any,
 			resolvers,
 			selectors,
 		} );

--- a/packages/data-stores/src/verticals-templates/index.ts
+++ b/packages/data-stores/src/verticals-templates/index.ts
@@ -24,7 +24,7 @@ export function register(): typeof STORE_KEY {
 		registerStore< State >( STORE_KEY, {
 			actions,
 			controls,
-			reducer,
+			reducer: reducer as any,
 			resolvers,
 			selectors,
 		} );

--- a/packages/data-stores/src/verticals/index.ts
+++ b/packages/data-stores/src/verticals/index.ts
@@ -24,7 +24,7 @@ export function register(): typeof STORE_KEY {
 		registerStore< State >( STORE_KEY, {
 			actions,
 			controls,
-			reducer,
+			reducer: reducer as any,
 			resolvers,
 			selectors,
 		} );


### PR DESCRIPTION
Something breaks the typechecker on our data-stores reducer when after running `npm run update-deps`.

Adds an `any` cast at the location of the problem until a true fix can be found and applied.

_This is a workaround._

## Testing
- `/gutenboarding` continues to work
- `npm run update-deps` works