### PR TITLE
Removing Domain move paragraph test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -144,7 +144,6 @@ class RegisterDomainStep extends React.Component {
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
 		showTestCopy: PropTypes.bool,
-		showTestParagraph: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,
@@ -582,10 +581,6 @@ class RegisterDomainStep extends React.Component {
 		}
 
 		if ( this.props.showExampleSuggestions ) {
-			if ( this.props.showTestParagraph ) {
-				return this.renderFreeDomainExplainer();
-			}
-
 			return this.renderExampleSuggestions();
 		}
 
@@ -1245,10 +1240,7 @@ class RegisterDomainStep extends React.Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				showTestCopy={ this.props.showTestCopy }
 			>
-				{ this.props.showTestCopy &&
-					hasResults &&
-					! this.props.showTestParagraph &&
-					this.renderFreeDomainExplainer() }
+				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer() }
 
 				{ showTldFilterBar && (
 					<TldFilterBar

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -97,15 +97,6 @@ export default {
 		defaultVariation: 'variantShowUpdates',
 		allowExistingUsers: true,
 	},
-	domainStepMoveParagraph: {
-		datestamp: '20191216',
-		variations: {
-			variantMoveParagraph: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	nonEnglishDomainStepCopyUpdates: {
 		datestamp: '20191219',
 		variations: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -130,12 +130,6 @@ class DomainsStep extends React.Component {
 		) {
 			this.showTestCopy = true;
 		}
-
-		this.showTestParagraph = false;
-
-		if ( this.showTestCopy && 'variantMoveParagraph' === abtest( 'domainStepMoveParagraph' ) ) {
-			this.showTestParagraph = true;
-		}
 	}
 
 	static getDerivedStateFromProps( nextProps ) {
@@ -471,7 +465,6 @@ class DomainsStep extends React.Component {
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
 				showTestCopy={ this.showTestCopy }
-				showTestParagraph={ this.showTestParagraph }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor( true ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes an AB test. You can find more information here p8Eqe3-ZD

#### Testing instructions

* Go through the signup flow at /start

* The AB test definition `domainStepMoveParagraph` should not appear in the AB tests menu.

* Go to the Domains step and before typing anything, verify that the design looks like this:

![image](https://user-images.githubusercontent.com/538790/72917891-f2df1c80-3d44-11ea-8765-b68faf55011c.png)

* Type anything in the search form. 

* If you are assigned to the `control` group of the `domainStepCopyUpdates` test, it means you're in the Holdout group, so you should not see the `domainStepCopyUpdates` from https://github.com/Automattic/wp-calypso/pull/37661. Verify the following:
    - The domain step UI and copy remain the same as before (no copy updates, no explanation paragraph).
    - Complete signup and check the launch flow steps - they should remain unchanged

* If you are assigned to the `variantShowUpdates` group of the `domainStepCopyUpdates` test:

    - You should see the new copy for the Domains step, with the Free One-Year Domain explanation paragraph showing up *only after* you type some domain to search. 
 


Note: This test should not show in the site launch flow or in the Add domain page.

