### PR TITLE
Migration: fix migration start on confirmation step

### DIFF
--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -31,12 +31,12 @@ class StepConfirmMigration extends Component {
 	};
 
 	handleClick = () => {
-		const { sourceSite, targetSite, targetSiteSlug } = this.props;
+		const { sourceSite, startMigration, targetSite, targetSiteSlug } = this.props;
 		const sourceSiteId = get( sourceSite, 'ID' );
 		const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
 		const planSlug = get( targetSite, 'plan.product_slug' );
 		if ( planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS ) ) {
-			return this.startMigration();
+			return startMigration();
 		}
 
 		page( `/migrate/upgrade/from/${ sourceSiteSlug }/to/${ targetSiteSlug }` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes an issue introduced in #39006 on the migration confirmation screen when starting a migration if you already have purchased the business plan

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/import` on a site where you already have a business plan
* When you get to the confirmation screen, you should be taken to the migration status view after starting a migration (prior to this change, you received an error in the console)


