### PR TITLE
Plugins: Prevent Atomic Sites Installing Incompatible Ones

### DIFF
--- a/client/my-sites/plugins/incompatible-plugins.js
+++ b/client/my-sites/plugins/incompatible-plugins.js
@@ -1,0 +1,136 @@
+/**
+ * This is a list of plugins not supported on WordPress.com Atomic sites.
+ *
+ * If this list is modified, please ensure that the support document also reflects
+ * any changes made:
+ *  - https://en.support.wordpress.com/incompatible-plugins
+ *
+ * Please keep this list alphabetized within the different categories!
+ */
+
+export const IncompatiblePlugins = [
+	// "reset" - break/interfere with provided functionality
+	'advanced-database-cleaner',
+	'advanced-reset-wp',
+	'advanced-wp-reset',
+	'armember-membership',
+	'autoptimize',
+	'backup',
+	'better-wp-security',
+	'cf7-pipedrive-integration',
+	'database-browser',
+	'duplicator',
+	'extended-wp-reset',
+	'file-manager-advanced',
+	'file-manager',
+	'plugins-garbage-collector',
+	'post-type-switcher',
+	'reset-wp',
+	'secure-file-manager',
+	'ultimate-wp-reset',
+	'username-changer',
+	'username-updater',
+	'wd-youtube',
+	'wordpress-database-reset',
+	'wordpress-reset',
+	'wp-automatic',
+	'wp-clone-by-wp-academy',
+	'wp-config-file-editor',
+	'wp-dbmanager',
+	'wp-file-manager',
+	'wp-prefix-changer',
+	'wp-reset',
+	'wp-uninstaller-by-azed',
+	'wpmu-database-reset',
+	'wps-hide-login',
+	'z-inventory-manager',
+
+	// backup
+	'backup-wd',
+	'backupwordpress',
+	'backwpup',
+	'wp-db-backup',
+
+	// caching
+	'cache-enabler',
+	'comet-cache',
+	'hyper-cache',
+	'powered-cache',
+	'jch-optimize',
+	'quick-cache',
+	'sg-cachepress',
+	'w3-total-cache',
+	'wp-cache',
+	'wp-fastest-cache',
+	'wp-rocket',
+	'wp-speed-of-light',
+	'wp-super-cache',
+
+	// sql heavy
+	'another-wordpress-classifieds-plugin',
+	'broken-link-checker',
+	'leads',
+	'native-ads-adnow',
+	'ol_scrapes',
+	'page-visit-counter',
+	'post-views-counter',
+	'tokenad',
+	'top-10',
+	'userpro',
+	'wordpress-popular-posts',
+	'wp-cerber',
+	'wp-inject',
+	'wp-postviews',
+	'wp-rss-aggregator',
+	'wp-rss-feed-to-post',
+	'wp-rss-wordai',
+	'wp-session-manager',
+	'wp-slimstat',
+	'wp-statistics',
+	'wp-ulike',
+	'WPRobot5',
+
+	// security
+	'wordfence',
+	'wp-simple-firewall',
+
+	// spam
+	'e-mail-broadcasting',
+	'mailit',
+	'send-email-from-admin',
+
+	// cloning/staging
+	'wp-staging',
+
+	// misc
+	'adult-mass-photos-downloader',
+	'adult-mass-videos-embedder',
+	'ari-adminer',
+	'automatic-video-posts',
+	'bwp-minify',
+	'clearfy',
+	'cornerstone',
+	'cryptocurrency-pricing-list',
+	'event-espresso-decaf',
+	'facetwp-manipulator',
+	'fast-velocity-minify',
+	'nginx-helper',
+	'p3',
+	'porn-embed',
+	'propellerads-official',
+	'speed-contact-bar',
+	'unplug-jetpack',
+	'really-simple-ssl',
+	'robo-gallery',
+	'under-construction-page',
+	'video-importer',
+	'woozone',
+	'wp-cleanfix',
+	'wp-file-upload',
+	'wp-monero-miner-pro',
+	'wp-monero-miner-using-coin-hive',
+	'wp-optimize-by-xtraffic',
+	'wpematico',
+	'yuzo-related-post',
+	'zapp-proxy-server',
+];

--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -8,7 +8,8 @@
  * Please keep this list alphabetized within the different categories!
  */
 
-export const IncompatiblePlugins = [
+export function isCompatiblePlugin( pluginSlug ) {
+	const incompatiblePlugins = [
 	// "reset" - break/interfere with provided functionality
 	'advanced-database-cleaner',
 	'advanced-reset-wp',
@@ -134,3 +135,6 @@ export const IncompatiblePlugins = [
 	'yuzo-related-post',
 	'zapp-proxy-server',
 ];
+	
+	return ! incompatiblePlugins.includes( pluginSlug );
+}

--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -8,8 +8,7 @@
  * Please keep this list alphabetized within the different categories!
  */
 
-export function isCompatiblePlugin( pluginSlug ) {
-	const incompatiblePlugins = [
+const incompatiblePlugins = new Set( [
 	// "reset" - break/interfere with provided functionality
 	'advanced-database-cleaner',
 	'advanced-reset-wp',
@@ -134,7 +133,8 @@ export function isCompatiblePlugin( pluginSlug ) {
 	'wpematico',
 	'yuzo-related-post',
 	'zapp-proxy-server',
-];
-	
-	return ! incompatiblePlugins.includes( pluginSlug );
+] );
+
+export function isCompatiblePlugin( pluginSlug ) {
+	return ! incompatiblePlugins.has( pluginSlug );
 }

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -342,7 +342,7 @@ export default connect(
 		return {
 			siteId,
 			siteIsConnected: getSiteConnectionStatus( state, siteId ),
-			isSiteWpcomAtomic: isSiteWpcomAtomic( state, siteId ),
+			isWpcomAtomicSite: isSiteWpcomAtomic( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -11,7 +11,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ import QuerySiteConnectionStatus from 'components/data/query-site-connection-sta
 import getSiteConnectionStatus from 'state/selectors/get-site-connection-status';
 import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 import { localizeUrl } from 'lib/i18n-utils';
-import { IncompatiblePlugins } from '../incompatible-plugins';
+import { isCompatiblePlugin } from '../plugin-compatibility';
 
 /**
  * Style dependencies
@@ -297,13 +296,13 @@ export class PluginInstallButton extends Component {
 	}
 
 	renderNoticeOrButton() {
-		const { isWpcomAtomicSite, plugin, selectedSite, siteIsConnected } = this.props;
+		const { plugin, selectedSite, siteIsConnected, siteIsWpcomAtomic } = this.props;
 
 		if ( siteIsConnected === false ) {
 			return this.renderUnreachableNotice();
 		}
 
-		if ( includes( IncompatiblePlugins, plugin.slug ) && isWpcomAtomicSite ) {
+		if ( ! isCompatiblePlugin( plugin.slug ) && siteIsWpcomAtomic ) {
 			return this.renderIncompatiblePluginNotice();
 		}
 
@@ -342,7 +341,7 @@ export default connect(
 		return {
 			siteId,
 			siteIsConnected: getSiteConnectionStatus( state, siteId ),
-			isWpcomAtomicSite: isSiteWpcomAtomic( state, siteId ),
+			siteIsWpcomAtomic: isSiteWpcomAtomic( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -297,13 +297,13 @@ export class PluginInstallButton extends Component {
 	}
 
 	renderNoticeOrButton() {
-		const { isSiteWpcomAtomic, plugin, selectedSite, siteIsConnected } = this.props;
+		const { isWpcomAtomicSite, plugin, selectedSite, siteIsConnected } = this.props;
 
 		if ( siteIsConnected === false ) {
 			return this.renderUnreachableNotice();
 		}
 
-		if ( includes( IncompatiblePlugins, plugin.slug ) && isSiteWpcomAtomic ) {
+		if ( includes( IncompatiblePlugins, plugin.slug ) && isWpcomAtomicSite ) {
 			return this.renderIncompatiblePluginNotice();
 		}
 
@@ -333,7 +333,6 @@ PluginInstallButton.propTypes = {
 	isInstalling: PropTypes.bool,
 	isMock: PropTypes.bool,
 	disabled: PropTypes.bool,
-	plugin: PropTypes.object.isRequired,
 };
 
 export default connect(

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -25,7 +25,7 @@ import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import config from 'config';
-import { IncompatiblePlugins } from 'my-sites/plugins/incompatible-plugins';
+import { isCompatiblePlugin } from 'my-sites/plugins/plugin-compatibility';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import PluginInformation from 'my-sites/plugins/plugin-information';
@@ -232,15 +232,13 @@ export class PluginMeta extends Component {
 	isWpcomInstallDisabled() {
 		const { isTransfering, plugin } = this.props;
 
-		return (
-			! this.hasBusinessPlan() || includes( IncompatiblePlugins, plugin.slug ) || isTransfering
-		);
+		return ! this.hasBusinessPlan() || ! isCompatiblePlugin( plugin.slug ) || isTransfering;
 	}
 
 	isJetpackInstallDisabled() {
 		const { automatedTransferSite, plugin } = this.props;
 
-		return automatedTransferSite && includes( IncompatiblePlugins, plugin.slug );
+		return automatedTransferSite && ! isCompatiblePlugin( plugin.slug );
 	}
 
 	getInstallButton() {
@@ -263,7 +261,7 @@ export class PluginMeta extends Component {
 	maybeDisplayUnsupportedNotice() {
 		const { plugin, selectedSite } = this.props;
 
-		if ( selectedSite && includes( IncompatiblePlugins, plugin.slug ) ) {
+		if ( selectedSite && ! isCompatiblePlugin( plugin.slug ) ) {
 			return (
 				<Notice
 					text={ this.props.translate(

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -25,6 +25,7 @@ import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import config from 'config';
+import { IncompatiblePlugins } from 'my-sites/plugins/incompatible-plugins';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import PluginInformation from 'my-sites/plugins/plugin-information';
@@ -228,151 +229,18 @@ export class PluginMeta extends Component {
 		} );
 	}
 
-	isUnsupportedPluginForAT() {
-		const { plugin } = this.props;
-
-		// Pressable prevents installation of some plugins, so we need to disable AT for them.
-		// More info here: https://kb.pressable.com/faq/does-pressable-restrict-any-plugins/
-		const unsupportedPlugins = [
-			// "reset" - break/interfere with provided functionality
-			'advanced-database-cleaner',
-			'advanced-reset-wp',
-			'advanced-wp-reset',
-			'armember-membership',
-			'autoptimize',
-			'backup',
-			'better-wp-security',
-			'cf7-pipedrive-integration',
-			'database-browser',
-			'duplicator',
-			'extended-wp-reset',
-			'file-manager-advanced',
-			'file-manager',
-			'plugins-garbage-collector',
-			'post-type-switcher',
-			'reset-wp',
-			'secure-file-manager',
-			'ultimate-wp-reset',
-			'username-changer',
-			'username-updater',
-			'wd-youtube',
-			'wordpress-database-reset',
-			'wordpress-reset',
-			'wp-automatic',
-			'wp-clone-by-wp-academy',
-			'wp-config-file-editor',
-			'wp-dbmanager',
-			'wp-file-manager',
-			'wp-prefix-changer',
-			'wp-reset',
-			'wp-uninstaller-by-azed',
-			'wpmu-database-reset',
-			'wps-hide-login',
-			'z-inventory-manager',
-
-			// backup
-			'backup-wd',
-			'backupwordpress',
-			'backwpup',
-			'wp-db-backup',
-
-			// caching
-			'cache-enabler',
-			'comet-cache',
-			'hyper-cache',
-			'powered-cache',
-			'jch-optimize',
-			'quick-cache',
-			'sg-cachepress',
-			'w3-total-cache',
-			'wp-cache',
-			'wp-fastest-cache',
-			'wp-rocket',
-			'wp-speed-of-light',
-			'wp-super-cache',
-
-			// sql heavy
-			'another-wordpress-classifieds-plugin',
-			'broken-link-checker',
-			'leads',
-			'native-ads-adnow',
-			'ol_scrapes',
-			'page-visit-counter',
-			'post-views-counter',
-			'tokenad',
-			'top-10',
-			'userpro',
-			'wordpress-popular-posts',
-			'wp-cerber',
-			'wp-inject',
-			'wp-postviews',
-			'wp-rss-aggregator',
-			'wp-rss-feed-to-post',
-			'wp-rss-wordai',
-			'wp-session-manager',
-			'wp-slimstat',
-			'wp-statistics',
-			'wp-ulike',
-			'WPRobot5',
-
-			// security
-			'wordfence',
-			'wp-simple-firewall',
-
-			// spam
-			'e-mail-broadcasting',
-			'mailit',
-			'send-email-from-admin',
-
-			// cloning/staging
-			'wp-staging',
-
-			// misc
-			'adult-mass-photos-downloader',
-			'adult-mass-videos-embedder',
-			'ari-adminer',
-			'automatic-video-posts',
-			'bwp-minify',
-			'clearfy',
-			'cornerstone',
-			'cryptocurrency-pricing-list',
-			'event-espresso-decaf',
-			'facetwp-manipulator',
-			'fast-velocity-minify',
-			'nginx-helper',
-			'p3',
-			'porn-embed',
-			'propellerads-official',
-			'speed-contact-bar',
-			'unplug-jetpack',
-			'really-simple-ssl',
-			'robo-gallery',
-			'under-construction-page',
-			'video-importer',
-			'woozone',
-			'wp-cleanfix',
-			'wp-file-upload',
-			'wp-monero-miner-pro',
-			'wp-monero-miner-using-coin-hive',
-			'wp-optimize-by-xtraffic',
-			'wpematico',
-			'yuzo-related-post',
-			'zapp-proxy-server',
-		];
-
-		return includes( unsupportedPlugins, plugin.slug );
-	}
-
 	isWpcomInstallDisabled() {
-		const { isTransfering } = this.props;
+		const { isTransfering, plugin } = this.props;
 
-		return ! this.hasBusinessPlan() || this.isUnsupportedPluginForAT() || isTransfering;
+		return (
+			! this.hasBusinessPlan() || includes( IncompatiblePlugins, plugin.slug ) || isTransfering
+		);
 	}
 
 	isJetpackInstallDisabled() {
-		const { automatedTransferSite } = this.props;
+		const { automatedTransferSite, plugin } = this.props;
 
-		return automatedTransferSite && this.isUnsupportedPluginForAT();
+		return automatedTransferSite && includes( IncompatiblePlugins, plugin.slug );
 	}
 
 	getInstallButton() {
@@ -393,9 +261,9 @@ export class PluginMeta extends Component {
 	}
 
 	maybeDisplayUnsupportedNotice() {
-		const { selectedSite } = this.props;
+		const { plugin, selectedSite } = this.props;
 
-		if ( selectedSite && this.isUnsupportedPluginForAT() ) {
+		if ( selectedSite && includes( IncompatiblePlugins, plugin.slug ) ) {
 			return (
 				<Notice
 					text={ this.props.translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Firstly, this creates a separate file for the list of incompatible plugins, so it can be used in multiple files. 

It also prevents incompatible ones being installed on WP.com Atomic sites on the "All My Sites" view, since that was causing a series of bugs as mentioned in the initial issue.

<img width="876" alt="Screenshot 2020-01-22 at 19 18 02" src="https://user-images.githubusercontent.com/43215253/72926999-4d7c7680-3d4d-11ea-8cd4-f43c054e1422.png">

#### Testing instructions

1. Ensure you have a WP.com atomic site 
2. Visit `/plugins/wp-super-cache` (example of an incompatible plugin) and verify that you **can't** install it on your WP.com atomic site
3. Visit `/plugins/woocommerce` (example of a compatible plugin) and verify that you **can** install it on your WP.com atomic site

The wording is similar to the error that appears when you visit the plugin page on a single-site view. If you'd like, you can verify this still appears, since that now uses the list created in this PR.

<img width="911" alt="Screenshot 2020-01-22 at 19 44 36" src="https://user-images.githubusercontent.com/43215253/72928352-b9f87500-3d4f-11ea-817a-fee4fc4375d5.png"> 

Fixes #17305
