### PR TITLE
Customer Home: Remove margin bottom of "Go Mobile" card on mobile devices

### DIFF
--- a/client/my-sites/customer-home/go-mobile-card/style.scss
+++ b/client/my-sites/customer-home/go-mobile-card/style.scss
@@ -1,7 +1,3 @@
-.go-mobile-card__row {
-	margin-bottom: 1rem;
-}
-
 .go-mobile-card__subheader {
 	color: var( --color-text-subtle );
 	font-size: 0.85rem;
@@ -17,6 +13,7 @@
 }
 
 .go-mobile-card__email-link-button {
+	margin-top: 1rem;
 	width: 100%;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After hiding the "email download link" button on mobile devices in https://github.com/Automattic/wp-calypso/pull/38960, I noted there is an extra margin at the bottom we missed to remove (since that margin is intended for separating the badges from the button).

This PR removes the margin the card is displayed on mobile devices.

Mobile device | Before | After
--- | --- | ---
iPhone / Android | <img width="407" alt="Screenshot 2020-01-23 at 13 59 22" src="https://user-images.githubusercontent.com/1233880/72986908-8c600a00-3de9-11ea-8f02-497a60adddeb.png"> | <img width="404" alt="Screenshot 2020-01-23 at 13 59 51" src="https://user-images.githubusercontent.com/1233880/72986925-941fae80-3de9-11ea-90e6-8d0c1fad8938.png">
Other | <img width="417" alt="Screenshot 2020-01-23 at 14 00 59" src="https://user-images.githubusercontent.com/1233880/72986944-a4378e00-3de9-11ea-82d7-ac1a8d76b548.png"> | <img width="415" alt="Screenshot 2020-01-23 at 14 01 12" src="https://user-images.githubusercontent.com/1233880/72986959-aa2d6f00-3de9-11ea-83b5-b5df7cf2f28e.png">

#### Testing instructions

* Go to `/home/:site`.
* On a desktop viewport, verify the store badges are still separated from the "Email download link" button.
* On a mobile viewport, verify there is no margin below the store badges (see screenshots above).
