### PR TITLE
Update deps: Skip pupeteer install

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"test-server:watch": "npm run -s test-server -- --watch",
 		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!apps/full-site-editing/**' '!**/node_modules/**'",
 		"typecheck": "tsc --noEmit",
-		"update-deps": "npx rimraf package-lock.json && npm run -s distclean && npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
+		"update-deps": "npx rimraf package-lock.json && npm run -s distclean && cross-env-shell PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
 		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",
 		"whybundled": "whybundled stats.json",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"test-server:watch": "npm run -s test-server -- --watch",
 		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!apps/full-site-editing/**' '!**/node_modules/**'",
 		"typecheck": "tsc --noEmit",
-		"update-deps": "npx rimraf package-lock.json && npm run -s distclean && cross-env-shell PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
+		"update-deps": "npx rimraf package-lock.json && npm run -s distclean && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
 		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",
 		"whybundled": "whybundled stats.json",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't install pupeteer on `update-deps`, like #38900 (https://github.com/Automattic/wp-calypso/pull/38900#pullrequestreview-347276574)

#### Testing instructions

`npm run update-deps` works and skips pupeteer.