### PR TITLE
Jetpack: fix full sync UI

### DIFF
--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -68,7 +68,7 @@ function isPendingSyncStart( state, siteId ) {
  * @param  {number} siteId   Site ID
  * @returns {boolean}        Whether a site is using immediate full sync
  */
-function isImmediateFull( state, siteId ) {
+function isImmediateFullSync( state, siteId ) {
 	const syncStatus = getSyncStatus( state, siteId );
 	return ! get( syncStatus, 'queue' ); // Immediate full sync sites will not have a `queue` property.
 }
@@ -131,7 +131,7 @@ function isFullSyncing( state, siteId ) {
  * @returns {number}          The percentage of sync completed, expressed as an integer
  */
 function getSyncProgressPercentage( state, siteId ) {
-	if ( isImmediateFull( state, siteId ) ) {
+	if ( isImmediateFullSync( state, siteId ) ) {
 		return getImmediateSyncProgressPercentage( state, siteId );
 	}
 
@@ -181,4 +181,5 @@ export default {
 	isPendingSyncStart,
 	isFullSyncing,
 	getSyncProgressPercentage,
+	isImmediateFullSync,
 };

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -6,6 +6,7 @@ import { get, reduce } from 'lodash';
 
 /**
  * Returns a sync status object by site ID.
+ *
  * @param  {object} state    Global state tree
  * @param  {number} siteId   Site ID
  * @returns {object}          Sync status object
@@ -16,6 +17,7 @@ function getSyncStatus( state, siteId ) {
 
 /**
  * Returns a full sync request object by site ID.
+ *
  * @param  {object} state    Global state tree
  * @param  {number} siteId   Site ID
  * @returns {object}          Full sync request object
@@ -26,6 +28,7 @@ function getFullSyncRequest( state, siteId ) {
 
 /**
  * Returns a boolean for whether a full sync is pending start.
+ *
  * @param  {object} state    Global state tree
  * @param  {number} siteId   Site ID
  * @returns {boolean}         Whether a sync is pending start for site
@@ -59,7 +62,33 @@ function isPendingSyncStart( state, siteId ) {
 }
 
 /**
+ * Sites on Jetpack 8.2 may be using an immediate full sync.
+ *
+ * @param  {object} state    Global state tree
+ * @param  {number} siteId   Site ID
+ * @returns {boolean}        Whether a site is using immediate full sync
+ */
+function isImmediateFull( state, siteId ) {
+	const syncStatus = getSyncStatus( state, siteId );
+	return get( syncStatus, 'config' );
+}
+
+/**
+ * Returns a rounded up percentage the amount of sync completed for sites using immediate full sync.
+ *
+ * @param  {object} state    Global state tree
+ * @param  {number} siteId   Site ID
+ * @returns {number}         The percentage of sync completed, expressed as an integer
+ */
+function getImmediateSyncProgressPercentage( state, siteId ) {
+	const syncStatus = getSyncStatus( state, siteId );
+	console.log( 'doing IFS', syncStatus );
+	return 50;
+}
+
+/**
  * Returns a boolean for whether a site is in the process of a full sync.
+ *
  * @param  {object} state    Global state tree
  * @param  {number} siteId   Site ID
  * @returns {boolean}         Whether a sync is in the process of syncing
@@ -77,12 +106,16 @@ function isFullSyncing( state, siteId ) {
 }
 
 /**
- * Returns a rounded up percentage the amount of sync completed.
+ * Returns a rounded up percentage the amount of sync completed for sites using legacy full sync.
+ *
  * @param  {object} state    Global state tree
  * @param  {number} siteId   Site ID
  * @returns {number}          The percentage of sync completed, expressed as an integer
  */
 function getSyncProgressPercentage( state, siteId ) {
+	if ( isImmediateFull( state, siteId ) ) {
+		return getImmediateSyncProgressPercentage( state, siteId );
+	}
 	const syncStatus = getSyncStatus( state, siteId ),
 		queued = get( syncStatus, 'queue' ),
 		sent = get( syncStatus, 'sent' ),
@@ -120,7 +153,6 @@ function getSyncProgressPercentage( state, siteId ) {
 
 	const percentQueued = ( countQueued / countTotal ) * queuedMultiplier * 100;
 	const percentSent = ( countSent / countTotal ) * sentMultiplier * 100;
-
 	return Math.ceil( percentQueued + percentSent );
 }
 

--- a/client/state/jetpack-sync/test/reducer.js
+++ b/client/state/jetpack-sync/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { without } from 'lodash';
 
 /**
  * Internal dependencies
@@ -219,12 +220,15 @@ describe( 'reducer', () => {
 			expect( state )
 				.to.have.property( successfulSyncStatusRequest.siteId )
 				.to.have.all.keys(
-					getExpectedResponseKeys().concat( [
-						'error',
-						'isRequesting',
-						'lastSuccessfulStatus',
-						'errorCounter',
-					] )
+					without(
+						getExpectedResponseKeys().concat( [
+							'error',
+							'isRequesting',
+							'lastSuccessfulStatus',
+							'errorCounter',
+						] ),
+						'progress'
+					) // legacy sync status will not have `progress` property.
 				);
 		} );
 

--- a/client/state/jetpack-sync/test/selectors.js
+++ b/client/state/jetpack-sync/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	isPendingSyncStart,
 	isFullSyncing,
 	getSyncProgressPercentage,
+	isImmediateFullSync,
 } from '../selectors';
 
 const nonExistentId = '111111';
@@ -414,6 +415,18 @@ describe( 'selectors', () => {
 		test( 'should return accurate percent based on progress propety', () => {
 			const test = getSyncProgressPercentage( testState, immediateSyncId );
 			expect( test ).to.be.eql( 7 );
+		} );
+	} );
+
+	describe( '#isImmediateFullSync', () => {
+		test( 'should return false for sites running legacy sync', () => {
+			expect( isImmediateFullSync( testState, successfulSiteId ) ).to.be.false;
+			expect( isImmediateFullSync( testState, syncScheduledSiteID ) ).to.be.false;
+			expect( isImmediateFullSync( testState, syncStartedSiteId ) ).to.be.false;
+			expect( isImmediateFullSync( testState, syncInProgressSiteId ) ).to.be.false;
+		} );
+		test( 'should return true for sites running immediate sync', () => {
+			expect( isImmediateFullSync( testState, immediateSyncId ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/jetpack-sync/test/selectors.js
+++ b/client/state/jetpack-sync/test/selectors.js
@@ -22,6 +22,7 @@ const syncScheduledSiteID = '123455';
 const oldSyncSiteId = '987654321';
 const syncStartedSiteId = '87654321';
 const syncInProgressSiteId = '7654321';
+const immediateSyncId = '22222222';
 
 const syncStatusSuccessful = {
 	started: 1470085369,
@@ -236,6 +237,38 @@ const syncStatusInProgress = {
 	lastSuccessfulStatus: 1470069406000,
 };
 
+const syncStatusImmediate = {
+	started: 1579811550,
+	config: {
+		constants: true,
+		functions: true,
+		options: true,
+		terms: true,
+		themes: true,
+		users: true,
+		posts: true,
+		comments: true,
+		updates: true,
+		term_relationships: true,
+	},
+	queue_size: 0,
+	queue_lag: 0,
+	is_scheduled: false,
+	lastSuccessfulStatus: 1579811570143,
+	progress: {
+		constants: { total: 20, sent: 20, finished: true },
+		functions: { total: 33, sent: 33, finished: true },
+		options: { total: 142, sent: 0, finished: false },
+		updates: { total: 3, sent: 0, finished: false },
+		themes: { total: 1, sent: 0, finished: false },
+		users: { total: '7', sent: 0, finished: false },
+		terms: { total: '70', sent: 0, finished: false },
+		posts: { total: '203', sent: 0, finished: false },
+		comments: { total: '31', sent: 0, finished: false },
+		term_relationships: { total: '253', sent: 0, finished: false },
+	},
+};
+
 const fullSyncRequested = {
 	isRequesting: true,
 	lastRequested: 1467944517955,
@@ -273,6 +306,7 @@ const testState = {
 			[ oldSyncSiteId ]: syncStatusSuccessful,
 			[ syncStartedSiteId ]: syncStatusStarted,
 			[ syncInProgressSiteId ]: syncStatusInProgress,
+			[ immediateSyncId ]: syncStatusImmediate,
 		},
 		fullSyncRequest: {
 			[ requestedSiteId ]: fullSyncRequested,
@@ -373,6 +407,13 @@ describe( 'selectors', () => {
 		test( 'should return a non-zero integer if site has sent data to be synced', () => {
 			const test = getSyncProgressPercentage( testState, syncInProgressSiteId );
 			expect( test ).to.be.eql( 11 );
+		} );
+	} );
+
+	describe( '#getImmediateSyncProgressPercentage', () => {
+		test( 'should return accurate percent based on progress propety', () => {
+			const test = getSyncProgressPercentage( testState, immediateSyncId );
+			expect( test ).to.be.eql( 7 );
 		} );
 	} );
 } );

--- a/client/state/jetpack-sync/utils.js
+++ b/client/state/jetpack-sync/utils.js
@@ -17,6 +17,7 @@ export function getExpectedResponseKeys() {
 		'is_scheduled',
 		'total',
 		'config',
+		'progress',
 		'queue_size',
 		'queue_lag',
 		'full_queue_size',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures that the full sync UI in Settings -> Manage Site Connections works with the newly designed full sync.

#### Testing instructions

* Get this branch running locally at calypso.localhost:3000
* Ensure you get progress updates when you run a full sync for a Jetpack site
 * Find this UI in Settings -> General -> Manage Your Connection
 * Try with both a Jetpack site running latest stable, and a Jetpack site running bleeding edge
