### PR TITLE
Gutenboarding: Send customers to home after frankenflow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -15,7 +15,6 @@ export function generateFlows( {
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
 	getLaunchDestination = noop,
-	getEditorDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
 } = {} ) {
@@ -357,7 +356,7 @@ export function generateFlows( {
 	if ( isEnabled( 'gutenboarding' ) ) {
 		flows.frankenflow = {
 			steps: [ 'user', 'domains', 'plans' ],
-			destination: getEditorDestination,
+			destination: getSignupDestination,
 			description: 'Frankenflow testing flow for Gutenboarding',
 			lastModified: '2020-01-22',
 			pageTitle: translate( 'Launch your site' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Send users to Customer Home after completing the signup flow.

Fixes #38937

#### Testing instructions

* [`/start/frankenflow`](https://calypso.live/start/frankenflow?branch=gutenboarding/frankenflow-customer-home)
* Follow the steps and you should land at customer home `/home/SITE_SLUG` when the flow is complete.