### PR TITLE
Jetpack Cloud: add basic styles

### DIFF
--- a/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
+++ b/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
@@ -1,0 +1,60 @@
+// Jetpack Cloud color scheme for Calypso
+.color-scheme.is-group-jetpack-cloud {
+	/* Theme Properties */
+	--color-link: var( --studio-jetpack-green-40 );
+	--color-link-rgb: var( --studio-jetpack-green-40-rgb );
+	--color-link-dark: var( --studio-jetpack-green-60 );
+	--color-link-dark-rgb: var( --studio-jetpack-green-60-rgb );
+	--color-link-light: var( --studio-jetpack-green-20 );
+	--color-link-light-rgb: var( --studio-jetpack-green-20-rgb );
+	--color-link-0: var( --studio-jetpack-green-0 );
+	--color-link-0-rgb: var( --studio-jetpack-green-0-rgb );
+	--color-link-5: var( --studio-jetpack-green-5 );
+	--color-link-5-rgb: var( --studio-jetpack-green-5-rgb );
+	--color-link-10: var( --studio-jetpack-green-10 );
+	--color-link-10-rgb: var( --studio-jetpack-green-10-rgb );
+	--color-link-20: var( --studio-jetpack-green-20 );
+	--color-link-20-rgb: var( --studio-jetpack-green-20-rgb );
+	--color-link-30: var( --studio-jetpack-green-30 );
+	--color-link-30-rgb: var( --studio-jetpack-green-30-rgb );
+	--color-link-40: var( --studio-jetpack-green-40 );
+	--color-link-40-rgb: var( --studio-jetpack-green-40-rgb );
+	--color-link-50: var( --studio-jetpack-green-50 );
+	--color-link-50-rgb: var( --studio-jetpack-green-50-rgb );
+	--color-link-60: var( --studio-jetpack-green-60 );
+	--color-link-60-rgb: var( --studio-jetpack-green-60-rgb );
+	--color-link-70: var( --studio-jetpack-green-70 );
+	--color-link-70-rgb: var( --studio-jetpack-green-70-rgb );
+	--color-link-80: var( --studio-jetpack-green-80 );
+	--color-link-80-rgb: var( --studio-jetpack-green-80-rgb );
+	--color-link-90: var( --studio-jetpack-green-90 );
+	--color-link-90-rgb: var( --studio-jetpack-green-90-rgb );
+	--color-link-100: var( --studio-jetpack-green-100 );
+	--color-link-100-rgb: var( --studio-jetpack-green-100-rgb );
+
+	--color-surface: var( --studio-white );
+	--color-surface-rgb: var( --studio-white-rgb );
+	--color-surface-backdrop: var( --studio-white );
+	--color-surface-backdrop-rgb: var( --studio-white-rgb );
+
+	--color-text: var( --studio-gray-80 );
+	--color-text-rgb: var( --studio-gray-80-rgb );
+	--color-text-subtle: var( --studio-gray-60 );
+	--color-text-subtle-rgb: var( --studio-gray-60-rgb );
+	--color-text-inverted: var( --studio-white );
+	--color-text-inverted-rgb: var( --studio-white-rgb );
+
+	/* Component Properties */
+	--color-sidebar-background: var( --studio-gray-0 );
+	--color-sidebar-background-rgb: var( --studio-gray-0-rgb );
+	--color-sidebar-border: var( --studio-gray-5 );
+	--color-sidebar-text: var( --studio-gray-60 );
+	--color-sidebar-text-alternative: var( --studio-gray-70 );
+	--color-sidebar-gridicon-fill: var( --studio-gray-60 );
+	--color-sidebar-menu-selected-background: var( --studio-jetpack-green-10 );
+	--color-sidebar-menu-selected-background-rgb: var( --studio-jetpack-green-10-rgb );
+	--color-sidebar-menu-selected-text: var( --studio-jetpack-green-50 );
+	--color-sidebar-menu-hover-background: var( --studio-gray-5 );
+	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
+	--color-sidebar-menu-hover-text: var( --studio-gray-70 );
+}

--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -1,6 +1,10 @@
 // Color Schemes
-// Currently used only by Calypso dev badge shown in development mode
+// We're using the default base color scheme that gets altered by Jetpack Cloud custom scheme
 @import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import './calypso-color-scheme-jetpack-cloud';
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined
+
+// Global layout
+@import 'main';


### PR DESCRIPTION
This PR adds a basic Jetpack Cloud styles and Calypso color scheme.

It's best to test it out after #39011 is merged so that the sidebar has some structure:

<img width="637" alt="Screenshot 2020-01-23 at 17 53 31" src="https://user-images.githubusercontent.com/478735/73005840-ed97d580-3e09-11ea-9ae9-df27236485a9.png">

#### Changes proposed in this Pull Request

* Add basic Jetpack Cloud styles
* Add Calypso color scheme for Jetpack Cloud

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It's best to test after #39011 is merged. Optionally, you can rebase locally in order to see the Jetpack Cloud sidebar.

* Go to http://calypso.localhost:3000/jetpack-cloud
* Confirm that some basic styles are used on the page (custom fonts, Cloud color scheme, etc.)

Fixes n/a
