### PR TITLE
Update Jetpack Sync Status to handle fast completes

### DIFF
--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -51,17 +51,19 @@ export function fullSyncRequest( state = {}, action ) {
 
 export function syncStatus( state = {}, action ) {
 	switch ( action.type ) {
-		case JETPACK_SYNC_START_REQUEST:
+		case JETPACK_SYNC_START_REQUEST: {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: {},
 			} );
-		case JETPACK_SYNC_STATUS_REQUEST:
+		}
+		case JETPACK_SYNC_STATUS_REQUEST: {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: Object.assign( {}, get( state, [ action.siteId ], {} ), {
 					isRequesting: true,
 				} ),
 			} );
-		case JETPACK_SYNC_STATUS_SUCCESS:
+		}
+		case JETPACK_SYNC_STATUS_SUCCESS: {
 			const thisState = get( state, [ action.siteId ], {} );
 
 			// lastSuccessfulStatus is any status after we have started sycing
@@ -89,7 +91,8 @@ export function syncStatus( state = {}, action ) {
 					pick( action.data, getExpectedResponseKeys() )
 				),
 			} );
-		case JETPACK_SYNC_STATUS_ERROR:
+		}
+		case JETPACK_SYNC_STATUS_ERROR: {
 			const errorCounter = get( state, [ action.siteId, 'errorCounter' ], 0 );
 			return Object.assign( {}, state, {
 				[ action.siteId ]: Object.assign(
@@ -101,6 +104,7 @@ export function syncStatus( state = {}, action ) {
 					pick( action.data, getExpectedResponseKeys() )
 				),
 			} );
+		}
 	}
 	return state;
 }

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -72,7 +72,7 @@ export function syncStatus( state = {}, action ) {
 			}
 
 			// Check if Sync Completed before seeing a successful status request
-			if ( false !== get( thisState, 'started', false ) ) {
+			if ( false === lastSuccessfulStatus ) {
 				if ( get( action, 'data.started' ) < get( action, 'data.finished' ) ) {
 					lastSuccessfulStatus = Date.now();
 				}

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -70,6 +70,14 @@ export function syncStatus( state = {}, action ) {
 			if ( lastSuccessfulStatus || isFullSyncing ) {
 				lastSuccessfulStatus = Date.now();
 			}
+
+			// Check if Sync Completed before seeing a successful status request
+			if ( false !== get( thisState, 'started', false ) ) {
+				if ( get( action, 'data.started' ) < get( action, 'data.finished' ) ) {
+					lastSuccessfulStatus = Date.now();
+				}
+			}
+
 			return Object.assign( {}, state, {
 				[ action.siteId ]: Object.assign(
 					{

--- a/client/state/jetpack-sync/test/reducer.js
+++ b/client/state/jetpack-sync/test/reducer.js
@@ -214,6 +214,16 @@ describe( 'reducer', () => {
 				.to.be.at.least( startTime );
 		} );
 
+		test( 'should set lastSuccessfulStatus to current time when finished without progress for a site', () => {
+			let state = syncStatus( undefined, {} );
+			const startTime = Date.now();
+			state = syncStatus( state, successfulSyncStatusRequest );
+			expect( state )
+				.to.have.property( String( successfulSyncStatusRequest.siteId ) )
+				.to.have.property( 'lastSuccessfulStatus' )
+				.to.be.at.least( startTime );
+		} );
+
 		test( 'should store expected response keys on success', () => {
 			const state = syncStatus( undefined, successfulSyncStatusRequest );
 			expect( state )


### PR DESCRIPTION
Currently if a site doesn't have a lot of content to sync the progress bar never updates as it is stuck in initiating state. 

#### Changes proposed in this Pull Request
Update the sync status check so that when checking for status updates it can toggle to the progress bar if the sync requested has already finished.

#### Testing instructions

* Connect a Site via Jetpack with a small amount of content, (A new site with default content works
* Go to Settings > General > Site Tools > Manage Your Connection
* Click on "initiate a full sync"
* Progress bar will display "Full sync will begin shortly" and not progress further

Apply Patch 

* Click on "initiate a full sync"
* Progress bar will display "Full sync will begin shortly" 
* Progress bar will update to "Full sync in progress"
* Progress bar will update to "Last fully synced a few seconds ago"
