### PR TITLE
Activity log: highlight support first on non-fixable threats

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -44,6 +44,10 @@ export class ThreatAlert extends Component {
 		this.props.ignoreThreat( this.props.siteId, this.props.threat.id );
 	};
 
+	handleGetHelp = () => {
+		window.open( JETPACK_CONTACT_SUPPORT, '_blank' );
+	};
+
 	refreshRewindState = () => this.props.requestRewindState( this.props.siteId );
 
 	getDetailType() {
@@ -351,29 +355,26 @@ export class ThreatAlert extends Component {
 									<SplitButton
 										compact
 										primary
-										label={
-											threat.fixable ? translate( 'Fix threat' ) : translate( 'Ignore threat' )
-										}
-										onClick={ threat.fixable ? this.handleFix : this.handleIgnore }
+										label={ threat.fixable ? translate( 'Fix threat' ) : translate( 'Get help' ) }
+										onClick={ threat.fixable ? this.handleFix : this.handleGetHelp }
 										disabled={ inProgress }
 									>
-										<PopoverMenuItem
-											href={ JETPACK_CONTACT_SUPPORT }
-											className="activity-log__threat-menu-item"
-											icon="chat"
-											target="_blank"
-										>
-											<span>{ translate( 'Get help' ) }</span>
-										</PopoverMenuItem>
 										{ threat.fixable && (
 											<PopoverMenuItem
-												onClick={ this.handleIgnore }
+												onClick={ this.handleGetHelp }
 												className="activity-log__threat-menu-item"
-												icon="trash"
+												icon="chat"
 											>
-												<span>{ translate( 'Ignore threat' ) }</span>
+												<span>{ translate( 'Get help' ) }</span>
 											</PopoverMenuItem>
 										) }
+										<PopoverMenuItem
+											onClick={ this.handleIgnore }
+											className="activity-log__threat-menu-item"
+											icon="trash"
+										>
+											<span>{ translate( 'Ignore threat' ) }</span>
+										</PopoverMenuItem>
 									</SplitButton>
 								</div>
 								<span className="activity-log__threat-alert-type">{ this.renderSubtitle() }</span>

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -45,6 +45,7 @@ export class ThreatAlert extends Component {
 	};
 
 	handleGetHelp = () => {
+		this.props.trackGetHelp( this.props.threat.id );
 		window.open( JETPACK_CONTACT_SUPPORT, '_blank' );
 	};
 
@@ -404,5 +405,7 @@ export default connect( mapStateToProps, {
 			recordTracksEvent( 'calypso_activitylog_threat_ignore', { threat_id: threatId } ),
 			ignoreThreatAlert( siteId, threatId )
 		),
+	trackGetHelp: threatId =>
+		recordTracksEvent( 'calypso_activitylog_threat_gethelp', { threat_id: threatId } ),
 	requestRewindState,
 } )( localize( ThreatAlert ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update split menu to highlight support first on non-fixable threats.
* Moves `Get help` to the splitMenu face and hides `Ignore threat` inside the menu.
* See p6TEKc-3qn-p2 for more context.

#### Testing instructions

* Spin up this PR.
* Open the Activity log with a site that contains active non-fixable threats.
* Ensure the menu has the right order and that all actions work as expected.

#### Notes

Would love to add tracking to the `Get help` option, any takers?

#### Before

![image](https://user-images.githubusercontent.com/390760/73016199-4e78db00-3e15-11ea-883d-27f005ce6f8c.png)

#### After

![image](https://user-images.githubusercontent.com/390760/73016210-559fe900-3e15-11ea-8c96-d9cfa7931382.png)
