### PR TITLE
Gutenboarding: Change colors for signup for new flow

### DIFF
--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -33,9 +33,10 @@ const addBodyClass = toClass => value => () => {
 const addGroupClass = addBodyClass( g => `is-group-${ g }` );
 const addSectionClass = addBodyClass( s => `is-section-${ s }` );
 
-export default function BodySectionCssClass( { group, section } ) {
+export default function BodySectionCssClass( { group, section, bodyClass } ) {
 	React.useEffect( addGroupClass( group ), [ group ] );
 	React.useEffect( addSectionClass( section ), [ section ] );
+	React.useEffect( () => bodyClass && document.body.classList.add( bodyClass ) );
 
 	return null;
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -125,9 +125,23 @@ class Layout extends Component {
 			}
 		);
 
+		const optionalBodyProps = () => {
+			const optionalProps = {};
+
+			if ( this.props.isFrankenflow ) {
+				optionalProps.bodyClass = 'is-frankenflow';
+			}
+
+			return optionalProps;
+		};
+
 		return (
 			<div className={ sectionClass }>
-				<BodySectionCssClass group={ this.props.sectionGroup } section={ this.props.sectionName } />
+				<BodySectionCssClass
+					group={ this.props.sectionGroup }
+					section={ this.props.sectionName }
+					{ ...optionalBodyProps() }
+				/>
 				<HtmlIsIframeClassname />
 				<DocumentHead />
 				<QuerySites primaryAndRecent />
@@ -206,6 +220,7 @@ export default connect( state => {
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
+	const isFrankenflow = startsWith( currentRoute, '/start/frankenflow' );
 
 	return {
 		masterbarIsHidden:
@@ -234,5 +249,6 @@ export default connect( state => {
 		authorization, it would remove the newly connected site that has been fetched separately.
 		See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
+		isFrankenflow,
 	};
 } )( Layout );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -310,6 +310,18 @@ body.is-section-signup.is-frankenflow {
 	.signup-processing-screen__floaties .gridicon {
 		fill: var( --color-text );
 	}
+
+	.button.is-borderless.navigation-link {
+		color: var( --color-text );
+
+		svg {
+			fill: var( --color-text );
+		}
+	}
+
+	.flow-progress-indicator.flow-progress-indicator__frankenflow {
+		color: var( --color-text );
+	}
 }
 
 // Text and heading color override for new flow

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -294,3 +294,45 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		}
 	}
 }
+
+// Background color override for new flow
+body.is-section-signup.is-frankenflow {
+	background: var( --color-surface-backdrop );
+
+	.signup-header .wordpress-logo {
+		fill: var( --color-wordpress-com );
+	}
+
+	.signup-processing-screen__content {
+		color: var( --color-text );
+	}
+
+	.signup-processing-screen__floaties .gridicon {
+		fill: var( --color-text );
+	}
+}
+
+// Text and heading color override for new flow
+body.is-section-signup.is-frankenflow .layout:not( .dops ):not( .is-wccom-oauth-flow ) {
+	&.gravatar .formatted-header, .formatted-header {
+		.formatted-header__title {
+			color: var( --color-text );
+		}
+	
+		.formatted-header__subtitle {
+			color: var( --color-text );
+		}
+	
+		a {
+			color: var( --color-link );
+	
+			&:hover {
+				color: var( --color-link-dark );
+			}
+		}
+	}
+
+	.empty-content .empty-content__title {
+		color: var( --color-text );
+	}
+}


### PR DESCRIPTION
### Summary

This PR changes the colors in the signup process, only for the Gutenboarding/frankenflow signup flow, to match the [designs](https://github.com/Automattic/wp-calypso/issues/38934).

- Adds a custom class to the body through the `Layout` component when visiting the frankenflow route.
- Overrides existing styles for primary-colored background and inverted text/headers.

<hr>

### Specifics

- This does cause a flash of primary when visiting the `/frankenflow` route, as the `.is-frankenflow` class isn't added to the body until after the route is available in the `Layout` component - slightly later than the `.is-section-signup` class.
     - I imagine we can come back to this later, when we have more flags for Gutenboarding/Frankenflow in the store to hook into, instead of creating an arbitrary one now.
- Not sure the best naming system to use here, can take suggestions for an alternative to `.is-frankenflow`.
- Made the WP logo the brand default - this could also probably be a muted gray instead.

<hr>

### Screenshots

<img width="1433" alt="Screen Shot 2020-01-23 at 4 57 52 PM" src="https://user-images.githubusercontent.com/8892849/73027521-968e0280-3e01-11ea-95d6-b5c310b7ba40.png">
<img width="1429" alt="Screen Shot 2020-01-23 at 4 58 02 PM" src="https://user-images.githubusercontent.com/8892849/73027522-968e0280-3e01-11ea-9a05-6a71ab65b984.png">
<img width="1428" alt="Screen Shot 2020-01-23 at 4 58 12 PM" src="https://user-images.githubusercontent.com/8892849/73027523-968e0280-3e01-11ea-8d2c-d7ec00eccc42.png">

<hr>

### Testing

* Navigate to `/start/frankenflow`.
    * Ensure that the background is a light color, and text on the page is an appropriate contrasting color.
* Navigate to `/start`.
    * Ensure there are no regressions.

<hr>

Part of #38934