### PR TITLE
Gutenboarding - Add editor overrides + "Launch" Button

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/editor.js
+++ b/apps/wpcom-block-editor/src/calypso/editor.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import './features/iframe-bridge-server';
-
+import './features/launch-button-override';
 /**
  * Style dependencies
  */

--- a/apps/wpcom-block-editor/src/calypso/editor.js
+++ b/apps/wpcom-block-editor/src/calypso/editor.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import './features/iframe-bridge-server';
-import './features/launch-button-override';
+import './features/gutenboarding-editor-overrides';
 /**
  * Style dependencies
  */

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -14,7 +14,21 @@ import { __ } from '@wordpress/i18n';
 import './gutenboarding-editor-overrides.scss';
 
 domReady( () => {
-	// Ensure settings bar is rendered before proceeding.
+	calypsoifyGutenberg.isGutenboarding && updateEditor();
+	// Hook fallback incase setGutenboardingStatus runs after initial dom render.
+	window.wp.hooks.addAction( 'setGutenboardingStatus', 'a8c-gutenboarding', isGutenboarding => {
+		isGutenboarding && updateEditor();
+	} );
+} );
+
+function updateEditor() {
+	const body = document.querySelector( 'body' );
+	body.classList.add( 'gutenboarding-editor-overrides' );
+
+	updateSettingsBar();
+}
+
+function updateSettingsBar() {
 	const awaitSettingsBar = setInterval( () => {
 		const settingsBar = document.querySelector( '.edit-post-header__settings' );
 		if ( ! settingsBar ) {
@@ -22,34 +36,23 @@ domReady( () => {
 		}
 		clearInterval( awaitSettingsBar );
 
-		calypsoifyGutenberg.isGutenboarding && updateSettingsBar( settingsBar );
-		// Hook fallback incase updateLaunchButton data is set after initial dom render.
-		window.wp.hooks.addAction( 'updateLaunchButton', 'a8c-gutenboarding', isGutenboarding => {
-			isGutenboarding && updateSettingsBar( settingsBar );
-		} );
+		// 'Update'/'Publish' primary button to become 'Save' tertiary button.
+		const saveButton = settingsBar.querySelector( '.editor-post-publish-button' );
+		saveButton && ( saveButton.innerText = __( 'Save' ) );
+
+		// Create a 'Launch' button.
+		const launchButton = document.createElement( 'button' );
+		launchButton.className =
+			'gutenboarding-editor-overrides__launch-button components-button is-primary';
+		launchButton.innerText = __( 'Launch' );
+
+		// Wrap 'Launch' button in anchor to frankenflow.
+		const launchButtonWrapper = document.createElement( 'a' );
+		launchButtonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
+		launchButtonWrapper.append( launchButton );
+
+		// Put 'Launch' and 'Save' back on bar in desired order.
+		settingsBar.prepend( launchButtonWrapper );
+		settingsBar.prepend( saveButton );
 	} );
-} );
-
-function updateSettingsBar( settingsBar ) {
-	// Add gutenboarding-editor class to body (so React re-render wont reset the added class).
-	const body = document.querySelector( 'body' );
-	body.classList.add( 'gutenboarding-editor-overrides' );
-
-	// 'Update'/'Publish' primary button to become 'Save' tertiary button.
-	const saveButton = settingsBar.querySelector( '.editor-post-publish-button' );
-	saveButton && ( saveButton.innerText = __( 'Save' ) );
-
-	// Create a 'Launch' button.
-	const launchButton = document.createElement( 'button' );
-	launchButton.className = 'gutenboarding-editor-overrides__launch-button components-button is-primary';
-	launchButton.innerText = __( 'Launch' );
-
-	// Wrap 'Launch' button in anchor to frankenflow.
-	const launchButtonWrapper = document.createElement( 'a' );
-	launchButtonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
-	launchButtonWrapper.append( launchButton );
-
-	// Put 'Launch' and 'Save' back on bar in desired order.
-	settingsBar.prepend( launchButtonWrapper );
-	settingsBar.prepend( saveButton );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -49,6 +49,7 @@ function updateSettingsBar() {
 		// Wrap 'Launch' button in anchor to frankenflow.
 		const launchButtonWrapper = document.createElement( 'a' );
 		launchButtonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
+		launchButtonWrapper.target = '_top';
 		launchButtonWrapper.append( launchButton );
 
 		// Put 'Launch' and 'Save' back on bar in desired order.

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './launch-button-override.scss';
+import './gutenboarding-editor-overrides.scss';
 
 domReady( () => {
 	// Ensure settings bar is rendered before proceeding.
@@ -22,18 +22,18 @@ domReady( () => {
 		}
 		clearInterval( awaitSettingsBar );
 
-		calypsoifyGutenberg.isGutenboarding && updateButtonBar( settingsBar );
+		calypsoifyGutenberg.isGutenboarding && updateSettingsBar( settingsBar );
 		// Hook fallback incase updateLaunchButton data is set after initial dom render.
 		window.wp.hooks.addAction( 'updateLaunchButton', 'a8c-gutenboarding', isGutenboarding => {
-			isGutenboarding && updateButtonBar( settingsBar );
+			isGutenboarding && updateSettingsBar( settingsBar );
 		} );
 	} );
 } );
 
-function updateButtonBar( settingsBar ) {
+function updateSettingsBar( settingsBar ) {
 	// Add gutenboarding-editor class to body (so React re-render wont reset the added class).
 	const body = document.querySelector( 'body' );
-	body.classList.add( 'gutenboarding-editor' );
+	body.classList.add( 'gutenboarding-editor-overrides' );
 
 	// 'Update'/'Publish' primary button to become 'Save' tertiary button.
 	const saveButton = settingsBar.querySelector( '.editor-post-publish-button' );
@@ -41,7 +41,7 @@ function updateButtonBar( settingsBar ) {
 
 	// Create a 'Launch' button.
 	const launchButton = document.createElement( 'button' );
-	launchButton.className = 'launch-button-override__launch-button components-button is-primary';
+	launchButton.className = 'gutenboarding-editor-overrides__launch-button components-button is-primary';
 	launchButton.innerText = __( 'Launch' );
 
 	// Wrap 'Launch' button in anchor to frankenflow.

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
@@ -1,10 +1,10 @@
-.gutenboarding-editor {
+.gutenboarding-editor-overrides {
     .editor-post-switch-to-draft,
     .editor-post-preview {
         display: none;
     }
-
-    .launch-button-override__launch-button {
+    
+    .gutenboarding-editor-overrides__launch-button {
         padding: 0 12px;
         margin: 0 12px 0 3px;
     }

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -22,6 +22,7 @@ import { inIframe, isEditorReadyWithBlocks, sendMessage } from '../../utils';
 const debug = debugFactory( 'wpcom-block-editor:iframe-bridge-server' );
 
 /**
+ *
  * Monitors Gutenberg for when an editor is opened with content originally authored in the classic editor.
  *
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
@@ -680,19 +681,20 @@ function getCloseButtonUrl( calypsoPort ) {
 }
 
 // TODO - JSDOC this when you know what you are actually needing to do...
-function getLaunchButton( calypsoPort ) {
+function getGutenboardingStatus( calypsoPort ) {
 	const { port1, port2 } = new MessageChannel();
 	calypsoPort.postMessage(
 		{
-			action: 'getLaunchButton',
+			action: 'getGutenboardingStatus',
 			payload: {},
 		},
 		[ port2 ]
 	);
 	port1.onmessage = ( { data } ) => {
-		const { hasLaunchButtonOverride } = data;
-		calypsoifyGutenberg.hasLaunchButton = hasLaunchButtonOverride;
-		window.wp.hooks.doAction( 'updateLaunchButton', hasLaunchButtonOverride );
+		const { isGutenboarding, frankenflowUrl } = data;
+		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
+		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
+		window.wp.hooks.doAction( 'updateLaunchButton', isGutenboarding );
 	};
 }
 
@@ -802,7 +804,7 @@ function initPort( message ) {
 
 		getCloseButtonUrl( calypsoPort );
 
-		getLaunchButton( calypsoPort );
+		getGutenboardingStatus( calypsoPort );
 
 		handleUncaughtErrors( calypsoPort );
 	}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -700,6 +700,7 @@ function getGutenboardingStatus( calypsoPort ) {
 		const { isGutenboarding, frankenflowUrl } = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
+		// Hook necessary if message recieved after editor has loaded.
 		window.wp.hooks.doAction( 'updateLaunchButton', isGutenboarding );
 	};
 }

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -701,7 +701,7 @@ function getGutenboardingStatus( calypsoPort ) {
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
 		// Hook necessary if message recieved after editor has loaded.
-		window.wp.hooks.doAction( 'updateLaunchButton', isGutenboarding );
+		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding );
 	};
 }
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -680,7 +680,13 @@ function getCloseButtonUrl( calypsoPort ) {
 	};
 }
 
-// TODO - JSDOC this when you know what you are actually needing to do...
+/**
+ * Ensures gutenboarding status and corresponding data is placed on the calypsoifyGutenberg object.
+ * This is imporant because it allows us to adapt small changes to the editor when
+ * used in the context of Gutenboarding.
+ *
+ * @param {MessagePort} calypsoPort Port used for communication with parent frame.
+ */
 function getGutenboardingStatus( calypsoPort ) {
 	const { port1, port2 } = new MessageChannel();
 	calypsoPort.postMessage(

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -679,6 +679,24 @@ function getCloseButtonUrl( calypsoPort ) {
 	};
 }
 
+// TODO - JSDOC this when you know what you are actually needing to do...
+function getLaunchButton( calypsoPort ) {
+	const { port1, port2 } = new MessageChannel();
+	calypsoPort.postMessage(
+		{
+			action: 'getLaunchButton',
+			payload: {},
+		},
+		[ port2 ]
+	);
+	port1.onmessage = ( { data } ) => {
+		const { hasLaunchButtonOverride } = data;
+		calypsoifyGutenberg.hasLaunchButton = hasLaunchButtonOverride;
+
+		window.wp.hooks.doAction( 'updateLaunchButton', data );
+	};
+}
+
 /**
  * Passes uncaught errors in window.onerror to Calypso for logging.
  *
@@ -784,6 +802,8 @@ function initPort( message ) {
 		openTemplatePartLinks( calypsoPort );
 
 		getCloseButtonUrl( calypsoPort );
+
+		getLaunchButton( calypsoPort );
 
 		handleUncaughtErrors( calypsoPort );
 	}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -692,8 +692,7 @@ function getLaunchButton( calypsoPort ) {
 	port1.onmessage = ( { data } ) => {
 		const { hasLaunchButtonOverride } = data;
 		calypsoifyGutenberg.hasLaunchButton = hasLaunchButtonOverride;
-
-		window.wp.hooks.doAction( 'updateLaunchButton', data );
+		window.wp.hooks.doAction( 'updateLaunchButton', hasLaunchButtonOverride );
 	};
 }
 

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -31,22 +31,9 @@ domReady( () => {
 } );
 
 function updateButtonBar( settingsBar ) {
-	const hideClass = 'launch-button-override__hidden';
-
-	// Hide 'switch to draft' by '.editor-post-switch-to-draft'.
-	const switchToDraft = settingsBar.querySelector( '.editor-post-switch-to-draft' );
-	switchToDraft && switchToDraft.classList.add( hideClass );
-
-	// Hide 'preview' by '.editor-post-preview'.
-	// This is not initially added, we may need to wait for it.
-	const awaitPreview = setInterval( () => {
-		const preview = settingsBar.querySelector( '.editor-post-preview' );
-		if ( ! preview ) {
-			return;
-		}
-		clearInterval( awaitPreview );
-		preview.classList.add( 'launch-button-override__hidden' );
-	} );
+	// Add gutenboarding-editor class to body (so React re-render wont reset the added class).
+	const body = document.querySelector( 'body' );
+	body.classList.add( 'gutenboarding-editor' );
 
 	// 'Update'/'Publish' primary button to become 'Save' tertiary button.
 	const publish = settingsBar.querySelector( '.editor-post-publish-button' );

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -34,7 +34,7 @@ domReady( () => {
 
 function updateButtonBar( settingsBar ) {
 	const hideClass = 'launch-button-override__hidden';
-	if ( calypsoifyGutenberg.hasLaunchButton ) {
+	if ( calypsoifyGutenberg.isGutenboarding ) {
 		// Hide 'switch to draft' by '.editor-post-switch-to-draft'.
 		const switchToDraft = settingsBar.querySelector( '.editor-post-switch-to-draft' );
 		switchToDraft && switchToDraft.classList.add( hideClass );
@@ -61,8 +61,12 @@ function updateButtonBar( settingsBar ) {
 		const launchButton = document.createElement( 'button' );
 		launchButton.className = 'launch-button-override__launch-button components-button is-primary';
 		launchButton.innerText = __( 'Launch' );
-		// TODO - Launch goto /frankenflow
-		settingsBar.prepend( launchButton );
+		// Launch goto /start/frankenflow
+		const buttonWrapper = document.createElement( 'a' );
+		buttonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
+
+		buttonWrapper.append( launchButton );
+		settingsBar.prepend( buttonWrapper );
 		settingsBar.prepend( publish );
 	}
 }

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+import domReady from '@wordpress/dom-ready';
+import ReactDOM from 'react-dom';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+/* eslint-disable import/no-extraneous-dependencies */
+
+function LaunchButtonOverride( { defaultLabel, defaultUrl } ) {
+	const [ useLaunchButton, setUseLaunchButton ] = useState( false );
+	window.wp.hooks.addAction( 'updateLaunchButton', 'a8c-gutenboarding' /* ? */, data => {
+		setUseLaunchButton( data.hasLaunchButtonOverride );
+	} );
+
+	const url = useLaunchButton ? '/start/frankenflow' : defaultUrl;
+	const label = useLaunchButton ? __( 'Launch' ) : defaultLabel;
+
+	return (
+		<a href={ url } aria-label={ label }>
+			<Button className="launch-button-override__button components-button is-primary">
+				<div className="launch-button-override__label">{ label }</div>
+			</Button>
+		</a>
+	);
+}
+
+domReady( () => {
+	console.log( 'SANITY CHECK - THE DOM IS READY!' );
+	const awaitSettingsBar = setInterval( () => {
+		const settingsBar = document.querySelector( '.edit-post-header__settings' );
+
+		if ( ! settingsBar ) {
+			return;
+		}
+		clearInterval( awaitSettingsBar );
+
+		const buttonWrapper = document.createElement( 'div' );
+		settingsBar.prepend( buttonWrapper );
+
+		const originalButton = settingsBar.querySelector( '.editor-post-publish-button' );
+		const defaultLabel = originalButton.innerText;
+
+		ReactDOM.render(
+			<LaunchButtonOverride defaultLabel={ defaultLabel } defaultUrl={ null } />,
+			buttonWrapper
+		);
+	} );
+} );

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -36,21 +36,20 @@ function updateButtonBar( settingsBar ) {
 	body.classList.add( 'gutenboarding-editor' );
 
 	// 'Update'/'Publish' primary button to become 'Save' tertiary button.
-	const publish = settingsBar.querySelector( '.editor-post-publish-button' );
-	if ( publish ) {
-		publish.classList.remove( 'is-primary' );
-		publish.classList.add( 'is-tertiary' );
-		publish.innerText = __( 'Save' );
-	}
-	// 'Launch' button to replace update button.
+	const saveButton = settingsBar.querySelector( '.editor-post-publish-button' );
+	saveButton && ( saveButton.innerText = __( 'Save' ) );
+
+	// Create a 'Launch' button.
 	const launchButton = document.createElement( 'button' );
 	launchButton.className = 'launch-button-override__launch-button components-button is-primary';
 	launchButton.innerText = __( 'Launch' );
-	// Launch to lead into frankenflow.
-	const buttonWrapper = document.createElement( 'a' );
-	buttonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
-	buttonWrapper.append( launchButton );
+
+	// Wrap 'Launch' button in anchor to frankenflow.
+	const launchButtonWrapper = document.createElement( 'a' );
+	launchButtonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
+	launchButtonWrapper.append( launchButton );
+
 	// Put 'Launch' and 'Save' back on bar in desired order.
-	settingsBar.prepend( buttonWrapper );
-	settingsBar.prepend( publish );
+	settingsBar.prepend( launchButtonWrapper );
+	settingsBar.prepend( saveButton );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -59,7 +59,7 @@ function updateButtonBar( settingsBar ) {
 		}
 		// 'Launch' button to replace update button
 		const launchButton = document.createElement( 'button' );
-		launchButton.className = 'launch-button-override__button components-button is-primary';
+		launchButton.className = 'launch-button-override__launch-button components-button is-primary';
 		launchButton.innerText = __( 'Launch' );
 		// TODO - Launch goto /frankenflow
 		settingsBar.prepend( launchButton );

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -1,3 +1,5 @@
+/* global calypsoifyGutenberg */
+
 /**
  * External dependencies
  */
@@ -10,9 +12,13 @@ import { useState } from '@wordpress/element';
 /* eslint-disable import/no-extraneous-dependencies */
 
 function LaunchButtonOverride( { defaultLabel, defaultUrl } ) {
-	const [ useLaunchButton, setUseLaunchButton ] = useState( false );
-	window.wp.hooks.addAction( 'updateLaunchButton', 'a8c-gutenboarding' /* ? */, data => {
-		setUseLaunchButton( data.hasLaunchButtonOverride );
+	const [ useLaunchButton, setUseLaunchButton ] = useState(
+		!! calypsoifyGutenberg.hasLaunchButton
+	);
+
+	window.wp.hooks.addAction( 'updateLaunchButton', 'a8c-gutenboarding', data => {
+		// console.log( "Hooked! - launch button data: " + data )
+		setUseLaunchButton( data );
 	} );
 
 	const url = useLaunchButton ? '/start/frankenflow' : defaultUrl;
@@ -28,7 +34,7 @@ function LaunchButtonOverride( { defaultLabel, defaultUrl } ) {
 }
 
 domReady( () => {
-	console.log( 'SANITY CHECK - THE DOM IS READY!' );
+	// console.log( 'SANITY CHECK - THE DOM IS READY! 200' );
 	const awaitSettingsBar = setInterval( () => {
 		const settingsBar = document.querySelector( '.edit-post-header__settings' );
 

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -22,51 +22,48 @@ domReady( () => {
 		}
 		clearInterval( awaitSettingsBar );
 
-		updateButtonBar( settingsBar );
+		calypsoifyGutenberg.isGutenboarding && updateButtonBar( settingsBar );
 		// Hook fallback incase updateLaunchButton data is set after initial dom render.
 		window.wp.hooks.addAction( 'updateLaunchButton', 'a8c-gutenboarding', isGutenboarding => {
-			if ( isGutenboarding ) {
-				updateButtonBar( settingsBar );
-			}
+			isGutenboarding && updateButtonBar( settingsBar );
 		} );
 	} );
 } );
 
 function updateButtonBar( settingsBar ) {
 	const hideClass = 'launch-button-override__hidden';
-	if ( calypsoifyGutenberg.isGutenboarding ) {
-		// Hide 'switch to draft' by '.editor-post-switch-to-draft'.
-		const switchToDraft = settingsBar.querySelector( '.editor-post-switch-to-draft' );
-		switchToDraft && switchToDraft.classList.add( hideClass );
 
-		// Hide 'preview' by '.editor-post-preview'.
-		// This is not initially added, we may need to wait for it.
-		const awaitPreview = setInterval( () => {
-			const preview = settingsBar.querySelector( '.editor-post-preview' );
-			if ( ! preview ) {
-				return;
-			}
-			clearInterval( awaitPreview );
-			preview.classList.add( 'launch-button-override__hidden' );
-		} );
+	// Hide 'switch to draft' by '.editor-post-switch-to-draft'.
+	const switchToDraft = settingsBar.querySelector( '.editor-post-switch-to-draft' );
+	switchToDraft && switchToDraft.classList.add( hideClass );
 
-		// 'Update'/'Publish' primary button to become 'Save' tertiary button.
-		const publish = settingsBar.querySelector( '.editor-post-publish-button' );
-		if ( publish ) {
-			publish.classList.remove( 'is-primary' );
-			publish.classList.add( 'is-tertiary' );
-			publish.innerText = __( 'Save' );
+	// Hide 'preview' by '.editor-post-preview'.
+	// This is not initially added, we may need to wait for it.
+	const awaitPreview = setInterval( () => {
+		const preview = settingsBar.querySelector( '.editor-post-preview' );
+		if ( ! preview ) {
+			return;
 		}
-		// 'Launch' button to replace update button.
-		const launchButton = document.createElement( 'button' );
-		launchButton.className = 'launch-button-override__launch-button components-button is-primary';
-		launchButton.innerText = __( 'Launch' );
-		// Launch to lead into frankenflow.
-		const buttonWrapper = document.createElement( 'a' );
-		buttonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
-		buttonWrapper.append( launchButton );
-		// Put 'Launch' and 'Save' back on bar in desired order.
-		settingsBar.prepend( buttonWrapper );
-		settingsBar.prepend( publish );
+		clearInterval( awaitPreview );
+		preview.classList.add( 'launch-button-override__hidden' );
+	} );
+
+	// 'Update'/'Publish' primary button to become 'Save' tertiary button.
+	const publish = settingsBar.querySelector( '.editor-post-publish-button' );
+	if ( publish ) {
+		publish.classList.remove( 'is-primary' );
+		publish.classList.add( 'is-tertiary' );
+		publish.innerText = __( 'Save' );
 	}
+	// 'Launch' button to replace update button.
+	const launchButton = document.createElement( 'button' );
+	launchButton.className = 'launch-button-override__launch-button components-button is-primary';
+	launchButton.innerText = __( 'Launch' );
+	// Launch to lead into frankenflow.
+	const buttonWrapper = document.createElement( 'a' );
+	buttonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
+	buttonWrapper.append( launchButton );
+	// Put 'Launch' and 'Save' back on bar in desired order.
+	settingsBar.prepend( buttonWrapper );
+	settingsBar.prepend( publish );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.js
@@ -39,7 +39,7 @@ function updateButtonBar( settingsBar ) {
 		const switchToDraft = settingsBar.querySelector( '.editor-post-switch-to-draft' );
 		switchToDraft && switchToDraft.classList.add( hideClass );
 
-		// Hide 'preview' by '.editor-post-preview'
+		// Hide 'preview' by '.editor-post-preview'.
 		// This is not initially added, we may need to wait for it.
 		const awaitPreview = setInterval( () => {
 			const preview = settingsBar.querySelector( '.editor-post-preview' );
@@ -57,15 +57,15 @@ function updateButtonBar( settingsBar ) {
 			publish.classList.add( 'is-tertiary' );
 			publish.innerText = __( 'Save' );
 		}
-		// 'Launch' button to replace update button
+		// 'Launch' button to replace update button.
 		const launchButton = document.createElement( 'button' );
 		launchButton.className = 'launch-button-override__launch-button components-button is-primary';
 		launchButton.innerText = __( 'Launch' );
-		// Launch goto /start/frankenflow
+		// Launch to lead into frankenflow.
 		const buttonWrapper = document.createElement( 'a' );
 		buttonWrapper.href = calypsoifyGutenberg.frankenflowUrl;
-
 		buttonWrapper.append( launchButton );
+		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( buttonWrapper );
 		settingsBar.prepend( publish );
 	}

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
@@ -8,4 +8,16 @@
         padding: 0 12px;
         margin: 0 12px 0 3px;
     }
+
+    // Override 'Save' button to have tertiary styles.
+    .editor-post-publish-button {
+        color: #007cba !important;
+        background: none !important;
+        border: none !important;
+        box-shadow: none !important;
+
+        &[aria-disabled=true] {
+            opacity: 0.3 !important;
+        }
+    }
 }

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
@@ -1,0 +1,3 @@
+.launch-button-override__hidden {
+    display: none !important;
+}

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
@@ -1,3 +1,8 @@
 .launch-button-override__hidden {
-    display: none !important;
+    display: none;
+}
+
+.launch-button-override__launch-button {
+    padding: 0 12px;
+    margin: 0 12px 0 3px;
 }

--- a/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/launch-button-override.scss
@@ -1,8 +1,11 @@
-.launch-button-override__hidden {
-    display: none;
-}
+.gutenboarding-editor {
+    .editor-post-switch-to-draft,
+    .editor-post-preview {
+        display: none;
+    }
 
-.launch-button-override__launch-button {
-    padding: 0 12px;
-    margin: 0 12px 0 3px;
+    .launch-button-override__launch-button {
+        padding: 0 12px;
+        margin: 0 12px 0 3px;
+    }
 }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -98,6 +98,7 @@ enum EditorActions {
 	OpenTemplatePart = 'openTemplatePart',
 	GetCloseButtonUrl = 'getCloseButtonUrl',
 	LogError = 'logError',
+	GetLaunchButton = 'getLaunchButton',
 }
 
 class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
@@ -282,6 +283,15 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			ports[ 0 ].postMessage( {
 				closeUrl: `${ window.location.origin }${ closeUrl }`,
 				label: closeLabel,
+			} );
+		}
+
+		if ( EditorActions.GetLaunchButton === action ) {
+			// Some logic to determine if we want the launch button
+			// Gutenboarding context + unpublished site?
+			const hasLaunchButtonOverride = true;
+			ports[ 0 ].postMessage( {
+				hasLaunchButtonOverride,
 			} );
 		}
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -289,7 +289,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		if ( EditorActions.GetGutenboardingStatus === action ) {
 			// Some logic to determine if we want the launch button
 			// Gutenboarding context + unpublished site?
-			const isGutenboarding = true;
+			const isGutenboarding = config.isEnabled( 'gutenboarding' );
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl: `${ window.location.origin }/start/frankenflow`,

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -293,7 +293,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				config.isEnabled( 'gutenboarding' ) && urlParams.has( 'is-gutenboarding' );
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
-				frankenflowUrl: `${ window.location.origin }/start/frankenflow`,
+				frankenflowUrl: `${ window.location.origin }/start/frankenflow?siteSlug=${ this.props.siteId }`,
 			} );
 		}
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -98,7 +98,7 @@ enum EditorActions {
 	OpenTemplatePart = 'openTemplatePart',
 	GetCloseButtonUrl = 'getCloseButtonUrl',
 	LogError = 'logError',
-	GetLaunchButton = 'getLaunchButton',
+	GetGutenboardingStatus = 'getGutenboardingStatus',
 }
 
 class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
@@ -286,12 +286,13 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			} );
 		}
 
-		if ( EditorActions.GetLaunchButton === action ) {
+		if ( EditorActions.GetGutenboardingStatus === action ) {
 			// Some logic to determine if we want the launch button
 			// Gutenboarding context + unpublished site?
-			const hasLaunchButtonOverride = true;
+			const isGutenboarding = true;
 			ports[ 0 ].postMessage( {
-				hasLaunchButtonOverride: hasLaunchButtonOverride,
+				isGutenboarding,
+				frankenflowUrl: `${ window.location.origin }/start/frankenflow`,
 			} );
 		}
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -291,7 +291,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			// Gutenboarding context + unpublished site?
 			const hasLaunchButtonOverride = true;
 			ports[ 0 ].postMessage( {
-				hasLaunchButtonOverride,
+				hasLaunchButtonOverride: hasLaunchButtonOverride,
 			} );
 		}
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -287,9 +287,10 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
-			// Some logic to determine if we want the launch button
-			// Gutenboarding context + unpublished site?
-			const isGutenboarding = config.isEnabled( 'gutenboarding' );
+			// TODO - In future iterations, replace window param with gutenboarding site info.
+			const urlParams = new URLSearchParams( window.location.search );
+			const isGutenboarding =
+				config.isEnabled( 'gutenboarding' ) && urlParams.has( 'is-gutenboarding' );
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl: `${ window.location.origin }/start/frankenflow`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds an optional override to update the wpcom-block-editor for gutenboarding purposes.

Currently, this override will happen if both of two conditions are `true`:

1.  `config.isEnabled( 'gutenboarding' )` - Which is currently true only in development and wpcalypso (calypso.live) environments.
2. `is-gutenboarding` query param is present.

When enabled, the settings bar in the top right of the editor is changed from:
![Screen Shot 2020-01-24 at 4 25 33 PM](https://user-images.githubusercontent.com/28742426/73208327-45895180-4114-11ea-92bf-5d0c035bc540.png)

To:
![Screen Shot 2020-01-24 at 4 32 52 PM](https://user-images.githubusercontent.com/28742426/73208296-386c6280-4114-11ea-80cc-5c4c888a9e5e.png)

* The "Save" button is currently a re-styling of the original "Update" or "Publish" button.
* The "Launch" button is wrapped in an <a> tag leading to the frankenflow.

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR on calypso.
* Build and Sync wpcom-block-editor to your sandbox.  You can patch `D38314` or alternatively run `./bin/calypso/build-wpcom-block-editor.sh 583382` on your sandbox, where '583382' represents the circle-ci build number for the wpcom-block-editor found at the bottom of this PR. 
* Be sure to sandbox `widgets.wp.com` and `public-api.wordpress.com`.
* Navigate to the editor in a sandboxed site and verify there is NO "Launch" button.  
* Add the query param `?is-gutenboarding` to the end of the url in your browser window and load the editor again.
* Verify there are "Save" and "Launch" buttons, and that the styles match with the image shown above. 
 You may need to clear your browser's cache to see changes.
* Verify the "Launch" button leads to the first step of the Frankenflow.

Closes #38904 