### PR TITLE
[Gutenboarding]: Add reloadProxy to our wpcom wrapper

### DIFF
--- a/packages/data-stores/global.d.ts
+++ b/packages/data-stores/global.d.ts
@@ -3,6 +3,7 @@
  */
 declare module 'wpcom-proxy-request' {
 	import { WpcomRequestParams } from 'src/utils/wpcom-wrapper';
+	export function reloadProxy(): void;
 	export default function wpcomProxyRequest(
 		params: WpcomRequestParams,
 		callback: Function

--- a/packages/data-stores/src/utils/wpcom-wrapper.ts
+++ b/packages/data-stores/src/utils/wpcom-wrapper.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import wpcomProxyRequest from 'wpcom-proxy-request';
+import wpcomProxyRequest, { reloadProxy } from 'wpcom-proxy-request';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'data-stores:utils:wpcom-wrapper' );
@@ -28,6 +28,14 @@ export function wpcomRequest< T >( params: WpcomRequestParams ): Promise< T > {
 			err ? reject( err ) : resolve( res );
 		} );
 	} );
+}
+/*
+ * Reloading the proxy ensures that the proxy iframe has set the correct API cookie.
+ * This is particularly useful for making authenticated API requests
+ * *after* the user has logged in or signed up without the need for a hard browser refresh.
+ */
+export function reloadWpcomProxy(): void {
+	reloadProxy();
 }
 
 wpcomProxyRequest( { metaAPI: { accessAllUsersBlogs: true } }, ( error: Error ) => {


### PR DESCRIPTION
## Changes proposed in this Pull Request

**GIT**: What's this PR for?

**ME**: We have to add [reloadProxy()](https://github.com/Automattic/wpcom-proxy-request/blob/master/index.js#L463) to `wpcom-wrapper`.

**GIT**: Why? 

**ME**: So we can make authenticated API requests without having to refresh the browser. We'll need it for https://github.com/Automattic/wp-calypso/issues/38707 and, presumably, other tasks.

**GIT**: Fine. 

## Testing instructions

N/A

The true test will be when we start making authenticated API calls after a user creates an account 👍 



