### PR TITLE
Add Site data store to be used by Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -13,6 +13,13 @@ export const setupWpDataDebug = () => {
 			}
 			if ( ! window.wp.data ) {
 				window.wp.data = require( '@wordpress/data' );
+
+				const config = require( 'config' ).default;
+				const { Site } = require( '@automattic/data-stores' );
+				Site.register( {
+					client_id: config( 'wpcom_signup_id' ),
+					client_secret: config( 'wpcom_signup_key' ),
+				} );
 			}
 		}
 	}

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -3,10 +3,11 @@
  */
 import * as User from './user';
 import * as DomainSuggestions from './domain-suggestions';
+import * as Site from './site';
 import * as Verticals from './verticals';
 import * as VerticalsTemplates from './verticals-templates';
 
-export { User, DomainSuggestions, Verticals, VerticalsTemplates };
+export { User, DomainSuggestions, Site, Verticals, VerticalsTemplates };
 
 /**
  * Helper types

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import {
+	ActionType,
+	CreateSiteParams,
+	NewSiteErrorResponse,
+	NewSiteSuccessResponse,
+} from './types';
+
+export const fetchNewSite = () => ( {
+	type: ActionType.FETCH_NEW_SITE as const,
+} );
+
+export const receiveNewSite = ( response: NewSiteSuccessResponse ) => ( {
+	type: ActionType.RECEIVE_NEW_SITE as const,
+	response,
+} );
+
+export const receiveNewSiteFailed = ( error: NewSiteErrorResponse ) => ( {
+	type: ActionType.RECEIVE_NEW_SITE_FAILED as const,
+	error,
+} );
+
+export function* createSite( params: CreateSiteParams ) {
+	yield fetchNewSite();
+	try {
+		const newUser = yield {
+			type: ActionType.CREATE_SITE as const,
+			params,
+		};
+		return receiveNewSite( newUser );
+	} catch ( err ) {
+		return receiveNewSiteFailed( err );
+	}
+}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -25,11 +25,11 @@ export const receiveNewSiteFailed = ( error: NewSiteErrorResponse ) => ( {
 export function* createSite( params: CreateSiteParams ) {
 	yield fetchNewSite();
 	try {
-		const newUser = yield {
+		const newSite = yield {
 			type: ActionType.CREATE_SITE as const,
 			params,
 		};
-		return receiveNewSite( newUser );
+		return receiveNewSite( newSite );
 	} catch ( err ) {
 		return receiveNewSiteFailed( err );
 	}

--- a/packages/data-stores/src/site/constants.ts
+++ b/packages/data-stores/src/site/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/site';

--- a/packages/data-stores/src/site/controls.ts
+++ b/packages/data-stores/src/site/controls.ts
@@ -8,30 +8,30 @@ export default function createControls( clientCreds: WpcomClientCredentials ) {
 	return {
 		[ ActionType.CREATE_SITE ]: async ( action: CreateSiteAction ) => {
 			const { authToken, ...providedParams } = action.params;
-			
-            const defaultParams = {
-                client_id: clientCreds.client_id,
-                client_secret: clientCreds.client_secret,
-                // will find an available `*.wordpress.com` url based on the `blog_name`
-                find_available_url: true,
-                // Private site is default, but overridable, setting
-                public: -1,
-            };
 
-            const mergedParams = {
-                ...defaultParams,
-                ...providedParams,
-                // Set to false because site validation should be a separate action
-                validate: false,
-            };
+			const defaultParams = {
+				client_id: clientCreds.client_id,
+				client_secret: clientCreds.client_secret,
+				// will find an available `*.wordpress.com` url based on the `blog_name`
+				find_available_url: true,
+				// Private site is default, but overridable, setting
+				public: -1,
+			};
 
-            return wpcomRequest( {
-                path: '/sites/new',
-                apiVersion: '1.1',
-                method: 'post',
-                token: authToken || undefined,
-                body: mergedParams,
-            } );
-        },
+			const mergedParams = {
+				...defaultParams,
+				...providedParams,
+				// Set to false because site validation should be a separate action
+				validate: false,
+				token: authToken,
+			};
+
+			return wpcomRequest( {
+				path: '/sites/new',
+				apiVersion: '1.1',
+				method: 'post',
+				body: mergedParams,
+			} );
+		},
 	};
 }

--- a/packages/data-stores/src/site/controls.ts
+++ b/packages/data-stores/src/site/controls.ts
@@ -23,7 +23,6 @@ export default function createControls( clientCreds: WpcomClientCredentials ) {
 				...providedParams,
 				// Set to false because site validation should be a separate action
 				validate: false,
-				token: authToken,
 			};
 
 			return wpcomRequest( {
@@ -31,6 +30,7 @@ export default function createControls( clientCreds: WpcomClientCredentials ) {
 				apiVersion: '1.1',
 				method: 'post',
 				body: mergedParams,
+				token: authToken,
 			} );
 		},
 	};

--- a/packages/data-stores/src/site/controls.ts
+++ b/packages/data-stores/src/site/controls.ts
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import { wpcomRequest, WpcomClientCredentials } from '../utils';
+import { ActionType, CreateSiteAction } from './types';
+
+export default function createControls( clientCreds: WpcomClientCredentials ) {
+	return {
+		[ ActionType.CREATE_SITE ]: async ( action: CreateSiteAction ) => {
+			const { authToken, ...providedParams } = action.params;
+			const defaultParams = {
+				blog_title: '',
+				public: -1,
+				blog_name: '',
+				client_id: clientCreds.client_id,
+				client_secret: clientCreds.client_secret,
+				lang_id: 1,
+				locale: 'en',
+				options: {
+					theme: 'pub/maywood',
+					site_segment: 1,
+					site_vertical: 'p1',
+					site_vertical_name: 'Restaurant',
+					site_information: {
+						title: 'Test Site for Gutenboarding',
+					},
+					site_creation_flow: 'gutenboarding',
+				},
+			};
+			const mergedParams = Object.assign(
+				{},
+				defaultParams,
+				{ ...providedParams },
+				{ validate: false } // Set to false because account validation should be a separate action
+			);
+			const newUser = await wpcomRequest( {
+				path: '/sites/new',
+				apiVersion: '1.1',
+				method: 'post',
+				body: mergedParams,
+				token: authToken || undefined,
+			} );
+			return newUser;
+		},
+	};
+}

--- a/packages/data-stores/src/site/controls.ts
+++ b/packages/data-stores/src/site/controls.ts
@@ -8,39 +8,30 @@ export default function createControls( clientCreds: WpcomClientCredentials ) {
 	return {
 		[ ActionType.CREATE_SITE ]: async ( action: CreateSiteAction ) => {
 			const { authToken, ...providedParams } = action.params;
-			const defaultParams = {
-				blog_title: '',
-				public: -1,
-				blog_name: '',
-				client_id: clientCreds.client_id,
-				client_secret: clientCreds.client_secret,
-				lang_id: 1,
-				locale: 'en',
-				options: {
-					theme: 'pub/maywood',
-					site_segment: 1,
-					site_vertical: 'p1',
-					site_vertical_name: 'Restaurant',
-					site_information: {
-						title: 'Test Site for Gutenboarding',
-					},
-					site_creation_flow: 'gutenboarding',
-				},
-			};
-			const mergedParams = Object.assign(
-				{},
-				defaultParams,
-				{ ...providedParams },
-				{ validate: false } // Set to false because account validation should be a separate action
-			);
-			const newUser = await wpcomRequest( {
-				path: '/sites/new',
-				apiVersion: '1.1',
-				method: 'post',
-				body: mergedParams,
-				token: authToken || undefined,
-			} );
-			return newUser;
-		},
+			
+            const defaultParams = {
+                client_id: clientCreds.client_id,
+                client_secret: clientCreds.client_secret,
+                // will find an available `*.wordpress.com` url based on the `blog_name`
+                find_available_url: true,
+                // Private site is default, but overridable, setting
+                public: -1,
+            };
+
+            const mergedParams = {
+                ...defaultParams,
+                ...providedParams,
+                // Set to false because site validation should be a separate action
+                validate: false,
+            };
+
+            return wpcomRequest( {
+                path: '/sites/new',
+                apiVersion: '1.1',
+                method: 'post',
+                token: authToken || undefined,
+                body: mergedParams,
+            } );
+        },
 	};
 }

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import createControls from './controls';
+import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import { WpcomClientCredentials } from '../utils';
+
+export * from './types';
+export { State };
+
+let isRegistered = false;
+export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		const controls = createControls( clientCreds );
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			actions,
+			controls: controls as any,
+			reducer: reducer as any,
+			resolvers: {},
+			selectors,
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { Reducer } from 'redux';
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ActionType, NewSite, NewSiteErrorResponse } from './types';
+import * as Actions from './actions';
+
+const newSiteData: Reducer<
+	NewSite | {} | undefined,
+	| ReturnType< typeof Actions[ 'receiveNewSite' ] >
+	| ReturnType< typeof Actions[ 'receiveNewSiteFailed' ] >
+> = ( state = undefined, action ) => {
+	if ( action.type === ActionType.RECEIVE_NEW_SITE ) {
+		const { response } = action;
+		return {
+			...response.blog_details,
+		};
+	} else if ( action.type === ActionType.RECEIVE_NEW_SITE_FAILED ) {
+		return undefined;
+	}
+	return state;
+};
+
+const newSiteError: Reducer<
+	NewSiteErrorResponse | undefined,
+	| ReturnType< typeof Actions[ 'fetchNewSite' ] >
+	| ReturnType< typeof Actions[ 'receiveNewSite' ] >
+	| ReturnType< typeof Actions[ 'receiveNewSiteFailed' ] >
+> = ( state = undefined, action ) => {
+	switch ( action.type ) {
+		case ActionType.FETCH_NEW_SITE:
+			return undefined;
+		case ActionType.RECEIVE_NEW_SITE:
+			return undefined;
+		case ActionType.RECEIVE_NEW_SITE_FAILED:
+			return {
+				error: action.error.error,
+				status: action.error.status,
+				statusCode: action.error.statusCode,
+				name: action.error.name,
+				message: action.error.message,
+			};
+	}
+	return state;
+};
+
+const isFetchingNewUser: Reducer<
+	boolean | undefined,
+	| ReturnType< typeof Actions[ 'fetchNewSite' ] >
+	| ReturnType< typeof Actions[ 'receiveNewSite' ] >
+	| ReturnType< typeof Actions[ 'receiveNewSiteFailed' ] >
+> = ( state = false, action ) => {
+	switch ( action.type ) {
+		case ActionType.FETCH_NEW_SITE:
+			return true;
+		case ActionType.RECEIVE_NEW_SITE:
+			return false;
+		case ActionType.RECEIVE_NEW_SITE_FAILED:
+			return false;
+	}
+	return state;
+};
+
+const newSite = combineReducers( {
+	data: newSiteData,
+	error: newSiteError,
+	isFetching: isFetchingNewUser,
+} );
+
+const reducer = combineReducers( { newSite } );
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -49,7 +49,7 @@ const newSiteError: Reducer<
 	return state;
 };
 
-const isFetchingNewUser: Reducer<
+const isFetchingSite: Reducer<
 	boolean | undefined,
 	| ReturnType< typeof Actions[ 'fetchNewSite' ] >
 	| ReturnType< typeof Actions[ 'receiveNewSite' ] >
@@ -69,7 +69,7 @@ const isFetchingNewUser: Reducer<
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
-	isFetching: isFetchingNewUser,
+	isFetching: isFetchingSite,
 } );
 
 const reducer = combineReducers( { newSite } );

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { State } from './reducer';
+
+export const getState = ( state: State ) => state;
+
+export const getNewSite = ( state: State ) => state.newSite.data;
+export const getNewSiteError = ( state: State ) => state.newSite.error;
+export const isFetchingSiteUser = ( state: State ) => state.newSite.isFetching;
+export const isNewSite = ( state: State ) => !! state.newSite.data;

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -7,5 +7,5 @@ export const getState = ( state: State ) => state;
 
 export const getNewSite = ( state: State ) => state.newSite.data;
 export const getNewSiteError = ( state: State ) => state.newSite.error;
-export const isFetchingSiteUser = ( state: State ) => state.newSite.isFetching;
+export const isFetchingSite = ( state: State ) => state.newSite.isFetching;
 export const isNewSite = ( state: State ) => !! state.newSite.data;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -18,9 +18,17 @@ export interface NewSite {
 	blog_details: object;
 }
 
+export interface NewSiteSuccessResponseBlogDetails {
+	url: string;
+	blogid: number;
+	blogname: string;
+	xmlrpc: string;
+}
+
 export interface NewSiteSuccessResponse {
 	success: boolean;
-	blog_details: object;
+	blog_details: NewSiteSuccessResponseBlogDetails;
+	is_signup_sandbox?: boolean;
 }
 
 export interface NewSiteErrorResponse {
@@ -31,7 +39,14 @@ export interface NewSiteErrorResponse {
 	message: string;
 }
 
-export type NewSiteResponse = NewSiteSuccessResponse | NewSiteErrorResponse;
+export interface NewSiteErrorCreateBlog {
+	blog_id?: any; // This has to be `any` as sites/new will return whatever value is passed to it as `$blog_id` if create blog fails.
+}
+
+export type NewSiteResponse =
+	| NewSiteSuccessResponse
+	| NewSiteErrorResponse
+	| NewSiteErrorCreateBlog;
 
 export interface CreateSiteParams {
 	blog_name: string;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+
+import { Action } from 'redux';
+
+export const enum ActionType {
+	CREATE_SITE = 'CREATE_SITE',
+	RECEIVE_NEW_SITE = 'RECEIVE_NEW_SITE',
+	RECEIVE_NEW_SITE_SUCCESS = 'RECEIVE_NEW_SITE',
+	RECEIVE_NEW_SITE_FAILED = 'RECEIVE_NEW_SITE_FAILED',
+	FETCH_NEW_SITE = 'FETCH_NEW_SITE',
+}
+
+export interface NewSite {
+	blogname: string;
+	blogid: string;
+	blog_details: object;
+}
+
+export interface NewSiteSuccessResponse {
+	success: boolean;
+	blog_details: object;
+}
+
+export interface NewSiteErrorResponse {
+	error: string;
+	status: number;
+	statusCode: number;
+	name: string;
+	message: string;
+}
+
+export type NewSiteResponse = NewSiteSuccessResponse | NewSiteErrorResponse;
+
+export interface CreateSiteParams {
+	blog_name: string;
+	authToken?: string;
+}
+
+export interface CreateSiteAction extends Action {
+	params: CreateSiteParams;
+}

--- a/packages/data-stores/src/utils/wpcom-wrapper.ts
+++ b/packages/data-stores/src/utils/wpcom-wrapper.ts
@@ -16,6 +16,7 @@ export interface WpcomRequestParams {
 	method?: string;
 	apiVersion?: string;
 	body?: object;
+	token?: string;
 	metaAPI?: {
 		accessAllUsersBlogs?: boolean;
 	};


### PR DESCRIPTION
This PR adds a Site data store, responsible for making API calls to create a new site using the `sites/new` endpoint. It follows the same basic pattern as the User store added in https://github.com/Automattic/wp-calypso/pull/38823.

#### Changes proposed in this Pull Request

* Add a Site data store to fire off requests to create a new site via the `sites/new` endpoint
* Store information about the created site
* Support passing in a bearer token to create the site (allowing site creation after a new user is created but before they're logged in / before they've reloaded the page)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure you're in an incognito browser / you are not already logged in to WP.com. Also ensure that you do not reload the page while doing the following steps, to test that it works without requiring a page reload.

1. Create a new user at: `http://calypso.localhost:3000/gutenboarding/signup`

2. Open up the console and enter the following, one by one: ( replace `blog_name` with a unique name for the blog's subdomain )

```js
const { bearerToken } = wp.data.select( 'automattic/user' ).getNewUser();
console.log( wp.data.dispatch( 'automattic/site' ).createSite( { blog_name: 'myfakesite202001241229', authToken: bearerToken } ) );
console.log( wp.data.select( 'automattic/site' ).getNewSite() );
````

Related to: https://github.com/Automattic/wp-calypso/issues/38707