### PR TITLE
Notifications panel: Revert title size back to 14px

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -441,8 +441,9 @@
 				-webkit-line-clamp: 2;
 				@extend %ellipsy-box;
 				color: var( --color-text-subtle );
-				font-size: 14px;
+				font-size: $wpnc__font-size;
 				letter-spacing: 0.25px;
+				padding-top: 2px;
 			}
 		}
 

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -412,7 +412,8 @@
 				max-height: 3em;
 				-webkit-line-clamp: 2;
 				@extend %ellipsy-box;
-				font-size: 16px;
+				font-size: $wpnc__font-size;
+				line-height: $wpnc__line-height;
 				letter-spacing: 0.15px;
 			}
 

--- a/apps/notifications/src/panel/boot/stylesheets/shared/sizes.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/sizes.scss
@@ -1,7 +1,7 @@
 $wpnc__icon-size: 40px;
 $wpnc__icon-size-detail: 32px;
 $wpnc__font-size: 14px;
-$wpnc__line-height: 21px;
+$wpnc__line-height: 1.4;
 $wpnc__capital-font-size: 12px;
 
 // Padding
@@ -14,5 +14,5 @@ $wpnc__user-margin-adjustment: 4px;
 // - apps/notifications/src/panel/templates/note-list.jsx
 // - apps/notifications/src/panel/templates/empty-message.jsx
 $wpnc__title-bar-height: 38px;
-$wpnc__header-height: 34px;
+$wpnc__header-height: 31px;
 $wpnc__filter-height: 38px;


### PR DESCRIPTION
This is a follow-up to #38647 due to feedback that increasing the title font size to 16px was too big. As per @osullivanchris this reverts it to 14px and adjusts the line height to 1.4.

See p9zg7s-5h-p2

#### Changes proposed in this Pull Request

**Before:**
<img width="414" alt="Screen Shot 2020-01-23 at 10 48 38 PM" src="https://user-images.githubusercontent.com/52152/73049999-39ab4000-3e33-11ea-9286-6bbe8fb2f049.png">

**After:**
<img width="418" alt="Screen Shot 2020-01-23 at 10 48 22 PM" src="https://user-images.githubusercontent.com/52152/73050004-416ae480-3e33-11ea-86ad-ad2919ab26e7.png">

#### Testing instructions

* Check the notifications panel with various sorts of notifications and make sure the styles look consistent
* Particularly look for any issues with height overflow in long post titles