### PR TITLE
Calypsoify-iframe: Janitorial types and fixes

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -601,7 +601,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 }
 
 const mapStateToProps = (
-	state,
+	state: T.AppState,
 	{ postId, postType, duplicatePostId, fseParentPageId, creatingNewHomepage }: Props
 ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -559,7 +559,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				<div className="main main-column calypsoify is-iframe" role="main">
 					{ ! isIframeLoaded && <Placeholder /> }
 					{ ( shouldLoadIframe || isIframeLoaded ) && (
-						/* eslint-disable-next-line jsx-a11y/iframe-has-title */
+						/* eslint-disable jsx-a11y/iframe-has-title */
 						<iframe
 							ref={ this.iframeRef }
 							/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
@@ -571,6 +571,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 								this.onIframeLoaded( iframeUrl );
 							} }
 						/>
+						/* eslint-enable jsx-a11y/iframe-has-title */
 					) }
 				</div>
 				<MediaLibrarySelectedData siteId={ siteId }>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -54,6 +54,7 @@ import * as T from 'types';
  */
 import './style.scss';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 interface Props {
 	duplicatePostId: T.PostId;
 	postId: T.PostId;
@@ -77,6 +78,7 @@ interface State {
 	postUrl?: T.URL;
 	previewUrl: T.URL;
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 enum WindowActions {
 	Loaded = 'loaded',

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { assign } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:media' );
@@ -19,7 +18,16 @@ import MediaListStore from './list-store';
 import MediaValidationStore from './validation-store';
 
 /**
- * Module variables
+ * @typedef MediaActions
+ *
+ * TODO: Better method types
+ *
+ * @property {Function} fetch
+ * @property {Function} setLibrarySelectedItems
+ */
+
+/**
+ * @type {MediaActions} MediaActions
  */
 const MediaActions = {
 	_fetching: {},

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { values } from 'lodash';
 
 /**
@@ -13,7 +12,19 @@ import emitter from 'lib/mixins/emitter';
 import MediaValidationStore from './validation-store';
 
 /**
- * Module variables
+ * @typedef {import('events').EventEmitter} Emitter
+ */
+
+/**
+ * @typedef MediaStoreShape
+ *
+ * TODO: Better method types
+ *
+ * @property {Function} get
+ */
+
+/**
+ * @type {Emitter & MediaStoreShape} MediaStore
  */
 const MediaStore = {
 	_media: {},


### PR DESCRIPTION
Some fixes and improvements to reduce type issues in calypsoify-iframe. It would be great to resurrect #32872 

Inspired by https://github.com/Automattic/wp-calypso/pull/39048#pullrequestreview-347768041

- Bare minimum JSDoc typings on MediaStore and MediaActions
- Some lint tweaks and ignores
- Use `globalThis` for browser globals.


### Testing instructions

- The iframe editor continues to work. There should be no behavioral changes. Be sure to check the media modal.