### PR TITLE
Jetpack Cloud: Use separate environments

### DIFF
--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -20,7 +20,7 @@ window.AppBoot = () => {
 	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
 		window.location.href = '/';
 	} else {
-		initJetpackCloudRoutes( '/jetpack-cloud' );
+		initJetpackCloudRoutes();
 		page.start( { decodeURLComponents: false } );
 	}
 };

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -15,12 +15,12 @@ import {
 	setupSidebar,
 } from './controller';
 
-const router = ( baseRoute = '' ) => {
-	page( baseRoute + '/', setupSidebar, jetpackCloud, makeLayout, clientRender );
+const router = () => {
+	page( '/', setupSidebar, jetpackCloud, makeLayout, clientRender );
 
-	page( baseRoute + '/backups', setupSidebar, jetpackBackups, makeLayout, clientRender );
+	page( '/backups', setupSidebar, jetpackBackups, makeLayout, clientRender );
 
-	page( baseRoute + '/scan', setupSidebar, jetpackScan, makeLayout, clientRender );
+	page( '/scan', setupSidebar, jetpackScan, makeLayout, clientRender );
 };
 
 export default router;

--- a/client/landing/jetpack-cloud/section.js
+++ b/client/landing/jetpack-cloud/section.js
@@ -1,6 +1,6 @@
 export const JETPACK_CLOUD_SECTION_DEFINITION = {
 	name: 'jetpack-cloud',
-	paths: [ '/jetpack-cloud' ],
+	paths: [ '/', '/scan', '/backups' ],
 	module: 'jetpack-cloud',
 	secondary: false,
 	group: 'jetpack-cloud',

--- a/client/landing/jetpack-cloud/sidebar.jsx
+++ b/client/landing/jetpack-cloud/sidebar.jsx
@@ -8,13 +8,13 @@ export default function() {
 		<div>
 			<ul>
 				<li>
-					<a href="/jetpack-cloud">Dashboard</a>
+					<a href="/">Dashboard</a>
 				</li>
 				<li>
-					<a href="/jetpack-cloud/backups">Backups</a>
+					<a href="/backups">Backups</a>
 				</li>
 				<li>
-					<a href="/jetpack-cloud/scan">Scan</a>
+					<a href="/scan">Scan</a>
 				</li>
 			</ul>
 		</div>

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -635,6 +635,12 @@ function handleLocaleSubdomains( req, res, next ) {
 	next();
 }
 
+const jetpackCloudEnvs = [
+	'jetpack-cloud-development',
+	'jetpack-cloud-stage',
+	'jetpack-cloud-production',
+];
+
 module.exports = function() {
 	const app = express();
 
@@ -644,6 +650,13 @@ module.exports = function() {
 	app.use( cookieParser() );
 	app.use( setupLoggedInContext );
 	app.use( handleLocaleSubdomains );
+
+	if ( jetpackCloudEnvs.includes( process.env.CALYPSO_ENV ) ) {
+		JETPACK_CLOUD_SECTION_DEFINITION.paths.forEach( sectionPath =>
+			handleSectionPath( JETPACK_CLOUD_SECTION_DEFINITION, sectionPath, 'entry-jetpack-cloud' )
+		);
+		return app;
+	}
 
 	// redirect homepage if the Reader is disabled
 	app.get( '/', function( request, response, next ) {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -651,7 +651,7 @@ module.exports = function() {
 	app.use( setupLoggedInContext );
 	app.use( handleLocaleSubdomains );
 
-	if ( jetpackCloudEnvs.includes( process.env.CALYPSO_ENV ) ) {
+	if ( jetpackCloudEnvs.includes( calypsoEnv ) ) {
 		JETPACK_CLOUD_SECTION_DEFINITION.paths.forEach( sectionPath =>
 			handleSectionPath( JETPACK_CLOUD_SECTION_DEFINITION, sectionPath, 'entry-jetpack-cloud' )
 		);

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -1,0 +1,16 @@
+{
+	"env": "development",
+	"env_id": "jetpack-cloud-development",
+	"favicon_url": "/calypso/images/favicons/favicon-development.ico",
+	"client_slug": "browser",
+	"protocol": "http",
+	"hostname": "jetpack.cloud.localhost",
+	"i18n_default_locale_slug": "en",
+	"port": 3000,
+	"rtl": false,
+	"login_url": "https://wordpress.com/wp-login.php",
+	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"features": {
+		"jetpack-cloud": true
+	}
+}

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -1,0 +1,14 @@
+{
+	"env": "production",
+	"env_id": "jetpack-cloud-production",
+	"favicon_url": "//s1.wp.com/i/favicon.ico",
+	"client_slug": "browser",
+	"hostname": "cloud.jetpack.com",
+	"i18n_default_locale_slug": "en",
+	"rtl": false,
+	"login_url": "https://wordpress.com/wp-login.php",
+	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"features": {
+		"jetpack-cloud": true
+	}
+}

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -1,0 +1,14 @@
+{
+	"env": "production",
+	"env_id": "jetpack-cloud-stage",
+	"favicon_url": "/calypso/images/favicons/favicon-staging.ico",
+	"client_slug": "browser",
+	"hostname": "cloud.jetpack.com",
+	"i18n_default_locale_slug": "en",
+	"rtl": false,
+	"login_url": "https://wordpress.com/wp-login.php",
+	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"features": {
+		"jetpack-cloud": true
+	}
+}


### PR DESCRIPTION
This PR is an experiment to make the Jetpack Cloud work as a separate development and production instance by taking advantage of new Calypso environments. Here we're introducing 3 new environments:

* `jetpack-cloud-development` - Local, development environment. This is the Jetpack Cloud version of the regular Calypso development environment.
* `jetpack-cloud-stage` - Staging environment. This is the Jetpack Cloud version of the regular Calypso staging environment, which is close to the production one but used for testing (when proxied) before deploying to production.
* `jetpack-cloud-production` - Production environment. This is the Jetpack Cloud version of the regular Calypso production environment. 

Those will be accessible in their corresponding domains, as follows:

* `jetpack-cloud-development` accessible locally on http://jetpack.cloud.localhost:3000/
* `jetpack-cloud-stage` accessible on https://cloud.jetpack.com/ (when proxied)
* `jetpack-cloud-production` accessible on https://cloud.jetpack.com/ (when not proxied)

By using Calypso environments we can natively take advantage of all the Calypso features, use the existing development features, staging and production, and deployment infrastructure.

Note that the proxied/non-proxied logic will have to be set up additionally, likely with the help of systems.

#### Changes proposed in this Pull Request

* Introduce 3 new environments for Jetpack Cloud: `development`, `stage` and `production`.
* Remove base route prefix for Jetpack Cloud to make the routes accessible from the root.
* Update server pages to load the Jetpack Cloud entry point for those environments

#### Testing instructions

* Checkout this branch.
* Point `jetpack.cloud.localhost:3000` to `127.0.0.1` in your hosts file.
* Point `cloud.jetpack.com` to `127.0.0.1` in your hosts file.
* Run `CALYPSO_ENV=jetpack-cloud-development npm start`
* Go to http://jetpack.cloud.localhost:3000/
* Verify you can access the page and you can navigate to the other pages.
* Go to http://jetpack.cloud.localhost:3000/scan directly and verify you can access it.
* Stop the process.
* Make sure you have Docker installed and it's currently running.
* Make sure you're setup Docker to use 8G of memory and add some CPUs if possible (as documented in FG here: PCYsg-5XR-p2)
* Run `npm run build-docker` - note that it takes time (15 to 30 min) and takes over your machine 😉 
* When it finishes, run: `docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso`
* Go to http://cloud.jetpack.com/
* Verify you can access the page and you can navigate to the other pages.
* Note that because this is a subdomain of jetpack.com, testing it may not work for the first time. You may have to try the following:
	* Your browser might be forcing usage of https. Verify you're running http and not https.
	* Delete any browser cache (including the domain one on chrome://net-internals/#hsts).
	* Delete your system's DNS cache, and/or force reconnection if using autoproxxy.
	* Restart your browser.
	* Try with and without a proxy.
	* Try in incognito mode.
	* Try in another browser.
* Go to http://cloud.jetpack.com/scan directly and verify you can access it.
* Stop the process.
* Run `npm start`.
* Smoke test Calypso (http://calypso.localhost:3000/) and verify it still works well.
* Bonus: run production calypso in your local Docker instance and verify it works: 
  * Point `wpcalypso.wordpress.com` to `127.0.0.1` in your hosts file.
  * Delete the domain security policies on chrome://net-internals/#hsts if using Chrome.
  * Run `docker run -it --env CALYPSO_ENV=production --name wp-calypso --rm -p 80:3000 wp-calypso`.
  * Open http://wpcalypso.wordpress.com/ (note the HTTP) and verify it works.

#### Notes

Note that the commit for making staging/production http-only will be removed prior to merging. It's been added only to facilitate easier testing.