### PR TITLE
Server: Fix service worker path

### DIFF
--- a/client/server/pwa/index.js
+++ b/client/server/pwa/index.js
@@ -19,7 +19,7 @@ export default () => {
 	app.use(
 		'/service-worker.js',
 		express.static(
-			path.resolve( __dirname, '..', '..', 'client', 'lib', 'service-worker', 'service-worker.js' )
+			path.resolve( __dirname, '..', '..', 'lib', 'service-worker', 'service-worker.js' )
 		)
 	);
 


### PR DESCRIPTION
This PR fixes the path to the service worker. 

#### Changes proposed in this Pull Request

* Server: Fix service worker path

Before:
![](https://cldup.com/TswEnG05eU.png)

After:
![](https://cldup.com/KrBpbnSYxh.png)

#### Testing instructions

* Checkout this branch.
* Run Calypso
* Verify you don't get 404s for the service worker anymore.

#### Context

Found while working on #39058