### PR TITLE
Fix select drop down

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -87,7 +87,6 @@ type FormFieldWrapperProps = {
 const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
 	select {
 		width: 100%;
-		min-width: auto;
 	}
 `;
 

--- a/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
+++ b/packages/composite-checkout-wpcom/src/components/form-field-annotation.tsx
@@ -87,6 +87,7 @@ type FormFieldWrapperProps = {
 const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
 	select {
 		width: 100%;
+		min-width: auto;
 	}
 `;
 

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -534,5 +534,6 @@ function joinNonEmptyValues( joinString, ...values ) {
 const StateSelectWrapper = styled.div`
 	& select {
 		width: 100%;
+		min-width: 0;
 	}
 `;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes: https://github.com/Automattic/wp-calypso/issues/38969

Before:
![image](https://user-images.githubusercontent.com/6981253/73085431-b0c8ee80-3e9c-11ea-9b8a-05db70b189ce.png)

After:
![image](https://user-images.githubusercontent.com/6981253/73085876-76138600-3e9d-11ea-80cd-b08360f012c9.png)

#### Testing instructions

* Get checkout running locally or use Calypso.live
* Add a plan + domain to your cart
* Check the field in Safari's Developer > Responsive mode to make sure the field doesn't expand out of view.
