### PR TITLE
Jetpack Checklist: Include Inline Help in Guided Tour

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
@@ -29,7 +29,7 @@ export const JetpackChecklistTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<Next step="finish">{ translate( 'Got it' ) }</Next>
+						<Next step="return-button">{ translate( 'Got it' ) }</Next>
 					</ButtonRow>
 				</>
 			) }
@@ -37,7 +37,7 @@ export const JetpackChecklistTour = makeTour(
 
 		<Step
 			arrow="bottom-right"
-			name="finish"
+			name="return-button"
 			placement="above"
 			style={ {
 				marginTop: '-25px',
@@ -52,6 +52,25 @@ export const JetpackChecklistTour = makeTour(
 								'admin here or continue using this dashboard.'
 						) }
 					</p>
+					<ButtonRow>
+						<Next step="finish">{ translate( 'Got it' ) }</Next>
+					</ButtonRow>
+				</>
+			) }
+		</Step>
+
+		<Step
+			arrow="bottom-right"
+			name="finish"
+			placement="above"
+			style={ {
+				margin: '-20px 0 0 -2px',
+			} }
+			target=".inline-help"
+		>
+			{ ( { translate } ) => (
+				<>
+					<p>{ translate( "If you run into any issues, we'd be happy to help!" ) }</p>
 					<ButtonRow>
 						<Quit primary>{ translate( 'Got it' ) }</Quit>
 					</ButtonRow>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This includes the Inline Help button as part of the guided tour for the Jetpack Checklist.

#### Testing instructions

Visit `/plans/my-plan/site?thank-you&jetpackChecklistTour` on a Jetpack site and complete the tour. Also, is the wording okay?

<img width="774" alt="Screenshot 2020-01-24 at 16 56 08" src="https://user-images.githubusercontent.com/43215253/73087880-19c75b00-3ecb-11ea-8793-a79a5e45e91f.png">

Fixes #33733
