### PR TITLE
Site Migration: Unify Site information Component between views

### DIFF
--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Site from 'blocks/site';
+import Gridicon from 'components/gridicon';
+import FormTextInput from 'components/forms/form-text-input';
+import { getUrlParts } from 'lib/url';
+
+export default class SitesBlock extends Component {
+	state = {};
+
+	renderFauxSiteSelector() {
+		const { onUrlChange, url } = this.props;
+		const { error } = this.state;
+		const isError = !! error;
+
+		return (
+			<div className="sites-block__faux-site-selector">
+				<div className="sites-block__faux-site-selector-content">
+					<div className="sites-block__faux-site-selector-icon" />
+					<div className="sites-block__faux-site-selector-info">
+						<div className="sites-block__faux-site-selector-label">Import from...</div>
+						<div className="sites-block__faux-site-selector-url">
+							<FormTextInput isError={ isError } onChange={ onUrlChange } value={ url } />
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	getSourceSiteOrInput = () => {
+		const { sourceSite } = this.props;
+
+		if ( ! sourceSite ) {
+			return this.renderFauxSiteSelector();
+		}
+
+		return (
+			<Site
+				site={ this.convertSourceSiteObjectToSiteComponent( sourceSite ) }
+				indicator={ false }
+			/>
+		);
+	};
+
+	convertSourceSiteObjectToSiteComponent = sourceSite => {
+		const { hostname } = getUrlParts( sourceSite.site_url );
+		return {
+			icon: { img: sourceSite.site_favicon },
+			title: sourceSite.site_title,
+			domain: hostname,
+		};
+	};
+
+	render() {
+		const { targetSite } = this.props;
+		return (
+			<div className="sites-block__sites">
+				<div className="sites-block__sites-item">{ this.getSourceSiteOrInput() }</div>
+				<div className="sites-block__sites-arrow-wrapper">
+					<Gridicon className="sites-block__sites-arrow" icon="arrow-right" />
+				</div>
+				<div className="sites-block__sites-item">
+					<Site site={ targetSite } indicator={ false } />
+					<div className="sites-block__sites-labels-container">
+						<span className="sites-block__token-label migrate__token-label">This site</span>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+SitesBlock.propTypes = {
+	sourceSite: PropTypes.object,
+	loadingSourceSite: PropTypes.bool,
+	targetSite: PropTypes.object.isRequired,
+};

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -1,0 +1,91 @@
+.sites-block__sites {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
+
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+	background-color: var( --color-surface );
+
+	& > * {
+		flex-grow: 1;
+		flex-shrink: 0;
+	}
+
+	.sites-block__sites-arrow-wrapper {
+		width: 1px;
+		border-left: 1px solid var( --color-border-subtle );
+		overflow: visible;
+		flex-grow:0;
+		flex-shrink: 0;
+		position: relative;
+
+		margin: 0 16px;
+
+		.sites-block__sites-arrow {
+			position: absolute;
+			left: -16px;
+			background: white;
+			padding: 5px;
+			top: calc( 50% - 16px );
+			color: var( --color-text-subtle );
+		}
+	}
+
+	.sites-block__sites-labels-container {
+		margin-left: 40px;
+		width: auto;
+	}
+
+	.sites-block__sites-item {
+		padding: 25px;
+	}
+
+	.site__content {
+		padding: 0; /* Reduce spacing below the site component, so we can put labels under it */
+	}
+
+
+
+	.sites-block__faux-site-selector {
+		box-sizing: border-box;
+		display: flex;
+		flex: 1 0 auto;
+		justify-content: space-between;
+		padding: 0;
+		position: relative;
+	}
+
+	.sites-block__faux-site-selector-content {
+		display: flex;
+		justify-content: space-between;
+		overflow: hidden;
+		padding: 0 16px;
+		position: relative;
+		width: 100%;
+	}
+
+	.sites-block__faux-site-selector-icon {
+		height: 32px;
+		width: 32px;
+		line-height: 32px;
+		border: 1px dashed var( --color-text-subtle );
+		position: relative;
+		overflow: hidden;
+		align-self: flex-start;
+		margin-right: 8px;
+		flex: 0 0 auto;
+	}
+
+	.sites-block__faux-site-selector-info {
+		width: 0;
+		flex: 1 0 auto;
+	}
+
+	.sites-block__faux-site-selector-label {
+		color: var( --color-text );
+		display: block;
+		font-size: 13px;
+		font-weight: 400;
+		line-height: 1.3;
+	}
+}

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -479,6 +479,7 @@ class SectionMigrate extends Component {
 						migrationElement = (
 							<StepImportOrMigrate
 								onJetpackSelect={ this.handleJetpackSelect }
+								sourceSite={ this.state.siteInfo }
 								targetSite={ targetSite }
 								targetSiteSlug={ targetSiteSlug }
 								sourceHasJetpack={ this.state.isJetpackConnected }

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -25,49 +25,6 @@
 	}
 }
 
-.migrate__faux-site-selector {
-	box-sizing: border-box;
-	display: flex;
-	flex: 1 0 auto;
-	justify-content: space-between;
-	padding: 0;
-	position: relative;
-}
-
-.migrate__faux-site-selector-content {
-	display: flex;
-	justify-content: space-between;
-	overflow: hidden;
-	padding: 0 16px;
-	position: relative;
-	width: 100%;
-}
-
-.migrate__faux-site-selector-icon {
-	height: 32px;
-	width: 32px;
-	line-height: 32px;
-	border: 1px dashed var( --color-text-subtle );
-	position: relative;
-	overflow: hidden;
-	align-self: flex-start;
-    margin-right: 8px;
-    flex: 0 0 auto;
-}
-
-.migrate__faux-site-selector-info {
-	width: 0;
-	flex: 1 0 auto;
-}
-
-.migrate__faux-site-selector-label {
-	color: var( --color-text );
-	display: block;
-	font-size: 13px;
-	font-weight: 400;
-	line-height: 1.3;
-}
-
 .migrate__card-footer {
 	color: var( --color-text-subtle );
 	font-size: 13px;
@@ -75,53 +32,6 @@
 	a {
 		color: var( --color-text-subtle );
 		text-decoration: underline;
-	}
-}
-
-.migrate__sites {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: nowrap;
-
-	box-shadow: 0 0 0 1px var( --color-border-subtle );
-	background-color: var( --color-surface );
-
-	& > * {
-		flex-grow: 1;
-		flex-shrink: 0;
-	}
-
-	.migrate__sites-arrow-wrapper {
-		width: 1px;
-		border-left: 1px solid var( --color-border-subtle );
-		overflow: visible;
-		flex-grow:0;
-		flex-shrink: 0;
-		position: relative;
-
-		margin: 0 16px;
-
-		.migrate__sites-arrow {
-			position: absolute;
-			left: -16px;
-			background: white;
-			padding: 5px;
-			top: calc( 50% - 16px );
-			color: var( --color-text-subtle );
-		}
-	}
-
-	.migrate__sites-labels-container {
-		margin-left: 40px;
-		width: auto;
-	}
-
-	.migrate__sites-item {
-		padding: 25px;
-	}
-
-	.site__content {
-		padding: 0; /* Reduce spacing below the site component, so we can put labels under it */
 	}
 }
 

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -9,9 +9,7 @@ import { Button, CompactCard } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
-import Site from 'blocks/site';
 
 /**
  * Style dependencies
@@ -21,6 +19,7 @@ import ImportTypeChoice from 'my-sites/migrate/components/import-type-choice';
 import MigrateButton from 'my-sites/migrate/migrate-button';
 import { get } from 'lodash';
 import { redirectTo } from 'my-sites/migrate/helpers';
+import SitesBlock from 'my-sites/migrate/components/sites-block';
 
 class StepImportOrMigrate extends Component {
 	static propTypes = {
@@ -71,7 +70,7 @@ class StepImportOrMigrate extends Component {
 	};
 
 	render() {
-		const { targetSite, targetSiteSlug, sourceHasJetpack } = this.props;
+		const { targetSite, targetSiteSlug, sourceHasJetpack, sourceSite } = this.props;
 		const backHref = `/migrate/${ targetSiteSlug }`;
 
 		const targetSiteDomain = get( targetSite, 'domain' );
@@ -79,10 +78,9 @@ class StepImportOrMigrate extends Component {
 		return (
 			<>
 				<HeaderCake backHref={ backHref }>Import from WordPress</HeaderCake>
-				<CompactCard className="migrate__sites">
-					<Gridicon className="migrate__sites-arrow" icon="arrow-right" />
-					<Site site={ targetSite } indicator={ false } />
-				</CompactCard>
+
+				<SitesBlock sourceSite={ sourceSite } targetSite={ targetSite } />
+
 				<CompactCard>
 					<h3>What do you want to import?</h3>
 

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -11,16 +11,14 @@ import page from 'page';
  * Internal dependencies
  */
 import CardHeading from 'components/card-heading';
-import FormTextInput from 'components/forms/form-text-input';
-import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
-import Site from 'blocks/site';
 import wpLib from 'lib/wp';
 
 /**
  * Style dependencies
  */
 import './section-migrate.scss';
+import SitesBlock from 'my-sites/migrate/components/sites-block';
 
 const wpcom = wpLib.undocumented();
 
@@ -83,26 +81,6 @@ class StepSourceSelect extends Component {
 		} );
 	};
 
-	renderFauxSiteSelector() {
-		const { onUrlChange, url } = this.props;
-		const { error } = this.state;
-		const isError = !! error;
-
-		return (
-			<div className="migrate__faux-site-selector">
-				<div className="migrate__faux-site-selector-content">
-					<div className="migrate__faux-site-selector-icon"></div>
-					<div className="migrate__faux-site-selector-info">
-						<div className="migrate__faux-site-selector-label">Import from...</div>
-						<div className="migrate__faux-site-selector-url">
-							<FormTextInput isError={ isError } onChange={ onUrlChange } value={ url } />
-						</div>
-					</div>
-				</div>
-			</div>
-		);
-	}
-
 	render() {
 		const { targetSite, targetSiteSlug } = this.props;
 		const backHref = `/import/${ targetSiteSlug }`;
@@ -118,11 +96,12 @@ class StepSourceSelect extends Component {
 						backup file, you can <a href={ uploadHref }>upload it to import content</a>.
 					</div>
 				</CompactCard>
-				<CompactCard className="migrate__sites">
-					{ this.renderFauxSiteSelector() }
-					<Gridicon className="migrate__sites-arrow" icon="arrow-right" />
-					<Site site={ targetSite } indicator={ false } />
-				</CompactCard>
+				<SitesBlock
+					sourceSite={ null }
+					loadingSourceSite={ this.state.isLoading }
+					targetSite={ targetSite }
+					onUrlChange={ this.props.onUrlChange }
+				/>
 				<CompactCard>
 					<Button busy={ this.state.isLoading } onClick={ this.handleContinue } primary={ true }>
 						Continue


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR introduces a single Site Information component that can is reused in multiple views in the flow, instead of ad-hoc implementations for the site information view.

#### Testing instructions

* Checkout branch or use Calypso.live link
* Go to Migrate
* Enter Site URL
* Continue
* Confirm that you want to perform a migration
* Take notice of the source and destination site information in the views. It should be updated properly between steps.
