### PR TITLE
UpsellNudge: Fix for spacing in narrow display areas

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -51,6 +51,7 @@
 	.banner__title {
 		color: var( --color-text-inverted );
 		font-weight: normal;
+		margin-right: 8px;
 	}
 
 	.banner__description {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* With a medium length title, call to action, and dismiss action, the compact nudge gets crowded. This adds some margin between the title and the button to prevent that.

**Before**

<img width="284" alt="Screen Shot 2020-01-24 at 1 31 12 PM" src="https://user-images.githubusercontent.com/2124984/73094275-428d2780-3eae-11ea-9e7e-e8a12019d3ef.png">

**After**

<img width="283" alt="Screen Shot 2020-01-24 at 1 30 23 PM" src="https://user-images.githubusercontent.com/2124984/73094279-4620ae80-3eae-11ea-84f3-b14230bf2295.png">

#### Testing instructions

* Switch to this PR
* Add an `UpsellNudge` in the sidebar in the render function of `/client/current-site/notice.jsx`
* Enable the `dismissPreferenceName`, `callToAction`, and add a medium or long-length `title` as component properties.
* Check visual appearance on multiple screen widths.
