### PR TITLE
Renovate: add assignees for wordpress-packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,12 @@
 		{
 			"extends": "monorepo:wordpress",
 			"separateMajorMinor": false,
-			"prPriority": 2
+			"prPriority": 2,
+			"assignees": [
+				"@Automattic/cylon",
+				"@Automattic/ganon",
+				"@Automattic/luna",
+			],
 		},
 		{
 			"extends": "monorepo:babel",

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
 			"extends": "monorepo:wordpress",
 			"separateMajorMinor": false,
 			"prPriority": 2,
-			"assignees": [
+			"reviewers": [
 				"@Automattic/cylon",
 				"@Automattic/ganon",
 				"@Automattic/luna"

--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,8 @@
 			"assignees": [
 				"@Automattic/cylon",
 				"@Automattic/ganon",
-				"@Automattic/luna",
-			],
+				"@Automattic/luna"
+			]
 		},
 		{
 			"extends": "monorepo:babel",


### PR DESCRIPTION
Adds 3 teams as assignees for `@wordpress/*` package updates in the repo.

We'd like to get notified when these packages are getting updates. It's not like Team Calypso needs to wait for us to update these but in practice, we all likely need to collaborate on each round of updates.

https://docs.renovatebot.com/configuration-options/#assignees

Not entirely sure if the GitHub team handles work and not sure how to test this either. :-)
