### PR TITLE
Migrate: Polish up the visual styles

### DIFF
--- a/client/my-sites/migrate/components/import-type-choice/index.jsx
+++ b/client/my-sites/migrate/components/import-type-choice/index.jsx
@@ -5,6 +5,11 @@ import React, { Component } from 'react';
 import { findKey, map } from 'lodash';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import Badge from 'components/badge';
+
 import './style.scss';
 import PropTypes from 'prop-types';
 
@@ -77,11 +82,12 @@ export default class ImportTypeChoice extends Component {
 					<div className="import-type-choice__option-header">
 						<p className="import-type-choice__option-title">{ item.title }</p>
 
-						{ item.labels.map( ( label, idx ) => (
-							<div className="migrate__token-label" key={ idx }>
-								{ label }
-							</div>
-						) ) }
+						{ item.labels &&
+							item.labels.map( ( label, idx ) => (
+								<Badge type="info" key={ idx }>
+									{ label }
+								</Badge>
+							) ) }
 					</div>
 					<div className="import-type-choice__option-description">{ item.description }</div>
 				</div>

--- a/client/my-sites/migrate/components/import-type-choice/style.scss
+++ b/client/my-sites/migrate/components/import-type-choice/style.scss
@@ -5,14 +5,15 @@
 		justify-content: flex-start;
 		align-items: flex-start;
 
-		padding: 20px;
+		padding: 16px;
 
 		cursor: pointer;
 
 		border: 1px solid var( --color-border ); /* TODO fix color */
 		border-radius: 4px;
 
-		margin-bottom: 10px;
+		margin-bottom: 8px;
+		transition: all 150ms;
 
 		&.disabled {
 			pointer-events: none;
@@ -25,7 +26,8 @@
 
 		&.selected {
 			pointer-events: none;
-			border-color: blue;
+			border-color: var( --color-primary );
+			box-shadow: 0 0 0 2px var( --color-primary );
 		}
 
 
@@ -39,7 +41,9 @@
 				align-items: flex-start;
 
 				.import-type-choice__option-title {
-					font-size: 18px;
+					font-size: 16px;
+					font-weight: 500;
+					line-height: 1.3;
 					margin: 0 10px 0 0;
 				}
 			}

--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -10,6 +10,9 @@ import './style.scss';
 import Site from 'blocks/site';
 import Gridicon from 'components/gridicon';
 import FormTextInput from 'components/forms/form-text-input';
+import FormLabel from 'components/forms/form-label';
+import FormInputValidation from 'components/forms/form-input-validation';
+import Badge from 'components/badge';
 import { getUrlParts } from 'lib/url';
 
 export default class SitesBlock extends Component {
@@ -25,9 +28,21 @@ export default class SitesBlock extends Component {
 				<div className="sites-block__faux-site-selector-content">
 					<div className="sites-block__faux-site-selector-icon" />
 					<div className="sites-block__faux-site-selector-info">
-						<div className="sites-block__faux-site-selector-label">Import from...</div>
+						<FormLabel
+							className="sites-block__faux-site-selector-label"
+							htmlFor="sites-block__faux-site-selector-url-input"
+						>
+							Import from...
+						</FormLabel>
 						<div className="sites-block__faux-site-selector-url">
-							<FormTextInput isError={ isError } onChange={ onUrlChange } value={ url } />
+							<FormTextInput
+								isError={ isError }
+								onChange={ onUrlChange }
+								value={ url }
+								placeholder="example.com"
+								id="sites-block__faux-site-selector-url-input"
+								name="sites-block__faux-site-selector-url-input"
+							/>
 						</div>
 					</div>
 				</div>
@@ -70,7 +85,7 @@ export default class SitesBlock extends Component {
 				<div className="sites-block__sites-item">
 					<Site site={ targetSite } indicator={ false } />
 					<div className="sites-block__sites-labels-container">
-						<span className="sites-block__token-label migrate__token-label">This site</span>
+						<Badge type="info">This site</Badge>
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -19,8 +19,7 @@ export default class SitesBlock extends Component {
 	state = {};
 
 	renderFauxSiteSelector() {
-		const { onUrlChange, url } = this.props;
-		const { error } = this.state;
+		const { onUrlChange, url, error } = this.props;
 		const isError = !! error;
 
 		return (
@@ -43,6 +42,7 @@ export default class SitesBlock extends Component {
 								id="sites-block__faux-site-selector-url-input"
 								name="sites-block__faux-site-selector-url-input"
 							/>
+							{ error !== '' && <FormInputValidation isError text={ error } /> }
 						</div>
 					</div>
 				</div>
@@ -97,4 +97,5 @@ SitesBlock.propTypes = {
 	sourceSite: PropTypes.object,
 	loadingSourceSite: PropTypes.bool,
 	targetSite: PropTypes.object.isRequired,
+	error: PropTypes.string,
 };

--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -11,7 +11,6 @@ import Site from 'blocks/site';
 import Gridicon from 'components/gridicon';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
-import FormInputValidation from 'components/forms/form-input-validation';
 import Badge from 'components/badge';
 import { getUrlParts } from 'lib/url';
 
@@ -19,7 +18,8 @@ export default class SitesBlock extends Component {
 	state = {};
 
 	renderFauxSiteSelector() {
-		const { onUrlChange, url, error } = this.props;
+		const { onUrlChange, url } = this.props;
+		const { error } = this.state;
 		const isError = !! error;
 
 		return (
@@ -42,7 +42,6 @@ export default class SitesBlock extends Component {
 								id="sites-block__faux-site-selector-url-input"
 								name="sites-block__faux-site-selector-url-input"
 							/>
-							{ error !== '' && <FormInputValidation isError text={ error } /> }
 						</div>
 					</div>
 				</div>
@@ -97,5 +96,4 @@ SitesBlock.propTypes = {
 	sourceSite: PropTypes.object,
 	loadingSourceSite: PropTypes.bool,
 	targetSite: PropTypes.object.isRequired,
-	error: PropTypes.string,
 };

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -8,7 +8,7 @@
 
 	& > * {
 		flex-grow: 1;
-		flex-shrink: 0;
+		flex-shrink: 1;
 	}
 
 	.sites-block__sites-arrow-wrapper {
@@ -32,12 +32,17 @@
 	}
 
 	.sites-block__sites-labels-container {
-		margin-left: 40px;
+		margin: 4px 0 0 40px;
 		width: auto;
+
+		.badge {
+			font-size: 12px;
+		}
 	}
 
 	.sites-block__sites-item {
 		padding: 25px;
+		width: 50%;
 	}
 
 	.site__content {
@@ -58,8 +63,6 @@
 	.sites-block__faux-site-selector-content {
 		display: flex;
 		justify-content: space-between;
-		overflow: hidden;
-		padding: 0 16px;
 		position: relative;
 		width: 100%;
 	}
@@ -68,7 +71,7 @@
 		height: 32px;
 		width: 32px;
 		line-height: 32px;
-		border: 1px dashed var( --color-text-subtle );
+		border: 1px dashed var( --color-border );
 		position: relative;
 		overflow: hidden;
 		align-self: flex-start;
@@ -84,8 +87,12 @@
 	.sites-block__faux-site-selector-label {
 		color: var( --color-text );
 		display: block;
-		font-size: 13px;
+		font-size: 16px;
 		font-weight: 400;
 		line-height: 1.3;
+	}
+
+	.site__title {
+		font-size: 16px;
 	}
 }

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -13,6 +13,10 @@
 	text-align: center;
 }
 
+.is-section-migrate .card > .card-heading {
+	margin-bottom: 4px;
+}
+
 .migrate__card {
 	.site__content, .site-selector__hidden-sites-message {
 		border-bottom: 1px solid var( --color-neutral-10 );

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -147,5 +147,5 @@
 }
 
 .migrate__buttons-wrapper {
-	margin-top: 20px;
+	margin: 24px 0 8px;
 }

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -10,6 +10,7 @@ import { Button, CompactCard } from '@automattic/components';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
+import CardHeading from 'components/card-heading';
 
 /**
  * Style dependencies
@@ -57,15 +58,13 @@ class StepImportOrMigrate extends Component {
 					<a href={ `https://wordpress.com/jetpack/connect/install?url=${ sourceSiteDomain }` }>
 						Jetpack
 					</a>{ ' ' }
-					installed on your site to be able to import over everything
+					installed on your site to be able to import everything.
 				</p>
 			);
 		}
 
 		if ( ! isTargetSiteAtomic ) {
-			return (
-				<p>A Business Plan (i) is required to import everything. Importing only content is free.</p>
-			);
+			return <p>Import your entire site with the Business Plan.</p>;
 		}
 	};
 
@@ -82,7 +81,7 @@ class StepImportOrMigrate extends Component {
 				<SitesBlock sourceSite={ sourceSite } targetSite={ targetSite } />
 
 				<CompactCard>
-					<h3>What do you want to import?</h3>
+					<CardHeading>What do you want to import?</CardHeading>
 
 					{ this.getJetpackOrUpgradeMessage() }
 					<ImportTypeChoice
@@ -90,14 +89,13 @@ class StepImportOrMigrate extends Component {
 						radioOptions={ {
 							everything: {
 								title: 'Everything',
-								labels: [ 'Upgrade Required', 'Something Else', 'Third bubble' ],
+								labels: [ 'Upgrade' ],
 								description: "All your site's content, themes, plugins, users and settings",
 								enabled: sourceHasJetpack,
 							},
 							'content-only': {
 								key: 'content-only',
 								title: 'Content only',
-								labels: [ 'Free', 'Only content', 'Third bubble' ],
 								description: 'Import posts, pages, comments, and media.',
 								enabled: true,
 							},

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { Button, CompactCard } from '@automattic/components';
+import { Button, CompactCard, Card } from '@automattic/components';
 import page from 'page';
 
 /**
@@ -102,11 +102,11 @@ class StepSourceSelect extends Component {
 					targetSite={ targetSite }
 					onUrlChange={ this.props.onUrlChange }
 				/>
-				<CompactCard>
+				<Card>
 					<Button busy={ this.state.isLoading } onClick={ this.handleContinue } primary={ true }>
 						Continue
 					</Button>
-				</CompactCard>
+				</Card>
 			</>
 		);
 	}

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -31,7 +31,7 @@ class StepSourceSelect extends Component {
 	};
 
 	state = {
-		error: '',
+		error: null,
 		isLoading: false,
 	};
 
@@ -40,7 +40,7 @@ class StepSourceSelect extends Component {
 			return;
 		}
 
-		this.setState( { error: '', isLoading: true }, () => {
+		this.setState( { error: null, isLoading: true }, () => {
 			wpcom
 				.isSiteImportable( this.props.url )
 				.then( result => {
@@ -99,7 +99,6 @@ class StepSourceSelect extends Component {
 				<SitesBlock
 					sourceSite={ null }
 					loadingSourceSite={ this.state.isLoading }
-					error={ this.state.error }
 					targetSite={ targetSite }
 					onUrlChange={ this.props.onUrlChange }
 				/>

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -31,7 +31,7 @@ class StepSourceSelect extends Component {
 	};
 
 	state = {
-		error: null,
+		error: '',
 		isLoading: false,
 	};
 
@@ -40,7 +40,7 @@ class StepSourceSelect extends Component {
 			return;
 		}
 
-		this.setState( { error: null, isLoading: true }, () => {
+		this.setState( { error: '', isLoading: true }, () => {
 			wpcom
 				.isSiteImportable( this.props.url )
 				.then( result => {
@@ -99,6 +99,7 @@ class StepSourceSelect extends Component {
 				<SitesBlock
 					sourceSite={ null }
 					loadingSourceSite={ this.state.isLoading }
+					error={ this.state.error }
 					targetSite={ targetSite }
 					onUrlChange={ this.props.onUrlChange }
 				/>

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -69,12 +69,12 @@ class StepSourceSelect extends Component {
 						case 'rest_invalid_param':
 							return this.setState( {
 								error: "We couldn't reach that site. Please check the URL and try again.",
-								loading: false,
+								isLoading: false,
 							} );
 						default:
 							return this.setState( {
 								error: 'Something went wrong. Please check the URL and try again.',
-								loading: false,
+								isLoading: false,
 							} );
 					}
 				} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Polish the styles for the migrate section
* Use proper form components for accessibility
* Fix a loading state bug when submitting the source site URL
* These styles do not affect mobile viewports yet since this is still behind a feature flag

Before | After
------------ | -------------
<img width="300" alt="Screen Shot 2020-01-24 at 4 53 03 PM" src="https://user-images.githubusercontent.com/448298/73106731-197a9000-3eca-11ea-9a4e-35c8b73704c2.png"> | <img width="300" src="https://user-images.githubusercontent.com/448298/73101951-cd761e00-3ebe-11ea-9a87-3c7b52a74a9a.png">
<img width="300" alt="Screen Shot 2020-01-24 at 4 53 16 PM" src="https://user-images.githubusercontent.com/448298/73106735-1da6ad80-3eca-11ea-98c8-5e5706a9645a.png"> | <img width="300" alt="Screen Shot 2020-01-24 at 4 19 03 PM" src="https://user-images.githubusercontent.com/448298/73105131-301ee800-3ec6-11ea-8bbb-19bfe2b0a2a3.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/migrate/{site}` with the `tools/migrate` feature flag enabled
* Make sure the styles look like the screenshot above