### PR TITLE
Jetpack Cloud: Refactor and Use Calypso Boot in Jetpack Cloud

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -2,46 +2,15 @@
 import './polyfills';
 
 /**
- * External dependencies
- */
-import debugFactory from 'debug';
-import page from 'page';
-
-/**
  * Internal dependencies
  */
-import { configureReduxStore, setupMiddlewares, utils } from './common';
-import { setupLocale } from './locale';
-import { createReduxStore } from 'state';
-import initialReducer from 'state/reducer';
-import { getInitialState, persistOnChange, loadAllState } from 'state/initial-state';
-import detectHistoryNavigation from 'lib/detect-history-navigation';
-import userFactory from 'lib/user';
+import { bootApp } from './common';
 
 /**
  * Style dependencies
  */
 import 'assets/stylesheets/style.scss';
 
-const debug = debugFactory( 'calypso' );
-
-const boot = currentUser => {
-	debug( "Starting Calypso. Let's do this." );
-
-	utils();
-	loadAllState().then( () => {
-		const initialState = getInitialState( initialReducer );
-		const reduxStore = createReduxStore( initialState, initialReducer );
-		persistOnChange( reduxStore );
-		setupLocale( currentUser.get(), reduxStore );
-		configureReduxStore( currentUser, reduxStore );
-		setupMiddlewares( currentUser, reduxStore );
-		detectHistoryNavigation.start();
-		page.start( { decodeURLComponents: false } );
-	} );
-};
-
 window.AppBoot = () => {
-	const user = userFactory();
-	user.initialize().then( () => boot( user ) );
+	bootApp( 'Calypso' );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -417,6 +417,7 @@ function renderLayout( reduxStore ) {
 const boot = currentUser => {
 	utils();
 	loadAllState().then( () => {
+		const initialState = getInitialState( initialReducer );
 		const reduxStore = createReduxStore( initialState, initialReducer );
 		persistOnChange( reduxStore );
 		setupLocale( currentUser.get(), reduxStore );

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -15,6 +15,7 @@ import store from 'store';
 /**
  * Internal dependencies
  */
+import { setupLocale } from './locale';
 import config from 'config';
 import { ReduxWrappedLayout } from 'controller';
 import notices from 'notices';
@@ -44,6 +45,11 @@ import { setRoute as setRouteAction } from 'state/ui/actions';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import setupGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
+import { createReduxStore } from 'state';
+import initialReducer from 'state/reducer';
+import { getInitialState, persistOnChange, loadAllState } from 'state/initial-state';
+import detectHistoryNavigation from 'lib/detect-history-navigation';
+import userFactory from 'lib/user';
 
 const debug = debugFactory( 'calypso' );
 
@@ -183,7 +189,7 @@ const unsavedFormsMiddleware = () => {
 	page.exit( '*', checkFormHandler );
 };
 
-export const utils = () => {
+const utils = () => {
 	debug( 'Executing Calypso utils.' );
 
 	// Infer touch screen by checking if device supports touch events
@@ -201,7 +207,7 @@ export const utils = () => {
 	Modal.setAppElement( document.getElementById( 'wpcom' ) );
 };
 
-export const configureReduxStore = ( currentUser, reduxStore ) => {
+const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
 
 	bindWpLocaleState( reduxStore );
@@ -231,7 +237,7 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 	}
 };
 
-export const setupMiddlewares = ( currentUser, reduxStore ) => {
+const setupMiddlewares = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso setup middlewares.' );
 
 	installPerfmonPageHandlers();
@@ -407,3 +413,24 @@ function renderLayout( reduxStore ) {
 
 	debug( 'Main layout rendered.' );
 }
+
+const boot = currentUser => {
+	utils();
+	loadAllState().then( () => {
+		const reduxStore = createReduxStore( initialState, initialReducer );
+		persistOnChange( reduxStore );
+		setupLocale( currentUser.get(), reduxStore );
+		configureReduxStore( currentUser, reduxStore );
+		setupMiddlewares( currentUser, reduxStore );
+		detectHistoryNavigation.start();
+		page.start( { decodeURLComponents: false } );
+	} );
+};
+
+export const bootApp = appName => {
+	const user = userFactory();
+	user.initialize().then( () => {
+		debug( `Starting ${ appName }. Let's do this.` );
+		boot( user );
+	} );
+};

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -2,20 +2,12 @@
  * External dependencies
  */
 import config from '../../config';
-import page from 'page';
-import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-import { configureReduxStore, setupMiddlewares, utils } from 'boot/common';
 import initJetpackCloudRoutes from './routes';
-import userFactory from 'lib/user';
-import { createReduxStore } from 'state';
-import initialReducer from 'state/reducer';
-import { setupLocale } from 'boot/locale';
-import detectHistoryNavigation from 'lib/detect-history-navigation';
-import { getInitialState, persistOnChange } from 'state/initial-state';
+import { bootApp } from 'boot/common';
 
 /**
  * Style dependencies
@@ -24,31 +16,11 @@ import 'components/environment-badge/style.scss';
 import 'layout/style.scss';
 import 'assets/stylesheets/jetpack-cloud.scss';
 
-const debug = debugFactory( 'jetpack-cloud' );
-
-const boot = currentUser => {
-	debug( "Starting Jetpack Cloud. Let's do this." );
-	utils();
-	getInitialState( initialReducer ).then( initialState => {
-		const reduxStore = createReduxStore( initialState, initialReducer );
-		initJetpackCloudRoutes( '/jetpack-cloud' );
-		persistOnChange( reduxStore );
-		setupLocale( currentUser.get(), reduxStore );
-		configureReduxStore( currentUser, reduxStore );
-		setupMiddlewares( currentUser, reduxStore );
-		detectHistoryNavigation.start();
-
-		page.start( { decodeURLComponents: false } );
-	} );
-};
-
 window.AppBoot = () => {
 	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
 		window.location.href = '/';
 	} else {
-		debug( 'before userFactory' );
-		const user = userFactory();
-		debug( 'after userFactory' );
-		user.initialize().then( () => boot( user ) );
+		initJetpackCloudRoutes( '/jetpack-cloud' );
+		bootApp( 'Jetpack' );
 	}
 };

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -3,11 +3,19 @@
  */
 import config from '../../config';
 import page from 'page';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
+import { configureReduxStore, setupMiddlewares, utils } from 'boot/common';
 import initJetpackCloudRoutes from './routes';
+import userFactory from 'lib/user';
+import { createReduxStore } from 'state';
+import initialReducer from 'state/reducer';
+import { setupLocale } from 'boot/locale';
+import detectHistoryNavigation from 'lib/detect-history-navigation';
+import { getInitialState, persistOnChange } from 'state/initial-state';
 
 /**
  * Style dependencies
@@ -16,11 +24,31 @@ import 'components/environment-badge/style.scss';
 import 'layout/style.scss';
 import 'assets/stylesheets/jetpack-cloud.scss';
 
+const debug = debugFactory( 'jetpack-cloud' );
+
+const boot = currentUser => {
+	debug( "Starting Jetpack Cloud. Let's do this." );
+	utils();
+	getInitialState( initialReducer ).then( initialState => {
+		const reduxStore = createReduxStore( initialState, initialReducer );
+		initJetpackCloudRoutes( '/jetpack-cloud' );
+		persistOnChange( reduxStore );
+		setupLocale( currentUser.get(), reduxStore );
+		configureReduxStore( currentUser, reduxStore );
+		setupMiddlewares( currentUser, reduxStore );
+		detectHistoryNavigation.start();
+
+		page.start( { decodeURLComponents: false } );
+	} );
+};
+
 window.AppBoot = () => {
 	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
 		window.location.href = '/';
 	} else {
-		initJetpackCloudRoutes();
-		page.start( { decodeURLComponents: false } );
+		debug( 'before userFactory' );
+		const user = userFactory();
+		debug( 'after userFactory' );
+		user.initialize().then( () => boot( user ) );
 	}
 };

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -21,6 +21,6 @@ window.AppBoot = () => {
 		window.location.href = '/';
 	} else {
 		initJetpackCloudRoutes();
-		bootApp( 'Jetpack ☁️' );
+		bootApp( 'Jetpack Cloud' );
 	}
 };

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -20,7 +20,7 @@ window.AppBoot = () => {
 	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
 		window.location.href = '/';
 	} else {
-		initJetpackCloudRoutes( '/jetpack-cloud' );
-		bootApp( 'Jetpack' );
+		initJetpackCloudRoutes();
+		bootApp( 'Jetpack ☁️' );
 	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR takes an alternative approach to https://github.com/Automattic/wp-calypso/pull/38977 by creating the Jetpack Cloud boot sequence by refactoring the Calypso boot so that the boot code is not duplicated between the two apps.

#### Testing instructions

* Test that visiting `http://calypso.localhost:3000/` or the equivalent URL in your environment loads Calypso, and verify that user specific data such as the site list is showing.
* Test that visiting `http://jetpack.cloud.localhost:3000/` or the equivalent URL in your environment loads the Jetpack Cloud.
* Test that when visiting Jetpack Cloud the user data is retrieved via XHR, and the Redux store exists.