### PR TITLE
Frankenflow: get theme and site title from query

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -206,6 +206,11 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		newSiteParams.options.site_segment = 1;
 	}
 
+	// Provide siteTitle from Gutenboarding
+	if ( 'frankenflow' === lastKnownFlow ) {
+		newSiteParams.blog_title = dependencies.siteTitle;
+	}
+
 	if ( isEligibleForPageBuilder( siteSegment, flowToCheck ) && shouldEnterPageBuilder() ) {
 		newSiteParams.options.in_page_builder = true;
 	}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -355,11 +355,12 @@ export function generateFlows( {
 
 	if ( isEnabled( 'gutenboarding' ) ) {
 		flows.frankenflow = {
-			steps: [ 'user', 'domains', 'plans' ],
+			steps: [ 'prelaunch-domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Frankenflow testing flow for Gutenboarding',
 			lastModified: '2020-01-22',
 			pageTitle: translate( 'Launch your site' ),
+			providesDependenciesInQuery: [ 'theme', 'siteTitle' ],
 		};
 	}
 

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -61,6 +61,7 @@ const stepNameToModuleName = {
 	'domains-with-preview': 'domains',
 	'site-title-with-preview': 'site-title',
 	passwordless: 'passwordless',
+	'prelaunch-domains': 'domains',
 };
 
 export async function getStepComponent( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -576,6 +576,22 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'email', 'username' ],
 			unstorableDependencies: [ 'bearer_token' ],
 		},
+		'prelaunch-domains': {
+			stepName: 'prelaunch-domains',
+			apiRequestFunction: createSiteWithCart,
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+				'shouldHideFreePlan',
+			],
+			props: {
+				isDomainOnly: false,
+			},
+			delayApiRequestUntilComplete: true,
+			dependencies: [ 'theme', 'siteTitle' ],
+		},
 	};
 }
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -586,6 +586,7 @@ export function generateSteps( {
 				'themeItem',
 				'shouldHideFreePlan',
 			],
+			optionalDependencies: [ 'shouldHideFreePlan' ],
 			props: {
 				isDomainOnly: false,
 			},


### PR DESCRIPTION
Part of #38937 

#### Changes proposed in this Pull Request

* Update frankenflow to get `theme` and `siteTitle` as query params and use them when creating a site.

#### Testing instructions

* While being already logged in, go to http://calypso.localhost:3000/start/frankenflow?theme=stratford&siteTitle=mywebsite
* After ending the flow and landing in Home check the theme and site title to be as expected.
