### PR TITLE
Try Enabling Customer Home for all Simple and Atomic Sites

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -57,6 +57,7 @@ import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 import GoMobileCard from 'my-sites/customer-home/go-mobile-card';
 import StatsCard from './stats-card';
+import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 
 /**
  * Style dependencies
@@ -596,7 +597,7 @@ const connectHome = connect(
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
 
 		return {
-			displayChecklist: !! ( ! isAtomic && hasChecklistData && ! isChecklistComplete ),
+			displayChecklist: isEligibleForDotcomChecklist( state, siteId ),
 			site: getSelectedSite( state ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),

--- a/client/state/sites/selectors/can-current-user-use-customer-home.js
+++ b/client/state/sites/selectors/can-current-user-use-customer-home.js
@@ -13,6 +13,7 @@ import isVipSite from 'state/selectors/is-vip-site';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSite from './get-site';
+import config from 'config';
 
 /**
  * Returns true if the current user should be able to use the customer home screen
@@ -34,15 +35,17 @@ export default function canCurrentUserUseCustomerHome( state, siteId = null ) {
 		return false;
 	}
 
-	const siteOptions = getSiteOptions( state, siteId );
-	const createdAt = get( siteOptions, 'created_at', '' );
+	if ( ! config.isEnabled( 'home/all' ) ) {
+		const siteOptions = getSiteOptions( state, siteId );
+		const createdAt = get( siteOptions, 'created_at', '' );
 
-	if (
-		! createdAt ||
-		createdAt.substr( 0, 4 ) === '0000' ||
-		new Date( createdAt ) < new Date( '2019-08-06' )
-	) {
-		return false;
+		if (
+			! createdAt ||
+			createdAt.substr( 0, 4 ) === '0000' ||
+			new Date( createdAt ) < new Date( '2019-08-06' )
+		) {
+			return false;
+		}
 	}
 
 	const site = getSite( state, siteId );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3857,30 +3857,6 @@ describe( 'selectors', () => {
 			},
 		} );
 
-		test( 'should return true for a simple site created after 2019-08-06', () => {
-			expect( canCurrentUserUseCustomerHome( createState( { created_at: '2020-01-01' } ) ) ).toBe(
-				true
-			);
-		} );
-
-		test( 'should return false for a simple site created before 2019-08-06', () => {
-			expect( canCurrentUserUseCustomerHome( createState( { created_at: '2019-08-01' } ) ) ).toBe(
-				false
-			);
-		} );
-
-		test( 'should return false for a simple site created on the 2019-08-06', () => {
-			expect( canCurrentUserUseCustomerHome( createState( { created_at: '2019-08-06' } ) ) ).toBe(
-				true
-			);
-		} );
-
-		test( "should return false for site with a zero'd out created_at option", () => {
-			expect(
-				canCurrentUserUseCustomerHome( createState( { created_at: '0000-00-00T00:00:00+00:00' } ) )
-			).toBe( false );
-		} );
-
 		test( "should return false if user can't manage site options", () => {
 			expect(
 				canCurrentUserUseCustomerHome(

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -35,6 +35,7 @@
 		"google-my-business": false,
 		"help": true,
 		"help/courses": true,
+		"home/all": false,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/development.json
+++ b/config/development.json
@@ -62,6 +62,7 @@
 		"gutenboarding": true,
 		"help": true,
 		"help/courses": true,
+		"home/all": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -38,6 +38,7 @@
 		"happychat": false,
 		"help": true,
 		"help/courses": true,
+		"home/all": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -38,7 +38,7 @@
 		"happychat": false,
 		"help": true,
 		"help/courses": true,
-		"home/all": false,
+		"home/all": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -37,6 +37,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"home/all": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"home/all": false,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/test.json
+++ b/config/test.json
@@ -36,6 +36,7 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,
+		"home/all": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -46,6 +46,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"home/all": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/38999 

This PR adds a new feature flag `home/all` enabled in `development` and `horizon`, that skips the site age check if the flag is set to true and also fixes a small bug where an empty checklist would render for sites created before Aug 19th.

<img width="1319" alt="Screen Shot 2020-01-24 at 4 41 27 PM" src="https://user-images.githubusercontent.com/1270189/73113377-6a898480-3ec8-11ea-897a-5e752b8a2961.png">

### Open Question
- Should we include VIP sites? I can update logic to filter them out. **Answer:** We'll exclude VIP sites for now.

p9GBOq-1A2-p2

### Testing Instructions
- Create a new site on WordPress.com
- Checkout this branch, verify that "My Home" is visible in sidebar and that a checklist renders in the page
- Switch sites to a site created before Aug 2019. The checklist should not render and instead we should see Site tools
- Customer Home should not be visible to Jetpack or VIP sites
