### PR TITLE
Customer Home: Collapse Site Tools on Mobile

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -23,7 +23,7 @@ class FoldableCard extends Component {
 	static displayName = 'FoldableCard';
 
 	static propTypes = {
-		actionButton: PropTypes.element,
+		actionButton: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 		actionButtonExpanded: PropTypes.element,
 		cardKey: PropTypes.string,
 		compact: PropTypes.bool,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -16,6 +16,7 @@ import Banner from 'components/banner';
 import { Button, Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import EmptyContent from 'components/empty-content';
+import FoldableCard from 'components/foldable-card';
 import Main from 'components/main';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
@@ -368,8 +369,12 @@ class Home extends Component {
 							<WpcomChecklist displayMode={ checklistMode } />
 						</>
 					) : (
-						<Card className="customer-home__card-boxes">
-							<CardHeading>{ translate( 'Site Tools' ) }</CardHeading>
+						<FoldableCard
+							className="customer-home__card-boxes card-heading-21"
+							header={ translate( 'Site Tools' ) }
+							expanded={ ! isMobile() }
+							actionButton={ isMobile() ? null : ' ' }
+						>
 							<div className="customer-home__boxes">
 								<ActionBox
 									onClick={ () => {
@@ -455,7 +460,7 @@ class Home extends Component {
 									/>
 								) }
 							</div>
-						</Card>
+						</FoldableCard>
 					) }
 				</div>
 				<div className="customer-home__layout-col customer-home__layout-col-right">

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -108,6 +108,23 @@
 	&__card-checklist-heading {
 		margin-bottom: -16px;
 	}
+	&__card-boxes.foldable-card {
+		&.is-expanded .foldable-card__header {
+			padding-bottom: 0;
+		}
+		.foldable-card {
+			@include breakpoint( '<480px' ) {
+				&__header {
+					min-height: 0;
+					padding: 12px 16px;
+				}
+			}
+
+			&__content {
+				border: 0;
+			}
+		}
+	}
 	@include breakpoint( '>480px' ) {
 		&__card-boxes.card.foldable-card {
 			margin-top: 0;
@@ -118,7 +135,6 @@
 			}
 
 			.foldable-card__content {
-				border: 0;
 				padding: 0 24px;
 			}
 		}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -64,7 +64,6 @@
 		.button {
 			border-width: 1px;
 			display: flex;
-			min-height: 85px;
 			height: 100%;
 			min-width: 100%;
 			padding: 16px;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -63,12 +63,18 @@
 
 		.button {
 			border-width: 1px;
-			display: block;
+			display: flex;
 			min-height: 85px;
 			height: 100%;
 			min-width: 100%;
-			padding: 24px;
+			padding: 16px;
 			text-align: center;
+
+			@include breakpoint( '>480px' ) {
+				display: block;
+				min-height: 85px;
+				padding: 24px;
+			}
 		}
 		.button:hover {
 			box-shadow: 0 2px 3px 0 rgba( 98, 109, 118, 0.15 );
@@ -76,6 +82,11 @@
 
 		span {
 			display: block;
+
+			@include breakpoint( '<480px' ) {
+				font-weight: 300;
+				margin: auto 14px;
+			}
 		}
 
 		@mixin box-action-two-col {
@@ -98,8 +109,20 @@
 	&__card-checklist-heading {
 		margin-bottom: -16px;
 	}
-	&__card-boxes {
-		padding-bottom: 0;
+	@include breakpoint( '>480px' ) {
+		&__card-boxes.card.foldable-card {
+			margin-top: 0;
+			padding-bottom: 0;
+
+			.foldable-card__header {
+				padding: 0 24px;
+			}
+
+			.foldable-card__content {
+				border: 0;
+				padding: 0 24px;
+			}
+		}
 	}
 	&__boxes {
 		display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This replaces the Card used for the Site Tools with a Foldable Card, so that on mobile, it can be collapsed

#### Testing instructions

On desktop, things shouldn't change. It shouldn't be possible to collapse the column.

<img width="1132" alt="Screenshot 2020-01-26 at 17 45 29" src="https://user-images.githubusercontent.com/43215253/73139221-a86ee000-4063-11ea-9c5a-0e1f60a3a5e5.png">

However, on mobile, it should be possible to collapse the tools.

<img width="461" alt="Screenshot 2020-01-26 at 17 40 24" src="https://user-images.githubusercontent.com/43215253/73139224-bde40a00-4063-11ea-8f2d-dc12d9715111.png">

This is how it should look like after the card has been expanded, following the design in the original issue.

<img width="414" alt="Screenshot 2020-01-26 at 17 48 39" src="https://user-images.githubusercontent.com/43215253/73139269-203d0a80-4064-11ea-9aee-50d3b5b2c562.png">

Fixes #39005
