### PR TITLE
PostTrends: drop use of i18n.moment.

### DIFF
--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { max, throttle, values } from 'lodash';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -128,10 +128,7 @@ class PostTrends extends React.Component {
 		const months = [];
 
 		for ( let i = 11; i >= 0; i-- ) {
-			const startDate = i18n
-				.moment()
-				.subtract( i, 'months' )
-				.startOf( 'month' );
+			const startDate = this.props.moment.subtract( i, 'months' ).startOf( 'month' );
 			months.push(
 				<Month key={ i } startDate={ startDate } streakData={ streakData } max={ maxPosts } />
 			);
@@ -196,14 +193,12 @@ class PostTrends extends React.Component {
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const query = {
-		startDate: i18n
-			.moment()
+		startDate: moment
 			.locale( 'en' )
 			.subtract( 1, 'year' )
 			.startOf( 'month' )
 			.format( 'YYYY-MM-DD' ),
-		endDate: i18n
-			.moment()
+		endDate: moment
 			.locale( 'en' )
 			.endOf( 'month' )
 			.format( 'YYYY-MM-DD' ),

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -193,12 +193,12 @@ class PostTrends extends React.Component {
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const query = {
-		startDate: moment
+		startDate: moment()
 			.locale( 'en' )
 			.subtract( 1, 'year' )
 			.startOf( 'month' )
 			.format( 'YYYY-MM-DD' ),
-		endDate: moment
+		endDate: moment()
 			.locale( 'en' )
 			.endOf( 'month' )
 			.format( 'YYYY-MM-DD' ),

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -128,7 +128,10 @@ class PostTrends extends React.Component {
 		const months = [];
 
 		for ( let i = 11; i >= 0; i-- ) {
-			const startDate = this.props.moment.subtract( i, 'months' ).startOf( 'month' );
+			const startDate = this.props
+				.moment()
+				.subtract( i, 'months' )
+				.startOf( 'month' );
 			months.push(
 				<Month key={ i } startDate={ startDate } streakData={ streakData } max={ maxPosts } />
 			);


### PR DESCRIPTION
It appears I missed this file when converting code across Calypso.

#### Changes proposed in this Pull Request

* Switch file to not depend on the now removed `moment` export in `i18n-calypso`.

#### Testing instructions

* Go to `/stats/insights/`
* Choose a site
* Verify that the page does not crash and works correctly