### PR TITLE
Composite checkout: fix scroll issue on mobile

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-terms-and-conditions.js
@@ -91,8 +91,12 @@ export default function WPTermsAndConditions( { domainName } ) {
 
 const TermsAndConditionsWrapper = styled.div`
 	padding: 24px 0 0;
-	margin: 24px 30px 8px 0;
+	margin: 24px 30px 100px 0;
 	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
+
+	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
+		margin-bottom: 8px;
+	}
 `;
 
 const TermsParagraph = styled.p`


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes: https://github.com/Automattic/wp-calypso/issues/38968

**Before:**
![image](https://user-images.githubusercontent.com/6981253/73188452-e534e880-40f0-11ea-94f3-2d3c69618c11.png)


**After:**
![image](https://user-images.githubusercontent.com/6981253/73188472-ecf48d00-40f0-11ea-84c4-172bf8267c8e.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get Calypso up and running locally or via Calypso.live
* Add a product to the cart and make your way to checkout
* Add the following query string to your url: `?flags=composite-checkout-wpcom`
* Make your way to the end of checkout. 
* See if the TOS is visible on desktop and mobile layouts.
