### PR TITLE
Domains: Allow users to remove domain mapping from Atomic sites

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -19,7 +19,13 @@ import { CANCEL_FLOW_TYPE } from 'components/marketing-survey/cancel-purchase-fo
 import GSuiteCancellationPurchaseDialog from 'components/marketing-survey/gsuite-cancel-purchase-dialog';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { isDataLoading } from '../utils';
-import { isDomainRegistration, isGoogleApps, isJetpackPlan, isPlan } from 'lib/products-values';
+import {
+	isDomainMapping,
+	isDomainRegistration,
+	isGoogleApps,
+	isJetpackPlan,
+	isPlan,
+} from 'lib/products-values';
 import notices from 'notices';
 import { purchasesRoot } from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
@@ -259,6 +265,10 @@ class RemovePurchase extends Component {
 
 		if ( isDomainRegistration( purchase ) ) {
 			return this.renderDomainDialog();
+		}
+
+		if ( isDomainMapping( purchase ) ) {
+			return this.this.renderPlanDialog();
 		}
 
 		if ( this.props.isAtomicSite ) {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -268,7 +268,7 @@ class RemovePurchase extends Component {
 		}
 
 		if ( isDomainMapping( purchase ) ) {
-			return this.this.renderPlanDialog();
+			return this.renderPlanDialog();
 		}
 
 		if ( this.props.isAtomicSite ) {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/38266

As confirmed there, it's OK now to remove domain registrations on Atomic sites. It should also be OK to remove domain mappings now - it's driving a lot of support requests right now.

### Testing

Try to remove a domain mapping on your Atomic site - verify that it's still working afterwards!