### PR TITLE
UpsellNudge: Make SCSS more specific to override Banner properties

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -48,7 +48,7 @@
 		color: var( --color-text-inverted );
 	}
 
-	.banner__title {
+	.banner__info .banner__title {
 		color: var( --color-text-inverted );
 		font-weight: normal;
 		margin-right: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ran into an issue while deploying #38881 where sometimes the text of the UpsellNudge would turn dark gray upon visiting the call to action. It appears to be Banner's SCSS overwriting UpsellNudge; making this rule more specific should fix it.

**Before**

<img width="285" alt="Screen Shot 2020-01-27 at 1 21 02 PM" src="https://user-images.githubusercontent.com/2124984/73201869-ed4c5280-4107-11ea-8633-a172730cff51.png">

**After**

<img width="283" alt="Screen Shot 2020-01-27 at 1 21 10 PM" src="https://user-images.githubusercontent.com/2124984/73201883-f2a99d00-4107-11ea-95f2-b125cb08226a.png">

#### Testing instructions

* Visit a site on a free plan, no domain attached, with A/B test `sidebarUpsellNudgeUnification` set to `variantShowUnifiedUpsells`
* You should see an UpsellNudge like the above in the sidebar. 
* Click the UpsellNudge call to action. 
* Verify the text remains white and legible.
