### PR TITLE
Consolidate the eslint config generation for packages

### DIFF
--- a/bin/lint-changed-files.sh
+++ b/bin/lint-changed-files.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+FILES_TO_LINT=$(
+  git diff --name-only --diff-filter=d origin/master... \
+    | grep -E '^(client/|server/|packages/)'            \
+    | grep -E '\.[jt]sx?$'
+) || exit 0
+
+if [[ ! -z $FILES_TO_LINT ]]; then
+  ./node_modules/.bin/eslint $FILES_TO_LINT
+fi

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,3 +1,4 @@
+const path = require( 'path' );
 module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
@@ -8,7 +9,10 @@ module.exports = {
 			rules: {
 				'import/no-extraneous-dependencies': [
 					'error',
-					{ packageDir: [ __dirname, __dirname + '/..' ] },
+					{
+						devDependencies: true,
+						packageDir: [ __dirname, path.join( __dirname, '..' ) ],
+					},
 				],
 				'import/no-nodejs-modules': 'off',
 			},

--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
 		"prettier": "npm:wp-prettier@1.19.1",
 		"react-docgen-typescript-loader": "3.6.0",
 		"react-test-renderer": "16.12.0",
+		"react-dom": "16.12.0",
 		"readline-sync": "1.4.10",
 		"replace": "1.1.1",
 		"rimraf": "3.0.0",

--- a/packages/babel-plugin-i18n-calypso/.eslintrc.js
+++ b/packages/babel-plugin-i18n-calypso/.eslintrc.js
@@ -1,6 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-		'import/no-nodejs-modules': 0,
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/calypso-build/.eslintrc.js
+++ b/packages/calypso-build/.eslintrc.js
@@ -1,8 +1,2 @@
-module.exports = {
-	parserOptions: {
-		sourceType: 'script', // force the cli to use require instead of import, which it should be to node compatible
-	},
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/calypso-codemods/.eslintrc.js
+++ b/packages/calypso-codemods/.eslintrc.js
@@ -1,6 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-nodejs-modules': 'off',
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/calypso-color-schemes/.eslintrc.js
+++ b/packages/calypso-color-schemes/.eslintrc.js
@@ -1,5 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForClient } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForClient( __dirname );

--- a/packages/calypso-polyfills/.eslintrc.js
+++ b/packages/calypso-polyfills/.eslintrc.js
@@ -1,5 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForClient } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForClient( __dirname );

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -1,3 +1,4 @@
+const path = require( 'path' );
 module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
@@ -14,7 +15,7 @@ module.exports = {
 			rules: {
 				'import/no-extraneous-dependencies': [
 					'error',
-					{ packageDir: [ __dirname, __dirname + '/../..' ] },
+					{ packageDir: [ __dirname, path.join( __dirname, '..', '..' ) ] },
 				],
 				'import/no-nodejs-modules': 'off',
 			},

--- a/packages/data-stores/.eslintrc.js
+++ b/packages/data-stores/.eslintrc.js
@@ -1,5 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForClient } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForClient( __dirname );

--- a/packages/eslint-config-wpcalypso/.eslintrc.js
+++ b/packages/eslint-config-wpcalypso/.eslintrc.js
@@ -1,8 +1,2 @@
-module.exports = {
-	parserOptions: {
-		sourceType: 'script',
-	},
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/eslint-plugin-wpcalypso/.eslintrc.js
+++ b/packages/eslint-plugin-wpcalypso/.eslintrc.js
@@ -1,9 +1,2 @@
-module.exports = {
-	parserOptions: {
-		sourceType: 'script',
-	},
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-		'import/no-nodejs-modules': 0,
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/format-currency/.eslintrc.js
+++ b/packages/format-currency/.eslintrc.js
@@ -1,5 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForClient } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForClient( __dirname );

--- a/packages/generate-eslintrc-for-packages.js
+++ b/packages/generate-eslintrc-for-packages.js
@@ -1,0 +1,54 @@
+const path = require( 'path' );
+module.exports = {
+	generateForClient: function( dirname ) {
+		return {
+			rules: {
+				'import/no-extraneous-dependencies': [ 'error', { packageDir: dirname } ],
+			},
+			overrides: [
+				{
+					files: [ '**/test/**/*' ],
+					rules: {
+						'import/no-extraneous-dependencies': [
+							'error',
+							{
+								devDependencies: true,
+								packageDir: [ dirname, path.join( dirname, '..', '..' ) ],
+							},
+						],
+						'import/no-nodejs-modules': 'off',
+					},
+				},
+			],
+		};
+	},
+	generateForServer: function( dirname ) {
+		return {
+			parserOptions: {
+				sourceType: 'script', // force the cli to use require instead of import, which it should be to node compatible
+			},
+			rules: {
+				'import/no-extraneous-dependencies': [ 'error', { packageDir: dirname } ],
+				'import/no-nodejs-modules': 'off',
+			},
+			overrides: [
+				{
+					files: [ '**/test/**/*' ],
+					parserOptions: {
+						sourceType: 'module',
+					},
+					rules: {
+						'import/no-extraneous-dependencies': [
+							'error',
+							{
+								devDependencies: true,
+								packageDir: [ dirname, path.join( dirname, '..', '..' ) ],
+							},
+						],
+						'import/no-nodejs-modules': 'off',
+					},
+				},
+			],
+		};
+	},
+};

--- a/packages/generate-eslintrc-for-packages.js
+++ b/packages/generate-eslintrc-for-packages.js
@@ -25,7 +25,7 @@ module.exports = {
 	generateForServer: function( dirname ) {
 		return {
 			parserOptions: {
-				sourceType: 'script', // force the cli to use require instead of import, which it should be to node compatible
+				sourceType: 'script', // force CommonJS `require` instead of ESM `import` for Node compatibility.
 			},
 			rules: {
 				'import/no-extraneous-dependencies': [ 'error', { packageDir: dirname } ],

--- a/packages/i18n-calypso-cli/.eslintrc.js
+++ b/packages/i18n-calypso-cli/.eslintrc.js
@@ -1,9 +1,2 @@
-module.exports = {
-	parserOptions: {
-		sourceType: 'script', // force the cli to use require instead of import, which it should be to node compatible
-	},
-	rules: {
-		'import/no-nodejs-modules': 0,
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/i18n-calypso/.eslintrc.js
+++ b/packages/i18n-calypso/.eslintrc.js
@@ -1,5 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForClient } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForClient( __dirname );

--- a/packages/photon/.eslintrc.js
+++ b/packages/photon/.eslintrc.js
@@ -1,5 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForClient } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForClient( __dirname );

--- a/packages/tree-select/.eslintrc.js
+++ b/packages/tree-select/.eslintrc.js
@@ -1,5 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-	},
-};
+const { generateForClient } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForClient( __dirname );

--- a/packages/webpack-config-flag-plugin/.eslintrc.js
+++ b/packages/webpack-config-flag-plugin/.eslintrc.js
@@ -1,6 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-		'import/no-nodejs-modules': 0,
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
+++ b/packages/webpack-extensive-lodash-replacement-plugin/.eslintrc.js
@@ -1,6 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-		'import/no-nodejs-modules': 0,
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );

--- a/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
+++ b/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
@@ -1,6 +1,2 @@
-module.exports = {
-	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
-		'import/no-nodejs-modules': 0,
-	},
-};
+const { generateForServer } = require( '../generate-eslintrc-for-packages' );
+module.exports = generateForServer( __dirname );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Consolidate the eslint config generation for packages
* Fix some lint errors
* Teach packages that tests can depend on the root devDependencies 

#### Testing instructions

* run `npx eslint --ext .js --ext .jsx --ext .ts --ext .tsx  packages`
* you should see no errors about extraneous imports

