### PR TITLE
Customer Home: explicitly exclude VIP sites from loading Customer Home

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -51,6 +51,11 @@ class Sites extends Component {
 			return true;
 		}
 
+		// Supported on Simple and Atomic Sites
+		if ( /^\/home/.test( path ) ) {
+			return ! site.is_vip && ! ( site.jetpack && ! site.options.is_automated_transfer );
+		}
+
 		return site;
 	};
 

--- a/client/state/sites/selectors/can-current-user-use-customer-home.js
+++ b/client/state/sites/selectors/can-current-user-use-customer-home.js
@@ -9,6 +9,7 @@ import { get } from 'lodash';
 import canCurrentUser from 'state/selectors/can-current-user';
 import getSiteOptions from 'state/selectors/get-site-options';
 import { isJetpackSite } from 'state/sites/selectors';
+import isVipSite from 'state/selectors/is-vip-site';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSite from './get-site';
@@ -23,6 +24,10 @@ import getSite from './get-site';
 export default function canCurrentUserUseCustomerHome( state, siteId = null ) {
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
+	}
+
+	if ( isVipSite( state, siteId ) ) {
+		return false;
 	}
 
 	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3829,7 +3829,13 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'canCurrentUserUseCustomerHome()', () => {
-		const createState = ( { created_at, manage_options = true, jetpack = false } = {} ) => ( {
+		const createState = ( {
+			created_at,
+			manage_options = true,
+			jetpack = false,
+			vip = false,
+			atomic = false,
+		} = {} ) => ( {
 			ui: {
 				selectedSiteId: 1,
 			},
@@ -3844,7 +3850,8 @@ describe( 'selectors', () => {
 				items: {
 					1: {
 						jetpack,
-						options: { is_automated_transfer: false, created_at },
+						...( vip ? { is_vip: true } : {} ),
+						options: { is_automated_transfer: atomic, created_at },
 					},
 				},
 			},
@@ -3886,6 +3893,20 @@ describe( 'selectors', () => {
 			expect(
 				canCurrentUserUseCustomerHome( createState( { created_at: '2020-01-01', jetpack: true } ) )
 			).toBe( false );
+		} );
+
+		test( 'should return false for VIP site', () => {
+			expect(
+				canCurrentUserUseCustomerHome( createState( { created_at: '2020-01-01', vip: true } ) )
+			).toBe( false );
+		} );
+
+		test( 'should return true for Atomic site', () => {
+			expect(
+				canCurrentUserUseCustomerHome(
+					createState( { created_at: '2020-01-01', jetpack: true, atomic: true } )
+				)
+			).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR makes sure that Customer Home will not load for VIP sites for now.

### Testing Instructions
- Try visiting /home with a new VIP site or with an older VIP site with the date check in `/client/state/sites/selectors/can-current-user-use-customer-home.js` commented out
- Verify that the section does not load and redirects to stats