### PR TITLE
Ignore built TypeScript types in packages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,6 +12,9 @@ node_modules/
 # Built packages
 /packages/*/dist/
 
+# Built package types
+/packages/**/*.d.ts
+
 #
 # Eslint won't lint json, but prettier shares this ignore
 # Don't operate on these files


### PR DESCRIPTION
This prevents eslint from running against d.ts files.

#### Changes proposed in this Pull Request

* Adds `*.d.ts` files under packages to the list of eslint ignores

#### Testing instructions

* `npx eslint --ext .js --ext .jsx --ext .ts --ext .tsx packages/data-stores` should not include errors from built type files. It does on master
