### PR TITLE
Domains: Include WPCOM and .blog subdomain suggestions for Blog segment

### DIFF
--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -40,7 +40,6 @@ class FreeDomainExplainer extends React.Component {
 							borderless
 							className="free-domain-explainer__subtitle-link"
 							onClick={ this.handleClick }
-							href
 						>
 							{ translate( 'Review our plans to get started' ) } &raquo;
 						</Button>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -927,7 +927,7 @@ class RegisterDomainStep extends React.Component {
 	getSubdomainSuggestions = ( domain, timestamp ) => {
 		const subdomainQuery = {
 			query: domain,
-			quantity: this.props.includeDotBlogSubdomain ? 2 : 1,
+			quantity: this.props.includeWordPressDotCom + this.props.includeDotBlogSubdomain,
 			include_wordpressdotcom: true,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			only_wordpressdotcom: this.props.includeDotBlogSubdomain,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -376,6 +376,9 @@ class RegisterDomainStep extends React.Component {
 		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
 			if ( this.state.loadingSubdomainResults && ! this.state.loadingResults ) {
 				suggestions.unshift( { is_placeholder: true } );
+				if ( this.props.includeDotBlogSubdomain ) {
+					suggestions.unshift( { is_placeholder: true } );
+				}
 			} else if ( ! isEmpty( this.state.subdomainSearchResults ) ) {
 				if ( this.props.includeDotBlogSubdomain && this.state.subdomainSearchResults.length > 1 ) {
 					// Let's put the .blog subdomain first

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -155,13 +155,15 @@ class RegisterDomainStep extends React.Component {
 
 	static defaultProps = {
 		analyticsSection: 'domains',
+		deemphasiseTlds: [],
+		includeDotBlogSubdomain: false,
+		includeWordPressDotCom: false,
 		isDomainOnly: false,
 		onAddDomain: noop,
 		onAddMapping: noop,
 		onDomainsAvailabilityChange: noop,
 		onSave: noop,
 		vendor: getSuggestionsVendor(),
-		deemphasiseTlds: [],
 	};
 
 	constructor( props ) {
@@ -821,10 +823,9 @@ class RegisterDomainStep extends React.Component {
 	};
 
 	getDomainsSuggestions = ( domain, timestamp ) => {
-		const suggestionQuantity =
-			this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain
-				? SUGGESTION_QUANTITY - 1
-				: SUGGESTION_QUANTITY;
+		const freeSubdomainSuggestionsQuantity =
+			this.props.includeWordPressDotCom + this.props.includeDotBlogSubdomain;
+		const suggestionQuantity = SUGGESTION_QUANTITY - freeSubdomainSuggestionsQuantity;
 
 		const query = {
 			query: domain,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -347,6 +347,10 @@ class RegisterDomainStep extends React.Component {
 		}
 	}
 
+	getFreeSubdomainSuggestionsQuantity() {
+		return this.props.includeWordPressDotCom + this.props.includeDotBlogSubdomain;
+	}
+
 	getNewRailcarId() {
 		return `${ uuid().replace( /-/g, '' ) }-domain-suggestion`;
 	}
@@ -377,10 +381,10 @@ class RegisterDomainStep extends React.Component {
 
 		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
 			if ( this.state.loadingSubdomainResults && ! this.state.loadingResults ) {
-				suggestions.unshift( { is_placeholder: true } );
-				if ( this.props.includeDotBlogSubdomain ) {
-					suggestions.unshift( { is_placeholder: true } );
-				}
+				const freeSubdomainPlaceholders = Array(
+					this.getFreeSubdomainSuggestionsQuantity()
+				).fill( { is_placeholder: true } );
+				suggestions.unshift( ...freeSubdomainPlaceholders );
 			} else if ( ! isEmpty( this.state.subdomainSearchResults ) ) {
 				suggestions.unshift( ...this.state.subdomainSearchResults );
 			}
@@ -823,9 +827,7 @@ class RegisterDomainStep extends React.Component {
 	};
 
 	getDomainsSuggestions = ( domain, timestamp ) => {
-		const freeSubdomainSuggestionsQuantity =
-			this.props.includeWordPressDotCom + this.props.includeDotBlogSubdomain;
-		const suggestionQuantity = SUGGESTION_QUANTITY - freeSubdomainSuggestionsQuantity;
+		const suggestionQuantity = SUGGESTION_QUANTITY - this.getFreeSubdomainSuggestionsQuantity();
 
 		const query = {
 			query: domain,
@@ -927,7 +929,7 @@ class RegisterDomainStep extends React.Component {
 	getSubdomainSuggestions = ( domain, timestamp ) => {
 		const subdomainQuery = {
 			query: domain,
-			quantity: this.props.includeWordPressDotCom + this.props.includeDotBlogSubdomain,
+			quantity: this.getFreeSubdomainSuggestionsQuantity(),
 			include_wordpressdotcom: true,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			only_wordpressdotcom: this.props.includeDotBlogSubdomain,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -376,7 +376,11 @@ class RegisterDomainStep extends React.Component {
 		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
 			if ( this.state.loadingSubdomainResults && ! this.state.loadingResults ) {
 				suggestions.unshift( { is_placeholder: true } );
-			} else if ( this.state.subdomainSearchResults && this.state.subdomainSearchResults.length ) {
+			} else if ( ! isEmpty( this.state.subdomainSearchResults ) ) {
+				if ( this.props.includeDotBlogSubdomain && this.state.subdomainSearchResults.length > 1 ) {
+					// Let's put the .blog subdomain first
+					suggestions.unshift( this.state.subdomainSearchResults[ 1 ] );
+				}
 				suggestions.unshift( this.state.subdomainSearchResults[ 0 ] );
 			}
 		}
@@ -923,9 +927,10 @@ class RegisterDomainStep extends React.Component {
 	getSubdomainSuggestions = ( domain, timestamp ) => {
 		const subdomainQuery = {
 			query: domain,
-			quantity: 1,
-			include_wordpressdotcom: ! this.props.includeDotBlogSubdomain,
+			quantity: this.props.includeDotBlogSubdomain ? 2 : 1,
+			include_wordpressdotcom: true,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
+			only_wordpressdotcom: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
 			vertical: this.props.vertical,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -380,11 +380,7 @@ class RegisterDomainStep extends React.Component {
 					suggestions.unshift( { is_placeholder: true } );
 				}
 			} else if ( ! isEmpty( this.state.subdomainSearchResults ) ) {
-				if ( this.props.includeDotBlogSubdomain && this.state.subdomainSearchResults.length > 1 ) {
-					// Let's put the .blog subdomain first
-					suggestions.unshift( this.state.subdomainSearchResults[ 1 ] );
-				}
-				suggestions.unshift( this.state.subdomainSearchResults[ 0 ] );
+				suggestions.unshift( ...this.state.subdomainSearchResults );
 			}
 		}
 		return suggestions;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -415,15 +415,8 @@ class DomainsStep extends React.Component {
 
 		if (
 			// If we landed here from /domains Search or with a suggested domain.
-			( initialQuery && this.searchOnInitialRender ) ||
-			// If the subdomain type has changed, rerun the search
-			( initialState &&
-				initialState.subdomainSearchResults &&
-				endsWith(
-					get( initialState, 'subdomainSearchResults[0].domain_name', '' ),
-					// Inverted the ending, so we know it's the wrong subdomain in the saved results
-					this.shouldIncludeDotBlogSubdomain() ? '.wordpress.com' : '.blog'
-				) )
+			initialQuery &&
+			this.searchOnInitialRender
 		) {
 			this.searchOnInitialRender = false;
 			if ( initialState ) {

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -15,6 +15,7 @@ import {
 	SIGNUP_PROGRESS_PROCESS_STEP,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
+	SIGNUP_STEPS_SITE_TYPE_SET,
 } from 'state/action-types';
 import { withSchemaValidation } from 'state/utils';
 import { schema } from './schema';
@@ -116,6 +117,9 @@ export default withSchemaValidation( schema, ( state = {}, action ) => {
 			return saveStep( state, action );
 		case SIGNUP_PROGRESS_SUBMIT_STEP:
 			return submitStep( state, action );
+		case SIGNUP_STEPS_SITE_TYPE_SET:
+			delete state[ 'domains-with-preview' ];
+			return state;
 	}
 
 	return state;


### PR DESCRIPTION
As discussed in p99Zz8-VK-p2 - let's start showing _both_ a WPCOM subdomain suggestion and a .blog subdomain suggestion in the Blog segment.

### Before

<img width="982" alt="Screenshot 2020-01-27 at 22 33 17" src="https://user-images.githubusercontent.com/3392497/73219889-092a1580-4155-11ea-9a04-683014ea9257.png">

### After
<img width="983" alt="Screenshot 2020-01-27 at 22 33 12" src="https://user-images.githubusercontent.com/3392497/73219899-0f1ff680-4155-11ea-85f5-55832e58b388.png">

(please ignore the quality of results - they are dependent on the verticals selected in the previous steps, etc.)

## Testing

Go to wordpress.com/start and select the `Blog` segment. Without the patch, you should only have one free .blog subdomain in the domains step. With the patch, you should have both a .blog subdomain _and_ a WPCOM subdomain. Always one of each, always .blog first, WPCOM second.

Check also other segments and make sure that there are no regressions (or .blog subdomains...) showing there. Check `/domains` and if everything works as expected as you (re)start the flow from - first from `/domains` then from `/start` and vice versa.

Fixes #38952