### PR TITLE
Adds highlight for FoldableCard component

### DIFF
--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -40,3 +40,4 @@ Name | Type | Default | Description
 `onOpen` | `function` | null | Function to be executed in addition to the expand action when the card is opened.
 `summary` | `string` | null | A string or component to show next to the action button when closed.
 `clickableHeader` | `bool` | false | Indicates if the whole header can be clicked to open the card.
+`highlight` | `string` | null | Displays a colored highlight. If specified (default is no highlight), can be one of `info`, `success`, `error`, or `warning`.

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * External dependencies
  */
@@ -61,7 +62,9 @@ export default class FoldableCardExample extends PureComponent {
 								</div>
 							</div>
 						}
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						summary={ <button className="button">Update</button> }
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						expandedSummary={ <button className="button">Update</button> }
 						screenReaderText="More"
 					>

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -35,6 +35,15 @@ export default class FoldableCardExample extends PureComponent {
 				</div>
 				<div>
 					<FoldableCard
+						header="This is a highlighted card"
+						highlight="info"
+						screenReaderText="More"
+					>
+						I'm highlighted!
+					</FoldableCard>
+				</div>
+				<div>
+					<FoldableCard
 						header="This is a foldable card with a custom action icon"
 						icon="arrow-down"
 						screenReaderText="More"

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -36,6 +36,7 @@ class FoldableCard extends Component {
 		onOpen: PropTypes.func,
 		screenReaderText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		summary: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+		highlight: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -150,7 +151,7 @@ class FoldableCard extends Component {
 		} );
 
 		return (
-			<Container className={ itemSiteClasses }>
+			<Container className={ itemSiteClasses } highlight={ this.props.highlight }>
 				{ this.renderHeader() }
 				{ this.state.expanded && this.renderContent() }
 			</Container>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a `highlight` prop to the `FoldableCard` component. This passes this prop to the container component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run Calypso with `npm start`.
* Navigate to http://calypso.localhost:3000/devdocs/design/foldable-card.
* Examine card in devdocs.

Screenshot:
<img width="1367" alt="Screen Shot 2020-01-27 at 5 46 25 PM" src="https://user-images.githubusercontent.com/1760168/73220698-0fa49700-412d-11ea-9cea-c3ea53a2d38c.png">

Related ticket: 1156570014567299-as-1159067512361665.
