### PR TITLE
Creates LogItem component for Cloud logs

### DIFF
--- a/client/landing/jetpack-cloud/components/log-item/docs/example.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/docs/example.tsx
@@ -11,7 +11,7 @@ import LogItem from '../';
 import CardHeading from 'components/card-heading';
 
 export default class LogItemExample extends PureComponent {
-	static displayName = 'LogItemExample';
+	static displayName = 'LogItem';
 
 	render(): ReactNode {
 		return (

--- a/client/landing/jetpack-cloud/components/log-item/docs/example.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/docs/example.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+
+import React, { PureComponent, ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import LogItem from '../';
+import CardHeading from 'components/card-heading';
+
+export default class LogItemExample extends PureComponent {
+	static displayName = 'LogItemExample';
+
+	render(): ReactNode {
+		return (
+			<div>
+				<LogItem header="Default Log Item" subheader="This is the subheader">
+					This is a default log item.
+				</LogItem>
+				<LogItem header="Custom tag" subheader="^ there's a custom tag" tag="Custom">
+					This log item has a custom tag.
+				</LogItem>
+				<LogItem header="HTML Contents" subheader="This is the subheader">
+					<CardHeading tag="h2" size={ 18 }>
+						This is a header!
+					</CardHeading>
+				</LogItem>
+				<LogItem header="Success!" subheader="Success type" highlight="success">
+					This is a success log item.
+				</LogItem>
+				<LogItem header="Warning Log Item" subheader="This is the subheader" highlight="warning">
+					This is a warning log item.
+				</LogItem>
+				<LogItem header="Error Log Item" subheader="This is the subheader" highlight="error">
+					This is a error log item.
+				</LogItem>
+			</div>
+		);
+	}
+}

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -6,8 +6,8 @@ import React, { ReactNode } from 'react';
 /**
  * Internal dependencies
  */
-import FoldableCard from 'components/foldable-card';
 import CardHeading from 'components/card-heading';
+import FoldableCard from 'components/foldable-card';
 
 import './style.scss';
 

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -14,7 +14,7 @@ import './style.scss';
 interface Props {
 	children?: ReactNode;
 	header: string;
-	subheader: string;
+	subheader?: string;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;
 }
@@ -29,7 +29,7 @@ class LogItem extends React.PureComponent< Props > {
 				<CardHeading tagName="h2" size={ 18 }>
 					{ header }
 				</CardHeading>
-				<p className="log-item__subheader">{ subheader }</p>
+				{ subheader && <p className="log-item__subheader">{ subheader }</p> }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 	children?: ReactNode;
 	header: string;
 	subheader: string;
-	highlight?: string;
+	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;
 }
 

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -20,17 +20,12 @@ interface Props {
 }
 
 class LogItem extends React.PureComponent< Props > {
-	static defaultProps = {
-		highlight: 'info',
-		tag: 'new',
-	};
-
 	renderHeader() {
 		const { header, subheader, tag } = this.props;
 
 		return (
 			<div className="log-item__header-wrapper">
-				<span className="log-item__tag">{ tag }</span>
+				{ tag && <span className="log-item__tag">{ tag }</span> }
 				<CardHeading tagName="h2" size={ 18 }>
 					{ header }
 				</CardHeading>

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React, { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+import CardHeading from 'components/card-heading';
+
+import './style.scss';
+
+interface Props {
+	children?: ReactNode;
+	header: string;
+	subheader: string;
+	highlight?: string;
+	tag?: string;
+}
+
+class LogItem extends React.PureComponent< Props > {
+	static defaultProps = {
+		highlight: 'info',
+		tag: 'new',
+	};
+
+	renderHeader() {
+		const { header, subheader, tag } = this.props;
+
+		return (
+			<div className="log-item__header-wrapper">
+				<span className="log-item__tag">{ tag }</span>
+				<CardHeading tagName="h2" size={ 18 }>
+					{ header }
+				</CardHeading>
+				<p className="log-item__subheader">{ subheader }</p>
+			</div>
+		);
+	}
+
+	render() {
+		const { highlight, children } = this.props;
+		return (
+			<FoldableCard header={ this.renderHeader() } className="log-item" highlight={ highlight }>
+				{ children }
+			</FoldableCard>
+		);
+	}
+}
+
+export default LogItem;

--- a/client/landing/jetpack-cloud/components/log-item/style.scss
+++ b/client/landing/jetpack-cloud/components/log-item/style.scss
@@ -1,0 +1,72 @@
+.log-item {
+	border-radius: 3px;
+
+	&__header-wrapper {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+	}
+
+	&__tag {
+		display: block;
+		margin-right: 10px;
+		padding: 2px 6px;
+		border-radius: 3px;
+		background-color: var( --color-primary-20 );
+		font-size: 10px;
+		color: var( --color-primary-0 );
+		text-transform: uppercase;
+		text-align: center;
+		min-width: 48px;
+		font-weight: 600;
+		height: 16px;
+	}
+
+	&__header-wrapper .card-heading {
+		font-weight: 600;
+		margin: 0;
+		color: var( --color-primary-20 );
+	}
+
+	&__subheader {
+		flex-basis: 100%;
+		margin: 0;
+	}
+
+	&.is-expanded .foldable-card__content {
+		border-top-width: 0;
+	}
+
+	&.is-error {
+		.log-item {
+			&__tag {
+				background-color: var( --color-error-20 );
+			}
+			&__header-wrapper .card-heading {
+				color: var( --color-error-20 );
+			}
+		}
+	}
+
+	&.is-success {
+		.log-item {
+			&__tag {
+				background-color: var( --color-success-20 );
+			}
+			&__header-wrapper .card-heading {
+				color: var( --color-success-20 );
+			}
+		}
+	}
+
+	&.is-warning {
+		.log-item {
+			&__tag {
+				background-color: var( --color-warning-20 );
+			}
+			&__header-wrapper .card-heading {
+				color: var( --color-warning-20 );
+			}
+		}
+	}
+}

--- a/client/landing/jetpack-cloud/components/log-item/style.scss
+++ b/client/landing/jetpack-cloud/components/log-item/style.scss
@@ -1,5 +1,13 @@
 .log-item {
 	border-radius: 3px;
+	--color-log-item: var( --color-text );
+
+	$highlights: ( 'info': 'primary-20', 'success': 'success-20', 'error': 'error-20', 'warning': 'warning-20' );
+	@each $type, $color in $highlights {
+		&.is-#{$type} {
+			--color-log-item: var( --color-#{$color} );
+		}
+	}
 
 	&__header-wrapper {
 		display: flex;
@@ -12,9 +20,9 @@
 		margin-right: 10px;
 		padding: 2px 6px;
 		border-radius: 3px;
-		background-color: var( --color-primary-20 );
+		background-color: var( --color-log-item );
 		font-size: 10px;
-		color: var( --color-primary-0 );
+		color: var( --color-text-inverted );
 		text-transform: uppercase;
 		text-align: center;
 		min-width: 48px;
@@ -25,7 +33,7 @@
 	&__header-wrapper .card-heading {
 		font-weight: 600;
 		margin: 0;
-		color: var( --color-primary-20 );
+		color: var( --color-log-item );
 	}
 
 	&__subheader {
@@ -35,38 +43,5 @@
 
 	&.is-expanded .foldable-card__content {
 		border-top-width: 0;
-	}
-
-	&.is-error {
-		.log-item {
-			&__tag {
-				background-color: var( --color-error-20 );
-			}
-			&__header-wrapper .card-heading {
-				color: var( --color-error-20 );
-			}
-		}
-	}
-
-	&.is-success {
-		.log-item {
-			&__tag {
-				background-color: var( --color-success-20 );
-			}
-			&__header-wrapper .card-heading {
-				color: var( --color-success-20 );
-			}
-		}
-	}
-
-	&.is-warning {
-		.log-item {
-			&__tag {
-				background-color: var( --color-warning-20 );
-			}
-			&__header-wrapper .card-heading {
-				color: var( --color-warning-20 );
-			}
-		}
 	}
 }

--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -9,6 +9,7 @@ import ReactDom from 'react-dom';
  */
 import JetpackCloudLayout from './layout';
 import JetpackCloudSidebar from './components/sidebar';
+import LogItem from './components/log-item';
 
 export const makeLayout = ( context, next ) => {
 	const { primary, secondary } = context;
@@ -33,7 +34,28 @@ export function jetpackCloud( context, next ) {
 }
 
 export function jetpackBackups( context, next ) {
-	context.primary = <div>This is the Jetpack Backup landing page!</div>;
+	context.primary = (
+		<div>
+			This is the Jetpack Backup landing page!
+			<LogItem
+				header="Unexpected core file: sx--a4bp.php"
+				subheader="Threat found on 14 September, 2019"
+			>
+				<h3>Item Header</h3>
+				<p>Foo</p>
+				<h3>Item Header 2</h3>
+				<p>Bar</p>
+			</LogItem>
+			<LogItem
+				header="Unexpected core file: sx--a4bp.php"
+				subheader="Threat found on 14 September, 2019"
+				tag="critical"
+				highlight="error"
+			>
+				Hello
+			</LogItem>
+		</div>
+	);
 	next();
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a new component to Jetpack Cloud, `LogItem`, used to display log entry items.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build and run Calypso with `npm start`.
* Navigate to http://calypso.localhost:3000/jetpack-cloud.
* Examine landing page for log entries.

#### Notes

Related ticket: 1156570014567299-as-1159067512361665.
Relies on #39093 to display highlight. Note that highlight colors aren't quite as expected, so will need to resolve that with a separate PR.