### PR TITLE
[Coming soon] Set wpcom_coming_soon option for new sites

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -37,6 +37,7 @@ import { requestSites } from 'state/sites/actions';
 import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
 import getNewSitePublicSetting from 'state/selectors/get-new-site-public-setting';
+import getNewSiteComingSoonSetting from 'state/selectors/get-new-site-coming-soon-setting';
 
 // Current directory dependencies
 import { isValidLandingPageVertical } from './verticals';
@@ -172,6 +173,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				title: siteTitle,
 			},
 			site_creation_flow: flowToCheck,
+			wpcom_coming_soon: getNewSiteComingSoonSetting( state ),
 		},
 		public: getNewSitePublicSetting( state ),
 		validate: false,
@@ -511,7 +513,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		blog_name: site,
 		blog_title: '',
 		public: getNewSitePublicSetting( state ),
-		options: { theme: themeSlugWithRepo },
+		options: { theme: themeSlugWithRepo, wpcom_coming_soon: getNewSiteComingSoonSetting( state ) },
 		validate: false,
 	};
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -10,6 +10,7 @@ import { parse as parseURL } from 'url';
  */
 
 // Libraries
+import config from 'config';
 import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
@@ -173,11 +174,14 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				title: siteTitle,
 			},
 			site_creation_flow: flowToCheck,
-			wpcom_coming_soon: getNewSiteComingSoonSetting( state ),
 		},
 		public: getNewSitePublicSetting( state ),
 		validate: false,
 	};
+
+	if ( config.isEnabled( 'coming-soon' ) ) {
+		newSiteParams.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
+	}
 
 	const shouldSkipDomainStep = ! siteUrl && isDomainStepSkippable( flowToCheck );
 	const shouldHideFreePlan = get( signupDependencies, 'shouldHideFreePlan', false );
@@ -513,9 +517,13 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		blog_name: site,
 		blog_title: '',
 		public: getNewSitePublicSetting( state ),
-		options: { theme: themeSlugWithRepo, wpcom_coming_soon: getNewSiteComingSoonSetting( state ) },
+		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};
+
+	if ( config.isEnabled( 'coming-soon' ) ) {
+		data.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
+	}
 
 	wpcom.undocumented().sitesNew( data, function( errors, response ) {
 		let providedDependencies, siteSlug;

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -11,7 +11,6 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import notices from 'notices';
 import EmptyContent from 'components/empty-content';
 import CreditsPaymentBox from './credits-payment-box';
@@ -218,16 +217,14 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 
-		if ( ! config.isEnabled( 'coming-soon' ) ) {
-			// Until Atomic sites support being private / unlaunched, set them to public on upgrade
-			debug( 'Setting site to public because it is an Atomic plan' );
-			const response = await this.props.saveSiteSettings( selectedSiteId, {
-				blog_public: 1,
-			} );
+		// Until Atomic sites support being private / unlaunched, set them to public on upgrade
+		debug( 'Setting site to public because it is an Atomic plan' );
+		const response = await this.props.saveSiteSettings( selectedSiteId, {
+			blog_public: 1,
+		} );
 
-			if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
-				throw 'Invalid response';
-			}
+		if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
+			throw 'Invalid response';
 		}
 	}
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -11,6 +11,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import notices from 'notices';
 import EmptyContent from 'components/empty-content';
 import CreditsPaymentBox from './credits-payment-box';
@@ -217,14 +218,16 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 
-		// Until Atomic sites support being private / unlaunched, set them to public on upgrade
-		debug( 'Setting site to public because it is an Atomic plan' );
-		const response = await this.props.saveSiteSettings( selectedSiteId, {
-			blog_public: 1,
-		} );
+		if ( ! config.isEnabled( 'coming-soon' ) ) {
+			// Until Atomic sites support being private / unlaunched, set them to public on upgrade
+			debug( 'Setting site to public because it is an Atomic plan' );
+			const response = await this.props.saveSiteSettings( selectedSiteId, {
+				blog_public: 1,
+			} );
 
-		if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
-			throw 'Invalid response';
+			if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
+				throw 'Invalid response';
+			}
 		}
 	}
 

--- a/client/state/selectors/get-new-site-coming-soon-setting.ts
+++ b/client/state/selectors/get-new-site-coming-soon-setting.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import shouldNewSiteBePrivateByDefault from './should-new-site-be-private-by-default';
+
+/**
+ * Get the numeric value that should be provided to the "new site" endpoint
+ *
+ * @param state The current client state
+ * @returns `-1` for private by default & `1` for public
+ */
+export default function getNewSiteComingSoonSetting( state: object ): number {
+	return shouldNewSiteBePrivateByDefault( state ) && config.isEnabled( 'coming-soon' ) ? 1 : 0;
+}

--- a/client/state/selectors/get-new-site-coming-soon-setting.ts
+++ b/client/state/selectors/get-new-site-coming-soon-setting.ts
@@ -11,5 +11,5 @@ import shouldNewSiteBePrivateByDefault from './should-new-site-be-private-by-def
  * @returns `-1` for private by default & `1` for public
  */
 export default function getNewSiteComingSoonSetting( state: object ): number {
-	return shouldNewSiteBePrivateByDefault( state ) && config.isEnabled( 'coming-soon' ) ? 1 : 0;
+	return shouldNewSiteBePrivateByDefault( state ) ? 1 : 0;
 }

--- a/client/state/selectors/get-new-site-coming-soon-setting.ts
+++ b/client/state/selectors/get-new-site-coming-soon-setting.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
 import shouldNewSiteBePrivateByDefault from './should-new-site-be-private-by-default';
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to Coming Soon mode. More context available here: paObgF-MY-p2

This diff makes sure the `wpcom_coming_soon` option is set for all new sites. For now just behind a feature flag.

#### Testing instructions

1. Apply D38260-code
1. Open calypso.localhost 
1. Create a new site
1. Confirm it has `wpcom_coming_soon` option set to 1
1. Try this diff on calypso.live
1. Create a new site
1. Confirm it does **not** have the `wpcom_coming_soon` option at all
