### PR TITLE
Upwork: fix invisible button text in Themes

### DIFF
--- a/client/blocks/upwork-banner/style.scss
+++ b/client/blocks/upwork-banner/style.scss
@@ -46,7 +46,6 @@
 	}
 
 	.button.upwork-banner__cta {
-		color: white;
 		margin-top: 1em;
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -53,3 +53,7 @@
 .themes__hidden-content {
 	display: none;
 }
+
+.theme-showcase__all-themes .button.upwork-banner__cta {
+	color: inherit;
+}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -53,7 +53,3 @@
 .themes__hidden-content {
 	display: none;
 }
-
-.theme-showcase__all-themes .button.upwork-banner__cta {
-	color: inherit;
-}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/38048 reported by @arunsathiya.

#### Changes proposed in this Pull Request

The Upwork banner has invisible button text when displayed on the Themes page:

<img width="969" alt="Screen Shot 2020-01-28 at 15 16 45" src="https://user-images.githubusercontent.com/17325/73230209-55229c00-41e1-11ea-8705-a9cc7ea8424a.png">

This PR fixes it.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Choose one of your sites (either Jetpack or Atomic) and go to `/themes`. 
2. Scroll down and click the 'Show all themes' button.
3. Look for the Upwork banner. If you don't see it, you might need to add yourself to the `builderReferralThemesBanner` A/B test like so:

<img width="373" alt="Screen Shot 2020-01-28 at 15 18 49" src="https://user-images.githubusercontent.com/17325/73230283-8f8c3900-41e1-11ea-9816-7d6b8d89100c.png">

Ensure that the button text is legible.

After:

<img width="971" alt="Screen Shot 2020-01-28 at 15 16 28" src="https://user-images.githubusercontent.com/17325/73230306-a3379f80-41e1-11ea-9c8b-39721f324003.png">

