### PR TITLE
Add basic test for stats insights page.

### DIFF
--- a/test/e2e/lib/pages/stats-page.js
+++ b/test/e2e/lib/pages/stats-page.js
@@ -16,6 +16,14 @@ export default class StatsPage extends AsyncBaseContainer {
 		super( driver, By.css( '.stats-module' ) );
 	}
 
+	async openInsights() {
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.stats-navigation__insights' ) );
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.stats__section-header' )
+		);
+	}
+
 	async _expandNavIfMobile() {
 		if ( driverManager.currentScreenSize() !== 'mobile' ) {
 			return await this.waitForPage();

--- a/test/e2e/lib/pages/stats-page.js
+++ b/test/e2e/lib/pages/stats-page.js
@@ -16,7 +16,12 @@ export default class StatsPage extends AsyncBaseContainer {
 		super( driver, By.css( '.stats-module' ) );
 	}
 
+	async openStats() {
+		return await driverHelper.clickWhenClickable( this.driver, By.css( '.sidebar__menu .stats' ) );
+	}
+
 	async openInsights() {
+		await this._expandNavIfMobile();
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.stats-navigation__insights' ) );
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,

--- a/test/e2e/lib/pages/stats-page.js
+++ b/test/e2e/lib/pages/stats-page.js
@@ -16,10 +16,6 @@ export default class StatsPage extends AsyncBaseContainer {
 		super( driver, By.css( '.stats-module' ) );
 	}
 
-	async openStats() {
-		return await driverHelper.clickWhenClickable( this.driver, By.css( '.sidebar__menu .stats' ) );
-	}
-
 	async openInsights() {
 		await this._expandNavIfMobile();
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.stats-navigation__insights' ) );

--- a/test/e2e/specs/wp-stats-insights-spec.js
+++ b/test/e2e/specs/wp-stats-insights-spec.js
@@ -9,6 +9,7 @@ import config from 'config';
 import LoginFlow from '../lib/flows/login-flow.js';
 
 import NavBarComponent from '../lib/components/nav-bar-component.js';
+import SidebarComponent from '../lib/components/sidebar-component.js';
 
 import StatsPage from '../lib/pages/stats-page.js';
 
@@ -42,8 +43,9 @@ describe( 'Stats: (' + screenSize + ') @parallel', function() {
 			let statsPage;
 
 			step( 'Can open the stats page', async function() {
+				const sidebarComponent = await SidebarComponent.Expect( driver );
+				await sidebarComponent.selectStats();
 				statsPage = await StatsPage.Expect( driver );
-				await statsPage.openStats();
 			} );
 
 			step( 'Can open the stats insights page', async function() {

--- a/test/e2e/specs/wp-stats-insights-spec.js
+++ b/test/e2e/specs/wp-stats-insights-spec.js
@@ -30,7 +30,7 @@ describe( 'Stats: (' + screenSize + ') @parallel', function() {
 	describe( 'Log in as user', function() {
 		step( 'Can log in as user', async function() {
 			this.loginFlow = new LoginFlow( driver );
-			return await this.loginFlow.login( { useFreshLogin: true } );
+			return await this.loginFlow.login();
 		} );
 
 		step( 'Can open the sidebar', async function() {

--- a/test/e2e/specs/wp-stats-insights-spec.js
+++ b/test/e2e/specs/wp-stats-insights-spec.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import NavBarComponent from '../lib/components/nav-bar-component.js';
+
+import StatsPage from '../lib/pages/stats-page.js';
+
+import * as driverManager from '../lib/driver-manager.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+let driver;
+
+before( async function() {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( 'Stats: (' + screenSize + ') @parallel', function() {
+	this.timeout( mochaTimeOut );
+	describe( 'Log in as user', function() {
+		step( 'Can log in as user', async function() {
+			this.loginFlow = new LoginFlow( driver );
+			return await this.loginFlow.login( { useFreshLogin: true } );
+		} );
+
+		step( 'Can open the sidebar', async function() {
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
+		} );
+
+		describe( 'Can navigate to the stats insights page', function() {
+			let statsPage;
+
+			step( 'Can open the stats page', async function() {
+				statsPage = await StatsPage.Expect( driver );
+			} );
+
+			step( 'Can open the stats insights page', async function() {
+				await statsPage.openInsights();
+			} );
+		} );
+	} );
+} );

--- a/test/e2e/specs/wp-stats-insights-spec.js
+++ b/test/e2e/specs/wp-stats-insights-spec.js
@@ -43,6 +43,7 @@ describe( 'Stats: (' + screenSize + ') @parallel', function() {
 
 			step( 'Can open the stats page', async function() {
 				statsPage = await StatsPage.Expect( driver );
+				await statsPage.openStats();
 			} );
 
 			step( 'Can open the stats insights page', async function() {


### PR DESCRIPTION
The insights page in stats (`/stats/insights/<blog>`) is a very popular destination, so I'm adding this E2E test to ensure that it opens correctly.

This was prompted by a change that inadvertently broke the page with an error on load, which unfortunately wasn't detected until it shipped.

Note that I haven't added this test to any suites, as I'm: a) not sure where that configuration lives; b) not sure what suite(s) it would be appropriate to add this to.

I apologise in advance if I incorrectly added you as a reviewer; I just went with the kind folks who answered my questions as I was preparing to write this 🙂 Please feel free to ignore the PR or punt it to someone else if that's the case.

#### Changes proposed in this Pull Request

* Add E2E test to ensure that `/stats/insights/<blog>` opens without crashing

#### Testing instructions

To ensure the test passes when it should:

* Run master on your development branch
* Run `specs/wp-stats-insights-spec.js` and ensure that it passes

To ensure that the test fails when it should:

* Modify e.g. `client/my-sites/stats/post-trends/index.jsx` to throw an error on render
* Run `specs/wp-stats-insights-spec.js` against your local development server with the above change, and ensure that it fails
