### PR TITLE
Domains: Fix the transfer out support link to point to the correct section

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -90,6 +90,7 @@ export const STATS_TOP_POSTS_PAGES = `${ root }/stats/#top-posts-pages`;
 export const STATS_VIEWS_BY_COUNTRY = `${ root }/stats/#views-by-country`;
 export const SUPPORT_ROOT = `${ root }/`;
 export const TRANSFER_DOMAIN_REGISTRATION = `${ root }/transfer-domain-registration`;
+export const TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR = `${ root }/transfer-domain-registration#starting-the-transfer-with-your-new-registrar`;
 export const TWITTER_TIMELINE_WIDGET = `${ root }/widgets/twitter-timeline-widget`;
 export const UPDATE_CONTACT_INFORMATION = `${ root }/update-contact-information/`;
 export const UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES = `${ root }/update-contact-information/#email-or-name-changes`;

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -18,7 +18,7 @@ import {
 } from 'lib/domains/wapi-domain-info/actions';
 import notices from 'notices';
 import { displayRequestTransferCodeResponseNotice } from './shared';
-import { CALYPSO_CONTACT, TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
+import { CALYPSO_CONTACT, TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR } from 'lib/url/support';
 
 class Unlocked extends React.Component {
 	state = {
@@ -30,17 +30,17 @@ class Unlocked extends React.Component {
 		this.setStateIfMounted = noop;
 	}
 
-	/**
-	 * Wrap setState calls that might occur after unmounting.
-	 *
-	 * When we cancel a transfer, that might update locking or privacy,
-	 * but errors mean we can't know in time - the store gets the information
-	 * before we do.
-	 *
-	 * The recommended solution is cancellable promises, but we don't want to
-	 * cancel these requests if we navigate away, so that won't work for us here.
-	 */
 	setStateIfMounted( ...args ) {
+		/**
+		 * Wrap setState calls that might occur after unmounting.
+		 *
+		 * When we cancel a transfer, that might update locking or privacy,
+		 * but errors mean we can't know in time - the store gets the information
+		 * before we do.
+		 *
+		 * The recommended solution is cancellable promises, but we don't want to
+		 * cancel these requests if we navigate away, so that won't work for us here.
+		 */
 		this.setState( ...args );
 	}
 
@@ -292,7 +292,11 @@ class Unlocked extends React.Component {
 						{ submitting && <p>{ translate( 'Sending request…' ) }</p> }
 						{ domainStateMessage && <p>{ domainStateMessage }</p> }
 						{ this.renderBody( domain ) }
-						<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
+						<a
+							href={ TRANSFER_DOMAIN_REGISTRATION_WITH_NEW_REGISTRAR }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
 							{ translate( 'Learn More.' ) }
 						</a>
 					</div>


### PR DESCRIPTION
As part of a small usability fixes we're working on for the domain management screens this will change where the "Learn more" link sends you

#### Changes proposed in this Pull Request

* Update the Learn More link on the unlocked domain screen to point to the relevant support doc section

#### Testing instructions

* Unlock a domain and click on the "Learn more" link
