### PR TITLE
Jetpack Connect: Respect redirect url on retryAuth

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -172,7 +172,7 @@ export class JetpackAuthorize extends Component {
 			// as controlled by MAX_AUTH_ATTEMPTS.
 			const attempts = this.props.authAttempts || 0;
 			this.retryingAuth = true;
-			return retryAuth( site, attempts + 1, nextProps.authQuery.from );
+			return retryAuth( site, attempts + 1, nextProps.authQuery.from, redirectAfterAuth );
 		}
 	}
 

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -169,7 +169,7 @@ export function checkUrl( url, isUrlOnSites ) {
 	};
 }
 
-export function retryAuth( url, attemptNumber, fromParam ) {
+export function retryAuth( url, attemptNumber, fromParam, redirectAfterAuth ) {
 	return dispatch => {
 		debug( 'retrying auth', url, attemptNumber );
 		dispatch( {
@@ -184,6 +184,8 @@ export function retryAuth( url, attemptNumber, fromParam ) {
 			} )
 		);
 		debug( 'retryAuth', url );
+		// If redirectAfterAuth use that as the destination url, otherwise default to url arg
+		const destinationUrl = redirectAfterAuth || url + REMOTE_PATH_AUTH;
 		externalRedirect(
 			addQueryArgs(
 				{
@@ -192,7 +194,7 @@ export function retryAuth( url, attemptNumber, fromParam ) {
 					auth_type: 'jetpack',
 					from: fromParam,
 				},
-				url + REMOTE_PATH_AUTH
+				destinationUrl
 			)
 		);
 	};

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -184,8 +184,6 @@ export function retryAuth( url, attemptNumber, fromParam, redirectAfterAuth ) {
 			} )
 		);
 		debug( 'retryAuth', url );
-		// If redirectAfterAuth use that as the destination url, otherwise default to url arg
-		const destinationUrl = redirectAfterAuth || url + REMOTE_PATH_AUTH;
 		externalRedirect(
 			addQueryArgs(
 				{
@@ -193,8 +191,9 @@ export function retryAuth( url, attemptNumber, fromParam, redirectAfterAuth ) {
 					calypso_env: calypsoEnv,
 					auth_type: 'jetpack',
 					from: fromParam,
+					redirect_after_auth: redirectAfterAuth,
 				},
-				destinationUrl
+				url + REMOTE_PATH_AUTH
 			)
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #39003 

Please see the bug above for the full background on this proposed fix, but TL;DR;

When an Jetpack Connect auth flow fails, the `retryAuth()` action does not utilize the `redirectAfterAuth` argument that is passed in from the connecting flow. This bug was discovered during the testing of the new WooCommerce onboarding flow that is now live in WooCommerce 3.9 for 10% of users.

#### Testing instructions

This one is a bit difficult to test because the auth fail doesn't always happen, and I haven't been able to figure out a way to always make it break. As such I ended up hacking a bit in the the auth action to dispatch a connection error. To setup for the test, I borrowed these instructions from a prior PR by @ebinnion 

- Check out this patch
- npm start in Calypso
- On a fresh Jetpack site, perhaps using https://jurassic.ninja, install WooCommerce, and force yourself into the a/b test group that uses the new onboarding flow by setting the following option:
`update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'b' );`
- Visit `/wp-admin?page=wc-setup`, your screen should look like this:

<img width="722" alt="image" src="https://user-images.githubusercontent.com/22080/73292132-55597200-41b6-11ea-94ae-cb165f1f85fa.png">

- Click Yes Please and being the Jetpack connect flow
- On the resulting Jetpack Connect URL that you end up on, replace wordpress.com with calypso.localhost:3000
- Here you could verify that the normal flow where auth works fine still functions as expected. You should be returned to the WooCommerce onboarding screen *not* the Jetpack dashboard on the remote wp-admin install
- You might encounter the failed auth randomly, which is great and you could test that flow too.
- Based upon the test above, try to re-test the opposite flow ( either normal success first try, or retry via forcing it by modifying some code, [here is what i did to force the error](https://gist.github.com/timmyc/ba87390aba75b89181193bc55ed0ef9d) )

Tagging a few folks for review that have worked in this file before, sorry if you aren't the correct folks, and I'm totally open to alternate fixes. The solution here of adding in another argument felt a bit hacky to me, but I wasn't certain the history behind the retryAuth method signature so just kept it as-is.