### PR TITLE
Domains: Don't reorder the suggestion results

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -113,8 +113,6 @@ const MAX_PAGES = 3;
 const SUGGESTION_QUANTITY = isPaginationEnabled ? PAGE_SIZE * MAX_PAGES : PAGE_SIZE;
 const MIN_QUERY_LENGTH = 2;
 
-const FEATURED_SUGGESTIONS_AT_TOP = [ 'group_7', 'group_8' ];
-
 function getQueryObject( props ) {
 	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
 		return null;
@@ -909,7 +907,7 @@ class RegisterDomainStep extends React.Component {
 			suggestions,
 			this.state.exactMatchDomain,
 			getStrippedDomainBase( domain ),
-			includes( FEATURED_SUGGESTIONS_AT_TOP, this.props.vendor ),
+			true,
 			this.props.deemphasiseTlds
 		);
 


### PR DESCRIPTION
Since we introduced the "Best match" and "Best alternative" labels we're technically reordering the results from the suggestion endpoint. This leads to some unexpected results because we surface as "Best alternative" a result wich does not match exactly in the SLD part. However that shows up hyphenated result as second suggestion and we don't want that. Also it is reordering the results from the suggestion endpoint and we don't want to do that either since the suggestion provider should give us the best order. So this diff will stop reordering the suggestions.

#### Changes proposed in this Pull Request

* Don't reorder the suggestion results based on the SLD match

#### Testing instructions

* Search for some unique domain name and make sure that the results are displayed in the same order they were in the suggestion endpoint results

