### PR TITLE
E2E- Update to fix twitter issues that are still occurring

### DIFF
--- a/test/e2e/lib/pages/twitter-feed-page.js
+++ b/test/e2e/lib/pages/twitter-feed-page.js
@@ -9,7 +9,7 @@ import config from 'config';
  */
 import * as slackNotifier from '../slack-notifier';
 import AsyncBaseContainer from '../async-base-container';
-import { getElementCount } from '../driver-helper';
+import { isEventuallyPresentAndDisplayed } from '../driver-helper';
 
 export default class TwitterFeedPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
@@ -19,7 +19,7 @@ export default class TwitterFeedPage extends AsyncBaseContainer {
 				: '';
 			url = `https://twitter.com/${ publicizeTwitterAccount }`;
 		}
-		super( driver, by.css( '.ProfileCanopy, div[data-testid*=tweet]' ), url );
+		super( driver, by.css( '.ProfileCanopy, div[data-testid*=primaryColumn]' ), url );
 	}
 
 	async checkLatestTweetsContain( expectedTweetText ) {
@@ -27,11 +27,11 @@ export default class TwitterFeedPage extends AsyncBaseContainer {
 		return await driver
 			.wait( async function() {
 				await driver.navigate().refresh();
-				return await getElementCount(
+				return await isEventuallyPresentAndDisplayed(
 					driver,
 					by.css( '.stream-item, div[data-testid*=tweet]' )
-				).then( tweetCount => {
-					if ( tweetCount >= 5 ) {
+				).then( tweetsShown => {
+					if ( tweetsShown ) {
 						return driver.getPageSource().then( function( source ) {
 							return source.indexOf( expectedTweetText ) > -1;
 						} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the container selector for the newer twitter page and waits to see if tweets are shown before retrying.

I think we were having two issues. First, twitter must be a/b testing two versions of their user feed pages. We need to be able to recognize either one of them. Second, the way the test was structured before, it would keep refreshing until the expected tweet showed up. With the new version of the Twitter page, the tweets are loaded by AJAX after the page loads. The test wouldn't see the text it was expecting because the tweets hadn't been loaded yet. It would keep refreshing and retrying. Every refresh was making API calls and it didn't take long for it to reach the API rate limit and start showing the "Something went wrong" message.

This PR waits for the tweets to show before trying to refresh. This should keep it from making so many calls.

#### Testing instructions

* Ensure it passes in CI
* Ensure that it pass locally
* Locally again, start the test and stop it at a breakpoint. Open a new tab go to the twitter page for the test account. Refresh the page a bunch of times until the "Something Went Wrong" message appears. Close the new tab. Continue the test and make sure it passes. Also make sure that the message that the expected text wasn't found shows in the console. 
