### PR TITLE
Jetpack Cloud error pages

### DIFF
--- a/client/landing/jetpack-cloud/layout.js
+++ b/client/landing/jetpack-cloud/layout.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import JetpackCloudMasterbar from './masterbar';
+import EmptyContent from 'components/empty-content';
 
 class JetpackCloudLayout extends Component {
 	static propTypes = {
@@ -25,7 +26,7 @@ class JetpackCloudLayout extends Component {
 						{ this.props.secondary }
 					</div>
 					<div id="primary" className="layout__primary">
-						{ this.props.primary }
+						{ this.props.primary || <EmptyContent /> }
 					</div>
 				</div>
 			</div>

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -22,7 +22,8 @@ import {
 	split,
 } from 'lodash';
 import bodyParser from 'body-parser';
-import superagent from 'superagent';
+// eslint-disable-next-line no-restricted-imports
+import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
 import { matchesUA } from 'browserslist-useragent';
 
 /**
@@ -87,6 +88,7 @@ function getInitialServerState( serializedServerState ) {
 
 /**
  * Checks whether a user agent is included in the browser list for an environment.
+ *
  * @param {string} userAgentString The user agent string.
  * @param {string} environment The `browserslist` environment.
  *
@@ -604,7 +606,7 @@ function renderServerError( err, req, res, next ) {
  * @param {object} req Express request object
  * @param {object} res Express response object
  * @param {Function} next a callback to call when done
- * @returns {Function|Undefined} res.redirect if not logged in
+ * @returns {Function|undefined} res.redirect if not logged in
  */
 function handleLocaleSubdomains( req, res, next ) {
 	const langSlug = endsWith( req.hostname, config( 'hostname' ) )

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -486,6 +486,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 /**
  * Sets up a Content Security Policy header
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
  * @param {object} req Express request object
  * @param {object} res Express response object
@@ -571,21 +572,21 @@ function setUpRoute( req, res, next ) {
 	);
 }
 
-function render404( req, res ) {
+const render404 = ( entrypoint = 'entry-main' ) => ( req, res ) => {
 	const ctx = {
 		faviconURL: config( 'favicon_url' ),
 		isRTL: config( 'rtl' ),
-		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), 'entry-main' ),
+		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), entrypoint ),
 	};
 
 	res.status( 404 ).send( renderJsx( '404', ctx ) );
-}
+};
 
 /* We don't use `next` but need to add it for express.js to
    recognize this function as an error handler, hence the
 	 eslint-disable. */
 // eslint-disable-next-line no-unused-vars
-function renderServerError( err, req, res, next ) {
+const renderServerError = ( entrypoint = 'entry-main' ) => ( err, req, res, next ) => {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		console.error( err );
 	}
@@ -593,11 +594,11 @@ function renderServerError( err, req, res, next ) {
 	const ctx = {
 		faviconURL: config( 'favicon_url' ),
 		isRTL: config( 'rtl' ),
-		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), 'entry-main' ),
+		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), entrypoint ),
 	};
 
 	res.status( err.status || 500 ).send( renderJsx( '500', ctx ) );
-}
+};
 
 /**
  * Sets language properties to context if
@@ -657,6 +658,13 @@ module.exports = function() {
 		JETPACK_CLOUD_SECTION_DEFINITION.paths.forEach( sectionPath =>
 			handleSectionPath( JETPACK_CLOUD_SECTION_DEFINITION, sectionPath, 'entry-jetpack-cloud' )
 		);
+
+		// catchall to render 404 for all routes not whitelisted in client/sections
+		app.use( render404( 'entry-jetpack-cloud' ) );
+
+		// Error handling middleware for displaying the server error 500 page must be the very last middleware defined
+		app.use( renderServerError( 'entry-jetpack-cloud' ) );
+
 		return app;
 	}
 
@@ -923,10 +931,10 @@ module.exports = function() {
 	} );
 
 	// catchall to render 404 for all routes not whitelisted in client/sections
-	app.use( render404 );
+	app.use( render404() );
 
 	// Error handling middleware for displaying the server error 500 page must be the very last middleware defined
-	app.use( renderServerError );
+	app.use( renderServerError() );
 
 	return app;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds logic for 404 and 500 error pages for Jetpack Cloud. These pages are loaded using the same component as Calypso pages, but load the Jetpack Cloud CSS instead.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Jetpack Cloud via `CALYPSO_ENV=jetpack-cloud-development npm start`.
* Go to route that doesn't exist.
* Observe error page.
* Build Calypso and smoke test.

Fixes 1156570014567299-as-1159128713000441
