### PR TITLE
[Coming Soon] Stop launching atomic sites on upgrade

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -11,6 +11,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import notices from 'notices';
 import EmptyContent from 'components/empty-content';
 import CreditsPaymentBox from './credits-payment-box';
@@ -217,14 +218,16 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 
-		// Until Atomic sites support being private / unlaunched, set them to public on upgrade
-		debug( 'Setting site to public because it is an Atomic plan' );
-		const response = await this.props.saveSiteSettings( selectedSiteId, {
-			blog_public: 1,
-		} );
+		if ( ! config.isEnabled( 'coming-soon' ) ) {
+			// Until Atomic sites support being private / unlaunched, set them to public on upgrade
+			debug( 'Setting site to public because it is an Atomic plan' );
+			const response = await this.props.saveSiteSettings( selectedSiteId, {
+				blog_public: 1,
+			} );
 
-		if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
-			throw 'Invalid response';
+			if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
+				throw 'Invalid response';
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to Coming Soon mode. More context available here: paObgF-MY-p2

As private sites support becomes available on Atomic platform, this PR makes sure we don't switch atomic sites to `blog_public=1` on upgrade.

#### Testing instructions

This PR is not testable yet, it depends on a few other PRs. I will update this description once we're ready to test it.

1. On calypso.localhost:
1. Create a new site on a free plan, make sure it's a private+coming soon site
1. Upgrade to business
1. Install a plugin
1. Confirm your site is still private+coming soon