### PR TITLE
SPTs: Add new templates and template organization

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -65,9 +65,6 @@ const TemplateSelectorItem = props => {
 			aria-labelledby={ `${ id } ${ labelId }` }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
-			<span className="template-selector-item__template-title" id={ labelId }>
-				{ label }
-			</span>
 		</button>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -225,20 +225,26 @@ class PageTemplateModal extends Component {
 		};
 	};
 
-	renderTemplatesList = ( templatesList, legendLabel ) => (
-		<fieldset className="page-template-modal__list">
-			<legend className="page-template-modal__form-title">{ legendLabel }</legend>
-			<TemplateSelectorControl
-				label={ __( 'Layout', 'full-site-editing' ) }
-				templates={ templatesList }
-				blocksByTemplates={ this.getBlocksByTemplateSlugs( this.props.templates ) }
-				onTemplateSelect={ this.previewTemplate }
-				useDynamicPreview={ false }
-				siteInformation={ this.props.siteInformation }
-				selectedTemplate={ this.state.previewedTemplate }
-			/>
-		</fieldset>
-	);
+	renderTemplatesList = ( templatesList, legendLabel ) => {
+		if ( 0 === templatesList.length ) {
+			return null;
+		}
+
+		return (
+			<fieldset className="page-template-modal__list">
+				<legend className="page-template-modal__form-title">{ legendLabel }</legend>
+				<TemplateSelectorControl
+					label={ __( 'Layout', 'full-site-editing' ) }
+					templates={ templatesList }
+					blocksByTemplates={ this.getBlocksByTemplateSlugs( this.props.templates ) }
+					onTemplateSelect={ this.previewTemplate }
+					useDynamicPreview={ false }
+					siteInformation={ this.props.siteInformation }
+					selectedTemplate={ this.state.previewedTemplate }
+				/>
+			</fieldset>
+		);
+	};
 
 	render() {
 		const { previewedTemplate, isOpen, isLoading } = this.state;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -324,12 +324,6 @@ class PageTemplateModal extends Component {
 									__( 'Contact Pages', 'full-site-editing' )
 								) }
 
-								{ ! this.props.isFrontPage &&
-									this.renderTemplatesList(
-										homepageTemplates,
-										__( 'Home Pages', 'full-site-editing' )
-									) }
-
 								{ this.renderTemplatesList(
 									menuTemplates,
 									__( 'Menu Pages', 'full-site-editing' )
@@ -349,6 +343,12 @@ class PageTemplateModal extends Component {
 									teamTemplates,
 									__( 'Team Pages', 'full-site-editing' )
 								) }
+
+								{ ! this.props.isFrontPage &&
+									this.renderTemplatesList(
+										homepageTemplates,
+										__( 'Home Pages', 'full-site-editing' )
+									) }
 							</form>
 							<TemplateSelectorPreview
 								blocks={ this.getBlocksByTemplateSlug( previewedTemplate ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -217,8 +217,10 @@ class PageTemplateModal extends Component {
 			aboutTemplates: filter( this.props.templates, { category: 'about' } ),
 			blogTemplates: filter( this.props.templates, { category: 'blog' } ),
 			contactTemplates: filter( this.props.templates, { category: 'contact' } ),
+			eventTemplates: filter( this.props.templates, { category: 'event' } ),
 			menuTemplates: filter( this.props.templates, { category: 'menu' } ),
 			portfolioTemplates: filter( this.props.templates, { category: 'portfolio' } ),
+			productTemplates: filter( this.props.templates, { category: 'product' } ),
 			servicesTemplates: filter( this.props.templates, { category: 'services' } ),
 			teamTemplates: filter( this.props.templates, { category: 'team' } ),
 			homepageTemplates: sortBy( filter( this.props.templates, { category: 'home' } ), 'title' ),
@@ -259,8 +261,10 @@ class PageTemplateModal extends Component {
 			aboutTemplates,
 			blogTemplates,
 			contactTemplates,
+			eventTemplates,
 			menuTemplates,
 			portfolioTemplates,
+			productTemplates,
 			servicesTemplates,
 			teamTemplates,
 			homepageTemplates,
@@ -325,6 +329,11 @@ class PageTemplateModal extends Component {
 								) }
 
 								{ this.renderTemplatesList(
+									eventTemplates,
+									__( 'Event Pages', 'full-site-editing' )
+								) }
+
+								{ this.renderTemplatesList(
 									menuTemplates,
 									__( 'Menu Pages', 'full-site-editing' )
 								) }
@@ -332,6 +341,11 @@ class PageTemplateModal extends Component {
 								{ this.renderTemplatesList(
 									portfolioTemplates,
 									__( 'Portfolio Pages', 'full-site-editing' )
+								) }
+
+								{ this.renderTemplatesList(
+									productTemplates,
+									__( 'Product Pages', 'full-site-editing' )
 								) }
 
 								{ this.renderTemplatesList(

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,18 +2,7 @@
 /**
  * External dependencies
  */
-import {
-	find,
-	isEmpty,
-	reduce,
-	get,
-	keyBy,
-	mapValues,
-	memoize,
-	filter,
-	reject,
-	sortBy,
-} from 'lodash';
+import { find, isEmpty, reduce, get, keyBy, mapValues, memoize, filter, sortBy } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -10,7 +10,7 @@ import {
 	keyBy,
 	mapValues,
 	memoize,
-	partition,
+	filter,
 	reject,
 	sortBy,
 } from 'lodash';
@@ -223,26 +223,17 @@ class PageTemplateModal extends Component {
 	}
 
 	getTemplateGroups = () => {
-		const [ homepageTemplates, defaultTemplates ] = partition( this.props.templates, {
-			category: 'home',
-		} );
-
-		const currentThemeTemplate =
-			find( this.props.templates, { slug: this.props.theme } ) ||
-			find( this.props.templates, { slug: DEFAULT_HOMEPAGE_TEMPLATE } );
-
-		if ( ! this.props.isFrontPage || ! currentThemeTemplate ) {
-			return { homepageTemplates: sortBy( homepageTemplates, 'title' ), defaultTemplates };
-		}
-
-		const otherHomepageTemplates = reject( homepageTemplates, { slug: currentThemeTemplate.slug } );
-
-		const sortedHomepageTemplates = [
-			currentThemeTemplate,
-			...sortBy( otherHomepageTemplates, 'title' ),
-		];
-
-		return { homepageTemplates: sortedHomepageTemplates, defaultTemplates };
+		return {
+			blankTemplate: filter( this.props.templates, { slug: 'blank' } ),
+			aboutTemplates: filter( this.props.templates, { category: 'about' } ),
+			blogTemplates: filter( this.props.templates, { category: 'blog' } ),
+			contactTemplates: filter( this.props.templates, { category: 'contact' } ),
+			menuTemplates: filter( this.props.templates, { category: 'menu' } ),
+			portfolioTemplates: filter( this.props.templates, { category: 'portfolio' } ),
+			servicesTemplates: filter( this.props.templates, { category: 'services' } ),
+			teamTemplates: filter( this.props.templates, { category: 'team' } ),
+			homepageTemplates: sortBy( filter( this.props.templates, { category: 'home' } ), 'title' ),
+		};
 	};
 
 	renderTemplatesList = ( templatesList, legendLabel ) => (
@@ -268,7 +259,17 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
-		const { homepageTemplates, defaultTemplates } = this.getTemplateGroups();
+		const {
+			blankTemplate,
+			aboutTemplates,
+			blogTemplates,
+			contactTemplates,
+			menuTemplates,
+			portfolioTemplates,
+			servicesTemplates,
+			teamTemplates,
+			homepageTemplates,
+		} = this.getTemplateGroups();
 
 		return (
 			<Modal
@@ -305,28 +306,53 @@ class PageTemplateModal extends Component {
 					) : (
 						<>
 							<form className="page-template-modal__form">
-								{ this.props.isFrontPage ? (
-									<>
-										{ this.renderTemplatesList(
-											homepageTemplates,
-											__( 'Recommended Layouts', 'full-site-editing' )
-										) }
-										{ this.renderTemplatesList(
-											defaultTemplates,
-											__( 'Other Page Layouts', 'full-site-editing' )
-										) }
-									</>
-								) : (
-									<>
-										{ this.renderTemplatesList(
-											defaultTemplates,
-											__( 'Recommended Layouts', 'full-site-editing' )
-										) }
-										{ this.renderTemplatesList(
-											homepageTemplates,
-											__( 'Homepage Layouts', 'full-site-editing' )
-										) }
-									</>
+								{ this.props.isFrontPage &&
+									this.renderTemplatesList(
+										homepageTemplates,
+										__( 'Home Pages', 'full-site-editing' )
+									) }
+
+								{ this.renderTemplatesList( blankTemplate, __( 'Blank', 'full-site-editing' ) ) }
+
+								{ this.renderTemplatesList(
+									aboutTemplates,
+									__( 'About Pages', 'full-site-editing' )
+								) }
+
+								{ this.renderTemplatesList(
+									blogTemplates,
+									__( 'Blog Pages', 'full-site-editing' )
+								) }
+
+								{ this.renderTemplatesList(
+									contactTemplates,
+									__( 'Contact Pages', 'full-site-editing' )
+								) }
+
+								{ ! this.props.isFrontPage &&
+									this.renderTemplatesList(
+										homepageTemplates,
+										__( 'Home Pages', 'full-site-editing' )
+									) }
+
+								{ this.renderTemplatesList(
+									menuTemplates,
+									__( 'Menu Pages', 'full-site-editing' )
+								) }
+
+								{ this.renderTemplatesList(
+									portfolioTemplates,
+									__( 'Portfolio Pages', 'full-site-editing' )
+								) }
+
+								{ this.renderTemplatesList(
+									servicesTemplates,
+									__( 'Services Pages', 'full-site-editing' )
+								) }
+
+								{ this.renderTemplatesList(
+									teamTemplates,
+									__( 'Team Pages', 'full-site-editing' )
 								) }
 							</form>
 							<TemplateSelectorPreview

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -136,12 +136,12 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .template-selector-control__options {
 	display: grid;
 	grid-template-columns: 1fr;
-	grid-gap: 1.75em;
+	grid-gap: 0.75em;
 
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		margin-top: 0;
 		grid-template-columns: repeat(
-			auto-fit,
+			auto-fill,
 			minmax( 110px, 1fr )
 		); // allow grid to take over number of cols on large screens
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -238,20 +238,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	left: 0;
 }
 
-// Blank template
-@media screen and ( max-width: ( $breakpoint-mobile - 1px ) ) {
-	.template-selector-control__template:first-child {
-		.template-selector-item__preview-wrap {
-			padding-top: 0%;
-			height: $template-selector-blank-template-mobile-height;
-		}
-		.template-selector-item__template-title {
-			height: $template-selector-blank-template-mobile-height;
-			line-height: $template-selector-blank-template-mobile-height;
-		}
-	}
-}
-
 .page-template-modal__form {
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		max-width: 20%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will address the changes needed in https://github.com/Automattic/wp-calypso/issues/38811.

* Update the template selector modal to support categorization of page templates that have more than one template for a category.

Companion diff: ~D38317-code~ (deployed)

#### Testing instructions

1. Check out this branch and build a copy of the FSE plugin
2. Apply D38317 on your sandbox and make sure public-api.wordpress.com is pointing there
3. Run and activate the FSE plugin and Gutenberg plugin on a WordPress install
4. Add a new page and confirm you see the equivalent to https://github.com/Automattic/wp-calypso/pull/39120#issuecomment-579899372
5. Confirm that templates are all selectable and insert correctly.

#### Visuals:

![page-layout-selector](https://user-images.githubusercontent.com/908665/72805374-9e577680-3c4a-11ea-98cc-f85499d1cf00.png)


Fixes #38811
