### PR TITLE
FSE: Fix full width blocks in the editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -23,14 +23,10 @@
 .post-type-page,
 .post-type-wp_template_part {
 	@media ( min-width: 768px ) {
-		// @TODO: remove .edit-post-layout__content when Gutenberg 7.0.0 lands in production
-		.edit-post-layout__content,
 		.edit-post-editor-regions__content {
 			background: #eee;
 		}
 
-		// @TODO: remove .edit-post-layout__content when Gutenberg 7.0.0 lands in production
-		.edit-post-layout__content .edit-post-visual-editor,
 		.edit-post-editor-regions__content .edit-post-visual-editor {
 			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
 				0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
@@ -42,6 +38,11 @@
 	.block-editor-block-list__layout {
 		padding-left: 0;
 		padding-right: 0;
+
+		.block-editor-block-list__block[data-align='full'] {
+			margin-left: 0;
+			margin-right: 0;
+		}
 	}
 
 	.block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit {


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Align full width blocks to the edge of the editor border. Something must have broken the styles in the last update.

**Before: Template Part Block.**
<img width="1427" alt="Screen Shot 2020-01-28 at 7 00 17 PM" src="https://user-images.githubusercontent.com/6265975/73329122-78a90f00-4200-11ea-9358-24098a5d9f2f.png">

**After: Template Part Block.**
<img width="1379" alt="Screen Shot 2020-01-28 at 6 58 15 PM" src="https://user-images.githubusercontent.com/6265975/73329125-78a90f00-4200-11ea-8528-7d42c715eb52.png">


**Before: full width image**
<img width="1489" alt="Screen Shot 2020-01-28 at 7 00 27 PM" src="https://user-images.githubusercontent.com/6265975/73329120-78107880-4200-11ea-86d2-a17b327416bb.png">

**After: full width image**
<img width="1389" alt="Screen Shot 2020-01-28 at 6 58 27 PM" src="https://user-images.githubusercontent.com/6265975/73329123-78a90f00-4200-11ea-801f-82eae321f53c.png">

I also verified that wide-width blocks work as expected.
 
### Testing instructions
* Build this and sync to your sandbox. Sandbox the site you'll test against.
* Open the FSE editor and verify that full width blocks are aligned to the editor frame. (Also double check a full-width block inside of the template part block.
