### PR TITLE
Jetpack Cloud: Add Jetpack Cloud Production redirect

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -651,7 +651,7 @@ module.exports = function() {
 	app.use( setupLoggedInContext );
 	app.use( handleLocaleSubdomains );
 
-	// Temporaryly redirect cloud.jetpack.com to jetpack.com in the production enviroment
+	// Temporarily redirect cloud.jetpack.com to jetpack.com in the production enviroment
 	app.use( function( req, res, next ) {
 		if ( 'jetpack-cloud-production' === calypsoEnv ) {
 			res.redirect( 'https://jetpack.com/' );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -651,6 +651,14 @@ module.exports = function() {
 	app.use( setupLoggedInContext );
 	app.use( handleLocaleSubdomains );
 
+	// Temporaryly redirect cloud.jetpack.com to jetpack.com in the production enviroment
+	app.use( function( req, res, next ) {
+		if ( 'jetpack-cloud-production' === calypsoEnv ) {
+			res.redirect( 'https://jetpack.com/' );
+		}
+		next();
+	} );
+
 	if ( jetpackCloudEnvs.includes( calypsoEnv ) ) {
 		JETPACK_CLOUD_SECTION_DEFINITION.paths.forEach( sectionPath =>
 			handleSectionPath( JETPACK_CLOUD_SECTION_DEFINITION, sectionPath, 'entry-jetpack-cloud' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a redirect for the production cloud.jetpack.com to be redirected to jetpack.com

#### Testing instructions
1. Run npm start. 
2. Make sure that everything still works as expected. 
3. If everything looks good shut down calyspo
4. Run CALYPSO_ENV=jetpack-cloud-production npm start
5. Your browser should get redirected to jetpack.com
