### PR TITLE
Gutenboarding: add site creation and frankenflow launch

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -7,11 +7,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent, useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
 import classnames from 'classnames';
+import { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import { DomainSuggestions } from '@automattic/data-stores';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { USER_STORE } from '../../stores/user';
 import './style.scss';
@@ -75,11 +75,12 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 		</span>
 	);
 
+	const siteUrl = currentDomain?.domain_name || siteTitle || currentUser?.username;
 	const siteCreationData = {
 		siteTitle,
-		siteUrl: currentDomain?.domain_name || siteTitle || currentUser?.username,
-		theme: selectedDesign?.slug,
 		siteVertical,
+		...( siteUrl && { siteUrl } ),
+		...( selectedDesign?.slug && { theme: selectedDesign?.slug } ),
 	};
 
 	return (

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -4,8 +4,7 @@
 import { __ as NO__ } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
 import classnames from 'classnames';
 
@@ -14,10 +13,12 @@ import classnames from 'classnames';
  */
 import { DomainSuggestions } from '@automattic/data-stores';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { USER_STORE } from '../../stores/user';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
 import { selectorDebounce } from '../../constants';
 import Link from '../link';
+import { createSite } from '../../utils';
 
 const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
@@ -26,17 +27,14 @@ interface Props {
 }
 
 const Header: FunctionComponent< Props > = ( { prev } ) => {
+	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
 	const { domain, selectedDesign, siteTitle, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
 	const hasSelectedDesign = !! selectedDesign;
 	const { setDomain } = useDispatch( ONBOARD_STORE );
 
-	const [ domainSearch ] = useDebounce(
-		// If we know a domain, do not search.
-		! domain && siteTitle,
-		selectorDebounce
-	);
+	const [ domainSearch ] = useDebounce( siteTitle, selectorDebounce );
 	const freeDomainSuggestion = useSelect(
 		select => {
 			if ( ! domainSearch ) {
@@ -51,6 +49,12 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 		},
 		[ domainSearch, siteVertical ]
 	);
+
+	useEffect( () => {
+		if ( ! siteTitle ) {
+			setDomain( undefined );
+		}
+	}, [ siteTitle, setDomain ] );
 
 	const currentDomain = domain ?? freeDomainSuggestion;
 
@@ -70,6 +74,13 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 			{ currentDomain ? currentDomain.domain_name : 'example.wordpress.com' }
 		</span>
 	);
+
+	const siteCreationData = {
+		siteTitle,
+		siteUrl: currentDomain?.domain_name || siteTitle || currentUser?.username,
+		theme: selectedDesign?.slug,
+		siteVertical,
+	};
 
 	return (
 		<div
@@ -106,14 +117,10 @@ const Header: FunctionComponent< Props > = ( { prev } ) => {
 				<div className="gutenboarding__header-group">
 					{ hasSelectedDesign && (
 						<Button
-							href={ addQueryArgs( '/start/frankenflow', {
-								siteTitle: siteTitle,
-								...( selectedDesign?.slug && { theme: selectedDesign.slug } ),
-								...( currentDomain?.domain_name && { domainName: currentDomain.domain_name } ),
-							} ) }
 							className="gutenboarding__header-next-button"
 							isPrimary
 							isLarge
+							onClick={ () => createSite( siteCreationData ) }
 						>
 							{ NO__( 'Create my site' ) }
 						</Button>

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -11,7 +11,7 @@ import { ActionType, SiteVertical } from './types';
 type Template = VerticalsTemplates.Template;
 
 export const setDomain = (
-	domain: import('@automattic/data-stores').DomainSuggestions.DomainSuggestion
+	domain: import('@automattic/data-stores').DomainSuggestions.DomainSuggestion | undefined
 ) => ( {
 	type: ActionType.SET_DOMAIN as const,
 	domain,

--- a/client/landing/gutenboarding/tsconfig.json
+++ b/client/landing/gutenboarding/tsconfig.json
@@ -3,6 +3,10 @@
 	"compilerOptions": {
 		// Disallow features that require cross-file information for emit.
 		// Must be used with babel typescript
-		"isolatedModules": true
+		"isolatedModules": true,
+
+		"paths": {
+			"*": [ "*", "client/*" ]
+		}
 	}
 }

--- a/client/landing/gutenboarding/tsconfig.json
+++ b/client/landing/gutenboarding/tsconfig.json
@@ -5,8 +5,9 @@
 		// Must be used with babel typescript
 		"isolatedModules": true,
 
+		"baseUrl": ".",
 		"paths": {
-			"*": [ "*", "client/*" ]
+			"*": [ "*", "../../*" ]
 		}
 	}
 }

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -15,6 +15,7 @@ import { DomainName } from '@automattic/data-stores/types/domain-suggestions';
  * ⚠️😱 Calypso dependencies 😱⚠️
  */
 import wpcom from '../../lib/wp';
+import { untrailingslashit } from '../../lib/route';
 import { urlToSlug } from '../../lib/url';
 
 interface CreateSite {
@@ -50,7 +51,7 @@ export function createSite( { siteTitle, siteUrl, theme, siteVertical }: CreateS
 			throw new Error( 'No url in response!' );
 		}
 
-		const siteSlug = urlToSlug( url );
+		const siteSlug = urlToSlug( untrailingslashit( url ) );
 		window.location.href = `/block-editor/page/${ siteSlug }/home?is-gutenboarding`;
 	} );
 }

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -1,14 +1,21 @@
 /**
- * External dependencies
+ * ***Do not reproduce this pattern for Gutenboarding work.***
+ *
+ * FIXME: Replace this with another pattern:
+ *   - Side-effect (control) of dispatched action?
  */
-import wpcom from 'lib/wp';
 
 /**
  * Internal dependencies
  */
-import { parse as parseURL } from 'url';
 import { SiteVertical } from './stores/onboard/types';
 import { DomainName } from '@automattic/data-stores/types/domain-suggestions';
+
+/**
+ * ⚠️😱 Calypso dependencies 😱⚠️
+ */
+import wpcom from '../../lib/wp';
+import { urlToSlug } from '../../lib/url';
 
 interface CreateSite {
 	siteTitle: string | undefined;
@@ -33,14 +40,17 @@ export function createSite( { siteTitle, siteUrl, theme, siteVertical }: CreateS
 		validate: false,
 		find_available_url: true,
 	};
-	wpcom.undocumented().sitesNew( newSiteParams, function( error, response ) {
+	wpcom.undocumented().sitesNew( newSiteParams, function( error: any, response: any ) {
 		if ( error ) {
 			throw new Error( error );
 		}
 
-		const parsedBlogURL = parseURL( response.blog_details.url );
+		const url = response?.blog_details?.url;
+		if ( ! url ) {
+			throw new Error( 'No url in response!' );
+		}
 
-		const siteSlug = parsedBlogURL.hostname;
+		const siteSlug = urlToSlug( url );
 		window.location.href = `/block-editor/page/${ siteSlug }/home?is-gutenboarding`;
 	} );
 }

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -18,9 +18,9 @@ import wpcom from '../../lib/wp';
 import { urlToSlug } from '../../lib/url';
 
 interface CreateSite {
-	siteTitle: string | undefined;
-	siteUrl: DomainName | undefined;
-	theme: string | undefined;
+	siteTitle?: string;
+	siteUrl?: DomainName;
+	theme?: string;
 	siteVertical: SiteVertical | undefined;
 }
 

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -19,7 +19,7 @@ interface CreateSite {
 
 export function createSite( { siteTitle, siteUrl, theme, siteVertical }: CreateSite ) {
 	const newSiteParams = {
-		blog_name: siteUrl,
+		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
 		options: {
 			theme: `pub/${ theme }`,

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -41,6 +41,7 @@ export function createSite( { siteTitle, siteUrl, theme, siteVertical }: CreateS
 		validate: false,
 		find_available_url: true,
 	};
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	wpcom.undocumented().sitesNew( newSiteParams, function( error: any, response: any ) {
 		if ( error ) {
 			throw new Error( error );

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import wpcom from 'lib/wp';
+
+/**
+ * Internal dependencies
+ */
+import { parse as parseURL } from 'url';
+import { SiteVertical } from './stores/onboard/types';
+import { DomainName } from '@automattic/data-stores/types/domain-suggestions';
+
+interface CreateSite {
+	siteTitle: string | undefined;
+	siteUrl: DomainName | undefined;
+	theme: string | undefined;
+	siteVertical: SiteVertical | undefined;
+}
+
+export function createSite( { siteTitle, siteUrl, theme, siteVertical }: CreateSite ) {
+	const newSiteParams = {
+		blog_name: siteUrl,
+		blog_title: siteTitle,
+		options: {
+			theme: `pub/${ theme }`,
+			site_vertical: siteVertical?.id,
+			site_vertical_name: siteVertical?.label,
+			site_information: {
+				title: siteTitle,
+			},
+		},
+		public: -1,
+		validate: false,
+		find_available_url: true,
+	};
+	wpcom.undocumented().sitesNew( newSiteParams, function( error, response ) {
+		if ( error ) {
+			throw new Error( error );
+		}
+
+		const parsedBlogURL = parseURL( response.blog_details.url );
+
+		const siteSlug = parsedBlogURL.hostname;
+		window.location.href = `/block-editor/page/${ siteSlug }/home?is-gutenboarding`;
+	} );
+}

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -212,11 +212,6 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		newSiteParams.options.site_segment = 1;
 	}
 
-	// Provide siteTitle from Gutenboarding
-	if ( 'frankenflow' === lastKnownFlow ) {
-		newSiteParams.blog_title = dependencies.siteTitle;
-	}
-
 	if ( isEligibleForPageBuilder( siteSegment, flowToCheck ) && shouldEnterPageBuilder() ) {
 		newSiteParams.options.in_page_builder = true;
 	}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -355,12 +355,12 @@ export function generateFlows( {
 
 	if ( isEnabled( 'gutenboarding' ) ) {
 		flows.frankenflow = {
-			steps: [ 'prelaunch-domains', 'plans' ],
-			destination: getSignupDestination,
-			description: 'Frankenflow testing flow for Gutenboarding',
+			steps: [ 'domains-launch', 'plans-launch', 'launch' ],
+			destination: getLaunchDestination,
+			description: 'Frankenflow launch for a site created from Gutenboarding',
 			lastModified: '2020-01-22',
 			pageTitle: translate( 'Launch your site' ),
-			providesDependenciesInQuery: [ 'theme', 'siteTitle' ],
+			providesDependenciesInQuery: [ 'siteSlug' ],
 		};
 	}
 

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -61,7 +61,6 @@ const stepNameToModuleName = {
 	'domains-with-preview': 'domains',
 	'site-title-with-preview': 'site-title',
 	passwordless: 'passwordless',
-	'prelaunch-domains': 'domains',
 };
 
 export async function getStepComponent( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -576,23 +576,6 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'email', 'username' ],
 			unstorableDependencies: [ 'bearer_token' ],
 		},
-		'prelaunch-domains': {
-			stepName: 'prelaunch-domains',
-			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [
-				'siteId',
-				'siteSlug',
-				'domainItem',
-				'themeItem',
-				'shouldHideFreePlan',
-			],
-			optionalDependencies: [ 'shouldHideFreePlan' ],
-			props: {
-				isDomainOnly: false,
-			},
-			delayApiRequestUntilComplete: true,
-			dependencies: [ 'theme', 'siteTitle' ],
-		},
 	};
 }
 


### PR DESCRIPTION
Fix #39101 
Part of #37329 by creating the site in which we open the `block-editor`

#### Changes proposed in this Pull Request
* Using domain name, site title and design from Gutenboarding we are creating a site for a logged in user (or for a passwordless sign up using http://calypso.localhost:3000/gutenboarding/signup
* The user lands in block-editor of the newly created site where https://github.com/Automattic/wp-calypso/pull/39048 will add the Launch button that redirects to `start/frankenflow` for launch.
* Until https://github.com/Automattic/wp-calypso/issues/38904 is done, a user could manually access the frankenflow launch flow by going to `/start/frankenflow?siteSlug=DOMAIN_NAME` after the site has been created.

#### Testing instructions
* With a logged in user, go through Gutenboarding and press Create my site.
* [Optional] In a clean browser (incognito window), go first to `/gutenboarding/signup`. When getting the success message inside the modal, go to `/gutenboarding` then complete Gutenboarding flow and create the site.
* The new site should have the domain name from Domain Picker if a site title was provided.
* If the user skipped the site title step, username will be used in the domain name.
* Theme should correspond to the last selected design.
