### PR TITLE
Customer Home: Show Site Tools when checklist is complete

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -624,7 +624,8 @@ const connectHome = connect(
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
 
 		return {
-			displayChecklist: isEligibleForDotcomChecklist( state, siteId ),
+			displayChecklist:
+				isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
 			site: getSelectedSite( state ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Originally reported by @andrewserong in p1580270924269500-slack-dotcom-manage

Fixes a regression that was included in https://github.com/Automattic/wp-calypso/pull/39071 causing the checklist to be displayed even if it is completed.

Before | After
--- | ---
<img width="979" alt="Screenshot 2020-01-29 at 11 31 29" src="https://user-images.githubusercontent.com/1233880/73349399-6b853200-428b-11ea-855f-3464dce071cf.png"> | <img width="970" alt="Screenshot 2020-01-29 at 11 33 20" src="https://user-images.githubusercontent.com/1233880/73349416-717b1300-428b-11ea-9a8d-b9694c7289c2.png">


#### Testing instructions

* Create a new site.
* Complete the checklist.
* Make sure the Site Tools are displayed when the checklist has been completed.
