### PR TITLE
Customer Home: Hide "My Site" and "Grow & Earn" cards if checklist is uncompleted

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -509,7 +509,7 @@ class Home extends Component {
 						</Card>
 					) }
 					{ ! siteIsUnlaunched && <StatsCard /> }
-					{ ! siteIsUnlaunched && (
+					{ ! siteIsUnlaunched && isChecklistComplete && (
 						<Card>
 							<CardHeading>{ translate( 'My Site' ) }</CardHeading>
 							<h6 className="customer-home__card-subheader">
@@ -545,7 +545,7 @@ class Home extends Component {
 							</div>
 						</Card>
 					) }
-					{ ! siteIsUnlaunched && (
+					{ ! siteIsUnlaunched && isChecklistComplete && (
 						<Card className="customer-home__grow-earn">
 							<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>
 							<h6 className="customer-home__card-subheader">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

"My Site" provides a link to edit the homepage which is already part of the checklist, and "Grow & Earn" are likely premature steps before users finish setting up their sites.

In order to save some space, this PR hides the "My Site" and "Grow & Earn" cards from the Customer Home until after the checklist has been completed. 

#### Testing instructions

* Create a new site.
* Launch it.
* Make sure the "My Site" and "Grow & Earn" cards are not visible in `/home/:site`.
* Complete the checklist.
* Make sure the "My Site" and "Grow & Earn" cards are visible now.

Part of #39119
