### PR TITLE
Plans: update the plans page copy for users that are not the main plan owner.

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -347,7 +347,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
 				{ translate(
-					"This plan was purchased by a different WordPress.com account. Please log into that account, or contact that account's owner to manage this plan."
+					"This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner."
 				) }
 			</Notice>,
 			bannerContainer

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -346,7 +346,9 @@ export class PlanFeatures extends Component {
 		}
 		return ReactDOM.createPortal(
 			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
-				{ translate( 'You need to be the plan owner to manage this site.' ) }
+				{ translate(
+					"This plan was purchased by a different WordPress.com account. Please log into that account, or contact that account's owner to manage this plan."
+				) }
 			</Notice>,
 			bannerContainer
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Before:
<img width="1102" alt="Screen Shot 2020-01-29 at 3 00 25 PM" src="https://user-images.githubusercontent.com/115071/73363283-c0837100-42a8-11ea-876e-4055c5b28cb6.png">

After:
<img width="1082" alt="Screen Shot 2020-01-29 at 3 01 44 PM" src="https://user-images.githubusercontent.com/115071/73363292-c416f800-42a8-11ea-9aa3-9426b01cd492.png">


On mobile after:
<img width="527" alt="Screen Shot 2020-01-29 at 3 05 59 PM" src="https://user-images.githubusercontent.com/115071/73363361-e14bc680-42a8-11ea-82db-998833850641.png">

#### Testing instructions

* Login as an admin to a site that you didn't pay for the plan for. 
http://calypso.localhost:3000/plans/example.com

