### PR TITLE
Domains: Unify the free domain nudge in the domain management screen

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -125,10 +125,11 @@ export class List extends React.Component {
 
 		return (
 			<Notice
-				status="is-info"
+				status="is-success"
 				showDismiss={ false }
 				text={ translate( 'Free domain available' ) }
-				icon="globe"
+				icon="info-outline"
+				className="domain-management__claim-free-domain"
 			>
 				<NoticeAction
 					onClick={ this.props.clickClaimDomainNotice }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -117,3 +117,9 @@ input[type='radio'].domain-management-list-item__radio {
 .list-all__container .list-all__site {
 	margin-bottom: 10px;
 }
+
+.domain-management__claim-free-domain {
+	@include breakpoint( '>660px' ) {
+		display: none;
+	}
+}


### PR DESCRIPTION
Since we shoul the nudge both in the navigation and in the domain management screen @fditrapani suggested that:

#### Changes proposed in this Pull Request

* we should use the same style (color and icon) for both nudges
* we should hide the nudge on desktop and only show it in the mobile so that we don't have 2 versions of the same nudge on screen

#### Testing instructions

* get a plan for a site but without a domain
* open the Manage > Domains screen - you should only see one nudge in the navigation. If you go in the mobile version you should see the nudge in the navigation menu and in Manage > Domains
