### PR TITLE
Update/domains clean up section headers

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -20,7 +20,6 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
 import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
-import SectionHeader from 'components/section-header';
 import isRequestingWhois from 'state/selectors/is-requesting-whois';
 
 class EditContactInfo extends React.Component {
@@ -74,7 +73,6 @@ class EditContactInfo extends React.Component {
 
 		return (
 			<div>
-				<SectionHeader label={ this.props.translate( 'Edit Contact Info' ) } />
 				<EditContactInfoFormCard
 					domainRegistrationAgreementUrl={ domain.domainRegistrationAgreementUrl }
 					selectedDomain={ getSelectedDomain( this.props ) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card, Button } from '@automattic/components';
-import SectionHeader from 'components/section-header';
 import { resendIcannVerification } from 'lib/domains';
 import notices from 'notices';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
@@ -43,28 +42,32 @@ class IcannVerification extends React.Component {
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Transfer Domain' ) }>
-					<Button onClick={ this.handleClick } disabled={ this.state.submitting } compact primary>
+				<Card className="transfer-out__card">
+					<p>
+						{ translate(
+							'You must verify your email address before you can transfer this domain. ' +
+								'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+							{
+								components: {
+									learnMoreLink: (
+										<a
+											href={ TRANSFER_DOMAIN_REGISTRATION }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+					<Button
+						className="transfer-out__action-button"
+						onClick={ this.handleClick }
+						disabled={ this.state.submitting }
+						primary
+					>
 						{ translate( 'Resend Verification Email' ) }
 					</Button>
-				</SectionHeader>
-
-				<Card className="transfer-out__card">
-					{ translate(
-						'You must verify your email address before you can transfer this domain. ' +
-							'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
-						{
-							components: {
-								learnMoreLink: (
-									<a
-										href={ TRANSFER_DOMAIN_REGISTRATION }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card, Button } from '@automattic/components';
-import SectionHeader from 'components/section-header';
 import { getSelectedDomain } from 'lib/domains';
 import { fetchWapiDomainInfo, requestTransferCode } from 'lib/domains/wapi-domain-info/actions';
 import { displayRequestTransferCodeResponseNotice } from './shared';
@@ -62,8 +61,6 @@ class Locked extends React.Component {
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Transfer Domain' ) } />
-
 				<Card className="transfer-out__card">
 					<p>
 						{ privateDomain

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -12,7 +12,6 @@ import debugFactory from 'debug';
  */
 import { Card, Dialog, Suggestions } from '@automattic/components';
 import SearchCard from 'components/search-card';
-import SectionHeader from 'components/section-header';
 import FormButton from 'components/forms/form-button';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -219,7 +218,6 @@ class SelectIpsTag extends Component {
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Transfer Domain To Another Registrar' ) } />
 				<Card>
 					<p>
 						{ translate(

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -33,6 +33,7 @@ class SelectIpsTag extends Component {
 	};
 
 	componentDidMount() {
+		// eslint-disable-next-line no-undef
 		fetch( SelectIpsTag.ipsTagListUrl )
 			.then( async response => {
 				this.receiveIpsTagList( await response.json() );

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-lock.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-lock.jsx
@@ -8,7 +8,6 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import SectionHeader from 'components/section-header';
 import { useLocalizedMoment } from 'components/localized-moment';
 import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from 'lib/url/support';
 import { getSelectedDomain } from 'lib/domains';
@@ -20,7 +19,6 @@ const TransferLock = props => {
 
 	return (
 		<div>
-			<SectionHeader label={ translate( 'Transfer Domain' ) } />
 			<Card className="transfer-out__card">
 				{ translate(
 					'Due to recent contact information updates, ' +

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
@@ -9,12 +9,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import SectionHeader from 'components/section-header';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 const TransferProhibited = ( { translate } ) => (
 	<div>
-		<SectionHeader label={ translate( 'Transfer Domain' ) } />
 		<Card className="transfer-out__card">
 			{ translate(
 				'It is only possible to transfer a domain after 60 days after the registration date. This 60 day lock is ' +

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -9,7 +9,6 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { Card, Button } from '@automattic/components';
-import SectionHeader from 'components/section-header';
 import { getSelectedDomain } from 'lib/domains';
 import {
 	cancelTransferRequest,
@@ -147,9 +146,9 @@ class Unlocked extends React.Component {
 
 		return (
 			<Button
+				className="transfer-out__action-button"
 				onClick={ this.handleCancelTransferClick }
 				disabled={ this.state.submitting || ! this.state.sent }
-				compact
 			>
 				{ this.props.translate( 'Cancel Transfer' ) }
 			</Button>
@@ -166,9 +165,9 @@ class Unlocked extends React.Component {
 
 		return (
 			<Button
+				className="transfer-out__action-button"
 				onClick={ this.handleSendConfirmationCodeClick }
 				disabled={ this.state.submitting }
-				compact
 				primary
 			>
 				{ this.state.sent
@@ -279,14 +278,6 @@ class Unlocked extends React.Component {
 
 		return (
 			<div>
-				<SectionHeader
-					label={ translate( 'Transfer Domain' ) }
-					className="transfer-out__section-header"
-				>
-					{ this.renderCancelButton( domain ) }
-					{ this.renderSendButton( domain ) }
-				</SectionHeader>
-
 				<Card className="transfer-out__card">
 					<div>
 						{ submitting && <p>{ translate( 'Sending request…' ) }</p> }
@@ -296,6 +287,8 @@ class Unlocked extends React.Component {
 							{ translate( 'Learn More.' ) }
 						</a>
 					</div>
+					{ this.renderSendButton( domain ) }
+					{ this.renderCancelButton( domain ) }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -29,17 +29,17 @@ class Unlocked extends React.Component {
 		this.setStateIfMounted = noop;
 	}
 
-	/**
-	 * Wrap setState calls that might occur after unmounting.
-	 *
-	 * When we cancel a transfer, that might update locking or privacy,
-	 * but errors mean we can't know in time - the store gets the information
-	 * before we do.
-	 *
-	 * The recommended solution is cancellable promises, but we don't want to
-	 * cancel these requests if we navigate away, so that won't work for us here.
-	 */
 	setStateIfMounted( ...args ) {
+		/**
+		 * Wrap setState calls that might occur after unmounting.
+		 *
+		 * When we cancel a transfer, that might update locking or privacy,
+		 * but errors mean we can't know in time - the store gets the information
+		 * before we do.
+		 *
+		 * The recommended solution is cancellable promises, but we don't want to
+		 * cancel these requests if we navigate away, so that won't work for us here.
+		 */
 		this.setState( ...args );
 	}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -23,7 +23,6 @@ import { domainManagementList, domainManagementTransfer } from 'my-sites/domains
 import { getSelectedDomain } from 'lib/domains';
 import NonOwnerCard from 'my-sites/domains/domain-management/components/domain/non-owner-card';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
-import SectionHeader from 'components/section-header';
 import TransferConfirmationDialog from './confirmation-dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import wp from 'lib/wp';
@@ -159,7 +158,6 @@ export class TransferToOtherSite extends React.Component {
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Transfer Domain To Another Site' ) } />
 				<Card className="transfer-to-other-site__card">
 					<p>{ message }</p>
 					<SiteSelector

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -23,7 +23,6 @@ import wp from 'lib/wp';
 import { getSelectedDomain } from 'lib/domains';
 import NonOwnerCard from 'my-sites/domains/domain-management/components/domain/non-owner-card';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
-import SectionHeader from 'components/section-header';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import DesignatedAgentNotice from 'my-sites/domains/domain-management/components/designated-agent-notice';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -222,7 +221,6 @@ class TransferOtherUser extends React.Component {
 
 		return (
 			<Fragment>
-				<SectionHeader label={ translate( 'Transfer Domain To Another User' ) } />
 				<Card>
 					<p>
 						{ translate(

--- a/client/my-sites/email/email-forwarding/index.jsx
+++ b/client/my-sites/email/email-forwarding/index.jsx
@@ -26,7 +26,6 @@ import getEmailForwardingType from 'state/selectors/get-email-forwarding-type';
 import { getEmailForwards } from 'state/selectors/get-email-forwards';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryEmailForwards from 'components/data/query-email-forwards';
-import SectionHeader from 'components/section-header';
 
 /**
  * Style dependencies
@@ -51,7 +50,6 @@ class EmailForwarding extends Component {
 				<Header onClick={ this.goToEditEmail } selectedDomainName={ selectedDomainName }>
 					{ translate( 'Email Forwarding' ) }
 				</Header>
-				<SectionHeader label={ translate( 'Email Forwarding' ) } />
 				{ this.renderContent() }
 			</Main>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There are a bunch of section headers that duplicate the header text - we don't need them
* The affected pages are:
** Email Forwarding
** Edit Contacts
** Transfer to another registrar
** Transfer to another user
** Transfer to another site
* Moved the buttons for cancelling a transfer and resending the auth code out of the section header and inside the card body

#### Testing instructions

* Just go to the above sections for a domain and verify that there is no section header with the same title as the heading title
* The "Transfer to another registrar" section needs more testing with locked domain, unlocked domain, domain with contact recently updated, unverified domain, recently registered domain and a .uk domain for the IPS tag form... you can also short circuit those in the `transfer-out/index.jsx` file
