### PR TITLE
Remove default request handler from wpcom

### DIFF
--- a/packages/wpcom.js/History.md
+++ b/packages/wpcom.js/History.md
@@ -3,6 +3,7 @@
 
  * Remove dependency on `core-js`: the package user needs to provide the needed JS environment
  * Move the published `build/` folder to `dist/` to align with other Calypso packages
+ * No longer provide default request handler. This avoids a mandatory dependency on `wpcom-xhr-request`.
 
 5.4.2 / 2018-07-23
 ==================
@@ -289,7 +290,7 @@
   * test: add site.shortcodesList test
   * post: propagate `id` and `slug` when post is added
   * improve tests
- 
+
 3.1.1 / 2014-12-08
 ==================
 

--- a/packages/wpcom.js/README.md
+++ b/packages/wpcom.js/README.md
@@ -21,8 +21,8 @@ npm install --save wpcom
 
 ```js
 // Edit a post on a site
-var reqHandler = require( 'wpcom-xhr-request' );
-var wpcom = require( 'wpcom' )( '<your-token>', reqHandler );
+var wpcomXhrRequest = require( 'wpcom-xhr-request' );
+var wpcom = require( 'wpcom' )( '<your-token>', wpcomXhrRequest );
 
 wpcom
 	.site( 'your-blog.wordpress.com' )
@@ -46,7 +46,7 @@ npm install --save wpcom
 import wpcomXhrRequest from 'wpcom-xhr-request';
 import wpcomFactory from 'wpcom';
 
-const wpcom = wpcomFactory( '<your-token>', reqHandler );
+const wpcom = wpcomFactory( '<your-token>', wpcomXhrRequest );
 
 wpcom
 	.site( 'your-blog.wordpress.com' )
@@ -88,7 +88,7 @@ If you do need a token, here are some links that will help you generate one:
 import wpcomXhrRequest from 'wpcom-xhr-request';
 import wpcomFactory from 'wpcom';
 
-const wpcom = wpcomFactory( '<your-token>', reqHandler );
+const wpcom = wpcomFactory( '<your-token>', wpcomXhrRequest );
 const blog = wpcom.site( 'your-blog.wordpress.com' );
 blog.post( { slug: 'a-post-slug' } ).update( data )
 	.then( res => { ... } )
@@ -102,7 +102,7 @@ You can omit the API token for operations that don't require permissions:
 import wpcomXhrRequest from 'wpcom-xhr-request';
 import wpcomFactory from 'wpcom';
 
-const wpcom = wpcomFactory( undefined, reqHandler );
+const wpcom = wpcomFactory( undefined, wpcomXhrRequest );
 const blog = wpcom.site( 'your-blog.wordpress.com' );
 blog.postsList( { number: 8 } )
 	.then( list => { ... } )

--- a/packages/wpcom.js/README.md
+++ b/packages/wpcom.js/README.md
@@ -102,7 +102,7 @@ You can omit the API token for operations that don't require permissions:
 import wpcomXhrRequest from 'wpcom-xhr-request';
 import wpcomFactory from 'wpcom';
 
-const wpcom = wpcomFactory( undefined, wpcomXhrRequest );
+const wpcom = wpcomFactory( wpcomXhrRequest );
 const blog = wpcom.site( 'your-blog.wordpress.com' );
 blog.postsList( { number: 8 } )
 	.then( list => { ... } )

--- a/packages/wpcom.js/README.md
+++ b/packages/wpcom.js/README.md
@@ -21,7 +21,8 @@ npm install --save wpcom
 
 ```js
 // Edit a post on a site
-var wpcom = require( 'wpcom' )( '<your-token>' );
+var reqHandler = require( 'wpcom-xhr-request' );
+var wpcom = require( 'wpcom' )( '<your-token>', reqHandler );
 
 wpcom
 	.site( 'your-blog.wordpress.com' )
@@ -30,19 +31,28 @@ wpcom
 		.catch( error => { ... } );
 ```
 
-### Browser
+### Client-side code (with a build process)
 
-Include `dist/wpcom.js`.
+Introduce the `wpcom` dependency into your `package.json` ...
 
-```html
-<script src="wpcom.js"></script>
-<script>
-	var wpcom = WPCOM( '<your-token>' );
-	var blog = wpcom.site( 'your-blog.wordpress.com' );
-	blog.postsList( { number: 8 } )
+```cli
+npm install --save wpcom
+```
+
+... and then initialize it with your API token ([optional](#authentication)).
+
+```js
+// Edit a post on a site
+import wpcomXhrRequest from 'wpcom-xhr-request';
+import wpcomFactory from 'wpcom';
+
+const wpcom = wpcomFactory( '<your-token>', reqHandler );
+
+wpcom
+	.site( 'your-blog.wordpress.com' )
+	.postsList( { number: 8 } )
 		.then( list => { ... } )
 		.catch( error => { ... } );
-</script>
 ```
 
 ### Authentication
@@ -75,8 +85,11 @@ If you do need a token, here are some links that will help you generate one:
 
 ```js
 // Edit a post on a site
-var wpcom = require( 'wpcom' )( '<your-token>' );
-var blog = wpcom.site( 'your-blog.wordpress.com' );
+import wpcomXhrRequest from 'wpcom-xhr-request';
+import wpcomFactory from 'wpcom';
+
+const wpcom = wpcomFactory( '<your-token>', reqHandler );
+const blog = wpcom.site( 'your-blog.wordpress.com' );
 blog.post( { slug: 'a-post-slug' } ).update( data )
 	.then( res => { ... } )
 	.catch( err => { ... } );
@@ -86,8 +99,11 @@ You can omit the API token for operations that don't require permissions:
 
 ```js
 // List the last 8 posts on a site
-var wpcom = require( 'wpcom' )();
-var blog = wpcom.site( 'your-blog.wordpress.com' );
+import wpcomXhrRequest from 'wpcom-xhr-request';
+import wpcomFactory from 'wpcom';
+
+const wpcom = wpcomFactory( undefined, reqHandler );
+const blog = wpcom.site( 'your-blog.wordpress.com' );
 blog.postsList( { number: 8 } )
 	.then( list => { ... } )
 	.catch( error => { ... } );

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -39,7 +39,6 @@
 	"dependencies": {
 		"@babel/runtime": "^7.8.3",
 		"debug": "^4.1.1",
-		"qs": "^6.5.2",
-		"wpcom-xhr-request": "^1.1.2"
+		"qs": "^6.5.2"
 	}
 }

--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import requestHandler from 'wpcom-xhr-request';
 import debugModule from 'debug';
 
 /**
@@ -55,21 +54,11 @@ export default function WPCOM( token, reqHandler ) {
 
 	// Set default request handler
 	if ( ! reqHandler ) {
-		debug( 'No request handler. Adding default XHR request handler' );
-
-		this.request = function( params, fn ) {
-			params = params || {};
-
-			// token is optional
-			if ( token ) {
-				params.authToken = token;
-			}
-
-			return requestHandler( params, fn );
-		};
-	} else {
-		this.request = reqHandler;
+		debug( 'No request handler. Failing.' );
+		throw new Error( 'No request handler provided' );
 	}
+
+	this.request = reqHandler;
 
 	// Add Req instance
 	this.req = new Request( this );

--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -1,11 +1,11 @@
 /**
- * Module dependencies.
+ * External dependencies
  */
 import requestHandler from 'wpcom-xhr-request';
 import debugModule from 'debug';
 
 /**
- * Local module dependencies.
+ * Internal dependencies
  */
 import Batch from './lib/batch';
 import Domain from './lib/domain';
@@ -166,19 +166,18 @@ WPCOM.prototype.freshlyPressed = function( query, fn ) {
 	return this.req.get( '/freshly-pressed', query, fn );
 };
 
-/**
- * Expose send-request
- *
- * @TODO: use `this.req` instead of this method
- */
+// Expose send-request
+// TODO: use `this.req` instead of this method
 WPCOM.prototype.sendRequest = function( params, query, body, fn ) {
-	var msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';
+	const msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';
 
+	/* eslint-disable no-console */
 	if ( console && console.warn ) {
 		console.warn( msg );
 	} else {
 		console.log( msg );
 	}
+	/* eslint-enable no-console */
 
 	return sendRequest.call( this, params, query, body, fn );
 };
@@ -209,15 +208,15 @@ if ( ! Promise.prototype.timeout ) {
 	 * @returns {Promise} promise
 	 */
 	Promise.prototype.timeout = function( delay = DEFAULT_ASYNC_TIMEOUT ) {
-		let cancelTimeout, timer, timeout;
+		let timer;
 
-		timeout = new Promise( ( resolve, reject ) => {
+		const timeout = new Promise( ( resolve, reject ) => {
 			timer = setTimeout( () => {
 				reject( new Error( 'Action timed out while waiting for response.' ) );
 			}, delay );
 		} );
 
-		cancelTimeout = () => {
+		const cancelTimeout = () => {
 			clearTimeout( timer );
 			return this;
 		};

--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -52,13 +52,12 @@ export default function WPCOM( token, reqHandler ) {
 		this.token = token;
 	}
 
-	// Set default request handler
-	if ( ! reqHandler ) {
+	const noHandler = () => {
 		debug( 'No request handler. Failing.' );
 		throw new Error( 'No request handler provided' );
-	}
+	};
 
-	this.request = reqHandler;
+	this.request = reqHandler || noHandler;
 
 	// Add Req instance
 	this.req = new Request( this );

--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -52,9 +52,9 @@ export default function WPCOM( token, reqHandler ) {
 		this.token = token;
 	}
 
-	const noHandler = () => {
+	const noHandler = ( params, fn ) => {
 		debug( 'No request handler. Failing.' );
-		throw new Error( 'No request handler provided' );
+		fn( new Error( 'No request handler provided' ) );
 	};
 
 	this.request = reqHandler || noHandler;


### PR DESCRIPTION
This avoids a runtime dependency on `wpcom-xhr-request`, which may be entirely unwanted if the user has already provided a different request handler, such as `wpcom-proxy-request`.

#### Changes proposed in this Pull Request

* Remove default request handler logic from `wpcom`. It now simply fails when a request is made without one having been provided.
* Update documentation and history
* Minor lint fixes to modified files.

#### Testing instructions

Ensure that API requests in Calypso continue to work normally, by making basic use of "My Sites" functionality. No changes to its code should be needed, since it uses `wpcom-proxy-request`.
