### PR TITLE
Excludes restriction on superagent for server JS

### DIFF
--- a/client/server/.eslintrc.js
+++ b/client/server/.eslintrc.js
@@ -1,0 +1,19 @@
+const { rules: parentRules } = require( '../../.eslintrc.js' );
+
+const newRestrictedImports = parentRules[ 'no-restricted-imports' ];
+const filteredRestrictedPaths = newRestrictedImports[ 1 ].paths.filter(
+	path => 'object' !== typeof path || 'superagent' !== path.name
+);
+
+module.exports = {
+	rules: {
+		'no-console': 0,
+		'import/no-nodejs-modules': 0,
+		'no-restricted-imports': [
+			newRestrictedImports[ 0 ],
+			{
+				paths: filteredRestrictedPaths,
+			},
+		],
+	},
+};

--- a/client/server/.eslintrc.json
+++ b/client/server/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-	"rules": {
-		"no-console": 0,
-		"import/no-nodejs-modules": 0
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This updates the eslint configuration for server code to allow superagent, as per discussion in #39115.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run ESLint on code before checking out branch.
* Check out branch and run again.
* Superagent should no longer be flagged in server code.

Fixes #39115
