### PR TITLE
Jetpack Backups: Enable site cloning for all Calypso environments

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -103,7 +103,7 @@ class SiteTools extends Component {
 						description={ changeAddressText }
 					/>
 				) }
-				{ showClone && config.isEnabled( 'rewind/clone-site' ) && (
+				{ showClone && (
 					<SiteToolsLink href={ cloneUrl } title={ cloneTitle } description={ cloneText } />
 				) }
 				{ showThemeSetup && (

--- a/config/development.json
+++ b/config/development.json
@@ -138,7 +138,6 @@
 		"recommend-plugins": true,
 		"resume-editing": true,
 		"republicize": true,
-		"rewind/clone-site": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,7 +90,6 @@
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,
-		"rewind/clone-site": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -100,7 +100,6 @@
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,
-		"rewind/clone-site": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,7 +112,6 @@
 		"recommend-plugins": true,
 		"resume-editing": true,
 		"republicize": true,
-		"rewind/clone-site": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR eliminates the `rewind/site-cloning` feature flag and makes the `Clone` option available in all Calypso environments.

#### Testing instructions

Navigate to Manage > Settings and scroll to the bottom. You should see the clone option available in the Site Tools section, and clicking it should link to the cloning flow.
